### PR TITLE
fix(jest-expo): Add `@react-native/babel-preset` to transform ignore patterns

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add `@react-native/babel-preset` to ignored transform patterns, since it's part of the transformer pipeline ([#44152](https://github.com/expo/expo/pull/44152) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ### ⚠️ Notices

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -103,6 +103,8 @@ jestPreset.transformIgnorePatterns = [
   '/node_modules/(?!(.pnpm|react-native|@react-native|@react-native-community|expo|@expo|@expo-google-fonts|react-navigation|@react-navigation|@sentry/react-native|native-base))',
   // Disable transforming the reanimated plugin in multi-platform tests, causing "Reentrant plugin detected trying to load react-native-reanimated/plugin.."
   '/node_modules/react-native-reanimated/plugin/',
+  // Disable transforming the react-native babel preset, since it's part of the transformer itself
+  '/node_modules/@react-native/babel-preset/',
 ];
 
 // setupFiles


### PR DESCRIPTION
# Why

This can be reproduced in #44057 by running `pnpm jest --watch false` in `expo-web-browser` (and potentially other packages), and is triggered by the platform resolver's transformations after tests are run.

Transforming the `@react-native/babel-preset` with the Babel pipeline itself is self-reentrant, and will fail.

# How

- Add `@react-native/babel-preset` to `transformIgnorePatterns`

# Test Plan

See reproduction above. For this branch, we expect all tests to pass unchanged.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
