### PR TITLE
[core] Fix registry access thread safety

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`. ([#43634](https://github.com/expo/expo/pull/43634) by [@tjzel](https://github.com/tjzel))
 - [iOS] Fixed `PersistentFileLog.readEntries` race condition by serializing reads on the dispatch queue. ([#43958](https://github.com/expo/expo/pull/43958) by [@ramonclaudio](https://github.com/ramonclaudio))
-- [iOS] Make access to module registry thread safe.
+- [iOS] Make access to module registry thread safe. ([#44042](https://github.com/expo/expo/pull/44042) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed compilation issues due to missing fallthrough case in `EXJavaScriptSerializable`. ([#43634](https://github.com/expo/expo/pull/43634) by [@tjzel](https://github.com/tjzel))
 - [iOS] Fixed `PersistentFileLog.readEntries` race condition by serializing reads on the dispatch queue. ([#43958](https://github.com/expo/expo/pull/43958) by [@ramonclaudio](https://github.com/ramonclaudio))
+- [iOS] Make access to module registry thread safe.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleRegistry.swift
@@ -5,6 +5,7 @@ public final class ModuleRegistry: Sequence {
 
   private var registry: [String: ModuleHolder] = [:]
   private var overrideDisallowModules = Set<String>()
+  private let lock = NSLock()
 
   init(appContext: AppContext) {
     self.appContext = appContext
@@ -16,6 +17,8 @@ public final class ModuleRegistry: Sequence {
   internal func register(holder: ModuleHolder, preventModuleOverriding: Bool = false) {
     log.info("Registering module '\(holder.name)'")
 
+    lock.lock()
+    defer { lock.unlock() }
     // if overriding is disallowed for this module and the module already registered, don't re-register
     if overrideDisallowModules.contains(holder.name) && registry[holder.name] != nil {
       log.info("Not re-registering module '\(holder.name)' since a previous registration specified preventModuleOverriding: true")
@@ -63,45 +66,61 @@ public final class ModuleRegistry: Sequence {
    Unregisters given module from the registry.
    */
   public func unregister(module: AnyModule) {
-    if let index = registry.firstIndex(where: { $1.module === module }) {
-      registry.remove(at: index)
+    withLock {
+      if let index = registry.firstIndex(where: { $1.module === module }) {
+        registry.remove(at: index)
+      }
     }
   }
 
   public func unregister(moduleName: String) {
-    if registry[moduleName] != nil {
-      log.info("Unregistering module '\(moduleName)'")
-      registry[moduleName] = nil
+    withLock {
+      if registry[moduleName] != nil {
+        log.info("Unregistering module '\(moduleName)'")
+        registry[moduleName] = nil
+      }
     }
   }
 
   public func has(moduleWithName moduleName: String) -> Bool {
-    return registry[moduleName] != nil
+    return withLock {
+      return registry[moduleName] != nil
+    }
   }
 
   public func get(moduleHolderForName moduleName: String) -> ModuleHolder? {
-    return registry[moduleName]
+    return withLock {
+      return registry[moduleName]
+    }
   }
 
   public func get(moduleWithName moduleName: String) -> AnyModule? {
-    return registry[moduleName]?.module
+    return withLock {
+      registry[moduleName]?.module
+    }
   }
 
   internal func getModule<ModuleProtocol>(implementing protocol: ModuleProtocol.Type) -> ModuleProtocol? {
-    for holder in registry.values {
-      if let module = holder.module as? ModuleProtocol {
-        return module
+    return withLock {
+      for holder in registry.values {
+        if let module = holder.module as? ModuleProtocol {
+          return module
+        }
       }
+      return nil
     }
-    return nil
   }
 
   public func getModuleNames() -> [String] {
-    return Array(registry.keys)
+    return withLock {
+      return Array(registry.keys)
+    }
   }
 
   public func makeIterator() -> IndexingIterator<[ModuleHolder]> {
-    return registry.map({ $1 }).makeIterator()
+    return withLock {
+      return registry.map({ $1 }).makeIterator()
+    }
   }
 
   internal func post(event: EventName) {
@@ -116,5 +135,11 @@ public final class ModuleRegistry: Sequence {
     forEach { holder in
       holder.post(event: event, payload: payload)
     }
+  }
+
+  private func withLock<T>(block: () -> T) -> T {
+    lock.lock()
+    defer { lock.unlock() }
+    return block()
   }
 }


### PR DESCRIPTION
# Why
Closes #44032

# How
The module registry is not currently thread safe. I've added a lock to do this. The reads and writes are minimal so GCD would be overkill here.

# Test Plan
Bare expo. Tests are passing

