### PR TITLE
 [docs] Fix gradle config reference

### DIFF
--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -541,12 +541,6 @@ public class CustomViewController: UIViewController, AppControllerDelegate {
 
 <FAQ>
 
-<Collapsible summary="Is there a working example of this integration?">
-
-See the [brownfield-tester](https://github.com/expo/expo/tree/main/apps/brownfield-tester) app in the Expo GitHub repository for a working example of EAS Update integrated in a brownfield app.
-
-</Collapsible>
-
 <Collapsible summary="How long will this take to add to my app?">
 
 Assuming you are using the latest version of React Native supported by the Expo SDK, and you are comfortable with the React Native integration in your native projects, then you can likely integrate EAS Update in a similar amount of time as it would take you to integrate with a tool like CodePush or Sentry.

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -40,7 +40,7 @@ The next step is to disable the default behavior of `expo-updates` to automatica
 
 ### Disable automatic setup on Android
 
-Modify **android/settings.gradle** to set the property that disables automatic updates initialization, as in the example below:
+Modify **android/gradle.properties** to set the property that disables automatic updates initialization, as in the example below:
 
 <DiffBlock source="/static/diffs/eas-update-custom-initialization.diff" />
 
@@ -540,6 +540,12 @@ public class CustomViewController: UIViewController, AppControllerDelegate {
 ## Common questions
 
 <FAQ>
+
+<Collapsible summary="Is there a working example of this integration?">
+
+See the [brownfield-tester](https://github.com/expo/expo/tree/main/apps/brownfield-tester) app in the Expo GitHub repository for a working example of EAS Update integrated in a brownfield app.
+
+</Collapsible>
 
 <Collapsible summary="How long will this take to add to my app?">
 


### PR DESCRIPTION
# Why

The EAS Update brownfield integration guide incorrectly references **android/settings.gradle** when the actual diff modifies **android/gradle.properties**. This was flagged by a community contributor in PR #44127.

# How

- Fix the file reference from `android/settings.gradle` to `android/gradle.properties` to match the actual diff at `static/diffs/eas-update-custom-initialization.diff`.

# Test Plan

Visit `/eas-update/integration-in-existing-native-apps` and verify the "Disable automatic setup on Android" section references **gradle.properties**.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
