### PR TITLE
[screen-orientation] fix interop with react-native-screens

### DIFF
--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -124,6 +124,12 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
       // Greenfield: add DevLauncherViewController as a child of the window's root VC
       // so react-native-screens finds a VC in the containment hierarchy with correct
       // layout margins.
+      //
+      // Note: this inserts DevLauncherViewController between ScreenOrientationViewController
+      // (the window root VC) and RNSNavigationController, which blocks react-native-screens'
+      // single-level VC traversal for orientation and other window traits.
+      // ScreenOrientationViewController.vcWithRNScreenOrientation() works around this by
+      // searching one level deeper through child VCs.
       rootViewController.view = rootView
       if rootViewController.parent != windowRootVC {
         windowRootVC.addChild(rootViewController)

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed per-screen orientation not working with expo-dev-client by searching child VCs for react-native-screens orientation when an intermediate VC blocks the traversal. ([#44181](https://github.com/expo/expo/pull/44181) by [@vonovak](https://github.com/vonovak))
+
 ### 💡 Others
 
 - [iOS] Added explicit `import React` for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -64,9 +64,15 @@ class ScreenOrientationViewController: UIViewController {
   }
 
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-    guard !shouldUseRNScreenOrientation() else {
-      return super.supportedInterfaceOrientations
+    if let vc = vcWithRNScreenOrientation() {
+      // react-native-screens has per-screen orientation set. Return that VC's
+      // supportedInterfaceOrientations — which RNScreens has swizzled to resolve
+      // the active screen's orientation mask.
+      return vc.supportedInterfaceOrientations
     }
+
+    // No react-native-screens orientation — use expo-screen-orientation's registry mask
+    // (set via lockAsync) or the default from Info.plist.
     let mask = screenOrientationRegistry.requiredOrientationMask()
     return !mask.isEmpty ? mask : defaultOrientationMask
   }
@@ -92,12 +98,24 @@ class ScreenOrientationViewController: UIViewController {
     })
   }
 
-  private func shouldUseRNScreenOrientation() -> Bool {
-    // If RNScreens has set the orientation we want to use it instead of our orientation
+  /// Finds the VC whose subtree has a react-native-screens screen with orientation set.
+  /// Checks self first (the common case), then each child VC. The child-level search handles
+  /// cases where an intermediate VC (e.g. DevLauncherViewController from expo-dev-client)
+  /// sits between this root VC and the RNSNavigationController, blocking the single-level
+  /// traversal that RNScreens' shouldAskScreensForScreenOrientation performs.
+  private func vcWithRNScreenOrientation() -> UIViewController? {
     guard let screenWindowTraitsClass = NSClassFromString("RNSScreenWindowTraits") else {
-      return false
+      return nil
     }
-    return screenWindowTraitsClass.shouldAskScreensForScreenOrientation?(in: self) ?? false
+    if screenWindowTraitsClass.shouldAskScreensForScreenOrientation?(in: self) ?? false {
+      return self
+    }
+    for child in children {
+      if screenWindowTraitsClass.shouldAskScreensForScreenOrientation?(in: child) ?? false {
+        return child
+      }
+    }
+    return nil
   }
 
   /**


### PR DESCRIPTION
# Why

Per-screen orientation (via react-native-screens' `orientation` prop on `Stack.Screen`) is broken when `expo-dev-client` is installed. `DevLauncherViewController` sits between `ScreenOrientationViewController` and `RNSNavigationController` in the VC hierarchy, blocking RNScreens' single-level VC traversal for orientation. Fixes #43692.

# How

- Replaced `shouldUseRNScreenOrientation()` with `vcWithRNScreenOrientation()` in `ScreenOrientationViewController`. The new method checks `self` first (existing behavior), then searches child VCs one level deeper. When an intermediate VC like `DevLauncherViewController` is present, this finds `RNSNavigationController` through the child and delegates to its swizzled `supportedInterfaceOrientations`.
- Added a comment in `ExpoDevLauncherReactDelegateHandler.swift` documenting that the VC hierarchy blocks the traversal and pointing to the workaround.

To fix "lockAsync() silently ignored on iOS 16+ during react-native-screens navigation transitions" (as reported), per-screen orientation definition using the `orientation` option are needed: `<Stack.Screen name="landscape" options={{ orientation: 'landscape_right' }} />`

# Test Plan

1. Create an Expo Router app with `expo-dev-client` and `expo-screen-orientation` installed
2. Set `"orientation": "default"` in `app.json`
3. **In `_layout.tsx`, set per-screen orientation: `<Stack.Screen name="landscape" options={{ orientation: 'landscape_right' }} />`**
4. Navigate to the landscape screen and back, repeat multiple times
5. Verify the screen rotates to landscape on push and back to portrait on pop, with no cancelled transitions

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
