### PR TITLE
[browser][Android] Bring back the `experimentalLauncherActivity` config plugin option

### DIFF
--- a/apps/bare-expo/android/app/src/main/AndroidManifest.xml
+++ b/apps/bare-expo/android/app/src/main/AndroidManifest.xml
@@ -54,15 +54,12 @@
         <data android:scheme="dev.expo.payments"/>
         <data android:scheme="exp+bare-expo"/>
       </intent-filter>
-
+    </activity>
+    <activity android:name=".BrowserLauncherActivity" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
-
-    </activity>
-    <activity android:name=".BrowserLauncherActivity" android:theme="@style/Theme.App.SplashScreen" android:exported="true">
-
     </activity>
   </application>
 </manifest>

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/BrowserLauncherActivity.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/BrowserLauncherActivity.kt
@@ -7,11 +7,14 @@ import android.os.Bundle
 class BrowserLauncherActivity : Activity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    val application = application as MainApplication
-    if (!application.isActivityInBackStack(MainActivity::class.java)) {
-      val intent = Intent(this, MainActivity::class.java)
-      startActivity(intent)
-    }
+    startActivity(
+      Intent(intent).apply {
+        setClassName(
+          this@BrowserLauncherActivity,
+          MainActivity::class.java.name
+        )
+      }
+    )
     finish()
   }
 }

--- a/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
+++ b/apps/bare-expo/android/app/src/main/java/dev/expo/payments/MainApplication.kt
@@ -1,14 +1,10 @@
 package dev.expo.payments
 
-import android.app.Activity
 import android.app.Application
 import android.content.res.Configuration
-import android.os.Bundle
-
 import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
-import com.facebook.react.ReactPackage
 import com.facebook.react.ReactHost
 
 import expo.modules.ApplicationLifecycleDispatcher
@@ -31,36 +27,10 @@ class MainApplication : Application(), ReactApplication {
     super.onCreate()
     loadReactNative(this)
     ApplicationLifecycleDispatcher.onApplicationCreate(this)
-    registerActivityLifecycleCallbacks(lifecycleCallbacks)
   }
 
   override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
     ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
-  }
-
-  private val runningActivities = ArrayList<Class<*>>()
-
-  private val lifecycleCallbacks = object : ActivityLifecycleCallbacks {
-    override fun onActivityCreated(activity: Activity, p1: Bundle?) {
-      if (!runningActivities.contains(activity::class.java)) runningActivities.add(activity::class.java)
-    }
-
-    override fun onActivityStarted(p0: Activity) = Unit
-    override fun onActivityResumed(p0: Activity) = Unit
-    override fun onActivityPaused(p0: Activity) = Unit
-    override fun onActivityStopped(p0: Activity) = Unit
-    override fun onActivitySaveInstanceState(p0: Activity, p1: Bundle) = Unit
-
-    override fun onActivityDestroyed(activity: Activity) {
-      if (runningActivities.contains(activity::class.java)) runningActivities.remove(activity::class.java)
-    }
-  }
-
-  fun isActivityInBackStack(cls: Class<*>?) = runningActivities.contains(cls)
-
-  override fun onTerminate() {
-    super.onTerminate()
-    unregisterActivityLifecycleCallbacks(lifecycleCallbacks)
   }
 }

--- a/apps/bare-expo/app.json
+++ b/apps/bare-expo/app.json
@@ -92,6 +92,12 @@
           }
         }
       ],
