### PR TITLE
docs: clarify firebase version requirement wording

### DIFF
--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -49,7 +49,7 @@ Firebase JS SDK does not support all services for mobile apps. Some of these ser
 
 ### Install and initialize Firebase JS SDK
 
-> **warning** Expo SDK 53 and later only support `firebase@^12.0.0`. Versions before this version cause ES module resolution errors.
+> **warning** Starting from Expo SDK 53, only `firebase@^12.0.0` is supported. Earlier versions of the Firebase JS SDK cause ES module resolution errors.
 
 <Step label="1">
 #### Install the SDK
@@ -68,7 +68,6 @@ To initialize the Firebase instance in your Expo project, you must create a conf
 The config object requires an API key and other unique identifiers. To obtain these values, you will have to register a web app in your Firebase project. You can find these instructions in the [Firebase documentation](https://firebase.google.com/docs/web/setup#register-app).
 
 After you have the API key and other identifiers, you can paste the following code snippet by creating a new **firebaseConfig.js** file in your project's root directory or any other directory where you keep the configuration files.
-
 ```js firebaseConfig.js
 import { initializeApp } from 'firebase/app';
 


### PR DESCRIPTION
# Why
## Why
Rephrased the Firebase version warning to be clearer for developers on SDK 55. The previous wording ("SDK 53 and later") read as a recent change, which is now confusing since SDK 55 is current.

<!-- disable:changelog-checks -->
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
