### PR TITLE
[docs] Update docs to use iOS 16.4 as the minimum version

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -54,10 +54,10 @@ Once installation is complete, apply the changes from the following diffs to con
 
 Optionally, you can also add additional delegate methods to your **AppDelegate.swift**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.swift](https://github.com/expo/expo/blob/sdk-54/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift#L24-L42).
 
-Save all of your changes and update your iOS Deployment Target in Xcode to <code>iOS 15.1</code>:
+Save all of your changes and update your iOS Deployment Target in Xcode to <code>iOS 16.4</code>:
 
 - Open **your-project-name.xcworkspace** in Xcode, select your project in the left sidebar.
-- Select **Targets** > **your-project-name** > **Build Settings** > **iOS Deployment Target** and set it to <code>iOS 15.1</code>.
+- Select **Targets** > **your-project-name** > **Build Settings** > **iOS Deployment Target** and set it to <code>iOS 16.4</code>.
 
 The last step is to install the project's CocoaPods again to pull in Expo modules that are detected by `use_expo_modules!` directive that we added to the **Podfile**:
 

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -284,7 +284,7 @@ require File.join(File.dirname(`node --print "require.resolve('react-native/pack
 
 require 'json'
 
-platform :ios, '15.1'
+platform :ios, '16.4'
 install! 'cocoapods',
   :deterministic_uuids => false
 


### PR DESCRIPTION
# Why

Follow-up #44068

# How

Updated the minimum version of iOS in unversioned docs
