### PR TITLE
[docs] Fix broken type links and empty tables in API references

### DIFF
--- a/docs/components/plugins/api/APIDataTypes.ts
+++ b/docs/components/plugins/api/APIDataTypes.ts
@@ -232,7 +232,7 @@ export type TypeGeneralData = {
 export type TypeDeclarationContentData = {
   name?: string;
   kind?: TypeDocKind;
-  indexSignature?: TypeSignaturesData;
+  indexSignatures?: TypeSignaturesData[];
   signatures?: TypeSignaturesData[];
   parameters?: MethodParamData[];
   children?: PropData[];

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -197,7 +197,8 @@ const renderType = (
           includePlatforms={false}
           afterContent={defaultValueElement}
         />
-        {declaration.children && renderTypeDeclarationTable(declaration, sdkVersion)}
+        {(declaration.children || declaration.indexSignatures) &&
+          renderTypeDeclarationTable(declaration, sdkVersion)}
         {signature ? (
           <div key={`type-definition-signature-${signature.name}`}>
             <APICommentTextBlock comment={signature.comment} />

--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -43,7 +43,7 @@ export type APISectionTypesProps = {
 const COLLAPSED_LITERAL_MESSAGE = 'Acceptable values are: See description for available values.';
 
 const renderTypeDeclarationTable = (
-  { children, indexSignature, comment }: TypeDeclarationContentData,
+  { children, indexSignatures, comment }: TypeDeclarationContentData,
   sdkVersion: string,
   index?: number
 ) => (
@@ -59,7 +59,11 @@ const renderTypeDeclarationTable = (
       <APIParamsTableHeadRow mainCellLabel="Property" />
       <tbody>
         {children?.map(prop => renderTypePropertyRow(prop, sdkVersion))}
-        {indexSignature?.parameters?.map(param => renderTypePropertyRow(param, sdkVersion))}
+        {indexSignatures?.map(sig =>
+          sig.parameters?.map(param =>
+            renderTypePropertyRow({ ...param, type: sig.type ?? param.type }, sdkVersion)
+          )
+        )}
       </tbody>
     </Table>
   </Fragment>

--- a/docs/components/plugins/api/APISectionUtils.test.tsx
+++ b/docs/components/plugins/api/APISectionUtils.test.tsx
@@ -131,16 +131,18 @@ describe('APISectionUtils.resolveTypeName', () => {
               type: 'reflection',
               declaration: {
                 name: '__type',
-                indexSignature: {
-                  name: '__index',
-                  parameters: [
-                    {
-                      name: 'column',
-                      type: { type: 'intrinsic', name: 'string' },
-                    },
-                  ],
-                  type: { type: 'intrinsic', name: 'any' },
-                },
+                indexSignatures: [
+                  {
+                    name: '__index',
+                    parameters: [
+                      {
+                        name: 'column',
+                        type: { type: 'intrinsic', name: 'string' },
+                      },
+                    ],
+                    type: { type: 'intrinsic', name: 'any' },
+                  },
+                ],
               },
             },
           },

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -248,7 +248,7 @@ export const resolveTypeName = (
       return <>{resolveTypeName(elementType, sdkVersion)}[]</>;
     } else if (elementType?.declaration) {
       if (type === 'array') {
-        const { parameters, type: paramType } = elementType.declaration.indexSignature ?? {};
+        const { parameters, type: paramType } = elementType.declaration.indexSignatures?.[0] ?? {};
         if (parameters && paramType) {
           return (
             <>

--- a/docs/components/plugins/api/APIStaticData.ts
+++ b/docs/components/plugins/api/APIStaticData.ts
@@ -329,11 +329,8 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     NativeModule: '/versions/v54.0.0/sdk/expo/#nativemoduletype',
     SharedObject: '/versions/v54.0.0/sdk/expo/#sharedobjecttype',
     SharedRef: '/versions/v54.0.0/sdk/expo/#sharedreftype',
-    VectorIconProps: '/versions/v54.0.0/sdk/router/#vectoriconprops',
   },
   'v55.0.0': {
-    BaseNativeTabsTriggerIconProps:
-      '/versions/v55.0.0/sdk/router/native-tabs/#basenativetabstriggericonprops',
     BufferOptions: '/versions/v55.0.0/sdk/video/#bufferoptions-1',
     ButtonElementColors: '/versions/v55.0.0/sdk/ui/jetpack-compose/button/#buttonelementcolors',
     CameraPosition: '/versions/v55.0.0/sdk/maps/#cameraposition-2',
@@ -359,8 +356,6 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     VectorIconProps: '/versions/v55.0.0/sdk/router/#vectoriconprops',
   },
   latest: {
-    BaseNativeTabsTriggerIconProps:
-      '/versions/latest/sdk/router/native-tabs/#basenativetabstriggericonprops',
     BufferOptions: '/versions/latest/sdk/video/#bufferoptions-1',
     ButtonElementColors: '/versions/latest/sdk/ui/jetpack-compose/button/#buttonelementcolors',
     CameraPosition: '/versions/latest/sdk/maps/#cameraposition-2',
@@ -407,7 +402,7 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     SharedObject: '/versions/unversioned/sdk/expo/#sharedobjecttype',
     SharedRef: '/versions/unversioned/sdk/expo/#sharedreftype',
     SharedRefType: '/versions/unversioned/sdk/expo/#sharedreftype',
-    SingularOptions: '/versions/unversioned/sdk/router/stack/#singularoptions',
+    SingularOptions: '/versions/unversioned/sdk/router/#singularoptions',
     StackToolbarBadgeProps: '/versions/unversioned/sdk/router/stack/#stacktoolbarbadgeprops',
     StackToolbarIconProps: '/versions/unversioned/sdk/router/stack/#stacktoolbariconprops',
     StackToolbarLabelProps: '/versions/unversioned/sdk/router/stack/#stacktoolbarlabelprops',

--- a/docs/components/plugins/api/APIStaticData.ts
+++ b/docs/components/plugins/api/APIStaticData.ts
@@ -325,7 +325,7 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     BufferOptions: '/versions/v54.0.0/sdk/video/#bufferoptions-1',
     CameraPosition: '/versions/v54.0.0/sdk/maps/#cameraposition-2',
     EventEmitter: '/versions/v54.0.0/sdk/expo/#eventemittertype',
-    Href: '/versions/v54.0.0/sdk/router/#href-1',
+    Href: '/versions/v54.0.0/sdk/router/#hreft',
     NativeModule: '/versions/v54.0.0/sdk/expo/#nativemoduletype',
     SharedObject: '/versions/v54.0.0/sdk/expo/#sharedobjecttype',
     SharedRef: '/versions/v54.0.0/sdk/expo/#sharedreftype',
@@ -340,7 +340,7 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     CornerRadii: '/versions/v55.0.0/sdk/ui/jetpack-compose/shape/#cornerradii',
     EventEmitter: '/versions/v55.0.0/sdk/expo/#eventemittertype',
     ExpoModifier: '/versions/v55.0.0/sdk/ui/jetpack-compose/modifiers/#expomodifier',
-    Href: '/versions/v55.0.0/sdk/router/#href-1',
+    Href: '/versions/v55.0.0/sdk/router/#hreft',
     NativeModule: '/versions/v55.0.0/sdk/expo/#nativemoduletype',
     NativeTabsTriggerBadgeProps:
       '/versions/v55.0.0/sdk/router/native-tabs/#nativetabstriggerbadgeprops',
@@ -367,7 +367,7 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     CornerRadii: '/versions/latest/sdk/ui/jetpack-compose/shape/#cornerradii',
     EventEmitter: '/versions/latest/sdk/expo/#eventemittertype',
     ExpoModifier: '/versions/latest/sdk/ui/jetpack-compose/modifiers/#expomodifier',
-    Href: '/versions/latest/sdk/router/#href-1',
+    Href: '/versions/latest/sdk/router/#hreft',
     NativeModule: '/versions/latest/sdk/expo/#nativemoduletype',
     NativeTabsTriggerBadgeProps:
       '/versions/latest/sdk/router/native-tabs/#nativetabstriggerbadgeprops',
@@ -392,7 +392,7 @@ export const sdkVersionHardcodedTypeLinks: Record<string, Record<string, string 
     CornerRadii: '/versions/unversioned/sdk/ui/jetpack-compose/shape/#cornerradii',
     EventEmitter: '/versions/unversioned/sdk/expo/#eventemittertype',
     ExpoModifier: '/versions/unversioned/sdk/ui/jetpack-compose/modifiers/#expomodifier',
-    Href: '/versions/unversioned/sdk/router/#href-1',
+    Href: '/versions/unversioned/sdk/router/#hreft',
     HrefObject: '/versions/unversioned/sdk/router/#hrefobject',
     NativeModule: '/versions/unversioned/sdk/expo/#nativemoduletype',
     NativeTabsTriggerBadgeProps:


### PR DESCRIPTION
# Why

Fix ENG-20231 ENG-20232 ENG-20233

# How

**Broken/dead hardcoded links (`APIStaticData.ts`):**
- Fix `Href` anchor from `#href-1` to `#hreft` in v54, v55, latest, and unversioned entries.
- Fix `SingularOptions` to point to `/sdk/router/` instead of `/sdk/router/stack/`.
- Remove dead entries: `BaseNativeTabsTriggerIconProps` (v55, latest), `VectorIconProps` (v54).

**Index signature field mismatch (`APIDataTypes.ts`, `APISectionUtils.tsx`, `APISectionUtils.test.tsx`):**
- Rename `indexSignature?: TypeSignaturesData` to `indexSignatures?: TypeSignaturesData[]` to match TypeDoc output. All 73 occurrences in JSON data use the plural form, none use singular.
- Update `APISectionUtils.tsx` inline array rendering to use `indexSignatures?.[0]`.
- Update test data and snapshots to match.

**Empty type tables (`APISectionTypes.tsx`):**
- Update `renderTypeDeclarationTable` to iterate over the `indexSignatures` array and pass the signature's return type (e.g., `ColorValue`) instead of the parameter's key type (`string`).
- Update the `renderType` guard to also check `declaration.indexSignatures`, so types like `GlobalEventPayload` that only have index signatures (no children) render their table.

# Test Plan

Navigate to the Expo Router SDK reference page and click any `Href` type link in the `useRouter()` return type table. Confirm it scrolls to the `Href<T>` type definition.

Navigate to the Expo Router color page and confirm the Android color types (`AndroidBaseColor`, `AndroidBaseColorAttr`, `AndroidDynamicMaterialColor`, `AndroidMaterialColor`) show a table row with "key (index signature)" and type `ColorValue` instead of an empty table.

Navigate to the SwiftUI modifiers page and confirm `GlobalEventPayload` shows a table row instead of an empty box.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).