### PR TITLE
[iOS][location] Ignore `locationUnknown` errors in `watchPositionAsync`

### DIFF
--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Ignore [`locationUnknown`](https://developer.apple.com/documentation/corelocation/clerror-swift.struct/locationunknown) errors in `watchPositionAsync`.
+- [iOS] Ignore [`locationUnknown`](https://developer.apple.com/documentation/corelocation/clerror-swift.struct/locationunknown) errors in `watchPositionAsync`. ([#44027](https://github.com/expo/expo/pull/44027) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Ignore [`locationUnknown`](https://developer.apple.com/documentation/corelocation/clerror-swift.struct/locationunknown) errors in `watchPositionAsync`.
+
 ### 💡 Others
 
 ### ⚠️ Notices

--- a/packages/expo-location/ios/Providers/LocationsStreamer.swift
+++ b/packages/expo-location/ios/Providers/LocationsStreamer.swift
@@ -48,6 +48,12 @@ internal class LocationsStreamer: BaseStreamer {
   }
 
   func locationManager(_ manager: CLLocationManager, didFailWithError error: any Error) {
+    // Ignore `locationUnknown` (code 0) as it might be a temporary issue.
+    // The location manager will keep trying to obtain the location.
+    // It's a common error on simulator when there is no default location set in the scheme.
+    guard let clError = error as? CLError, clError.code != .locationUnknown else {
+      return
+    }
     continuation?.finish(throwing: Exceptions.LocationUnavailable().causedBy(error))
     locationsStream = nil
     continuation = nil


### PR DESCRIPTION
# Why

Fixes #44003 

# How

`locationManager(_:didFailWithError:)` may sometimes be called with [`locationUnknown`](https://developer.apple.com/documentation/corelocation/clerror-swift.struct/locationunknown) error which shouldn't stop `watchPositionAsync` from watching for location updates. This error might be temporary and seems to be common on simulators when the current scheme doesn't have the default location set.

# Test Plan

Tested with the repro provided in #44003 and in bare-expo.
