### PR TITLE
fix(cli): Limit `/open-stack-frame` to server root paths

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Add internal `--skip-server` flag to skip server bundling in `export:embed` ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
 - Add `package.json:exports` with no-op reexport paths ([#44002](https://github.com/expo/expo/pull/44002) by [@kitten](https://github.com/kitten), [@hassankhan](https://github.com/hassankhan))
 - Add `react-native-web` to autolinking module resolution modules ([#44160](https://github.com/expo/expo/pull/44160) by [@kitten](https://github.com/kitten))
+- Limit `/open-stack-frame` to paths within server root ([#44039](https://github.com/expo/expo/pull/44039) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMetroMiddleware.test.ts
@@ -1,3 +1,5 @@
+import { vol } from 'memfs';
+
 import { withMetroServer } from './utils';
 import { openInEditorAsync } from '../../../../../utils/editor';
 import { createMetroMiddleware } from '../createMetroMiddleware';
@@ -5,6 +7,10 @@ import { createMetroMiddleware } from '../createMetroMiddleware';
 jest.mock('../../../../../utils/editor');
 
 describe(createMetroMiddleware, () => {
+  afterEach(() => {
+    vol.reset();
+  });
+
   const { metro, server, projectRoot } = withMetroServer();
 
   it('responds to a bundle request with compression', async () => {
@@ -70,19 +76,38 @@ describe(createMetroMiddleware, () => {
     await expect(response.text()).resolves.toBe('packager-status:running');
   });
 
-  it('responds to /open-stack-frame requests', async () => {
-    // Avoid opening the fake file
-    jest.mocked(openInEditorAsync).mockResolvedValue(true);
+  describe('/open-stack-frame', () => {
+    it('rejects calls to /open-stack-frame outside of server root', async () => {
+      vol.fromJSON({ '/other/test-file.ts': '' });
 
-    const response = await server.fetch('/open-stack-frame', {
-      method: 'POST',
-      body: JSON.stringify({ file: 'test-file.ts', lineNumber: 1337 }),
+      // Avoid opening the fake file
+      jest.mocked(openInEditorAsync).mockResolvedValue(true);
+
+      const response = await server.fetch('/open-stack-frame', {
+        method: 'POST',
+        body: JSON.stringify({ file: '/other/test-file.ts', lineNumber: 1337 }),
+      });
+
+      expect(response.status).toBe(400);
+      expect(openInEditorAsync).not.toHaveBeenCalled();
     });
 
-    // Ensure the request is successful
-    expect(response.status).toBe(200);
-    // Ensure the open in editor was called
-    expect(openInEditorAsync).toHaveBeenCalledWith('test-file.ts', 1337);
+    it('responds to /open-stack-frame requests', async () => {
+      vol.fromJSON({ '/project/test-file.ts': '' });
+
+      // Avoid opening the fake file
+      jest.mocked(openInEditorAsync).mockResolvedValue(true);
+
+      const response = await server.fetch('/open-stack-frame', {
+        method: 'POST',
+        body: JSON.stringify({ file: '/project/test-file.ts', lineNumber: 1337 }),
+      });
+
+      // Ensure the request is successful
+      expect(response.status).toBe(200);
+      // Ensure the open in editor was called
+      expect(openInEditorAsync).toHaveBeenCalledWith('/project/test-file.ts', 1337);
+    });
   });
 
   describe('websockets', () => {

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -1,7 +1,9 @@
+import { getMetroServerRoot } from '@expo/config/paths';
 import type { MetroConfig } from '@expo/metro/metro';
 import type MetroBundler from '@expo/metro/metro/Bundler';
 import connect from 'connect';
 import { Body } from 'fetch-nodeshim';
+import path from 'node:path';
 
 import { compression } from './compression';
 import { createEventsSocket } from './createEventSocket';
@@ -11,6 +13,11 @@ import { openInEditorAsync } from '../../../../utils/editor';
 
 interface MetroMiddlewareOptions {
   getMetroBundler(): MetroBundler;
+}
+
+interface StackFrame {
+  file: string;
+  lineNumber?: number | undefined;
 }
 
 export function createMetroMiddleware(
@@ -24,7 +31,7 @@ export function createMetroMiddleware(
     .use(noCacheMiddleware)
     .use(compression)
     // Support opening stack frames from clients directly in the editor
-    .use('/open-stack-frame', metroOpenStackFrameMiddleware)
+    .use('/open-stack-frame', createMetroOpenStackFrameMiddleware(metroConfig))
     // Support status check to detect if the packager needs to be started from the native side
     .use('/status', createMetroStatusMiddleware(metroConfig, options));
 
@@ -39,26 +46,12 @@ export function createMetroMiddleware(
   };
 }
 
-const noCacheMiddleware: connect.NextHandleFunction = (req, res, next) => {
+const noCacheMiddleware: connect.NextHandleFunction = (_req, res, next) => {
   res.setHeader('Surrogate-Control', 'no-store');
   res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
   res.setHeader('Pragma', 'no-cache');
   res.setHeader('Expires', '0');
   next();
-};
-
-const metroOpenStackFrameMiddleware: connect.NextHandleFunction = async (req, res, next) => {
-  if (req.method !== 'POST') {
-    return next();
-  }
-  try {
-    const frame = await new Body(req).json();
-    await openInEditorAsync(frame.file, frame.lineNumber);
-    return res.end('OK');
-  } catch {
-    res.statusCode = 400;
-    return res.end('Open stack frame requires the JSON stack frame as request body');
-  }
 };
 
 function createMetroStatusMiddleware(
@@ -72,3 +65,51 @@ function createMetroStatusMiddleware(
     res.end('packager-status:running');
   };
 }
+
+function createMetroOpenStackFrameMiddleware(
+  metroConfig: Pick<MetroConfig, 'projectRoot'>
+): connect.NextHandleFunction {
+  return async (req, res, next) => {
+    if (req.method !== 'POST') {
+      return next();
+    }
+
+    let frame: StackFrame | undefined;
+    try {
+      const json = await new Body(req).json();
+      if (typeof json === 'object' && json != null && typeof json.file === 'string') {
+        frame = {
+          file: json.file,
+          lineNumber:
+            typeof json.lineNumber === 'number' && Number.isSafeInteger(json.lineNumber)
+              ? json.lineNumber
+              : undefined,
+        };
+      }
+    } catch {}
+    if (!frame) {
+      res.statusCode = 400;
+      return res.end('Open stack frame requires the JSON stack frame as request body');
+    }
+
+    const root = getMetroServerRoot(metroConfig.projectRoot!);
+    if (!isFileInRootDirectory(root, frame.file)) {
+      res.statusCode = 400;
+      return res.end('Open stack frame requires target file to be in server root');
+    }
+
+    try {
+      await openInEditorAsync(frame.file, frame.lineNumber);
+      return res.end('OK');
+    } catch {
+      res.statusCode = 5006;
+      return res.end('Open stack frame failed to open local editor');
+    }
+  };
+}
+
+const isFileInRootDirectory = (root: string, otherFile: string) => {
+  // Cannot be accessed using Metro's server API, we need to move the file
+  // into the project root and try again.
+  return !path.relative(root, otherFile).startsWith('..' + path.sep);
+};

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -113,14 +113,14 @@ function createMetroOpenStackFrameMiddleware(
 const ensureFileInRootDirectory = async (root: string, file: string): Promise<string | null> => {
   try {
     file = await fs.promises.realpath(file);
+    // Cannot be accessed using Metro's server API, we need to move the file
+    // into the project root and try again.
+    if (!path.relative(root, file).startsWith('..' + path.sep)) {
+      return file;
+    } else {
+      return null;
+    }
   } catch {
-    return null;
-  }
-  // Cannot be accessed using Metro's server API, we need to move the file
-  // into the project root and try again.
-  if (!path.relative(root, file).startsWith('..' + path.sep)) {
-    return file;
-  } else {
     return null;
   }
 };

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -94,7 +94,7 @@ function createMetroOpenStackFrameMiddleware(
     }
 
     const root = getMetroServerRoot(metroConfig.projectRoot!);
-    const file = await ensureFileInRootDirectory(root, absolute);
+    const file = await ensureFileInRootDirectory(root, frame.file);
     if (!file) {
       res.statusCode = 400;
       return res.end('Open stack frame requires target file to be in server root');

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -94,7 +94,7 @@ function createMetroOpenStackFrameMiddleware(
     }
 
     const root = getMetroServerRoot(metroConfig.projectRoot!);
-    const file = await ensureFileInRootDirectory(root, frame.file);
+    const file = await ensureFileInRootDirectory(root, absolute);
     if (!file) {
       res.statusCode = 400;
       return res.end('Open stack frame requires target file to be in server root');
@@ -112,6 +112,7 @@ function createMetroOpenStackFrameMiddleware(
 
 const ensureFileInRootDirectory = async (root: string, file: string): Promise<string | null> => {
   try {
+    file = path.resolve(root, file);
     file = await fs.promises.realpath(file);
     // Cannot be accessed using Metro's server API, we need to move the file
     // into the project root and try again.

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -3,6 +3,7 @@ import type { MetroConfig } from '@expo/metro/metro';
 import type MetroBundler from '@expo/metro/metro/Bundler';
 import connect from 'connect';
 import { Body } from 'fetch-nodeshim';
+import fs from 'node:fs';
 import path from 'node:path';
 
 import { compression } from './compression';
@@ -93,13 +94,14 @@ function createMetroOpenStackFrameMiddleware(
     }
 
     const root = getMetroServerRoot(metroConfig.projectRoot!);
-    if (!isFileInRootDirectory(root, frame.file)) {
+    const file = await ensureFileInRootDirectory(root, frame.file);
+    if (!file) {
       res.statusCode = 400;
       return res.end('Open stack frame requires target file to be in server root');
     }
 
     try {
-      await openInEditorAsync(frame.file, frame.lineNumber);
+      await openInEditorAsync(file, frame.lineNumber);
       return res.end('OK');
     } catch {
       res.statusCode = 5006;
@@ -108,8 +110,17 @@ function createMetroOpenStackFrameMiddleware(
   };
 }
 
-const isFileInRootDirectory = (root: string, otherFile: string) => {
+const ensureFileInRootDirectory = async (root: string, file: string): Promise<string | null> => {
+  try {
+    file = await fs.promises.realpath(file);
+  } catch {
+    return null;
+  }
   // Cannot be accessed using Metro's server API, we need to move the file
   // into the project root and try again.
-  return !path.relative(root, otherFile).startsWith('..' + path.sep);
+  if (!path.relative(root, file).startsWith('..' + path.sep)) {
+    return file;
+  } else {
+    return null;
+  }
 };


### PR DESCRIPTION
# Why

We'd like `/open-stack-frame` to be more limited and not open files in the user's editor that are outside of the server root. This isn't typically a way in which this endpoint is invoked, but it could be done by calling the server externally.

# How

- Resolve server root and check if file is in server root via optional realpath
- Valiate incoming JSON structure more strictly

# Test Plan

- Manually validated

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
