### PR TITLE
[docs] Fix broken links to archived expo/eas-build repository

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -306,7 +306,6 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 - [npm cache](/build-reference/caching/#javascript-dependencies)
 - [CocoaPods cache](/build-reference/caching/#ios-dependencies)
-- `cocoapods-nexus-plugin`
 - Global npm configuration in **~/.npmrc**:
 
   ```ini ~/.npmrc

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -306,7 +306,7 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
 
 - [npm cache](/build-reference/caching/#javascript-dependencies)
 - [CocoaPods cache](/build-reference/caching/#ios-dependencies)
-- [`cocoapods-nexus-plugin`](https://github.com/expo/eas-build/tree/main/packages/cocoapods-nexus-plugin)
+- `cocoapods-nexus-plugin`
 - Global npm configuration in **~/.npmrc**:
 
   ```ini ~/.npmrc

--- a/docs/pages/custom-builds/schema.mdx
+++ b/docs/pages/custom-builds/schema.mdx
@@ -900,7 +900,7 @@ steps:
   title="eas/maestro_test source code"
   description="View the source code for the eas/maestro_test function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functionGroups/maestroTest.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functionGroups/maestroTest.ts"
 />
 
 #### `eas/checkout`
@@ -923,7 +923,7 @@ build:
   title="eas/checkout source code"
   description="View the source code for the eas/checkout function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/checkout.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/checkout.ts"
 />
 
 #### `eas/use_npm_token`
@@ -948,7 +948,7 @@ build:
   title="eas/use_npm_token source code"
   description="View the source code for the eas/use_npm_token function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/useNpmToken.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/useNpmToken.ts"
 />
 
 #### `eas/install_node_modules`
@@ -969,7 +969,7 @@ build:
   title="eas/install_node_modules source code"
   description="View the source code for the eas/install_node_modules function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
 />
 
 #### `eas/restore_build_cache`
@@ -1018,7 +1018,7 @@ build:
   title="eas/restore_build_cache source code"
   description="View the source code for the eas/restore_build_cache function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/restoreBuildCache.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/restoreBuildCache.ts"
 />
 
 #### `eas/save_build_cache`
@@ -1055,7 +1055,7 @@ build:
   title="eas/save_build_cache source code"
   description="View the source code for the eas/save_build_cache function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/saveBuildCache.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/saveBuildCache.ts"
 />
 
 #### `eas/resolve_build_config`
@@ -1068,7 +1068,7 @@ This function is automatically executed by the [`eas/build`](#easbuild) function
   title="eas/resolve_build_config source code"
   description="View the source code for the eas/resolve_build_config function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/resolveBuildConfig.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/resolveBuildConfig.ts"
 />
 
 #### `eas/get_credentials_for_build_triggered_by_github_integration`
@@ -1105,7 +1105,7 @@ build:
   title="eas/resolve_apple_team_id_from_credentials source code"
   description="View the source code for the eas/resolve_apple_team_id_from_credentials function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/resolveAppleTeamIdFromCredentials.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/resolveAppleTeamIdFromCredentials.ts"
 />
 
 #### `eas/prebuild`
@@ -1149,7 +1149,7 @@ build:
   title="eas/prebuild source code"
   description="View the source code for the eas/resolve_apple_team_id_from_credentials function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/prebuild.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/prebuild.ts"
 />
 
 #### `eas/configure_eas_update`
@@ -1195,7 +1195,7 @@ build:
   title="eas/configure_eas_update source code"
   description="View the source code for the eas/configure_eas_update function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/configureEASUpdateIfInstalled.ts"
 />
 
 #### `eas/inject_android_credentials`
@@ -1225,7 +1225,7 @@ build:
   title="eas/inject_android_credentials source code"
   description="View the source code for the eas/inject_android_credentials function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/injectAndroidCredentials.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/injectAndroidCredentials.ts"
 />
 
 #### `eas/configure_ios_credentials`
@@ -1261,7 +1261,7 @@ build:
   title="eas/configure_ios_credentials source code"
   description="View the source code for the eas/configure_ios_credentials function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/configureIosCredentials.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/configureIosCredentials.ts"
 />
 
 #### `eas/configure_android_version`
@@ -1313,7 +1313,7 @@ build:
   title="eas/configure_android_version source code"
   description="View the source code for the eas/configure_android_version function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/configureAndroidVersion.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/configureAndroidVersion.ts"
 />
 
 #### `eas/configure_ios_version`
@@ -1377,7 +1377,7 @@ build:
   title="eas/configure_ios_version source code"
   description="View the source code for the eas/configure_ios_version function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/configureIosVersion.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/configureIosVersion.ts"
 />
 
 #### `eas/run_gradle`
@@ -1425,7 +1425,7 @@ build:
   title="eas/run_gradle source code"
   description="View the source code for the eas/run_gradle function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/runGradle.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/runGradle.ts"
 />
 
 #### `eas/generate_gymfile_from_template`
@@ -1582,7 +1582,7 @@ build:
   title="eas/generate_gymfile_from_template source code"
   description="View the source code for the eas/generate_gymfile_from_template function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/generateGymfileFromTemplate.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/generateGymfileFromTemplate.ts"
 />
 
 #### `eas/run_fastlane`
@@ -1631,7 +1631,7 @@ build:
   title="eas/run_fastlane source code"
   description="View the source code for the eas/run_fastlane function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/runFastlane.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/runFastlane.ts"
 />
 
 #### `eas/find_and_upload_build_artifacts`
@@ -1695,7 +1695,7 @@ build:
   title="eas/find_and_upload_build_artifacts source code"
   description="View the source code for the eas/find_and_upload_build_artifacts function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/findAndUploadBuildArtifacts.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/findAndUploadBuildArtifacts.ts"
 />
 
 #### `eas/upload_artifact`
@@ -1734,7 +1734,7 @@ build:
   title="eas/upload_artifact source code"
   description="View the source code for the eas/upload_artifact function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/uploadArtifact.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/uploadArtifact.ts"
 />
 
 #### `eas/install_maestro`
@@ -1771,7 +1771,7 @@ build:
   title="eas/install_maestro source code"
   description="View the source code for the eas/install_maestro function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/installMaestro.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/installMaestro.ts"
 />
 
 #### `eas/start_android_emulator`
@@ -1802,7 +1802,7 @@ build:
   title="eas/start_android_emulator source code"
   description="View the source code for the eas/start_android_emulator function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/startAndroidEmulator.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/startAndroidEmulator.ts"
 />
 
 #### `eas/start_ios_simulator`
@@ -1828,7 +1828,7 @@ build:
   title="eas/start_ios_simulator source code"
   description="View the source code for the eas/start_ios_simulator function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/startIosSimulator.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/startIosSimulator.ts"
 />
 
 #### `eas/send_slack_message`
@@ -1949,7 +1949,7 @@ build:
   title="eas/send_slack_message source code"
   description="View the source code for the eas/send_slack_message function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/sendSlackMessage.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/sendSlackMessage.ts"
 />
 
 ### Using built-in EAS functions to build an app

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -659,7 +659,7 @@ jobs:
   title="${{ github }} context"
   description="View the ${{ github }} definition source code."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/eas-build-job/src/common.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/eas-build-job/src/common.ts"
 />
 
 #### `workflow`
@@ -1442,7 +1442,7 @@ jobs:
   title="eas/checkout source code"
   description="View the source code for the eas/checkout function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/checkout.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/checkout.ts"
 />
 
 #### `eas/install_node_modules`
@@ -1463,7 +1463,7 @@ jobs:
   title="eas/install_node_modules source code"
   description="View the source code for the eas/install_node_modules function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/installNodeModules.ts"
 />
 
 #### `eas/download_build`
@@ -1515,7 +1515,7 @@ jobs:
   title="eas/download_build source code"
   description="View the source code for the eas/download_build function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/downloadBuild.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/downloadBuild.ts"
 />
 
 #### `eas/prebuild`
@@ -1558,7 +1558,7 @@ jobs:
   title="eas/prebuild source code"
   description="View the source code for the eas/prebuild function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/prebuild.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/prebuild.ts"
 />
 
 #### `eas/restore_cache`
@@ -1606,7 +1606,7 @@ jobs:
   title="eas/restore_cache source code"
   description="View the source code for the eas/restore_cache function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/restoreCache.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/restoreCache.ts"
 />
 
 #### `eas/save_cache`
@@ -1643,7 +1643,7 @@ jobs:
   title="eas/save_cache source code"
   description="View the source code for the eas/save_cache function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/saveCache.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/saveCache.ts"
 />
 
 #### `eas/send_slack_message`
@@ -1676,7 +1676,7 @@ jobs:
   title="eas/send_slack_message source code"
   description="View the source code for the eas/send_slack_message function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/sendSlackMessage.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/sendSlackMessage.ts"
 />
 
 #### `eas/use_npm_token`
@@ -1702,7 +1702,7 @@ jobs:
   title="eas/use_npm_token source code"
   description="View the source code for the eas/use_npm_token function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/useNpmToken.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/useNpmToken.ts"
 />
 
 #### `eas/download_artifact`
@@ -1756,7 +1756,7 @@ jobs:
   title="eas/download_artifact source code"
   description="View the source code for the eas/download_artifact function on GitHub."
   Icon={GithubIcon}
-  href="https://github.com/expo/eas-build/blob/main/packages/build-tools/src/steps/functions/downloadArtifact.ts"
+  href="https://github.com/expo/eas-cli/blob/main/packages/build-tools/src/steps/functions/downloadArtifact.ts"
 />
 
 ## Built-in shell functions


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20234

# Why

The `expo/eas-build` repository was archived on 2026-02-24. All packages were relocated to `expo/eas-cli` at identical paths. This left 27 broken source code links across 3 docs pages pointing to files that no longer exist in the archived repo.

Fixes ENG-20234

# How

- Replace `github.com/expo/eas-build/blob/main/packages/` with `github.com/expo/eas-cli/blob/main/packages/` across 26 links in `docs/pages/custom-builds/schema.mdx` (22 links) and `docs/pages/eas/workflows/syntax.mdx` (10 links). All target files verified to exist at identical paths in `expo/eas-cli`.
- This package does not exist in either the archived `eas-build` or the new `eas-cli` repo. The text reference is kept as the plugin is still part of the iOS build server infrastructure.

# Test Plan

See diff or run the docs app locally to test.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
