### PR TITLE
[docs] Update widget component type from WidgetBase to Widget

### DIFF
--- a/docs/pages/versions/unversioned/sdk/widgets.mdx
+++ b/docs/pages/versions/unversioned/sdk/widgets.mdx
@@ -155,13 +155,13 @@ Start by creating a Widget using the `createWidget` function and pass the widget
 ```tsx
 import { Text, VStack } from '@expo/ui/swift-ui';
 import { font, foregroundStyle } from '@expo/ui/swift-ui/modifiers';
-import { createWidget, WidgetBase } from 'expo-widgets';
+import { createWidget, Widget } from 'expo-widgets';
 
 type MyWidgetProps = {
   count: number;
 };
 
-const MyWidget = (props: WidgetBase<MyWidgetProps>) => {
+const MyWidget = (props: Widget<MyWidgetProps>) => {
   'widget';
   return (
     <VStack>
@@ -213,14 +213,14 @@ Widget component receives a `family` prop indicating which size is being rendere
 
 ```tsx
 import { HStack, Text, VStack } from '@expo/ui/swift-ui';
-import { createWidget, WidgetBase } from 'expo-widgets';
+import { createWidget, Widget } from 'expo-widgets';
 
 type WeatherWidgetProps = {
   temperature: number;
   condition: string;
 };
 
-const WeatherWidget = (props: WidgetBase<WeatherWidgetProps>) => {
+const WeatherWidget = (props: Widget<WeatherWidgetProps>) => {
   'widget';
   // Render different layouts based on size
   if (props.family === 'systemSmall') {


### PR DESCRIPTION
I reported in an issue that WidgetBase (per the docs) is invalid, there is no exported member or anything regarding WidgetBase in the code for expo-widgets. There IS `Widget` which has the same methods as what looks like it should've been `WidgetBase` 

<img width="1160" height="394" alt="image" src="https://github.com/user-attachments/assets/e0d322c0-07a5-4350-b953-820f81b53db2" />


https://github.com/expo/expo/pull/43654#issuecomment-4049270447

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

To resolve a documentation inaccuracy. This is on the latest `expo: 55.0.7` and `expo-widgets 55.0.5`

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
