### PR TITLE
[cli] export: deduplicate assets

### DIFF
--- a/packages/@expo/cli/src/export/__tests__/createMetadataJson-test.ts
+++ b/packages/@expo/cli/src/export/__tests__/createMetadataJson-test.ts
@@ -67,6 +67,23 @@ describe(createMetadataJson, () => {
       version: expect.any(Number),
     });
   });
+  it(`deduplicates assets with the same file hash`, () => {
+    const metadata = createMetadataJson({
+      fileNames: { ios: ['ios-bundle.js'] },
+      bundles: {
+        ios: {
+          assets: [
+            { hash: 'abc', type: 'png', fileHashes: ['hash1', 'hash2'] } as any,
+            { hash: 'abc', type: 'png', fileHashes: ['hash1', 'hash2'] } as any,
+          ],
+        },
+      },
+    });
+    expect(metadata.fileMetadata.ios.assets).toEqual([
+      { ext: 'png', path: 'assets/hash1' },
+      { ext: 'png', path: 'assets/hash2' },
+    ]);
+  });
   it(`writes metadata manifest with dom components asset`, async () => {
     const metadata = await createMetadataJson({
       fileNames: { ios: ['_expo/static/js/ios/ios-xxfooxxbarxx.js', 'other'] },

--- a/packages/@expo/cli/src/export/createMetadataJson.ts
+++ b/packages/@expo/cli/src/export/createMetadataJson.ts
@@ -35,7 +35,8 @@ export function createMetadataJson({
       (metadata, [platform, bundle]) => {
         if (platform === 'web') return metadata;
 
-        // Collect all of the assets and convert them to the serial format.
+        // Collect all of the assets and convert them to the serial format, deduplicating by path.
+        const seen = new Set<string>();
         const assets = bundle.assets
           .filter((asset) => !embeddedHashSet || !embeddedHashSet.has(asset.hash))
           .map((asset) =>
@@ -46,7 +47,12 @@ export function createMetadataJson({
             }))
           )
           .filter(Boolean)
-          .flat();
+          .flat()
+          .filter((a) => {
+            if (seen.has(a.path)) return false;
+            seen.add(a.path);
+            return true;
+          });
 
         if (domComponentAssetsMetadata?.[platform] != null) {
           assets.push(...domComponentAssetsMetadata?.[platform]);

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -229,14 +229,15 @@ export async function exportEmbedBundleAndAssetsAsync(
       });
     }
 
-    // TODO: Remove duplicates...
-    const expoDomComponentReferences = bundles.artifacts
-      .map((artifact) =>
-        Array.isArray(artifact.metadata.expoDomComponentReferences)
-          ? artifact.metadata.expoDomComponentReferences
-          : []
-      )
-      .flat();
+    const expoDomComponentReferences = [...new Set(
+      bundles.artifacts
+        .map((artifact) =>
+          Array.isArray(artifact.metadata.expoDomComponentReferences)
+            ? artifact.metadata.expoDomComponentReferences
+            : []
+        )
+        .flat()
+    )];
     if (expoDomComponentReferences.length > 0) {
       await Promise.all(
         // TODO: Make a version of this which uses `this.metro.getBundler().buildGraphForEntries([])` to bundle all the DOM components at once.

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -229,15 +229,17 @@ export async function exportEmbedBundleAndAssetsAsync(
       });
     }
 
-    const expoDomComponentReferences = [...new Set(
-      bundles.artifacts
-        .map((artifact) =>
-          Array.isArray(artifact.metadata.expoDomComponentReferences)
-            ? artifact.metadata.expoDomComponentReferences
-            : []
-        )
-        .flat()
-    )];
+    const expoDomComponentReferences = [
+      ...new Set(
+        bundles.artifacts
+          .map((artifact) =>
+            Array.isArray(artifact.metadata.expoDomComponentReferences)
+              ? artifact.metadata.expoDomComponentReferences
+              : []
+          )
+          .flat()
+      ),
+    ];
     if (expoDomComponentReferences.length > 0) {
       await Promise.all(
         // TODO: Make a version of this which uses `this.metro.getBundler().buildGraphForEntries([])` to bundle all the DOM components at once.

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -15,11 +15,7 @@ import {
   transformDomEntryForMd5Filename,
 } from './exportDomComponents';
 import { assertEngineMismatchAsync, isEnableHermesManaged } from './exportHermes';
-import {
-  exportApiRoutesStandaloneAsync,
-  exportFromServerAsync,
-  injectScriptTags,
-} from './exportStaticAsync';
+import { exportApiRoutesStandaloneAsync, exportFromServerAsync } from './exportStaticAsync';
 import { getVirtualFaviconAssetsAsync } from './favicon';
 import { getPublicExpoManifestAsync } from './getPublicExpoManifest';
 import { copyPublicFolderAsync } from './publicFolder';
@@ -224,14 +220,17 @@ export async function exportAppAsync(
             isServerHosted: devServer.isReactServerComponentsEnabled || hostedNative,
           });
 
-          // TODO: Remove duplicates...
-          const expoDomComponentReferences = bundle.artifacts
-            .map((artifact) =>
-              Array.isArray(artifact.metadata.expoDomComponentReferences)
-                ? artifact.metadata.expoDomComponentReferences
-                : []
-            )
-            .flat();
+          const expoDomComponentReferences = [
+            ...new Set(
+              bundle.artifacts
+                .map((artifact) =>
+                  Array.isArray(artifact.metadata.expoDomComponentReferences)
+                    ? artifact.metadata.expoDomComponentReferences
+                    : []
+                )
+                .flat()
+            ),
+          ];
           await Promise.all(
             // TODO: Make a version of this which uses `this.metro.getBundler().buildGraphForEntries([])` to bundle all the DOM components at once.
             expoDomComponentReferences.map(async (filePath) => {
@@ -248,9 +247,10 @@ export async function exportAppAsync(
                   useMd5Filename: true,
                 });
 
-              // Merge the assets from the DOM component into the output assets.
+              // Merge the assets from the DOM component into the output assets, deduplicating by hash.
+              const existingHashes = new Set(bundle.assets.map((a) => a.hash));
               (bundle.assets as (typeof bundle.assets)[0][]).push(
-                ...platformDomComponentsBundle.assets
+                ...platformDomComponentsBundle.assets.filter((a) => !existingHashes.has(a.hash))
               );
 
               transformNativeBundleForMd5Filename({


### PR DESCRIPTION
# Why

This PR fixes duplicate asset handling in the export process. Previously, assets with the same file hash or path could be included multiple times in the exported metadata and bundle, leading to unnecessary duplication.

Context: https://exponent-internal.slack.com/archives/C013ZK4SA12/p1773144051660209

# How

Added deduplication logic in three key areas:

1. **Asset metadata creation**: Added a `Set` to track seen asset paths and filter out duplicates when creating metadata JSON
2. **DOM component references**: Used `Set` to deduplicate expo DOM component references in both embed export and regular export flows  
3. **DOM component asset merging**: Added hash-based deduplication when merging DOM component assets into the main bundle

The changes ensure that assets are only included once based on their unique identifiers (path for metadata, hash for bundle assets).

# Test Plan

- checkout sdk55 repro project with dom components: https://github.com/quinlanj/sdk-55-test
- Repro issue with old cli by running: `npx expo export --platform ios`, see `metadata.json` has duplicate assets
- Verify issue is fixed with new cli by running: `npx tsx /Users/quin/Documents/expo/packages/@expo/cli/bin/cli.ts export --no-bytecode   --platform ios`, see `metadata.json` has no more duplicate assets
