### PR TITLE
[web][sqlite] Fix sync worker result length encoding in WorkerChannel

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [Web] Fixed sync worker result length encoding for `SharedArrayBuffer` results in `WorkerChannel`, preventing truncated JSON deserialization errors.
+- [Web] Fixed sync worker result length encoding for `SharedArrayBuffer` results in `WorkerChannel`, preventing truncated JSON deserialization errors. ([#44148](https://github.com/expo/expo/pull/44148) by [@silto](https://github.com/silto))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Web] Fixed sync worker result length encoding for `SharedArrayBuffer` results in `WorkerChannel`, preventing truncated JSON deserialization errors.
+
 ### 💡 Others
 
 - Session changesets now use native `ArrayBuffer`s. ([#42638](https://github.com/expo/expo/pull/42638) by [@barthap](https://github.com/barthap))

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Web] Fixed sync worker result length encoding for `SharedArrayBuffer` results in `WorkerChannel`, preventing truncated JSON deserialization errors.
+- [Web] Fixed sync worker result length encoding for `SharedArrayBuffer` results in `WorkerChannel`, preventing truncated JSON deserialization errors. ([#44148](https://github.com/expo/expo/pull/44148) by [@silto](https://github.com/silto))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Web] Fixed sync worker result length encoding for `SharedArrayBuffer` results in `WorkerChannel`, preventing truncated JSON deserialization errors. ([#44148](https://github.com/expo/expo/pull/44148) by [@silto](https://github.com/silto))
+- [Web] Fixed sync worker result length encoding and made oversized results fail immediately instead of timing out. ([#44148](https://github.com/expo/expo/pull/44148) by [@silto](https://github.com/silto))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Web] Fixed sync worker result length encoding for `SharedArrayBuffer` results in `WorkerChannel`, preventing truncated JSON deserialization errors.
+
 ### 💡 Others
 
 - Upgrade React Native to 0.88.0-rc.0 ([#49910](https://github.com/expo/expo/pull/49910) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-sqlite/src/__tests__/WorkerChannel-test.web.ts
+++ b/packages/expo-sqlite/src/__tests__/WorkerChannel-test.web.ts
@@ -1,0 +1,56 @@
+import { invokeWorkerSync, sendWorkerResult } from '../../web/WorkerChannel';
+
+describe('WorkerChannel sync transport', () => {
+  beforeAll(() => {
+    // jsdom in the version used in jest-expo doesn't support TextEncoder/TextDecoder, so we need to mock them
+    // Remove this once jest-environment-jsdom update their jsdom dependency to > 27.4.0 and jest-expo dependencies are updated
+    if (typeof globalThis.TextEncoder === 'undefined') {
+      (globalThis as any).TextEncoder = class {
+        encode(value: string) {
+          const bytes = new Uint8Array(value.length);
+          for (let i = 0; i < value.length; i++) {
+            bytes[i] = value.charCodeAt(i);
+          }
+          return bytes;
+        }
+      };
+    }
+    if (typeof globalThis.TextDecoder === 'undefined') {
+      (globalThis as any).TextDecoder = class {
+        decode(value: Uint8Array) {
+          let result = '';
+          for (let i = 0; i < value.length; i++) {
+            result += String.fromCharCode(value[i]);
+          }
+          return result;
+        }
+      };
+    }
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('decodes payloads larger than 255 bytes', () => {
+    const payload = 'x'.repeat(300);
+    const worker = {
+      postMessage(message: any) {
+        sendWorkerResult({
+          id: message.id,
+          result: { payload } as any,
+          error: null,
+          syncTrait: {
+            lockBuffer: message.lockBuffer,
+            resultBuffer: message.resultBuffer,
+          },
+        });
+      },
+    };
+
+    const result = invokeWorkerSync(worker as unknown as Worker, 'open' as any, {} as any) as {
+      payload: string;
+    };
+    expect(result.payload).toBe(payload);
+  });
+});

--- a/packages/expo-sqlite/src/__tests__/WorkerChannel-test.web.ts
+++ b/packages/expo-sqlite/src/__tests__/WorkerChannel-test.web.ts
@@ -1,39 +1,37 @@
-import { invokeWorkerSync, sendWorkerResult } from '../../web/WorkerChannel';
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import { TextDecoder, TextEncoder } from 'node:util';
+
+const { invokeWorkerSync, sendWorkerResult } = require('../../web/WorkerChannel');
 
 describe('WorkerChannel sync transport', () => {
+  const originalTextDecoder = globalThis.TextDecoder;
+  const originalTextEncoder = globalThis.TextEncoder;
+
   beforeAll(() => {
-    // jsdom in the version used in jest-expo doesn't support TextEncoder/TextDecoder, so we need to mock them
-    // Remove this once jest-environment-jsdom update their jsdom dependency to > 27.4.0 and jest-expo dependencies are updated
-    if (typeof globalThis.TextEncoder === 'undefined') {
-      (globalThis as any).TextEncoder = class {
-        encode(value: string) {
-          const bytes = new Uint8Array(value.length);
-          for (let i = 0; i < value.length; i++) {
-            bytes[i] = value.charCodeAt(i);
-          }
-          return bytes;
-        }
-      };
-    }
-    if (typeof globalThis.TextDecoder === 'undefined') {
-      (globalThis as any).TextDecoder = class {
-        decode(value: Uint8Array) {
-          let result = '';
-          for (let i = 0; i < value.length; i++) {
-            result += String.fromCharCode(value[i]);
-          }
-          return result;
-        }
-      };
-    }
+    (globalThis as any).TextDecoder = TextDecoder;
+    (globalThis as any).TextEncoder = TextEncoder;
   });
 
   afterAll(() => {
-    jest.restoreAllMocks();
+    if (originalTextDecoder === undefined) {
+      delete (globalThis as any).TextDecoder;
+    } else {
+      globalThis.TextDecoder = originalTextDecoder;
+    }
+    if (originalTextEncoder === undefined) {
+      delete (globalThis as any).TextEncoder;
+    } else {
+      globalThis.TextEncoder = originalTextEncoder;
+    }
   });
 
-  it('decodes payloads larger than 255 bytes', () => {
-    const payload = 'x'.repeat(300);
+  it('round-trips a UTF-8 payload larger than 255 bytes', () => {
+    const payload = '🚀漢字'.repeat(100);
+    const encodedPayload = new TextEncoder().encode(payload);
+    expect(encodedPayload.byteLength).toBeGreaterThan(255);
+    expect(encodedPayload.byteLength).not.toBe(payload.length);
+
     const worker = {
       postMessage(message: any) {
         sendWorkerResult({
@@ -52,5 +50,49 @@ describe('WorkerChannel sync transport', () => {
       payload: string;
     };
     expect(result.payload).toBe(payload);
+  });
+
+  it('reports an oversized result and resolves the sync lock', () => {
+    const payload = 'x'.repeat(1024 * 1024);
+    let lock: Int32Array | undefined;
+    const worker = {
+      postMessage(message: any) {
+        lock = new Int32Array(message.lockBuffer);
+        sendWorkerResult({
+          id: message.id,
+          result: { payload } as any,
+          error: null,
+          syncTrait: {
+            lockBuffer: message.lockBuffer,
+            resultBuffer: message.resultBuffer,
+          },
+        });
+      },
+    };
+
+    let thrownError: Error | undefined;
+    try {
+      invokeWorkerSync(worker as unknown as Worker, 'open' as any, {} as any);
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    expect(thrownError?.message).toContain('Sync result too large for shared buffer');
+    expect(thrownError?.message).not.toContain('Sync operation timeout');
+    expect(Atomics.load(lock!, 0)).toBe(2);
+  });
+
+  it('rejects a decoded result length outside the buffer bounds', () => {
+    const worker = {
+      postMessage(message: any) {
+        const lock = new Int32Array(message.lockBuffer);
+        new DataView(message.resultBuffer).setUint32(0, message.resultBuffer.byteLength, true);
+        Atomics.store(lock, 0, 2);
+      },
+    };
+
+    expect(() => invokeWorkerSync(worker as unknown as Worker, 'open' as any, {} as any)).toThrow(
+      'Invalid sync result length: 1048576'
+    );
   });
 });

--- a/packages/expo-sqlite/web/WorkerChannel.ts
+++ b/packages/expo-sqlite/web/WorkerChannel.ts
@@ -40,7 +40,10 @@ export function sendWorkerResult({
     const resultJson = error != null ? serialize({ error }) : serialize({ result });
     const resultBytes = new TextEncoder().encode(resultJson);
     const length = resultBytes.length;
-    resultArray.set(new Uint32Array([length]), 0);
+    if (length > resultArray.byteLength - 4) {
+      throw new Error(`Sync result too large for shared buffer: ${length} bytes`);
+    }
+    new DataView(resultBuffer).setUint32(0, length, true);
     resultArray.set(resultBytes, 4);
     Atomics.store(lock, 0, RESOLVED);
   } else {
@@ -137,7 +140,10 @@ export function invokeWorkerSync<T extends SQLiteWorkerMessageType & keyof Resul
     }
   }
 
-  const length = new Uint32Array(resultArray.buffer, 0, 1)[0];
+  const length = new DataView(resultBuffer).getUint32(0, true);
+  if (length > resultArray.byteLength - 4) {
+    throw new Error(`Invalid sync result length: ${length}`);
+  }
   const resultCopy = new Uint8Array(length);
   resultCopy.set(new Uint8Array(resultArray.buffer, 4, length));
   const resultJson = new TextDecoder().decode(resultCopy);

--- a/packages/expo-sqlite/web/WorkerChannel.ts
+++ b/packages/expo-sqlite/web/WorkerChannel.ts
@@ -120,7 +120,6 @@ export function invokeWorkerSync<T extends SQLiteWorkerMessageType & keyof Resul
   });
 
   let i = 0;
-  // @ts-expect-error: Remove this when TypeScript supports Atomics.pause
   const useAtomicsPause = typeof Atomics.pause === 'function';
   while (Atomics.load(lock, 0) === PENDING) {
     ++i;
@@ -129,7 +128,6 @@ export function invokeWorkerSync<T extends SQLiteWorkerMessageType & keyof Resul
       if (i > 1_000_000) {
         throw new Error('Sync operation timeout');
       }
-      // @ts-expect-error: Remove this when TypeScript supports Atomics.pause
       Atomics.pause();
     } else {
       // NOTE(kudo): Unfortunate for the busy loop,

--- a/packages/expo-sqlite/web/WorkerChannel.ts
+++ b/packages/expo-sqlite/web/WorkerChannel.ts
@@ -13,6 +13,7 @@ let messageId = 0;
 const deferredMap = new Map<number, Deferred>();
 const PENDING = 1;
 const RESOLVED = 2;
+const RESULT_LENGTH_HEADER_SIZE = 4;
 
 let hasWarnedSync = false;
 
@@ -37,14 +38,17 @@ export function sendWorkerResult({
     const { lockBuffer, resultBuffer } = syncTrait;
     const lock = new Int32Array(lockBuffer);
     const resultArray = new Uint8Array(resultBuffer);
-    const resultJson = error != null ? serialize({ error }) : serialize({ result });
-    const resultBytes = new TextEncoder().encode(resultJson);
-    const length = resultBytes.length;
-    if (length > resultArray.byteLength - 4) {
-      throw new Error(`Sync result too large for shared buffer: ${length} bytes`);
+    let resultJson = error != null ? serialize({ error }) : serialize({ result });
+    let resultBytes = new TextEncoder().encode(resultJson);
+    const resultCapacity = resultArray.byteLength - RESULT_LENGTH_HEADER_SIZE;
+    if (resultBytes.byteLength > resultCapacity) {
+      resultJson = serialize({
+        error: `Sync result too large for shared buffer: ${resultBytes.byteLength} bytes (maximum ${resultCapacity} bytes)`,
+      });
+      resultBytes = new TextEncoder().encode(resultJson);
     }
-    new DataView(resultBuffer).setUint32(0, length, true);
-    resultArray.set(resultBytes, 4);
+    new DataView(resultBuffer).setUint32(0, resultBytes.byteLength, true);
+    resultArray.set(resultBytes, RESULT_LENGTH_HEADER_SIZE);
     Atomics.store(lock, 0, RESOLVED);
   } else {
     if (result) {
@@ -139,11 +143,11 @@ export function invokeWorkerSync<T extends SQLiteWorkerMessageType & keyof Resul
   }
 
   const length = new DataView(resultBuffer).getUint32(0, true);
-  if (length > resultArray.byteLength - 4) {
+  if (length > resultArray.byteLength - RESULT_LENGTH_HEADER_SIZE) {
     throw new Error(`Invalid sync result length: ${length}`);
   }
   const resultCopy = new Uint8Array(length);
-  resultCopy.set(new Uint8Array(resultArray.buffer, 4, length));
+  resultCopy.set(new Uint8Array(resultArray.buffer, RESULT_LENGTH_HEADER_SIZE, length));
   const resultJson = new TextDecoder().decode(resultCopy);
   const { result, error } = deserialize<{ result: ResultTypeMap[T]; error?: string }>(resultJson);
   if (error) throw new Error(error);


### PR DESCRIPTION
# Why

Fixes #45186.

While using `expo-sqlite` on web with Drizzle ORM (with synchronous statement execution), I hit a repeatable runtime error during query result deserialization:

- `SyntaxError: Unterminated string in JSON at position 4...`
- stack reaches `SyncSerializer.deserialize` via `invokeWorkerSync`.

Root cause is in `packages/expo-sqlite/web/WorkerChannel.ts`: the sync result length prefix is written with:

```ts
resultArray.set(new Uint32Array([length]), 0);
```

`resultArray` is a `Uint8Array`, so this performs element-wise assignment and can truncate a 32-bit length to 8 bits. The main thread then reads an incorrect length, slices incomplete JSON, and `JSON.parse` fails.

There is a separate failure mode when a serialized synchronous result exceeds the fixed 1 MiB shared buffer. Throwing from `sendWorkerResult` leaves the shared lock in `PENDING` because the worker has already exited its error boundary. The caller then spins until it reports `Sync operation timeout`, losing the meaningful size error.

This PR keeps the fixed capacity but makes oversized results fail immediately: the worker writes a compact error envelope into the shared buffer and sets the lock to `RESOLVED`. Applications handling large reads should still prefer asynchronous APIs or page their queries.

# How

- Encode and decode the four-byte length prefix with `DataView` using explicit little-endian byte order.
- Validate decoded lengths before allocating or copying the result.
- When a serialized result exceeds the shared-buffer capacity, replace it with a compact string error envelope, write that envelope into the existing buffer, and set the lock to `RESOLVED`.
- Keep the fixed capacity and avoid truncating results or attempting automatic pagination.

The string error envelope also ensures `invokeWorkerSync` receives a useful message without duplicating the broader error-serialization work in #42265.

# Test Plan

Run from `packages/expo-sqlite`:

- `corepack pnpm@12.2.1 test --runInBand --no-watchman`
  - 12 suites and 222 tests passed.
- `corepack pnpm@12.2.1 run typecheck`
- `corepack pnpm@12.2.1 run lint`
- `corepack pnpm@12.2.1 run format --check`
- `corepack pnpm@12.2.1 run depscheck`
- `corepack pnpm@12.2.1 run build`
- `corepack pnpm@12.2.1 run prepublishOnly`

New transport tests verify:

- A multibyte UTF-8 payload larger than 255 bytes round-trips correctly.
- An oversized result immediately throws the meaningful size error and leaves the lock in `RESOLVED`, rather than timing out.
- A malformed decoded length outside the buffer bounds is rejected.
- Real Node `TextEncoder`/`TextDecoder` implementations are used and modified globals are explicitly restored.

# Checklist

- [x] I added a `CHANGELOG.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). -> not applicable, web only
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) -> not applicable, no new doc, just a bug fix