+      [
+        "expo-web-browser",
+        {
+          "experimentalLauncherActivity": true
+        }
+      ],
       "./plugins/withAndroidNetworkSecurityConfig",
       "./plugins/withBenchmarkModules"
     ],

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Bring back the `experimentalLauncherActivity` config plugin option.
+
 ## 55.0.9 — 2026-02-25
 
 ### 🎉 New features

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [Android] Bring back the `experimentalLauncherActivity` config plugin option.
+- [Android] Bring back the `experimentalLauncherActivity` config plugin option. ([#44073](https://github.com/expo/expo/pull/44073) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/expo-web-browser/plugin/build/withWebBrowser.d.ts
+++ b/packages/expo-web-browser/plugin/build/withWebBrowser.d.ts
@@ -1,6 +1,4 @@
 import { ConfigPlugin } from 'expo/config-plugins';
-type PluginConfig = {
-    experimentalLauncherActivity?: boolean;
-};
+import { PluginConfig } from './withWebBrowserAndroid';
 declare const _default: ConfigPlugin<PluginConfig | null>;
 export default _default;

--- a/packages/expo-web-browser/plugin/build/withWebBrowser.js
+++ b/packages/expo-web-browser/plugin/build/withWebBrowser.js
@@ -1,12 +1,15 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
+const withWebBrowserAndroid_1 = require("./withWebBrowserAndroid");
 const pkg = require('expo-web-browser/package.json');
 const withWebBrowser = (config, props) => {
-    if (props?.experimentalLauncherActivity) {
-        console.warn('The `experimentalLauncherActivity` option has been removed. To achieve similar behaviour, set both `createTask` and `useProxyActivity` to true when using `openBrowserAsync` or `openAuthSessionAsync`.');
+    if (!props) {
         return config;
     }
-    return config;
+    if (!props.experimentalLauncherActivity) {
+        return config;
+    }
+    return (0, withWebBrowserAndroid_1.withWebBrowserAndroid)(config);
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withWebBrowser, pkg.name, pkg.version);

--- a/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.d.ts
+++ b/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.d.ts
@@ -1,0 +1,5 @@
+import { ConfigPlugin } from 'expo/config-plugins';
+export type PluginConfig = {
+    experimentalLauncherActivity?: boolean;
+};
+export declare const withWebBrowserAndroid: ConfigPlugin;

--- a/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
+++ b/packages/expo-web-browser/plugin/build/withWebBrowserAndroid.js
@@ -1,0 +1,79 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withWebBrowserAndroid = void 0;
+const config_plugins_1 = require("expo/config-plugins");
+const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
+const withWebBrowserAndroid = (config) => {
+    config = addActivityToManifest(config);
+    config = addLauncherClassToProject(config);
+    return config;
+};
+exports.withWebBrowserAndroid = withWebBrowserAndroid;
+function addActivityToManifest(config) {
+    return (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+        const manifest = config.modResults.manifest;
+        const application = manifest?.application?.[0];
+        for (const activity of application?.activity ?? []) {
+            if (activity.$['android:name'] === '.BrowserLauncherActivity') {
+                return config;
+            }
+        }
+        const theme = application?.activity?.[0]?.$['android:theme'];
+        application?.activity?.[0]['intent-filter']?.splice(0, 1);
+        const launcherActivity = {
+            $: {
+                'android:name': '.BrowserLauncherActivity',
+                'android:theme': theme,
+                'android:exported': 'true',
+            },
+            'intent-filter': [
+                {
+                    action: [{ $: { 'android:name': 'android.intent.action.MAIN' } }],
+                    category: [{ $: { 'android:name': 'android.intent.category.LAUNCHER' } }],
+                },
+            ],
+        };
+        application?.activity?.push(launcherActivity);
+        return config;
+    });
+}
+function addLauncherClassToProject(config) {
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'android',
+        async (config) => {
+            const fileName = 'BrowserLauncherActivity.kt';
+            const dir = path_1.default.dirname(config_plugins_1.AndroidConfig.Paths.getProjectFilePath(config.modRequest.projectRoot, 'MainApplication'));
+            const fullPath = path_1.default.join(dir, fileName);
+            if (fs_1.default.existsSync(fullPath)) {
+                return config;
+            }
+            const classTemplate = `package ${config.android?.package || ''}
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+class BrowserLauncherActivity : Activity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    startActivity(
+      Intent(intent).apply {
+        setClassName(
+          this@BrowserLauncherActivity,
+          MainActivity::class.java.name
+        )
+      }
+    )
+    finish()
+  }
+}
+`;
+            await fs_1.default.promises.writeFile(fullPath, classTemplate);
+            return config;
+        },
+    ]);
+}

--- a/packages/expo-web-browser/plugin/src/withWebBrowser.ts
+++ b/packages/expo-web-browser/plugin/src/withWebBrowser.ts
@@ -1,20 +1,19 @@
 import { ConfigPlugin, createRunOncePlugin } from 'expo/config-plugins';
 
