### PR TITLE
[inline-modules][docs] Add reference and tutorial for inline modules

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -310,6 +310,7 @@ export const general = [
       makeSection('Tutorials', [
         makePage('modules/native-module-tutorial.mdx'),
         makePage('modules/native-view-tutorial.mdx'),
+        makePage('modules/inline-modules-tutorial.mdx'),
         makePage('modules/config-plugin-and-native-module-tutorial.mdx'),
         makePage('modules/use-standalone-expo-module-in-your-project.mdx'),
         makePage('modules/third-party-library.mdx'),
@@ -318,6 +319,7 @@ export const general = [
       ]),
       makeSection('Reference', [
         makePage('modules/module-api.mdx'),
+        makePage('modules/inline-modules-reference.mdx'),
         makePage('modules/android-lifecycle-listeners.mdx'),
         makePage('modules/appdelegate-subscribers.mdx'),
         makePage('modules/autolinking.mdx'),

--- a/docs/pages/modules/inline-modules-reference.mdx
+++ b/docs/pages/modules/inline-modules-reference.mdx
@@ -1,0 +1,55 @@
+---
+title: Inline modules reference
+description: A reference of Expo inline modules.
+sidebar_title: Inline modules reference
+---
+
+import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
+
+Inline modules is a set of functionalities which allow for simple native module creation and usage.
+
+## Configuration
+
+### App config
+
+<PaddedAPIBox header="expo.experiments.inlineModules">
+When defined, enables inline modules functionality in Expo CLI and Expo Modules Autolinking.
+
+```json app.json
+{
+  "expo": {
+    "experiments": {
+      "inlineModules": {}
+    }
+  }
+}
+```
+
+</PaddedAPIBox>
+
+<PaddedAPIBox header="expo.inlineModules.watchedDirectories">
+Configures in which directories the inline modules can be created.
+ 
+```json app.json
+{
+  "expo": {
+    "experiments": {
+      "inlineModules": {
+        "watchedDirectories": ["app", "src"]
+      }
+    }
+  }
+}
+```
+
+Files inside nested directories will also be used, for example if `watchedDirectories = ["app"]`
+and there exists a `app/nested/directory/SomeModule.kt` then the SomeModule will be used.
+
+A directory in `watchedDirectories`:
+
+- needs to be inside a JS project, that is have an ancestor in the directory tree which has `package.json`. For example `watchedDirectories: ["app", "src/some/directory", pathToOtherProject]` should work and `"watchedDirectories": ["/", pathToFolderNotInNodeProject] won't.
+- cannot be the whole project directory `"./"`, nor an ancestor of it (for example `../`).
+- cannot be a subdirectory of other directory in `watchedDirectories`. For example `watchedDirectories` cannot be ["app", "app/nested/directory"], however you can just set `watchedDirectories` to `["app"]`.
+- cannot contain special characters like `" ", "(", ")", "$"`. Note that this means you cannot have `"app/(tabs)"` in the `watchedDirectories`, but you can have `"app"` and it should still use native files from `"app/(tabs)"` directory.
+
+</PaddedAPIBox>

--- a/docs/pages/modules/inline-modules-reference.mdx
+++ b/docs/pages/modules/inline-modules-reference.mdx
@@ -10,8 +10,6 @@ Inline modules is a set of functionalities which allow for simple native module 
 
 ## Configuration
 
-### App config
-
 <PaddedAPIBox header="expo.experiments.inlineModules">
 When defined, enables inline modules functionality in Expo CLI and Expo Modules Autolinking.
 
@@ -27,7 +25,7 @@ When defined, enables inline modules functionality in Expo CLI and Expo Modules 
 
 </PaddedAPIBox>
 
-<PaddedAPIBox header="expo.inlineModules.watchedDirectories">
+<PaddedAPIBox header="expo.experiments.inlineModules.watchedDirectories">
 Configures in which directories the inline modules can be created.
  
 ```json app.json
@@ -43,13 +41,32 @@ Configures in which directories the inline modules can be created.
 ```
 
 Files inside nested directories will also be used, for example if `watchedDirectories = ["app"]`
-and there exists a `app/nested/directory/SomeModule.kt` then the SomeModule will be used.
+and there exists a `app/nested/directory/SomeModule.kt` then the `SomeModule` will be used.
 
 A directory in `watchedDirectories`:
 
-- needs to be inside a JS project, that is have an ancestor in the directory tree which has `package.json`. For example `watchedDirectories: ["app", "src/some/directory", pathToOtherProject]` should work and `"watchedDirectories": ["/", pathToFolderNotInNodeProject] won't.
+- needs to be inside a JS project, that is have an ancestor in the directory tree which has `package.json`. For example `"watchedDirectories": ["app", "src/some/directory", pathToOtherProject]` should work and `"watchedDirectories": ["/", pathToFolderNotInNodeProject]` won't.
 - cannot be the whole project directory `"./"`, nor an ancestor of it (for example `../`).
-- cannot be a subdirectory of other directory in `watchedDirectories`. For example `watchedDirectories` cannot be ["app", "app/nested/directory"], however you can just set `watchedDirectories` to `["app"]`.
+- cannot be a subdirectory of other directory in `watchedDirectories`. For example `watchedDirectories` cannot be `["app", "app/nested/directory"]`, however you can just set `watchedDirectories` to `["app"]`.
 - cannot contain special characters like `" ", "(", ")", "$"`. Note that this means you cannot have `"app/(tabs)"` in the `watchedDirectories`, but you can have `"app"` and it should still use native files from `"app/(tabs)"` directory.
 
 </PaddedAPIBox>
+
+> **Warning** You need to run `yarn expo prebuild` after changing the `app.json` configuration, for it to take effect.
+
+## General information
+
+Inline module file name has to match the native module name. This means that if you have a `SimpleModule.kt` then the inline module inside it has to be:
+
+```kt
+// SimpleModule.kt
+// ...
+class SimpleModule: Module() { // Note that the class name has to match the filename.
+    public func definition() -> ModuleDefinition {
+        // Name("SimpleModule") // Note that `Name` also has to match the filename. So you can just omit it.
+    }
+}
+
+```
+
+This means that you cannot have different inline modules with the same name in different directories.

--- a/docs/pages/modules/inline-modules-reference.mdx
+++ b/docs/pages/modules/inline-modules-reference.mdx
@@ -1,12 +1,14 @@
 ---
 title: Inline modules reference
 description: A reference of Expo inline modules.
-sidebar_title: Inline modules reference
 ---
 
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 
-Inline modules is a set of functionalities which allow for simple native module creation and usage.
+> **warning** **Warning:** Inline modules are currently experimental. The API is subject to breaking changes.
+
+Inline modules let you write native module code (Kotlin and Swift) directly in your Expo project directory,
+without creating a separate Expo module package. Expo discovers these files automatically and includes them in the build during prebuild.
 
 ## Configuration
 
@@ -40,25 +42,27 @@ Configures in which directories the inline modules can be created.
 }
 ```
 
-Files inside nested directories will also be used, for example if `watchedDirectories = ["app"]`
-and there exists a `app/nested/directory/SomeModule.kt` then the `SomeModule` will be used.
+Files inside nested directories will also be used.
+For example, if `watchedDirectories = ["app"]` is defined in the app config,
+and a module file such as **app/nested/directory/SomeModule.kt** exists in a nested path, then `SomeModule` can be used in your app.
 
 A directory in `watchedDirectories`:
 
-- needs to be inside a JS project, that is have an ancestor in the directory tree which has `package.json`. For example `"watchedDirectories": ["app", "src/some/directory", pathToOtherProject]` should work and `"watchedDirectories": ["/", pathToFolderNotInNodeProject]` won't.
-- cannot be the whole project directory `"./"`, nor an ancestor of it (for example `../`).
-- cannot be a subdirectory of other directory in `watchedDirectories`. For example `watchedDirectories` cannot be `["app", "app/nested/directory"]`, however you can just set `watchedDirectories` to `["app"]`.
-- cannot contain special characters like `" ", "(", ")", "$"`. Note that this means you cannot have `"app/(tabs)"` in the `watchedDirectories`, but you can have `"app"` and it should still use native files from `"app/(tabs)"` directory.
+- Needs to be inside a TypeScript/JavaScript project. This means it needs to have an ancestor in the directory tree that has **package.json**. For example, `"watchedDirectories": ["app", "src/some/directory", pathToOtherProject]` should work and `"watchedDirectories": ["/", pathToFolderNotInNodeProject]` won't.
+- Cannot be the whole project directory, for example,`"./"`, nor an ancestor of it (for example `../`).
+- Cannot be a subdirectory of the other directory in `watchedDirectories`. For example, `watchedDirectories` cannot be `["app", "app/nested/directory"]`, you can just set `watchedDirectories` to `["app"]`.
+- Cannot contain special characters like `" ", "(", ")", "$"`. This means you cannot have `"app/(tabs)"` in the `watchedDirectories`, but you can have `"app"` and it should still use native files from `"app/(tabs)"` directory.
 
 </PaddedAPIBox>
 
-> **Warning** You need to run `yarn expo prebuild` after changing the `app.json` configuration, for it to take effect.
+> **Warning** You need to run `npx expo prebuild` after changing the [app config](/workflow/configuration/), for it to take effect.
 
-## General information
+## Naming convention
 
-Inline module file name has to match the native module name. This means that if you have a `SimpleModule.kt` then the inline module inside it has to be:
+The inline module file name has to match the native module name (which needs to be unique in your whole app).
+If you have a **SimpleModule.kt**, then the inline module inside it has that file name. For example:
 
-```kt
+```kotlin
 // SimpleModule.kt
 // ...
 class SimpleModule: Module() { // Note that the class name has to match the filename.
@@ -66,7 +70,4 @@ class SimpleModule: Module() { // Note that the class name has to match the file
         // Name("SimpleModule") // Note that `Name` also has to match the filename. So you can just omit it.
     }
 }
-
 ```
-
-This means that you cannot have different inline modules with the same name in different directories.

--- a/docs/pages/modules/inline-modules-reference.mdx
+++ b/docs/pages/modules/inline-modules-reference.mdx
@@ -8,7 +8,7 @@ import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 > **warning** **Warning:** Inline modules are currently experimental. The API is subject to breaking changes.
 
 Inline modules let you write native module code (Kotlin and Swift) directly in your Expo project directory,
-without creating a separate Expo module package. Expo discovers these files automatically and includes them in the build during prebuild.
+without creating a separate Expo module package. Expo discovers these files automatically and includes them in the build.
 
 ## Configuration
 

--- a/docs/pages/modules/inline-modules-tutorial.mdx
+++ b/docs/pages/modules/inline-modules-tutorial.mdx
@@ -1,0 +1,259 @@
+---
+title: 'Tutorial: Create an inline module'
+sidebar_title: Create an inline module
+description: A tutorial on creating inline modules.
+---
+
+import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Terminal } from '~/ui/components/Snippet';
+import { Step } from '~/ui/components/Step';
+import { PageLink } from '~/ui/components/Navigation/PageLink';
+
+In this tutorial, you'll build a simple inline module.
+
+<Step label="1">
+
+## Setup your project
+
+Open the `app.json` and set `expo.experiments.inlineModules.watchedDirectories` to `["app"]`
+
+```json app.json
+{
+  "expo": {
+    "experiments": {
+      "inlineModules": {
+        "watchedDirectories": ["app"]
+      }
+    }
+  }
+}
+```
+
+Defining `expo.experiments.inlineModules` enables inline modules functionalities in Expo. Note that you will need to prebuild the ios after changing this option as it changes Xcode project files!
+
+In `expo.inlineModules.watchedDirectories` you can specify in which directories are your inline modules. Note that not all directories are allowed, checkout the [inline modules reference](/modules/inline-modules-reference).
+
+</Step>
+
+<Step label="2">
+
+## Run prebuild
+
+Run the prebuild command to generate android and ios projects with the inline modules setup.
+
+<Terminal cmdCopy="yarn expo prebuild" cmd={['$ yarn expo prebuild']} />
+
+</Step>
+
+<Step label="3">
+
+## Create an inline module
+
+Create a kotlin file `FirstInlineModule.kt` in the `app` directory and write a module in there.
+
+```kotlin app/FirstInlineModule.kt
+package app
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+
+class FirstInlineModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Constant("Hello") { ->
+      "Hello android inline modules!"
+    }
+  }
+}
+
+```
+
+Also create a `FirstInlineModule.swift` in the `app` directory and write a similar module.
+
+```swift app/FirstInlineModule.swift
+import ExpoModulesCore
+
+public class FirstInlineModule: Module {
+  public func definition() -> ModuleDefinition {
+    Constant("Hello") {
+      return "Hello ios inline modules!"
+    }
+  }
+}
+
+```
+
+</Step>
+
+<Step label="4">
+
+## Use the module inside your components
+
+In TS/JS you can use the module in a following way
+
+```tsx app/index.tsx
+import { requireNativeModule } from 'expo';
+import { Text } from 'react-native';
+
+const FirstInlineModule = requireNativeModule('FirstInlineModule');
+
+export default function InlineModulesDemoComponent() {
+  return <Text> {FirstInlineModule.Hello} </Text>;
+}
+```
+
+You can run you android app
+
+<Terminal cmdCopy="yarn expo run:android" cmd={['$ yarn expo run:android']} />
+
+Or your ios app
+
+<Terminal cmdCopy="yarn expo run:ios" cmd={['$ yarn expo run:ios']} />
+
+When run you should see the application with the text constant from the appropriate android/ios module.
+
+</Step>
+
+<Step label="5">
+## Create a native view
+
+Create a kotlin file `FirstInlineView.kt` in the `app` directory and write a view in there.
+We will use a ExpoWebView created in native views tutorial.
+
+```kotlin app/FirstInlineView.kt
+package app
+
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.net.URL
+
+import android.content.Context
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.ExpoView
+
+class FirstInlineView : Module() {
+  override fun definition() = ModuleDefinition {
+    View(ExpoWebView::class) {
+      Events("onLoad")
+
+      Prop("url") { view: ExpoWebView, url: URL? ->
+        view.webView.loadUrl(url.toString())
+      }
+    }
+  }
+}
+
+class ExpoWebView(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
+  private val onLoad by EventDispatcher()
+
+  internal val webView = WebView(context).also {
+    it.layoutParams = LayoutParams(
+      LayoutParams.MATCH_PARENT,
+      LayoutParams.MATCH_PARENT
+    )
+
+    it.webViewClient = object : WebViewClient() {
+      override fun onPageFinished(view: WebView, url: String) {
+        onLoad(mapOf("url" to url))
+      }
+    }
+
+    addView(it)
+  }
+}
+
+```
+
+Now create a swift file `FirstInlineView.swift` in the `app` directory.
+
+```swift app/FirstInlineView.swift
+import ExpoModulesCore
+import WebKit
+
+public class FirstInlineView: Module {
+  public func definition() -> ModuleDefinition {
+    View(ExpoWebView.self) {
+      Events("onLoad")
+
+      Prop("url") { (view, url: URL) in
+        if view.webView.url != url {
+          let urlRequest = URLRequest(url: url)
+          view.webView.load(urlRequest)
+        }
+      }
+    }
+  }
+}
+
+class ExpoWebView: ExpoView, WKNavigationDelegate {
+  let webView = WKWebView()
+  let onLoad = EventDispatcher()
+
+  required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    clipsToBounds = true
+    webView.navigationDelegate = self
+    addSubview(webView)
+  }
+
+  override func layoutSubviews() {
+    webView.frame = bounds
+  }
+
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    if let url = webView.url {
+      onLoad([
+        "url": url.absoluteString
+      ])
+    }
+  }
+}
+
+```
+
+</Step>
+
+<Step label="6">
+## Use the native view
+You use the inline view in a similar way to the inline modules:
+
+```tsx app/index.tsx
+import { requireNativeModule, requireNativeView } from 'expo';
+import { Text } from 'react-native';
+
+const FirstInlineModule = requireNativeModule('FirstInlineModule');
+const FirstInlineView = requireNativeView('FirstInlineView');
+
+export default function InlineModulesDemoComponent() {
+  return (
+    <>
+      <Text> {FirstInlineModule.Hello} </Text>
+      <FirstInlineView style={{ flex: 1 }} url="https://docs.expo.dev/modules/" />
+    </>
+  );
+}
+```
+
+</Step>
+
+Congratulations! You've created your first Expo inline module and inline view!
+
+## Next steps
+
+<BoxLink
+  title="Expo inline modules reference"
+  description="Create inline modules using Kotlin and Swift."
+  href="/modules/inline-modules-reference"
+  Icon={Grid01Icon}
+/>
+
+<BoxLink
+  title="Tutorial: Creating a native module"
+  description="A tutorial on creating a native module that persists settings with Expo Modules API."
+  href="/modules/native-module-tutorial/"
+  Icon={Grid01Icon}
+/>

--- a/docs/pages/modules/inline-modules-tutorial.mdx
+++ b/docs/pages/modules/inline-modules-tutorial.mdx
@@ -9,7 +9,6 @@ import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { PageLink } from '~/ui/components/Navigation/PageLink';
 
 In this tutorial, you'll build a simple inline module and an inline view.
 

--- a/docs/pages/modules/inline-modules-tutorial.mdx
+++ b/docs/pages/modules/inline-modules-tutorial.mdx
@@ -11,13 +11,13 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { PageLink } from '~/ui/components/Navigation/PageLink';
 
-In this tutorial, you'll build a simple inline module.
+In this tutorial, you'll build a simple inline module and an inline view.
 
 <Step label="1">
 
 ## Setup your project
 
-Open the `app.json` and set `expo.experiments.inlineModules.watchedDirectories` to `["app"]`
+Open the `app.json` and set the `expo.experiments.inlineModules.watchedDirectories` to `["app"]`
 
 ```json app.json
 {
@@ -33,7 +33,7 @@ Open the `app.json` and set `expo.experiments.inlineModules.watchedDirectories` 
 
 Defining `expo.experiments.inlineModules` enables inline modules functionalities in Expo. Note that you will need to prebuild the ios after changing this option as it changes Xcode project files!
 
-In `expo.inlineModules.watchedDirectories` you can specify in which directories are your inline modules. Note that not all directories are allowed, checkout the [inline modules reference](/modules/inline-modules-reference).
+In `expo.experiments.inlineModules.watchedDirectories` you can specify in which directories your inline modules lie. Note that not all directories are allowed, checkout the [inline modules reference](/modules/inline-modules-reference) for more information.
 
 </Step>
 
@@ -62,7 +62,7 @@ import expo.modules.kotlin.modules.ModuleDefinition
 class FirstInlineModule : Module() {
   override fun definition() = ModuleDefinition {
     Constant("Hello") { ->
-      "Hello android inline modules!"
+      "Hello Android inline modules!"
     }
   }
 }
@@ -77,7 +77,7 @@ import ExpoModulesCore
 public class FirstInlineModule: Module {
   public func definition() -> ModuleDefinition {
     Constant("Hello") {
-      return "Hello ios inline modules!"
+      return "Hello Ios inline modules!"
     }
   }
 }
@@ -88,7 +88,7 @@ public class FirstInlineModule: Module {
 
 <Step label="4">
 
-## Use the module inside your components
+## Use the module in JS
 
 In TS/JS you can use the module in a following way
 
@@ -119,7 +119,7 @@ When run you should see the application with the text constant from the appropri
 ## Create a native view
 
 Create a kotlin file `FirstInlineView.kt` in the `app` directory and write a view in there.
-We will use a ExpoWebView created in native views tutorial.
+We will use the ExpoWebView created in the native views tutorial.
 
 ```kotlin app/FirstInlineView.kt
 package app
@@ -218,8 +218,8 @@ class ExpoWebView: ExpoView, WKNavigationDelegate {
 </Step>
 
 <Step label="6">
-## Use the native view
-You use the inline view in a similar way to the inline modules:
+## Use the native view in JS
+You use the inline view in a similar way to the inline module:
 
 ```tsx app/index.tsx
 import { requireNativeModule, requireNativeView } from 'expo';
@@ -240,7 +240,7 @@ export default function InlineModulesDemoComponent() {
 
 </Step>
 
-Congratulations! You've created your first Expo inline module and inline view!
+Congratulations! You've created your first Expo inline module and view!
 
 ## Next steps
 

--- a/docs/pages/modules/inline-modules-tutorial.mdx
+++ b/docs/pages/modules/inline-modules-tutorial.mdx
@@ -43,7 +43,7 @@ Note that not all directories are allowed. For more information, see the [inline
 
 ## Run prebuild
 
-Run the prebuild command to generate **android** and **iOS** native projects with the inline modules setup.
+Run the prebuild command to generate **android** and **ios** native projects with the inline modules setup.
 
 <Terminal cmdCopy="npx expo prebuild" cmd={['$ npx expo prebuild']} />
 
@@ -123,6 +123,7 @@ After running the above command(s), you will see the app with text constant comi
 ## Create a native view
 
 To create a native view inside the **app** directory, let's use the `ExpoWebView` example.
+
 For Android, create a Kotlin file called **FirstInlineView.kt** inside the **app** directory and add a view similar to the following:
 
 ```kotlin app/FirstInlineView.kt
@@ -248,7 +249,7 @@ const styles = StyleSheet.create({
 });
 ```
 
-Now run your example app by compiling it using `npx expo run:android` or `npx expo run:ios` command to view the inline view.
+Now run your example app by compiling it using `npx expo run:android` or `npx expo run:ios` command.
 
 After running the above command(s), you will see the app with a text constant coming from the native android/iOS module and a web view coming from a native view.
 

--- a/docs/pages/modules/inline-modules-tutorial.mdx
+++ b/docs/pages/modules/inline-modules-tutorial.mdx
@@ -10,6 +10,8 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
+> **warning** **Warning:** Inline modules are currently experimental. The API is subject to breaking changes.
+
 In this tutorial, you will create an example native module and a native view directly inside your Expo project's **app** directory using inline modules.
 Unlike the standard Expo Modules, inline modules don't require a separate package or `create-expo-module` scaffolding.
 You write Kotlin and Swift files alongside your app code, and Expo discovers them automatically.
@@ -18,7 +20,7 @@ You write Kotlin and Swift files alongside your app code, and Expo discovers the
 
 ## Setup your project
 
-Open the [app config](/workflow/configuration/) and set the `expo.experiments.inlineModules.watchedDirectories` to `["app"]`
+Open the [app config](/workflow/configuration/) and set the `expo.experiments.inlineModules.watchedDirectories` to `["app"]`:
 
 ```json app.json
 {

--- a/docs/pages/modules/inline-modules-tutorial.mdx
+++ b/docs/pages/modules/inline-modules-tutorial.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Tutorial: Create an inline module'
 sidebar_title: Create an inline module
-description: A tutorial on creating inline modules.
+description: A tutorial on creating a native module and view directly in your Expo project using inline modules.
 ---
 
 import { Grid01Icon } from '@expo/styleguide-icons/outline/Grid01Icon';
@@ -10,13 +10,15 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-In this tutorial, you'll build a simple inline module and an inline view.
+In this tutorial, you will create an example native module and a native view directly inside your Expo project's **app** directory using inline modules.
+Unlike the standard Expo Modules, inline modules don't require a separate package or `create-expo-module` scaffolding.
+You write Kotlin and Swift files alongside your app code, and Expo discovers them automatically.
 
 <Step label="1">
 
 ## Setup your project
 
-Open the `app.json` and set the `expo.experiments.inlineModules.watchedDirectories` to `["app"]`
+Open the [app config](/workflow/configuration/) and set the `expo.experiments.inlineModules.watchedDirectories` to `["app"]`
 
 ```json app.json
 {
@@ -30,9 +32,10 @@ Open the `app.json` and set the `expo.experiments.inlineModules.watchedDirectori
 }
 ```
 
-Defining `expo.experiments.inlineModules` enables inline modules functionalities in Expo. Note that you will need to prebuild the ios after changing this option as it changes Xcode project files!
+Defining `expo.experiments.inlineModules` enables inline modules functionalities in an Expo project.
 
-In `expo.experiments.inlineModules.watchedDirectories` you can specify in which directories your inline modules lie. Note that not all directories are allowed, checkout the [inline modules reference](/modules/inline-modules-reference) for more information.
+In `expo.experiments.inlineModules.watchedDirectories` you can specify in which directories your inline modules live.
+Note that not all directories are allowed. For more information, see the [inline modules reference](/modules/inline-modules-reference).
 
 </Step>
 
@@ -40,9 +43,9 @@ In `expo.experiments.inlineModules.watchedDirectories` you can specify in which 
 
 ## Run prebuild
 
-Run the prebuild command to generate android and ios projects with the inline modules setup.
+Run the prebuild command to generate **android** and **iOS** native projects with the inline modules setup.
 
-<Terminal cmdCopy="yarn expo prebuild" cmd={['$ yarn expo prebuild']} />
+<Terminal cmdCopy="npx expo prebuild" cmd={['$ npx expo prebuild']} />
 
 </Step>
 
@@ -50,7 +53,7 @@ Run the prebuild command to generate android and ios projects with the inline mo
 
 ## Create an inline module
 
-Create a kotlin file `FirstInlineModule.kt` in the `app` directory and write a module in there.
+For Android, create a Kotlin file called **FirstInlineModule.kt** inside the **app** directory and add a module similar to the following:
 
 ```kotlin app/FirstInlineModule.kt
 package app
@@ -65,31 +68,29 @@ class FirstInlineModule : Module() {
     }
   }
 }
-
 ```
 
-Also create a `FirstInlineModule.swift` in the `app` directory and write a similar module.
+For iOS, create a Swift file called **FirstInlineModule.swift** inside the **app** directory:
 
 ```swift app/FirstInlineModule.swift
-import ExpoModulesCore
+internal import ExpoModulesCore
 
-public class FirstInlineModule: Module {
+class FirstInlineModule: Module {
   public func definition() -> ModuleDefinition {
     Constant("Hello") {
-      return "Hello Ios inline modules!"
+      return "Hello iOS inline modules!"
     }
   }
 }
-
 ```
 
 </Step>
 
 <Step label="4">
 
-## Use the module in JS
+## Use the module in your app
 
-In TS/JS you can use the module in a following way
+In your app's TypeScript/JavaScript code you can use the module in the following way:
 
 ```tsx app/index.tsx
 import { requireNativeModule } from 'expo';
@@ -102,23 +103,27 @@ export default function InlineModulesDemoComponent() {
 }
 ```
 
-You can run you android app
+Now, you can run the example app:
 
-<Terminal cmdCopy="yarn expo run:android" cmd={['$ yarn expo run:android']} />
+<Terminal
+  cmd={[
+    '# Run the example app on Android',
+    '$ npx expo run:android',
+    '',
+    '# Run the example app on iOS',
+    '$ npx expo run:ios',
+  ]}
+/>
 
-Or your ios app
-
-<Terminal cmdCopy="yarn expo run:ios" cmd={['$ yarn expo run:ios']} />
-
-When run you should see the application with the text constant from the appropriate android/ios module.
+After running the above command(s), you will see the app with text constant coming from the native android/iOS module.
 
 </Step>
 
 <Step label="5">
 ## Create a native view
 
-Create a kotlin file `FirstInlineView.kt` in the `app` directory and write a view in there.
-We will use the ExpoWebView created in the native views tutorial.
+To create a native view inside the **app** directory, let's use the `ExpoWebView` example.
+For Android, create a Kotlin file called **FirstInlineView.kt** inside the **app** directory and add a view similar to the following:
 
 ```kotlin app/FirstInlineView.kt
 package app
@@ -164,16 +169,15 @@ class ExpoWebView(context: Context, appContext: AppContext) : ExpoView(context, 
     addView(it)
   }
 }
-
 ```
 
-Now create a swift file `FirstInlineView.swift` in the `app` directory.
+For iOS, create a Swift file called **FirstInlineView.swift** inside the **app** directory:
 
 ```swift app/FirstInlineView.swift
-import ExpoModulesCore
+internal import ExpoModulesCore
 import WebKit
 
-public class FirstInlineView: Module {
+class FirstInlineView: Module {
   public func definition() -> ModuleDefinition {
     View(ExpoWebView.self) {
       Events("onLoad")
@@ -211,18 +215,17 @@ class ExpoWebView: ExpoView, WKNavigationDelegate {
     }
   }
 }
-
 ```
 
 </Step>
 
 <Step label="6">
-## Use the native view in JS
+## Use the native view in your app
 You use the inline view in a similar way to the inline module:
 
 ```tsx app/index.tsx
 import { requireNativeModule, requireNativeView } from 'expo';
-import { Text } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 
 const FirstInlineModule = requireNativeModule('FirstInlineModule');
 const FirstInlineView = requireNativeView('FirstInlineView');
@@ -230,22 +233,34 @@ const FirstInlineView = requireNativeView('FirstInlineView');
 export default function InlineModulesDemoComponent() {
   return (
     <>
-      <Text> {FirstInlineModule.Hello} </Text>
-      <FirstInlineView style={{ flex: 1 }} url="https://docs.expo.dev/modules/" />
+      <View style={styles.textBox}>
+        <Text style={styles.text}> {FirstInlineModule.Hello} </Text>
+      </View>
+      <FirstInlineView style={styles.inlineView} url="https://docs.expo.dev/modules/" />
     </>
   );
 }
+
+const styles = StyleSheet.create({
+  textBox: { height: 100, justifyContent: 'flex-end', alignItems: 'center' },
+  text: { fontSize: 26 },
+  inlineView: { flex: 1 },
+});
 ```
+
+Now run your example app by compiling it using `npx expo run:android` or `npx expo run:ios` command to view the inline view.
+
+After running the above command(s), you will see the app with a text constant coming from the native android/iOS module and a web view coming from a native view.
 
 </Step>
 
-Congratulations! You've created your first Expo inline module and view!
+Congratulations! You've created your first Expo inline module and view.
 
 ## Next steps
 
 <BoxLink
   title="Expo inline modules reference"
-  description="Create inline modules using Kotlin and Swift."
+  description="A reference on how to create inline modules using Kotlin and Swift."
   href="/modules/inline-modules-reference"
   Icon={Grid01Icon}
 />


### PR DESCRIPTION
# Why
Inline modules are undocumented.

# How
Added a tutorial and reference pages for inline modules under modules API.
# Test Plan
Checked the docs locally.
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
