### PR TITLE
chore: Add "on hold" label to exempt stale issue labels

### DIFF
--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -15,7 +15,7 @@ jobs:
           days-before-issue-stale: 90
           days-before-issue-close: 7
           stale-issue-label: 'stale'
-          exempt-issue-labels: 'Issue accepted'
+          exempt-issue-labels: 'Issue accepted,✋ on hold'
           stale-issue-message: 'This issue is stale because it has been open for 90 days with no activity. If there is no activity in the next 7 days, the issue will be closed.'
           close-issue-message: 'This issue was closed because it has been inactive for 7 days since being marked as stale. Please open a new issue if you believe you are encountering a related problem.'
           days-before-pr-stale: -1


### PR DESCRIPTION
# Why

The label stands for issues that are not quite accepted, but aren't ready to be worked on. This means they're not stale and kept open on purpose. As per the label description, this is used for:
- features that are unstable, or will be reworked, so we can't accept bug reports for them, as is
- known issues that we'd like to mark but don't have an estimate for a fix for (e.g. because of the above)
- issues that need prerequisites to be fulfilled before they're ready to be worked on, which might invalidate the issue (e.g. another feature/rework/refactor that will make the issue obsolete)

This issue is useful when an issue itself will either not be addressed directly, immediately, or isn't relevant because the feature itself is changing or unstable.

**In short:** This label is for issues where we have no estimate on when the issue itself will be addressed or an estimate doesn't apply.

# How

- Add to ignored labels

# Test Plan

> [!NOTE]
> It's unclear to me if the emoji in the issue will work, but looking at the docs for the action, it doesn't seem to support yaml lists or make any mention of special characters

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
