### PR TITLE
[ios][expo-camera] Use runtime camera checks on simulator to open a path for virtual camera streaming capabilities

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Web] Fix `isAvailableAsync` returning `true` on devices without a camera. ([#43932](https://github.com/expo/expo/pull/43932) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Use runtime camera availability checks in Simulator so camera code paths can run when a runtime video device is present while preserving fallback behavior when no device is available. (by [@kmagiera](https://github.com/kmagiera))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### 🐛 Bug fixes
 
 - [Web] Fix `isAvailableAsync` returning `true` on devices without a camera. ([#43932](https://github.com/expo/expo/pull/43932) by [@alanjhughes](https://github.com/alanjhughes))
-- [iOS] Use runtime camera availability checks in Simulator so camera code paths can run when a runtime video device is present while preserving fallback behavior when no device is available. (by [@kmagiera](https://github.com/kmagiera))
+- [iOS] Use runtime camera availability checks in Simulator so camera code paths can run when a runtime video device is present while preserving fallback behavior when no device is available. (by [@kmagiera](https://github.com/kmagiera)) ([#44159](https://github.com/expo/expo/pull/44159) by [@kmagiera](https://github.com/kmagiera))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -259,16 +259,20 @@ public final class CameraViewModule: Module, ScannerResultHandler {
 
       AsyncFunction("takePictureRef") { (view, options: TakePictureOptions) -> PictureRef in
         #if targetEnvironment(simulator)
-        return try takePictureRefForSimulator(self.appContext, view, options)
-        #else
-        return try await view.takePictureRef(options: options)
+        if AVCaptureDevice.default(for: .video) == nil {
+          return try takePictureRefForSimulator(self.appContext, view, options)
+        }
         #endif
+        return try await view.takePictureRef(options: options)
       }
 
       AsyncFunction("takePicture") { (view, options: TakePictureOptions, promise: Promise) in
-        #if targetEnvironment(simulator) // simulator
-        try takePictureForSimulator(self.appContext, view, options, promise)
-        #else
+        #if targetEnvironment(simulator)
+        if AVCaptureDevice.default(for: .video) == nil {
+          try takePictureForSimulator(self.appContext, view, options, promise)
+          return
+        }
+        #endif
         Task {
           do {
             let result = try await view.takePicturePromise(options: options)
@@ -277,17 +281,17 @@ public final class CameraViewModule: Module, ScannerResultHandler {
             promise.reject(error)
           }
         }
-        #endif
       }
 
       AsyncFunction("record") { (view, options: CameraRecordingOptions, promise: Promise) in
         #if targetEnvironment(simulator)
-        throw Exceptions.SimulatorNotSupported()
-        #else
+        if AVCaptureDevice.default(for: .video) == nil {
+          throw Exceptions.SimulatorNotSupported()
+        }
+        #endif
         Task {
           await view.record(options: options, promise: promise)
         }
-        #endif
       }
 
       AsyncFunction("toggleRecording") { view in
@@ -300,10 +304,11 @@ public final class CameraViewModule: Module, ScannerResultHandler {
 
       AsyncFunction("stopRecording") { view in
         #if targetEnvironment(simulator)
-        throw Exceptions.SimulatorNotSupported()
-        #else
-        view.stopRecording()
+        if AVCaptureDevice.default(for: .video) == nil {
+          throw Exceptions.SimulatorNotSupported()
+        }
         #endif
+        view.stopRecording()
       }
     }
 

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -52,7 +52,9 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
   }
 
   func updateSessionPreset(preset: AVCaptureSession.Preset, withSessionConfiguration: Bool = true) {
-#if !targetEnvironment(simulator)
+    guard hasAvailableCameraDevice else {
+      return
+    }
     if session.canSetSessionPreset(preset) {
       if session.sessionPreset != preset {
         if withSessionConfiguration {
@@ -64,7 +66,6 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
         }
       }
     } else {
-      // The selected preset cannot be used on the current device so we fall back to the highest available.
       if session.sessionPreset != .high {
         if withSessionConfiguration {
           session.beginConfiguration()
@@ -75,7 +76,6 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
         }
       }
     }
-#endif
   }
 
   func updateDevice() {
@@ -272,9 +272,10 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
   }
 
   func stopSession() {
-#if targetEnvironment(simulator)
-    return
-#else
+    guard hasAvailableCameraDevice else {
+      return
+    }
+
     runtimeErrorTask?.cancel()
     runtimeErrorTask = nil
     session.beginConfiguration()
@@ -290,7 +291,6 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
     if session.isRunning {
       session.stopRunning()
     }
-#endif
   }
 
   func addErrorNotification() {
@@ -356,10 +356,15 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
     }
   }
 
+  private var hasAvailableCameraDevice: Bool {
+    return AVCaptureDevice.default(for: .video) != nil
+  }
+
   private func startSession() {
-#if targetEnvironment(simulator)
-    return
-#else
+    guard hasAvailableCameraDevice else {
+      return
+    }
+
     guard let delegate else {
       return
     }
@@ -394,6 +399,5 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
       delegate?.onCameraReady()
     }
     enableTorch()
-#endif
   }
 }

--- a/packages/expo-camera/ios/Current/CameraView.swift
+++ b/packages/expo-camera/ios/Current/CameraView.swift
@@ -160,9 +160,7 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
     videoRecording = CameraVideoRecording(delegate: self)
     session = sessionManager.session
 
-    #if !targetEnvironment(simulator)
     setupPreview()
-    #endif
     barcodeScanner = createBarcodeScanner()
     UIDevice.current.beginGeneratingDeviceOrientationNotifications()
     NotificationCenter.default.addObserver(
@@ -208,14 +206,12 @@ public class CameraView: ExpoView, EXAppLifecycleListener, EXCameraInterface, Ca
   }
 
   private func updatePictureSize() {
-#if !targetEnvironment(simulator)
     sessionQueue.async {
       if self.mode == .picture {
         let preset = self.pictureSize.toCapturePreset()
         self.sessionManager.updateSessionPreset(preset: preset)
       }
     }
-#endif
   }
 
   func setBarcodeScannerSettings(settings: BarcodeSettings) {


### PR DESCRIPTION
# Why

The iOS implementation currently relies on compile-time simulator guards that block camera code paths unconditionally when running in Simulator. This prevents virtual camera providers in Simulator from using the same capture paths as physical devices and makes simulator behavior diverge from real runtime capability.

# How

This change replaces unconditional simulator-only branching with runtime camera availability checks and keeps those checks scoped to simulator-only code paths where fallback behavior is required. In CameraViewModule, simulator fallbacks for taking pictures and simulator-only errors for recording are now triggered only when AVCaptureDevice.default(for: .video) is unavailable. In CameraSessionManager, session preset updates and start/stop lifecycle work are guarded by runtime video-device availability so simulator behavior remains safe when no camera exists while allowing normal flow when a runtime camera is present. CameraView no longer disables preview or picture-size wiring via compile-time simulator guards, because those paths are now safely governed by runtime session guards.

# Test Plan

On iOS Simulator without a runtime video device, verify that mounting the camera view preserves existing no-camera behavior, photo capture falls back to simulator-generated output, and recording APIs continue to report simulator-not-supported behavior. On iOS Simulator with a runtime video device available, verify that preview renders, photo capture uses the normal capture flow, and recording start/stop follows the standard path. On a physical iOS device, verify that camera mount, preview, photo capture, recording, and permission-denied behavior remain unchanged, and confirm that querying available lenses does not itself trigger additional permission prompts.

# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
