### PR TITLE
fix(cli): Add fallback resolution for `../../App` in `expo/AppEntry.js`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Sort async chunks by route `entryPoints` order when `asyncRoutes` is enabled ([#43531](https://github.com/expo/expo/pull/43531) by [@hassankhan](https://github.com/hassankhan))
 - Fix `SimulatorAppPrerequisite` to fall back to reading `Simulator.app/Contents/Info.plist` directly when LaunchServices has not indexed the app (e.g. Xcode installed on an external or renamed volume). This prevents a spurious "Simulator is most likely not installed" error when running `expo run:ios --device` on a physical device. ([#43597](https://github.com/expo/expo/pull/43597) by [@ciospettw](https://github.com/ciospettw))
 - Add missing support for self-resolution via fallback resolver ([#44077](https://github.com/expo/expo/pull/44077) by [@kitten](https://github.com/kitten))
+- Add fallback resolution for `../../App` in `expo/AppEntry.js` ([#44084](https://github.com/expo/expo/pull/44084) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroMultiPlatform.test.ts
@@ -1127,6 +1127,53 @@ describe(withExtendedResolver, () => {
       );
     });
 
+    it('resolves `../../App` from `expo/AppEntry.js` as `./App` from the project root', () => {
+      const platform = 'ios';
+      const modified = getModifiedConfig();
+
+      jest.mocked(getResolveFunc()).mockImplementation((context, moduleName, _platform) => {
+        if (
+          context.originModulePath === '/root/node_modules/expo/AppEntry.js' &&
+          moduleName === '../../App'
+        ) {
+          throw new FailedToResolveNameError();
+        } else {
+          return { type: 'empty' };
+        }
+      });
+
+      modified.resolver.resolveRequest!(
+        getResolverContext({
+          originModulePath: '/root/node_modules/expo/AppEntry.js',
+        }),
+        '../../App',
+        platform
+      );
+
+      expect(getResolveFunc()).toHaveBeenCalledTimes(2);
+
+      // 1: Fails to resolve `../../App` from `expo/AppEntry.js`
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          originModulePath: '/root/node_modules/expo/AppEntry.js',
+        }),
+        '../../App',
+        platform
+      );
+
+      // 2: Retries as `./App` from the project root
+      expect(getResolveFunc()).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          originModulePath: '/root/index.js',
+          nodeModulesPaths: [],
+        }),
+        './App',
+        platform
+      );
+    });
+
     it('resolves no fallback modules if no origin modules were found', () => {
       const platform = 'ios';
       const modified = getModifiedConfig();

--- a/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoFallbackResolver.ts
@@ -165,6 +165,27 @@ export function createFallbackModuleResolver({
   const fileSpecifierRe = /^[\\/]|^\.\.?(?:$|[\\/])/i;
 
   return function requestFallbackModule(immutableContext, moduleName, platform) {
+    if (moduleName === '../../App') {
+      // Fix up the `../../App` relative path, escaping `node_modules/expo` for monorepos and isolated dependencies
+      // NOTE(@kitten): If `expo/AppEntry.js` changes, this will likely have to change too!
+      if (/[/\\]node_modules[/\\]expo[/\\]AppEntry\.js$/.test(immutableContext.originModulePath)) {
+        // We instead resolve from the project root
+        const context: ResolutionContext = {
+          ...immutableContext,
+          nodeModulesPaths: [],
+          // NOTE(@kitten): We need to add a fake filename here. Metro performs a `path.dirname` on this path
+          // and then searches `${path.dirname(originModulePath)}/node_modules`. If we don't add it, we miss
+          // fallback resolution for packages that failed to hoist
+          originModulePath: path.join(projectRoot, 'index.js'),
+        };
+        const res = getStrictResolver(context, platform)('./App');
+        debug(`"../../App" resolution for ${platform}: "./App" -> from origin: ${projectRoot}`);
+        return res;
+      } else {
+        return null;
+      }
+    }
+
     // Early return if `moduleName` cannot be a module specifier
     // This doesn't have to be accurate as this resolver is a fallback for failed resolutions and
     // we're only doing this to avoid unnecessary resolution work


### PR DESCRIPTION
# Why

There's probably better ways to handle this, but this has been an issue for a while, and is blocking #23800 potentially, if we're switching away from hoisted installs in some of our E2E install tests.

The `../../App` path is meant to escape `node_modules/expo`. It's a very old addition, and it's not the best option, given that it only works in unhoisted, non-monorepo flat dependencies. This is guaranteed to fail in monorepos and with isolated dependencies, in most cases.

# How

We can work around this by replacing `../../App` in `expo/AppEntry.js` with `./App` from `<projectRoot>` while resolving. It'd be better if we could add a special identifier to this path, or make it special in another way. However, to ensure that this `AppEntry.js` still works the same in most projects, we shouldn't change it until we're sure we can.

# Test Plan

- Create a bare pnpm project and export/run

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
