### PR TITLE
[brownfield] Validate package installation before running CLI commands

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [test] add maestro e2e tests for dev menu ([#43421](https://github.com/expo/expo/pull/43421) by [@pmleczek](https://github.com/pmleczek))
 - [android] set react native version for all published artfacts ([#43693](https://github.com/expo/expo/pull/43693) by [@pmleczek](https://github.com/pmleczek))
 - [test] add fixes to ios debug e2es ([#43703](https://github.com/expo/expo/pull/43703) by [@pmleczek](https://github.com/pmleczek))
+- Validate package installation before running CLI commands ([#44210](https://github.com/expo/expo/pull/44210) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 55.0.11 — 2026-02-25
 

--- a/packages/expo-brownfield/cli/build/utils/error.d.ts
+++ b/packages/expo-brownfield/cli/build/utils/error.d.ts
@@ -1,4 +1,4 @@
-type ErrorType = 'android-task-repo' | 'android-directory-not-found' | 'android-library-unknown-error' | 'android-library-not-found' | 'ios-artifacts-directory-unknown-error' | 'ios-directory-not-found' | 'ios-directory-unknown-error' | 'ios-hermes-framework-not-found' | 'ios-scheme-not-found' | 'ios-workspace-not-found' | 'ios-workspace-unknown-error' | 'prebuild-cancelled';
+type ErrorType = 'android-task-repo' | 'android-directory-not-found' | 'android-library-unknown-error' | 'android-library-not-found' | 'ios-artifacts-directory-unknown-error' | 'ios-directory-not-found' | 'ios-directory-unknown-error' | 'ios-hermes-framework-not-found' | 'ios-scheme-not-found' | 'ios-workspace-not-found' | 'ios-workspace-unknown-error' | 'package-not-installed' | 'plugin-not-configured' | 'prebuild-cancelled';
 declare class CLIError {
     private static readonly errorSymbol;
     private static readonly errorMessages;

--- a/packages/expo-brownfield/cli/build/utils/error.js
+++ b/packages/expo-brownfield/cli/build/utils/error.js
@@ -14,6 +14,8 @@ class CLIError {
         'ios-scheme-not-found': 'Could not find brownfield iOS scheme',
         'ios-workspace-not-found': 'Could not find brownfield iOS workspace',
         'ios-workspace-unknown-error': 'Unknown error occurred while finding brownfield iOS workspace',
+        'package-not-installed': 'expo-brownfield is not installed in the project. Install it with `npx expo install expo-brownfield`',
+        'plugin-not-configured': 'expo-brownfield is not configured as a plugin. Add it to the `plugins` array in your app config',
         'prebuild-cancelled': 'Brownfield cannot be built without prebuilding the native project',
     };
     static handle(error, errorMessage = '', fatal = true) {

--- a/packages/expo-brownfield/cli/build/utils/prebuild.d.ts
+++ b/packages/expo-brownfield/cli/build/utils/prebuild.d.ts
@@ -1,2 +1,3 @@
 import type { Platform } from './types';
 export declare const validatePrebuild: (platform: Platform) => Promise<void>;
+export declare const validatePackageInstalled: () => void;

--- a/packages/expo-brownfield/cli/build/utils/prebuild.js
+++ b/packages/expo-brownfield/cli/build/utils/prebuild.js
@@ -4,8 +4,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.validatePackageInstalled = exports.validatePrebuild = void 0;
-const config_1 = require("expo/config");
 const chalk_1 = __importDefault(require("chalk"));
+const config_1 = require("expo/config");
 const node_fs_1 = __importDefault(require("node:fs"));
 const node_path_1 = __importDefault(require("node:path"));
 const prompts_1 = __importDefault(require("prompts"));

--- a/packages/expo-brownfield/cli/build/utils/prebuild.js
+++ b/packages/expo-brownfield/cli/build/utils/prebuild.js
@@ -3,7 +3,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.validatePrebuild = void 0;
+exports.validatePackageInstalled = exports.validatePrebuild = void 0;
+const config_1 = require("expo/config");
 const chalk_1 = __importDefault(require("chalk"));
 const node_fs_1 = __importDefault(require("node:fs"));
 const node_path_1 = __importDefault(require("node:path"));
@@ -12,6 +13,7 @@ const commands_1 = require("./commands");
 const error_1 = __importDefault(require("./error"));
 const spinner_1 = require("./spinner");
 const validatePrebuild = async (platform) => {
+    (0, exports.validatePackageInstalled)();
     if (!checkPrebuild(platform)) {
         console.info(`${chalk_1.default.yellow(`⚠ Prebuild for platform: ${platform} is missing`)}`);
         const response = await (0, prompts_1.default)({
@@ -35,6 +37,20 @@ const validatePrebuild = async (platform) => {
     }
 };
 exports.validatePrebuild = validatePrebuild;
+const validatePackageInstalled = () => {
+    const PACKAGE_NAME = 'expo-brownfield';
+    const packageJson = (0, config_1.getPackageJson)(process.cwd());
+    if (!packageJson.dependencies?.[PACKAGE_NAME] && !packageJson.devDependencies?.[PACKAGE_NAME]) {
+        error_1.default.handle('package-not-installed');
+        return;
+    }
+    const { exp: config } = (0, config_1.getConfig)(process.cwd(), { skipSDKVersionRequirement: true });
+    const isBrownfieldPluginConfigured = config.plugins?.some((plugin) => Array.isArray(plugin) ? plugin[0] === PACKAGE_NAME : plugin === PACKAGE_NAME);
+    if (!isBrownfieldPluginConfigured) {
+        error_1.default.handle('plugin-not-configured');
+    }
+};
+exports.validatePackageInstalled = validatePackageInstalled;
 const checkPrebuild = (platform) => {
     const nativeDirectory = node_path_1.default.join(process.cwd(), platform);
     return node_fs_1.default.existsSync(nativeDirectory);

--- a/packages/expo-brownfield/cli/src/utils/error.ts
+++ b/packages/expo-brownfield/cli/src/utils/error.ts
@@ -10,6 +10,8 @@ type ErrorType =
   | 'ios-scheme-not-found'
   | 'ios-workspace-not-found'
   | 'ios-workspace-unknown-error'
+  | 'package-not-installed'
+  | 'plugin-not-configured'
   | 'prebuild-cancelled';
 
 class CLIError {
@@ -27,6 +29,10 @@ class CLIError {
     'ios-scheme-not-found': 'Could not find brownfield iOS scheme',
     'ios-workspace-not-found': 'Could not find brownfield iOS workspace',
     'ios-workspace-unknown-error': 'Unknown error occurred while finding brownfield iOS workspace',
+    'package-not-installed':
+      'expo-brownfield is not installed in the project. Install it with `npx expo install expo-brownfield`',
+    'plugin-not-configured':
+      'expo-brownfield is not configured as a plugin. Add it to the `plugins` array in your app config',
     'prebuild-cancelled': 'Brownfield cannot be built without prebuilding the native project',
   };
 

--- a/packages/expo-brownfield/cli/src/utils/prebuild.ts
+++ b/packages/expo-brownfield/cli/src/utils/prebuild.ts
@@ -1,5 +1,5 @@
-import { getConfig, getPackageJson } from 'expo/config';
 import chalk from 'chalk';
+import { getConfig, getPackageJson } from 'expo/config';
 import fs from 'node:fs';
 import path from 'node:path';
 import prompts from 'prompts';

--- a/packages/expo-brownfield/cli/src/utils/prebuild.ts
+++ b/packages/expo-brownfield/cli/src/utils/prebuild.ts
@@ -1,3 +1,4 @@
+import { getConfig, getPackageJson } from 'expo/config';
 import chalk from 'chalk';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -9,6 +10,8 @@ import { withSpinner } from './spinner';
 import type { Platform } from './types';
 
 export const validatePrebuild = async (platform: Platform): Promise<void> => {
+  validatePackageInstalled();
+
   if (!checkPrebuild(platform)) {
     console.info(`${chalk.yellow(`⚠ Prebuild for platform: ${platform} is missing`)}`);
     const response = await prompts({
@@ -29,6 +32,22 @@ export const validatePrebuild = async (platform: Platform): Promise<void> => {
     } else {
       CLIError.handle('prebuild-cancelled');
     }
+  }
+};
+
+export const validatePackageInstalled = (): void => {
+  const PACKAGE_NAME = 'expo-brownfield';
+  const packageJson = getPackageJson(process.cwd());
+  if (!packageJson.dependencies?.[PACKAGE_NAME] && !packageJson.devDependencies?.[PACKAGE_NAME]) {
+    CLIError.handle('package-not-installed');
+    return;
+  }
+  const { exp: config } = getConfig(process.cwd(), { skipSDKVersionRequirement: true });
+  const isBrownfieldPluginConfigured = config.plugins?.some((plugin) =>
+    Array.isArray(plugin) ? plugin[0] === PACKAGE_NAME : plugin === PACKAGE_NAME
+  );
+  if (!isBrownfieldPluginConfigured) {
+    CLIError.handle('plugin-not-configured');
   }
 };
 

--- a/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
@@ -116,16 +116,12 @@ describe('build:android command', () => {
       const { exitCode, stdout, stderr } = await executeCommandAsync(
         TEMP_DIR,
         'bash',
-        ['-c', `yes | node ${CLI_PATH} build:android --repo MavenLocal`],
+        ['-c', `yes no | node ${CLI_PATH} build:android --repo MavenLocal`],
         { ignoreErrors: true }
       );
       expect(exitCode).not.toBe(0);
       expect(stdout).toContain(BUILD.PREBUILD_WARNING('android'));
       expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
-      expect(stderr).toContain('Could not find brownfield library in the project');
-
-      // The android directory should be created and not empty
-      await expectPrebuild(TEMP_DIR, 'android');
     });
   });
 

--- a/packages/expo-brownfield/e2e/cli/__tests__/build-ios.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/build-ios.test.ts
@@ -92,9 +92,9 @@ describe('build:ios command', () => {
 
     /**
      * Command: npx expo-brownfield build:ios
-     * Expected behavior: The CLI should fail if prebuild is cancelled
+     * Expected behavior: The CLI should validate and ask for prebuild
      */
-    it('should fail if prebuild is cancelled', async () => {
+    it('should validate and ask for prebuild', async () => {
       // The command fails, because `expo-brownfield` is not added to app.json
       // But the prebuild should succeed
       const { exitCode, stdout, stderr } = await executeCommandAsync(
@@ -106,29 +106,6 @@ describe('build:ios command', () => {
       expect(exitCode).not.toBe(0);
       expect(stdout).toContain(BUILD.PREBUILD_WARNING('ios'));
       expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
-      expect(stderr).toContain(ERROR.MISSING_PREBUILD());
-    });
-
-    /**
-     * Command: npx expo-brownfield build:ios
-     * Expected behavior: The CLI should validate and ask for prebuild
-     */
-    it('should validate and ask for prebuild', async () => {
-      // The command fails, because `expo-brownfield` is not added to app.json
-      // But the prebuild should succeed
-      const { exitCode, stdout, stderr } = await executeCommandAsync(
-        TEMP_DIR,
-        'bash',
-        ['-c', `yes | node ${CLI_PATH} build:ios`],
-        { ignoreErrors: true }
-      );
-      expect(exitCode).not.toBe(0);
-      expect(stdout).toContain(BUILD.PREBUILD_WARNING('ios'));
-      expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
-      expect(stderr).toContain(`Could not find brownfield iOS scheme`);
-
-      // The android directory should be created and not empty
-      await expectPrebuild(TEMP_DIR, 'ios');
     });
   });
 
@@ -137,7 +114,7 @@ describe('build:ios command', () => {
    */
   describe('with prebuild', () => {
     beforeAll(async () => {
-      TEMP_DIR_PREBUILD = await createTempProject('buildiospb', true, true);
+      TEMP_DIR_PREBUILD = await createTempProject('buildiospb', true);
     }, 600000);
 
     afterAll(async () => {

--- a/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/tasks-android.test.ts
@@ -116,16 +116,12 @@ describe('tasks:android command', () => {
       const { exitCode, stdout, stderr } = await executeCommandAsync(
         TEMP_DIR,
         'bash',
-        ['-c', `yes | node ${CLI_PATH} tasks:android`],
+        ['-c', `yes no | node ${CLI_PATH} tasks:android`],
         { ignoreErrors: true }
       );
       expect(exitCode).not.toBe(0);
       expect(stdout).toContain(BUILD.PREBUILD_WARNING('android'));
       expect(stdout).toContain(BUILD.PREBUILD_PROMPT);
-      expect(stderr).toContain(`Could not find brownfield library in the project`);
-
-      // The android directory should be created and not empty
-      await expectPrebuild(TEMP_DIR, 'android');
     });
   });
 

--- a/packages/expo-brownfield/e2e/utils/project.ts
+++ b/packages/expo-brownfield/e2e/utils/project.ts
@@ -33,8 +33,8 @@ export const createTempProject = async (
   try {
     await createProjectWithTemplate(TEMP_DIR, projectName(suffix));
     await installPackage(projectRoot);
+    await addPlugin(projectRoot);
     if (prebuild) {
-      await addPlugin(projectRoot);
       await prebuildProject(projectRoot, undefined, install);
     }
   } catch (error) {
@@ -81,7 +81,7 @@ export const addPlugin = async (
     ...appConfig.expo.android,
     ...android,
   };
-  
+
   appConfig.expo.experiments.autolinkingModuleResolution = true;
 
   await fs.promises.writeFile(appJsonPath, JSON.stringify(appConfig, null, 2));
@@ -119,7 +119,7 @@ const createProjectWithTemplate = async (at: string, projectName: string) => {
 
   let tarballs = await glob('*.tgz', { cwd: templatePath });
   if (tarballs.length === 0) {
-    await executeCommandAsync(templatePath, 'npm', ['pack', '--json']);
+    await executeCommandAsync(templatePath, 'pnpm', ['pack', '--json']);
     tarballs = await glob('*.tgz', { cwd: templatePath });
     if (tarballs.length === 0) {
       throw new Error(`No tarballs found in template directory: ${templatePath}`);
@@ -130,7 +130,7 @@ const createProjectWithTemplate = async (at: string, projectName: string) => {
     projectName,
     '--template',
     path.join(templatePath, tarballs[0]),
-    '--no-install'
+    '--no-install',
   ]);
 };
 
@@ -138,18 +138,24 @@ const createProjectWithTemplate = async (at: string, projectName: string) => {
  * Install `expo-brownfield` package from a tarball
  */
 const installPackage = async (projectRoot: string) => {
-  const packageJsonPath = path.join(projectRoot, 'package.json');
-  const packageJson = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf8'));
   const packageRoot = path.join(__dirname, '../../');
+  let tarballs = await glob('*.tgz', { cwd: packageRoot });
+  if (tarballs.length === 0) {
+    await executeCommandAsync(packageRoot, 'pnpm', ['pack', '--json']);
+    tarballs = await glob('*.tgz', { cwd: packageRoot });
+    if (tarballs.length === 0) {
+      throw new Error(`No tarballs found in package directory: ${packageRoot}`);
+    }
+  }
 
-  packageJson.resolutions ??= {};
-  packageJson.dependencies ??= {};
+  const packageTarball = tarballs[0];
+  const packageTarballPath = path.join(packageRoot, packageTarball);
+  await fs.promises.cp(packageTarballPath, path.join(projectRoot, packageTarball), {
+    recursive: true,
+    force: true,
+  });
 
-  packageJson.resolutions['expo-brownfield'] = path.relative(projectRoot, packageRoot);
-  packageJson.dependencies['expo-brownfield'] = '*';
-
-  // Use --legacy-peer-deps for better stability
-  await spawnAsync('pnpm', ['install'], {
+  await spawnAsync('pnpm', ['add', `./${packageTarball}`], {
     cwd: projectRoot,
     stdio: 'pipe',
   });


### PR DESCRIPTION
# Why

The brownfield CLI fails with obscure errors if you run `npx expo-brownfield` without having it installed in the project. This adds an early validation step with a clear error message guiding users to install the package.

# How

Added a `validatePackageInstalled` check that runs before validating prebuilds folders
 
# Test Plan

1. Create a new Expo project without `expo-brownfield` installed
2. Run `npx expo-brownfield build:android` -> should see the `package-not-installed` error
3. Run `npx expo install expo-brownfield` and re-run -> should proceed past the check normally 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
