### PR TITLE
fix(cli): Add `react-native-web` to autolinking module resolution

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Pass on `tls` options from Metro config to Metro `runServer` fork ([#43186](https://github.com/expo/expo/pull/43186) by [@cortinico](https://github.com/cortinico))
 - Add internal `--skip-server` flag to skip server bundling in `export:embed` ([#43602](https://github.com/expo/expo/pull/43602) by [@kitten](https://github.com/kitten))
 - Add `package.json:exports` with no-op reexport paths ([#44002](https://github.com/expo/expo/pull/44002) by [@kitten](https://github.com/kitten), [@hassankhan](https://github.com/hassankhan))
+- Add `react-native-web` to autolinking module resolution modules ([#44160](https://github.com/expo/expo/pull/44160) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/src/start/server/metro/createExpoAutolinkingResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoAutolinkingResolver.ts
@@ -17,6 +17,9 @@ const KNOWN_STICKY_DEPENDENCIES = [
   // NOTE: react-native won't be in autolinking output, since it's special
   // We include it here manually, since we know it should be an unduplicated direct dependency
   'react-native',
+  // NOTE: We may redirect dependencies from react-native to react-native-web. This fails if
+  // a sub-dependency cannot access react-native-web, so we define it here
+  'react-native-web',
   // Peer dependencies from expo
   'react-native-webview',
   '@expo/dom-webview',


### PR DESCRIPTION
# Why

We have a resolution rule that redirects `react-native` to `react-native-web` in Web builds. However, this doesn't mean that `react-native-web` is installed in projects or accessible. It will usually be accessible in the project since it must be installed directly, however, when bundling the `expo` package (or other expo dependencies) outside of the project root, we must resolve it otherwise.

# How

- Add `react-native-web` to autolinking module resolution list

**Note:** For `expo-doctor`, it's already included since it's in `bundledNativeModules.json`

# Test Plan

- CI should pass unchanged. Only really affects #44057

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
