### PR TITLE
docs(splash-screen): add Android splash icon dimensions

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -43,6 +43,8 @@ To create a splash screen icon, you can use this [Figma template](https://www.fi
 - Use a **.png** file.
 - Use a transparent background.
 
+**Android:** For the app icon without an icon background, the splash icon must be **288×288 dp** and fit within a circle **192 dp** in diameter. See [Android's splash screen documentation](https://developer.android.com/develop/ui/views/launch/splash-screen) for details.
+
 </Step>
 
 <Step label="2">

--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -22,6 +22,8 @@ The `SplashScreen` module from the `expo-splash-screen` library provides control
 
 Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
 
+> **info** **Android splash icon dimensions:** For the app icon without an icon background, the image must be **288×288 dp** and fit within a circle **192 dp** in diameter. See [Android's splash screen documentation](https://developer.android.com/develop/ui/views/launch/splash-screen) for details.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v55.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/splash-screen.mdx
@@ -22,6 +22,8 @@ The `SplashScreen` module from the `expo-splash-screen` library provides control
 
 Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
 
+> **info** **Android splash icon dimensions:** For the app icon without an icon background, the image must be **288×288 dp** and fit within a circle **192 dp** in diameter. See [Android's splash screen documentation](https://developer.android.com/develop/ui/views/launch/splash-screen) for details.
+
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
Fixes #43924

## Summary

Adds Android-specific splash screen icon dimension requirements to the docs, as recommended in the issue. Users will now see that for the app icon without an icon background:
- Image must be **288×288 dp**
- Must fit within a circle **192 dp** in diameter

## Changes

- **splash-screen-and-app-icon.mdx**: Added Android dimension note in the "Create a splash screen icon" section
- **splash-screen.mdx** (v55 + unversioned): Added info callout with link to [Android splash screen documentation](https://developer.android.com/develop/ui/views/launch/splash-screen)

Made with [Cursor](https://cursor.com)