### PR TITLE
[autolinking][ios] Add a warning when a package is not linked due to deployment target mismatch

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add `package.json:exports` with no-op reexport paths ([#44002](https://github.com/expo/expo/pull/44002) by [@kitten](https://github.com/kitten), [@hassankhan](https://github.com/hassankhan))
 - [iOS] Add early escape in generateModulesProviderAsync to avoid touching files that hasn't changed ([#44289](https://github.com/expo/expo/pull/44289) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Added `@OptimizedFunction` macros support for Expo modules. ([#44262](https://github.com/expo/expo/pull/44262) by [@kudo](https://github.com/kudo))
+- [iOS] Add more detailed warnings when a package is not linked due to a mismatch between project and package deployment target. ([#44200](https://github.com/expo/expo/pull/44200) by [@behenate](https://github.com/behenate))
 
 ## 55.0.8 — 2026-02-25
 

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -71,9 +71,10 @@ module Expo
               next
             end
 
-            # Skip if the podspec doesn't include the platform for the current target.
+            # Skip if the podspec doesn't include the platform for the current target or if deployment targets are incompatible.
             unless pod.supports_platform?(@target_definition.platform)
-              UI.message '- ' << package.name.green << " doesn't support #{@target_definition.platform.string_name} platform".yellow
+              reason = pod.platform_skip_reason(@target_definition.platform)
+              UI.warn "[Expo] ".blue << package.name.green << " was not linked: #{reason}".yellow
               next
             end
 

--- a/packages/expo-modules-autolinking/scripts/ios/package.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/package.rb
@@ -26,6 +26,29 @@ module Expo
       end
     end
 
+    # Returns a human-readable string explaining why this pod cannot be linked for the given platform.
+    def platform_skip_reason(platform)
+      return "no platform specified" unless platform
+
+      matching_by_name = @spec.available_platforms.select do |available|
+        available.name == platform.name
+      end
+
+      if matching_by_name.empty?
+        supported = @spec.available_platforms.map(&:string_name).join(', ')
+        return "supports #{supported.empty? ? 'no platforms' : supported} but target is #{platform.string_name}"
+      end
+
+      # Pod's minimum deployment target exceeds the app's deployment target.
+      required = matching_by_name.map(&:deployment_target).compact.min
+      if required
+        app_target = platform.deployment_target || 'an unspecified version'
+        return "requires #{platform.string_name} #{required} but app targets #{app_target}"
+      end
+
+      return "incompatible with #{platform.string_name} #{platform.deployment_target}"
+    end
+
   end # class PackagePod
 
   class Package


### PR DESCRIPTION
# Why

This was suggested by Evan in `create-expo-module` revamp suggestions. We don't give enough feedback when a package is not linked due to misconfiguration.

# How

Warn when a package is not linked due to deployment target mismatch.

# Test Plan

Tested in `expo/expo` by mismatching a package deployment target and running `pod install` 

Output example:

<img width="814" height="158" alt="image" src="https://github.com/user-attachments/assets/2b09c81a-c8e4-444e-bae3-13faeb8d5983" />
