### PR TITLE
fix(babel-preset-expo): Update plugin resolution to resolve from project root

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Opt `"widget"` functions for `expo-widgets` out of react-compiler ([#43451](https://github.com/expo/expo/pull/43451) by [@kitten](https://github.com/kitten))
 - Fix `"use no memo"` and `"use no forget"` default opt-out directives being ineffective in react-compiler transform ([#43521](https://github.com/expo/expo/pull/43521) by [@Titozzz](https://github.com/Titozzz), [@kitten](https://github.com/kitten))
-- Opt into `expo-router` plugins by default since `hasModule` is a heuristic ([#44114](https://github.com/expo/expo/pull/44114) by [@kitten](https://github.com/kitten))
+- Update plugin detection to resolve from project root ([#44197](https://github.com/expo/expo/pull/44197) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/babel-preset-expo/build/common.d.ts
+++ b/packages/babel-preset-expo/build/common.d.ts
@@ -1,5 +1,4 @@
 import type { NodePath, types as t } from '@babel/core';
-export declare function hasModule(name: string): boolean;
 /** Determine which bundler is being used. */
 export declare function getBundler(caller?: any): "metro" | "webpack" | null;
 export declare function getPlatform(caller?: any): string | null | undefined;

--- a/packages/babel-preset-expo/build/common.js
+++ b/packages/babel-preset-expo/build/common.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.hasModule = hasModule;
 exports.getBundler = getBundler;
 exports.getPlatform = getPlatform;
 exports.getPossibleProjectRoot = getPossibleProjectRoot;
@@ -27,17 +26,6 @@ exports.toPosixPath = toPosixPath;
 // @ts-expect-error: missing types
 const helper_module_imports_1 = require("@babel/helper-module-imports");
 const node_path_1 = __importDefault(require("node:path"));
-function hasModule(name) {
-    try {
-        return !!require.resolve(name);
-    }
-    catch (error) {
-        if (error.code === 'MODULE_NOT_FOUND' && error.message.includes(name)) {
-            return false;
-        }
-        throw error;
-    }
-}
 /** Determine which bundler is being used. */
 function getBundler(caller) {
     assertExpoBabelCaller(caller);

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -12,6 +12,7 @@ const restricted_react_api_plugin_1 = require("./restricted-react-api-plugin");
 const server_actions_plugin_1 = require("./server-actions-plugin");
 const server_data_loaders_plugin_1 = require("./server-data-loaders-plugin");
 const use_dom_directive_plugin_1 = require("./use-dom-directive-plugin");
+const resolveModule_1 = require("./utils/resolveModule");
 const widgets_plugin_1 = require("./widgets-plugin");
 function getOptions(options, platform) {
     const tag = platform === 'web' ? 'web' : 'native';
@@ -181,13 +182,15 @@ function babelPresetExpo(api, options = {}) {
     if (bundler !== 'webpack') {
         extraPlugins.push(expo_inline_manifest_plugin_1.expoInlineManifestPlugin);
     }
-    extraPlugins.push(expo_router_plugin_1.expoRouterBabelPlugin);
-    // Process `loader()` functions for client, loader and server bundles (excluding RSC)
-    // - Client bundles: Remove loader exports, they run on server only
-    // - Server bundles: Keep loader exports (needed for SSG)
-    // - Loader-only bundles: Keep only loader exports, remove everything else
-    if (!isReactServer) {
-        extraPlugins.push(server_data_loaders_plugin_1.serverDataLoadersPlugin);
+    if ((0, resolveModule_1.hasModule)(api, 'expo-router/package.json')) {
+        extraPlugins.push(expo_router_plugin_1.expoRouterBabelPlugin);
+        // Process `loader()` functions for client, loader and server bundles (excluding RSC)
+        // - Client bundles: Remove loader exports, they run on server only
+        // - Server bundles: Keep loader exports (needed for SSG)
+        // - Loader-only bundles: Keep only loader exports, remove everything else
+        if (!isReactServer) {
+            extraPlugins.push(server_data_loaders_plugin_1.serverDataLoadersPlugin);
+        }
     }
     extraPlugins.push(client_module_proxy_plugin_1.reactClientReferencesPlugin);
     // Ensure these only run when the user opts-in to bundling for a react server to prevent unexpected behavior for
@@ -204,7 +207,7 @@ function babelPresetExpo(api, options = {}) {
     extraPlugins.push(environment_restricted_imports_1.environmentRestrictedImportsPlugin);
     // Transform widget component JSX expressions to capture widget components for native-side evaluation.
     // This enables the native side to re-evaluate widget components with updated props without re-sending the entire layout.
-    if ((0, common_1.hasModule)('expo-widgets')) {
+    if ((0, resolveModule_1.hasModule)(api, 'expo-widgets/package.json')) {
         extraPlugins.push(widgets_plugin_1.widgetsPlugin);
     }
     if (platformOptions.enableReactFastRefresh ||
@@ -312,15 +315,23 @@ function babelPresetExpo(api, options = {}) {
                 require('@babel/plugin-proposal-decorators'),
                 platformOptions.decorators ?? { legacy: true },
             ],
-            // Automatically add `react-native-reanimated/plugin` when the package is installed.
-            // TODO: Move to be a customTransformOption.
-            (0, common_1.hasModule)('react-native-worklets') &&
-                platformOptions.worklets !== false &&
-                platformOptions.reanimated !== false
-                ? [require('react-native-worklets/plugin')]
-                : (0, common_1.hasModule)('react-native-reanimated') &&
-                    platformOptions.reanimated !== false && [require('react-native-reanimated/plugin')],
-        ].filter(Boolean),
+            // Automatically add worklets or reanimated plugin when package is installed.
+            (() => {
+                if (platformOptions.worklets !== false && platformOptions.reanimated !== false) {
+                    const workletsPlugin = (0, resolveModule_1.resolveModule)(api, 'react-native-worklets/plugin');
+                    if (workletsPlugin) {
+                        return [require(workletsPlugin)];
+                    }
+                }
+                if (platformOptions.reanimated !== false) {
+                    const reanimatedPlugin = (0, resolveModule_1.resolveModule)(api, 'react-native-reanimated/plugin');
+                    if (reanimatedPlugin) {
+                        return [require(reanimatedPlugin)];
+                    }
+                }
+                return null;
+            })(),
+        ].filter((x) => !!x),
     };
 }
 exports.default = babelPresetExpo;

--- a/packages/babel-preset-expo/build/utils/resolveModule.d.ts
+++ b/packages/babel-preset-expo/build/utils/resolveModule.d.ts
@@ -1,0 +1,3 @@
+import type { ConfigAPI } from '@babel/core';
+export declare function resolveModule(api: ConfigAPI, id: string): string | null;
+export declare function hasModule(api: ConfigAPI, id: string): boolean;

--- a/packages/babel-preset-expo/build/utils/resolveModule.js
+++ b/packages/babel-preset-expo/build/utils/resolveModule.js
@@ -1,0 +1,28 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolveModule = resolveModule;
+exports.hasModule = hasModule;
+const common_1 = require("../common");
+function resolveModule(api, id) {
+    const possibleProjectRoot = api.caller(common_1.getPossibleProjectRoot) ?? process.cwd();
+    try {
+        return require.resolve(id, {
+            paths: [possibleProjectRoot, __dirname],
+        });
+    }
+    catch (error) {
+        if (error.code === 'MODULE_NOT_FOUND' && error.message.includes(id)) {
+            return null;
+        }
+        throw error;
+    }
+}
+function hasModule(api, id) {
+    try {
+        return resolveModule(api, id) != null;
+    }
+    catch {
+        // We should always fail silently for a "hasModule" check
+        return false;
+    }
+}

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -79,8 +79,7 @@
     "babel-plugin-react-native-web": "~0.21.0",
     "babel-plugin-syntax-hermes-parser": "^0.33.3",
     "babel-plugin-transform-flow-enums": "^0.0.2",
-    "debug": "^4.3.4",
-    "resolve-from": "^5.0.0"
+    "debug": "^4.3.4"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
@@ -91,6 +90,7 @@
     "babel-plugin-module-resolver": "^5.0.2",
     "expo-module-scripts": "^55.0.2",
     "jest": "^29.2.1",
-    "react-refresh": "^0.14.2"
+    "react-refresh": "^0.14.2",
+    "resolve-from": "^5.0.0"
   }
 }

--- a/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/hermes-bytecode.test.ts
@@ -7,22 +7,27 @@ function getCaller(props: Record<string, string | boolean>): babel.TransformCall
   return props as unknown as babel.TransformCaller;
 }
 
-jest.mock('../common.ts', () => ({
-  ...jest.requireActual('../common.ts'),
-  hasModule: jest.fn((moduleId) => {
+jest.mock('../utils/resolveModule.ts', () => {
+  function resolveModule(_api: any, id: string): string | null {
     if (
       [
-        'react-native-worklets',
-        'react-native-reanimated',
-        'expo-router',
+        'react-native-worklets/plugin',
+        'react-native-reanimated/plugin',
+        'expo-router/package.json',
         '@expo/vector-icons',
-      ].includes(moduleId)
+      ].includes(id)
     ) {
-      return true;
+      return id;
     }
-    return false;
-  }),
-}));
+    return null;
+  }
+
+  return {
+    ...jest.requireActual('../utils/resolveModule.ts'),
+    resolveModule: jest.fn(resolveModule),
+    hasModule: jest.fn((api, id) => !!resolveModule(api, id)),
+  };
+});
 
 const SAMPLE_CODE = `
 try {

--- a/packages/babel-preset-expo/src/__tests__/index.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/index.test.ts
@@ -8,22 +8,28 @@ function getCaller(props: Record<string, string | boolean>): babel.TransformCall
   return props as unknown as babel.TransformCaller;
 }
 
-jest.mock('../common.ts', () => ({
-  ...jest.requireActual('../common.ts'),
-  hasModule: jest.fn((moduleId) => {
+jest.mock('../utils/resolveModule.ts', () => {
+  function resolveModule(_api: any, id: string): string | null {
     if (
       [
-        'react-native-worklets',
-        'react-native-reanimated',
-        'expo-router',
+        'react-native-worklets/plugin',
+        'react-native-reanimated/plugin',
+        'expo-router/package.json',
+        'expo-widgets/package.json',
         '@expo/vector-icons',
-      ].includes(moduleId)
+      ].includes(id)
     ) {
-      return true;
+      return id;
     }
-    return false;
-  }),
-}));
+    return null;
+  }
+
+  return {
+    ...jest.requireActual('../utils/resolveModule.ts'),
+    resolveModule: jest.fn(resolveModule),
+    hasModule: jest.fn((api, id) => !!resolveModule(api, id)),
+  };
+});
 
 describe('flow + esm', () => {
   const BABEL_OPTIONS = {

--- a/packages/babel-preset-expo/src/common.ts
+++ b/packages/babel-preset-expo/src/common.ts
@@ -4,17 +4,6 @@ import { addNamed as addNamedImport } from '@babel/helper-module-imports';
 import type { ExpoBabelCaller } from '@expo/metro-config/build/babel-transformer';
 import path from 'node:path';
 
-export function hasModule(name: string): boolean {
-  try {
-    return !!require.resolve(name);
-  } catch (error: any) {
-    if (error.code === 'MODULE_NOT_FOUND' && error.message.includes(name)) {
-      return false;
-    }
-    throw error;
-  }
-}
-
 /** Determine which bundler is being used. */
 export function getBundler(caller?: any) {
   assertExpoBabelCaller(caller);

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -16,7 +16,6 @@ import {
   getIsServer,
   getReactCompiler,
   getMetroSourceType,
-  hasModule,
 } from './common';
 import { environmentRestrictedImportsPlugin } from './environment-restricted-imports';
 import { expoInlineManifestPlugin } from './expo-inline-manifest-plugin';
@@ -28,6 +27,7 @@ import { environmentRestrictedReactAPIsPlugin } from './restricted-react-api-plu
 import { reactServerActionsPlugin } from './server-actions-plugin';
 import { serverDataLoadersPlugin } from './server-data-loaders-plugin';
 import { expoUseDomDirectivePlugin } from './use-dom-directive-plugin';
+import { hasModule, resolveModule } from './utils/resolveModule';
 import { widgetsPlugin } from './widgets-plugin';
 
 type BabelPresetExpoPlatformOptions = {
@@ -315,7 +315,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
 
   // Transform widget component JSX expressions to capture widget components for native-side evaluation.
   // This enables the native side to re-evaluate widget components with updated props without re-sending the entire layout.
-  if (hasModule('expo-widgets')) {
+  if (hasModule(api, 'expo-widgets')) {
     extraPlugins.push(widgetsPlugin);
   }
 
@@ -448,11 +448,11 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
 
       // Automatically add `react-native-reanimated/plugin` when the package is installed.
       // TODO: Move to be a customTransformOption.
-      hasModule('react-native-worklets') &&
+      hasModule(api, 'react-native-worklets') &&
       platformOptions.worklets !== false &&
       platformOptions.reanimated !== false
         ? [require('react-native-worklets/plugin')]
-        : hasModule('react-native-reanimated') &&
+        : hasModule(api, 'react-native-reanimated') &&
           platformOptions.reanimated !== false && [require('react-native-reanimated/plugin')],
     ].filter(Boolean) as PluginItem[],
   };

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -289,13 +289,15 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     extraPlugins.push(expoInlineManifestPlugin);
   }
 
-  extraPlugins.push(expoRouterBabelPlugin);
-  // Process `loader()` functions for client, loader and server bundles (excluding RSC)
-  // - Client bundles: Remove loader exports, they run on server only
-  // - Server bundles: Keep loader exports (needed for SSG)
-  // - Loader-only bundles: Keep only loader exports, remove everything else
-  if (!isReactServer) {
-    extraPlugins.push(serverDataLoadersPlugin);
+  if (hasModule(api, 'expo-router/package.json')) {
+    extraPlugins.push(expoRouterBabelPlugin);
+    // Process `loader()` functions for client, loader and server bundles (excluding RSC)
+    // - Client bundles: Remove loader exports, they run on server only
+    // - Server bundles: Keep loader exports (needed for SSG)
+    // - Loader-only bundles: Keep only loader exports, remove everything else
+    if (!isReactServer) {
+      extraPlugins.push(serverDataLoadersPlugin);
+    }
   }
 
   extraPlugins.push(reactClientReferencesPlugin);

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -466,7 +466,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
 
         return null;
       })(),
-    ].filter((x): x is PluginItem => !!x) as PluginItem[],
+    ].filter((x): x is PluginItem => !!x),
   };
 }
 

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -317,7 +317,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
 
   // Transform widget component JSX expressions to capture widget components for native-side evaluation.
   // This enables the native side to re-evaluate widget components with updated props without re-sending the entire layout.
-  if (hasModule(api, 'expo-widgets')) {
+  if (hasModule(api, 'expo-widgets/package.json')) {
     extraPlugins.push(widgetsPlugin);
   }
 
@@ -450,7 +450,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
 
       // Automatically add worklets or reanimated plugin when package is installed.
       ((): PluginItem | null => {
-        if (platformOptions.worklets !== false) {
+        if (platformOptions.worklets !== false && platformOptions.reanimated !== false) {
           const workletsPlugin = resolveModule(api, 'react-native-worklets/plugin');
           if (workletsPlugin) {
             return [require(workletsPlugin)];

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -446,15 +446,25 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
         platformOptions.decorators ?? { legacy: true },
       ],
 
-      // Automatically add `react-native-reanimated/plugin` when the package is installed.
-      // TODO: Move to be a customTransformOption.
-      hasModule(api, 'react-native-worklets') &&
-      platformOptions.worklets !== false &&
-      platformOptions.reanimated !== false
-        ? [require('react-native-worklets/plugin')]
-        : hasModule(api, 'react-native-reanimated') &&
-          platformOptions.reanimated !== false && [require('react-native-reanimated/plugin')],
-    ].filter(Boolean) as PluginItem[],
+      // Automatically add worklets or reanimated plugin when package is installed.
+      ((): PluginItem | null => {
+        if (platformOptions.worklets !== false) {
+          const workletsPlugin = resolveModule(api, 'react-native-worklets/plugin');
+          if (workletsPlugin) {
+            return [require(workletsPlugin)];
+          }
+        }
+
+        if (platformOptions.reanimated !== false) {
+          const reanimatedPlugin = resolveModule(api, 'react-native-reanimated/plugin');
+          if (reanimatedPlugin) {
+            return [require(reanimatedPlugin)];
+          }
+        }
+
+        return null;
+      })(),
+    ].filter((x): x is PluginItem => !!x) as PluginItem[],
   };
 }
 

--- a/packages/babel-preset-expo/src/utils/resolveModule.ts
+++ b/packages/babel-preset-expo/src/utils/resolveModule.ts
@@ -1,0 +1,26 @@
+import type { ConfigAPI } from '@babel/core';
+
+import { getPossibleProjectRoot } from '../common';
+
+export function resolveModule(api: ConfigAPI, id: string): string | null {
+  const possibleProjectRoot = api.caller(getPossibleProjectRoot) ?? process.cwd();
+  try {
+    return require.resolve(id, {
+      paths: [possibleProjectRoot, __dirname],
+    });
+  } catch (error: any) {
+    if (error.code === 'MODULE_NOT_FOUND' && error.message.includes(id)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+export function hasModule(api: ConfigAPI, id: string): boolean {
+  try {
+    return resolveModule(api, id) != null;
+  } catch {
+    // We should always fail silently for a "hasModule" check
+    return false;
+  }
+}


### PR DESCRIPTION
# Why

The `hasModule` implementation is unaware of the `projectRoot` currently, and doesn't attempt to resolve other modules from there. This can lead to build issues, if the plugins we're looking for aren't resolvable hierarchically. In isolated dependencies this can happen if the store folder isn't under the project root (isolated modules and hoisting), and no peer dependency is present.

This affects detection of:
- expo-router (Reverting detection removal from #44114)
- expo-widgets
- react-native-reanimated / react-native-worklets

# How

- Add `resolveModule` (and `hasModule`) detecting from `projectRoot` as well as `__dirname` by reading root from caller, falling back to CWD

# Test Plan

- Existing E2E and unit tests should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
