### PR TITLE
[docs] Add missing Link component in SwiftUI Expo UI reference

### DIFF
--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/link.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/link.mdx
@@ -1,0 +1,61 @@
+---
+title: Link
+description: A SwiftUI Link component for displaying clickable links.
+sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
+packageName: '@expo/ui'
+platforms: ['ios', 'tvos']
+---
+
+import APISection from '~/components/plugins/APISection';
+import { APIInstallSection } from '~/components/plugins/InstallSection';
+
+Expo UI Link matches the official SwiftUI [Link API](https://developer.apple.com/documentation/swiftui/link).
+
+## Installation
+
+<APIInstallSection />
+
+## Usage
+
+### Basic link
+
+```tsx BasicLinkExample.tsx
+import { Host, Link } from '@expo/ui/swift-ui';
+
+export default function BasicLinkExample() {
+  return (
+    <Host style={{ flex: 1 }}>
+      <Link label="Visit Expo" destination="https://expo.dev" />
+    </Host>
+  );
+}
+```
+
+### Custom label content
+
+You can pass custom components as `children` for more complex link label content.
+
+```tsx CustomContentExample.tsx
+import { Host, Link, VStack, Image, Text } from '@expo/ui/swift-ui';
+
+export default function CustomContentExample() {
+  return (
+    <Host matchContents>
+      <Link destination="https://expo.dev">
+        <VStack spacing={4}>
+          <Image systemName="link" />
+          <Text>Expo</Text>
+        </VStack>
+      </Link>
+    </Host>
+  );
+}
+```
+
+## API
+
+```tsx
+import { Link } from '@expo/ui/swift-ui';
+```
+
+<APISection packageName="expo-ui/swift-ui/link" apiName="Link" />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/43983


# How

- Add `docs/pages/versions/v55.0.0/sdk/ui/swift-ui/link.mdx` matching the unversioned page content. The JSON API data file for v55 was already added in #43983.

# Test Plan

Visit `/versions/v55.0.0/sdk/ui/swift-ui/link/` on the local dev server and confirm the page renders with the installation section, usage examples, and API reference.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
