### PR TITLE
fix(expo-dev-menu,expo-dev-launcher): Update podspec `reactNativeVersion` resolution

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Fix missing navigation bar padding ([#43672](https://github.com/expo/expo/pull/43672) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix orientation change regression. ([#43847](https://github.com/expo/expo/pull/43847) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix hard-coded usage of http with exps URLs ([#43982](https://github.com/expo/expo/pull/43982) by [@muvaf](https://github.com/muvaf))
+- [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/expo-dev-launcher.podspec
+++ b/packages/expo-dev-launcher/expo-dev-launcher.podspec
@@ -4,7 +4,13 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 reactNativeVersion = '0.0.0'
 begin
-  reactNativeVersion = `node --print "require('react-native/package.json').version"`
+  absolute_react_native_path = ''
+  if !ENV['REACT_NATIVE_PATH'].nil?
+    absolute_react_native_path = File.expand_path(ENV['REACT_NATIVE_PATH'], Pod::Config.instance.project_root)
+  else
+    absolute_react_native_path = File.dirname(`node --print "require.resolve('react-native/package.json')"`)
+  end
+  reactNativeVersion = `node --print "require('#{absolute_react_native_path}/package.json').version"`
 rescue
   reactNativeVersion = '0.0.0'
 end

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^22.14.0"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react-native": "*"
   }
 }

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - [iOS] Fix support for react-native 0.84 ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fix crash in FabState coerceTo ([#43752](https://github.com/expo/expo/pull/43752) by [@kot331107](https://github.com/kot331107))
+- [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/expo-dev-menu.podspec
+++ b/packages/expo-dev-menu/expo-dev-menu.podspec
@@ -4,10 +4,17 @@ package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 reactNativeVersion = '0.0.0'
 begin
-  reactNativeVersion = `node --print "require('react-native/package.json').version"`
+  absolute_react_native_path = ''
+  if !ENV['REACT_NATIVE_PATH'].nil?
+    absolute_react_native_path = File.expand_path(ENV['REACT_NATIVE_PATH'], Pod::Config.instance.project_root)
+  else
+    absolute_react_native_path = File.dirname(`node --print "require.resolve('react-native/package.json')"`)
+  end
+  reactNativeVersion = `node --print "require('#{absolute_react_native_path}/package.json').version"`
 rescue
   reactNativeVersion = '0.0.0'
 end
+
 reactNativeTargetVersion = reactNativeVersion.split('.')[1].to_i
 
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1 -Wno-comma -Wno-shorten-64-to-32'

--- a/packages/expo-dev-menu/package.json
+++ b/packages/expo-dev-menu/package.json
@@ -45,6 +45,7 @@
     "react-native": "0.85.0-rc.5"
   },
   "peerDependencies": {
-    "expo": "*"
+    "expo": "*",
+    "react-native": "*"
   }
 }


### PR DESCRIPTION
# Why

This seems to be done in several different ways across several modules (and in the future it'd be great to align this), but the more important part here, which is coming up in the pnpm branch, is that these two modules aren't using `REACT_NATIVE_PATH` and have no `rescue` path.

We should probably have a follow-up PR to review all of these and align them.

# How

- Add full `REACT_NATIVE_PATH` and `rescue` parts to `reactNativeVersion` resolution in `expo-dev-launcher` and `expo-dev-menu`'s podspecs
- Also add missing `peerDependencies['react-native']` entries

# Test Plan

- CI should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
