### PR TITLE
fix(cli): Add missing self-resolution support to Metro via `createExpoFallbackResolver`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,13 +16,14 @@
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))
 - Avoid `ERR_TTY_INIT_FAILED` when `LOG_EVENTS=1` or `LOG_EVENTS=2` is used in non-interactive terminals. ([#43796](https://github.com/expo/expo/pull/43796) by [@krystofwoldrich](https://github.com/krystofwoldrich))
-- Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))`
+- Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))
 - Prevent hanging when installing iOS apps on device. ([#43618](https://github.com/expo/expo/pull/43618) by [@EvanBacon](https://github.com/EvanBacon))
 - Correctly handle JavaScript assets when `asyncRoutes: true` in SSR ([#43446](https://github.com/expo/expo/pull/43446) by [@hassankhan](https://github.com/hassankhan))
 - Fix server being started before Metro is ready, or, if it's started, status middleware responding too soon ([#43557](https://github.com/expo/expo/pull/43557) by [@kitten](https://github.com/kitten))
 - Don't let `expo start`'s dependency validation fail the `start` command ([#43619](https://github.com/expo/expo/pull/43619) by [@kitten](https://github.com/kitten))
 - Sort async chunks by route `entryPoints` order when `asyncRoutes` is enabled ([#43531](https://github.com/expo/expo/pull/43531) by [@hassankhan](https://github.com/hassankhan))
 - Fix `SimulatorAppPrerequisite` to fall back to reading `Simulator.app/Contents/Info.plist` directly when LaunchServices has not indexed the app (e.g. Xcode installed on an external or renamed volume). This prevents a spurious "Simulator is most likely not installed" error when running `expo run:ios --device` on a physical device. ([#43597](https://github.com/expo/expo/pull/43597) by [@ciospettw](https://github.com/ciospettw))
+- Add missing support for self-resolution via fallback resolver ([#44077](https://github.com/expo/expo/pull/44077) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -1166,6 +1166,86 @@ describe(withExtendedResolver, () => {
       );
     });
 
+    it('resolves self-referencing module when getPackageForModule returns matching package name', () => {
+      const platform = 'ios';
+      const modified = getModifiedConfig();
+
+      jest.mocked(getResolveFunc()).mockImplementation((context, moduleName, _platform) => {
+        if (
+          context.originModulePath === '/root/node_modules/my-package/src/index.js' &&
+          moduleName === 'my-package/utils' &&
+          !context.extraNodeModules?.['my-package']
+        ) {
+          throw new FailedToResolveNameError();
+        } else if (moduleName === 'expo/package.json') {
+          return { type: 'sourceFile', filePath: `/node_modules/${moduleName}` };
+        } else if (moduleName === 'expo-router/package.json') {
+          return { type: 'sourceFile', filePath: `/node_modules/${moduleName}` };
+        } else {
+          return { type: 'empty' };
+        }
+      });
+
+      modified.resolver.resolveRequest!(
+        getResolverContext({
+          originModulePath: '/root/node_modules/my-package/src/index.js',
+          getPackage: () => null,
+          getPackageForModule: (modulePath: string) => {
+            if (modulePath === '/root/node_modules/my-package/src/index.js') {
+              return {
+                rootPath: '/root/node_modules/my-package',
+                packageJson: { name: 'my-package' },
+              };
+            }
+            return null;
+          },
+        }),
+        'my-package/utils',
+        platform
+      );
+
+      expect(getResolveFunc()).toHaveBeenCalledTimes(4);
+
+      // 1: Fails to resolve the module normally
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          originModulePath: '/root/node_modules/my-package/src/index.js',
+        }),
+        'my-package/utils',
+        platform
+      );
+
+      // 2: Resolves the origin root module path for `expo`
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ originModulePath: '/root/package.json' }),
+        'expo/package.json',
+        platform
+      );
+
+      // 3: Resolves the origin root module path for `expo-router`
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        3,
+        expect.objectContaining({ originModulePath: '/root/package.json' }),
+        'expo-router/package.json',
+        platform
+      );
+
+      // 4: Self-resolution resolves the module via extraNodeModules
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        4,
+        expect.objectContaining({
+          nodeModulesPaths: [],
+          extraNodeModules: {
+            'my-package': '/root/node_modules/my-package',
+          },
+        }),
+        'my-package/utils',
+        platform
+      );
+    });
+
     it('resolves no fallback modules if origin module dependencies mismatch', () => {
       // Empty dependencies should cause no modules to match
       vol.fromJSON(

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -192,6 +192,24 @@ export function createFallbackModuleResolver({
       }
     }
 
+    // Self-resolution
+    const pkg = immutableContext.getPackageForModule(immutableContext.originModulePath);
+    const pkgName = pkg?.packageJson.name;
+    if (pkgName && dependenciesToRegex([pkgName]).test(moduleName)) {
+      const context: ResolutionContext = {
+        ...immutableContext,
+        nodeModulesPaths: [],
+        // NOTE(@kitten): Metro currently fails self-resolution, so if the package failed to resolve itself
+        // from within itself, we add a hint to where to find itself to the `extraNodeModules` lookups
+        extraNodeModules: {
+          [pkgName]: pkg.rootPath,
+        },
+      };
+      const res = getStrictResolver(context, platform)(moduleName);
+      debug(`Self resolution for ${platform}: ${moduleName} -> from origin: ${pkg.rootPath}`);
+      return res;
+    }
+
     return null;
   };
 }


### PR DESCRIPTION
# Why

Metro currently doesn't handle self-resolution correctly. As we're migrating to pnpm, this will become a larger issue. Self-resolution is the `PACKAGE_SELF_RESOLVE` procedure in the documented Node.js resolution spec: https://nodejs.org/api/esm.html

This basically allows packages to resolve into themselves by using their own module name. This shouldn't require the module itself to be in a `node_modules` folder, which would be how self-resolution is usually done (traversing upwards to the parent `node_modules` and resolving again). In monorepos this won't necessarily be the case, unless the module is re-referenced in the root of the monorepo.

# How

In the fallback resolver, resolve the module's enclosing package. If it has an enclosing package (parent `package.json`), match the `name` against the currently resolving `moduleName`. If they match, we add the current module to `extraNodeModules` to help out Metro's resolution.

# Test Plan

- Unit tests added
- Manually tested against `@expo/router-server` resolution in pnpm branch

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
