### PR TITLE
[ci] don't trigger native build for change in docs

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -12,6 +12,7 @@ on:
       - tools/**
       - yarn.lock
       - '!packages/@expo/cli/**'
+      - '!tools/src/commands/GenerateDocsAPIData.ts'
   pull_request:
     paths:
       - .github/workflows/android-unit-tests.yml
@@ -21,6 +22,7 @@ on:
       - tools/**
       - yarn.lock
       - '!packages/@expo/cli/**'
+      - '!tools/src/commands/GenerateDocsAPIData.ts'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
# Why

we add a lot of new pages for expo ui like here https://github.com/expo/expo/pull/44202 which change that file, and that triggers expensive native builds for no reason

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
