### PR TITLE
[core][ui][android] add AsyncFunction support to ExpoUIView DSL

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Refactored `ComposableScope` and allow extensibility. ([#44698](https://github.com/expo/expo/pull/44698) by [@kudo](https://github.com/kudo))
 - [iOS] Added broader colors support to convertibles. ([#44630](https://github.com/expo/expo/pull/44630) by [@kudo](https://github.com/kudo))
 - Throwing error when converting invalid color array. ([#44734](https://github.com/expo/expo/pull/44734) by [@kudo](https://github.com/kudo))
+- [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -5,11 +5,13 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.RecomposeScope
 import androidx.compose.runtime.currentRecomposeScope
 import androidx.compose.runtime.key
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.size
@@ -225,6 +227,180 @@ class FunctionalComposableScope(
   inline fun <reified T> EventDispatcher(noinline coalescingKey: CoalescingKey<T>? = null): ViewEventDelegate<T> {
     return view.EventDispatcher<T>(coalescingKey)
   }
+
+  /**
+   * Creates a [AsyncFunctionHandlerScope] for a function declared with
+   * [ComposeViewFunctionDefinitionBuilder.Function].
+   * The returned scope can be passed to child composables, which call it with
+   * a handler lambda that has access to local compose state.
+   *
+   * This is the counterpart to [EventDispatcher] — events push data to JS,
+   * while function handlers receive calls from JS.
+   *
+   * Usage in the ExpoUIView composable:
+   * ```
+   * val onHide = AsyncFunctionHandler("hide")
+   * ModalBottomSheetContent(props, onHide) { ... }
+   * ```
+   * Usage in the content composable:
+   * ```
+   * onHide { sheetState.hide() }
+   * ```
+   */
+  fun AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope<Unit> {
+    return AsyncFunctionHandlerScope(name, view)
+  }
+
+  @JvmName("AsyncFunctionHandler1")
+  fun <P0> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope<P0> {
+    return AsyncFunctionHandlerScope(name, view)
+  }
+
+  @JvmName("AsyncFunctionHandler2")
+  fun <P0, P1> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope2<P0, P1> {
+    return AsyncFunctionHandlerScope2(name, view)
+  }
+
+  @JvmName("AsyncFunctionHandler3")
+  fun <P0, P1, P2> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope3<P0, P1, P2> {
+    return AsyncFunctionHandlerScope3(name, view)
+  }
+
+  @JvmName("AsyncFunctionHandler4")
+  fun <P0, P1, P2, P3> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope4<P0, P1, P2, P3> {
+    return AsyncFunctionHandlerScope4(name, view)
+  }
+
+  @JvmName("AsyncFunctionHandler5")
+  fun <P0, P1, P2, P3, P4> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope5<P0, P1, P2, P3, P4> {
+    return AsyncFunctionHandlerScope5(name, view)
+  }
+
+  @JvmName("AsyncFunctionHandler6")
+  fun <P0, P1, P2, P3, P4, P5> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope6<P0, P1, P2, P3, P4, P5> {
+    return AsyncFunctionHandlerScope6(name, view)
+  }
+
+  @JvmName("AsyncFunctionHandler7")
+  fun <P0, P1, P2, P3, P4, P5, P6> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope7<P0, P1, P2, P3, P4, P5, P6> {
+    return AsyncFunctionHandlerScope7(name, view)
+  }
+}
+
+/**
+ * Scope objects returned by [FunctionalComposableScope.AsyncFunctionHandler].
+ * Call [invoke] with a typed suspend lambda to register the handler.
+ * The handler is updated on recomposition and cleaned up on disposal.
+ *
+ * For no-argument functions (`AsyncFunctionHandlerScope<Unit>`), the lambda parameter
+ * is `Unit` and can be ignored: `onHide { doStuff() }`.
+ */
+class AsyncFunctionHandlerScope<P0>(
+  private val name: String,
+  private val view: ComposeFunctionHolder<*>
+) {
+  @Suppress("UNCHECKED_CAST")
+  @Composable
+  operator fun invoke(handler: suspend (P0) -> Any?) {
+    val currentHandler = rememberUpdatedState(handler)
+    DisposableEffect(name) {
+      view.functionHandlers[name] = { args ->
+        val arg = if (args.isEmpty()) Unit as P0 else args[0] as P0
+        currentHandler.value(arg)
+      }
+      onDispose { view.functionHandlers.remove(name) }
+    }
+  }
+}
+
+class AsyncFunctionHandlerScope2<P0, P1>(
+  private val name: String,
+  private val view: ComposeFunctionHolder<*>
+) {
+  @Suppress("UNCHECKED_CAST")
+  @Composable
+  operator fun invoke(handler: suspend (P0, P1) -> Any?) {
+    val currentHandler = rememberUpdatedState(handler)
+    DisposableEffect(name) {
+      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1) }
+      onDispose { view.functionHandlers.remove(name) }
+    }
+  }
+}
+
+class AsyncFunctionHandlerScope3<P0, P1, P2>(
+  private val name: String,
+  private val view: ComposeFunctionHolder<*>
+) {
+  @Suppress("UNCHECKED_CAST")
+  @Composable
+  operator fun invoke(handler: suspend (P0, P1, P2) -> Any?) {
+    val currentHandler = rememberUpdatedState(handler)
+    DisposableEffect(name) {
+      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2) }
+      onDispose { view.functionHandlers.remove(name) }
+    }
+  }
+}
+
+class AsyncFunctionHandlerScope4<P0, P1, P2, P3>(
+  private val name: String,
+  private val view: ComposeFunctionHolder<*>
+) {
+  @Suppress("UNCHECKED_CAST")
+  @Composable
+  operator fun invoke(handler: suspend (P0, P1, P2, P3) -> Any?) {
+    val currentHandler = rememberUpdatedState(handler)
+    DisposableEffect(name) {
+      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3) }
+      onDispose { view.functionHandlers.remove(name) }
+    }
+  }
+}
+
+class AsyncFunctionHandlerScope5<P0, P1, P2, P3, P4>(
+  private val name: String,
+  private val view: ComposeFunctionHolder<*>
+) {
+  @Suppress("UNCHECKED_CAST")
+  @Composable
+  operator fun invoke(handler: suspend (P0, P1, P2, P3, P4) -> Any?) {
+    val currentHandler = rememberUpdatedState(handler)
+    DisposableEffect(name) {
+      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4) }
+      onDispose { view.functionHandlers.remove(name) }
+    }
+  }
+}
+
+class AsyncFunctionHandlerScope6<P0, P1, P2, P3, P4, P5>(
+  private val name: String,
+  private val view: ComposeFunctionHolder<*>
+) {
+  @Suppress("UNCHECKED_CAST")
+  @Composable
+  operator fun invoke(handler: suspend (P0, P1, P2, P3, P4, P5) -> Any?) {
+    val currentHandler = rememberUpdatedState(handler)
+    DisposableEffect(name) {
+      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5) }
+      onDispose { view.functionHandlers.remove(name) }
+    }
+  }
+}
+
+class AsyncFunctionHandlerScope7<P0, P1, P2, P3, P4, P5, P6>(
+  private val name: String,
+  private val view: ComposeFunctionHolder<*>
+) {
+  @Suppress("UNCHECKED_CAST")
+  @Composable
+  operator fun invoke(handler: suspend (P0, P1, P2, P3, P4, P5, P6) -> Any?) {
+    val currentHandler = rememberUpdatedState(handler)
+    DisposableEffect(name) {
+      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6) }
+      onDispose { view.functionHandlers.remove(name) }
+    }
+  }
 }
 
 @SuppressLint("ViewConstructor")
