### PR TITLE
[widgets] Support `PlatformColor`

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Pass environment to AppIntent ([#43925](https://github.com/expo/expo/pull/43925) by [@jakex7](https://github.com/jakex7))
 - Automatically add `target` for `Button`. ([#43977](https://github.com/expo/expo/pull/43977) by [@jakex7](https://github.com/jakex7))
 - Add support for `Link` view from `@expo/ui`. ([#43985](https://github.com/expo/expo/pull/43985) by [@jakex7](https://github.com/jakex7))
+- Support `PlatformColor`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Pass environment to AppIntent ([#43925](https://github.com/expo/expo/pull/43925) by [@jakex7](https://github.com/jakex7))
 - Automatically add `target` for `Button`. ([#43977](https://github.com/expo/expo/pull/43977) by [@jakex7](https://github.com/jakex7))
 - Add support for `Link` view from `@expo/ui`. ([#43985](https://github.com/expo/expo/pull/43985) by [@jakex7](https://github.com/jakex7))
-- Support `PlatformColor`.
+- Support `PlatformColor`. ([#44193](https://github.com/expo/expo/pull/44193) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/bundle/index.ts
+++ b/packages/expo-widgets/bundle/index.ts
@@ -5,6 +5,7 @@ import * as modifiers from '@expo/ui/swift-ui/modifiers';
 
 import { decorateInteractiveTargets } from './decorator';
 import * as jsxRuntime from './jsx-runtime-stub';
+import * as ReactNative from './react-native-stub';
 import * as React from './react-stub';
 
 type Dictionary = Record<string, unknown>;
@@ -61,6 +62,7 @@ Object.assign(globalThis, {
   ...modifiers,
   ...jsxRuntime,
   ...React,
+  ...ReactNative,
   React,
   __expoWidgetRender,
   __expoWidgetHandlePress,

--- a/packages/expo-widgets/bundle/react-native-stub.ts
+++ b/packages/expo-widgets/bundle/react-native-stub.ts
@@ -1,0 +1,3 @@
+export const PlatformColor = (...names: string[]) => {
+  return { semantic: names };
+};

--- a/packages/expo-widgets/metro.config.js
+++ b/packages/expo-widgets/metro.config.js
@@ -7,6 +7,7 @@ const config = getDefaultConfig(projectRoot);
 
 const expoStubPath = path.resolve(__dirname, './bundle/expo-module-stub.ts');
 const reactStubPath = path.resolve(__dirname, './bundle/react-stub.ts');
+const reactNativeStubPath = path.resolve(__dirname, './bundle/react-native-stub.ts');
 const jsxRuntimeStubPath = path.resolve(__dirname, './bundle/jsx-runtime-stub.ts');
 
 // The `projectRoot` won't be included by default, since we alter it to be `__dirname`
@@ -47,7 +48,7 @@ const buildConfig = {
         case 'react/jsx-dev-runtime':
           return { type: 'sourceFile', filePath: jsxRuntimeStubPath };
         case 'react-native':
-          return { type: 'empty' };
+          return { type: 'sourceFile', filePath: reactNativeStubPath };
         default:
           return context.resolveRequest(context, moduleName, platform);
       }


### PR DESCRIPTION
# Why

For example `pink` is converted to web-standard pink, not the pretty one from SwiftUI

# How

Polyfill `PlatformColor` in widgets bundle. 

# Test Plan

Instead of this
```tsx
<VStack modifiers={[containerBackground('pink', 'widget')]}>
```
<img width="313" height="165" alt="image" src="https://github.com/user-attachments/assets/b9f9aae8-1d1f-4609-b057-490884c6dcdb" />

---

can be this
```tsx
<VStack modifiers={[containerBackground(PlatformColor('systemPink'), 'widget')]}>
```
<img width="302" height="164" alt="image" src="https://github.com/user-attachments/assets/ce9cda71-a041-4c69-b7f2-72d1f97d3622" />

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
