### PR TITLE
[file-system] Fix OOM when calculating md5

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,7 +12,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix copy/move support for SAF and content provider URIs. ([#42887](https://github.com/expo/expo/pull/42887) by [@barthap](https://github.com/barthap))
-- Fix out-of-memory errors when calculating file `md5` hash.
+- Fix out-of-memory errors when calculating file `md5` hash. ([#44064](https://github.com/expo/expo/pull/44064) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Fix copy/move support for SAF and content provider URIs. ([#42887](https://github.com/expo/expo/pull/42887) by [@barthap](https://github.com/barthap))
+- Fix out-of-memory errors when calculating file `md5` hash.
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -149,9 +149,13 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
   val md5: String get() {
     validatePermission(FilePermissionService.Permission.READ)
     val md = MessageDigest.getInstance("MD5")
-    file.inputStream().use {
-      val digest = md.digest(it.readBytes())
-      return digest.toHexString()
+    file.inputStream().use { stream ->
+      val buffer = ByteArray(8192)
+      var bytesRead: Int
+      while (stream.read(buffer).also { bytesRead = it } != -1) {
+        md.update(buffer, 0, bytesRead)
+      }
+      return md.digest().toHexString()
     }
   }
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -147,10 +147,12 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   @OptIn(ExperimentalStdlibApi::class)
   val md5: String get() {
+    val bufferSize = 65536
+
     validatePermission(FilePermissionService.Permission.READ)
     val md = MessageDigest.getInstance("MD5")
     file.inputStream().use { stream ->
-      val buffer = ByteArray(8192)
+      val buffer = ByteArray(bufferSize)
       var bytesRead: Int
       while (stream.read(buffer).also { bytesRead = it } != -1) {
         md.update(buffer, 0, bytesRead)

--- a/packages/expo-file-system/ios/FileSystemFile.swift
+++ b/packages/expo-file-system/ios/FileSystemFile.swift
@@ -53,8 +53,16 @@ internal final class FileSystemFile: FileSystemPath {
   var md5: String {
     get throws {
       return try withCorrectTypeAndScopedAccess(permission: .read) {
-        let fileData = try Data(contentsOf: url)
-        let hash = Insecure.MD5.hash(data: fileData)
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { handle.closeFile() }
+        var hasher = Insecure.MD5()
+        while autoreleasepool(invoking: {
+          let chunk = handle.readData(ofLength: 8192)
+          guard !chunk.isEmpty else { return false }
+          hasher.update(data: chunk)
+          return true
+        }) {}
+        let hash = hasher.finalize()
         return hash.map { String(format: "%02hhx", $0) }.joined()
       }
     }

--- a/packages/expo-file-system/ios/FileSystemFile.swift
+++ b/packages/expo-file-system/ios/FileSystemFile.swift
@@ -53,15 +53,16 @@ internal final class FileSystemFile: FileSystemPath {
   var md5: String {
     get throws {
       return try withCorrectTypeAndScopedAccess(permission: .read) {
+        let bufferSize = 65536
+
         let handle = try FileHandle(forReadingFrom: url)
-        defer { handle.closeFile() }
+        defer { try? handle.close() } // Modern close throws
+
         var hasher = Insecure.MD5()
-        while autoreleasepool(invoking: {
-          let chunk = handle.readData(ofLength: 8192)
-          guard !chunk.isEmpty else { return false }
+        while let chunk = try handle.read(upToCount: bufferSize), !chunk.isEmpty {
           hasher.update(data: chunk)
-          return true
-        }) {}
+        }
+
         let hash = hasher.finalize()
         return hash.map { String(format: "%02hhx", $0) }.joined()
       }

--- a/packages/expo-file-system/ios/FileSystemFile.swift
+++ b/packages/expo-file-system/ios/FileSystemFile.swift
@@ -56,7 +56,7 @@ internal final class FileSystemFile: FileSystemPath {
         let bufferSize = 65536
 
         let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() } // Modern close throws
+        defer { try? handle.close() }
 
         var hasher = Insecure.MD5()
         while let chunk = try handle.read(upToCount: bufferSize), !chunk.isEmpty {


### PR DESCRIPTION
## Why

Fixes #43962 (issue 1)

The `md5` property on `FileSystemFile` reads the entire file into memory before hashing, which causes out-of-memory crashes for large files on both iOS and Android.

## How

Changed both iOS and Android implementations to use streaming/chunked reading (8KB buffer) instead of loading the full file contents into memory at once:

- **Android**: Replaced `it.readBytes()` with a loop using `stream.read(buffer)` and `md.update()`
- **iOS**: Replaced `Data(contentsOf:)` with `FileHandle` chunked reads

> Aside, another problem is that `md5` is a property with synchronous getter, and hashing is blocking the JS thread

## Test Plan

- Test suite on both platforms (md5 correctness)
- No OOM on large files (>1GB)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