@@ -236,6 +412,9 @@ class ComposeFunctionHolder<Props : ComposeProps>(
   override val props: Props
 ) : ExpoComposeView<Props>(context, appContext), ViewFunctionHolder {
   val propsMutableState = mutableStateOf(props)
+
+  @PublishedApi
+  internal val functionHandlers = mutableMapOf<String, suspend (Array<out Any?>) -> Any?>()
 
   @Composable
   override fun ComposableScope.Content() {

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -19,7 +19,9 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.CoalescingKey
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.viewevent.ViewEvent
+import expo.modules.kotlin.viewevent.ViewEventCallback
 import expo.modules.kotlin.viewevent.ViewEventDelegate
+import kotlin.reflect.KProperty
 
 /**
  * A scope interface passed through the compose view hierarchy.
@@ -228,80 +230,20 @@ class FunctionalComposableScope(
     return view.EventDispatcher<T>(coalescingKey)
   }
 
+  //region Handle-based DSL (for View<Props> { Content { } } style)
+
   /**
-   * Creates a [AsyncFunctionHandlerScope] for a function declared with
-   * [ComposeViewFunctionDefinitionBuilder.Function].
-   * The returned scope can be passed to child composables, which call it with
-   * a handler lambda that has access to local compose state.
+   * Binds a handler for an async function declared via
+   * [ComposeViewBuilderScope.AsyncFunction] (e.g. `val focus by AsyncFunction()`).
+   * Call inside the `Content { props -> ... }` lambda. The handler is updated
+   * on recomposition and cleaned up on disposal.
    *
-   * This is the counterpart to [EventDispatcher] — events push data to JS,
-   * while function handlers receive calls from JS.
-   *
-   * Usage in the ExpoUIView composable:
-   * ```
-   * val onHide = AsyncFunctionHandler("hide")
-   * ModalBottomSheetContent(props, onHide) { ... }
-   * ```
-   * Usage in the content composable:
-   * ```
-   * onHide { sheetState.hide() }
-   * ```
+   * For no-argument functions the lambda parameter is [Unit] and can be
+   * ignored: `focus.handle { focusRequester.requestFocus() }`.
    */
-  fun AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope<Unit> {
-    return AsyncFunctionHandlerScope(name, view)
-  }
-
-  @JvmName("AsyncFunctionHandler1")
-  fun <P0> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope<P0> {
-    return AsyncFunctionHandlerScope(name, view)
-  }
-
-  @JvmName("AsyncFunctionHandler2")
-  fun <P0, P1> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope2<P0, P1> {
-    return AsyncFunctionHandlerScope2(name, view)
-  }
-
-  @JvmName("AsyncFunctionHandler3")
-  fun <P0, P1, P2> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope3<P0, P1, P2> {
-    return AsyncFunctionHandlerScope3(name, view)
-  }
-
-  @JvmName("AsyncFunctionHandler4")
-  fun <P0, P1, P2, P3> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope4<P0, P1, P2, P3> {
-    return AsyncFunctionHandlerScope4(name, view)
-  }
-
-  @JvmName("AsyncFunctionHandler5")
-  fun <P0, P1, P2, P3, P4> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope5<P0, P1, P2, P3, P4> {
-    return AsyncFunctionHandlerScope5(name, view)
-  }
-
-  @JvmName("AsyncFunctionHandler6")
-  fun <P0, P1, P2, P3, P4, P5> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope6<P0, P1, P2, P3, P4, P5> {
-    return AsyncFunctionHandlerScope6(name, view)
-  }
-
-  @JvmName("AsyncFunctionHandler7")
-  fun <P0, P1, P2, P3, P4, P5, P6> AsyncFunctionHandler(name: String): AsyncFunctionHandlerScope7<P0, P1, P2, P3, P4, P5, P6> {
-    return AsyncFunctionHandlerScope7(name, view)
-  }
-}
-
-/**
- * Scope objects returned by [FunctionalComposableScope.AsyncFunctionHandler].
- * Call [invoke] with a typed suspend lambda to register the handler.
- * The handler is updated on recomposition and cleaned up on disposal.
- *
- * For no-argument functions (`AsyncFunctionHandlerScope<Unit>`), the lambda parameter
- * is `Unit` and can be ignored: `onHide { doStuff() }`.
- */
-class AsyncFunctionHandlerScope<P0>(
-  private val name: String,
-  private val view: ComposeFunctionHolder<*>
-) {
   @Suppress("UNCHECKED_CAST")
   @Composable
-  operator fun invoke(handler: suspend (P0) -> Any?) {
+  fun <P0> AsyncFunctionHandle<P0>.handle(handler: suspend (P0) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
       view.functionHandlers[name] = { args ->
@@ -311,97 +253,149 @@ class AsyncFunctionHandlerScope<P0>(
       onDispose { view.functionHandlers.remove(name) }
     }
   }
-}
 
-class AsyncFunctionHandlerScope2<P0, P1>(
-  private val name: String,
-  private val view: ComposeFunctionHolder<*>
-) {
   @Suppress("UNCHECKED_CAST")
   @Composable
-  operator fun invoke(handler: suspend (P0, P1) -> Any?) {
+  @JvmName("handle2")
+  fun <P0, P1> AsyncFunctionHandle2<P0, P1>.handle(handler: suspend (P0, P1) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
       view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1) }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
-}
 
-class AsyncFunctionHandlerScope3<P0, P1, P2>(
-  private val name: String,
-  private val view: ComposeFunctionHolder<*>
-) {
   @Suppress("UNCHECKED_CAST")
   @Composable
-  operator fun invoke(handler: suspend (P0, P1, P2) -> Any?) {
+  @JvmName("handle3")
+  fun <P0, P1, P2> AsyncFunctionHandle3<P0, P1, P2>.handle(handler: suspend (P0, P1, P2) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
       view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2) }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
-}
 
-class AsyncFunctionHandlerScope4<P0, P1, P2, P3>(
-  private val name: String,
-  private val view: ComposeFunctionHolder<*>
-) {
   @Suppress("UNCHECKED_CAST")
   @Composable
-  operator fun invoke(handler: suspend (P0, P1, P2, P3) -> Any?) {
+  @JvmName("handle4")
+  fun <P0, P1, P2, P3> AsyncFunctionHandle4<P0, P1, P2, P3>.handle(handler: suspend (P0, P1, P2, P3) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
       view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3) }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
-}
 
-class AsyncFunctionHandlerScope5<P0, P1, P2, P3, P4>(
-  private val name: String,
-  private val view: ComposeFunctionHolder<*>
-) {
   @Suppress("UNCHECKED_CAST")
   @Composable
-  operator fun invoke(handler: suspend (P0, P1, P2, P3, P4) -> Any?) {
+  @JvmName("handle5")
+  fun <P0, P1, P2, P3, P4> AsyncFunctionHandle5<P0, P1, P2, P3, P4>.handle(handler: suspend (P0, P1, P2, P3, P4) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
       view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4) }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
-}
 
-class AsyncFunctionHandlerScope6<P0, P1, P2, P3, P4, P5>(
-  private val name: String,
-  private val view: ComposeFunctionHolder<*>
-) {
   @Suppress("UNCHECKED_CAST")
   @Composable
-  operator fun invoke(handler: suspend (P0, P1, P2, P3, P4, P5) -> Any?) {
+  @JvmName("handle6")
+  fun <P0, P1, P2, P3, P4, P5> AsyncFunctionHandle6<P0, P1, P2, P3, P4, P5>.handle(handler: suspend (P0, P1, P2, P3, P4, P5) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
       view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5) }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
-}
 
-class AsyncFunctionHandlerScope7<P0, P1, P2, P3, P4, P5, P6>(
-  private val name: String,
-  private val view: ComposeFunctionHolder<*>
-) {
   @Suppress("UNCHECKED_CAST")
   @Composable
-  operator fun invoke(handler: suspend (P0, P1, P2, P3, P4, P5, P6) -> Any?) {
+  @JvmName("handle7")
+  fun <P0, P1, P2, P3, P4, P5, P6> AsyncFunctionHandle7<P0, P1, P2, P3, P4, P5, P6>.handle(handler: suspend (P0, P1, P2, P3, P4, P5, P6) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
       view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6) }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
+
+  /**
+   * Dispatches an event declared via [ComposeViewBuilderScope.Event]
+   * (e.g. `val onValueChange by Event<String>()`).
+   * Callable anywhere the [FunctionalComposableScope] is in scope, including
+   * event-callback lambdas inside the `Content { }` block.
+   */
+  operator fun <T> EventHandle<T>.invoke(payload: T) {
+    view.getOrCreateEventCallback(name, coalescingKey).invoke(payload)
+  }
+
+  //endregion Handle-based DSL
 }
+
+//region Handle types — lightweight name carriers produced by ComposeViewBuilderScope delegates
+
+/**
+ * A handle for an async function declared with
+ * [ComposeViewBuilderScope.AsyncFunction] (0- or 1-argument variant).
+ * The handle carries only the function name; bind a handler inside the
+ * `Content { }` block via [FunctionalComposableScope.handle].
+ */
+class AsyncFunctionHandle<P0> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String
+) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): AsyncFunctionHandle<P0> = this
+}
+
+class AsyncFunctionHandle2<P0, P1> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String
+) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): AsyncFunctionHandle2<P0, P1> = this
+}
+
+class AsyncFunctionHandle3<P0, P1, P2> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String
+) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): AsyncFunctionHandle3<P0, P1, P2> = this
+}
+
+class AsyncFunctionHandle4<P0, P1, P2, P3> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String
+) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): AsyncFunctionHandle4<P0, P1, P2, P3> = this
+}
+
+class AsyncFunctionHandle5<P0, P1, P2, P3, P4> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String
+) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): AsyncFunctionHandle5<P0, P1, P2, P3, P4> = this
+}
+
+class AsyncFunctionHandle6<P0, P1, P2, P3, P4, P5> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String
+) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): AsyncFunctionHandle6<P0, P1, P2, P3, P4, P5> = this
+}
+
+class AsyncFunctionHandle7<P0, P1, P2, P3, P4, P5, P6> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String
+) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): AsyncFunctionHandle7<P0, P1, P2, P3, P4, P5, P6> = this
+}
+
+/**
+ * A handle for an event declared with [ComposeViewBuilderScope.Event]
+ * (e.g. `val onValueChange by Event<String>()`). Dispatch by invoking
+ * the handle directly: `onValueChange(payload)`.
+ */
+class EventHandle<T> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String,
+  @PublishedApi internal val coalescingKey: CoalescingKey<T>?
+) {
+  operator fun getValue(thisRef: Any?, property: KProperty<*>): EventHandle<T> = this
+}
+
+//endregion Handle types
 
 @SuppressLint("ViewConstructor")
 class ComposeFunctionHolder<Props : ComposeProps>(
@@ -415,6 +409,26 @@ class ComposeFunctionHolder<Props : ComposeProps>(
 
   @PublishedApi
   internal val functionHandlers = mutableMapOf<String, suspend (Array<out Any?>) -> Any?>()
+
+  /**
+   * Per-instance cache of [ViewEventCallback]s keyed by event name. Populated
+   * lazily by [getOrCreateEventCallback] to avoid re-creating [ViewEvent]
+   * (and repeating its one-time validation) on every dispatch from an
+   * [EventHandle] inside a composable body.
+   */
+  @PublishedApi
+  internal val eventCallbacks = mutableMapOf<String, ViewEventCallback<*>>()
+
+  @PublishedApi
+  @Suppress("UNCHECKED_CAST")
+  internal fun <T> getOrCreateEventCallback(
+    name: String,
+    coalescingKey: CoalescingKey<T>?
+  ): ViewEventCallback<T> {
+    return eventCallbacks.getOrPut(name) {
+      ViewEvent<T>(name, this, coalescingKey)
+    } as ViewEventCallback<T>
+  }
 
   @Composable
   override fun ComposableScope.Content() {

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -8,14 +8,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.RecomposeScope
 import androidx.compose.runtime.currentRecomposeScope
-import androidx.compose.runtime.key
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.size
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.viewevent.CoalescingKey
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.viewevent.ViewEvent
@@ -241,81 +242,100 @@ class FunctionalComposableScope(
    * For no-argument functions the lambda parameter is [Unit] and can be
    * ignored: `focus.handle { focusRequester.requestFocus() }`.
    */
-  @Suppress("UNCHECKED_CAST")
+  @SuppressLint("ComposableNaming")
   @Composable
-  fun <P0> AsyncFunctionHandle<P0>.handle(handler: suspend (P0) -> Any?) {
+  inline fun <reified P0> AsyncFunctionHandle<P0>.handle(noinline handler: suspend (P0) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
       view.functionHandlers[name] = { args ->
-        val arg = if (args.isEmpty()) Unit as P0 else args[0] as P0
+        val arg = if (args.isEmpty()) Unit else args[0]
+        enforceType<P0>(arg)
         currentHandler.value(arg)
       }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
+  @SuppressLint("ComposableNaming")
   @Composable
-  @JvmName("handle2")
-  fun <P0, P1> AsyncFunctionHandle2<P0, P1>.handle(handler: suspend (P0, P1) -> Any?) {
+  inline fun <reified P0, reified P1> AsyncFunctionHandle2<P0, P1>.handle(noinline handler: suspend (P0, P1) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
-      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1) }
+      view.functionHandlers[name] = { args ->
+        val p0 = args[0]; val p1 = args[1]
+        enforceType<P0, P1>(p0, p1)
+        currentHandler.value(p0, p1)
+      }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
+  @SuppressLint("ComposableNaming")
   @Composable
-  @JvmName("handle3")
-  fun <P0, P1, P2> AsyncFunctionHandle3<P0, P1, P2>.handle(handler: suspend (P0, P1, P2) -> Any?) {
+  inline fun <reified P0, reified P1, reified P2> AsyncFunctionHandle3<P0, P1, P2>.handle(noinline handler: suspend (P0, P1, P2) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
-      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2) }
+      view.functionHandlers[name] = { args ->
+        val p0 = args[0]; val p1 = args[1]; val p2 = args[2]
+        enforceType<P0, P1, P2>(p0, p1, p2)
+        currentHandler.value(p0, p1, p2)
+      }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
+  @SuppressLint("ComposableNaming")
   @Composable
-  @JvmName("handle4")
-  fun <P0, P1, P2, P3> AsyncFunctionHandle4<P0, P1, P2, P3>.handle(handler: suspend (P0, P1, P2, P3) -> Any?) {
+  inline fun <reified P0, reified P1, reified P2, reified P3> AsyncFunctionHandle4<P0, P1, P2, P3>.handle(noinline handler: suspend (P0, P1, P2, P3) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
-      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3) }
+      view.functionHandlers[name] = { args ->
+        val p0 = args[0]; val p1 = args[1]; val p2 = args[2]; val p3 = args[3]
+        enforceType<P0, P1, P2, P3>(p0, p1, p2, p3)
+        currentHandler.value(p0, p1, p2, p3)
+      }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
+  @SuppressLint("ComposableNaming")
   @Composable
-  @JvmName("handle5")
-  fun <P0, P1, P2, P3, P4> AsyncFunctionHandle5<P0, P1, P2, P3, P4>.handle(handler: suspend (P0, P1, P2, P3, P4) -> Any?) {
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunctionHandle5<P0, P1, P2, P3, P4>.handle(noinline handler: suspend (P0, P1, P2, P3, P4) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
-      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4) }
+      view.functionHandlers[name] = { args ->
+        val p0 = args[0]; val p1 = args[1]; val p2 = args[2]; val p3 = args[3]; val p4 = args[4]
+        enforceType<P0, P1, P2, P3, P4>(p0, p1, p2, p3, p4)
+        currentHandler.value(p0, p1, p2, p3, p4)
+      }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
+  @SuppressLint("ComposableNaming")
   @Composable
-  @JvmName("handle6")
-  fun <P0, P1, P2, P3, P4, P5> AsyncFunctionHandle6<P0, P1, P2, P3, P4, P5>.handle(handler: suspend (P0, P1, P2, P3, P4, P5) -> Any?) {
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunctionHandle6<P0, P1, P2, P3, P4, P5>.handle(noinline handler: suspend (P0, P1, P2, P3, P4, P5) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
-      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5) }
+      view.functionHandlers[name] = { args ->
+        val p0 = args[0]; val p1 = args[1]; val p2 = args[2]; val p3 = args[3]; val p4 = args[4]; val p5 = args[5]
+        enforceType<P0, P1, P2, P3, P4, P5>(p0, p1, p2, p3, p4, p5)
+        currentHandler.value(p0, p1, p2, p3, p4, p5)
+      }
       onDispose { view.functionHandlers.remove(name) }
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
+  @SuppressLint("ComposableNaming")
   @Composable
-  @JvmName("handle7")
-  fun <P0, P1, P2, P3, P4, P5, P6> AsyncFunctionHandle7<P0, P1, P2, P3, P4, P5, P6>.handle(handler: suspend (P0, P1, P2, P3, P4, P5, P6) -> Any?) {
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunctionHandle7<P0, P1, P2, P3, P4, P5, P6>.handle(noinline handler: suspend (P0, P1, P2, P3, P4, P5, P6) -> Any?) {
     val currentHandler = rememberUpdatedState(handler)
     DisposableEffect(name) {
-      view.functionHandlers[name] = { args -> currentHandler.value(args[0] as P0, args[1] as P1, args[2] as P2, args[3] as P3, args[4] as P4, args[5] as P5, args[6] as P6) }
+      view.functionHandlers[name] = { args ->
+        val p0 = args[0]; val p1 = args[1]; val p2 = args[2]; val p3 = args[3]; val p4 = args[4]; val p5 = args[5]; val p6 = args[6]
+        enforceType<P0, P1, P2, P3, P4, P5, P6>(p0, p1, p2, p3, p4, p5, p6)
+        currentHandler.value(p0, p1, p2, p3, p4, p5, p6)
+      }
       onDispose { view.functionHandlers.remove(name) }
     }
   }

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -3,12 +3,15 @@
 package expo.modules.kotlin.views
 
 import androidx.compose.runtime.Composable
+import expo.modules.kotlin.functions.Queues
+import expo.modules.kotlin.functions.SuspendFunctionComponent
 import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.modules.InternalModuleDefinitionBuilder
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.descriptors.toTypeDescriptor
 import expo.modules.kotlin.types.descriptors.typeDescriptorOf
+import expo.modules.kotlin.types.toArgsArray
 import expo.modules.kotlin.views.decorators.UseCSSProps
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
@@ -44,42 +47,21 @@ open class ModuleDefinitionBuilderWithCompose(
   @JvmName("ComposeView")
   inline fun <reified Props : ComposeProps> View(
     name: String,
-    events: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
+    events: ComposeViewEventDefinitionBuilder.() -> Unit = {},
+    functions: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
     noinline viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit
   ) {
-    val definitionBuilder = ComposeViewFunctionDefinitionBuilder(name, Props::class, viewFunction)
-    events.invoke(definitionBuilder)
-    registerViewDefinition(definitionBuilder.build())
+    val eventBuilder = ComposeViewEventDefinitionBuilder()
+    events.invoke(eventBuilder)
+    val functionBuilder = ComposeViewFunctionDefinitionBuilder(name, Props::class, viewFunction, eventBuilder)
+    functions.invoke(functionBuilder)
+    registerViewDefinition(functionBuilder.build())
   }
 }
 
 @DefinitionMarker
-class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
-  val name: String,
-  val propsClass: KClass<Props>,
-  val viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit
-) {
-  private var callbacksDefinition: CallbacksDefinition = CallbacksDefinition(arrayOf(GLOBAL_EVENT_NAME))
-
-  fun build(): ViewManagerDefinition {
-    return ViewManagerDefinition(
-      name = name,
-      viewFactory = { context, appContext ->
-        val instance: Props = try {
-          propsClass.createInstance()
-        } catch (e: Exception) {
-          throw IllegalStateException("Could not instantiate props instance of $name compose component.", e)
-        }
-        ComposeFunctionHolder(context, appContext, name, viewFunction, instance)
-      },
-      callbacksDefinition = callbacksDefinition,
-      viewType = ComposeFunctionHolder::class.java,
-      props = propsClass.memberProperties.associate { prop ->
-        val kType = prop.returnType
-        prop.name to ComposeViewProp(prop.name, AnyType(kType.toTypeDescriptor()), prop)
-      }
-    )
-  }
+class ComposeViewEventDefinitionBuilder {
+  internal var callbacksDefinition: CallbacksDefinition = CallbacksDefinition(arrayOf(GLOBAL_EVENT_NAME))
 
   /**
    * Defines prop names that should be treated as callbacks.
@@ -97,6 +79,109 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
   fun Events(callbacks: Array<String>) {
     callbacksDefinition = CallbacksDefinition(
       arrayOf(GLOBAL_EVENT_NAME, *callbacks)
+    )
+  }
+}
+
+@DefinitionMarker
+class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
+  val name: String,
+  val propsClass: KClass<Props>,
+  val viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit,
+  private val eventBuilder: ComposeViewEventDefinitionBuilder = ComposeViewEventDefinitionBuilder()
+) {
+  @PublishedApi
+  internal val viewType = typeDescriptorOf<ComposeFunctionHolder<ComposeProps>>()
+
+  @PublishedApi
+  internal var deferredFunctions = mutableMapOf<String, SuspendFunctionComponent>()
+
+  /**
+   * Declares an async function whose implementation is provided by
+   * [FunctionalComposableScope.AsyncFunctionHandler] inside the composable lambda.
+   */
+  fun AsyncFunction(name: String) {
+    deferredFunctions[name] = SuspendFunctionComponent(
+      name,
+      arrayOf(AnyType(viewType))
+    ) { args ->
+      val view = args[0] as ComposeFunctionHolder<*>
+      val handler = view.functionHandlers[name]
+        ?: error("No AsyncFunctionHandler registered for '$name' in the composable")
+      handler(emptyArray())
+    }
+  }
+
+  @JvmName("AsyncFunctionWith1Arg")
+  inline fun <reified P0> AsyncFunction(name: String) {
+    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0>())
+  }
+
+  @JvmName("AsyncFunctionWith2Args")
+  inline fun <reified P0, reified P1> AsyncFunction(name: String) {
+    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1>())
+  }
+
+  @JvmName("AsyncFunctionWith3Args")
+  inline fun <reified P0, reified P1, reified P2> AsyncFunction(name: String) {
+    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2>())
+  }
+
+  @JvmName("AsyncFunctionWith4Args")
+  inline fun <reified P0, reified P1, reified P2, reified P3> AsyncFunction(name: String) {
+    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3>())
+  }
+
+  @JvmName("AsyncFunctionWith5Args")
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunction(name: String) {
+    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4>())
+  }
+
+  @JvmName("AsyncFunctionWith6Args")
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunction(name: String) {
+    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4, P5>())
+  }
+
+  @JvmName("AsyncFunctionWith7Args")
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunction(name: String) {
+    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4, P5, P6>())
+  }
+
+  @PublishedApi
+  internal fun deferredFunctionWithArgs(name: String, argsTypes: Array<AnyType>) {
+    deferredFunctions[name] = SuspendFunctionComponent(name, argsTypes) { args ->
+      val view = args[0] as ComposeFunctionHolder<*>
+      val handler = view.functionHandlers[name]
+        ?: error("No AsyncFunctionHandler registered for '$name' in the composable")
+      handler(args.sliceArray(1 until args.size))
+    }
+  }
+
+  fun build(): ViewManagerDefinition {
+    val allFunctions = deferredFunctions
+    allFunctions.forEach { (_, function) ->
+      function.runOnQueue(Queues.MAIN)
+      function.ownerType = viewType
+      function.canTakeOwner = true
+    }
+
+    return ViewManagerDefinition(
+      name = name,
+      viewFactory = { context, appContext ->
+        val instance: Props = try {
+          propsClass.createInstance()
+        } catch (e: Exception) {
+          throw IllegalStateException("Could not instantiate props instance of $name compose component.", e)
+        }
+        ComposeFunctionHolder(context, appContext, name, viewFunction, instance)
+      },
+      callbacksDefinition = eventBuilder.callbacksDefinition,
+      viewType = ComposeFunctionHolder::class.java,
+      props = propsClass.memberProperties.associate { prop ->
+        val kType = prop.returnType
+        prop.name to ComposeViewProp(prop.name, AnyType(kType.toTypeDescriptor()), prop)
+      },
+      asyncFunctions = allFunctions.values.toList()
     )
   }
 }

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -205,8 +205,7 @@ class ComposeViewBuilderScope<Props : ComposeProps> @PublishedApi internal const
    *
    * Usage: `val onValueChange by Event<String>()`
    */
