### PR TITLE
[launcher][Android] Filter running bundlers by Expo account

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
@@ -18,6 +18,8 @@ import expo.modules.devlauncher.services.ErrorRegistryService
 import expo.modules.devlauncher.services.NsdPreferences
 import expo.modules.devlauncher.services.PackagerInfo
 import expo.modules.devlauncher.services.PackagerService
+import expo.modules.devlauncher.services.SessionService
+import expo.modules.devlauncher.services.UserState
 import expo.modules.devlauncher.services.inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
@@ -46,6 +48,7 @@ class HomeViewModel : ViewModel(), DefaultLifecycleObserver {
   val packagerService = inject<PackagerService>()
   val errorRegistryService = inject<ErrorRegistryService>()
   private val nsdPreferences = inject<NsdPreferences>()
+  private val sessionService = inject<SessionService>()
 
   private val appPackageName: String = devLauncherController.context.packageName
 
@@ -82,6 +85,15 @@ class HomeViewModel : ViewModel(), DefaultLifecycleObserver {
     packagerService.resumeHealthCheck()
     ProcessLifecycleOwner.get().lifecycle.addObserver(this)
     nsdPreferences.addOnChangeListener(nsdListener)
+
+    sessionService
+      .user
+      .onEach {
+        _state.value = _state.value.copy(
+          runningPackagers = filterPackagers(allPackagers)
+        )
+      }
+      .launchIn(viewModelScope)
   }
 
   override fun onResume(owner: LifecycleOwner) {
@@ -108,6 +120,14 @@ class HomeViewModel : ViewModel(), DefaultLifecycleObserver {
     val slugFilter = nsdPreferences.filterBySlug
     if (slugFilter.isNotBlank()) {
       filtered = filtered.filter { it.slug == slugFilter }.toSet()
+    }
+
+    if (nsdPreferences.filterByUsername) {
+      val currentUsername = (sessionService.user.value as? UserState.LoggedIn)
+        ?.data?.meUserActor?.username
+      if (currentUsername != null) {
+        filtered = filtered.filter { it.username == currentUsername }.toSet()
+      }
     }
 
     return filtered

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/SettingsViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/SettingsViewModel.kt
@@ -17,7 +17,8 @@ data class SettingsState(
   // TODO @behenate - make true the default for VR
   val showFabAtLaunch: Boolean = false,
   val filterByPackageName: Boolean = false,
-  val filterBySlug: String = ""
+  val filterBySlug: String = "",
+  val filterByUsername: Boolean = false
 )
 
 sealed interface SettingsAction {
@@ -28,6 +29,7 @@ sealed interface SettingsAction {
   data class ToggleShowFabAtLaunch(val newValue: Boolean) : SettingsAction
   data class ToggleFilterByPackageName(val newValue: Boolean) : SettingsAction
   data class UpdateFilterBySlug(val newValue: String) : SettingsAction
+  data class ToggleFilterByUsername(val newValue: Boolean) : SettingsAction
 }
 
 class SettingsViewModel : ViewModel() {
@@ -44,7 +46,8 @@ class SettingsViewModel : ViewModel() {
       applicationInfo = appService.applicationInfo,
       showFabAtLaunch = menuPreferences.showFab,
       filterByPackageName = nsdPreferences.filterByPackageName,
-      filterBySlug = nsdPreferences.filterBySlug
+      filterBySlug = nsdPreferences.filterBySlug,
+      filterByUsername = nsdPreferences.filterByUsername
     )
   )
 
@@ -64,7 +67,8 @@ class SettingsViewModel : ViewModel() {
   private val nsdListener = {
     _state.value = _state.value.copy(
       filterByPackageName = nsdPreferences.filterByPackageName,
-      filterBySlug = nsdPreferences.filterBySlug
+      filterBySlug = nsdPreferences.filterBySlug,
+      filterByUsername = nsdPreferences.filterByUsername
     )
   }
 
@@ -88,6 +92,7 @@ class SettingsViewModel : ViewModel() {
       is SettingsAction.ToggleShowFabAtLaunch -> menuPreferences.showFab = action.newValue
       is SettingsAction.ToggleFilterByPackageName -> nsdPreferences.filterByPackageName = action.newValue
       is SettingsAction.UpdateFilterBySlug -> nsdPreferences.filterBySlug = action.newValue
+      is SettingsAction.ToggleFilterByUsername -> nsdPreferences.filterByUsername = action.newValue
     }
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
@@ -113,7 +113,7 @@ fun SettingsScreen(
     Spacer(NewAppTheme.spacing.`3`)
 
     NewText(
-      "Filter discovered packagers by the current app's package name or a specific project slug. Only matching development servers will be shown on the home screen.",
+      "Filter discovered packagers by the current app's package name, your Expo account, or a specific project slug. Only matching development servers will be shown on the home screen.",
       style = NewAppTheme.font.md.merge(
         lineHeight = 21.sp
       ),
@@ -252,6 +252,32 @@ private fun NSDSection(state: SettingsState, onAction: (SettingsAction) -> Unit)
           color = NewAppTheme.colors.border.default
         )
 
+        NewMenuButton(
+          withSurface = false,
+          icon = {
+            LauncherIcons.User(
+              size = 20.dp,
+              tint = NewAppTheme.colors.icon.tertiary
+            )
+          },
+          content = {
+            NewText(
+              text = "Filter by Expo account"
+            )
+          },
+          rightComponent = {
+            ToggleSwitch(
+              isToggled = state.filterByUsername
+            )
+          },
+          onClick = { onAction(SettingsAction.ToggleFilterByUsername(!state.filterByUsername)) }
+        )
+
+        Divider(
+          thickness = 0.5.dp,
+          color = NewAppTheme.colors.border.default
+        )
+
         Column(
           modifier = Modifier
             .background(NewAppTheme.colors.background.subtle)
@@ -328,6 +354,7 @@ fun SettingsScreenPreview() {
           projectUrl = "https://u.expo.dev/01980973-2cf9-71fb-a891-a53444132a6e"
         ),
         filterByPackageName = true,
+        filterByUsername = false,
         filterBySlug = "bare-expo"
       )
     )

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryApi34.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryApi34.kt
@@ -23,9 +23,10 @@ internal class NsdDiscoveryApi34(
         val name = resolved.getAttribute("name")
         val slug = resolved.getAttribute("slug")
         val androidPackage = resolved.getAttribute("androidPackage")
+        val username = resolved.getAttribute("username")
 
         if (url != null && name != null) {
-          healthCheckLoop(serviceName, url, name, slug, androidPackage)
+          healthCheckLoop(serviceName, url, name, slug, androidPackage, username)
         }
       }
   }
@@ -35,7 +36,8 @@ internal class NsdDiscoveryApi34(
     url: String,
     name: String,
     slug: String?,
-    androidPackage: String?
+    androidPackage: String?,
+    username: String?
   ) {
     while (coroutineScope.isActive) {
       awaitHealthCheckActive()
@@ -44,7 +46,7 @@ internal class NsdDiscoveryApi34(
       coroutineScope.ensureActive()
 
       if (isAlive) {
-        addDiscoveredPackager(serviceName, url, name, slug, androidPackage)
+        addDiscoveredPackager(serviceName, url, name, slug, androidPackage, username)
       } else {
         removeDiscoveredPackager(serviceName)
       }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryBase.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryBase.kt
@@ -173,13 +173,15 @@ internal abstract class NsdDiscoveryBase(
     url: String,
     name: String,
     slug: String?,
-    androidPackage: String?
+    androidPackage: String?,
+    username: String?
   ) {
     alivePackagers[serviceName] = PackagerInfo(
       url = url,
       description = name,
       slug = slug,
-      androidPackage = androidPackage
+      androidPackage = androidPackage,
+      username = username
     )
     publishDiscoveredPackagers()
   }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryLegacy.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/nsd/NsdDiscoveryLegacy.kt
@@ -24,6 +24,7 @@ internal class NsdDiscoveryLegacy(
         val name = resolved.getAttribute("name")
         val slug = resolved.getAttribute("slug")
         val androidPackage = resolved.getAttribute("androidPackage")
+        val username = resolved.getAttribute("username")
 
         if (url != null && name != null) {
           val isAlive = checkPackagerStatus(url)
@@ -35,7 +36,8 @@ internal class NsdDiscoveryLegacy(
               url,
               name,
               slug,
-              androidPackage
+              androidPackage,
+              username
             )
           } else {
             removeDiscoveredPackager(serviceName)

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/NsdPreferences.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/NsdPreferences.kt
@@ -43,4 +43,11 @@ class NsdPreferences(application: Application) {
    */
   var filterBySlug: String
     by stringPreferences(sharedPreferences, "")
+
+  /**
+   * When enabled, only NSD services whose `username` TXT record matches
+   * the current logged-in user's username will be shown.
+   */
+  var filterByUsername: Boolean
+    by preferences(sharedPreferences, false)
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/PackagerService.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/PackagerService.kt
@@ -8,7 +8,8 @@ data class PackagerInfo(
   val url: String,
   val description: String,
   val slug: String? = null,
-  val androidPackage: String? = null
+  val androidPackage: String? = null,
+  val username: String? = null
 )
 
 class PackagerService(


### PR DESCRIPTION
# Why

Adds the ability to filter running bundlers by Expo account, reducing the number of servers that show up. 

# How

Similar to other filters that were added before. 

# Test Plan

- bare-expo ✅ 