### PR TITLE
fix(expo-modules-core): Replace adhoc `react-native-worklets` resolution with pod/peer resolution

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [iOS] Fixed `PersistentFileLog.readEntries` race condition by serializing reads on the dispatch queue. ([#43958](https://github.com/expo/expo/pull/43958) by [@ramonclaudio](https://github.com/ramonclaudio))
 - [iOS] Make access to module registry thread safe. ([#44042](https://github.com/expo/expo/pull/44042) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fixed runtime setup crashing in the old bridge module. ([#44121](https://github.com/expo/expo/pull/44121) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Resolve `react-native-worklets` from existing podspec, falling back to peer resolution ([#44232](https://github.com/expo/expo/pull/44232) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ExpoModulesWorklets.podspec
+++ b/packages/expo-modules-core/ExpoModulesWorklets.podspec
@@ -85,13 +85,13 @@ Pod::Spec.new do |s|
   end
 
   if shouldEnableWorkletsIntegration
-    installation_root = Pod::Config.instance.installation_root.to_s
     rn_worklets_dep = Pod::Config.instance.podfile.dependencies.find { |dep| dep.name == 'RNWorklets' }
     rn_worklets_path = rn_worklets_dep&.external_source&.dig(:path)
     react_native_worklets_dir_absolute = if rn_worklets_path
-      File.expand_path(rn_worklets_path, installation_root)
+      File.expand_path(rn_worklets_path, Pod::Config.instance.installation_root.to_s)
     else
-      File.dirname(`cd "#{installation_root}" && node --print "require.resolve('react-native-worklets/package.json')"`)
+      project_root = ENV['PROJECT_ROOT'] || Pod::Config.instance.installation_root.to_s
+      File.dirname(`node --print "require.resolve('react-native-worklets/package.json', { paths: ['#{__dir__}', '#{project_root}'] })"`)
     end
 
     pods_root = Pod::Config.instance.project_pods_root

--- a/packages/expo-modules-core/ExpoModulesWorklets.podspec
+++ b/packages/expo-modules-core/ExpoModulesWorklets.podspec
@@ -85,9 +85,16 @@ Pod::Spec.new do |s|
   end
 
   if shouldEnableWorkletsIntegration
+    installation_root = Pod::Config.instance.installation_root.to_s
+    rn_worklets_dep = Pod::Config.instance.podfile.dependencies.find { |dep| dep.name == 'RNWorklets' }
+    rn_worklets_path = rn_worklets_dep&.external_source&.dig(:path)
+    react_native_worklets_dir_absolute = if rn_worklets_path
+      File.expand_path(rn_worklets_path, installation_root)
+    else
+      File.dirname(`cd "#{installation_root}" && node --print "require.resolve('react-native-worklets/package.json')"`)
+    end
+
     pods_root = Pod::Config.instance.project_pods_root
-    react_native_worklets_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-worklets/package.json')"`), '..')
-    react_native_worklets_dir_absolute = File.join(react_native_worklets_node_modules_dir, 'react-native-worklets')
     workletsPath = Pathname.new(react_native_worklets_dir_absolute).relative_path_from(pods_root).to_s
 
     header_search_paths.concat([

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -59,7 +59,13 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-worklets": "^0.7.4 || ^0.8.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-worklets": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4554,6 +4554,9 @@ importers:
       react-native:
         specifier: 0.85.0-rc.5
         version: 0.85.0-rc.5(@babel/core@7.29.0)(@react-native/jest-preset@0.85.0-rc.5(@babel/core@7.29.0)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3)
+      react-native-worklets:
+        specifier: ^0.7.4 || ^0.8.0
+        version: 0.7.4(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(react-native@0.85.0-rc.5(@babel/core@7.29.0)(@react-native/jest-preset@0.85.0-rc.5(@babel/core@7.29.0)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@testing-library/react-native':
         specifier: ^13.3.0


### PR DESCRIPTION
# Why

Related to the pnpm migration, this was something I discussed with @chrfalch separately. The problem with resolving `react-native-worklets/package.json` directly from the installation root is:
- `react-native-worklets` may not be a direct dependency of the project, and hence, won't resolve
- it might not be the same version that Cocoapods has received from autolinking
- when we're in a brownfield or isolated+transitive scenario, we can't guarantee resolution

> [!NOTE]
> I don't think Android/Gradle is affected and it already does something similar

# How

To resolve this, we should instead:
- use the pod's path directly, if it's available for `RNWorklets`, since we've detected that the pod is present itself anyway
- fall back to a peer dependency resolution (with an alternate project root resolution; due to brownfield, this should be the `PROJECT_ROOT` over the installation root, preferably, as far as I know)

The peer dependency is only used as a fallback, and the peer is marked as optional. That codepath should be unlikely to trigger, but is a nice fallback to capture what the intention is.

> [!NOTE]
> There's still a similar issue in `react-native-reanimated`, which uses the same pattern. A later PR removes this: https://github.com/software-mansion/react-native-reanimated/pull/8927
> However, with the current version we're targeting this is still an issue and will cause build failures in CI. There's a comment on the PR where I've added more info
>
> See related patch PR for this: https://github.com/expo/expo/pull/44233

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
