### PR TITLE
[expo-widgets] Fix ExpoWidgets.bundle not copied to widget extension with use_frameworks

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `ExpoWidgets.bundle` not copied to widget extension when `use_frameworks` is active. ([#44065](https://github.com/expo/expo/pull/44065) by [@marvwhere](https://github.com/marvwhere))
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
 - [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))
 - Skip server bundling in `export:embed` call for `expo-widgets` bundle ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))

--- a/packages/expo-widgets/ios/ExpoWidgets.podspec
+++ b/packages/expo-widgets/ios/ExpoWidgets.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
     :script => %Q{
       echo "Preparing ExpoWidgets.bundle..."
       source="#{__dir__}/../bundle/build/ExpoWidgets.bundle"
-      dest="${TARGET_BUILD_DIR}/ExpoWidgets.bundle/ExpoWidgets.bundle"
+      dest="${BUILT_PRODUCTS_DIR}/ExpoWidgets.bundle"
       echo "Copying ${source} to ${dest}"
       cp "${source}" "${dest}"
     },

--- a/packages/expo-widgets/ios/ExpoWidgets.podspec
+++ b/packages/expo-widgets/ios/ExpoWidgets.podspec
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
     :script => %Q{
       echo "Preparing ExpoWidgets.bundle..."
       source="#{__dir__}/../bundle/build/ExpoWidgets.bundle"
-      dest="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoWidgets.bundle"
+      dest="${TARGET_BUILD_DIR}/ExpoWidgets.bundle/ExpoWidgets.bundle"
       echo "Copying ${source} to ${dest}"
       cp "${source}" "${dest}"
     },


### PR DESCRIPTION
# Why

The `Prepare ExpoWidgets Resources` script phase in `ExpoWidgets.podspec` uses `${UNLOCALIZED_RESOURCES_FOLDER_PATH}` to determine the copy destination for the JS runtime bundle.

This Xcode build variable resolves differently depending on the target type:
- **Static library** → `ExpoWidgets.bundle` ✅
- **Framework (`use_frameworks! :linkage => :static`)** → `ExpoWidgets.framework` ❌

When `use_frameworks` is active, the JS file ends up at `ExpoWidgets.framework/ExpoWidgets.bundle` instead of `ExpoWidgets.bundle/ExpoWidgets.bundle`. The widget extension's `WidgetContext.swift` looks for the file inside the resource bundle directory and can't find it.

**Result:** Live Activities and widgets render as blank/black boxes.

## How to reproduce

```js
// app.config.ts
["expo-build-properties", {
  ios: {
    useFrameworks: "static",  // required for Firebase
  },
}],
["expo-widgets", { ... }],
```

This causes `use_frameworks! :linkage => :static` in the generated Podfile. The script phase then copies the JS bundle to the wrong destination.

# How

Hardcode the resource bundle name (`ExpoWidgets.bundle`) instead of relying on `UNLOCALIZED_RESOURCES_FOLDER_PATH`, since the target is always the `ExpoWidgets.bundle` resource bundle created by `s.resource_bundles`.

```diff
- dest="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoWidgets.bundle"
+ dest="${TARGET_BUILD_DIR}/ExpoWidgets.bundle/ExpoWidgets.bundle"
```

# Test Plan

- Verified with `ios.useFrameworks: "static"` (Firebase setup) + `expo-widgets`
- After fix, `ExpoWidgets.bundle/` inside the widget extension `.appex` contains both `Info.plist` and `ExpoWidgets.bundle` (~130KB JS file)
- Live Activity renders correctly instead of showing a black box