### PR TITLE
[expo-tools][support] add --unblocked parameter

### DIFF
--- a/tools/src/commands/GitHubInspectCommand.ts
+++ b/tools/src/commands/GitHubInspectCommand.ts
@@ -22,6 +22,8 @@ type ActionOptions = {
   week?: string;
   label?: string;
   staleDays?: string;
+  issue?: string;
+  unblocked?: boolean;
 };
 
 type IssueItem = Awaited<ReturnType<typeof listAllOpenIssuesAsync>>[number];
@@ -982,7 +984,67 @@ async function showDetailInteractive(item: QueueItem): Promise<void> {
   }
 }
 
+async function actionUnblockedIssue(issueNumber: number): Promise<void> {
+  const spinner = ora('Authenticating…').start();
+
+  try {
+    await getAuthenticatedUserAsync();
+  } catch {
+    spinner.fail('GitHub authentication failed. Set the GITHUB_TOKEN environment variable.');
+    process.exit(1);
+  }
+
+  if (!(await isAuthenticatedAsync())) {
+    spinner.fail('Unblocked API not configured. Set UNBLOCKED_API_KEY env var.');
+    process.exit(1);
+  }
+
+  spinner.text = `Fetching issue #${issueNumber}…`;
+  const issue = await getIssueAsync(issueNumber);
+  const isPR = 'pull_request' in issue && !!issue.pull_request;
+
+  const item: QueueItem = {
+    number: issue.number,
+    title: issue.title,
+    author: issue.user?.login ?? '-',
+    category: '',
+    isPR,
+  };
+
+  spinner.text = `Fetching details for #${issueNumber}…`;
+  const detail = await fetchDetailData(item);
+
+  spinner.text = `Loading comments for #${issueNumber}…`;
+  const comments = detail.comments > 0 ? await listAllCommentsAsync(detail.number) : [];
+
+  spinner.text = `Analyzing #${issueNumber} with Unblocked…`;
+  let analysisText: string;
+  try {
+    analysisText = await analyzeIssueAsync(detail, comments);
+  } catch (err: any) {
+    spinner.fail(`Analysis error: ${err.message ?? err}`);
+    process.exit(1);
+  }
+
+  spinner.stop();
+
+  // Print detail summary + analysis
+  const lines = renderDetailView(detail, true, false, analysisText);
+  for (const line of lines) logger.info(line);
+}
+
 async function action(options: ActionOptions) {
+  // Direct unblocked analysis mode — no interactive UI
+  if (options.unblocked && options.issue) {
+    const issueNumber = parseInt(options.issue, 10);
+    if (isNaN(issueNumber)) {
+      logger.error(`Invalid issue number: ${options.issue}`);
+      process.exit(1);
+    }
+    await actionUnblockedIssue(issueNumber);
+    return;
+  }
+
   const spinner = ora('Authenticating…').start();
 
   // Auth check
@@ -1029,5 +1091,10 @@ export default (program: Command) => {
     )
     .option('-l, --label <label>', 'Filter by GitHub label.')
     .option('-s, --stale-days <days>', 'Custom stale threshold in days (default: 14).')
+    .option('-i, --issue <number>', 'Issue or PR number to inspect directly.')
+    .option(
+      '--unblocked',
+      'Run Unblocked analysis directly on the issue (requires --issue). Outputs analysis without interactive UI.'
+    )
     .asyncAction(action);
 };


### PR DESCRIPTION
To be able to get the unblocked analysis for a given issue, we now support the --unblocked parameter when the --issue number is also set.

This makes it possible to run the command from an agent.