-  inline fun <reified T> Event(noinline coalescingKey: CoalescingKey<T>? = null):
-    PropertyDelegateProvider<Any?, EventHandle<T>> {
+  inline fun <reified T> Event(noinline coalescingKey: CoalescingKey<T>? = null): PropertyDelegateProvider<Any?, EventHandle<T>> {
     val scope = this
     return PropertyDelegateProvider { _, property ->
       scope.eventNames += property.name

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -12,7 +12,9 @@ import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.descriptors.toTypeDescriptor
 import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 import expo.modules.kotlin.types.toArgsArray
+import expo.modules.kotlin.viewevent.CoalescingKey
 import expo.modules.kotlin.views.decorators.UseCSSProps
+import kotlin.properties.PropertyDelegateProvider
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.memberProperties
@@ -44,17 +46,41 @@ open class ModuleDefinitionBuilderWithCompose(
     registerViewDefinition(viewDefinitionBuilder.build())
   }
 
+  /**
+   * Registers a compose view definition. Events and async functions are
+   * declared via `by Event<T>()` / `by AsyncFunction<T>()` property delegates
+   * on the builder scope; the composable body is supplied via
+   * `Content { props -> }`. Function/event names are derived from the
+   * variable name, so declaring and handling use a single Kotlin identifier.
+   */
   @JvmName("ComposeView")
   inline fun <reified Props : ComposeProps> View(
     name: String,
-    events: ComposeViewEventDefinitionBuilder.() -> Unit = {},
-    functions: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
+    block: ComposeViewBuilderScope<Props>.() -> Unit
+  ) {
+    val scope = ComposeViewBuilderScope<Props>(name, Props::class).apply(block)
+    registerViewDefinition(scope.build())
+  }
+
+  /**
+   * Legacy overload kept for source compatibility. `events` is required (pass
+   * `events = {}` if your view has no events) to disambiguate from the
+   * builder-scope overload above. Migrate to `View<Props>(name) { ... }`.
+   */
+  @Deprecated(
+    message = "Use the View<Props>(name) { ... Content { props -> ... } } builder-scope DSL. " +
+      "Declare events via `val onX by Event<T>()`.",
+    level = DeprecationLevel.WARNING
+  )
+  @JvmName("ComposeViewLegacy")
+  inline fun <reified Props : ComposeProps> View(
+    name: String,
+    events: ComposeViewEventDefinitionBuilder.() -> Unit,
     noinline viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit
   ) {
     val eventBuilder = ComposeViewEventDefinitionBuilder()
     events.invoke(eventBuilder)
     val functionBuilder = ComposeViewFunctionDefinitionBuilder(name, Props::class, viewFunction, eventBuilder)
-    functions.invoke(functionBuilder)
     registerViewDefinition(functionBuilder.build())
   }
 }
@@ -84,7 +110,7 @@ class ComposeViewEventDefinitionBuilder {
 }
 
 @DefinitionMarker
-class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
+class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps> @PublishedApi internal constructor(
   val name: String,
   val propsClass: KClass<Props>,
   val viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit,
@@ -96,68 +122,8 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
   @PublishedApi
   internal var deferredFunctions = mutableMapOf<String, SuspendFunctionComponent>()
 
-  /**
-   * Declares an async function whose implementation is provided by
-   * [FunctionalComposableScope.AsyncFunctionHandler] inside the composable lambda.
-   */
-  fun AsyncFunction(name: String) {
-    deferredFunctions[name] = SuspendFunctionComponent(
-      name,
-      arrayOf(AnyType(viewType))
-    ) { args ->
-      val view = args[0] as ComposeFunctionHolder<*>
-      val handler = view.functionHandlers[name]
-        ?: error("No AsyncFunctionHandler registered for '$name' in the composable")
-      handler(emptyArray())
-    }
-  }
-
-  @JvmName("AsyncFunctionWith1Arg")
-  inline fun <reified P0> AsyncFunction(name: String) {
-    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0>())
-  }
-
-  @JvmName("AsyncFunctionWith2Args")
-  inline fun <reified P0, reified P1> AsyncFunction(name: String) {
-    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1>())
-  }
-
-  @JvmName("AsyncFunctionWith3Args")
-  inline fun <reified P0, reified P1, reified P2> AsyncFunction(name: String) {
-    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2>())
-  }
-
-  @JvmName("AsyncFunctionWith4Args")
-  inline fun <reified P0, reified P1, reified P2, reified P3> AsyncFunction(name: String) {
-    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3>())
-  }
-
-  @JvmName("AsyncFunctionWith5Args")
-  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunction(name: String) {
-    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4>())
-  }
-
-  @JvmName("AsyncFunctionWith6Args")
-  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunction(name: String) {
-    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4, P5>())
-  }
-
-  @JvmName("AsyncFunctionWith7Args")
-  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunction(name: String) {
-    deferredFunctionWithArgs(name, toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4, P5, P6>())
-  }
-
   @PublishedApi
