### PR TITLE
chore: Add missing intermediary `bin/*` scripts for built CLIs

### DIFF
--- a/packages/create-expo-module/bin/create-expo-module.js
+++ b/packages/create-expo-module/bin/create-expo-module.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/index.js');

--- a/packages/create-expo-module/package.json
+++ b/packages/create-expo-module/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/expo/expo/issues"
   },
   "author": "Expo",
-  "bin": "build/index.js",
+  "bin": "bin/create-expo-module.js",
   "main": "build/index.js",
   "files": [
     "bin",

--- a/packages/create-expo/bin/create-expo.js
+++ b/packages/create-expo/bin/create-expo.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/index.js');

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-expo",
   "version": "3.6.6",
-  "bin": "./build/index.js",
+  "bin": "./bin/index.js",
   "main": "build",
   "description": "Create universal Expo apps",
   "license": "BSD-3-Clause",

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-expo",
   "version": "3.6.6",
-  "bin": "./bin/index.js",
+  "bin": "./bin/create-expo.js",
   "main": "build",
   "description": "Create universal Expo apps",
   "license": "BSD-3-Clause",

--- a/packages/expo-doctor/bin/expo-doctor.js
+++ b/packages/expo-doctor/bin/expo-doctor.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/index.js');

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Expo <support@expo.dev>",
   "license": "MIT",
-  "bin": "./build/index.js",
+  "bin": "./bin/expo-doctor.js",
   "files": [
     "build"
   ],

--- a/packages/expo-env-info/bin/expo-env-info.js
+++ b/packages/expo-env-info/bin/expo-env-info.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/index.js');

--- a/packages/expo-env-info/package.json
+++ b/packages/expo-env-info/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.11",
   "preferGlobal": true,
   "type": "module",
-  "bin": "./build/index.js",
+  "bin": "./bin/expo-env-info.js",
   "files": [
     "build"
   ],

--- a/packages/install-expo-modules/bin/install-expo-modules.js
+++ b/packages/install-expo-modules/bin/install-expo-modules.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/index.js');

--- a/packages/install-expo-modules/package.json
+++ b/packages/install-expo-modules/package.json
@@ -10,7 +10,7 @@
     "react-native",
     "react"
   ],
-  "bin": "build/index.js",
+  "bin": "bin/install-expo-modules.js",
   "main": "build/index.js",
   "files": [
     "build"

--- a/packages/pod-install/bin/pod-install.js
+++ b/packages/pod-install/bin/pod-install.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../build/index.js');

--- a/packages/pod-install/package.json
+++ b/packages/pod-install/package.json
@@ -12,7 +12,7 @@
     "typecheck": "expo-module typecheck",
     "watch": "yarn run build --watch"
   },
-  "bin": "./build/index.js",
+  "bin": "./bin/pod-install.js",
   "files": [
     "build"
   ],


### PR DESCRIPTION
# Why

Not all CLIs are built when we're installing, which means that the `bin` paths are ineffective. Yarn v1 doesn't warn us about this but pnpm does. We should add the missing intermediary bin files.

# How

- add missing `bin/*.js` scripts
- Update `package.json:bin` accordingly

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
