### PR TITLE
fix(ios): patch fmt consteval when building RN from source (Xcode 26.4+)

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] When `ios.buildReactNativeFromSource` is enabled, inject a Podfile `post_install` step that sets `FMT_USE_CONSTEVAL=0` in `fmt`'s `base.h` so Xcode 26.4+ can compile React Native's bundled `fmt` from source. ([#44229](https://github.com/expo/expo/issues/44229))
+
 ### 💡 Others
 
 - Update useHermesV1 to support React Native 0.84 ([#43625](https://github.com/expo/expo/pull/43625) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-build-properties/build/iosFmtConstevalFix.d.ts
+++ b/packages/expo-build-properties/build/iosFmtConstevalFix.d.ts
@@ -1,0 +1,11 @@
+import { CodeGenerator, type ConfigPlugin } from 'expo/config-plugins';
+import { PluginConfigType } from './pluginConfig';
+type MergeResults = ReturnType<typeof CodeGenerator.mergeContents>;
+export declare function addFmtConstevalFixToPodfile(src: string): MergeResults;
+export declare function removeFmtConstevalFixFromPodfile(src: string): MergeResults;
+/**
+ * Patches `fmt`'s `base.h` after `pod install` when building React Native from source, so Apple Clang in
+ * Xcode 26.4+ can compile `FMT_STRING` (see https://github.com/expo/expo/issues/44229).
+ */
+export declare const withIosFmtConstevalFix: ConfigPlugin<PluginConfigType>;
+export {};

--- a/packages/expo-build-properties/build/iosFmtConstevalFix.js
+++ b/packages/expo-build-properties/build/iosFmtConstevalFix.js
@@ -1,0 +1,112 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withIosFmtConstevalFix = void 0;
+exports.addFmtConstevalFixToPodfile = addFmtConstevalFixToPodfile;
+exports.removeFmtConstevalFixFromPodfile = removeFmtConstevalFixFromPodfile;
+const config_plugins_1 = require("expo/config-plugins");
+const pluginConfig_1 = require("./pluginConfig");
+const TAG = 'expo-fmt-use-consteval-fix';
+const FMT_FIX_RUBY = [
+    "    if podfile_properties['ios.buildReactNativeFromSource'] == 'true'",
+    "      fmt_base = File.join(installer.sandbox.root.to_s, 'fmt', 'include', 'fmt', 'base.h')",
+    '      if File.exist?(fmt_base)',
+    '        content = File.read(fmt_base)',
+    "        patched = content.gsub(/#\\s*define FMT_USE_CONSTEVAL 1/, '# define FMT_USE_CONSTEVAL 0')",
+    '        if patched != content',
+    '          File.chmod(0644, fmt_base)',
+    '          File.write(fmt_base, patched)',
+    '        end',
+    '      end',
+    '    end',
+].join('\n');
+/**
+ * @returns index of the character after the closing `)` of `react_native_post_install(...)`, or -1 if not found.
+ */
+function findIndexAfterReactNativePostInstallCall(src) {
+    const start = src.indexOf('react_native_post_install');
+    if (start === -1) {
+        return -1;
+    }
+    const openParen = src.indexOf('(', start);
+    if (openParen === -1) {
+        return -1;
+    }
+    let depth = 0;
+    for (let i = openParen; i < src.length; i++) {
+        const c = src[i];
+        if (c === '(') {
+            depth++;
+        }
+        else if (c === ')') {
+            depth--;
+            if (depth === 0) {
+                return i + 1;
+            }
+        }
+    }
+    return -1;
+}
+/**
+ * Returns the full line containing the closing `)` of `react_native_post_install`, for use as mergeContents anchor.
+ */
+function getReactNativePostInstallClosingLine(src) {
+    const endIdx = findIndexAfterReactNativePostInstallCall(src);
+    if (endIdx === -1) {
+        return null;
+    }
+    const before = src.slice(0, endIdx);
+    const lines = before.split('\n');
+    return lines[lines.length - 1] ?? null;
+}
+function addFmtConstevalFixToPodfile(src) {
+    const anchorLine = getReactNativePostInstallClosingLine(src);
+    if (!anchorLine) {
+        return { contents: src, didMerge: false, didClear: false };
+    }
+    return config_plugins_1.CodeGenerator.mergeContents({
+        tag: TAG,
+        src,
+        newSrc: FMT_FIX_RUBY,
+        anchor: new RegExp(`^${escapeRegExp(anchorLine)}$`),
+        offset: 1,
+        comment: '#',
+    });
+}
+function removeFmtConstevalFixFromPodfile(src) {
+    return config_plugins_1.CodeGenerator.removeContents({
+        tag: TAG,
+        src,
+    });
+}
+function escapeRegExp(input) {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+/**
+ * Patches `fmt`'s `base.h` after `pod install` when building React Native from source, so Apple Clang in
+ * Xcode 26.4+ can compile `FMT_STRING` (see https://github.com/expo/expo/issues/44229).
+ */
+const withIosFmtConstevalFix = (config, props) => {
+    const buildFromSource = (0, pluginConfig_1.resolveConfigValue)(props, 'ios', 'buildReactNativeFromSource') === true;
+    return (0, config_plugins_1.withPodfile)(config, async (config) => {
+        let results;
+        if (buildFromSource) {
+            try {
+                results = addFmtConstevalFixToPodfile(config.modResults.contents);
+            }
+            catch (error) {
+                if (error.code === 'ERR_NO_MATCH') {
+                    throw new Error(`Cannot add fmt consteval workaround to the project's ios/Podfile because it's missing a recognizable react_native_post_install call. Report this with a copy of your Podfile: https://github.com/expo/expo/issues`);
+                }
+                throw error;
+            }
+        }
+        else {
+            results = removeFmtConstevalFixFromPodfile(config.modResults.contents);
+        }
+        if (results.didMerge || results.didClear) {
+            config.modResults.contents = results.contents;
+        }
+        return config;
+    });
+};
+exports.withIosFmtConstevalFix = withIosFmtConstevalFix;

--- a/packages/expo-build-properties/build/withBuildProperties.js
+++ b/packages/expo-build-properties/build/withBuildProperties.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.withBuildProperties = void 0;
 const android_1 = require("./android");
 const ios_1 = require("./ios");
+const iosFmtConstevalFix_1 = require("./iosFmtConstevalFix");
 const pluginConfig_1 = require("./pluginConfig");
 /**
  * Config plugin allowing customizing native Android and iOS build properties for managed apps.
@@ -26,6 +27,7 @@ const withBuildProperties = (config, props) => {
     config = (0, android_1.withAndroidPurgeProguardRulesOnce)(config);
     config = (0, android_1.withAndroidDayNightTheme)(config, pluginConfig);
     config = (0, ios_1.withIosBuildProperties)(config, pluginConfig);
+    config = (0, iosFmtConstevalFix_1.withIosFmtConstevalFix)(config, pluginConfig);
     config = (0, ios_1.withIosDeploymentTarget)(config, pluginConfig);
     config = (0, ios_1.withIosInfoPlist)(config, pluginConfig);
     return config;

--- a/packages/expo-build-properties/src/__tests__/iosFmtConstevalFix-test.ts
+++ b/packages/expo-build-properties/src/__tests__/iosFmtConstevalFix-test.ts
@@ -1,0 +1,45 @@
+import {
+  addFmtConstevalFixToPodfile,
+  removeFmtConstevalFixFromPodfile,
+} from '../iosFmtConstevalFix';
+
+const SAMPLE_PODFILE = `target 'HelloWorld' do
+  use_expo_modules!
+
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      config[:reactNativePath],
+      :mac_catalyst_enabled => false,
+      :ccache_enabled => ccache_enabled?(podfile_properties),
+    )
+  end
+end
+`;
+
+describe('iosFmtConstevalFix', () => {
+  it('addFmtConstevalFixToPodfile inserts generated block after react_native_post_install', () => {
+    const { contents, didMerge } = addFmtConstevalFixToPodfile(SAMPLE_PODFILE);
+    expect(didMerge).toBe(true);
+    expect(contents).toContain("podfile_properties['ios.buildReactNativeFromSource'] == 'true'");
+    expect(contents).toContain('fmt_base = File.join(installer.sandbox.root.to_s');
+    expect(contents).toContain('@generated begin expo-fmt-use-consteval-fix');
+  });
+
+  it('removeFmtConstevalFixFromPodfile removes the generated block', () => {
+    const { contents: added } = addFmtConstevalFixToPodfile(SAMPLE_PODFILE);
+    const { contents: removed, didClear } = removeFmtConstevalFixFromPodfile(added);
+    expect(didClear).toBe(true);
+    expect(removed).not.toContain('expo-fmt-use-consteval-fix');
+    expect(removed.replace(/\s+/g, ' ')).toContain(
+      SAMPLE_PODFILE.replace(/\s+/g, ' ').trim().slice(0, 80)
+    );
+  });
+
+  it('addFmtConstevalFixToPodfile returns unchanged when react_native_post_install is missing', () => {
+    const src = 'target "X" do\nend\n';
+    const { contents, didMerge } = addFmtConstevalFixToPodfile(src);
+    expect(didMerge).toBe(false);
+    expect(contents).toBe(src);
+  });
+});

--- a/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
+++ b/packages/expo-build-properties/src/__tests__/withBuildProperties-test.ts
@@ -9,6 +9,7 @@ jest.mock('expo/config-plugins', () => {
   return {
     ...plugins,
     withDangerousMod: jest.fn().mockImplementation((config) => config),
+    withPodfile: jest.fn().mockImplementation((config) => config),
   };
 });
 
@@ -24,6 +25,7 @@ jest.mock('@expo/config-plugins/build/plugins/ios-plugins', () => {
   const plugins = jest.requireActual('@expo/config-plugins/build/plugins/ios-plugins');
   return {
     ...plugins,
+    withPodfile: jest.fn().mockImplementation((config) => config),
     withPodfileProperties: jest.fn().mockImplementation((config) => config),
   };
 });

--- a/packages/expo-build-properties/src/iosFmtConstevalFix.ts
+++ b/packages/expo-build-properties/src/iosFmtConstevalFix.ts
@@ -1,0 +1,121 @@
+import { CodeGenerator, withPodfile, type ConfigPlugin } from 'expo/config-plugins';
+
+import { PluginConfigType, resolveConfigValue } from './pluginConfig';
+
+type MergeResults = ReturnType<typeof CodeGenerator.mergeContents>;
+
+const TAG = 'expo-fmt-use-consteval-fix';
+
+const FMT_FIX_RUBY = [
+  "    if podfile_properties['ios.buildReactNativeFromSource'] == 'true'",
+  "      fmt_base = File.join(installer.sandbox.root.to_s, 'fmt', 'include', 'fmt', 'base.h')",
+  '      if File.exist?(fmt_base)',
+  '        content = File.read(fmt_base)',
+  "        patched = content.gsub(/#\\s*define FMT_USE_CONSTEVAL 1/, '# define FMT_USE_CONSTEVAL 0')",
+  '        if patched != content',
+  '          File.chmod(0644, fmt_base)',
+  '          File.write(fmt_base, patched)',
+  '        end',
+  '      end',
+  '    end',
+].join('\n');
+
+/**
+ * @returns index of the character after the closing `)` of `react_native_post_install(...)`, or -1 if not found.
+ */
+function findIndexAfterReactNativePostInstallCall(src: string): number {
+  const start = src.indexOf('react_native_post_install');
+  if (start === -1) {
+    return -1;
+  }
+  const openParen = src.indexOf('(', start);
+  if (openParen === -1) {
+    return -1;
+  }
+  let depth = 0;
+  for (let i = openParen; i < src.length; i++) {
+    const c = src[i];
+    if (c === '(') {
+      depth++;
+    } else if (c === ')') {
+      depth--;
+      if (depth === 0) {
+        return i + 1;
+      }
+    }
+  }
+  return -1;
+}
+
+/**
+ * Returns the full line containing the closing `)` of `react_native_post_install`, for use as mergeContents anchor.
+ */
+function getReactNativePostInstallClosingLine(src: string): string | null {
+  const endIdx = findIndexAfterReactNativePostInstallCall(src);
+  if (endIdx === -1) {
+    return null;
+  }
+  const before = src.slice(0, endIdx);
+  const lines = before.split('\n');
+  return lines[lines.length - 1] ?? null;
+}
+
+export function addFmtConstevalFixToPodfile(src: string): MergeResults {
+  const anchorLine = getReactNativePostInstallClosingLine(src);
+  if (!anchorLine) {
+    return { contents: src, didMerge: false, didClear: false };
+  }
+
+  return CodeGenerator.mergeContents({
+    tag: TAG,
+    src,
+    newSrc: FMT_FIX_RUBY,
+    anchor: new RegExp(`^${escapeRegExp(anchorLine)}$`),
+    offset: 1,
+    comment: '#',
+  });
+}
+
+export function removeFmtConstevalFixFromPodfile(src: string): MergeResults {
+  return CodeGenerator.removeContents({
+    tag: TAG,
+    src,
+  });
+}
+
+function escapeRegExp(input: string) {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Patches `fmt`'s `base.h` after `pod install` when building React Native from source, so Apple Clang in
+ * Xcode 26.4+ can compile `FMT_STRING` (see https://github.com/expo/expo/issues/44229).
+ */
+export const withIosFmtConstevalFix: ConfigPlugin<PluginConfigType> = (config, props) => {
+  const buildFromSource = resolveConfigValue(props, 'ios', 'buildReactNativeFromSource') === true;
+
+  return withPodfile(config, async (config) => {
+    let results: MergeResults;
+
+    if (buildFromSource) {
+      try {
+        results = addFmtConstevalFixToPodfile(config.modResults.contents);
+      } catch (error: any) {
+        if (error.code === 'ERR_NO_MATCH') {
+          throw new Error(
+            `Cannot add fmt consteval workaround to the project's ios/Podfile because it's missing a recognizable react_native_post_install call. Report this with a copy of your Podfile: https://github.com/expo/expo/issues`
+          );
+        }
+        throw error;
+      }
+    } else {
+      results = removeFmtConstevalFixFromPodfile(config.modResults.contents);
+    }
+
+    if (results.didMerge || results.didClear) {
+      config.modResults.contents = results.contents;
+    }
+
+    return config;
+  });
+};

--- a/packages/expo-build-properties/src/withBuildProperties.ts
+++ b/packages/expo-build-properties/src/withBuildProperties.ts
@@ -10,6 +10,7 @@ import {
   withAndroidSettingsGradle,
 } from './android';
 import { withIosBuildProperties, withIosDeploymentTarget, withIosInfoPlist } from './ios';
+import { withIosFmtConstevalFix } from './iosFmtConstevalFix';
 import { PluginConfigType, validateConfig } from './pluginConfig';
 
 /**
@@ -37,6 +38,7 @@ export const withBuildProperties: ConfigPlugin<PluginConfigType> = (config, prop
   config = withAndroidDayNightTheme(config, pluginConfig);
 
   config = withIosBuildProperties(config, pluginConfig);
+  config = withIosFmtConstevalFix(config, pluginConfig);
   config = withIosDeploymentTarget(config, pluginConfig);
   config = withIosInfoPlist(config, pluginConfig);
 


### PR DESCRIPTION
## Summary
When `ios.buildReactNativeFromSource` is enabled, CocoaPods compiles `fmt` 11.0.2 from source. Xcode 26.4+ Apple Clang enforces stricter `consteval` rules, causing `FMT_STRING` / `FMT_USE_CONSTEVAL` build failures (see issue).

This PR extends `expo-build-properties` to inject a generated Podfile `post_install` block that patches `Pods/fmt/include/fmt/base.h` to set `FMT_USE_CONSTEVAL` off when `podfile_properties['ios.buildReactNativeFromSource'] == 'true'`.

## Test plan
- [x] `yarn test` in `packages/expo-build-properties`

Fixes https://github.com/expo/expo/issues/44229


Made with [Cursor](https://cursor.com)