### PR TITLE
chore: Add minimum release age of 1d

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -14,12 +14,14 @@ on:
       - tools/**
       - packages/**
       - pnpm-lock.yaml
+      - pnpm-workspace.yaml
   pull_request:
     paths:
       - .github/workflows/sdk.yml
       - tools/**
       - packages/**
       - pnpm-lock.yaml
+      - pnpm-workspace.yaml
   schedule:
     - cron: 0 14 * * *
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,3 +37,5 @@ patchedDependencies:
   react-server-dom-webpack: patches/react-server-dom-webpack.patch
 
 preferWorkspacePackages: true
+
+minimumReleaseAge: 1440


### PR DESCRIPTION
# Why

We'd like to set a default minimum release age to pnpm, as a follow-up to the pnpm branch.

# How

- Set initial release age setting to one day

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
