### PR TITLE
[core][ui] soft missing host crash

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,7 +36,7 @@
 - [iOS] Fixed adding SwiftUI views to tabs BottomAccessory. ([#44247](https://github.com/expo/expo/pull/44247) by [@t0maboro](https://github.com/t0maboro))
 - [iOS] Fix finding EXConstants.bundle inside framework bundle for brownfield ([#44810](https://github.com/expo/expo/pull/44810) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix missing jsi headers when building static frameworks ([#44865](https://github.com/expo/expo/pull/44865) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Fixed runtime crash when missing Host component for swift-ui or jetpack-compose components. ([#44118](https://github.com/expo/expo/pull/44118) by [@kudo](https://github.com/kudo))
+- Fixed runtime crash when missing `Host` component for SwiftUI or Jetpack Compose components. ([#44118](https://github.com/expo/expo/pull/44118) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [iOS] Fixed adding SwiftUI views to tabs BottomAccessory. ([#44247](https://github.com/expo/expo/pull/44247) by [@t0maboro](https://github.com/t0maboro))
 - [iOS] Fix finding EXConstants.bundle inside framework bundle for brownfield ([#44810](https://github.com/expo/expo/pull/44810) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Fix missing jsi headers when building static frameworks ([#44865](https://github.com/expo/expo/pull/44865) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Fixed runtime crash when missing Host component for swift-ui or jetpack-compose components. ([#44118](https://github.com/expo/expo/pull/44118) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.views
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.runtime.Composable
@@ -16,6 +17,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.size
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.viewevent.CoalescingKey
 import expo.modules.kotlin.viewevent.EventDispatcher
@@ -90,6 +92,29 @@ abstract class ExpoComposeView<T : ComposeProps>(
         }
       }
     }
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    if (!withHostingView) {
+      validateHostingAncestor()
+    }
+  }
+
+  /**
+   * Validates that this non-hosting Compose view has a valid Compose parent.
+   * In a valid hierarchy the immediate parent is always an ExpoComposeView or ComposeView.
+   * If the parent is a regular ViewGroup (e.g. ReactViewGroup), the `<Host>` wrapper is missing.
+   */
+  private fun validateHostingAncestor() {
+    val parentView = parent
+    if (parentView is ExpoComposeView<*> || parentView is ComposeView) {
+      return
+    }
+    val componentName = (this as? ViewFunctionHolder)?.name ?: this.javaClass.simpleName
+    val exception = MissingHostException(componentName)
+    Log.e("ExpoComposeView", "", exception)
+    appContext.jsLogger?.error(exception.message ?: "Missing <Host>")
   }
 
   @Composable
@@ -479,3 +504,9 @@ class ComposeFunctionHolder<Props : ComposeProps>(
     }
   }
 }
+
+internal class MissingHostException(componentName: String) :
+  CodedException(
+    "A Jetpack Compose view \"$componentName\" must be rendered inside a <Host> component. " +
+      "Wrap your component with `<Host>` from '@expo/ui/jetpack-compose'."
+  )

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -103,8 +103,13 @@ abstract class ExpoComposeView<T : ComposeProps>(
 
   /**
    * Validates that this non-hosting Compose view has a valid Compose parent.
-   * In a valid hierarchy the immediate parent is always an ExpoComposeView or ComposeView.
-   * If the parent is a regular ViewGroup (e.g. ReactViewGroup), the `<Host>` wrapper is missing.
+   *
+   * This check is intentionally strict: the immediate parent must be an
+   * [ExpoComposeView] or a [ComposeView]. Compose's composition context does not
+   * propagate through arbitrary Android [ViewGroup]s, so inserting a plain RN
+   * `View` (or any other non-Compose [ViewGroup]) between `<Host>` and this
+   * component breaks the composition boundary — even though the ancestor chain
+   * eventually reaches a `<Host>`. The fix is to make `<Host>` the direct parent.
    */
   private fun validateHostingAncestor() {
     val parentView = parent
@@ -507,6 +512,8 @@ class ComposeFunctionHolder<Props : ComposeProps>(
 
 internal class MissingHostException(componentName: String) :
   CodedException(
-    "A Jetpack Compose view \"$componentName\" must be rendered inside a <Host> component. " +
-      "Wrap your component with `<Host>` from '@expo/ui/jetpack-compose'."
+    "A Jetpack Compose view \"$componentName\" must be rendered as a direct child of a <Host> component. " +
+      "Wrap your component with `<Host>` from '@expo/ui/jetpack-compose'. " +
+      "Note that inserting another `<View>` (or any non-Compose ViewGroup) between `<Host>` and this " +
+      "component breaks the Compose composition boundary and will still trigger this error."
   )

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSwiftUIViewType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSwiftUIViewType.swift
@@ -36,7 +36,16 @@ internal struct DynamicSwiftUIViewType<ViewType: ExpoSwiftUIView>: AnyDynamicTyp
     }
     // Direct match, the virtual view's content type matches exactly.
     // e.g. View(SlotView.self)
+    // Both the production (`SwiftUIVirtualView`, NSObject-based) and dev
+    // (`SwiftUIVirtualViewDev`, UIView-based) concrete classes are checked —
+    // only one is instantiated at runtime per build, but the type-erased
+    // `findView` lookup needs to know about both. Without this, dev builds
+    // would fall through to the `ViewWrapper` branch below, which recursively
+    // unwraps and is not strictly equivalent to returning `contentView` as-is.
     if let view = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.SwiftUIVirtualView<ViewType.Props, ViewType>.self) {
+      return view.contentView
+    }
+    if let view = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.SwiftUIVirtualViewDev<ViewType.Props, ViewType>.self) {
       return view.contentView
     }
     // For wrapper types

--- a/packages/expo-modules-core/ios/Core/Views/AppleView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/AppleView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /**
  An abstract view supports both UIKit and SwiftUI.
  */
-public enum AppleView: Sendable {
+public enum AppleView: @unchecked Sendable {
   case uikit(UIView)
   case swiftui(any ExpoSwiftUI.View)
 

--- a/packages/expo-modules-core/ios/Core/Views/AppleView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/AppleView.swift
@@ -4,6 +4,12 @@ import SwiftUI
 
 /**
  An abstract view supports both UIKit and SwiftUI.
+
+ Sendability is `@unchecked` because the dev-mode `SwiftUIVirtualViewDev` is a `UIView`
+ subclass (not `Sendable`). Safety is enforced by main-actor isolation at the producers
+ and consumers of this enum (see `SwiftUIViewDefinition.swift`), so it must never be
+ accessed off the main thread. Future changes that expose `AppleView` to background
+ execution need to reconsider this constraint.
  */
 public enum AppleView: @unchecked Sendable {
   case uikit(UIView)

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIViewDefinition.swift
@@ -6,7 +6,7 @@ import Combine
 /**
  A protocol for SwiftUI views that need to access props.
  */
-public protocol ExpoSwiftUIView<Props>: SwiftUI.View, AnyArgument, ExpoSwiftUI.AnyChild, Sendable {
+public protocol ExpoSwiftUIView<Props>: SwiftUI.View, AnyArgument, ExpoSwiftUI.AnyChild {
   associatedtype Props: ExpoSwiftUI.ViewProps
 
   var props: Props { get }
@@ -111,16 +111,19 @@ extension ExpoSwiftUI {
         if ViewType.self is ExpoSwiftUI.WithHostingView.Type {
           let view = ExpoSwiftUI.HostingView(viewType: ViewType.self, props: props, appContext: appContext)
           // Set up events to call view's `dispatchEvent` method.
-          // This is supported only on the new architecture, `dispatchEvent` exists only there.
           props.setUpEvents { [weak view] eventName, payload in view?.dispatchEvent(eventName, payload: payload) }
           return AppleView.from(view)
         }
-        
-        let view = ExpoSwiftUI.SwiftUIVirtualView(viewType: ViewType.self, props: props, viewDefinition: self, appContext: appContext)
-        // Set up events to call view's `dispatchEvent` method.
-        // This is supported only on the new architecture, `dispatchEvent` exists only there.
-        props.setUpEvents { [weak view] eventName, payload in view?.dispatchEvent(eventName, payload: payload) }
-        return AppleView.from(view)
+
+        if EXAppDefines.APP_RCT_DEV {
+          let view = ExpoSwiftUI.SwiftUIVirtualViewDev(viewType: ViewType.self, props: props, viewDefinition: self, appContext: appContext)
+          props.setUpEvents { [weak view] eventName, payload in view?.dispatchEvent(eventName, payload: payload) }
+          return .swiftui(view)
+        } else {
+          let view = ExpoSwiftUI.SwiftUIVirtualView(viewType: ViewType.self, props: props, viewDefinition: self, appContext: appContext)
+          props.setUpEvents { [weak view] eventName, payload in view?.dispatchEvent(eventName, payload: payload) }
+          return .swiftui(view)
+        }
       }
     }
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
@@ -2,17 +2,19 @@
 
 import SwiftUI
 
+// MARK: - Production class (NSObject base)
+
 extension ExpoSwiftUI {
   /**
    An NSObject acting as a fake UIView for RCTMountingManager to represent a SwiftUI view.
    This class is the Swift component of SwiftUIVirtualView, as referenced in ExpoFabricView.swift.
+   Used in production builds for minimal overhead.
    */
-  final class SwiftUIVirtualView<Props: ViewProps, ContentView: View<Props>>: SwiftUIVirtualViewObjC, ExpoSwiftUIView {
+  final class SwiftUIVirtualView<Props: ViewProps, ContentView: View<Props>>: SwiftUIVirtualViewObjC, @MainActor ExpoSwiftUIView {
     var uiView: UIView?
-    
+
     /**
      A weak reference to the app context associated with this view.
-     The app context is injected into the class after the context is initialized.
      */
     weak var appContext: AppContext?
 
@@ -41,9 +43,10 @@ extension ExpoSwiftUI {
       self.viewDefinition = viewDefinition
       self.appContext = appContext
       super.init()
+      self.componentName = String(describing: viewType)
 
       props.shadowNodeProxy.setViewSize = { [weak self] size in
-        self?.setViewSize(size)
+        self?.setShadowNodeSize(Float(size.width), height: Float(size.height))
       }
       props.shadowNodeProxy.setStyleSize = { [weak self] width, height in
         self?.setStyleSize(width, height: height)
@@ -55,10 +58,6 @@ extension ExpoSwiftUI {
     // swiftlint:disable:next unavailable_function - init(props:) is required from ExpoSwiftUIView protocol
     init(props: Props) {
       fatalError("init(props:) is not expected to be called directly")
-    }
-
-    func setViewSize(_ size: CGSize) {
-      super.setShadowNodeSize(Float(size.width), height: Float(size.height))
     }
 
     // MARK: - ExpoSwiftUIView implementations
@@ -81,19 +80,11 @@ extension ExpoSwiftUI {
      Updates the environment object with props, based on the given dictionary with raw props.
      */
     override func updateProps(_ rawProps: [String: Any]) {
-      guard let appContext else {
-        log.error("AppContext is not available, view props cannot be updated for \(self)")
-        return
-      }
-      do {
-        try props.updateRawProps(rawProps, appContext: appContext)
-      } catch let error {
-        log.error("Updating props for \(self) has failed: \(error.localizedDescription)")
-      }
+      virtualViewUpdateProps(rawProps, props: props, appContext: appContext)
     }
 
     /**
-     Returns the view's props
+     Returns the view's props.
      */
     func getProps() -> ExpoSwiftUI.ViewProps {
       return props
@@ -104,13 +95,7 @@ extension ExpoSwiftUI {
      */
     @MainActor
     override func viewDidUpdateProps() {
-      guard let viewDefinition else {
-        return
-      }
-      guard let view = AppleView.from(self) else {
-        return
-      }
-      viewDefinition.callLifecycleMethods(withType: .didUpdateProps, forView: view)
+      virtualViewDidUpdateProps(viewDefinition: viewDefinition, appleView: .swiftui(self))
     }
 
     /**
@@ -127,52 +112,22 @@ extension ExpoSwiftUI {
      Fabric calls this function when mounting (attaching) a child component view.
      */
     override func mountChildComponentView(_ childComponentView: UIView, index: Int) {
-      var children = props.children ?? []
-      let child: any AnyChild
-      if let view = childComponentView as AnyObject as? (any ExpoSwiftUI.View) {
-        child = view
-      } else {
-        child = UIViewHost(view: childComponentView)
-      }
-      children.insert(child, at: index)
-
-      props.children = children
-      props.objectWillChange.send()
+      virtualViewMountChild(childComponentView, index: index, props: props)
     }
 
     /**
      Fabric calls this function when unmounting (detaching) a child component view.
      */
     override func unmountChildComponentView(_ childComponentView: UIView, index: Int) {
-      // Make sure the view has no superview, React Native asserts against this.
-      childComponentView.removeFromSuperview()
+      virtualViewUnmountChild(childComponentView, index: index, props: props)
+    }
 
-      let childViewId: ObjectIdentifier
-      if let child = childComponentView as AnyObject as? (any AnyChild) {
-        childViewId = child.id
-      } else {
-        childViewId = ObjectIdentifier(childComponentView)
-      }
-
-      if let children = props.children {
-        props.children = children.filter({ $0.id != childViewId })
-        #if DEBUG
-        assert(props.children?.count == children.count - 1, "Failed to remove child view")
-        #endif
-        props.objectWillChange.send()
-      }
+    override func removeFromSuperview() {
+      virtualViewRemoveFromSuperview(contentView: contentView)
+      super.removeFromSuperview()
     }
 
     // MARK: - Privates
-
-    override func removeFromSuperview() {
-      // When the view is unmounted, the focus on TextFieldView stays active and it causes a crash, so we blur it here
-      // UIView does something similar to resign the first responder in removeFromSuperview, so we do the same for our virtual view
-      if let focusableView = contentView as? any ExpoSwiftUI.FocusableView {
-        focusableView.forceResignFirstResponder()
-      }
-      super.removeFromSuperview()
-    }
 
     /**
      Installs convenient event dispatchers for declared events, so the view can just invoke the block to dispatch the proper event.
@@ -191,7 +146,7 @@ extension ExpoSwiftUI {
   }
 }
 
-// MARK: - ViewWrapper
+// MARK: - ViewWrapper (Production)
 
 extension ExpoSwiftUI.SwiftUIVirtualView: @MainActor ExpoSwiftUI.ViewWrapper {
   func getWrappedView() -> Any {
@@ -199,5 +154,230 @@ extension ExpoSwiftUI.SwiftUIVirtualView: @MainActor ExpoSwiftUI.ViewWrapper {
       return wrapper.getWrappedView()
     }
     return contentView
+  }
+}
+
+// MARK: - Dev class (UIView base)
+
+extension ExpoSwiftUI {
+  /**
+   A UIView-based variant of SwiftUIVirtualView used in dev mode.
+   Because it inherits from UIView, `insertSubview:` won't crash when the component
+   is incorrectly placed without a `<Host>` wrapper. Instead, `didMoveToSuperview`
+   emits an RCTLogError.
+   */
+  final class SwiftUIVirtualViewDev<Props: ViewProps, ContentView: View<Props>>: SwiftUIVirtualViewObjCDev, @MainActor ExpoSwiftUIView {
+    var uiView: UIView?
+
+    /**
+     A weak reference to the app context associated with this view.
+     */
+    weak var appContext: AppContext?
+
+    /**
+     The view definition that setup from `ExpoFabricView.create()`.
+     */
+    private var viewDefinition: AnyViewDefinition?
+
+    /**
+     Props object that stores all the props for this particular view.
+     It's an observed object that is passed into the content view.
+     */
+    let props: Props
+
+    /**
+     The actual SwiftUI view.
+     */
+    let contentView: ContentView
+
+    /**
+     Initializes a SwiftUI hosting view with the given SwiftUI view type.
+     */
+    init(viewType: ContentView.Type, props: Props, viewDefinition: AnyViewDefinition?, appContext: AppContext) {
+      self.contentView = ContentView(props: props)
+      self.props = props
+      self.viewDefinition = viewDefinition
+      self.appContext = appContext
+      super.init()
+      self.componentName = String(describing: viewType)
+
+      props.shadowNodeProxy.setViewSize = { [weak self] size in
+        self?.setShadowNodeSize(Float(size.width), height: Float(size.height))
+      }
+      props.shadowNodeProxy.setStyleSize = { [weak self] width, height in
+        self?.setStyleSize(width, height: height)
+      }
+
+      installEventDispatchers()
+    }
+
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) is not expected to be called directly")
+    }
+
+    // swiftlint:disable:next unavailable_function - init(props:) is required from ExpoSwiftUIView protocol
+    init(props: Props) {
+      fatalError("init(props:) is not expected to be called directly")
+    }
+
+    // MARK: - ExpoSwiftUIView implementations
+
+    var body: some SwiftUI.View {
+      contentView
+    }
+
+    var childView: some SwiftUI.View {
+      contentView
+    }
+
+    var id: ObjectIdentifier {
+      ObjectIdentifier(self)
+    }
+
+    // MARK: - SwiftUIVirtualViewObjCDev implementations
+
+    /**
+     Updates the environment object with props, based on the given dictionary with raw props.
+     */
+    override func updateProps(_ rawProps: [String: Any]) {
+      virtualViewUpdateProps(rawProps, props: props, appContext: appContext)
+    }
+
+    /**
+     Returns the view's props.
+     */
+    func getProps() -> ExpoSwiftUI.ViewProps {
+      return props
+    }
+
+    /**
+     Calls lifecycle methods registered by `OnViewDidUpdateProps` definition component.
+     */
+    @MainActor
+    override func viewDidUpdateProps() {
+      virtualViewDidUpdateProps(viewDefinition: viewDefinition, appleView: .swiftui(self))
+    }
+
+    /**
+     Returns a bool value whether the view supports prop with the given name.
+     */
+    override func supportsProp(withName name: String) -> Bool {
+      // It doesn't hurt much to just allow all prop names here, just for SwiftUI views.
+      // Otherwise we would have to re-iterate over ViewProps fields which might be an expensive operation.
+      // TODO: ViewProps should lazy load and cache an array of fields
+      return true
+    }
+
+    /**
+     Fabric calls this function when mounting (attaching) a child component view.
+     */
+    override func mountChildComponentView(_ childComponentView: UIView, index: Int) {
+      virtualViewMountChild(childComponentView, index: index, props: props)
+    }
+
+    /**
+     Fabric calls this function when unmounting (detaching) a child component view.
+     */
+    override func unmountChildComponentView(_ childComponentView: UIView, index: Int) {
+      virtualViewUnmountChild(childComponentView, index: index, props: props)
+    }
+
+    override func removeFromSuperview() {
+      virtualViewRemoveFromSuperview(contentView: contentView)
+      super.removeFromSuperview()
+    }
+
+    // MARK: - Privates
+
+    /**
+     Installs convenient event dispatchers for declared events, so the view can just invoke the block to dispatch the proper event.
+     */
+    private func installEventDispatchers() {
+      viewDefinition?.eventNames.forEach { eventName in
+        installEventDispatcher(forEvent: eventName, onView: self) { [weak self] (body: [String: Any]) in
+          if let self = self {
+            self.dispatchEvent(eventName, payload: body)
+          } else {
+            log.error("Cannot dispatch an event while the managing ExpoFabricView is deallocated")
+          }
+        }
+      }
+    }
+  }
+}
+
+// MARK: - ViewWrapper (Dev)
+
+extension ExpoSwiftUI.SwiftUIVirtualViewDev: @MainActor ExpoSwiftUI.ViewWrapper {
+  func getWrappedView() -> Any {
+    if let wrapper = contentView as? ExpoSwiftUI.ViewWrapper {
+      return wrapper.getWrappedView()
+    }
+    return contentView
+  }
+}
+
+// MARK: - Shared helpers
+
+private func virtualViewUpdateProps<Props: ExpoSwiftUI.ViewProps>(_ rawProps: [String: Any], props: Props, appContext: AppContext?) {
+  guard let appContext else {
+    log.error("AppContext is not available, view props cannot be updated")
+    return
+  }
+  do {
+    try props.updateRawProps(rawProps, appContext: appContext)
+  } catch let error {
+    log.error("Updating props has failed: \(error.localizedDescription)")
+  }
+}
+
+@MainActor
+private func virtualViewDidUpdateProps(viewDefinition: AnyViewDefinition?, appleView: AppleView) {
+  guard let viewDefinition else {
+    return
+  }
+  viewDefinition.callLifecycleMethods(withType: .didUpdateProps, forView: appleView)
+}
+
+private func virtualViewMountChild<Props: ExpoSwiftUI.ViewProps>(_ childComponentView: UIView, index: Int, props: Props) {
+  var children = props.children ?? []
+  let child: any ExpoSwiftUI.AnyChild
+  if let view = childComponentView as AnyObject as? (any ExpoSwiftUI.View) {
+    child = view
+  } else {
+    child = ExpoSwiftUI.UIViewHost(view: childComponentView)
+  }
+  children.insert(child, at: index)
+
+  props.children = children
+  props.objectWillChange.send()
+}
+
+@MainActor
+private func virtualViewUnmountChild<Props: ExpoSwiftUI.ViewProps>(_ childComponentView: UIView, index: Int, props: Props) {
+  // Make sure the view has no superview, React Native asserts against this.
+  childComponentView.removeFromSuperview()
+
+  let childViewId: ObjectIdentifier
+  if let child = childComponentView as AnyObject as? (any ExpoSwiftUI.AnyChild) {
+    childViewId = child.id
+  } else {
+    childViewId = ObjectIdentifier(childComponentView)
+  }
+
+  if let children = props.children {
+    props.children = children.filter({ $0.id != childViewId })
+    #if DEBUG
+    assert(props.children?.count == children.count - 1, "Failed to remove child view")
+    #endif
+    props.objectWillChange.send()
+  }
+}
+
+private func virtualViewRemoveFromSuperview<ContentView: SwiftUI.View>(contentView: ContentView) {
+  // When the view is unmounted, the focus on TextFieldView stays active and it causes a crash, so we blur it here
+  // UIView does something similar to resign the first responder in removeFromSuperview, so we do the same for our virtual view
+  if let focusableView = contentView as? any ExpoSwiftUI.FocusableView {
+    focusableView.forceResignFirstResponder()
   }
 }

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualView.swift
@@ -80,7 +80,7 @@ extension ExpoSwiftUI {
      Updates the environment object with props, based on the given dictionary with raw props.
      */
     override func updateProps(_ rawProps: [String: Any]) {
-      virtualViewUpdateProps(rawProps, props: props, appContext: appContext)
+      virtualViewUpdateProps(rawProps, props: props, appContext: appContext, componentName: componentName)
     }
 
     /**
@@ -240,7 +240,7 @@ extension ExpoSwiftUI {
      Updates the environment object with props, based on the given dictionary with raw props.
      */
     override func updateProps(_ rawProps: [String: Any]) {
-      virtualViewUpdateProps(rawProps, props: props, appContext: appContext)
+      virtualViewUpdateProps(rawProps, props: props, appContext: appContext, componentName: componentName)
     }
 
     /**
@@ -319,15 +319,16 @@ extension ExpoSwiftUI.SwiftUIVirtualViewDev: @MainActor ExpoSwiftUI.ViewWrapper 
 
 // MARK: - Shared helpers
 
-private func virtualViewUpdateProps<Props: ExpoSwiftUI.ViewProps>(_ rawProps: [String: Any], props: Props, appContext: AppContext?) {
+private func virtualViewUpdateProps<Props: ExpoSwiftUI.ViewProps>(_ rawProps: [String: Any], props: Props, appContext: AppContext?, componentName: String?) {
+  let viewLabel = componentName ?? "<unknown>"
   guard let appContext else {
-    log.error("AppContext is not available, view props cannot be updated")
+    log.error("AppContext is not available, view props for \(viewLabel) cannot be updated")
     return
   }
   do {
     try props.updateRawProps(rawProps, appContext: appContext)
   } catch let error {
-    log.error("Updating props has failed: \(error.localizedDescription)")
+    log.error("Updating props for \(viewLabel) has failed: \(error.localizedDescription)")
   }
 }
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.mm
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjC.mm
@@ -3,7 +3,10 @@
 /**
  Production variant of SwiftUIVirtualView's ObjC layer.
  Inherits from NSObject (not UIView) for minimal overhead.
- UIView hierarchy stubs prevent crashes if incorrectly placed.
+ The UIView hierarchy stubs swallow layout calls so Fabric/RCTMountingManager can send
+ them without crashing. Mounting this view inside a standard UIView is still a fatal
+ error: `forwardingTargetForSelector:` detects UIKit's first-responder probe and throws
+ with an actionable message pointing at the missing `<Host>` wrapper.
  */
 
 #import <ExpoModulesCore/SwiftUIVirtualViewObjC.h>
@@ -99,14 +102,19 @@ static std::unordered_map<std::string, expo::ExpoViewComponentDescriptor<>::Flav
 }
 
 // Detect when this NSObject is incorrectly inserted into a UIKit view hierarchy.
-// UIKit calls a private selector early in `_isAncestorOfFirstResponder.
+// UIKit calls a private selector early in `_isAncestorOfFirstResponder`.
 // We intercept it here and throw before the insertion proceeds.
 // The selector name is constructed from fragments to
 // avoid a literal private API string in the binary.
 - (id)forwardingTargetForSelector:(SEL)aSelector
 {
-  NSString *selName = [@[@"_", @"isAncestor", @"OfFirst", @"Responder"] componentsJoinedByString:@""];
-  if (aSelector == NSSelectorFromString(selName)) {
+  static SEL hierarchyInsertionSelector;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSString *selName = [@[@"_", @"isAncestor", @"OfFirst", @"Responder"] componentsJoinedByString:@""];
+    hierarchyInsertionSelector = NSSelectorFromString(selName);
+  });
+  if (aSelector == hierarchyInsertionSelector) {
     @throw [NSException exceptionWithName:NSInternalInconsistencyException
                                    reason:[NSString stringWithFormat:
                                      @"A SwiftUI view \"%@\" (tag: %ld) is being mounted inside a standard UIView. "

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjCDev.h
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjCDev.h
@@ -7,11 +7,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- An NSObject acting as a fake UIView for RCTMountingManager to represent a SwiftUI view.
+ A UIView-based variant of SwiftUIVirtualViewObjC used in dev mode.
+ Because it inherits from UIView, `insertSubview:` won't crash even when
+ the component is incorrectly placed without a `<Host>` wrapper.
+ `didMoveToSuperview` emits an RCTLogError to alert the developer.
  */
-@interface SwiftUIVirtualViewObjC : NSObject
+@interface SwiftUIVirtualViewObjCDev : UIView
 
-@property (nonatomic) NSInteger tag;
+// `tag` is inherited from UIView
 @property (nonatomic, copy, nullable) NSString *componentName;
 
 - (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload;
@@ -29,14 +32,12 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * Called for mounting (attaching) a child component view inside `self` component view.
  */
-- (void)mountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index NS_SWIFT_UI_ACTOR;
+- (void)mountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index;
 
 /*
  * Called for unmounting (detaching) a child component view from `self` component view.
  */
-- (void)unmountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index NS_SWIFT_UI_ACTOR;
-
-- (void)removeFromSuperview NS_SWIFT_UI_ACTOR;
+- (void)unmountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index;
 
 @end
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjCDev.mm
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjCDev.mm
@@ -1,12 +1,12 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 /**
- Production variant of SwiftUIVirtualView's ObjC layer.
- Inherits from NSObject (not UIView) for minimal overhead.
- UIView hierarchy stubs prevent crashes if incorrectly placed.
+ Dev-mode variant of SwiftUIVirtualView's ObjC layer.
+ Inherits from UIView so that `_isAncestorOfFirstResponder` is safe when the component
+ is incorrectly placed without a `<Host>` wrapper.
  */
 
-#import <ExpoModulesCore/SwiftUIVirtualViewObjC.h>
+#import <ExpoModulesCore/SwiftUIVirtualViewObjCDev.h>
 #import <ExpoModulesCore/ExpoViewComponentDescriptor.h>
 #import <ExpoModulesCore/SwiftUIViewProps.h>
 
@@ -78,12 +78,11 @@ static NSString *normalizeEventName(NSString *eventName)
 } // namespace
 
 /**
- Cache for component flavors, where the key is a view class name and value is the flavor.
- Flavors must be cached in order to keep using the same component handle after app reloads.
+ Shared flavor cache — same static as the production class so both resolve identically.
  */
 static std::unordered_map<std::string, expo::ExpoViewComponentDescriptor<>::Flavor> _componentFlavorsCache;
 
-@implementation SwiftUIVirtualViewObjC {
+@implementation SwiftUIVirtualViewObjCDev {
   react::SharedViewProps _props;
   react::SharedViewEventEmitter _eventEmitter;
   expo::ExpoViewShadowNode<>::ConcreteState::Shared _state;
@@ -91,127 +90,40 @@ static std::unordered_map<std::string, expo::ExpoViewComponentDescriptor<>::Flav
 
 - (instancetype)init
 {
-  if (self = [super init]) {
+  if (self = [super initWithFrame:CGRectZero]) {
     static const auto defaultProps = std::make_shared<const expo::SwiftUIViewProps>();
     _props = defaultProps;
+    self.hidden = YES;
+#if TARGET_OS_IOS || TARGET_OS_TV
+    self.userInteractionEnabled = NO;
+#endif
   }
   return self;
 }
 
-// Detect when this NSObject is incorrectly inserted into a UIKit view hierarchy.
-// UIKit calls a private selector early in `_isAncestorOfFirstResponder.
-// We intercept it here and throw before the insertion proceeds.
-// The selector name is constructed from fragments to
-// avoid a literal private API string in the binary.
-- (id)forwardingTargetForSelector:(SEL)aSelector
-{
-  NSString *selName = [@[@"_", @"isAncestor", @"OfFirst", @"Responder"] componentsJoinedByString:@""];
-  if (aSelector == NSSelectorFromString(selName)) {
-    @throw [NSException exceptionWithName:NSInternalInconsistencyException
-                                   reason:[NSString stringWithFormat:
-                                     @"A SwiftUI view \"%@\" (tag: %ld) is being mounted inside a standard UIView. "
-                                     @"Wrap your component with `<Host>` from '@expo/ui/swift-ui'.",
-                                     self.componentName ?: NSStringFromClass([self class]), (long)self.tag]
-                                 userInfo:nil];
-  }
-
-  return [super forwardingTargetForSelector:aSelector];
-}
-
-#pragma mark - UIView(UIViewHierarchy)
-
-- (nullable UIView *)superview
-{
-  return nil;
-}
-
-- (NSArray<UIView *> *)subviews
-{
-  return @[];
-}
-
-- (nullable UIWindow *)window
-{
-  return nil;
-}
-
-- (void)removeFromSuperview
-{
-}
-
-- (void)insertSubview:(UIView *)view atIndex:(NSInteger)index
-{
-}
-
-- (void)exchangeSubviewAtIndex:(NSInteger)index1 withSubviewAtIndex:(NSInteger)index2
-{
-}
-
-- (void)addSubview:(UIView *)view
-{
-}
-
-- (void)insertSubview:(UIView *)view belowSubview:(UIView *)siblingSubview
-{
-}
-
-- (void)insertSubview:(UIView *)view aboveSubview:(UIView *)siblingSubview
-{
-}
-
-- (void)bringSubviewToFront:(UIView *)view
-{
-}
-
-- (void)sendSubviewToBack:(UIView *)view
-{
-}
-
-- (void)didAddSubview:(UIView *)subview
-{
-}
-
-- (void)willRemoveSubview:(UIView *)subview
-{
-}
-
-- (void)willMoveToSuperview:(nullable UIView *)newSuperview
-{
-}
-
+#if TARGET_OS_IOS || TARGET_OS_TV
 - (void)didMoveToSuperview
 {
+  [super didMoveToSuperview];
+  if (self.superview != nil) {
+    RCTLogError(@"A SwiftUI view \"%@\" (tag: %ld) is being mounted inside a standard UIView. "
+                @"Double check that in JSX you have wrapped your component with "
+                @"`<Host>` from '@expo/ui/swift-ui'.",
+                self.componentName ?: NSStringFromClass([self class]), (long)self.tag);
+  }
 }
-
-- (void)willMoveToWindow:(nullable UIWindow *)newWindow
+#else
+- (void)viewDidMoveToSuperview
 {
+  [super viewDidMoveToSuperview];
+  if (self.superview != nil) {
+    RCTLogError(@"A SwiftUI view \"%@\" (tag: %ld) is being mounted inside a standard NSView. "
+                @"Double check that in JSX you have wrapped your component with "
+                @"`<Host>` from '@expo/ui/swift-ui'.",
+                self.componentName ?: NSStringFromClass([self class]), (long)self.tag);
+  }
 }
-
-- (void)didMoveToWindow
-{
-}
-
-- (BOOL)isDescendantOfView:(UIView *)view
-{
-  return NO;
-}
-
-- (nullable UIView *)viewWithTag:(NSInteger)tag
-{
-  return nil;
-}
-
-- (void)setNeedsLayout
-{
-}
-
-- (void)layoutIfNeeded
-{
-}
-
-- (void)layoutSubviews
-{
-}
+#endif // TARGET_OS_IOS || TARGET_OS_TV
 
 #include "SwiftUIVirtualViewSharedImpl+Private.h"
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjCDev.mm
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewObjCDev.mm
@@ -78,7 +78,10 @@ static NSString *normalizeEventName(NSString *eventName)
 } // namespace
 
 /**
- Shared flavor cache — same static as the production class so both resolve identically.
+ Component flavor cache. Mirrors the cache in `SwiftUIVirtualViewObjC.mm`; each class owns
+ its own translation-unit-local copy and they function identically. They are NOT a single
+ shared static — only one of the two classes is instantiated in a given build (dev vs.
+ release), so no de-duplication is needed.
  */
 static std::unordered_map<std::string, expo::ExpoViewComponentDescriptor<>::Flavor> _componentFlavorsCache;
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewSharedImpl+Private.h
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewSharedImpl+Private.h
@@ -1,0 +1,194 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+// Shared RCTComponentViewProtocol implementation included by both
+// SwiftUIVirtualViewObjC.mm (NSObject base) and SwiftUIVirtualViewObjCDev.mm (UIView base).
+//
+// Before including this file, the .mm must:
+//   1. #import the relevant header
+//   2. Define the C++ namespace aliases and helper functions
+//   3. Open an @implementation block with these ivars:
+//        react::SharedViewProps _props;
+//        react::SharedViewEventEmitter _eventEmitter;
+//        expo::ExpoViewShadowNode<>::ConcreteState::Shared _state;
+
+#pragma mark - RCTComponentViewProtocol implementations
+
++ (react::ComponentDescriptorProvider)componentDescriptorProvider
+{
+  std::string className([NSStringFromClass([self class]) UTF8String]);
+
+  // We're caching the flavor pointer so that the component handle stay the same for the same class name.
+  // Otherwise, the component handle would change after reload which may cause memory leaks and unexpected view recycling behavior.
+  expo::ExpoViewComponentDescriptor<>::Flavor flavor = _componentFlavorsCache[className];
+
+  if (flavor == nullptr) {
+    flavor = _componentFlavorsCache[className] = std::make_shared<std::string const>(className);
+  }
+
+  ComponentName componentName = ComponentName { flavor->c_str() };
+  ComponentHandle componentHandle = reinterpret_cast<ComponentHandle>(componentName);
+
+  return ComponentDescriptorProvider {
+    componentHandle,
+    componentName,
+    flavor,
+    &facebook::react::concreteComponentDescriptorConstructor<expo::ExpoViewComponentDescriptor<>>
+  };
+}
+
++ (std::vector<react::ComponentDescriptorProvider>)supplementalComponentDescriptorProviders
+{
+  return {};
+}
+
+- (void)mountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index
+{
+  // Implemented in `SwiftUIVirtualView.swift`
+}
+
+- (void)unmountChildComponentView:(nonnull UIView *)childComponentView index:(NSInteger)index
+{
+  // Implemented in `SwiftUIVirtualView.swift`
+}
+
+- (void)updateProps:(const react::Props::Shared &)props oldProps:(const react::Props::Shared &)oldProps
+{
+  _props = std::static_pointer_cast<const ViewProps>(props);
+}
+
+- (void)updateEventEmitter:(const react::EventEmitter::Shared &)eventEmitter
+{
+  assert(std::dynamic_pointer_cast<const ViewEventEmitter>(eventEmitter));
+  _eventEmitter = std::static_pointer_cast<const ViewEventEmitter>(eventEmitter);
+}
+
+- (void)handleCommand:(NSString *)commandName args:(NSArray *)args
+{
+  // Default implementation does nothing.
+}
+
+- (void)updateLayoutMetrics:(const react::LayoutMetrics &)layoutMetrics
+           oldLayoutMetrics:(const react::LayoutMetrics &)oldLayoutMetrics
+{
+  // Yoga layout is not respected in SwiftUI integration.
+}
+
+- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
+{
+  if (updateMask & RNComponentViewUpdateMaskProps) {
+    const auto &newProps = static_cast<const expo::ExpoViewProps &>(*_props);
+    NSMutableDictionary<NSString *, id> *propsMap = [[NSMutableDictionary alloc] init];
+
+    for (const auto &item : newProps.propsMap) {
+      NSString *propName = [NSString stringWithUTF8String:item.first.c_str()];
+
+      // Ignore props inherited from the base view and Yoga.
+      if ([self supportsPropWithName:propName]) {
+        propsMap[propName] = convertFollyDynamicToId(item.second);
+      }
+    }
+
+    [self updateProps:propsMap];
+    [self viewDidUpdateProps];
+  }
+}
+
+- (void)prepareForRecycle
+{
+  // Default implementation does nothing.
+  _eventEmitter.reset();
+}
+
+- (react::Props::Shared)props
+{
+  RCTAssert(NO, @"props access should be implemented by RCTViewComponentView.");
+  return nullptr;
+}
+
+- (BOOL)isJSResponder
+{
+  // Default implementation always returns `NO`.
+  return NO;
+}
+
+- (void)setIsJSResponder:(BOOL)isJSResponder
+{
+  // Default implementation does nothing.
+}
+
+- (void)setPropKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN:(nullable NSSet<NSString *> *)propKeys
+{
+  // Default implementation does nothing.
+}
+
+- (nullable NSSet<NSString *> *)propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN
+{
+  return nil;
+}
+
+- (void)updateClippedSubviewsWithClipRect:(CGRect)clipRect relativeToView:(UIView *)clipView
+{
+  // Clipped subviews are not supported in SwiftUI integration.
+}
+
+- (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload
+{
+  const auto &eventEmitter = static_cast<const expo::ExpoViewEventEmitter &>(*_eventEmitter);
+
+  eventEmitter.dispatch([normalizeEventName(eventName) UTF8String], [payload](jsi::Runtime &runtime) {
+    return jsi::Value(runtime, expo::convertObjCObjectToJSIValue(runtime, payload));
+  });
+}
+
+#pragma mark - Methods to override in Swift
+
+- (void)updateProps:(nonnull NSDictionary<NSString *, id> *)props
+{
+  // Implemented in `SwiftUIVirtualView.swift`
+}
+
+- (void)updateState:(react::State::Shared const &)state oldState:(react::State::Shared const &)oldState
+{
+  _state = std::static_pointer_cast<const expo::ExpoViewShadowNode<>::ConcreteState>(state);
+}
+
+- (void)viewDidUpdateProps
+{
+  // Implemented in `SwiftUIVirtualView.swift`
+}
+
+- (void)setShadowNodeSize:(float)width height:(float)height
+{
+  if (_state) {
+#if REACT_NATIVE_TARGET_VERSION >= 82
+    _state->updateState(expo::ExpoViewState(width, height), EventQueue::UpdateMode::unstable_Immediate);
+#else
+    _state->updateState(expo::ExpoViewState(width, height));
+#endif
+  }
+}
+
+- (void)setStyleSize:(nullable NSNumber *)width height:(nullable NSNumber *)height
+{
+  if (_state) {
+    float widthValue = width ? [width floatValue] : std::numeric_limits<float>::quiet_NaN();
+    float heightValue = height ? [height floatValue] : std::numeric_limits<float>::quiet_NaN();
+#if REACT_NATIVE_TARGET_VERSION >= 82
+    _state->updateState(expo::ExpoViewState::withStyleDimensions(widthValue, heightValue), EventQueue::UpdateMode::unstable_Immediate);
+#else
+    _state->updateState(expo::ExpoViewState::withStyleDimensions(widthValue, heightValue));
+#endif
+  }
+}
+
+- (BOOL)supportsPropWithName:(nonnull NSString *)name
+{
+  // Implemented in `SwiftUIVirtualView.swift`
+  return NO;
+}
+
+- (void)invalidate
+{
+  // Default implementation does nothing.
+  [self prepareForRecycle];
+}

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewSharedImpl+Private.h
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewSharedImpl+Private.h
@@ -4,7 +4,7 @@
 // SwiftUIVirtualViewObjC.mm (NSObject base) and SwiftUIVirtualViewObjCDev.mm (UIView base).
 //
 // Before including this file, the .mm must:
-//   1. #import the relevant header
+//   1. #include this header inside the `@implementation` block
 //   2. Define the C++ namespace aliases and helper functions
 //   3. Open an @implementation block with these ivars:
 //        react::SharedViewProps _props;

--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -5,6 +5,7 @@
 #import <ExpoModulesCore/CoreModuleHelper.h>
 #import <ExpoModulesCore/SwiftUIViewProps.h>
 #import <ExpoModulesCore/SwiftUIVirtualViewObjC.h>
+#import <ExpoModulesCore/SwiftUIVirtualViewObjCDev.h>
 #import <ExpoModulesCore/EXAppDefines.h>
 #import <ExpoModulesCore/EXDefines.h>
 #import <ExpoModulesCore/ExpoModulesCore.h>

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -83,7 +83,7 @@
 - [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43592](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] fix modifiers export ([#43639](https://github.com/expo/expo/pull/43639) by [@Ubax](https://github.com/Ubax))
 - [jetpack-compose] Fixed `RNHostView` re-parenting exception. ([#44522](https://github.com/expo/expo/pull/44522) by [@kudo](https://github.com/kudo))
-- Fixed runtime crash when missing Host component for swift-ui or jetpack-compose components. ([#44118](https://github.com/expo/expo/pull/44118) by [@kudo](https://github.com/kudo))
+- Fixed runtime crash when missing `Host` component for SwiftUI or Jetpack Compose components. ([#44118](https://github.com/expo/expo/pull/44118) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -83,6 +83,7 @@
 - [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43592](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] fix modifiers export ([#43639](https://github.com/expo/expo/pull/43639) by [@Ubax](https://github.com/Ubax))
 - [jetpack-compose] Fixed `RNHostView` re-parenting exception. ([#44522](https://github.com/expo/expo/pull/44522) by [@kudo](https://github.com/kudo))
+- Fixed runtime crash when missing Host component for swift-ui or jetpack-compose components. ([#44118](https://github.com/expo/expo/pull/44118) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 


### PR DESCRIPTION
# Why

close ENG-17624

# How

- [compose] originally it's just no-op. this pr tries to validate and show error

<img width="60%" src="https://github.com/user-attachments/assets/af54ebeb-d675-45cc-a98e-05c59a3df14a" />

- [swift-ui] originally, there's a runtime crash because we are faking the UIView using NSObject. this pr tries to use UIView in dev mode and NSObject in release mode. so we can have a chance to show error message

<img width="60%" src="https://github.com/user-attachments/assets/459086e2-7e8e-46e5-82b7-ad6e53180dcf" />

# Test Plan

tested with missing Host case 

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
