### PR TITLE
xcasset prop on NativeTabs.Trigger.Icon doesn't work — gets converted to image URL instead of asset catalog lookup 

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `xcasset` prop on `NativeTabs.Trigger.Icon` being converted to image URL instead of asset catalog lookup. ([#44092](https://github.com/expo/expo/pull/44092) by [@felix-chexy](https://github.com/felix-chexy))
 - Fix pinned `react-navigation` dependencies ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Fix zoom transition to prefetched routes ([#43852](https://github.com/expo/expo/pull/43852) by [@Ubax](https://github.com/Ubax))
 - Fix `Stack.Protected` guard not applying to index routes. ([#43769](https://github.com/expo/expo/pull/43769) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-router/src/native-tabs/utils/icon.ts
+++ b/packages/expo-router/src/native-tabs/utils/icon.ts
@@ -96,10 +96,7 @@ export function convertOptionsIconToIOSPropsIcon(
   }
   
   if (icon && 'src' in icon && icon.src) {
-    const imageSource =
-      'xcasset' in icon && icon.xcasset
-        ? { uri: icon.xcasset }
-        : (icon as { src: ImageSourcePropType }).src;
+    const imageSource = icon.src;
     const renderingMode = 'renderingMode' in icon ? icon.renderingMode : undefined;
     const effectiveRenderingMode =
       renderingMode ?? (iconColor !== undefined ? 'template' : 'original');

--- a/packages/expo-router/src/native-tabs/utils/icon.ts
+++ b/packages/expo-router/src/native-tabs/utils/icon.ts
@@ -91,7 +91,11 @@ export function convertOptionsIconToIOSPropsIcon(
       name: icon.sf,
     };
   }
-  if (icon && (('xcasset' in icon && icon.xcasset) || ('src' in icon && icon.src))) {
+  if (icon && 'xcasset' in icon && icon.xcasset) {
+      return { type: 'xcasset', name: icon.xcasset };
+  }
+  
+  if (icon && 'src' in icon && icon.src) {
     const imageSource =
       'xcasset' in icon && icon.xcasset
         ? { uri: icon.xcasset }


### PR DESCRIPTION
  xcasset prop on NativeTabs.Trigger.Icon doesn't work — gets converted to image URL instead of asset catalog lookup                                                                                                                                                                               
                                                                                                                                                                                        
  Summary

  The xcasset prop on NativeTabs.Trigger.Icon doesn't correctly load custom SF Symbols from the Xcode asset catalog. Icons show as blank.

  Environment

  - Expo SDK 55, expo-router 55.0.3
  - react-native-screens 4.23.0
  - iOS 26

  Bug

  In node_modules/expo-router/build/native-tabs/utils/icon.js, the convertOptionsIconToIOSPropsIcon function handles xcasset and src in the same branch (line 63):
```javascript
  if (icon && (('xcasset' in icon && icon.xcasset) || ('src' in icon && icon.src))) {
      const imageSource = 'xcasset' in icon && icon.xcasset
          ? { uri: icon.xcasset }
          : icon.src;
      // ...
      return { type: 'templateSource', templateSource: imageSource };
  }
```

  This converts xcasset="house" into { type: 'templateSource', templateSource: { uri: 'house' } }, which the native layer tries to load as an image URL. It should instead produce {
  type: 'xcasset', name: 'house' }, which react-native-screens already supports and would correctly call UIImage(named:).

  Fix

  Separate the xcasset branch:

```javascript
  if (icon && 'xcasset' in icon && icon.xcasset) {
      return { type: 'xcasset', name: icon.xcasset };
  }
```

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
