### PR TITLE
[expo-doctor] Spawn expo config instead of importing @expo/config

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- Resolve project config by spawning `expo config` CLI instead of importing `@expo/config` directly ([#44044](https://github.com/expo/expo/pull/44044) by [@entiendonull](https://github.com/entiendonull))
 - Include `@react-navigation/native` and `@react-navigation/core` in duplicates check ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
 
 ## 1.18.8 — 2026-02-25

--- a/packages/expo-doctor/src/checks/ExpoConfigCommonIssueCheck.ts
+++ b/packages/expo-doctor/src/checks/ExpoConfigCommonIssueCheck.ts
@@ -63,7 +63,7 @@ export class ExpoConfigCommonIssueCheck implements DoctorCheck {
 function getExpoSDKVersionFromPackage(projectRoot: string): string | undefined {
   const packageJsonPath = resolveFrom.silent(projectRoot, 'expo/package.json');
   if (!packageJsonPath) {
-    // (probably) technically impossible - if this happens, `getConfig` throws and Doctor crashes
+    // (probably) technically impossible - if this happens, `getProjectConfigAsync` throws and Doctor crashes
     return undefined;
   }
   const expoPackageJson = JsonFile.read(packageJsonPath, { json5: true });

--- a/packages/expo-doctor/src/checks/ExpoConfigSchemaCheck.ts
+++ b/packages/expo-doctor/src/checks/ExpoConfigSchemaCheck.ts
@@ -1,5 +1,3 @@
-import { getConfigFilePaths } from '@expo/config';
-
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 import { getSchemaAsync } from '../api/getSchemaAsync';
 import { learnMore } from '../utils/TerminalLink';
@@ -10,7 +8,11 @@ export class ExpoConfigSchemaCheck implements DoctorCheck {
 
   sdkVersionRange = '*';
 
-  async runAsync({ exp, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+  async runAsync({
+    exp,
+    projectRoot,
+    staticConfigPath,
+  }: DoctorCheckParams): Promise<DoctorCheckResult> {
     const issues: string[] = [];
 
     let schema = await getSchemaAsync(exp.sdkVersion!);
@@ -23,15 +25,13 @@ export class ExpoConfigSchemaCheck implements DoctorCheck {
       isUsingUnversionedSchema = true;
     }
 
-    const configPaths = getConfigFilePaths(projectRoot);
-
     // this check can only validate a static config
-    if (configPaths.staticConfigPath) {
+    if (staticConfigPath) {
       const { schemaErrorMessage, assetsErrorMessage } = await validateWithSchemaAsync(
         projectRoot,
         exp,
         schema,
-        configPaths.staticConfigPath,
+        staticConfigPath,
         true
       );
 

--- a/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
+++ b/packages/expo-doctor/src/checks/InstalledDependencyVersionCheck.ts
@@ -1,32 +1,13 @@
-import spawnAsync, { SpawnResult } from '@expo/spawn-async';
-import resolveFrom from 'resolve-from';
+import type { SpawnResult } from '@expo/spawn-async';
 import semver from 'semver';
 
 import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 import { learnMore } from '../utils/TerminalLink';
 import { parseInstallCheckOutput } from '../utils/parseInstallCheckOutput';
+import { spawnExpoCLI } from '../utils/spawnExpoCLI';
 
 function isSpawnResult(result: any): result is SpawnResult {
   return 'stderr' in result && 'stdout' in result && 'status' in result;
-}
-
-async function spawnExpoCLI(
-  projectRoot: string,
-  args: string[],
-  options: Omit<spawnAsync.SpawnOptions, 'cwd'>
-) {
-  const expoCliPath = resolveFrom.silent(projectRoot, 'expo/bin/cli');
-  if (expoCliPath) {
-    return await spawnAsync('node', [expoCliPath, ...args], {
-      cwd: projectRoot,
-      ...options,
-    });
-  } else {
-    return await spawnAsync('npx', ['expo', ...args], {
-      cwd: projectRoot,
-      ...options,
-    });
-  }
 }
 
 export class InstalledDependencyVersionCheck implements DoctorCheck {

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -1,4 +1,3 @@
-import { getConfig } from '@expo/config';
 import { load as loadEnv } from '@expo/env';
 import chalk from 'chalk';
 
@@ -6,6 +5,7 @@ import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks/chec
 import { resolveChecksInScope } from './utils/checkResolver';
 import { env } from './utils/env';
 import { isNetworkError } from './utils/errors';
+import { getProjectConfigAsync } from './utils/getProjectConfig';
 import { isInteractive } from './utils/interactive';
 import { Log } from './utils/log';
 import { setNodeEnv } from './utils/nodeEnv';
@@ -133,7 +133,7 @@ export async function actionAsync(projectRoot: string, showVerboseTestResults: b
     setNodeEnv('development');
     loadEnv(projectRoot);
 
-    const projectConfig = getConfig(projectRoot);
+    const projectConfig = await getProjectConfigAsync(projectRoot);
 
     // expo-doctor relies on versioned CLI, which is only available for 44+
     if (ltSdkVersion(projectConfig.exp, '46.0.0')) {

--- a/packages/expo-doctor/src/utils/__tests__/getProjectConfig.test.ts
+++ b/packages/expo-doctor/src/utils/__tests__/getProjectConfig.test.ts
@@ -1,0 +1,117 @@
+import { getProjectConfigAsync } from '../getProjectConfig';
+import { spawnExpoCLI } from '../spawnExpoCLI';
+
+jest.mock('../spawnExpoCLI');
+const mockSpawnExpoCLI = spawnExpoCLI as jest.MockedFunction<typeof spawnExpoCLI>;
+
+describe(getProjectConfigAsync, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('parses valid JSON output from expo config', async () => {
+    const configOutput = {
+      exp: { name: 'test-app', slug: 'test-app', sdkVersion: '52.0.0' },
+      pkg: { name: 'test-app', dependencies: {} },
+      hasUnusedStaticConfig: false,
+      staticConfigPath: '/project/app.json',
+      dynamicConfigPath: null,
+    };
+
+    mockSpawnExpoCLI.mockResolvedValue({
+      stdout: JSON.stringify(configOutput),
+      stderr: '',
+      status: 0,
+      signal: null,
+      output: [JSON.stringify(configOutput), ''],
+      pid: 1234,
+    });
+
+    const result = await getProjectConfigAsync('/project');
+
+    expect(result).toEqual({
+      exp: configOutput.exp,
+      pkg: configOutput.pkg,
+      hasUnusedStaticConfig: false,
+      staticConfigPath: '/project/app.json',
+      dynamicConfigPath: null,
+    });
+
+    expect(mockSpawnExpoCLI).toHaveBeenCalledWith(
+      '/project',
+      ['config', '--json', '--full'],
+      expect.objectContaining({
+        stdio: 'pipe',
+        env: expect.objectContaining({ EXPO_DEBUG: '0' }),
+      })
+    );
+  });
+
+  it('throws on invalid JSON output', async () => {
+    mockSpawnExpoCLI.mockResolvedValue({
+      stdout: 'not json',
+      stderr: '',
+      status: 0,
+      signal: null,
+      output: ['not json', ''],
+      pid: 1234,
+    });
+
+    await expect(getProjectConfigAsync('/project')).rejects.toThrow(/Failed to parse JSON output/);
+  });
+
+  it('throws when exp or pkg fields are missing', async () => {
+    mockSpawnExpoCLI.mockResolvedValue({
+      stdout: JSON.stringify({ something: 'else' }),
+      stderr: '',
+      status: 0,
+      signal: null,
+      output: ['{}', ''],
+      pid: 1234,
+    });
+
+    await expect(getProjectConfigAsync('/project')).rejects.toThrow(
+      /missing 'exp' or 'pkg' fields/
+    );
+  });
+
+  it('defaults hasUnusedStaticConfig, staticConfigPath, dynamicConfigPath when absent', async () => {
+    const configOutput = {
+      exp: { name: 'test-app', slug: 'test-app', sdkVersion: '52.0.0' },
+      pkg: { name: 'test-app' },
+    };
+
+    mockSpawnExpoCLI.mockResolvedValue({
+      stdout: JSON.stringify(configOutput),
+      stderr: '',
+      status: 0,
+      signal: null,
+      output: [JSON.stringify(configOutput), ''],
+      pid: 1234,
+    });
+
+    const result = await getProjectConfigAsync('/project');
+
+    expect(result.hasUnusedStaticConfig).toBe(false);
+    expect(result.staticConfigPath).toBeNull();
+    expect(result.dynamicConfigPath).toBeNull();
+  });
+
+  it('throws when exp.sdkVersion is missing', async () => {
+    mockSpawnExpoCLI.mockResolvedValue({
+      stdout: JSON.stringify({
+        exp: { name: 'test-app', slug: 'test-app' },
+        pkg: { name: 'test-app' },
+      }),
+      stderr: '',
+      status: 0,
+      signal: null,
+      output: ['{}', ''],
+      pid: 1234,
+    });
+
+    await expect(getProjectConfigAsync('/project')).rejects.toThrow(
+      /Cannot determine the project's Expo SDK version/
+    );
+  });
+});

--- a/packages/expo-doctor/src/utils/getProjectConfig.ts
+++ b/packages/expo-doctor/src/utils/getProjectConfig.ts
@@ -1,0 +1,40 @@
+import { spawnExpoCLI } from './spawnExpoCLI';
+import type { DoctorCheckParams } from '../checks/checks.types';
+
+type ProjectConfig = Omit<DoctorCheckParams, 'projectRoot'>;
+
+export async function getProjectConfigAsync(projectRoot: string): Promise<ProjectConfig> {
+  const result = await spawnExpoCLI(projectRoot, ['config', '--json', '--full'], {
+    stdio: 'pipe',
+    env: { ...process.env, EXPO_DEBUG: '0' },
+  });
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    throw new Error(
+      `Failed to parse JSON output from 'npx expo config --json --full'.\nOutput: ${result.stdout.slice(0, 500)}`
+    );
+  }
+
+  if (!parsed.exp || !parsed.pkg) {
+    throw new Error(
+      `Unexpected output from 'npx expo config --json --full': missing 'exp' or 'pkg' fields.`
+    );
+  }
+
+  if (!parsed.exp.sdkVersion) {
+    throw new Error(
+      `Cannot determine the project's Expo SDK version. This usually means the \`expo\` package is not installed. Install it with \`npx expo install expo\` and try again.`
+    );
+  }
+
+  return {
+    exp: parsed.exp,
+    pkg: parsed.pkg,
+    hasUnusedStaticConfig: parsed.hasUnusedStaticConfig ?? false,
+    staticConfigPath: parsed.staticConfigPath ?? null,
+    dynamicConfigPath: parsed.dynamicConfigPath ?? null,
+  };
+}

--- a/packages/expo-doctor/src/utils/spawnExpoCLI.ts
+++ b/packages/expo-doctor/src/utils/spawnExpoCLI.ts
@@ -1,0 +1,21 @@
+import spawnAsync from '@expo/spawn-async';
+import resolveFrom from 'resolve-from';
+
+export async function spawnExpoCLI(
+  projectRoot: string,
+  args: string[],
+  options: Omit<spawnAsync.SpawnOptions, 'cwd'>
+) {
+  const expoCliPath = resolveFrom.silent(projectRoot, 'expo/bin/cli');
+  if (expoCliPath) {
+    return await spawnAsync('node', [expoCliPath, ...args], {
+      cwd: projectRoot,
+      ...options,
+    });
+  } else {
+    return await spawnAsync('npx', ['expo', ...args], {
+      cwd: projectRoot,
+      ...options,
+    });
+  }
+}


### PR DESCRIPTION
# Why

Addresses ENG-14449

expo-doctor imports getConfig() directly from @expo/config at runtime, shipping with a fixed version baked in. 
While this generally works, it can break if @expo/config's internals change across SDK versions, as the bundled version may not correctly handle projects on a different SDK. 

By consuming the CLI's --json output instead, config resolution runs through the expo CLI rather than importing @expo/config internals, making it resilient to changes across SDK versions.

# How

Replace the direct getConfig() import with a subprocess call to expo config --json --full. 

Specific changes:
- `src/utils/getProjectConfig.ts` (new) — Spawns expo config --json --full, parses the output, validates required fields (exp, pkg, sdkVersion), and returns a typed config object
- `src/utils/spawnExpoCLI.ts` (new) — Shared helper that resolves the local expo/bin/cli or falls back to npx expo, now reused by both config resolution and InstalledDependencyVersionCheck
- `src/doctor.ts` — Swaps getConfig() for getProjectConfigAsync()
- `src/checks/ExpoConfigSchemaCheck.ts` — Receives staticConfigPath via DoctorCheckParams instead of importing getConfigFilePaths from @expo/config
- `src/checks/InstalledDependencyVersionCheck.ts` — Uses the shared spawnExpoCLI utility instead of its own inline copy

# Test Plan

- Ran tests
- Tested locally in several projects

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
