### PR TITLE
fix(expo-dev-launcher): stop probing localhost:8085

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS][Android] Stop probing localhost port 8085 during local dev server discovery.
+
 ### 💡 Others
 
 ## 6.0.20 — 2025-12-05

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/PackagerService.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/PackagerService.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import okhttp3.Request
 
-private val portsToCheck = arrayOf(8081, 8082, 8083, 8084, 8085, 19000, 19001, 19002)
+private val portsToCheck = arrayOf(8081, 8082, 8083, 8084, 19000, 19001, 19002)
 private val hostToCheck = if (EmulatorUtilities.isRunningOnEmulator()) {
   "10.0.2.2"
 } else {

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -123,7 +123,7 @@ class DevLauncherViewModel: ObservableObject {
       var discoveredServers: [DevServer] = []
 
       // swiftlint:disable number_separator
-      let portsToCheck = [8081, 8082, 8_083, 8084, 8085, 19000, 19001, 19002]
+      let portsToCheck = [8081, 8082, 8_083, 8084, 19000, 19001, 19002]
       // swiftlint:enable number_separator
 
       let ipsToScan = NetworkUtilities.getIPAddressesToScan()


### PR DESCRIPTION
# Why

While testing `gcloud auth login` on `sdk-54` development builds, the simulator/emulator showed requests to `localhost:8085`.

That traffic comes from `expo-dev-launcher` fallback dev-server discovery, not the auth flow, which makes auth debugging misleading. `sdk-54` still probes `8085` even though Metro defaults to `8081`.

# How

- remove `8085` from the fallback probe list on iOS
- remove `8085` from the fallback probe list on Android
- add an `expo-dev-launcher` changelog entry
- target `sdk-54`, since `main` no longer has this code path

# Test Plan

Not run locally.

Manual repro:
1. Run a local server on `8085` that logs requests.
2. Launch an `sdk-54` development build with `expo-dev-client`.
3. Test around `gcloud auth login` while watching localhost traffic.
4. Before this patch, `8085` can be probed.
5. After this patch, it should not be.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)