### PR TITLE
[video][ios] Fix crashes when `VideoTrack` properties are non-finite

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix crash when loading PHAsset url fails ([#43373](https://github.com/expo/expo/pull/43373) by [@fractalbeauty](https://github.com/fractalbeauty))
+- [iOS] Fix crashes when `VideoTrack` properties are non-finite.
 
 ### 💡 Others
 

--- a/packages/expo-video/ios/Records/Tracks.swift
+++ b/packages/expo-video/ios/Records/Tracks.swift
@@ -87,14 +87,15 @@ internal struct VideoTrack: Record, Equatable {
     let supported = (try? await assetTrack.load(.isPlayable)) ?? true
     let mediaFormat = try? await assetTrack.mediaFormat
     let frameRate = try? await assetTrack.load(.nominalFrameRate)
+    let safeFrameRate = (frameRate?.isFinite == true) ? frameRate : nil
 
-    if let bitrateFloat = try? await assetTrack.load(.estimatedDataRate) {
+    if let bitrateFloat = try? await assetTrack.load(.estimatedDataRate), bitrateFloat.isFinite {
       averageBitrate = Int(bitrateFloat)
     }
 
     let peakBitrate = await assetTrack.getPeakBitrate()
 
-    if let cgSize = try? await assetTrack.load(.naturalSize) {
+    if let cgSize = try? await assetTrack.load(.naturalSize), cgSize.width.isFinite, cgSize.height.isFinite {
       size = VideoSize.from(cgSize)
     }
 
@@ -106,7 +107,7 @@ internal struct VideoTrack: Record, Equatable {
       peakBitrate: peakBitrate,
       averageBitrate: averageBitrate,
       isSupported: supported,
-      frameRate: frameRate
+      frameRate: safeFrameRate
     )
   }
 
@@ -120,9 +121,10 @@ internal struct VideoTrack: Record, Equatable {
     let id = extractHlsTrackId(trackUrl: trackUrl, mainUrl: mainUrl)
     let videoSize = videoAttributes.videoSize
     let mimeType = videoAttributes.getFormattedCodecString()
-    let frameRate = videoAttributes.nominalFrameRate.map(Float.init)
-    let peakBitrate = assetVariant.peakBitRate.map(Int.init)
-    let averageBitrate = assetVariant.averageBitRate.map(Int.init)
+    let frameRate = videoAttributes.nominalFrameRate.flatMap(Float.init)
+    let peakBitrate = assetVariant.peakBitRate.flatMap { $0.isFinite ? Int($0) : nil }
+    let averageBitrate = assetVariant.averageBitRate.flatMap { $0.isFinite ? Int($0) : nil }
+    let safeFrameRate = (frameRate?.isFinite == true) ? frameRate : nil
 
     return VideoTrack(
       id: id,
@@ -133,7 +135,7 @@ internal struct VideoTrack: Record, Equatable {
       peakBitrate: peakBitrate,
       averageBitrate: averageBitrate,
       isSupported: isPlayable,
-      frameRate: frameRate
+      frameRate: safeFrameRate
     )
   }
 

--- a/packages/expo-video/ios/Utils/AVAssetVariant+VideoTracks.swift
+++ b/packages/expo-video/ios/Utils/AVAssetVariant+VideoTracks.swift
@@ -1,7 +1,10 @@
 import AVKit
 
 extension AVAssetVariant.VideoAttributes {
-  var videoSize: VideoSize {
+  var videoSize: VideoSize? {
+    guard presentationSize.width.isFinite, presentationSize.height.isFinite else {
+      return nil
+    }
     return VideoSize(width: Int(presentationSize.width), height: Int(presentationSize.height))
   }
 


### PR DESCRIPTION
# Why

Fix https://github.com/expo/expo/issues/44053

Apparently for some video sources the reported values are non-finite, leading to crashes. I wasn't able to reproduce this with our sources but we can make the code a bit safer.

# How

Wrap the problematic values in checks to avoid crashes.

# Test Plan

Tested in BareExpo on iOS 26 simulator
