### PR TITLE
[docs] Update age-range.mdx to remove deprecated API details

### DIFF
--- a/docs/pages/versions/unversioned/sdk/age-range.mdx
+++ b/docs/pages/versions/unversioned/sdk/age-range.mdx
@@ -23,8 +23,6 @@ This library allows you to request age range information from your app users to 
 
 We strongly recommend testing the functionality on a real device, as simulator runtimes may not work as expected.
 
-On Android, the Play Age Signals API (beta) may throw an exception until January 1, 2026, as per the [official Android documentation](https://developer.android.com/google/play/age-signals/use-age-signals-api#integrate-play-age-signals). From January 1, the API will return live responses.
-
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
Removed outdated information about the Play Age Signals API exception timeline.

# Why

It's past January 1st, 2026.

# How

By removing the line from the text.

# Test Plan

Read it and see that it's gone.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
