### PR TITLE
[iOS][core] Add a polyfill for `Mutex` on older platform versions

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `NativeArrayBuffer` and `JavaScriptArrayBuffer` arguments now also accept typed arrays. ([#43082](https://github.com/expo/expo/pull/43082) by [@barthap](https://github.com/barthap))
 - [Android] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#43481](https://github.com/expo/expo/pull/43481) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `nativeModule` look up function and `bundleURL` to AppContext. ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions.
+- [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions. ([#44122](https://github.com/expo/expo/pull/44122) by [@tsapeta](https://github.com/tsapeta))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `NativeArrayBuffer` and `JavaScriptArrayBuffer` arguments now also accept typed arrays. ([#43082](https://github.com/expo/expo/pull/43082) by [@barthap](https://github.com/barthap))
 - [Android] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#43481](https://github.com/expo/expo/pull/43481) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `nativeModule` look up function and `bundleURL` to AppContext. ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/ios/Core/ModuleRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleRegistry.swift
@@ -3,9 +3,8 @@ public final class ModuleRegistry: Sequence {
 
   private weak var appContext: AppContext?
 
-  private var registry: [String: ModuleHolder] = [:]
+  private let registry = Mutex<[String: ModuleHolder]>([:])
   private var overrideDisallowModules = Set<String>()
-  private let lock = NSLock()
 
   init(appContext: AppContext) {
     self.appContext = appContext
@@ -17,18 +16,17 @@ public final class ModuleRegistry: Sequence {
   internal func register(holder: ModuleHolder, preventModuleOverriding: Bool = false) {
     log.info("Registering module '\(holder.name)'")
 
-    lock.lock()
-    defer { lock.unlock() }
-    // if overriding is disallowed for this module and the module already registered, don't re-register
-    if overrideDisallowModules.contains(holder.name) && registry[holder.name] != nil {
-      log.info("Not re-registering module '\(holder.name)' since a previous registration specified preventModuleOverriding: true")
-      return
-    }
-
     if preventModuleOverriding {
       overrideDisallowModules.insert(holder.name)
     }
-    registry[holder.name] = holder
+    registry.withLock { registry in
+      // if overriding is disallowed for this module and the module already registered, don't re-register
+      if overrideDisallowModules.contains(holder.name) && registry[holder.name] != nil {
+        log.info("Not re-registering module '\(holder.name)' since a previous registration specified preventModuleOverriding: true")
+        return
+      }
+      registry[holder.name] = holder
+    }
   }
 
   /**
@@ -66,7 +64,7 @@ public final class ModuleRegistry: Sequence {
    Unregisters given module from the registry.
    */
   public func unregister(module: AnyModule) {
-    withLock {
+    registry.withLock { registry in
       if let index = registry.firstIndex(where: { $1.module === module }) {
         registry.remove(at: index)
       }
@@ -74,7 +72,7 @@ public final class ModuleRegistry: Sequence {
   }
 
   public func unregister(moduleName: String) {
-    withLock {
+    registry.withLock { registry in
       if registry[moduleName] != nil {
         log.info("Unregistering module '\(moduleName)'")
         registry[moduleName] = nil
@@ -83,25 +81,25 @@ public final class ModuleRegistry: Sequence {
   }
 
   public func has(moduleWithName moduleName: String) -> Bool {
-    return withLock {
+    return registry.withLock { registry in
       return registry[moduleName] != nil
     }
   }
 
   public func get(moduleHolderForName moduleName: String) -> ModuleHolder? {
-    return withLock {
+    return registry.withLock { registry in
       return registry[moduleName]
     }
   }
 
   public func get(moduleWithName moduleName: String) -> AnyModule? {
-    return withLock {
+    return registry.withLock { registry in
       registry[moduleName]?.module
     }
   }
 
   internal func getModule<ModuleProtocol>(implementing protocol: ModuleProtocol.Type) -> ModuleProtocol? {
-    return withLock {
+    return registry.withLock { registry in
       for holder in registry.values {
         if let module = holder.module as? ModuleProtocol {
           return module
@@ -112,13 +110,13 @@ public final class ModuleRegistry: Sequence {
   }
 
   public func getModuleNames() -> [String] {
-    return withLock {
+    return registry.withLock { registry in
       return Array(registry.keys)
     }
   }
 
   public func makeIterator() -> IndexingIterator<[ModuleHolder]> {
-    return withLock {
+    return registry.withLock { registry in
       return registry.map({ $1 }).makeIterator()
     }
   }
@@ -137,9 +135,4 @@ public final class ModuleRegistry: Sequence {
     }
   }
 
-  private func withLock<T>(block: () -> T) -> T {
-    lock.lock()
-    defer { lock.unlock() }
-    return block()
-  }
 }

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
@@ -25,28 +25,36 @@ public final class SharedObjectRegistry {
    */
   private weak var appContext: AppContext?
 
-  /**
-   The counter of IDs to assign to the shared object pairs.
-   The next pair added to the registry will be saved using this ID.
-   */
-  internal /* visible for testing */ var nextId: SharedObjectId = 1
+  internal struct State {
+    /**
+     A dictionary of shared object pairs.
+     */
+    var pairs = [SharedObjectId: SharedObjectPair]()
+
+    /**
+     The counter of IDs to assign to the shared object pairs.
+     The next pair added to the registry will be saved using this ID.
+     */
+    var nextId: SharedObjectId = 1
+  }
+
+  private let state = Mutex(State())
 
   /**
-   A dictionary of shared object pairs.
+   The next shared object ID, exposed for testing.
    */
-  private var pairs = [SharedObjectId: SharedObjectPair]()
-
-  /**
-   The lock to keep thread safety for internal data structures.
-   */
-  private let lock = NSLock()
+  internal var nextId: SharedObjectId {
+    return state.withLock {
+      return $0.nextId
+    }
+  }
 
   /**
    A number of all pairs stored in the registry.
    */
   internal var size: Int {
-    return lock.withLock {
-      return pairs.count
+    return state.withLock {
+      return $0.pairs.count
     }
   }
 
@@ -69,9 +77,9 @@ public final class SharedObjectRegistry {
    */
   @discardableResult
   internal func pullNextId() -> SharedObjectId {
-    return lock.withLock {
-      let id = nextId
-      nextId += 1
+    return state.withLock { state in
+      let id = state.nextId
+      state.nextId += 1
       return id
     }
   }
@@ -80,8 +88,8 @@ public final class SharedObjectRegistry {
    Returns a pair of shared objects with given ID or `nil` when there is no such pair in the registry.
    */
   internal func get(_ id: SharedObjectId) -> SharedObjectPair? {
-    return lock.withLock {
-      return pairs[id]
+    return state.withLock { state in
+      return state.pairs[id]
     }
   }
 
@@ -117,8 +125,8 @@ public final class SharedObjectRegistry {
 
     // Save the pair in the dictionary.
     let jsWeakObject = jsObject.createWeak()
-    lock.withLock {
-      self.pairs[id] = (native: nativeObject, javaScript: jsWeakObject)
+    state.withLock { state in
+      state.pairs[id] = (native: nativeObject, javaScript: jsWeakObject)
     }
 
     return id
@@ -128,14 +136,14 @@ public final class SharedObjectRegistry {
    Deletes the shared objects pair with a given ID.
    */
   internal func delete(_ id: SharedObjectId) {
-    lock.withLock {
-      if let pair = self.pairs[id] {
+    state.withLock { state in
+      if let pair = state.pairs[id] {
         pair.native.sharedObjectWillRelease()
         // Reset an ID on the objects.
         pair.native.sharedObjectId = 0
 
         // Delete the pair from the dictionary.
-        self.pairs[id] = nil
+        state.pairs[id] = nil
         pair.native.sharedObjectDidRelease()
       }
     }
@@ -146,8 +154,8 @@ public final class SharedObjectRegistry {
    */
   internal func toNativeObject(_ jsObject: JavaScriptObject) -> SharedObject? {
     if let objectId = try? jsObject.getProperty(sharedObjectIdPropertyName).asInt() {
-      return lock.withLock {
-        return pairs[objectId]?.native
+      return state.withLock { state in
+        return state.pairs[objectId]?.native
       }
     }
     return nil
@@ -158,8 +166,8 @@ public final class SharedObjectRegistry {
    */
   internal func toJavaScriptObject(_ nativeObject: SharedObject) -> JavaScriptObject? {
     let objectId = nativeObject.sharedObjectId
-    return lock.withLock {
-      return pairs[objectId]?.javaScript.lock()
+    return state.withLock { state in
+      return state.pairs[objectId]?.javaScript.lock()
     }
   }
 
@@ -184,8 +192,8 @@ public final class SharedObjectRegistry {
   }
 
   internal func clear() {
-    lock.withLock {
-      self.pairs.removeAll()
+    state.withLock { state in
+      state.pairs.removeAll()
     }
   }
 }

--- a/packages/expo-modules-core/ios/Tests/ModuleRegistryTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ModuleRegistryTests.swift
@@ -40,6 +40,64 @@ struct ModuleRegistryTests {
     #expect(moduleRegistry.get(moduleWithName: "TestModule") is TestModule)
   }
 
+  @Test
+  func `concurrent registrations are thread safe`() async {
+    let iterations = 1000
+    let initialModulesCount = appContext.moduleRegistry.getModuleNames().count
+
+    await withTaskGroup(of: Void.self) { group in
+      for i in 0..<iterations {
+        group.addTask {
+          appContext.moduleRegistry.register(moduleType: UnnamedModule.self, name: "Module\(i)")
+        }
+      }
+    }
+
+    #expect(appContext.moduleRegistry.getModuleNames().count == initialModulesCount + iterations)
+  }
+
+  @Test
+  func `concurrent reads and writes are thread safe`() async {
+    let iterations = 1000
+    let initialModulesCount = appContext.moduleRegistry.getModuleNames().count
+
+    await withTaskGroup(of: Void.self) { group in
+      for i in 0..<iterations {
+        group.addTask {
+          appContext.moduleRegistry.register(moduleType: UnnamedModule.self, name: "Module\(i)")
+        }
+        group.addTask {
+          _ = appContext.moduleRegistry.has(moduleWithName: "Module\(i)")
+        }
+        group.addTask {
+          _ = appContext.moduleRegistry.get(moduleWithName: "Module\(i)")
+        }
+      }
+    }
+
+    #expect(appContext.moduleRegistry.getModuleNames().count == initialModulesCount + iterations)
+  }
+
+  @Test
+  func `concurrent unregistrations are thread safe`() async {
+    let iterations = 1000
+    let initialModulesCount = appContext.moduleRegistry.getModuleNames().count
+
+    for i in 0..<iterations {
+      appContext.moduleRegistry.register(moduleType: UnnamedModule.self, name: "Module\(i)")
+    }
+
+    await withTaskGroup(of: Void.self) { group in
+      for i in 0..<iterations {
+        group.addTask {
+          appContext.moduleRegistry.unregister(moduleName: "Module\(i)")
+        }
+      }
+    }
+
+    #expect(appContext.moduleRegistry.getModuleNames().count == initialModulesCount)
+  }
+
   private func testRegister<ModuleType: AnyModule>(moduleType: ModuleType.Type, name: String) {
     let moduleRegistry = appContext.moduleRegistry
 

--- a/packages/expo-modules-core/ios/Utilities/Mutex.swift
+++ b/packages/expo-modules-core/ios/Utilities/Mutex.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// A backport of `Mutex` from the Synchronization framework (iOS 18+).
+/// Protects mutable state with a lock, providing a safe `withLock` API
+/// identical to the one in the standard library.
+@available(iOS, deprecated: 18.0, message: "Use Mutex from the Synchronization framework")
+@available(macOS, deprecated: 15.0, message: "Use Mutex from the Synchronization framework")
+@available(tvOS, deprecated: 18.0, message: "Use Mutex from the Synchronization framework")
+public final class Mutex<Value>: @unchecked Sendable {
+  private var _value: Value
+  private let _lock = NSLock()
+
+  public init(_ initialValue: Value) {
+    _value = initialValue
+  }
+
+  @discardableResult
+  public func withLock<T>(_ body: (inout Value) throws -> T) rethrows -> T {
+    _lock.lock()
+    defer { _lock.unlock() }
+    return try body(&_value)
+  }
+}


### PR DESCRIPTION
# Why

We recently added `NSLock`s to `ModuleRegistry` and `SharedObjectRegistry`. As of Swift 6 there is a more modern solution for mutual exclusion locks – [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex). Unfortunately it requires iOS/tvOS >=18.0 and macOS >=15.0 but luckily enough it can be polyfilled.

# How

I used a simple implementation that uses `NSLock` under the hood. Key differences from the real `Mutex`:

- `class` vs `struct` — The real one is a non-copyable struct. We can't replicate `~Copyable` struct + `Sendable` safely without the runtime support, so final class is the standard workaround (small heap allocation cost).
- `os_unfair_lock` vs `NSLock` — The real `Mutex` uses `os_unfair_lock` under the hood. We could too, but it's a C value type that must not be moved in memory, so we'd need to box it in an `UnsafeMutablePointer`. `NSLock` is simpler and the performance difference is negligible in most cases.
- borrowing/consuming parameter conventions — not reproducible pre-iOS 18, but irrelevant at the call site for the `withLock` pattern.

The API surface (`init(_:)` + `withLock`) is identical, so when we eventually drop support for these OS versions, migration is just deleting the polyfill.

This PR also migrates all usages of `NSLock` with `Mutex` in `expo-modules-core`.

# Test Plan

Tests are passing, behavior remains unchanged.