### PR TITLE
[docs] Fix broken video URLs in SDK examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/unversioned/sdk/video-thumbnails.mdx
@@ -34,7 +34,7 @@ export default function App() {
   const generateThumbnail = async () => {
     try {
       const { uri } = await VideoThumbnails.getThumbnailAsync(
-        'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
         {
           time: 15000,
         }

--- a/docs/pages/versions/v53.0.0/sdk/video-av.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/video-av.mdx
@@ -42,7 +42,7 @@ export default function App() {
         ref={video}
         style={styles.video}
         source={{
-          uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+          uri: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
         }}
         useNativeControls
         resizeMode={ResizeMode.CONTAIN}

--- a/docs/pages/versions/v53.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/video-thumbnails.mdx
@@ -31,7 +31,7 @@ export default function App() {
   const generateThumbnail = async () => {
     try {
       const { uri } = await VideoThumbnails.getThumbnailAsync(
-        'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
         {
           time: 15000,
         }

--- a/docs/pages/versions/v54.0.0/sdk/video-av.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/video-av.mdx
@@ -42,7 +42,7 @@ export default function App() {
         ref={video}
         style={styles.video}
         source={{
-          uri: 'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+          uri: 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
         }}
         useNativeControls
         resizeMode={ResizeMode.CONTAIN}

--- a/docs/pages/versions/v54.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/video-thumbnails.mdx
@@ -31,7 +31,7 @@ export default function App() {
   const generateThumbnail = async () => {
     try {
       const { uri } = await VideoThumbnails.getThumbnailAsync(
-        'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
         {
           time: 15000,
         }

--- a/docs/pages/versions/v55.0.0/sdk/video-thumbnails.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/video-thumbnails.mdx
@@ -34,7 +34,7 @@ export default function App() {
   const generateThumbnail = async () => {
     try {
       const { uri } = await VideoThumbnails.getThumbnailAsync(
-        'https://d23dyxeqlo5psv.cloudfront.net/big_buck_bunny.mp4',
+        'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
         {
           time: 15000,
         }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20235

# How

- Replace the dead CloudFront URL with the Google Cloud Storage hosted version of the same Big Buck Bunny video (`https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4`) across 7 files.
- Updated `video-thumbnails.mdx` in versions: v53, v54, v55, latest, and unversioned.
- Updated `video-av.mdx` in versions: v53 and v54.

# Test Plan

See diff or run the docs app locally and click the link manually.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
