### PR TITLE
fix(expo-router): add navigation to screenListeners and listeners callback type

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Bug fixes
 
+- fix(expo-router): add navigation to screenListeners and listeners callback type ([#44140](https://github.com/expo/expo/pull/44140) by [@kittipatv](https://github.com/kittipatv))
 - Fix pinned `react-navigation` dependencies ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Fix zoom transition to prefetched routes ([#43852](https://github.com/expo/expo/pull/43852) by [@Ubax](https://github.com/Ubax))
 - Fix `Stack.Protected` guard not applying to index routes. ([#43769](https://github.com/expo/expo/pull/43769) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-router/src/native-tabs/__tests__/listeners.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/listeners.test.ios.tsx
@@ -228,6 +228,43 @@ describe('NativeTabs screenListeners prop', () => {
     });
   });
 
+  it('calls functional screenListeners with route and navigation', () => {
+    const screenListener = jest.fn();
+    renderRouter({
+      _layout: () => (
+        <NativeTabs
+          screenListeners={({ route, navigation }) => ({
+            tabPress: () => {
+              screenListener({
+                routeName: route.name,
+                hasNavigation: !!navigation,
+              });
+            },
+          })}>
+          <NativeTabs.Trigger name="index" />
+          <NativeTabs.Trigger name="second" />
+        </NativeTabs>
+      ),
+      index: () => <View testID="index" />,
+      second: () => <View testID="second" />,
+    });
+
+    const indexTabKey = TabsScreen.mock.calls[0][0].tabKey;
+
+    triggerNativeFocusChange({
+      nativeEvent: { tabKey: indexTabKey, repeatedSelectionHandledBySpecialEffect: false },
+    } as NativeSyntheticEvent<{
+      tabKey: string;
+      repeatedSelectionHandledBySpecialEffect: boolean;
+    }>);
+
+    act(() => jest.runAllTimers());
+    expect(screenListener).toHaveBeenCalledWith({
+      routeName: 'index',
+      hasNavigation: true,
+    });
+  });
+
   it('calls both screenListeners and trigger listeners', () => {
     const screenListener = jest.fn();
     const triggerListener = jest.fn();

--- a/packages/expo-router/src/native-tabs/types.ts
+++ b/packages/expo-router/src/native-tabs/types.ts
@@ -1,6 +1,8 @@
 import type {
+  DefaultNavigatorOptions,
   DefaultRouterOptions,
   EventMapBase,
+  NavigationProp,
   NavigationState,
   ParamListBase,
   RouteProp,
@@ -308,11 +310,12 @@ export interface NativeTabsProps extends PropsWithChildren {
    * </NativeTabs>
    * ```
    */
-  screenListeners?:
-    | ScreenListeners<TabNavigationState<ParamListBase>, NativeTabNavigationEventMap>
-    | ((prop: {
-        route: RouteProp<ParamListBase, string>;
-      }) => ScreenListeners<TabNavigationState<ParamListBase>, NativeTabNavigationEventMap>);
+  screenListeners?: DefaultNavigatorOptions<
+    ParamListBase,
+    TabNavigationState<ParamListBase>,
+    any,
+    NativeTabNavigationEventMap
+  >['screenListeners'];
 }
 
 export interface InternalNativeTabsProps extends NativeTabsProps {
@@ -487,6 +490,7 @@ export interface NativeTabTriggerProps {
     | ScreenListeners<NavigationState, EventMapBase>
     | ((prop: {
         route: RouteProp<ParamListBase, string>;
+        navigation: NavigationProp<ParamListBase>;
       }) => ScreenListeners<NavigationState, EventMapBase>);
 }
 

--- a/packages/expo-router/src/useScreens.tsx
+++ b/packages/expo-router/src/useScreens.tsx
@@ -48,13 +48,13 @@ export type ScreenProps<
   initialParams?: Record<string, any>;
   options?:
     | TOptions
-    | ((prop: { route: RouteProp<ParamListBase, string>; navigation: any }) => TOptions);
+    | ((prop: { route: RouteProp<ParamListBase, string>; navigation: NavigationProp<ParamListBase> }) => TOptions);
 
   listeners?:
     | ScreenListeners<TState, TEventMap>
     | ((prop: {
         route: RouteProp<ParamListBase, string>;
-        navigation: any;
+        navigation: NavigationProp<ParamListBase>;
       }) => ScreenListeners<TState, TEventMap>);
 
   getId?: ({ params }: { params?: Record<string, any> }) => string | undefined;


### PR DESCRIPTION
The screenListeners and listeners props in NativeTabs were missing the navigation parameter in their callback forms. This PR adds the missing type definitions to match react-navigation behavior.