-type PluginConfig = {
-  experimentalLauncherActivity?: boolean;
-};
+import { withWebBrowserAndroid, PluginConfig } from './withWebBrowserAndroid';
 
 const pkg = require('expo-web-browser/package.json');
 
 const withWebBrowser: ConfigPlugin<PluginConfig | null> = (config, props) => {
-  if (props?.experimentalLauncherActivity) {
-    console.warn(
-      'The `experimentalLauncherActivity` option has been removed. To achieve similar behaviour, set both `createTask` and `useProxyActivity` to true when using `openBrowserAsync` or `openAuthSessionAsync`.'
-    );
+  if (!props) {
     return config;
   }
 
-  return config;
+  if (!props.experimentalLauncherActivity) {
+    return config;
+  }
+
+  return withWebBrowserAndroid(config);
 };
 
 export default createRunOncePlugin(withWebBrowser, pkg.name, pkg.version);

--- a/packages/expo-web-browser/plugin/src/withWebBrowserAndroid.ts
+++ b/packages/expo-web-browser/plugin/src/withWebBrowserAndroid.ts
@@ -1,0 +1,97 @@
+import type { ManifestActivity } from '@expo/config-plugins/build/android/Manifest';
+import type { ExpoConfig } from '@expo/config-types';
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  withAndroidManifest,
+  withDangerousMod,
+} from 'expo/config-plugins';
+import fs from 'fs';
+import path from 'path';
+
+export type PluginConfig = {
+  experimentalLauncherActivity?: boolean;
+};
+
+export const withWebBrowserAndroid: ConfigPlugin = (config) => {
+  config = addActivityToManifest(config);
+  config = addLauncherClassToProject(config);
+
+  return config;
+};
+
+function addActivityToManifest(config: ExpoConfig) {
+  return withAndroidManifest(config, (config) => {
+    const manifest = config.modResults.manifest;
+    const application = manifest?.application?.[0];
+
+    for (const activity of application?.activity ?? []) {
+      if (activity.$['android:name'] === '.BrowserLauncherActivity') {
+        return config;
+      }
+    }
+
+    const theme = application?.activity?.[0]?.$['android:theme'];
+    application?.activity?.[0]['intent-filter']?.splice(0, 1);
+
+    const launcherActivity: ManifestActivity = {
+      $: {
+        'android:name': '.BrowserLauncherActivity',
+        'android:theme': theme,
+        'android:exported': 'true',
+      },
+      'intent-filter': [
+        {
+          action: [{ $: { 'android:name': 'android.intent.action.MAIN' } }],
+          category: [{ $: { 'android:name': 'android.intent.category.LAUNCHER' } }],
+        },
+      ],
+    };
+
+    application?.activity?.push(launcherActivity);
+    return config;
+  });
+}
+
+function addLauncherClassToProject(config: ExpoConfig) {
+  return withDangerousMod(config, [
+    'android',
+    async (config) => {
+      const fileName = 'BrowserLauncherActivity.kt';
+      const dir = path.dirname(
+        AndroidConfig.Paths.getProjectFilePath(config.modRequest.projectRoot, 'MainApplication')
+      );
+
+      const fullPath = path.join(dir, fileName);
+
+      if (fs.existsSync(fullPath)) {
+        return config;
+      }
+
+      const classTemplate = `package ${config.android?.package || ''}
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+
+class BrowserLauncherActivity : Activity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    startActivity(
+      Intent(intent).apply {
+        setClassName(
+          this@BrowserLauncherActivity,
+          MainActivity::class.java.name
+        )
+      }
+    )
+    finish()
+  }
+}
+`;
+
+      await fs.promises.writeFile(fullPath, classTemplate);
+      return config;
+    },
+  ]);
+}


### PR DESCRIPTION
# Why

Bring back the `experimentalLauncherActivity` config plugin option originally implemented in https://github.com/expo/expo/pull/34160
 
# How

This PR restores the files added in the original PR, with one modification: I've updated the `BrowserLauncherActivity` so we don't have to change `MainApplication` to add the activity registry.


# Test Plan

- bare-expo ✅ 