### PR TITLE
[docs] Add CSS loading order warning for Expo Router

### DIFF
--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -113,6 +113,8 @@ import './global.css';
 
 > **info** If you are using [DOM components](/guides/dom-components), add this file import to each module using the `"use dom"` directive since they don't share globals.
 
+> **warning** Always import global CSS in your root **\_layout.tsx**, not in a nested layout. Expo Router traverses the dependency graph starting from the root layout. Importing CSS in a nested layout (for example, **app/blog/\_layout.tsx**) causes **node_modules** CSS to load before your custom styles, which can break your intended style order.
+
 </Step>
 
 <Step label="5">
@@ -185,6 +187,8 @@ import './global.css';
 </CodeBlocksTable>
 
 > **info** If you are using [DOM components](/guides/dom-components), add this file import to each module using the `"use dom"` directive since they don't share globals.
+
+> **warning** Always import global CSS in your root **\_layout.tsx** and not in a nested layout. Expo Router traverses the dependency graph starting from the root layout. Importing CSS in a nested layout (for example, **app/blog/\_layout.tsx**) causes **node_modules** CSS to load before your custom styles, which can break your intended style order.
 
 </Step>
 

--- a/docs/pages/router/web/static-rendering.mdx
+++ b/docs/pages/router/web/static-rendering.mdx
@@ -187,7 +187,7 @@ export default function Root({ children }: PropsWithChildren) {
 - The `children` prop comes with the root `<div id="root" />` tag included inside.
 - The JavaScript scripts are appended after the static render.
 - React Native web styles are statically injected automatically.
-- Global CSS should not be imported into this file. Instead, use the [Root Layout](/router/basics/layout/#root-layout) component.
+- Global CSS should not be imported into this file. Instead, use the [Root Layout](/router/basics/layout/#root-layout). Expo Router traverses the dependency graph starting from the root layout, so importing CSS elsewhere can cause unexpected loading order where **node_modules** CSS takes precedence over your custom styles.
 - Browser APIs like `window.location` are unavailable in this component as it only runs in Node.js during static rendering.
 
 ### `expo-router/html`

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -117,6 +117,8 @@ import 'emoji-mart/css/emoji-mart.css';
 - On native, all global stylesheets are automatically ignored.
 - Hot reloading is supported for global stylesheets, simply save the file and the changes will be applied.
 
+> **warning** When using Expo Router, always import global CSS in your root **\_layout.tsx**. Expo Router traverses the dependency graph starting from the root layout. Importing CSS in a nested layout causes **node_modules** CSS to load before your custom styles, which can break your intended style order.
+
 ### CSS Modules
 
 > **warning** CSS Modules for native are under development and currently only work on web.

--- a/docs/pages/versions/v55.0.0/config/metro.mdx
+++ b/docs/pages/versions/v55.0.0/config/metro.mdx
@@ -117,6 +117,8 @@ import 'emoji-mart/css/emoji-mart.css';
 - On native, all global stylesheets are automatically ignored.
 - Hot reloading is supported for global stylesheets, simply save the file and the changes will be applied.
 
+> **warning** When using Expo Router, always import global CSS in your root **\_layout.tsx**. Expo Router traverses the dependency graph starting from the root layout. Importing CSS in a nested layout causes **node_modules** CSS to load before your custom styles, which can break your intended style order.
+
 ### CSS Modules
 
 > **warning** CSS Modules for native are under development and currently only work on web.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20196

# How

- Add a `**warning**` callout in **guides/tailwind.mdx** (both v3 and v4 tabs) after the global CSS import step, explaining that global CSS must be imported in the root **\_layout.tsx** and what happens if imported in a nested layout.
- Add the same `**warning**` callout in the Global CSS section of **versions/unversioned/config/metro.mdx** and **versions/v55.0.0/config/metro.mdx**.
- Expand the existing bullet point in **router/web/static-rendering.mdx** about not importing global CSS in the HTML component to also explain the dependency graph traversal and loading order consequence.

# Test Plan

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
