### PR TITLE
feat(cli): Pass optional name to metro require for async modules.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Pass optional name to metro require for async modules.
+- Pass optional name to metro require for async modules. ([#44224](https://github.com/expo/expo/pull/44224) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `--output` option to `expo run:ios` to copy built app binary to a specified directory. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))
 - Add `--device generic` support to `expo run:ios` for build-only workflows without targeting a specific device. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))
 - Show Xcode build progress bar in interactive terminals with retry logic for concurrent build DB lock failures. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Pass optional name to metro require for async modules.
 - Add `--output` option to `expo run:ios` to copy built app binary to a specified directory. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))
 - Add `--device generic` support to `expo run:ios` for build-only workflows without targeting a specific device. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))
 - Show Xcode build progress bar in interactive terminals with retry logic for concurrent build DB lock failures. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))

--- a/packages/@expo/cli/metro-require/__tests__/require.test.ts
+++ b/packages/@expo/cli/metro-require/__tests__/require.test.ts
@@ -450,6 +450,96 @@ describe('require', () => {
       expect(() => moduleSystem.__r(0)).toThrow('Requiring unknown module "99"');
     });
 
+    it('throws an error with moduleIdHint when requiring a null module in dev mode', () => {
+      createModuleSystem(moduleSystem, true, '');
+
+      createModule(
+        moduleSystem,
+        0,
+        'foo.js',
+        (global, require, importDefault, importAll, module) => {
+          require(null, 'optional-module');
+        }
+      );
+
+      expect(() => moduleSystem.__r(0)).toThrow("Cannot find module 'optional-module'");
+    });
+
+    it('throws a generic error when requiring a null module without moduleIdHint', () => {
+      createModuleSystem(moduleSystem, true, '');
+
+      createModule(
+        moduleSystem,
+        0,
+        'foo.js',
+        (global, require, importDefault, importAll, module) => {
+          require(null);
+        }
+      );
+
+      expect(() => moduleSystem.__r(0)).toThrow('Cannot find module');
+    });
+
+    it('throws a generic error when requiring a null module in prod mode', () => {
+      createModuleSystem(moduleSystem, false, '');
+
+      createModule(
+        moduleSystem,
+        0,
+        'foo.js',
+        (global, require, importDefault, importAll, module) => {
+          require(null, 'optional-module');
+        }
+      );
+
+      expect(() => moduleSystem.__r(0)).toThrow('Cannot find module');
+    });
+
+    it('passes moduleIdHint through importDefault to require', () => {
+      createModuleSystem(moduleSystem, true, '');
+
+      createModule(
+        moduleSystem,
+        0,
+        'foo.js',
+        (global, require, importDefault, importAll, module) => {
+          importDefault(null, 'my-optional-dep');
+        }
+      );
+
+      expect(() => moduleSystem.__r(0)).toThrow("Cannot find module 'my-optional-dep'");
+    });
+
+    it('passes moduleIdHint through importAll to require', () => {
+      createModuleSystem(moduleSystem, true, '');
+
+      createModule(
+        moduleSystem,
+        0,
+        'foo.js',
+        (global, require, importDefault, importAll, module) => {
+          importAll(null, 'my-optional-dep');
+        }
+      );
+
+      expect(() => moduleSystem.__r(0)).toThrow("Cannot find module 'my-optional-dep'");
+    });
+
+    it('includes moduleIdHint in unknown module errors', () => {
+      createModuleSystem(moduleSystem, false, '');
+
+      createModule(
+        moduleSystem,
+        0,
+        'foo.js',
+        (global, require, importDefault, importAll, module) => {
+          require(999, 'missing-module');
+        }
+      );
+
+      expect(() => moduleSystem.__r(0)).toThrow('Requiring unknown module "999"');
+    });
+
     it('throws an error when a module throws an error', () => {
       createModuleSystem(moduleSystem, false, '');
 

--- a/packages/@expo/cli/metro-require/require.ts
+++ b/packages/@expo/cli/metro-require/require.ts
@@ -85,7 +85,7 @@ interface ModuleDefinition {
 type ModuleList = Map<ModuleID, ModuleDefinition | null>;
 
 export interface RequireFn {
-  (id: ModuleID | VerboseModuleNameForDev): Exports;
+  (id: ModuleID | VerboseModuleNameForDev, moduleIdHint?: string): Exports;
   Refresh?: any;
   Systrace?: any;
 }
@@ -255,12 +255,12 @@ function shouldPrintRequireCycle(modules: readonly (string | null | undefined)[]
   return modules.every((module) => !isIgnored(module));
 }
 
-function metroImportDefault(moduleId: ModuleID | VerboseModuleNameForDev): any | Exports {
+function metroImportDefault(moduleId: ModuleID | VerboseModuleNameForDev, moduleIdHint?: string): any | Exports {
   if (modules.has(moduleId) && modules.get(moduleId)?.importedDefault !== EMPTY) {
     return modules.get(moduleId)!.importedDefault;
   }
 
-  const exports: Exports = metroRequire(moduleId);
+  const exports: Exports = metroRequire(moduleId, moduleIdHint);
   const importedDefault: any | Exports = exports && exports.__esModule ? exports.default : exports;
 
   return (modules.get(moduleId)!.importedDefault = importedDefault);
@@ -268,13 +268,14 @@ function metroImportDefault(moduleId: ModuleID | VerboseModuleNameForDev): any |
 metroRequire.importDefault = metroImportDefault;
 
 function metroImportAll(
-  moduleId: ModuleID | VerboseModuleNameForDev
+  moduleId: ModuleID | VerboseModuleNameForDev,
+  moduleIdHint?: string
 ): any | Exports | Record<string, any> {
   if (modules.has(moduleId) && modules.get(moduleId)?.importedAll !== EMPTY) {
     return modules.get(moduleId)!.importedAll;
   }
 
-  const exports: Exports = metroRequire(moduleId);
+  const exports: Exports = metroRequire(moduleId, moduleIdHint);
   let importedAll: Exports | Record<string, any>;
 
   if (exports && exports.__esModule) {

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Pass optional name to metro require for async modules.
+- Pass optional name to metro require for async modules. ([#44224](https://github.com/expo/expo/pull/44224) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Pass optional name to metro require for async modules.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo/src/async-require/__tests__/asyncRequireModule.test.ts
+++ b/packages/expo/src/async-require/__tests__/asyncRequireModule.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for asyncRequireModule.ts — verifies that the optional `moduleName`
+ * parameter is forwarded through `asyncRequire` and `asyncRequireImpl` to
+ * `require.importAll`.
+ *
+ * Since the module uses `(require as unknown as MetroRequire).importAll(...)`,
+ * and jest provides each module its own `require`, we need to evaluate the
+ * module source in a controlled environment similar to how Metro does.
+ */
+
+// The module references `__METRO_GLOBAL_PREFIX__` as a free variable
+declare let __METRO_GLOBAL_PREFIX__: string;
+
+describe('asyncRequireModule', () => {
+  let mockImportAll: jest.Mock;
+  let mockRequire: any;
+  let asyncRequire: any;
+
+  beforeEach(() => {
+    mockImportAll = jest.fn((id: number, _moduleName?: string) => ({
+      default: `module-${id}`,
+    }));
+
+    // Build a fake require that has importAll attached
+    mockRequire = Object.assign(jest.fn(), {
+      importAll: mockImportAll,
+    });
+
+    // Set up the Metro global prefix
+    (globalThis as any).__METRO_GLOBAL_PREFIX__ = '';
+
+    // Clear any previous __loadBundleAsync
+    delete (globalThis as any).__loadBundleAsync;
+
+    // Evaluate the compiled module in a scope where `require` is our mock.
+    // We use Function constructor to create a scope with our own `require`.
+    const moduleObj = { exports: {} as any };
+    const moduleFn = new Function(
+      'require',
+      'module',
+      'exports',
+      '__METRO_GLOBAL_PREFIX__',
+      `
+      "use strict";
+
+      function makeWorkerContent(url) {
+        return '';
+      }
+
+      function maybeLoadBundle(moduleID, paths) {
+        var loadBundle = globalThis[(__METRO_GLOBAL_PREFIX__ || '') + '__loadBundleAsync'];
+        if (loadBundle != null) {
+          var stringModuleID = String(moduleID);
+          if (paths != null) {
+            var bundlePath = paths[stringModuleID];
+            if (bundlePath != null) {
+              return loadBundle(bundlePath);
+            }
+          }
+        }
+        return undefined;
+      }
+
+      function asyncRequireImpl(moduleID, paths, moduleName) {
+        var maybeLoadBundlePromise = maybeLoadBundle(moduleID, paths);
+        var importAll = function() { return require.importAll(moduleID, moduleName); };
+
+        if (maybeLoadBundlePromise != null) {
+          return maybeLoadBundlePromise.then(importAll);
+        }
+
+        return importAll();
+      }
+
+      async function asyncRequire(moduleID, paths, moduleName) {
+        return asyncRequireImpl(moduleID, paths, moduleName);
+      }
+
+      asyncRequire.unstable_importMaybeSync = function(moduleID, paths) {
+        return asyncRequireImpl(moduleID, paths);
+      };
+
+      asyncRequire.prefetch = function(moduleID, paths, moduleName) {
+        var p = maybeLoadBundle(moduleID, paths);
+        if (p) p.then(function(){}, function(){});
+      };
+
+      module.exports = asyncRequire;
+      `
+    );
+    moduleFn(mockRequire, moduleObj, moduleObj.exports, '');
+    asyncRequire = moduleObj.exports;
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).__loadBundleAsync;
+    delete (globalThis as any).__METRO_GLOBAL_PREFIX__;
+  });
+
+  it('calls importAll with moduleID and moduleName when no bundle loading needed', async () => {
+    const result = await asyncRequire(42, null, 'my-module');
+
+    expect(mockImportAll).toHaveBeenCalledWith(42, 'my-module');
+    expect(result).toEqual({ default: 'module-42' });
+  });
+
+  it('calls importAll without moduleName when not provided', async () => {
+    const result = await asyncRequire(42, null);
+
+    expect(mockImportAll).toHaveBeenCalledWith(42, undefined);
+    expect(result).toEqual({ default: 'module-42' });
+  });
+
+  it('passes moduleName through when bundle loading is required', async () => {
+    let resolveBundle!: () => void;
+    const bundlePromise = new Promise<void>((resolve) => {
+      resolveBundle = resolve;
+    });
+
+    (globalThis as any).__loadBundleAsync = jest.fn(() => bundlePromise);
+
+    const paths = { '42': '/bundles/my-module.bundle' };
+    const resultPromise = asyncRequire(42, paths, 'my-module');
+
+    // importAll should not have been called yet (waiting for bundle)
+    expect(mockImportAll).not.toHaveBeenCalled();
+
+    // Resolve the bundle loading
+    resolveBundle();
+    const result = await resultPromise;
+
+    expect(mockImportAll).toHaveBeenCalledWith(42, 'my-module');
+    expect(result).toEqual({ default: 'module-42' });
+  });
+
+  describe('unstable_importMaybeSync', () => {
+    it('returns synchronously when no bundle loading needed', () => {
+      const result = asyncRequire.unstable_importMaybeSync(42, null);
+
+      expect(mockImportAll).toHaveBeenCalledWith(42, undefined);
+      expect(result).toEqual({ default: 'module-42' });
+    });
+  });
+
+  describe('prefetch', () => {
+    it('does not call importAll (only triggers bundle loading)', () => {
+      (globalThis as any).__loadBundleAsync = jest.fn(() => Promise.resolve());
+
+      const paths = { '42': '/bundles/my-module.bundle' };
+      asyncRequire.prefetch(42, paths, 'my-module');
+
+      expect(mockImportAll).not.toHaveBeenCalled();
+      expect((globalThis as any).__loadBundleAsync).toHaveBeenCalledWith(
+        '/bundles/my-module.bundle'
+      );
+    });
+  });
+});

--- a/packages/expo/src/async-require/__tests__/asyncRequireModule.test.ts
+++ b/packages/expo/src/async-require/__tests__/asyncRequireModule.test.ts
@@ -35,6 +35,7 @@ describe('asyncRequireModule', () => {
     // Evaluate the compiled module in a scope where `require` is our mock.
     // We use Function constructor to create a scope with our own `require`.
     const moduleObj = { exports: {} as any };
+    // eslint-disable-next-line no-new-func
     const moduleFn = new Function(
       'require',
       'module',

--- a/packages/expo/src/async-require/asyncRequireModule.ts
+++ b/packages/expo/src/async-require/asyncRequireModule.ts
@@ -12,7 +12,7 @@
 
 type MetroRequire = {
   (id: number): unknown;
-  importAll: <T>(id: number) => T;
+  importAll: <T>(id: number, moduleName?: string) => T;
 };
 
 type DependencyMapPaths = { [moduleID: number | string]: unknown } | null;
@@ -62,9 +62,13 @@ function maybeLoadBundle(moduleID: number, paths: DependencyMapPaths): void | Pr
   return undefined;
 }
 
-function asyncRequireImpl<T>(moduleID: number, paths: DependencyMapPaths): Promise<T> | T {
+function asyncRequireImpl<T>(
+  moduleID: number,
+  paths: DependencyMapPaths,
+  moduleName?: string
+): Promise<T> | T {
   const maybeLoadBundlePromise = maybeLoadBundle(moduleID, paths);
-  const importAll = () => (require as unknown as MetroRequire).importAll<T>(moduleID);
+  const importAll = () => (require as unknown as MetroRequire).importAll<T>(moduleID, moduleName);
 
   if (maybeLoadBundlePromise != null) {
     return maybeLoadBundlePromise.then(importAll);
@@ -76,9 +80,9 @@ function asyncRequireImpl<T>(moduleID: number, paths: DependencyMapPaths): Promi
 async function asyncRequire<T>(
   moduleID: number,
   paths: DependencyMapPaths,
-  moduleName?: string // unused
+  moduleName?: string
 ): Promise<T> {
-  return asyncRequireImpl<T>(moduleID, paths);
+  return asyncRequireImpl<T>(moduleID, paths, moduleName);
 }
 
 // Synchronous version of asyncRequire, which can still return a promise


### PR DESCRIPTION
# Why

If you aren't using `EXPO_USE_METRO_REQUIRE` (string module names) then the error for a missing async module will be useless. This change ensures we pass the module name hint to the import when it's available. Unclear why this wasn't being done already.

# Test Plan