-  internal fun deferredFunctionWithArgs(name: String, argsTypes: Array<AnyType>) {
-    deferredFunctions[name] = SuspendFunctionComponent(name, argsTypes) { args ->
-      val view = args[0] as ComposeFunctionHolder<*>
-      val handler = view.functionHandlers[name]
-        ?: error("No AsyncFunctionHandler registered for '$name' in the composable")
-      handler(args.sliceArray(1 until args.size))
-    }
-  }
-
-  fun build(): ViewManagerDefinition {
+  internal fun build(): ViewManagerDefinition {
     val allFunctions = deferredFunctions
     allFunctions.forEach { (_, function) ->
       function.runOnQueue(Queues.MAIN)
@@ -183,5 +149,222 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
       },
       asyncFunctions = allFunctions.values.toList()
     )
+  }
+}
+
+/**
+ * Receiver of the `View<Props>(name) { ... }` block. Collects events and
+ * async function declarations (via `by Event<T>()` / `by AsyncFunction<T>()`
+ * property delegates) and the composable body (`Content { props -> ... }`),
+ * then hands them off to [ComposeViewFunctionDefinitionBuilder] at build time.
+ *
+ * Example:
+ * ```
+ * View<TextFieldProps>("TextFieldView") {
+ *   val focus by AsyncFunction()
+ *   val onValueChange by Event<String>()
+ *
+ *   Content { props ->
+ *     focus.handle { focusRequester.requestFocus() }
+ *     TextFieldContent(props, onValueChange = { onValueChange(it) })
+ *   }
+ * }
+ * ```
+ */
+@DefinitionMarker
+class ComposeViewBuilderScope<Props : ComposeProps> @PublishedApi internal constructor(
+  @PublishedApi internal val name: String,
+  @PublishedApi internal val propsClass: KClass<Props>
+) {
+  @PublishedApi
+  internal val viewType = typeDescriptorOf<ComposeFunctionHolder<ComposeProps>>()
+
+  @PublishedApi
+  internal val eventNames = mutableListOf<String>()
+
+  @PublishedApi
+  internal val asyncFunctions = mutableMapOf<String, SuspendFunctionComponent>()
+
+  @PublishedApi
+  internal var contentLambda: (@Composable FunctionalComposableScope.(Props) -> Unit)? = null
+
+  /**
+   * Declares one or more event names (callback props) without creating a typed
+   * [EventHandle]. Use this for callbacks whose dispatch site lives in a
+   * sibling composable that already has a payload type via its own
+   * `EventDispatcher<T>()`.
+   */
+  fun Events(vararg callbacks: String) {
+    eventNames += callbacks
+  }
+
+  /**
+   * Declares an event via property delegation. The event name is derived from
+   * the `val` identifier. The returned [EventHandle] dispatches by invocation
+   * inside the [Content] block, e.g. `onValueChange(payload)`.
+   *
+   * Usage: `val onValueChange by Event<String>()`
+   */
+  inline fun <reified T> Event(noinline coalescingKey: CoalescingKey<T>? = null):
+    PropertyDelegateProvider<Any?, EventHandle<T>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.eventNames += property.name
+      EventHandle(property.name, coalescingKey)
+    }
+  }
+
+  /**
+   * Declares a 0-arg async function via property delegation. The JS-visible
+   * function name is taken from the `val` identifier. Bind the handler inside
+   * [Content] with `handle.handle { ... }`.
+   *
+   * Usage: `val focus by AsyncFunction()`
+   */
+  fun AsyncFunction(): PropertyDelegateProvider<Any?, AsyncFunctionHandle<Unit>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.registerNoArgAsyncFunction(property.name)
+      AsyncFunctionHandle(property.name)
+    }
+  }
+
+  @JvmName("AsyncFunctionWith1Arg")
+  inline fun <reified P0> AsyncFunction(): PropertyDelegateProvider<Any?, AsyncFunctionHandle<P0>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.registerAsyncFunctionWithArgs(
+        property.name,
+        toArgsArray<ComposeFunctionHolder<ComposeProps>, P0>()
+      )
+      AsyncFunctionHandle(property.name)
+    }
+  }
+
+  @JvmName("AsyncFunctionWith2Args")
+  inline fun <reified P0, reified P1> AsyncFunction(): PropertyDelegateProvider<Any?, AsyncFunctionHandle2<P0, P1>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.registerAsyncFunctionWithArgs(
+        property.name,
+        toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1>()
+      )
+      AsyncFunctionHandle2(property.name)
+    }
+  }
+
+  @JvmName("AsyncFunctionWith3Args")
+  inline fun <reified P0, reified P1, reified P2> AsyncFunction(): PropertyDelegateProvider<Any?, AsyncFunctionHandle3<P0, P1, P2>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.registerAsyncFunctionWithArgs(
+        property.name,
+        toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2>()
+      )
+      AsyncFunctionHandle3(property.name)
+    }
+  }
+
+  @JvmName("AsyncFunctionWith4Args")
+  inline fun <reified P0, reified P1, reified P2, reified P3> AsyncFunction(): PropertyDelegateProvider<Any?, AsyncFunctionHandle4<P0, P1, P2, P3>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.registerAsyncFunctionWithArgs(
+        property.name,
+        toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3>()
+      )
+      AsyncFunctionHandle4(property.name)
+    }
+  }
+
+  @JvmName("AsyncFunctionWith5Args")
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> AsyncFunction(): PropertyDelegateProvider<Any?, AsyncFunctionHandle5<P0, P1, P2, P3, P4>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.registerAsyncFunctionWithArgs(
+        property.name,
+        toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4>()
+      )
+      AsyncFunctionHandle5(property.name)
+    }
+  }
+
+  @JvmName("AsyncFunctionWith6Args")
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> AsyncFunction(): PropertyDelegateProvider<Any?, AsyncFunctionHandle6<P0, P1, P2, P3, P4, P5>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.registerAsyncFunctionWithArgs(
+        property.name,
+        toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4, P5>()
+      )
+      AsyncFunctionHandle6(property.name)
+    }
+  }
+
+  @JvmName("AsyncFunctionWith7Args")
+  inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> AsyncFunction(): PropertyDelegateProvider<Any?, AsyncFunctionHandle7<P0, P1, P2, P3, P4, P5, P6>> {
+    val scope = this
+    return PropertyDelegateProvider { _, property ->
+      scope.registerAsyncFunctionWithArgs(
+        property.name,
+        toArgsArray<ComposeFunctionHolder<ComposeProps>, P0, P1, P2, P3, P4, P5, P6>()
+      )
+      AsyncFunctionHandle7(property.name)
+    }
+  }
+
+  @PublishedApi
+  internal fun registerNoArgAsyncFunction(fnName: String) {
+    require(fnName !in asyncFunctions) {
+      "AsyncFunction '$fnName' is already declared on view '$name'. Each function name must be unique within a view."
+    }
+    asyncFunctions[fnName] = SuspendFunctionComponent(
+      fnName,
+      arrayOf(AnyType(viewType))
+    ) { args ->
+      val view = args[0] as ComposeFunctionHolder<*>
+      val handler = view.functionHandlers[fnName]
+        ?: error("No handler registered for AsyncFunction '$fnName' on view '${view.name}'. Did you forget to bind it with `$fnName.handle { ... }` inside the Content { } block?")
+      handler(emptyArray())
+    }
+  }
+
+  @PublishedApi
+  internal fun registerAsyncFunctionWithArgs(fnName: String, argsTypes: Array<AnyType>) {
+    require(fnName !in asyncFunctions) {
+      "AsyncFunction '$fnName' is already declared on view '$name'. Each function name must be unique within a view."
+    }
+    asyncFunctions[fnName] = SuspendFunctionComponent(fnName, argsTypes) { args ->
+      val view = args[0] as ComposeFunctionHolder<*>
+      val handler = view.functionHandlers[fnName]
+        ?: error("No handler registered for AsyncFunction '$fnName' on view '${view.name}'. Did you forget to bind it with `$fnName.handle { ... }` inside the Content { } block?")
+      handler(args.sliceArray(1 until args.size))
+    }
+  }
+
+  /**
+   * Sets the composable body for this view. Must be called exactly once.
+   */
+  fun Content(block: @Composable FunctionalComposableScope.(Props) -> Unit) {
+    require(contentLambda == null) {
+      "Content { } must be set exactly once for view '$name'."
+    }
+    contentLambda = block
+  }
+
+  @PublishedApi
+  internal fun build(): ViewManagerDefinition {
+    val content = requireNotNull(contentLambda) {
+      "Content { } was not set for view '$name'. Add `Content { props -> ... }` inside the builder block."
+    }
+    val eventBuilder = ComposeViewEventDefinitionBuilder()
+    if (eventNames.isNotEmpty()) {
+      eventBuilder.Events(*eventNames.toTypedArray())
+    }
+    val functionBuilder = ComposeViewFunctionDefinitionBuilder(name, propsClass, content, eventBuilder)
+    asyncFunctions.forEach { (fnName, component) ->
+      functionBuilder.deferredFunctions[fnName] = component
+    }
+    return functionBuilder.build()
   }
 }

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -93,6 +93,7 @@
 - Refactored `ComposableScope` and allow extensibility. ([#44698](https://github.com/expo/expo/pull/44698) by [@kudo](https://github.com/kudo))
 - [jetpack-compose] Reuse `HorizontalAlignment` converter in `LazyColumn`. ([#44755](https://github.com/expo/expo/pull/44755) by [@kudo](https://github.com/kudo))
 - [jetpack-compose] Added `horizontalScroll` and `verticalScroll` modifiers. ([#44464](https://github.com/expo/expo/pull/44464) by [@kudo](https://github.com/kudo))
+- [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
 
 ## 55.0.1 — 2026-02-25
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.AsyncFunctionHandlerScope
+import expo.modules.kotlin.views.AsyncFunctionHandle
 import expo.modules.kotlin.views.FunctionalComposableScope
 
 data class ModalBottomSheetPropertiesRecord(
@@ -38,13 +38,13 @@ data class ModalBottomSheetViewProps(
 @Composable
 fun FunctionalComposableScope.ModalBottomSheetContent(
   props: ModalBottomSheetViewProps,
-  onHide: AsyncFunctionHandlerScope<Unit>,
+  hide: AsyncFunctionHandle<Unit>,
   onDismissRequest: () -> Unit
 ) {
   val sheetState = rememberModalBottomSheetState(props.skipPartiallyExpanded)
   val scope = rememberCoroutineScope()
 
-  onHide {
+  hide.handle {
     try {
       withContext(scope.coroutineContext) {
         sheetState.hide()

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -2,30 +2,22 @@
 
 package expo.modules.ui
 
-import android.annotation.SuppressLint
-import android.content.Context
 import android.graphics.Color
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.viewevent.EventDispatcher
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.ExpoComposeView
+import expo.modules.kotlin.views.AsyncFunctionHandlerScope
+import expo.modules.kotlin.views.FunctionalComposableScope
 
 data class ModalBottomSheetPropertiesRecord(
   @Field val shouldDismissOnBackPress: Boolean = true,
@@ -33,31 +25,29 @@ data class ModalBottomSheetPropertiesRecord(
 ) : Record
 
 data class ModalBottomSheetViewProps(
-  val skipPartiallyExpanded: MutableState<Boolean> = mutableStateOf(false),
-  val containerColor: MutableState<Color?> = mutableStateOf(null),
-  val contentColor: MutableState<Color?> = mutableStateOf(null),
-  val scrimColor: MutableState<Color?> = mutableStateOf(null),
-  val showDragHandle: MutableState<Boolean> = mutableStateOf(true),
-  val sheetGesturesEnabled: MutableState<Boolean> = mutableStateOf(true),
-  val properties: MutableState<ModalBottomSheetPropertiesRecord> = mutableStateOf(ModalBottomSheetPropertiesRecord()),
-  val modifiers: MutableState<ModifierList> = mutableStateOf(emptyList())
+  val skipPartiallyExpanded: Boolean = false,
+  val containerColor: Color? = null,
+  val contentColor: Color? = null,
+  val scrimColor: Color? = null,
+  val showDragHandle: Boolean = true,
+  val sheetGesturesEnabled: Boolean = true,
+  val properties: ModalBottomSheetPropertiesRecord = ModalBottomSheetPropertiesRecord(),
+  val modifiers: ModifierList = emptyList()
 ) : ComposeProps
 
-@SuppressLint("ViewConstructor")
-class ModalBottomSheetView(context: Context, appContext: AppContext) :
-  ExpoComposeView<ModalBottomSheetViewProps>(context, appContext) {
-  override val props = ModalBottomSheetViewProps()
-  internal val onDismissRequest by EventDispatcher<Unit>()
+@Composable
+fun FunctionalComposableScope.ModalBottomSheetContent(
+  props: ModalBottomSheetViewProps,
+  onHide: AsyncFunctionHandlerScope<Unit>,
+  onDismissRequest: () -> Unit
+) {
+  val sheetState = rememberModalBottomSheetState(props.skipPartiallyExpanded)
+  val scope = rememberCoroutineScope()
 
-  internal var sheetState: SheetState? = null
-  private var composeScope: CoroutineScope? = null
-
-  suspend fun hide() {
-    val scope = composeScope ?: return
-    val state = sheetState ?: return
+  onHide {
     try {
       withContext(scope.coroutineContext) {
-        state.hide()
+        sheetState.hide()
       }
     } catch (_: CancellationException) {
       // Swipe-dismiss may cancel the coroutine scope while hide() is in-flight.
@@ -65,43 +55,33 @@ class ModalBottomSheetView(context: Context, appContext: AppContext) :
     }
   }
 
-  @Composable
-  override fun ComposableScope.Content() {
-    val sheetState = rememberModalBottomSheetState(props.skipPartiallyExpanded.value)
-    val scope = rememberCoroutineScope()
-    this@ModalBottomSheetView.sheetState = sheetState
-    this@ModalBottomSheetView.composeScope = scope
+  val resolvedContainerColor = props.containerColor.composeOrNull ?: BottomSheetDefaults.ContainerColor
+  val resolvedContentColor = props.contentColor.composeOrNull ?: contentColorFor(resolvedContainerColor)
+  val resolvedScrimColor = props.scrimColor.composeOrNull ?: BottomSheetDefaults.ScrimColor
+  val dragHandleSlotView = findChildSlotView(view, "dragHandle")
 
-    val resolvedContainerColor = props.containerColor.value.composeOrNull ?: BottomSheetDefaults.ContainerColor
-    val resolvedContentColor = props.contentColor.value.composeOrNull ?: contentColorFor(resolvedContainerColor)
-    val resolvedScrimColor = props.scrimColor.value.composeOrNull ?: BottomSheetDefaults.ScrimColor
-    val dragHandleSlotView = findChildSlotView(this@ModalBottomSheetView, "dragHandle")
-
-    ModalBottomSheet(
-      sheetState = sheetState,
-      onDismissRequest = {
-        onDismissRequest(Unit)
-      },
-      containerColor = resolvedContainerColor,
-      contentColor = resolvedContentColor,
-      scrimColor = resolvedScrimColor,
-      sheetGesturesEnabled = props.sheetGesturesEnabled.value,
-      dragHandle = when {
-        dragHandleSlotView != null -> {
-          { with(UIComposableScope()) { with(dragHandleSlotView) { Content() } } }
-        }
-        props.showDragHandle.value -> {
-          { BottomSheetDefaults.DragHandle() }
-        }
-        else -> null
-      },
-      properties = ModalBottomSheetProperties(
-        shouldDismissOnBackPress = props.properties.value.shouldDismissOnBackPress,
-        shouldDismissOnClickOutside = props.properties.value.shouldDismissOnClickOutside
-      ),
-      modifier = ModifierRegistry.applyModifiers(props.modifiers.value, appContext, this@Content, globalEventDispatcher)
-    ) {
-      Children(UIComposableScope(), filter = { !isSlotView(it) })
-    }
+  ModalBottomSheet(
+    sheetState = sheetState,
+    onDismissRequest = onDismissRequest,
+    containerColor = resolvedContainerColor,
+    contentColor = resolvedContentColor,
+    scrimColor = resolvedScrimColor,
+    sheetGesturesEnabled = props.sheetGesturesEnabled,
+    dragHandle = when {
+      dragHandleSlotView != null -> {
+        { with(UIComposableScope()) { with(dragHandleSlotView) { Content() } } }
+      }
+      props.showDragHandle -> {
+        { BottomSheetDefaults.DragHandle() }
+      }
+      else -> null
+    },
+    properties = ModalBottomSheetProperties(
+      shouldDismissOnBackPress = props.properties.shouldDismissOnBackPress,
+      shouldDismissOnClickOutside = props.properties.shouldDismissOnClickOutside
+    ),
+    modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
+  ) {
+    Children(UIComposableScope(), filter = { !isSlotView(it) })
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -580,7 +580,11 @@ class ExpoUIModule : Module() {
       val onButtonPressed by Event<Unit>()
 
       Content { props ->
-        val clickHandler = if (props.clickable) { { onButtonPressed(Unit) } } else null
+        val clickHandler = if (props.clickable) {
+          { onButtonPressed(Unit) }
+        } else {
+          null
+        }
         RadioButtonContent(props, clickHandler)
       }
     }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -5,10 +5,8 @@ package expo.modules.ui
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.ToggleButtonDefaults
-import androidx.compose.runtime.remember
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import expo.modules.kotlin.viewevent.getValue
 import expo.modules.ui.button.ButtonContent
 import expo.modules.ui.button.ButtonPressedEvent
 import expo.modules.ui.button.ButtonProps
@@ -115,428 +113,507 @@ class ExpoUIModule : Module() {
 
     //region Expo UI views
 
-    ExpoUIView(
-      "ModalBottomSheetView",
-      events = {
-        Events("onDismissRequest")
-      },
-      functions = {
-        AsyncFunction("hide")
+    ExpoUIView<ModalBottomSheetViewProps>("ModalBottomSheetView") {
+      val hide by AsyncFunction()
+      val onDismissRequest by Event<Unit>()
+
+      Content { props ->
+        ModalBottomSheetContent(props, hide) { onDismissRequest(Unit) }
       }
-    ) { props: ModalBottomSheetViewProps ->
-      val onHide = AsyncFunctionHandler("hide")
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      ModalBottomSheetContent(props, onHide) { onDismissRequest(Unit) }
     }
 
-    ExpoUIView("SingleChoiceSegmentedButtonRowView") { props: SingleChoiceSegmentedButtonRowProps ->
-      SingleChoiceSegmentedButtonRowContent(props)
+    ExpoUIView<SingleChoiceSegmentedButtonRowProps>("SingleChoiceSegmentedButtonRowView") {
+      Content { props ->
+        SingleChoiceSegmentedButtonRowContent(props)
+      }
     }
 
-    ExpoUIView("MultiChoiceSegmentedButtonRowView") { props: MultiChoiceSegmentedButtonRowProps ->
-      MultiChoiceSegmentedButtonRowContent(props)
+    ExpoUIView<MultiChoiceSegmentedButtonRowProps>("MultiChoiceSegmentedButtonRowView") {
+      Content { props ->
+        MultiChoiceSegmentedButtonRowContent(props)
+      }
     }
 
-    ExpoUIView("SegmentedButtonView", events = {
-      Events("onButtonPressed", "onCheckedChange")
-    }) { props: SegmentedButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<Unit>() }
-      val onCheckedChange by remember { EventDispatcher<GenericEventPayload1<Boolean>>() }
-      SegmentedButtonContent(props, { onButtonPressed(Unit) }, { onCheckedChange(it) })
+    ExpoUIView<SegmentedButtonProps>("SegmentedButtonView") {
+      val onButtonPressed by Event<Unit>()
+      val onCheckedChange by Event<GenericEventPayload1<Boolean>>()
+
+      Content { props ->
+        SegmentedButtonContent(props, { onButtonPressed(Unit) }, { onCheckedChange(it) })
+      }
     }
 
-    ExpoUIView("SwitchView", events = {
-      Events("onCheckedChange")
-    }) { props: SwitchProps ->
-      val onCheckedChange by remember { EventDispatcher<CheckedChangeEvent>() }
-      SwitchContent(props) { value -> onCheckedChange(CheckedChangeEvent(value)) }
+    ExpoUIView<SwitchProps>("SwitchView") {
+      val onCheckedChange by Event<CheckedChangeEvent>()
+
+      Content { props ->
+        SwitchContent(props) { value -> onCheckedChange(CheckedChangeEvent(value)) }
+      }
     }
 
-    ExpoUIView("CheckboxView", events = {
-      Events("onCheckedChange")
-    }) { props: CheckboxProps ->
-      val onCheckedChange by remember { EventDispatcher<CheckedChangeEvent>() }
-      CheckboxContent(props) { value -> onCheckedChange(CheckedChangeEvent(value)) }
+    ExpoUIView<CheckboxProps>("CheckboxView") {
+      val onCheckedChange by Event<CheckedChangeEvent>()
+
+      Content { props ->
+        CheckboxContent(props) { value -> onCheckedChange(CheckedChangeEvent(value)) }
+      }
     }
 
-    ExpoUIView("TriStateCheckboxView", events = {
-      Events("onNativeClick")
-    }) { props: TriStateCheckboxProps ->
-      val onNativeClick by remember { EventDispatcher<Unit>() }
-      TriStateCheckboxContent(props) { onNativeClick(Unit) }
+    ExpoUIView<TriStateCheckboxProps>("TriStateCheckboxView") {
+      val onNativeClick by Event<Unit>()
+
+      Content { props ->
+        TriStateCheckboxContent(props) { onNativeClick(Unit) }
+      }
     }
 
-    ExpoUIView("Button", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      ButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("Button") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        ButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("FilledTonalButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      FilledTonalButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("FilledTonalButton") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        FilledTonalButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("OutlinedButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      OutlinedButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("OutlinedButton") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        OutlinedButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("ElevatedButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      ElevatedButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("ElevatedButton") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        ElevatedButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("TextButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      TextButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("TextButton") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        TextButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("IconButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      IconButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("IconButton") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        IconButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("FilledIconButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      FilledIconButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("FilledIconButton") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        FilledIconButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("FilledTonalIconButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      FilledTonalIconButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("FilledTonalIconButton") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        FilledTonalIconButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("OutlinedIconButton", events = {
-      Events("onButtonPressed")
-    }) { props: ButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<ButtonPressedEvent>() }
-      OutlinedIconButtonContent(props) { onButtonPressed(it) }
+    ExpoUIView<ButtonProps>("OutlinedIconButton") {
+      val onButtonPressed by Event<ButtonPressedEvent>()
+
+      Content { props ->
+        OutlinedIconButtonContent(props) { onButtonPressed(it) }
+      }
     }
 
-    ExpoUIView("SliderView", events = {
+    ExpoUIView<SliderProps>("SliderView") {
       Events("onValueChange", "onValueChangeFinished")
-    }) { props: SliderProps ->
-      SliderContent(props)
-    }
 
-    ExpoUIView("ShapeView") { props: ShapeProps ->
-      ShapeContent(props)
-    }
-
-    ExpoUIView("HorizontalDividerView") { props: DividerProps ->
-      HorizontalDividerContent(props)
-    }
-
-    ExpoUIView("VerticalDividerView") { props: DividerProps ->
-      VerticalDividerContent(props)
-    }
-
-    ExpoUIView("DateTimePickerView", events = {
-      Events("onDateSelected")
-    }) { props: DateTimePickerProps ->
-      val onDateSelected by remember { EventDispatcher<DatePickerResult>() }
-      DateTimePickerContent(props) { onDateSelected(it) }
-    }
-
-    ExpoUIView("DatePickerDialogView", events = {
-      Events("onDateSelected", "onDismissRequest")
-    }) { props: DatePickerDialogProps ->
-      val onDateSelected by remember { EventDispatcher<DatePickerResult>() }
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      ExpoDatePickerDialogContent(props, { onDateSelected(it) }, { onDismissRequest(Unit) })
-    }
-
-    ExpoUIView("TimePickerDialogView", events = {
-      Events("onDateSelected", "onDismissRequest")
-    }) { props: TimePickerDialogProps ->
-      val onDateSelected by remember { EventDispatcher<DatePickerResult>() }
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      ExpoTimePickerDialogContent(props, { onDateSelected(it) }, { onDismissRequest(Unit) })
-    }
-
-    ExpoUIView("DropdownMenuView", events = {
-      Events("onDismissRequest")
-    }) { props: DropdownMenuProps ->
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      DropdownMenuContent(props) { onDismissRequest(Unit) }
-    }
-
-    ExpoUIView("DropdownMenuItemView", events = {
-      Events("onItemPressed")
-    }) { props: DropdownMenuItemProps ->
-      val onItemPressed by remember { EventDispatcher<Unit>() }
-      DropdownMenuItemContent(props) { onItemPressed(Unit) }
-    }
-
-    ExpoUIView("LinearProgressIndicatorView") { props: LinearProgressIndicatorProps ->
-      LinearProgressIndicatorContent(props)
-    }
-
-    ExpoUIView("CircularProgressIndicatorView") { props: CircularProgressIndicatorProps ->
-      CircularProgressIndicatorContent(props)
-    }
-
-    ExpoUIView("LinearWavyProgressIndicatorView") { props: LinearWavyProgressIndicatorProps ->
-      LinearWavyProgressIndicatorContent(props)
-    }
-
-    ExpoUIView("CircularWavyProgressIndicatorView") { props: CircularWavyProgressIndicatorProps ->
-      CircularWavyProgressIndicatorContent(props)
-    }
-
-    ExpoUIView("BoxView") { props: LayoutProps ->
-      BoxContent(props)
-    }
-
-    ExpoUIView("RowView") { props: LayoutProps ->
-      RowContent(props)
-    }
-
-    ExpoUIView("FlowRowView") { props: LayoutProps ->
-      FlowRowContent(props)
-    }
-
-    ExpoUIView("ColumnView") { props: LayoutProps ->
-      ColumnContent(props)
-    }
-
-    ExpoUIView("TextView") { props: TextProps ->
-      TextContent(props)
-    }
-
-    ExpoUIView("SearchBarView", events = {
-      Events("onSearch")
-    }) { props: SearchBarProps ->
-      val onSearch by remember { EventDispatcher<GenericEventPayload1<String>>() }
-      SearchBarContent(props) { onSearch(it) }
-    }
-
-    ExpoUIView("DockedSearchBarView", events = {
-      Events("onQueryChange")
-    }) { props: DockedSearchBarProps ->
-      val onQueryChange by remember { EventDispatcher<GenericEventPayload1<String>>() }
-      DockedSearchBarContent(props) { onQueryChange(it) }
-    }
-
-    ExpoUIView("HorizontalFloatingToolbarView") { props: HorizontalFloatingToolbarProps ->
-      HorizontalFloatingToolbarContent(props)
-    }
-
-    ExpoUIView("PullToRefreshBoxView", events = {
-      Events("onRefresh")
-    }) { props: PullToRefreshBoxProps ->
-      val onRefresh by remember { EventDispatcher<Unit>() }
-      PullToRefreshBoxContent(props) { onRefresh(Unit) }
-    }
-
-    ExpoUIView("HorizontalCenteredHeroCarouselView") { props: HorizontalCenteredHeroCarouselProps ->
-      HorizontalCenteredHeroCarouselContent(props)
-    }
-
-    ExpoUIView("HorizontalMultiBrowseCarouselView") { props: HorizontalMultiBrowseCarouselProps ->
-      HorizontalMultiBrowseCarouselContent(props)
-    }
-
-    ExpoUIView("HorizontalUncontainedCarouselView") { props: HorizontalUncontainedCarouselProps ->
-      HorizontalUncontainedCarouselContent(props)
-    }
-
-    ExpoUIView("AlertDialogView", events = {
-      Events("onDismissRequest")
-    }) { props: AlertDialogProps ->
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      AlertDialogContent(props) { onDismissRequest(Unit) }
-    }
-
-    ExpoUIView("AssistChipView", events = {
-      Events("onNativeClick")
-    }) { props: AssistChipProps ->
-      val onNativeClick by remember { EventDispatcher<ChipPressedEvent>() }
-      AssistChipContent(props) { onNativeClick(it) }
-    }
-
-    ExpoUIView("InputChipView", events = {
-      Events("onNativeClick")
-    }) { props: InputChipProps ->
-      val onNativeClick by remember { EventDispatcher<ChipPressedEvent>() }
-      InputChipContent(props) { onNativeClick(it) }
-    }
-
-    ExpoUIView("SuggestionChipView", events = {
-      Events("onNativeClick")
-    }) { props: SuggestionChipProps ->
-      val onNativeClick by remember { EventDispatcher<ChipPressedEvent>() }
-      SuggestionChipContent(props) { onNativeClick(it) }
-    }
-
-    ExpoUIView("FilterChipView", events = {
-      Events("onNativeClick")
-    }) { props: FilterChipProps ->
-      val onNativeClick by remember { EventDispatcher<ChipPressedEvent>() }
-      FilterChipContent(props) { onNativeClick(it) }
-    }
-
-    ExpoUIView("ToggleButton", events = {
-      Events("onCheckedChange")
-    }) { props: ToggleButtonProps ->
-      val onCheckedChange by remember { EventDispatcher<ToggleButtonValueChangeEvent>() }
-      ToggleButtonContent(props) { onCheckedChange(it) }
-    }
-
-    ExpoUIView("IconToggleButton", events = {
-      Events("onCheckedChange")
-    }) { props: ToggleButtonProps ->
-      val onCheckedChange by remember { EventDispatcher<ToggleButtonValueChangeEvent>() }
-      IconToggleButtonContent(props) { onCheckedChange(it) }
-    }
-
-    ExpoUIView("FilledIconToggleButton", events = {
-      Events("onCheckedChange")
-    }) { props: ToggleButtonProps ->
-      val onCheckedChange by remember { EventDispatcher<ToggleButtonValueChangeEvent>() }
-      FilledIconToggleButtonContent(props) { onCheckedChange(it) }
-    }
-
-    ExpoUIView("OutlinedIconToggleButton", events = {
-      Events("onCheckedChange")
-    }) { props: ToggleButtonProps ->
-      val onCheckedChange by remember { EventDispatcher<ToggleButtonValueChangeEvent>() }
-      OutlinedIconToggleButtonContent(props) { onCheckedChange(it) }
-    }
-
-    ExpoUIView("CardView") { props: CardProps ->
-      CardContent(props)
-    }
-
-    ExpoUIView("ElevatedCardView") { props: ElevatedCardProps ->
-      ElevatedCardContent(props)
-    }
-
-    ExpoUIView("OutlinedCardView") { props: OutlinedCardProps ->
-      OutlinedCardContent(props)
-    }
-
-    ExpoUIView("ListItemView") { props: ListItemProps ->
-      ListItemContent(props)
-    }
-
-    ExpoUIView("BadgeView") { props: BadgeProps ->
-      BadgeContent(props)
-    }
-
-    ExpoUIView("BadgedBoxView") { props: BadgedBoxProps ->
-      BadgedBoxContent(props)
-    }
-
-    ExpoUIView("SpacerView") { props: SpacerProps ->
-      SpacerContent(props)
-    }
-
-    ExpoUIView("BasicAlertDialogView", events = {
-      Events("onDismissRequest")
-    }) { props: BasicAlertDialogProps ->
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      BasicAlertDialogContent(props) { onDismissRequest(Unit) }
-    }
-
-    ExpoUIView("SurfaceView", events = {
-      Events("onSurfaceClick", "onCheckedChange")
-    }) { props: SurfaceProps ->
-      val onSurfaceClick by remember { EventDispatcher<Unit>() }
-      val onCheckedChange by remember { EventDispatcher<GenericEventPayload1<Boolean>>() }
-      SurfaceContent(props, onClick = { onSurfaceClick(Unit) }, onCheckedChange = { onCheckedChange(GenericEventPayload1(it)) })
-    }
-
-    ExpoUIView("AnimatedVisibilityView") { props: AnimatedVisibilityProps ->
-      AnimatedVisibilityContent(props)
-    }
-
-    ExpoUIView("TooltipBoxView",
-      functions = {
-        AsyncFunction("show")
-        AsyncFunction("dismiss")
+      Content { props ->
+        SliderContent(props)
       }
-    ) { props: TooltipBoxViewProps ->
-      val onShow = AsyncFunctionHandler("show")
-      val onDismiss = AsyncFunctionHandler("dismiss")
-      TooltipBoxContent(props, onShow, onDismiss)
     }
 
-    ExpoUIView("TextFieldView",
-      events = {
-        Events("onValueChange", "onFocusChanged", "onKeyboardAction")
-      },
-      functions = {
-        AsyncFunction<String>("setText")
-        AsyncFunction("focus")
-        AsyncFunction("blur")
+    ExpoUIView<ShapeProps>("ShapeView") {
+      Content { props ->
+        ShapeContent(props)
       }
-    ) { props: TextFieldProps ->
-      val onSetText = AsyncFunctionHandler<String>("setText")
-      val onFocus = AsyncFunctionHandler("focus")
-      val onBlur = AsyncFunctionHandler("blur")
-      val onValueChange by remember { EventDispatcher<GenericEventPayload1<String>>() }
-      val onFocusChanged by remember { EventDispatcher<GenericEventPayload1<Boolean>>() }
-      val onKeyboardAction by remember { EventDispatcher<KeyboardActionEvent>() }
-      TextFieldContent(
-        props,
-        onSetText,
-        onFocus,
-        onBlur,
-        onValueChanged = { onValueChange(it) },
-        onFocusChange = { onFocusChanged(it) },
-        onKeyboardActionTriggered = { onKeyboardAction(it) }
-      )
     }
 
-    ExpoUIView("RadioButtonView", events = {
-      Events("onButtonPressed")
-    }) { props: RadioButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<Unit>() }
-      val clickHandler = if (props.clickable) { { onButtonPressed(Unit) } } else null
-      RadioButtonContent(props, clickHandler)
+    ExpoUIView<DividerProps>("HorizontalDividerView") {
+      Content { props ->
+        HorizontalDividerContent(props)
+      }
     }
 
-    ExpoUIView("FloatingActionButtonView", events = {
-      Events("onButtonPressed")
-    }) { props: FloatingActionButtonProps ->
-      val onButtonPressed by remember { EventDispatcher<Unit>() }
-      FloatingActionButtonContent(props) { onButtonPressed(Unit) }
+    ExpoUIView<DividerProps>("VerticalDividerView") {
+      Content { props ->
+        VerticalDividerContent(props)
+      }
+    }
+
+    ExpoUIView<DateTimePickerProps>("DateTimePickerView") {
+      val onDateSelected by Event<DatePickerResult>()
+
+      Content { props ->
+        DateTimePickerContent(props) { onDateSelected(it) }
+      }
+    }
+
+    ExpoUIView<DatePickerDialogProps>("DatePickerDialogView") {
+      val onDateSelected by Event<DatePickerResult>()
+      val onDismissRequest by Event<Unit>()
+
+      Content { props ->
+        ExpoDatePickerDialogContent(props, { onDateSelected(it) }, { onDismissRequest(Unit) })
+      }
+    }
+
+    ExpoUIView<TimePickerDialogProps>("TimePickerDialogView") {
+      val onDateSelected by Event<DatePickerResult>()
+      val onDismissRequest by Event<Unit>()
+
+      Content { props ->
+        ExpoTimePickerDialogContent(props, { onDateSelected(it) }, { onDismissRequest(Unit) })
+      }
+    }
+
+    ExpoUIView<DropdownMenuProps>("DropdownMenuView") {
+      val onDismissRequest by Event<Unit>()
+
+      Content { props ->
+        DropdownMenuContent(props) { onDismissRequest(Unit) }
+      }
+    }
+
+    ExpoUIView<DropdownMenuItemProps>("DropdownMenuItemView") {
+      val onItemPressed by Event<Unit>()
+
+      Content { props ->
+        DropdownMenuItemContent(props) { onItemPressed(Unit) }
+      }
+    }
+
+    ExpoUIView<LinearProgressIndicatorProps>("LinearProgressIndicatorView") {
+      Content { props ->
+        LinearProgressIndicatorContent(props)
+      }
+    }
+
+    ExpoUIView<CircularProgressIndicatorProps>("CircularProgressIndicatorView") {
+      Content { props ->
+        CircularProgressIndicatorContent(props)
+      }
+    }
+
+    ExpoUIView<LinearWavyProgressIndicatorProps>("LinearWavyProgressIndicatorView") {
+      Content { props ->
+        LinearWavyProgressIndicatorContent(props)
+      }
+    }
+
+    ExpoUIView<CircularWavyProgressIndicatorProps>("CircularWavyProgressIndicatorView") {
+      Content { props ->
+        CircularWavyProgressIndicatorContent(props)
+      }
+    }
+
+    ExpoUIView<LayoutProps>("BoxView") {
+      Content { props ->
+        BoxContent(props)
+      }
+    }
+
+    ExpoUIView<LayoutProps>("RowView") {
+      Content { props ->
+        RowContent(props)
+      }
+    }
+
+    ExpoUIView<LayoutProps>("FlowRowView") {
+      Content { props ->
+        FlowRowContent(props)
+      }
+    }
+
+    ExpoUIView<LayoutProps>("ColumnView") {
+      Content { props ->
+        ColumnContent(props)
+      }
+    }
+
+    ExpoUIView<TextProps>("TextView") {
+      Content { props ->
+        TextContent(props)
+      }
+    }
+
+    ExpoUIView<SearchBarProps>("SearchBarView") {
+      val onSearch by Event<GenericEventPayload1<String>>()
+
+      Content { props ->
+        SearchBarContent(props) { onSearch(it) }
+      }
+    }
+
+    ExpoUIView<DockedSearchBarProps>("DockedSearchBarView") {
+      val onQueryChange by Event<GenericEventPayload1<String>>()
+
+      Content { props ->
+        DockedSearchBarContent(props) { onQueryChange(it) }
+      }
+    }
+
+    ExpoUIView<HorizontalFloatingToolbarProps>("HorizontalFloatingToolbarView") {
+      Content { props ->
+        HorizontalFloatingToolbarContent(props)
+      }
+    }
+
+    ExpoUIView<PullToRefreshBoxProps>("PullToRefreshBoxView") {
+      val onRefresh by Event<Unit>()
+
+      Content { props ->
+        PullToRefreshBoxContent(props) { onRefresh(Unit) }
+      }
+    }
+
+    ExpoUIView<HorizontalCenteredHeroCarouselProps>("HorizontalCenteredHeroCarouselView") {
+      Content { props ->
+        HorizontalCenteredHeroCarouselContent(props)
+      }
+    }
+
+    ExpoUIView<HorizontalMultiBrowseCarouselProps>("HorizontalMultiBrowseCarouselView") {
+      Content { props ->
+        HorizontalMultiBrowseCarouselContent(props)
+      }
+    }
+
+    ExpoUIView<HorizontalUncontainedCarouselProps>("HorizontalUncontainedCarouselView") {
+      Content { props ->
+        HorizontalUncontainedCarouselContent(props)
+      }
+    }
+
+    ExpoUIView<AlertDialogProps>("AlertDialogView") {
+      val onDismissRequest by Event<Unit>()
+
+      Content { props ->
+        AlertDialogContent(props) { onDismissRequest(Unit) }
+      }
+    }
+
+    ExpoUIView<AssistChipProps>("AssistChipView") {
+      val onNativeClick by Event<ChipPressedEvent>()
+
+      Content { props ->
+        AssistChipContent(props) { onNativeClick(it) }
+      }
+    }
+
+    ExpoUIView<InputChipProps>("InputChipView") {
+      val onNativeClick by Event<ChipPressedEvent>()
+
+      Content { props ->
+        InputChipContent(props) { onNativeClick(it) }
+      }
+    }
+
+    ExpoUIView<SuggestionChipProps>("SuggestionChipView") {
+      val onNativeClick by Event<ChipPressedEvent>()
+
+      Content { props ->
+        SuggestionChipContent(props) { onNativeClick(it) }
+      }
+    }
+
+    ExpoUIView<FilterChipProps>("FilterChipView") {
+      val onNativeClick by Event<ChipPressedEvent>()
+
+      Content { props ->
+        FilterChipContent(props) { onNativeClick(it) }
+      }
+    }
+
+    ExpoUIView<ToggleButtonProps>("ToggleButton") {
+      val onCheckedChange by Event<ToggleButtonValueChangeEvent>()
+
+      Content { props ->
+        ToggleButtonContent(props) { onCheckedChange(it) }
+      }
+    }
+
+    ExpoUIView<ToggleButtonProps>("IconToggleButton") {
+      val onCheckedChange by Event<ToggleButtonValueChangeEvent>()
+
+      Content { props ->
+        IconToggleButtonContent(props) { onCheckedChange(it) }
+      }
+    }
+
+    ExpoUIView<ToggleButtonProps>("FilledIconToggleButton") {
+      val onCheckedChange by Event<ToggleButtonValueChangeEvent>()
+
+      Content { props ->
+        FilledIconToggleButtonContent(props) { onCheckedChange(it) }
+      }
+    }
+
+    ExpoUIView<ToggleButtonProps>("OutlinedIconToggleButton") {
+      val onCheckedChange by Event<ToggleButtonValueChangeEvent>()
+
+      Content { props ->
+        OutlinedIconToggleButtonContent(props) { onCheckedChange(it) }
+      }
+    }
+
+    ExpoUIView<CardProps>("CardView") {
+      Content { props ->
+        CardContent(props)
+      }
+    }
+
+    ExpoUIView<ElevatedCardProps>("ElevatedCardView") {
+      Content { props ->
+        ElevatedCardContent(props)
+      }
+    }
+
+    ExpoUIView<OutlinedCardProps>("OutlinedCardView") {
+      Content { props ->
+        OutlinedCardContent(props)
+      }
+    }
+
+    ExpoUIView<ListItemProps>("ListItemView") {
+      Content { props ->
+        ListItemContent(props)
+      }
+    }
+
+    ExpoUIView<BadgeProps>("BadgeView") {
+      Content { props ->
+        BadgeContent(props)
+      }
+    }
+
+    ExpoUIView<BadgedBoxProps>("BadgedBoxView") {
+      Content { props ->
+        BadgedBoxContent(props)
+      }
+    }
+
+    ExpoUIView<SpacerProps>("SpacerView") {
+      Content { props ->
+        SpacerContent(props)
+      }
+    }
+
+    ExpoUIView<BasicAlertDialogProps>("BasicAlertDialogView") {
+      val onDismissRequest by Event<Unit>()
+
+      Content { props ->
+        BasicAlertDialogContent(props) { onDismissRequest(Unit) }
+      }
+    }
+
+    ExpoUIView<SurfaceProps>("SurfaceView") {
+      val onSurfaceClick by Event<Unit>()
+      val onCheckedChange by Event<GenericEventPayload1<Boolean>>()
+
+      Content { props ->
+        SurfaceContent(props, onClick = { onSurfaceClick(Unit) }, onCheckedChange = { onCheckedChange(GenericEventPayload1(it)) })
+      }
+    }
+
+    ExpoUIView<AnimatedVisibilityProps>("AnimatedVisibilityView") {
+      Content { props ->
+        AnimatedVisibilityContent(props)
+      }
+    }
+
+    ExpoUIView<TooltipBoxViewProps>("TooltipBoxView") {
+      val show by AsyncFunction()
+      val dismiss by AsyncFunction()
+
+      Content { props ->
+        TooltipBoxContent(props, show, dismiss)
+      }
+    }
+
+    ExpoUIView<TextFieldProps>("TextFieldView") {
+      val setText by AsyncFunction<String>()
+      val focus by AsyncFunction()
+      val blur by AsyncFunction()
+      val onValueChange by Event<GenericEventPayload1<String>>()
+      val onFocusChanged by Event<GenericEventPayload1<Boolean>>()
+      val onKeyboardAction by Event<KeyboardActionEvent>()
+
+      Content { props ->
+        TextFieldContent(
+          props,
+          setText,
+          focus,
+          blur,
+          onValueChanged = { onValueChange(it) },
+          onFocusChange = { onFocusChanged(it) },
+          onKeyboardActionTriggered = { onKeyboardAction(it) }
+        )
+      }
+    }
+
+    ExpoUIView<RadioButtonProps>("RadioButtonView") {
+      val onButtonPressed by Event<Unit>()
+
+      Content { props ->
+        val clickHandler = if (props.clickable) { { onButtonPressed(Unit) } } else null
+        RadioButtonContent(props, clickHandler)
+      }
+    }
+
+    ExpoUIView<FloatingActionButtonProps>("FloatingActionButtonView") {
+      val onButtonPressed by Event<Unit>()
+
+      Content { props ->
+        FloatingActionButtonContent(props) { onButtonPressed(Unit) }
+      }
     }
 
     // Experimental Compose state support to trigger synchronous state updates from UI worklet.
-    ExpoUIView("SyncSwitchView") { props: SyncSwitchProps ->
-      SyncSwitchContent(props)
+    ExpoUIView<SyncSwitchProps>("SyncSwitchView") {
+      Content { props ->
+        SyncSwitchContent(props)
+      }
     }
 
-    ExpoUIView("ExposedDropdownMenuBoxView", events = {
-      Events("onExpandedChange")
-    }) { props: ExposedDropdownMenuBoxProps ->
-      val onExpandedChange by remember { EventDispatcher<GenericEventPayload1<Boolean>>() }
-      ExposedDropdownMenuBoxContent(props) { onExpandedChange(GenericEventPayload1(it)) }
+    ExpoUIView<ExposedDropdownMenuBoxProps>("ExposedDropdownMenuBoxView") {
+      val onExpandedChange by Event<GenericEventPayload1<Boolean>>()
+
+      Content { props ->
+        ExposedDropdownMenuBoxContent(props) { onExpandedChange(GenericEventPayload1(it)) }
+      }
     }
 
-    ExpoUIView("ExposedDropdownMenuView", events = {
-      Events("onDismissRequest")
-    }) { props: ExposedDropdownMenuProps ->
-      val onDismissRequest by remember { EventDispatcher<Unit>() }
-      ExposedDropdownMenuContent(props) { onDismissRequest(Unit) }
+    ExpoUIView<ExposedDropdownMenuProps>("ExposedDropdownMenuView") {
+      val onDismissRequest by Event<Unit>()
+
+      Content { props ->
+        ExposedDropdownMenuContent(props) { onDismissRequest(Unit) }
+      }
     }
 
     //endregion Expo UI views

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.runtime.remember
-import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.viewevent.getValue
@@ -101,22 +100,6 @@ class ExpoUIModule : Module() {
 
     View(RNHostView::class)
 
-    View(TextFieldView::class) {
-      Events("onValueChange", "onFocusChanged", "onKeyboardAction")
-      Prop("defaultValue", "") { view: TextFieldView, text: String ->
-        if (view.text == null) { view.text = text }
-      }
-      AsyncFunction("setText") { view: TextFieldView, text: String ->
-        view.text = text
-      }
-      AsyncFunction("focus") { view: TextFieldView ->
-        view.focus()
-      }
-      AsyncFunction("blur") { view: TextFieldView ->
-        view.blur()
-      }
-    }
-
     View(SlotView::class) {
       Events("onSlotEvent")
     }
@@ -124,15 +107,26 @@ class ExpoUIModule : Module() {
     View(LazyColumnView::class)
     View(LazyRowView::class)
 
+    // Class-based views so TooltipBoxView can detect them by type via findChildOfType
+    View(PlainTooltipView::class)
+    View(RichTooltipView::class)
+
     //endregion Views use expo-modules-core DSL for uncommon features
 
     //region Expo UI views
 
-    View(ModalBottomSheetView::class) {
-      Events("onDismissRequest")
-      AsyncFunction("hide") Coroutine { view: ModalBottomSheetView ->
-        view.hide()
+    ExpoUIView(
+      "ModalBottomSheetView",
+      events = {
+        Events("onDismissRequest")
+      },
+      functions = {
+        AsyncFunction("hide")
       }
+    ) { props: ModalBottomSheetViewProps ->
+      val onHide = AsyncFunctionHandler("hide")
+      val onDismissRequest by remember { EventDispatcher<Unit>() }
+      ModalBottomSheetContent(props, onHide) { onDismissRequest(Unit) }
     }
 
     ExpoUIView("SingleChoiceSegmentedButtonRowView") { props: SingleChoiceSegmentedButtonRowProps ->
@@ -473,17 +467,42 @@ class ExpoUIModule : Module() {
       AnimatedVisibilityContent(props)
     }
 
-    // Class-based views so TooltipBoxView can detect them by type via findChildOfType
-    View(PlainTooltipView::class)
-    View(RichTooltipView::class)
+    ExpoUIView("TooltipBoxView",
+      functions = {
+        AsyncFunction("show")
+        AsyncFunction("dismiss")
+      }
+    ) { props: TooltipBoxViewProps ->
+      val onShow = AsyncFunctionHandler("show")
+      val onDismiss = AsyncFunctionHandler("dismiss")
+      TooltipBoxContent(props, onShow, onDismiss)
+    }
 
-    View(TooltipBoxView::class) {
-      AsyncFunction("show") Coroutine { view: TooltipBoxView ->
-        view.show()
+    ExpoUIView("TextFieldView",
+      events = {
+        Events("onValueChange", "onFocusChanged", "onKeyboardAction")
+      },
+      functions = {
+        AsyncFunction<String>("setText")
+        AsyncFunction("focus")
+        AsyncFunction("blur")
       }
-      AsyncFunction("dismiss") Coroutine { view: TooltipBoxView ->
-        view.dismiss()
-      }
+    ) { props: TextFieldProps ->
+      val onSetText = AsyncFunctionHandler<String>("setText")
+      val onFocus = AsyncFunctionHandler("focus")
+      val onBlur = AsyncFunctionHandler("blur")
+      val onValueChange by remember { EventDispatcher<GenericEventPayload1<String>>() }
+      val onFocusChanged by remember { EventDispatcher<GenericEventPayload1<Boolean>>() }
+      val onKeyboardAction by remember { EventDispatcher<KeyboardActionEvent>() }
+      TextFieldContent(
+        props,
+        onSetText,
+        onFocus,
+        onBlur,
+        onValueChanged = { onValueChange(it) },
+        onFocusChange = { onFocusChanged(it) },
+        onKeyboardActionTriggered = { onKeyboardAction(it) }
+      )
     }
 
     ExpoUIView("RadioButtonView", events = {

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.views.AsyncFunctionHandlerScope
+import expo.modules.kotlin.views.AsyncFunctionHandle
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -219,9 +219,9 @@ private fun String?.toImeAction(): ImeAction = when (this) {
 @Composable
 fun FunctionalComposableScope.TextFieldContent(
   props: TextFieldProps,
-  onSetText: AsyncFunctionHandlerScope<String>,
-  onFocus: AsyncFunctionHandlerScope<Unit>,
-  onBlur: AsyncFunctionHandlerScope<Unit>,
+  setText: AsyncFunctionHandle<String>,
+  focus: AsyncFunctionHandle<Unit>,
+  blur: AsyncFunctionHandle<Unit>,
   onValueChanged: (GenericEventPayload1<String>) -> Unit,
   onFocusChange: (GenericEventPayload1<Boolean>) -> Unit,
   onKeyboardActionTriggered: (KeyboardActionEvent) -> Unit
@@ -230,13 +230,13 @@ fun FunctionalComposableScope.TextFieldContent(
   val focusRequester = remember { FocusRequester() }
   val textState = remember { mutableStateOf<String?>(null) }
 
-  onSetText { text ->
+  setText.handle { text ->
     textState.value = text
   }
-  onFocus {
+  focus.handle {
     focusRequester.requestFocus()
   }
-  onBlur {
+  blur.handle {
     focusManager.clearFocus()
   }
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
@@ -1,7 +1,5 @@
 package expo.modules.ui
 
-import android.annotation.SuppressLint
-import android.content.Context
 import android.graphics.Color
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -12,9 +10,8 @@ import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.focus.FocusManager
+import androidx.compose.runtime.remember
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
@@ -22,14 +19,12 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
-import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.viewevent.EventDispatcher
-import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.AsyncFunctionHandlerScope
 import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.ExpoComposeView
+import expo.modules.kotlin.views.FunctionalComposableScope
 
 // region Records
 
@@ -101,6 +96,11 @@ data class TextFieldColorsRecord(
   @Field val errorSuffixColor: Color? = null,
 ) : Record
 
+data class KeyboardActionEvent(
+  @Field val action: String,
+  @Field val value: String,
+) : Record
+
 // endregion Records
 
 // region Color builder
@@ -160,19 +160,19 @@ fun TextFieldColorsRecord.toColors(isOutlined: Boolean): TextFieldColors {
 // region Props
 
 data class TextFieldProps(
-  val defaultValue: MutableState<String> = mutableStateOf(""),
-  val autoFocus: MutableState<Boolean> = mutableStateOf(false),
-  val variant: MutableState<TextFieldVariant> = mutableStateOf(TextFieldVariant.FILLED),
-  val enabled: MutableState<Boolean> = mutableStateOf(true),
-  val readOnly: MutableState<Boolean> = mutableStateOf(false),
-  val isError: MutableState<Boolean> = mutableStateOf(false),
-  val singleLine: MutableState<Boolean> = mutableStateOf(false),
-  val maxLines: MutableState<Int?> = mutableStateOf(null),
-  val minLines: MutableState<Int?> = mutableStateOf(null),
-  val keyboardOptions: MutableState<TextFieldKeyboardOptionsRecord?> = mutableStateOf(null),
-  val shape: MutableState<ShapeRecord?> = mutableStateOf(null),
-  val colors: MutableState<TextFieldColorsRecord?> = mutableStateOf(null),
-  val modifiers: MutableState<ModifierList> = mutableStateOf(emptyList()),
+  val defaultValue: String = "",
+  val autoFocus: Boolean = false,
+  val variant: TextFieldVariant = TextFieldVariant.FILLED,
+  val enabled: Boolean = true,
+  val readOnly: Boolean = false,
+  val isError: Boolean = false,
+  val singleLine: Boolean = false,
+  val maxLines: Int? = null,
+  val minLines: Int? = null,
+  val keyboardOptions: TextFieldKeyboardOptionsRecord? = null,
+  val shape: ShapeRecord? = null,
+  val colors: TextFieldColorsRecord? = null,
+  val modifiers: ModifierList = emptyList(),
 ) : ComposeProps
 
 // endregion Props
@@ -216,110 +216,109 @@ private fun String?.toImeAction(): ImeAction = when (this) {
 
 // region View
 
-@SuppressLint("ViewConstructor")
-class TextFieldView(context: Context, appContext: AppContext) :
-  ExpoComposeView<TextFieldProps>(context, appContext) {
-  override val props = TextFieldProps()
-  private val onValueChange by EventDispatcher()
-  private val onFocusChanged by EventDispatcher()
-  private val onKeyboardAction by EventDispatcher()
+@Composable
+fun FunctionalComposableScope.TextFieldContent(
+  props: TextFieldProps,
+  onSetText: AsyncFunctionHandlerScope<String>,
+  onFocus: AsyncFunctionHandlerScope<Unit>,
+  onBlur: AsyncFunctionHandlerScope<Unit>,
+  onValueChanged: (GenericEventPayload1<String>) -> Unit,
+  onFocusChange: (GenericEventPayload1<Boolean>) -> Unit,
+  onKeyboardActionTriggered: (KeyboardActionEvent) -> Unit
+) {
+  val focusManager = LocalFocusManager.current
+  val focusRequester = remember { FocusRequester() }
+  val textState = remember { mutableStateOf<String?>(null) }
 
-  private val textState = mutableStateOf<String?>(null)
-  private val focusRequester by lazy { FocusRequester() }
-  private var focusManager: FocusManager? = null
+  onSetText { text ->
+    textState.value = text
+  }
+  onFocus {
+    focusRequester.requestFocus()
+  }
+  onBlur {
+    focusManager.clearFocus()
+  }
 
-  var text: String?
-    get() = textState.value
-    set(value) {
-      textState.value = value
+  val value = textState.value ?: props.defaultValue
+  val onValueChange: (String) -> Unit = {
+    textState.value = it
+    onValueChanged(GenericEventPayload1(it))
+  }
+
+  // Slots
+  val label: (@Composable () -> Unit)? = findChildSlotView(view, "label")?.let { slot -> { slot.renderSlot() } }
+  val placeholder: (@Composable () -> Unit)? = findChildSlotView(view, "placeholder")?.let { slot -> { slot.renderSlot() } }
+  val leadingIcon: (@Composable () -> Unit)? = findChildSlotView(view, "leadingIcon")?.let { slot -> { slot.renderSlot() } }
+  val trailingIcon: (@Composable () -> Unit)? = findChildSlotView(view, "trailingIcon")?.let { slot -> { slot.renderSlot() } }
+  val prefix: (@Composable () -> Unit)? = findChildSlotView(view, "prefix")?.let { slot -> { slot.renderSlot() } }
+  val suffix: (@Composable () -> Unit)? = findChildSlotView(view, "suffix")?.let { slot -> { slot.renderSlot() } }
+  val supportingText: (@Composable () -> Unit)? = findChildSlotView(view, "supportingText")?.let { slot -> { slot.renderSlot() } }
+
+  // Keyboard
+  val kbOpts = props.keyboardOptions
+  val keyboardOptions = KeyboardOptions.Default.copy(
+    keyboardType = kbOpts?.keyboardType.toKeyboardType(),
+    autoCorrectEnabled = kbOpts?.autoCorrectEnabled ?: true,
+    capitalization = kbOpts?.capitalization.toCapitalization(),
+    imeAction = kbOpts?.imeAction.toImeAction()
+  )
+  val currentText = { textState.value ?: "" }
+  val keyboardActions = KeyboardActions(
+    onDone = { defaultKeyboardAction(ImeAction.Done); onKeyboardActionTriggered(KeyboardActionEvent("done", currentText())) },
+    onGo = { defaultKeyboardAction(ImeAction.Go); onKeyboardActionTriggered(KeyboardActionEvent("go", currentText())) },
+    onNext = { defaultKeyboardAction(ImeAction.Next); onKeyboardActionTriggered(KeyboardActionEvent("next", currentText())) },
+    onPrevious = { defaultKeyboardAction(ImeAction.Previous); onKeyboardActionTriggered(KeyboardActionEvent("previous", currentText())) },
+    onSearch = { defaultKeyboardAction(ImeAction.Search); onKeyboardActionTriggered(KeyboardActionEvent("search", currentText())) },
+    onSend = { defaultKeyboardAction(ImeAction.Send); onKeyboardActionTriggered(KeyboardActionEvent("send", currentText())) },
+  )
+
+  // Lines
+  val singleLine = props.singleLine
+  val maxLines = props.maxLines ?: if (singleLine) 1 else Int.MAX_VALUE
+  val minLines = props.minLines ?: 1
+
+  // Modifier
+  val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
+    .focusRequester(focusRequester)
+    .onFocusChanged { focusState ->
+      onFocusChange(GenericEventPayload1(focusState.isFocused))
     }
 
-  fun focus() = focusRequester.requestFocus()
-  fun blur() = focusManager?.clearFocus()
+  if (props.autoFocus) {
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+  }
 
-  @Composable
-  override fun ComposableScope.Content() {
-    focusManager = LocalFocusManager.current
-    val value = textState.value ?: props.defaultValue.value
-    val onValueChange: (String) -> Unit = {
-      textState.value = it
-      onValueChange(mapOf("value" to it))
-    }
+  val isOutlined = props.variant == TextFieldVariant.OUTLINED
+  val shape = shapeFromShapeRecord(props.shape)
+    ?: if (isOutlined) OutlinedTextFieldDefaults.shape else TextFieldDefaults.shape
+  val colors = props.colors?.toColors(isOutlined)
+    ?: if (isOutlined) OutlinedTextFieldDefaults.colors() else TextFieldDefaults.colors()
 
-    // Slots
-    val label: (@Composable () -> Unit)? = findChildSlotView(this@TextFieldView, "label")?.let { slot -> { slot.renderSlot() } }
-    val placeholder: (@Composable () -> Unit)? = findChildSlotView(this@TextFieldView, "placeholder")?.let { slot -> { slot.renderSlot() } }
-    val leadingIcon: (@Composable () -> Unit)? = findChildSlotView(this@TextFieldView, "leadingIcon")?.let { slot -> { slot.renderSlot() } }
-    val trailingIcon: (@Composable () -> Unit)? = findChildSlotView(this@TextFieldView, "trailingIcon")?.let { slot -> { slot.renderSlot() } }
-    val prefix: (@Composable () -> Unit)? = findChildSlotView(this@TextFieldView, "prefix")?.let { slot -> { slot.renderSlot() } }
-    val suffix: (@Composable () -> Unit)? = findChildSlotView(this@TextFieldView, "suffix")?.let { slot -> { slot.renderSlot() } }
-    val supportingText: (@Composable () -> Unit)? = findChildSlotView(this@TextFieldView, "supportingText")?.let { slot -> { slot.renderSlot() } }
-
-    // Keyboard
-    val kbOpts = props.keyboardOptions.value
-    val keyboardOptions = KeyboardOptions.Default.copy(
-      keyboardType = kbOpts?.keyboardType.toKeyboardType(),
-      autoCorrectEnabled = kbOpts?.autoCorrectEnabled ?: true,
-      capitalization = kbOpts?.capitalization.toCapitalization(),
-      imeAction = kbOpts?.imeAction.toImeAction()
+  if (isOutlined) {
+    OutlinedTextField(
+      value = value, onValueChange = onValueChange, modifier = modifier,
+      enabled = props.enabled, readOnly = props.readOnly,
+      label = label, placeholder = placeholder,
+      leadingIcon = leadingIcon, trailingIcon = trailingIcon,
+      prefix = prefix, suffix = suffix, supportingText = supportingText,
+      isError = props.isError,
+      keyboardOptions = keyboardOptions, keyboardActions = keyboardActions,
+      singleLine = singleLine, maxLines = maxLines, minLines = minLines,
+      shape = shape, colors = colors,
     )
-    val currentText = { textState.value ?: "" }
-    val keyboardActions = KeyboardActions(
-      onDone = { defaultKeyboardAction(ImeAction.Done); onKeyboardAction(mapOf("action" to "done", "value" to currentText())) },
-      onGo = { defaultKeyboardAction(ImeAction.Go); onKeyboardAction(mapOf("action" to "go", "value" to currentText())) },
-      onNext = { defaultKeyboardAction(ImeAction.Next); onKeyboardAction(mapOf("action" to "next", "value" to currentText())) },
-      onPrevious = { defaultKeyboardAction(ImeAction.Previous); onKeyboardAction(mapOf("action" to "previous", "value" to currentText())) },
-      onSearch = { defaultKeyboardAction(ImeAction.Search); onKeyboardAction(mapOf("action" to "search", "value" to currentText())) },
-      onSend = { defaultKeyboardAction(ImeAction.Send); onKeyboardAction(mapOf("action" to "send", "value" to currentText())) },
+  } else {
+    TextField(
+      value = value, onValueChange = onValueChange, modifier = modifier,
+      enabled = props.enabled, readOnly = props.readOnly,
+      label = label, placeholder = placeholder,
+      leadingIcon = leadingIcon, trailingIcon = trailingIcon,
+      prefix = prefix, suffix = suffix, supportingText = supportingText,
+      isError = props.isError,
+      keyboardOptions = keyboardOptions, keyboardActions = keyboardActions,
+      singleLine = singleLine, maxLines = maxLines, minLines = minLines,
+      shape = shape, colors = colors,
     )
-
-    // Lines
-    val singleLine = props.singleLine.value
-    val maxLines = props.maxLines.value ?: if (singleLine) 1 else Int.MAX_VALUE
-    val minLines = props.minLines.value ?: 1
-
-    // Modifier
-    val modifier = ModifierRegistry.applyModifiers(props.modifiers.value, appContext, this@Content, globalEventDispatcher)
-      .focusRequester(focusRequester)
-      .onFocusChanged { focusState ->
-        onFocusChanged(mapOf("value" to focusState.isFocused))
-      }
-
-    if (props.autoFocus.value) {
-      LaunchedEffect(Unit) { focusRequester.requestFocus() }
-    }
-
-    val isOutlined = props.variant.value == TextFieldVariant.OUTLINED
-    val shape = shapeFromShapeRecord(props.shape.value)
-      ?: if (isOutlined) OutlinedTextFieldDefaults.shape else TextFieldDefaults.shape
-    val colors = props.colors.value?.toColors(isOutlined)
-      ?: if (isOutlined) OutlinedTextFieldDefaults.colors() else TextFieldDefaults.colors()
-
-    if (isOutlined) {
-      OutlinedTextField(
-        value = value, onValueChange = onValueChange, modifier = modifier,
-        enabled = props.enabled.value, readOnly = props.readOnly.value,
-        label = label, placeholder = placeholder,
-        leadingIcon = leadingIcon, trailingIcon = trailingIcon,
-        prefix = prefix, suffix = suffix, supportingText = supportingText,
-        isError = props.isError.value,
-        keyboardOptions = keyboardOptions, keyboardActions = keyboardActions,
-        singleLine = singleLine, maxLines = maxLines, minLines = minLines,
-        shape = shape, colors = colors,
-      )
-    } else {
-      TextField(
-        value = value, onValueChange = onValueChange, modifier = modifier,
-        enabled = props.enabled.value, readOnly = props.readOnly.value,
-        label = label, placeholder = placeholder,
-        leadingIcon = leadingIcon, trailingIcon = trailingIcon,
-        prefix = prefix, suffix = suffix, supportingText = supportingText,
-        isError = props.isError.value,
-        keyboardOptions = keyboardOptions, keyboardActions = keyboardActions,
-        singleLine = singleLine, maxLines = maxLines, minLines = minLines,
-        shape = shape, colors = colors,
-      )
-    }
   }
 }
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TooltipView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TooltipView.kt
@@ -16,7 +16,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import expo.modules.kotlin.AppContext
-import expo.modules.kotlin.views.AsyncFunctionHandlerScope
+import expo.modules.kotlin.views.AsyncFunctionHandle
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
@@ -77,13 +77,13 @@ data class TooltipBoxViewProps(
 @Composable
 fun FunctionalComposableScope.TooltipBoxContent(
   props: TooltipBoxViewProps,
-  onShow: AsyncFunctionHandlerScope<Unit>,
-  onDismiss: AsyncFunctionHandlerScope<Unit>
+  show: AsyncFunctionHandle<Unit>,
+  dismiss: AsyncFunctionHandle<Unit>
 ) {
   val tooltipState = rememberTooltipState(isPersistent = props.isPersistent)
   val scope = rememberCoroutineScope()
 
-  onShow {
+  show.handle {
     try {
       withContext(scope.coroutineContext) {
         tooltipState.show()
@@ -94,7 +94,7 @@ fun FunctionalComposableScope.TooltipBoxContent(
     }
   }
 
-  onDismiss {
+  dismiss.handle {
     try {
       withContext(scope.coroutineContext) {
         tooltipState.dismiss()

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TooltipView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TooltipView.kt
@@ -10,19 +10,19 @@ import androidx.compose.material3.PlainTooltip
 import androidx.compose.material3.RichTooltip
 import androidx.compose.material3.TooltipBox
 import androidx.compose.material3.TooltipDefaults
-import androidx.compose.material3.TooltipState
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
-import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.withContext
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.views.AsyncFunctionHandlerScope
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
+import expo.modules.kotlin.views.FunctionalComposableScope
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 // --- PlainTooltipView ---
 
@@ -67,26 +67,26 @@ class RichTooltipView(context: Context, appContext: AppContext) :
 // --- TooltipBoxView ---
 
 data class TooltipBoxViewProps(
-  val isPersistent: MutableState<Boolean> = mutableStateOf(false),
-  val hasAction: MutableState<Boolean?> = mutableStateOf(null),
-  val enableUserInput: MutableState<Boolean> = mutableStateOf(true),
-  val focusable: MutableState<Boolean> = mutableStateOf(false),
-  val modifiers: MutableState<ModifierList> = mutableStateOf(emptyList())
+  val isPersistent: Boolean = false,
+  val hasAction: Boolean? = null,
+  val enableUserInput: Boolean = true,
+  val focusable: Boolean = false,
+  val modifiers: ModifierList = emptyList()
 ) : ComposeProps
 
-@SuppressLint("ViewConstructor")
-class TooltipBoxView(context: Context, appContext: AppContext) :
-  ExpoComposeView<TooltipBoxViewProps>(context, appContext) {
-  override val props = TooltipBoxViewProps()
-  internal var tooltipState: TooltipState? = null
-  private var composeScope: CoroutineScope? = null
+@Composable
+fun FunctionalComposableScope.TooltipBoxContent(
+  props: TooltipBoxViewProps,
+  onShow: AsyncFunctionHandlerScope<Unit>,
+  onDismiss: AsyncFunctionHandlerScope<Unit>
+) {
+  val tooltipState = rememberTooltipState(isPersistent = props.isPersistent)
+  val scope = rememberCoroutineScope()
 
-  suspend fun show() {
-    val scope = composeScope ?: return
-    val state = tooltipState ?: return
+  onShow {
     try {
       withContext(scope.coroutineContext) {
-        state.show()
+        tooltipState.show()
       }
     } catch (_: CancellationException) {
       // Can occur if the compose scope is cancelled (view disposed) or if a
@@ -94,12 +94,10 @@ class TooltipBoxView(context: Context, appContext: AppContext) :
     }
   }
 
-  suspend fun dismiss() {
-    val scope = composeScope ?: return
-    val state = tooltipState ?: return
+  onDismiss {
     try {
       withContext(scope.coroutineContext) {
-        state.dismiss()
+        tooltipState.dismiss()
       }
     } catch (_: CancellationException) {
       // Can occur if the compose scope is cancelled (view disposed) or if a
@@ -107,71 +105,62 @@ class TooltipBoxView(context: Context, appContext: AppContext) :
     }
   }
 
-  @Composable
-  override fun ComposableScope.Content() {
-    val tooltipSlotView = findChildSlotView(this@TooltipBoxView, "tooltip")
-    val plainTooltipView = tooltipSlotView?.let { findChildOfType<PlainTooltipView>(it) }
-    val richTooltipView = tooltipSlotView?.let { findChildOfType<RichTooltipView>(it) }
+  val tooltipSlotView = findChildSlotView(view, "tooltip")
+  val plainTooltipView = tooltipSlotView?.let { findChildOfType<PlainTooltipView>(it) }
+  val richTooltipView = tooltipSlotView?.let { findChildOfType<RichTooltipView>(it) }
 
-    val tooltipState = rememberTooltipState(isPersistent = props.isPersistent.value)
-    val scope = rememberCoroutineScope()
-    this@TooltipBoxView.tooltipState = tooltipState
-    this@TooltipBoxView.composeScope = scope
+  val actionSlotView = richTooltipView?.let { findChildSlotView(it, "action") }
+  val hasAction = props.hasAction ?: (actionSlotView != null)
 
-    val actionSlotView = richTooltipView?.let { findChildSlotView(it, "action") }
-    val hasAction = props.hasAction.value ?: (actionSlotView != null)
+  val positionProvider = if (richTooltipView != null) {
+    TooltipDefaults.rememberRichTooltipPositionProvider()
+  } else {
+    TooltipDefaults.rememberPlainTooltipPositionProvider()
+  }
 
-    val positionProvider = if (richTooltipView != null) {
-      TooltipDefaults.rememberRichTooltipPositionProvider()
-    } else {
-      TooltipDefaults.rememberPlainTooltipPositionProvider()
-    }
-
-    TooltipBox(
-      positionProvider = positionProvider,
-      enableUserInput = props.enableUserInput.value,
-      focusable = props.focusable.value,
-      hasAction = hasAction,
-      tooltip = {
-        if (plainTooltipView != null) {
-          PlainTooltip(
-            containerColor = plainTooltipView.props.containerColor.value.composeOrNull
-              ?: TooltipDefaults.plainTooltipContainerColor,
-            contentColor = plainTooltipView.props.contentColor.value.composeOrNull
-              ?: TooltipDefaults.plainTooltipContentColor,
-            modifier = ModifierRegistry.applyModifiers(plainTooltipView.props.modifiers.value, appContext, this@Content, globalEventDispatcher)
-          ) {
-            with(UIComposableScope()) { with(plainTooltipView) { Content() } }
-          }
-        } else if (richTooltipView != null) {
-          val titleSlotView = findChildSlotView(richTooltipView, "title")
-          val textSlotView = findChildSlotView(richTooltipView, "text")
-          val defaultColors = TooltipDefaults.richTooltipColors()
-
-          RichTooltip(
-            title = titleSlotView?.let { { it.renderSlot() } },
-            action = actionSlotView?.let { { it.renderSlot() } },
-            colors = TooltipDefaults.richTooltipColors(
-              containerColor = richTooltipView.props.containerColor.value.composeOrNull
-                ?: defaultColors.containerColor,
-              contentColor = richTooltipView.props.contentColor.value.composeOrNull
-                ?: defaultColors.contentColor,
-              titleContentColor = richTooltipView.props.titleContentColor.value.composeOrNull
-                ?: defaultColors.titleContentColor,
-              actionContentColor = richTooltipView.props.actionContentColor.value.composeOrNull
-                ?: defaultColors.actionContentColor
-            ),
-            modifier = ModifierRegistry.applyModifiers(richTooltipView.props.modifiers.value, appContext, this@Content, globalEventDispatcher)
-          ) {
-            textSlotView?.renderSlot()
-          }
+  TooltipBox(
+    positionProvider = positionProvider,
+    enableUserInput = props.enableUserInput,
+    focusable = props.focusable,
+    hasAction = hasAction,
+    tooltip = {
+      if (plainTooltipView != null) {
+        PlainTooltip(
+          containerColor = plainTooltipView.props.containerColor.value.composeOrNull
+            ?: TooltipDefaults.plainTooltipContainerColor,
+          contentColor = plainTooltipView.props.contentColor.value.composeOrNull
+            ?: TooltipDefaults.plainTooltipContentColor,
+          modifier = ModifierRegistry.applyModifiers(plainTooltipView.props.modifiers.value, appContext, composableScope, globalEventDispatcher)
+        ) {
+          with(UIComposableScope()) { with(plainTooltipView) { Content() } }
         }
-      },
-      state = tooltipState,
-      modifier = ModifierRegistry.applyModifiers(props.modifiers.value, appContext, this@Content, globalEventDispatcher)
-    ) {
-      Children(UIComposableScope(), filter = { !isSlotView(it) })
-    }
+      } else if (richTooltipView != null) {
+        val titleSlotView = findChildSlotView(richTooltipView, "title")
+        val textSlotView = findChildSlotView(richTooltipView, "text")
+        val defaultColors = TooltipDefaults.richTooltipColors()
+
+        RichTooltip(
+          title = titleSlotView?.let { { it.renderSlot() } },
+          action = actionSlotView?.let { { it.renderSlot() } },
+          colors = TooltipDefaults.richTooltipColors(
+            containerColor = richTooltipView.props.containerColor.value.composeOrNull
+              ?: defaultColors.containerColor,
+            contentColor = richTooltipView.props.contentColor.value.composeOrNull
+              ?: defaultColors.contentColor,
+            titleContentColor = richTooltipView.props.titleContentColor.value.composeOrNull
+              ?: defaultColors.titleContentColor,
+            actionContentColor = richTooltipView.props.actionContentColor.value.composeOrNull
+              ?: defaultColors.actionContentColor
+          ),
+          modifier = ModifierRegistry.applyModifiers(richTooltipView.props.modifiers.value, appContext, composableScope, globalEventDispatcher)
+        ) {
+          textSlotView?.renderSlot()
+        }
+      }
+    },
+    state = tooltipState,
+    modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
+  ) {
+    Children(UIComposableScope(), filter = { !isSlotView(it) })
   }
 }
-

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/UIBaseView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/UIBaseView.kt
@@ -2,14 +2,16 @@ package expo.modules.ui
 
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposeProps
+import expo.modules.kotlin.views.ComposeViewEventDefinitionBuilder
 import expo.modules.kotlin.views.ComposeViewFunctionDefinitionBuilder
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.views.ModuleDefinitionBuilderWithCompose
 
 inline fun <reified Props : ComposeProps> ModuleDefinitionBuilderWithCompose.ExpoUIView(
   name: String,
-  events: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
+  events: ComposeViewEventDefinitionBuilder.() -> Unit = {},
+  functions: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
   noinline viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit
 ) {
-  return View(name, events, viewFunction)
+  return View(name, events, functions, viewFunction)
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/UIBaseView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/UIBaseView.kt
@@ -1,17 +1,30 @@
 package expo.modules.ui
 
-import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.ComposeViewEventDefinitionBuilder
-import expo.modules.kotlin.views.ComposeViewFunctionDefinitionBuilder
-import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.ComposeViewBuilderScope
 import expo.modules.kotlin.views.ModuleDefinitionBuilderWithCompose
 
+/**
+ * Registers a Jetpack Compose view with Expo Modules. Declare events and
+ * async functions via `by Event<T>()` / `by AsyncFunction<T>()` property
+ * delegates; supply the composable body via `Content { props -> ... }`.
+ * Each event/function name is the `val` identifier (declared once).
+ *
+ * ```
+ * ExpoUIView<TextFieldProps>("TextFieldView") {
+ *   val focus by AsyncFunction()
+ *   val onValueChange by Event<String>()
+ *
+ *   Content { props ->
+ *     focus.handle { focusRequester.requestFocus() }
+ *     TextFieldContent(props, onValueChange = { onValueChange(it) })
+ *   }
+ * }
+ * ```
+ */
 inline fun <reified Props : ComposeProps> ModuleDefinitionBuilderWithCompose.ExpoUIView(
   name: String,
-  events: ComposeViewEventDefinitionBuilder.() -> Unit = {},
-  functions: ComposeViewFunctionDefinitionBuilder<Props>.() -> Unit = {},
-  noinline viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit
+  block: ComposeViewBuilderScope<Props>.() -> Unit
 ) {
-  return View(name, events, functions, viewFunction)
+  return View<Props>(name, block)
 }


### PR DESCRIPTION
# Why

try to support `AsyncFunction` for functional ExpoUIView DSL

# How

~it's a little tricky for the function composables. this is the current design that i cooked with ai~

<details>
```kotlin
    ExpoUIView(
      "TextInputView",
      events = {
        Events("onValueChanged")
      },
      functions = {
        AsyncFunction<String>("setText")
      }
    ) { props: TextInputProps ->
      val onSetText = AsyncFunctionHandler<String>("setText")
      val onValueChanged by remember { EventDispatcher<Map<String, Any?>>() }
      TextInputContent(props, onSetText) { value -> onValueChanged(mapOf("value" to value)) }
    }
```
~
</details>

~there're still two "setText" here. not sure if we can improve more~

new DSL recommended by @lukmccall

```kotlin
    ExpoUIView<TextFieldProps>("TextFieldView") {
      val setText by AsyncFunction<String>()
      val focus by AsyncFunction()
      val blur by AsyncFunction()
      val onValueChange by Event<GenericEventPayload1<String>>()
      val onFocusChanged by Event<GenericEventPayload1<Boolean>>()
      val onKeyboardAction by Event<KeyboardActionEvent>()

      Content { props ->
        TextFieldContent(
          props,
          setText,
          focus,
          blur,
          onValueChanged = { onValueChange(it) },
          onFocusChange = { onFocusChanged(it) },
          onKeyboardActionTriggered = { onKeyboardAction(it) }
        )
      }
    }
```

# Test Plan

NCL for ModalBottomSheet and TextInput

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
