### PR TITLE
[docs] Clean up stale SDK version references

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -9,8 +9,6 @@ import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-> **info** Available in **SDK 52 and later**.
-
 Expo offers a novel approach to work with modern web code directly in a native app via the `'use dom'` directive. This enables incremental migration for an entire website to a universal app by moving on a per-component basis.
 
 While the Expo native runtime generally does not support elements like `<div>` or `<img>`, there may be instances where you need to quickly incorporate web components. In such cases, DOM components provide a useful solution.

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -88,8 +88,6 @@ To create a development build, you can use [local app compilation](#local-app-co
 
 ## Local builds using Android product flavors
 
-> **warning** This feature is only available for SDK 52 and later.
-
 If you have a custom Android project with multiple product flavors using different application IDs, you can configure `npx expo run:android` to use the correct flavor and build type. Expo supports both `--variant` and `--app-id` to customize the build and launch behavior.
 
 The `--variant` flag can switch the Android build type from **debug** to **release**. This flag can also configure a product flavor and build type, when formatted in camelCase. For example, if you have both [**free** and **paid** product flavors](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with:

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -67,7 +67,7 @@ You can accelerate your local development by caching and reusing builds from a p
 
 ## Prebuilt Expo Modules for Android
 
-SDK 53 and later ship with prebuilt Expo Modules for Android that reduce the work Gradle performs on each build. You can continue using the defaults or selectively opt out when you need to modify a module's source code.
+Expo ships prebuilt Expo Modules for Android that reduce the work Gradle performs on each build. You can continue using the defaults or selectively opt out when you need to modify a module's source code.
 
 <BoxLink
   title="Prebuilt Expo Modules for Android"

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -14,9 +14,9 @@ Monorepos, or _"monolithic repositories"_, are single repositories containing mu
 
 <a id="automatic-configuration" />
 
-Since SDK 52, Expo configures Metro automatically for monorepos. You don't have to manually configure Metro when using monorepos if you use [`expo/metro-config`](/guides/customizing-metro/).
+Expo configures Metro automatically for monorepos. You don't have to manually configure Metro when using monorepos if you use [`expo/metro-config`](/guides/customizing-metro/).
 
-If you're migrating to an Expo SDK version after 52 and have a **metro.config.js** that manually modifies one of the following properties, delete these from your configuration:
+If you previously configured Metro manually for monorepos and have a **metro.config.js** that modifies one of the following properties, delete these from your configuration:
 
 - `watchFolders`
 - `resolver.nodeModulesPath`
@@ -31,9 +31,9 @@ After deleting these options, you'll need to run Expo with `npx expo start --cle
 
 <a id="manual-configuration" />
 
-Since SDK 52, Expo's Metro config has monorepo support for Bun, npm, pnpm and Yarn and configures itself automatically. You don't have to manually configure Metro when using monorepos if you use the config from [`expo/metro-config`](/guides/customizing-metro/). If that's the case, you don't need to manually configure monorepo support.
+Expo's Metro config has built-in monorepo support for Bun, npm, pnpm, and Yarn. You don't have to manually configure Metro when using monorepos if you use the config from [`expo/metro-config`](/guides/customizing-metro/).
 
-Before SDK 52, to configure a monorepo with Metro manually, there were two manual changes:
+Before SDK 52, configuring a monorepo with Metro required two manual changes:
 
 1. Metro had to be configured to watch code within the monorepo manually (for example, not just **apps/cool-app**.)
 2. Metro's resolution had to be adjusted to find packages in other workspaces and multiple `node_modules` folders (for example, **apps/cool-app/node_modules** or **node_modules**.)

--- a/docs/pages/guides/prebuilt-expo-modules.mdx
+++ b/docs/pages/guides/prebuilt-expo-modules.mdx
@@ -8,13 +8,13 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 When building React Native apps, longer build times can slow down your development workflow and reduce productivity. Each time you make changes to your code, you might need to wait for the build process to complete, which can add up to significant delays.
 
-**Starting from SDK 53**, Expo introduces prebuilt Expo Modules for Android to address this pain point. Instead of compiling Expo Modules source code from scratch during each build, your project can now use pre-compiled versions of these modules. Ultimately, this results in faster build times.
+Expo provides prebuilt Expo Modules for Android to address this pain point. Instead of compiling Expo Modules source code from scratch during each build, your project can use pre-compiled versions of these modules. This results in faster build times.
 
 ## Benefits
 
 - **Faster local development**: Up to 25% reduction in Android build times on local machines
 - **Improved developer experience**: Less waiting time during development iterations
-- **Automatic optimization**: Works out of the box with new projects for SDK 53 and later
+- **Automatic optimization**: Works out of the box with new projects
 
 ## How prebuilt Expo Modules for Android work
 
@@ -30,7 +30,7 @@ For example, after creating a project with SDK 53's default template, and runnin
 
 ## Configuration
 
-**For SDK 53 and later, no configuration steps are required for projects** that are created with one of the available [Expo templates](/more/create-expo/#--template).
+**No configuration steps are required for projects** that are created with one of the available [Expo templates](/more/create-expo/#--template).
 
 ### Opting out of prebuilt Expo Modules
 
@@ -76,6 +76,6 @@ You can also opt out of specific modules while keeping others prebuilt by specif
 
 ## Considerations
 
-- Existing projects can benefit from this feature when upgrading to SDK 53 and later
+- Existing projects can benefit from this feature
 - Performance improvements may vary based on your hardware configuration
 - Current improvements on EAS Builds are more modest but provide groundwork for future caching mechanisms

--- a/docs/pages/guides/prebuilt-expo-modules.mdx
+++ b/docs/pages/guides/prebuilt-expo-modules.mdx
@@ -76,6 +76,5 @@ You can also opt out of specific modules while keeping others prebuilt by specif
 
 ## Considerations
 
-- Existing projects can benefit from this feature
 - Performance improvements may vary based on your hardware configuration
 - Current improvements on EAS Builds are more modest but provide groundwork for future caching mechanisms

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -49,8 +49,6 @@ Firebase JS SDK does not support all services for mobile apps. Some of these ser
 
 ### Install and initialize Firebase JS SDK
 
-> **warning** Expo SDK 53 and later only support `firebase@^12.0.0`. Versions before this version cause ES module resolution errors.
-
 <Step label="1">
 #### Install the SDK
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -49,6 +49,7 @@ Firebase JS SDK does not support all services for mobile apps. Some of these ser
 
 ### Install and initialize Firebase JS SDK
 
+> **warning** Expo SDK only supports `firebase@12.0.0` and above. Versions before this version cause ES module resolution errors.
 <Step label="1">
 #### Install the SDK
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -50,6 +50,7 @@ Firebase JS SDK does not support all services for mobile apps. Some of these ser
 ### Install and initialize Firebase JS SDK
 
 > **warning** Expo SDK only supports `firebase@12.0.0` and above. Versions before this version cause ES module resolution errors.
+
 <Step label="1">
 #### Install the SDK
 

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -18,7 +18,7 @@ The core implementation can be found in the [`expo-modules-autolinking`](https:/
 2. code that integrates with the Gradle build system for Android
 3. code that integrates with CocoaPods for iOS
 
-Since SDK 52, Expo Autolinking not only links Expo modules, but also React Native modules. To use the React Native community CLI autolinking instead, see [opting out of Expo Autolinking for React Native modules](#opting-out-of-expo-autolinking-for-react-native-modules) section.
+Expo Autolinking links both Expo modules and React Native modules. To use the React Native community CLI autolinking instead, see [opting out of Expo Autolinking for React Native modules](#opting-out-of-expo-autolinking-for-react-native-modules) section.
 
 ## Linking behavior
 

--- a/docs/pages/preview/singular.mdx
+++ b/docs/pages/preview/singular.mdx
@@ -5,7 +5,7 @@ description: Learn how to enforce singular routes.
 
 import { FileTree } from '~/ui/components/FileTree';
 
-> **warning** Singular routes are available from SDK 53 and later. They are currently flagged as `dangerouslySingular` due to an upstream issue with `react-native-screens`. Expo is working with Software Mansion to resolve the issue.
+> **warning** Singular routes are currently flagged as `dangerouslySingular` due to an upstream issue with `react-native-screens`. Expo is working with Software Mansion to resolve the issue.
 
 While a `Stack` normally operates with `push`/`pop` actions, in advanced scenarios you may wish to enforce a singular version of a screen in the stack. When enabled, any time a new screen is pushed the history will be scanned and any matching screens will be removed to ensure only a singular version exists.
 

--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -5,7 +5,7 @@ description: How to implement authentication and protect routes with Expo Router
 hasVideoLink: true
 ---
 
-> **info** **Note:** This guide requires SDK 53 and later. For the previous version of this guide see [Authentication (redirects)](/router/advanced/authentication-rewrites/).
+> **info** For the previous version of this guide (SDK 52 and earlier), see [Authentication (redirects)](/router/advanced/authentication-rewrites/).
 
 import { Lock01Icon } from '@expo/styleguide-icons/outline/Lock01Icon';
 import { LockUnlocked01Icon } from '@expo/styleguide-icons/outline/LockUnlocked01Icon';

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -12,7 +12,7 @@ import { FAQ } from '~/ui/components/FAQ';
 import { FileTree } from '~/ui/components/FileTree';
 import { DiffBlock } from '~/ui/components/Snippet';
 
-> **important** Experimentally available in SDK 52 and later.
+> **important** This is an experimental feature.
 
 Expo Router offers a set of components to create custom tab layouts via the submodule [`expo-router/ui`](/versions/latest/sdk/router/ui/). Unlike the React Navigation styled `Tabs`, these components are unstyled and flexible. They are designed to allow you build complex UI patterns from scratch in your project.
 

--- a/docs/pages/router/advanced/protected.mdx
+++ b/docs/pages/router/advanced/protected.mdx
@@ -7,8 +7,6 @@ hasVideoLink: true
 import { FileTree } from '~/ui/components/FileTree';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-> **warning** Protected routes are available in SDK 53 and later.
-
 <VideoBoxLink
   videoId="zHZjJDTTHJg"
   title="Watch: Using protected routes"

--- a/docs/pages/router/web/api-routes.mdx
+++ b/docs/pages/router/web/api-routes.mdx
@@ -378,7 +378,7 @@ When you're ready to deploy to production, run the following command to create t
 
 <Terminal cmd={['$ npx expo export --platform web']} />
 
-This server can be tested locally with `npx expo serve` (available in Expo SDK 52 and later), visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
+This server can be tested locally with `npx expo serve`, visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
 You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
 
 If you want to export API routes and skip generating a website version of your app, you can use the following command, which will generate a **dist** directory containing only the server code of your project.
@@ -394,7 +394,7 @@ If you want to export API routes and skip generating a website version of your a
 
 ### Native deployment
 
-> **important** This is an alpha feature starting in SDK 52 and later. The process will be more automated and have better support in future versions.
+> **important** This is an alpha feature. The process will be more automated and have better support in future versions.
 
 Server features (API routes, and React Server Components) in Expo Router are centered around native implementations of `window.location` and `fetch` which point to the remote server. In development, we automatically point to the dev server running with `npx expo start`, but for production native builds to work you'll need to deploy the server to a secure host and set the `origin` property of the Expo Router Config Plugin.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

 Docs pages reference old SDK versions ("SDK 52 and later", "Since SDK 53") for features that are now standard behavior in SDK 55. This confuses developers who read these as recent constraints.

Follow-up https://github.com/expo/expo/pull/44145

# How

- Remove or rephrase stale SDK version callouts across 13 docs pages where the version context no longer adds value.
- Drop version-gated warnings for features that have been stable for 2-3 SDK releases (Firebase, DOM components, protected routes, prebuilt modules, monorepo Metro config, autolinking).
- Simplify experimental/alpha feature callouts to focus on the stability status rather than the SDK they shipped in.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
