### PR TITLE
[iOS][core] Fix runtime setup crashing in the old bridge module

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Fix crash that can occur when reloading JavaScript bundle due to object deallocating off the JavaScript thread. ([#43937](https://github.com/expo/expo/pull/43937) by [@cltnschlosser](https://github.com/cltnschlosser))
 - [iOS] Fixed `PersistentFileLog.readEntries` race condition by serializing reads on the dispatch queue. ([#43958](https://github.com/expo/expo/pull/43958) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [iOS] Make access to module registry thread safe. ([#44042](https://github.com/expo/expo/pull/44042) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fixed runtime setup crashing in the old bridge module.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -20,7 +20,7 @@
 - [iOS] Fix crash that can occur when reloading JavaScript bundle due to object deallocating off the JavaScript thread. ([#43937](https://github.com/expo/expo/pull/43937) by [@cltnschlosser](https://github.com/cltnschlosser))
 - [iOS] Fixed `PersistentFileLog.readEntries` race condition by serializing reads on the dispatch queue. ([#43958](https://github.com/expo/expo/pull/43958) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [iOS] Make access to module registry thread safe. ([#44042](https://github.com/expo/expo/pull/44042) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Fixed runtime setup crashing in the old bridge module.
+- [iOS] Fixed runtime setup crashing in the old bridge module. ([#44121](https://github.com/expo/expo/pull/44121) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
@@ -36,7 +36,6 @@ RCT_EXPORT_MODULE(ExpoModulesCore);
 - (void)setBridge:(RCTBridge *)bridge
 {
   _bridge = bridge;
-  [self maybeSetupAppContext];
 }
 
 - (void)maybeSetupAppContext
@@ -46,10 +45,15 @@ RCT_EXPORT_MODULE(ExpoModulesCore);
   }
   EXRuntime *runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:_bridge];
 
+  if (!runtime) {
+    NSLog(@"Unable to get the JSI runtime from the bridge instance, make sure to use ExpoReactNativeFactory for newer bridgeless integration");
+    return;
+  }
+
   // If `global.expo` is defined, the app context has already been initialized from `ExpoReactNativeFactory`.
   // The factory was introduced in SDK 55 and requires migration in bare workflow projects.
   // We keep this as an alternative way during the transitional period.
-  if (runtime && ![[runtime global] hasProperty:@"expo"]) {
+  if (![[runtime global] hasProperty:@"expo"]) {
     NSLog(@"Expo is being initialized from the deprecated ExpoBridgeModule, make sure to migrate to ExpoReactNativeFactory in your project");
 
     _appContext.reactBridge = _bridge;


### PR DESCRIPTION
# Why

Fixes #44102

# How

The crash originates in `setBridge` method which can be called on the main thread. Since `ExpoBridgeModule` is already a fallback that handles cases when `ExpoReactNativeFactory` is not used in the project, I think we can safely remove the runtime setup from `setBridge`. The runtime will still set up upon calling the synchronous `installModules` function, which is always called from the JS thread.

# Test Plan

It's actually hard to reproduce the crash so I couldn't reliably test it, but our existing tests and examples seem to work properly.