### PR TITLE
[video][android] Fix broken layout after returning from PiP when auto-enter if off

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Fix crash when loading PHAsset url fails ([#43373](https://github.com/expo/expo/pull/43373) by [@fractalbeauty](https://github.com/fractalbeauty))
 - [iOS] Fix crashes when `VideoTrack` properties are non-finite.
 - [Android] Fix PiP exiting immediately after auto-entering from fullscreen. ([#44157](https://github.com/expo/expo/pull/44157) by [@behenate](https://github.com/behenate))
+- [Android] Fix broken layout after returning from PiP when auto-enter if off. ([#44163](https://github.com/expo/expo/pull/44163) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/managers/PictureInPictureManager.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/managers/PictureInPictureManager.kt
@@ -298,7 +298,7 @@ class PictureInPictureManager(appContext: AppContext) : PictureInPictureFragment
   }
 
   private fun paramChangeInfluencesAutoEnter(previous: PiPParams, new: PiPParams): Boolean {
-    return previous.autoEnter != new.autoEnter || previous.canEnter != new.autoEnter || previous.blocksAppFromEntering != new.blocksAppFromEntering
+    return previous.autoEnter != new.autoEnter || previous.canEnter != new.canEnter || previous.blocksAppFromEntering != new.blocksAppFromEntering
   }
 
   private fun shouldPauseOnBackground(videoView: VideoView): Boolean {


### PR DESCRIPTION
# Why

When auto-enter is off and the user exits PiP (entered manually) the layout doesn't return to the original. (not sure how I missed that before the release 🙄) 

# How

This is due a simple copying error when writing the logic.

# Test Plan

Tested in BareExpo on Android API 36

