### PR TITLE
chore: Fix remaining `prepare` issues

### DIFF
--- a/packages/@expo/inline-modules/package.json
+++ b/packages/@expo/inline-modules/package.json
@@ -8,7 +8,6 @@
     "clean": "expo-module clean",
     "lint": "expo-module lint",
     "test": "expo-module test",
-    "prepare": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"
   },

--- a/packages/expo-module-scripts/bin/expo-module-prepare
+++ b/packages/expo-module-scripts/bin/expo-module-prepare
@@ -10,7 +10,6 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 process.env.EXPO_NONINTERACTIVE = 1;
 
 async function runAsync() {
-  console.log('Configuring module');
   await commandRunner(path.join(dirname, 'expo-module-configure'));
 }
 

--- a/packages/expo-module-scripts/bin/expo-module-readme
+++ b/packages/expo-module-scripts/bin/expo-module-readme
@@ -142,7 +142,7 @@ function generateREADME() {
 const readme = generateREADME();
 const readmePath = path.join(process.cwd(), 'README.md');
 if (fs.existsSync(readmePath)) {
-  console.log('expo-module-scripts: README.md exists, not updating');
+  // console.log('expo-module-scripts: README.md exists, not updating');
 } else {
   fs.writeFileSync(readmePath, readme, { encoding: 'utf8' });
 }


### PR DESCRIPTION
# Why

- `prepare` shouldn't log if it's doing nothing
- `@expo/inline-modules` hasn't been initialised yet; skip `prepare` there

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
