### PR TITLE
chore(apps): Remove invalid metro/blocklist options

### DIFF
--- a/apps/router-e2e/metro.config.js
+++ b/apps/router-e2e/metro.config.js
@@ -40,25 +40,8 @@ const config = getDefaultConfig(
     : undefined
 );
 
-const monorepoRoot = path.join(__dirname, '../..');
-
-// Minimize the "watched" folders that Metro crawls through to speed up Metro in big monorepos.
-// Note, omitting folders disables Metro from resolving files within these folders
-// This also happens when symlinks falls within these folders, but the real location doesn't.
-config.watchFolders = [
-  __dirname, // Allow Metro to resolve all files within this project
-  path.join(monorepoRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
-  path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
-];
-
 // Disable Babel's RC lookup, reducing the config loading in Babel - resulting in faster bootup for transformations
 config.transformer.enableBabelRCLookup = false;
-
-config.resolver.blockList = [
-  /\/expo-router\/node_modules\/@react-navigation/,
-  /node_modules\/@react-navigation\/native-stack\/node_modules\/@react-navigation\//,
-  /node_modules\/pretty-format\/node_modules\/react-is/,
-];
 
 const originalCustomizeFrame = config.symbolicator.customizeFrame;
 config.symbolicator.customizeFrame = (frame) => {

--- a/apps/sandbox/metro.config.js
+++ b/apps/sandbox/metro.config.js
@@ -7,22 +7,7 @@ const path = require('node:path');
 const config = getDefaultConfig(__dirname, { isCSSEnabled: true });
 const monorepoRoot = path.join(__dirname, '../..');
 
-// Minimize the "watched" folders that Metro crawls through to speed up Metro in big monorepos.
-// Note, omitting folders disables Metro from resolving files within these folders
-// This also happens when symlinks falls within these folders, but the real location doesn't.
-config.watchFolders = [
-  __dirname, // Allow Metro to resolve all files within this project
-  path.join(monorepoRoot, 'packages'), // Allow Metro to resolve all workspace files of the monorepo
-  path.join(monorepoRoot, 'node_modules'), // Allow Metro to resolve "shared" `node_modules` of the monorepo
-];
-
 // Disable Babel's RC lookup, reducing the config loading in Babel - resulting in faster bootup for transformations
 config.transformer.enableBabelRCLookup = false;
-
-config.resolver.blockList = [
-  /\/expo-router\/node_modules\/@react-navigation/,
-  /node_modules\/@react-navigation\/native-stack\/node_modules\/@react-navigation\//,
-  /node_modules\/pretty-format\/node_modules\/react-is/,
-];
 
 module.exports = config;

--- a/tools/src/commands/GenerateBareApp.ts
+++ b/tools/src/commands/GenerateBareApp.ts
@@ -283,25 +283,6 @@ const path = require('path');
 
 const config = getDefaultConfig('${projectRoot}');
 
-// 1. Watch expo packages within the monorepo
-config.watchFolders = ['${PACKAGES_DIR}'];
-
-// 2. Let Metro know where to resolve packages, and in what order
-config.resolver.nodeModulesPaths = [
-  path.resolve('${projectRoot}', 'node_modules'),
-  path.resolve('${PACKAGES_DIR}'),
-];
-
-// Use Node-style module resolution instead of Haste everywhere
-config.resolver.providesModuleNodeModules = [];
-
-// Ignore test files and JS files in the native Android and Xcode projects
-config.resolver.blockList = [
-  /\\/__tests__\\/.*/,
-  /.*\\/android\\/React(Android|Common)\\/.*/,
-  /.*\\/versioned-react-native\\/.*/,
-];
-
 module.exports = config;
 `;
 


### PR DESCRIPTION
# Why

- some of the invalid blocklists are breaking builds for isolated dependencies, and it's unclear why they were added. We shouldn't blocklist any node_modules ever
- Some `watchFolders` modifications are redundant

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
