### PR TITLE
[video][android] Fix PiP exiting immediately after auto-entering from fullscreen

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - [iOS] Fix crash when loading PHAsset url fails ([#43373](https://github.com/expo/expo/pull/43373) by [@fractalbeauty](https://github.com/fractalbeauty))
 - [iOS] Fix crashes when `VideoTrack` properties are non-finite.
+- [Android] Fix PiP exiting immediately after auto-entering from fullscreen. ([#44157](https://github.com/expo/expo/pull/44157) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -14,6 +14,7 @@ import android.view.WindowInsetsController
 import android.widget.ImageButton
 import androidx.media3.ui.PlayerView
 import expo.modules.kotlin.exception.CodedException
+import expo.modules.video.listeners.VideoManagerListener
 import expo.modules.video.player.VideoPlayer
 import expo.modules.video.records.FullscreenOptions
 import expo.modules.video.utils.FullscreenActivityOrientationHelper
@@ -25,7 +26,7 @@ import expo.modules.video.utils.calculateRectHint
 import expo.modules.video.managers.VideoManager
 
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
-class FullscreenPlayerActivity : Activity() {
+class FullscreenPlayerActivity : Activity(), VideoManagerListener {
   private lateinit var mContentView: View
   private var videoViewId: String? = null
   private var videoPlayer: VideoPlayer? = null
@@ -33,6 +34,7 @@ class FullscreenPlayerActivity : Activity() {
   private lateinit var videoView: VideoView
   private var didFinish = false
   private var wasAutoPaused = false
+  private var isStopped = false
   private lateinit var options: FullscreenOptions
   private var orientationHelper: FullscreenActivityOrientationHelper? = null
   private var captioningChangeListener: CaptioningManager.CaptioningChangeListener? = null
@@ -85,6 +87,7 @@ class FullscreenPlayerActivity : Activity() {
     }
 
     VideoManager.registerFullscreenPlayerActivity(hashCode().toString(), this)
+    VideoManager.registerListener(this)
     playerView.player?.let {
       val aspectRatio = calculatePiPAspectRatio(it.videoSize, playerView.width, playerView.height, videoView.contentFit)
       applyPiPParams(this, videoView.autoEnterPiP, aspectRatio)
@@ -151,6 +154,16 @@ class FullscreenPlayerActivity : Activity() {
     super.onPause()
   }
 
+  override fun onStop() {
+    isStopped = true
+    super.onStop()
+  }
+
+  override fun onStart() {
+    isStopped = false
+    super.onStart()
+  }
+
   override fun onDestroy() {
     super.onDestroy()
 
@@ -162,8 +175,19 @@ class FullscreenPlayerActivity : Activity() {
     }
 
     videoView.exitFullscreen()
+    VideoManager.unregisterListener(this)
     VideoManager.unregisterFullscreenPlayerActivity(hashCode().toString())
     orientationHelper?.stopOrientationEventListener()
+  }
+
+  // When the app enters the foreground, we need to decide whether to close this activity.
+  // - If stopped: the user went home from fullscreen and came back via app icon -> close
+  // - If in PiP: the user went home while in PiP and came back via app icon -> close
+  // - If only paused (not stopped, not yet in PiP): we're mid-transition into PiP -> keep alive
+  override fun onAppForegrounded() {
+    if (isStopped || isInPictureInPictureMode) {
+      finish()
+    }
   }
 
   private fun setupFullscreenButton() {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/managers/VideoManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/managers/VideoManager.kt
@@ -145,12 +145,6 @@ object VideoManager {
     listeners.forEach {
       it.get()?.onAppForegrounded()
     }
-
-    // Pressing the app icon will bring up the mainActivity instead of the fullscreen activity (at least for BareExpo)
-    // In this case we have to manually finish the fullscreen activity
-    for (fullscreenActivity in fullscreenPlayerActivities.values) {
-      fullscreenActivity.get()?.finish()
-    }
   }
 
   fun onAppBackgrounded() {


### PR DESCRIPTION
# Why

Fixes  https://github.com/expo/expo/issues/43930

When PiP auto-enter is enabled in fullscreen and the user minimizes the app, the PiP window will close just after entering PiP. This happens because in newer versions of Android the `MainActivity` will receive `onAppForegrounded` when the FullscreenActivity is entering PiP. This doesn't happen in Android 14.

# How

- Do not always exit PiP when `onAppForegrounded` is received.
- Use the fullscreen activity as a listener to make it manage itself.
- Check the state of the fullscreen activity to determine whether the PiP is being entered or if the app MainActivity has been opened.
- We have to check if the icon has been pressed to open the app - in that case the app will return to `MainActivity` which means that we have to exit fullscreen.

# Test Plan

Tested in BareExpo Android API 34 and 36
