### PR TITLE
docs(bare): require Metro to extend expo/metro-config without Expo CLI

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -36,6 +36,8 @@ To install and use Expo modules, the easiest way to get up and running is with t
   React Native project, then you need to perform manual installation and adapt the instructions here
   to your codebase.
 
+> **warning** If you skip installing Expo CLI when running `install-expo-modules`, you still need the [bundling configuration](#configure-expo-cli-for-bundling-on-android-and-ios) below. In particular, **metro.config.js** must extend `expo/metro-config`—without it, Metro may not resolve Expo modules correctly when using the React Native CLI (for example `npx react-native start` or `npm run start`).
+
 ## Manual installation
 
 The following instructions apply to installing the latest version of Expo modules in React Native 0.83. For previous versions, check the [native upgrade helper](/bare/upgrade) to see how these files are customized.
@@ -76,6 +78,8 @@ The last step is to install the project's CocoaPods again to pull in Expo module
 ### Configure Expo CLI for bundling on Android and iOS
 
 We recommend using Expo CLI and related tooling configurations to bundle your app JavaScript code and assets. This adds support for using the `"main"` field in **package.json** to use [Expo Router](/router/introduction/) library. Not using Expo CLI for bundling may result in unexpected behavior. [Learn more about Expo CLI](/bare/using-expo-cli/).
+
+Regardless of whether you use Expo CLI or only the React Native CLI for development, your **metro.config.js** should extend `expo/metro-config` so Metro can resolve Expo modules and match what `expo doctor` expects.
 
 <Collapsible summary="Use babel-preset-expo in your babel.config.js">
   <DiffBlock source="/static/diffs/babel-config.diff" />


### PR DESCRIPTION
Clarify that skipping Expo CLI during install-expo-modules still needs metro.config.js to extend expo/metro-config for correct resolution with the React Native dev server.

Related: https://github.com/expo/expo/issues/44174
Made-with: Cursor

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
