### PR TITLE
fix(expo-constants): Fall back to embedded app config when expoClient is missing from manifest

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fall back to embedded app config when `expoConfig` is missing `extra.expoClient` from the updates manifest, preventing crash loops on app version downgrades with the same fingerprint. ([#44091](https://github.com/expo/expo/issues/44091)) ([#44191](https://github.com/expo/expo/pull/44191) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.7 — 2026-05-11

--- a/packages/expo-constants/src/Constants.ts
+++ b/packages/expo-constants/src/Constants.ts
@@ -157,7 +157,10 @@ Object.defineProperties(constants, {
       }
 
       if (isExpoUpdatesManifest(maybeManifest)) {
-        return maybeManifest.extra?.expoClient ?? null;
+        // Fall back to the embedded app config when the manifest doesn't include
+        // extra.expoClient (e.g. a cached embedded update from a previous install
+        // with the same fingerprint but a different updateId).
+        return maybeManifest.extra?.expoClient ?? rawAppConfig;
       } else if (isEmbeddedManifest(maybeManifest)) {
         return maybeManifest as any;
       }

--- a/packages/expo-constants/src/__tests__/Constants-test.ts
+++ b/packages/expo-constants/src/__tests__/Constants-test.ts
@@ -179,6 +179,22 @@ describe(`manifest`, () => {
       expect(ConstantsWithMock.expoConfig).toEqual(fakeEmbeddedAppConfig);
       expect(console.warn).not.toHaveBeenCalled();
     });
+
+    it('falls back to embedded app config when updates manifest has no extra.expoClient', () => {
+      const manifestWithoutExpoClient: Manifest = {
+        id: 'fakeid-old',
+        metadata: {},
+        createdAt: '',
+        runtimeVersion: '1',
+        launchAsset: { url: '' },
+        assets: [],
+      };
+      mockExponentConstants({ manifest: fakeEmbeddedAppConfig });
+      mockExpoUpdates({ manifest: manifestWithoutExpoClient, isEmbeddedLaunch: false });
+      const ConstantsWithMock = require('../Constants').default;
+      expect(ConstantsWithMock.expoConfig).toEqual(fakeEmbeddedAppConfig);
+      expect(console.warn).not.toHaveBeenCalled();
+    });
   });
 
   // web will only ever be in bare environment


### PR DESCRIPTION
## Summary

- When reinstalling an app with the same native fingerprint but different JS, the expo-updates database may still hold a cached embedded update from the previous install. If that update is launched, `isEmbeddedLaunch` is `false` (updateIds differ) and the manifest lacks `extra.expoClient`, causing `Constants.expoConfig` to return `null`.
- Downstream packages like `expo-linking` then crash because they cannot resolve a scheme, leading to an infinite crash loop via ErrorRecovery.
- Falls back to `rawAppConfig` (the config baked into the binary) instead of returning `null`, matching the existing behaviour for `isEmbeddedLaunch === true`.

Fixes #44091

## Test plan

- Added test case: `falls back to embedded app config when updates manifest has no extra.expoClient`
- All 60 existing tests continue to pass across Android, iOS, Node, and Web