### PR TITLE
fix(log-box): Add native no-op for renderInShadowRoot to avoid react-dom dependency

### DIFF
--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Add native no-op for `renderInShadowRoot` to avoid `react-dom` resolution errors on native platforms. ([#43893](https://github.com/expo/expo/issues/43893)) ([#44190](https://github.com/expo/expo/pull/44190) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ### ⚠️ Notices

--- a/packages/@expo/log-box/src/utils/renderInShadowRoot.native.ts
+++ b/packages/@expo/log-box/src/utils/renderInShadowRoot.native.ts
@@ -1,0 +1,17 @@
+import React from 'react';
+
+/**
+ * Native no-op for renderInShadowRoot.
+ *
+ * The real implementation lives in renderInShadowRoot.ts (used on web) and
+ * depends on react-dom/client. This .native.ts variant ensures Metro never
+ * tries to resolve react-dom on iOS/Android.
+ */
+export function renderInShadowRoot(
+  _id: string,
+  _element: React.ReactNode
+): {
+  unmount: () => void;
+} {
+  throw new Error('renderInShadowRoot is not supported on native platforms.');
+}


### PR DESCRIPTION
## Summary

- `renderInShadowRoot.ts` unconditionally imports `react-dom/client` at the top level. On native platforms where `react-dom` is not installed, this causes a module resolution failure even though the function is never called outside of web.
- Adds a `.native.ts` variant that Metro picks on iOS/Android, so the bundler never reaches the `react-dom/client` import.

Fixes #43893

## Test plan

- Verified that the new `.native.ts` file exports the same function signature as the web version
- On native: Metro resolves `renderInShadowRoot.native.ts` (no react-dom import)
- On web: Metro resolves `renderInShadowRoot.ts` (existing implementation, unchanged)
- The function throws if accidentally called on native, providing a clear error message