### PR TITLE
chore(expo-localization): Add missing dev deps

### DIFF
--- a/packages/expo-localization/package.json
+++ b/packages/expo-localization/package.json
@@ -43,9 +43,11 @@
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
+    "@types/i18n-js": "^3.8.2",
     "@types/react": "~19.2.0",
     "@types/rtl-detect": "^1.0.3",
-    "expo-module-scripts": "^55.0.2"
+    "expo-module-scripts": "^55.0.2",
+    "i18n-js": "^3.9.2"
   },
   "peerDependencies": {
     "expo": "*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3838,10 +3838,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/i18n-js@^3.0.1":
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/@types/i18n-js/-/i18n-js-3.8.2.tgz#957a3fa268124d09e3b3b34695f0184118f4bc4f"
-  integrity sha512-F+AuFCjllE1A0W/YUxJB13q2t7cWITMqXOTXQ/InfXxxT8nXrrqL7s/8Pv6XThGjFPemukElwk6QlMOKCEg7eQ==
+"@types/i18n-js@^3.0.1", "@types/i18n-js@^3.8.2":
+  version "3.8.9"
+  resolved "https://registry.yarnpkg.com/@types/i18n-js/-/i18n-js-3.8.9.tgz#074d1389539d2db992e6afd7eb379aa02929ef93"
+  integrity sha512-bSxgya4x5O+x+QhfCGckiDDE+17XGPp1TNBgBA/vfF5EwdiZC70F4cKG5QK2v44+v62oY7/t/InreRhxskulcA==
 
 "@types/invariant@^2.2.33":
   version "2.2.35"
@@ -8385,7 +8385,7 @@ hyphenate-style-name@^1.0.3:
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz#1797bf50369588b47b72ca6d5e65374607cf4436"
   integrity sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==
 
-i18n-js@^3.1.0:
+i18n-js@^3.1.0, i18n-js@^3.9.2:
   version "3.9.2"
   resolved "https://registry.yarnpkg.com/i18n-js/-/i18n-js-3.9.2.tgz#4a015dcfabd4c9fc73115fc2d02d2627e4c15ca5"
   integrity sha512-+Gm8h5HL0emzKhRx2avMKX+nKiVPXeaOZm7Euf2/pbbFcLQoJ3zZYiUykAzoRasijCoWos2Kl1tslmScTgAQKw==


### PR DESCRIPTION
# Why

Missing `i18n-js` (used in tests)

# How

- Add current versions of `i18n-js` and `@types/i18n-js` (checked against `yarn list`)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
