### PR TITLE
Disable `search.followSymlinks` in VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   "search.exclude": {
     "packages/**/build": true,
     "docs/public/static/data": true
-  }
+  },
+  "search.followSymlinks": false
 }


### PR DESCRIPTION
# Why

After migration to pnpm, VSCode started using 100% of CPU via `rg` process.

<img width="597" height="109" alt="image" src="https://github.com/user-attachments/assets/780ea253-d240-4538-861c-608b3def84d9" />


# How

Added `"search.followSymlinks": false` to `.vscode/settings.json`

# Test Plan

It's back to normal
<img width="589" height="100" alt="image" src="https://github.com/user-attachments/assets/7cb1df51-b7d5-4732-8c9a-5b458ad8a121" />