### PR TITLE
[create-expo-module] When creating a local module comply with `expo.autolinking.nativeModulesDir` field

### DIFF
--- a/packages/create-expo-module/src/__tests__/create-expo-module-test.ts
+++ b/packages/create-expo-module/src/__tests__/create-expo-module-test.ts
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resolveLocalModuleDir } from '../create-expo-module';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'create-expo-module-test-'));
+}
+
+function writePackageJson(dir: string, content: object): string {
+  const filePath = path.join(dir, 'package.json');
+  fs.writeFileSync(filePath, JSON.stringify(content));
+  return filePath;
+}
+
+describe('resolveLocalModuleDir', () => {
+  it('defaults to modules/ when no nativeModulesDir is configured', () => {
+    const projectRoot = makeTmpDir();
+    try {
+      const packageJsonPath = writePackageJson(projectRoot, { name: 'my-app' });
+      const result = resolveLocalModuleDir(packageJsonPath, 'my-module');
+      expect(result).toBe(path.join(projectRoot, 'modules', 'my-module'));
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('uses nativeModulesDir from expo.autolinking when configured', () => {
+    const projectRoot = makeTmpDir();
+    try {
+      const packageJsonPath = writePackageJson(projectRoot, {
+        name: 'my-app',
+        expo: { autolinking: { nativeModulesDir: 'native-modules' } },
+      });
+      const result = resolveLocalModuleDir(packageJsonPath, 'my-module');
+      expect(result).toBe(path.resolve(projectRoot, 'native-modules', 'my-module'));
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('resolves nativeModulesDir as a path relative to the project root', () => {
+    const projectRoot = makeTmpDir();
+    try {
+      const packageJsonPath = writePackageJson(projectRoot, {
+        name: 'my-app',
+        expo: { autolinking: { nativeModulesDir: 'packages/native' } },
+      });
+      const result = resolveLocalModuleDir(packageJsonPath, 'camera');
+      expect(result).toBe(path.resolve(projectRoot, 'packages', 'native', 'camera'));
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to modules/ when expo config exists but autolinking is missing', () => {
+    const projectRoot = makeTmpDir();
+    try {
+      const packageJsonPath = writePackageJson(projectRoot, {
+        name: 'my-app',
+        expo: { name: 'My App' },
+      });
+      const result = resolveLocalModuleDir(packageJsonPath, 'my-module');
+      expect(result).toBe(path.join(projectRoot, 'modules', 'my-module'));
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to modules/ and prints a warning when package.json cannot be parsed', () => {
+    const projectRoot = makeTmpDir();
+    try {
+      const packageJsonPath = path.join(projectRoot, 'package.json');
+      fs.writeFileSync(packageJsonPath, 'this is not valid json');
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      const result = resolveLocalModuleDir(packageJsonPath, 'my-module');
+      consoleSpy.mockRestore();
+
+      expect(result).toBe(path.join(projectRoot, 'modules', 'my-module'));
+    } finally {
+      fs.rmSync(projectRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -123,6 +123,35 @@ function slugToAndroidPackage(slug: string): string {
   return `expo.modules.${namespace}`;
 }
 
+/**
+ * Resolves the target directory for a new local module given the project's `package.json` path.
+ * Respects `expo.autolinking.nativeModulesDir` when present; falls back to `modules/`.
+ * @internal Exported for testing.
+ */
+export function resolveLocalModuleDir(packageJsonPath: string, targetOrSlug: string): string {
+  let packageJson: any = {};
+  try {
+    const fileContent = fs.readFileSync(packageJsonPath, 'utf8');
+    packageJson = JSON.parse(fileContent);
+  } catch {
+    console.log(
+      chalk.yellow(
+        `⚠️ Could not parse package.json at ${packageJsonPath}. Using the \`modules\` directory in the root of the project as the module location.`
+      )
+    );
+  }
+
+  const { expo } = packageJson;
+  const projectRoot = path.dirname(packageJsonPath);
+  const nativeModulesDir = expo?.autolinking?.nativeModulesDir;
+
+  if (nativeModulesDir) {
+    return path.resolve(projectRoot, nativeModulesDir, targetOrSlug);
+  }
+
+  return path.join(projectRoot, 'modules', targetOrSlug);
+}
+
 async function getCorrectLocalDirectory(targetOrSlug: string) {
   let packageJsonPath: string | null = null;
   for (let dir = CWD; path.dirname(dir) !== dir; dir = path.dirname(dir)) {
@@ -146,27 +175,7 @@ async function getCorrectLocalDirectory(targetOrSlug: string) {
     return null;
   }
 
-  let packageJson: any = {};
-  try {
-    const fileContent = fs.readFileSync(packageJsonPath, 'utf8');
-    packageJson = JSON.parse(fileContent);
-  } catch (error) {
-    console.log(
-      chalk.yellow(
-        `⚠️ Could not parse package.json at ${packageJsonPath}. Using the \`modules\` directory in the root of the project as the module location.`
-      )
-    );
-  }
-
-  const { expo } = packageJson;
-  const projectRoot = path.dirname(packageJsonPath);
-  const nativeModulesDir = expo && expo.autolinking && expo.autolinking.nativeModulesDir;
-
-  if (nativeModulesDir) {
-    return path.resolve(projectRoot, nativeModulesDir, targetOrSlug);
-  }
-
-  return path.join(packageJsonPath, '..', 'modules', targetOrSlug);
+  return resolveLocalModuleDir(packageJsonPath, targetOrSlug);
 }
 
 /**
@@ -436,13 +445,14 @@ async function main(target: string | undefined, options: CommandOptions) {
 
   console.log();
   if (options.local) {
-    console.log(`✅ Successfully created Expo module in ${chalk.bold.italic(`modules/${slug}`)}`);
+    console.log(`✅ Successfully created Expo module in ${chalk.bold.italic(relativePath)}`);
+    const importPath = relativePath.startsWith('.') ? relativePath : `./${relativePath}`;
     printFurtherLocalInstructions(
       data.project.moduleName,
       data.project.viewName,
       data.project.name,
       options.barrel,
-      relativePath
+      importPath
     );
   } else {
     console.log('✅ Successfully created Expo module');
@@ -1054,17 +1064,13 @@ function printFurtherLocalInstructions(
   console.log(`You can now import this module inside your application.`);
   console.log(`For example, you can add these lines to your App.tsx or App.js file:`);
   if (barrel) {
-    console.log(
-      chalk.gray.italic(`import ${moduleName}, { ${viewName} } from '${relativePath}';`)
-    );
+    console.log(chalk.gray.italic(`import ${moduleName}, { ${viewName} } from '${relativePath}';`));
   } else {
     console.log(
       chalk.gray.italic(`import ${moduleName} from '${relativePath}/src/${moduleName}';`)
     );
     console.log(
-      chalk.gray.italic(
-        `import { default as ${viewName} } from '${relativePath}/src/${viewName}';`
-      )
+      chalk.gray.italic(`import { default as ${viewName} } from '${relativePath}/src/${viewName}';`)
     );
     console.log(chalk.gray.italic(`import type { } from '${relativePath}/src/${name}.types';`));
   }

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -140,11 +140,32 @@ async function getCorrectLocalDirectory(targetOrSlug: string) {
     );
     console.log(
       chalk.red(
-        'For native modules to autolink correctly, you need to place them in the `modules` directory in the root of the project.'
+        'For native modules to autolink correctly, you need to place them in the directory specified in `expo.autolinking.nativeModulesDir` field in `package.json` which defaults to `modules` directory in the root of the project when unspecified.'
       )
     );
     return null;
   }
+
+  let packageJson: any = {};
+  try {
+    const fileContent = fs.readFileSync(packageJsonPath, 'utf8');
+    packageJson = JSON.parse(fileContent);
+  } catch (error) {
+    console.log(
+      chalk.yellow(
+        `⚠️ Could not parse package.json at ${packageJsonPath}. Using the \`modules\` directory in the root of the project as the module location.`
+      )
+    );
+  }
+
+  const { expo } = packageJson;
+  const projectRoot = path.dirname(packageJsonPath);
+  const nativeModulesDir = expo && expo.autolinking && expo.autolinking.nativeModulesDir;
+
+  if (nativeModulesDir) {
+    return path.resolve(projectRoot, nativeModulesDir, targetOrSlug);
+  }
+
   return path.join(packageJsonPath, '..', 'modules', targetOrSlug);
 }
 
@@ -310,17 +331,6 @@ async function main(target: string | undefined, options: CommandOptions) {
     debug('Running in non-interactive mode');
   }
 
-  if (options.local) {
-    console.log();
-    console.log(
-      `${chalk.gray('The local module will be created in the ')}${chalk.gray.bold.italic(
-        'modules'
-      )} ${chalk.gray('directory in the root of your project. Learn more: ')}${chalk.gray.bold(
-        FYI_LOCAL_DIR
-      )}`
-    );
-    console.log();
-  }
   const slug = await askForPackageSlugAsync(target, options.local, options);
   const targetDir = options.local
     ? await getCorrectLocalDirectory(target || slug)
@@ -329,6 +339,19 @@ async function main(target: string | undefined, options: CommandOptions) {
   if (!targetDir) {
     return;
   }
+
+  const relativePath = path.relative(CWD, targetDir);
+
+  if (options.local) {
+    console.log();
+    console.log(
+      `${chalk.gray('The local module will be created in ')}${chalk.gray.bold.italic(
+        relativePath
+      )} ${chalk.gray('directory. Learn more: ')}${chalk.gray.bold(FYI_LOCAL_DIR)}`
+    );
+    console.log();
+  }
+
   await fs.promises.mkdir(targetDir, { recursive: true });
   await confirmTargetDirAsync(targetDir, options);
 
@@ -415,11 +438,11 @@ async function main(target: string | undefined, options: CommandOptions) {
   if (options.local) {
     console.log(`✅ Successfully created Expo module in ${chalk.bold.italic(`modules/${slug}`)}`);
     printFurtherLocalInstructions(
-      slug,
       data.project.moduleName,
       data.project.viewName,
       data.project.name,
-      options.barrel
+      options.barrel,
+      relativePath
     );
   } else {
     console.log('✅ Successfully created Expo module');
@@ -1021,29 +1044,29 @@ function printFurtherInstructions(
 }
 
 function printFurtherLocalInstructions(
-  slug: string,
   moduleName: string,
   viewName: string,
   name: string,
-  barrel: boolean
+  barrel: boolean,
+  relativePath: string
 ) {
   console.log();
   console.log(`You can now import this module inside your application.`);
   console.log(`For example, you can add these lines to your App.tsx or App.js file:`);
   if (barrel) {
     console.log(
-      chalk.gray.italic(`import ${moduleName}, { ${viewName} } from './modules/${slug}';`)
+      chalk.gray.italic(`import ${moduleName}, { ${viewName} } from '${relativePath}';`)
     );
   } else {
     console.log(
-      chalk.gray.italic(`import ${moduleName} from './modules/${slug}/src/${moduleName}';`)
+      chalk.gray.italic(`import ${moduleName} from '${relativePath}/src/${moduleName}';`)
     );
     console.log(
       chalk.gray.italic(
-        `import { default as ${viewName} } from './modules/${slug}/src/${viewName}';`
+        `import { default as ${viewName} } from '${relativePath}/src/${viewName}';`
       )
     );
-    console.log(chalk.gray.italic(`import type { } from './modules/${slug}/src/${name}.types';`));
+    console.log(chalk.gray.italic(`import type { } from '${relativePath}/src/${name}.types';`));
   }
   console.log();
   console.log(`Learn more on Expo Modules APIs: ${chalk.blue.bold(DOCS_URL)}`);


### PR DESCRIPTION
# Why

Currently `create-expo-module` always creates local modules int the `<PROJECT_ROOT>/modules` directory. They will not get autolinked if `package.json:expo.autolinking.nativeModulesDir` has been set to a different location.

# How

When `expo.autolinking.nativeModulesDir` is set, place the new directory inside of it.

# Test Plan

Tested by creating local modules in bare expo and specyfing a different module location in `package.json`