### PR TITLE
fix(expo-router): Preserve parenthesized query params when stripping groups

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Allow async routes to rehydrate synchronously by carrying through preloaded modules preventing FOUC in production output ([#46539](https://github.com/expo/expo/pull/46539) by [@kitten](https://github.com/kitten))
 - Fix type inference for `unstable_createStandardRouterNavigator` ([#46737](https://github.com/expo/expo/pull/46737) by [@Ubax](https://github.com/Ubax))
 - Preserve a system time mocked with `jest.setSystemTime` across `renderRouter` ([#46978](https://github.com/expo/expo/pull/46978) by [@Ubax](https://github.com/Ubax))
+- Preserve parenthesized values in query params and hash fragments when stripping group segments from paths. ([#26664](https://github.com/expo/expo/issues/26664) by [@mvincentong](https://github.com/mvincentong)) ([#44189](https://github.com/expo/expo/pull/44189) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-router/src/__tests__/matchers.test.ios.ts
+++ b/packages/expo-router/src/__tests__/matchers.test.ios.ts
@@ -14,6 +14,31 @@ describe(stripGroupSegmentsFromPath, () => {
     );
     expect(stripGroupSegmentsFromPath('(foo)/(bar)')).toBe('');
   });
+
+  it(`preserves query params containing parentheses`, () => {
+    expect(stripGroupSegmentsFromPath('/page?a=(value)')).toBe('/page?a=(value)');
+    expect(stripGroupSegmentsFromPath('/page?a=(a)&b=b')).toBe('/page?a=(a)&b=b');
+    expect(stripGroupSegmentsFromPath('/page?phone=(123)+456-7890')).toBe(
+      '/page?phone=(123)+456-7890'
+    );
+  });
+
+  it(`strips groups from pathname but preserves query params with parentheses`, () => {
+    expect(stripGroupSegmentsFromPath('/(group)/page?a=(value)')).toBe('/page?a=(value)');
+    expect(stripGroupSegmentsFromPath('/(app)/(tabs)/home?id=(abc)&name=test')).toBe(
+      '/home?id=(abc)&name=test'
+    );
+  });
+
+  it(`preserves hash fragments`, () => {
+    expect(stripGroupSegmentsFromPath('/page#section(1)')).toBe('/page#section(1)');
+    expect(stripGroupSegmentsFromPath('/(group)/page#(hash)')).toBe('/page#(hash)');
+  });
+
+  it(`preserves query params and hash together`, () => {
+    expect(stripGroupSegmentsFromPath('/page?a=(val)#(hash)')).toBe('/page?a=(val)#(hash)');
+    expect(stripGroupSegmentsFromPath('/(group)/page?a=(val)#frag')).toBe('/page?a=(val)#frag');
+  });
 });
 
 describe(matchGroupName, () => {

--- a/packages/expo-router/src/__tests__/push.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/push.test.ios.tsx
@@ -660,6 +660,51 @@ it('push should also add anchor routes', () => {
   });
 });
 
+it('preserves params containing parentheses', () => {
+  renderRouter({
+    _layout: () => <Stack />,
+    index: () => <Text testID="index" />,
+    test: function Test() {
+      const params = useLocalSearchParams();
+      return <Text testID="params">{JSON.stringify(params)}</Text>;
+    },
+  });
+
+  act(() =>
+    router.push({
+      pathname: '/test',
+      params: { a: '(value)', b: 'normal' },
+    })
+  );
+
+  expect(screen).toHavePathname('/test');
+  const params = JSON.parse(screen.getByTestId('params').props.children);
+  expect(params.a).toBe('(value)');
+  expect(params.b).toBe('normal');
+});
+
+it('preserves params with phone number format containing parentheses', () => {
+  renderRouter({
+    _layout: () => <Stack />,
+    index: () => <Text testID="index" />,
+    test: function Test() {
+      const params = useLocalSearchParams();
+      return <Text testID="params">{JSON.stringify(params)}</Text>;
+    },
+  });
+
+  act(() =>
+    router.push({
+      pathname: '/test',
+      params: { phone: '(123) 456-7890' },
+    })
+  );
+
+  expect(screen).toHavePathname('/test');
+  const params = JSON.parse(screen.getByTestId('params').props.children);
+  expect(params.phone).toBe('(123) 456-7890');
+});
+
 describe('singular', () => {
   test('can dynamically route using singular', () => {
     renderRouter(

--- a/packages/expo-router/src/matchers.tsx
+++ b/packages/expo-router/src/matchers.tsx
@@ -68,15 +68,23 @@ export function removeFileSystemDots(filePath: string): string {
 }
 
 export function stripGroupSegmentsFromPath(path: string): string {
-  return path
-    .split('/')
-    .reduce((acc, v) => {
-      if (matchGroupName(v) == null) {
-        acc.push(v);
-      }
-      return acc;
-    }, [] as string[])
-    .join('/');
+  // Separate query string and hash from the pathname to avoid
+  // stripping parenthesized values in query params (e.g., ?key=(value))
+  const searchIndex = path.search(/[?#]/);
+  const pathname = searchIndex === -1 ? path : path.substring(0, searchIndex);
+  const suffix = searchIndex === -1 ? '' : path.substring(searchIndex);
+
+  return (
+    pathname
+      .split('/')
+      .reduce((acc, v) => {
+        if (matchGroupName(v) == null) {
+          acc.push(v);
+        }
+        return acc;
+      }, [] as string[])
+      .join('/') + suffix
+  );
 }
 
 export function stripInvisibleSegmentsFromPath(path: string): string {


### PR DESCRIPTION
## Why

Fixes #26664. `stripGroupSegmentsFromPath` was processing the full URL, including query params and hash, as slash-delimited path segments. Parenthesized query or hash values could be matched as route groups and stripped.

This is the `expo-router` half split from the original combined PR per maintainer request. The `jest-expo` Babel config fix moved to #45683.

## How

Separate the pathname from the first `?` or `#`, strip group segments only from the pathname, then append the original suffix unchanged.

Added matcher unit coverage and `router.push` coverage for query params, hash fragments, and combined suffixes with parenthesized values.

## Test Plan

- [x] `git diff --check upstream/main...HEAD`
- [x] `pnpm --filter expo-router test -- src/__tests__/matchers.test.ios.ts src/__tests__/push.test.ios.tsx --runInBand`
- [x] `pnpm --filter expo-router exec eslint --max-warnings 0 src/matchers.tsx src/__tests__/matchers.test.ios.ts src/__tests__/push.test.ios.tsx`
- [x] `pnpm --filter expo-router build`

## Risk

Four-file `expo-router` diff: one helper, two focused tests, and one changelog entry. The implementation preserves the original suffix bytes and only changes group stripping for the pathname portion.
