### PR TITLE
Add pnpm-lock.yaml to .prettierignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -23,6 +23,7 @@
 **/kotlin/providers/**
 **/vendored/**
 /docs/public/static/**
+pnpm-lock.yaml
 
 !packages/@expo/config-plugins/src/android/**
 !packages/@expo/config-plugins/src/ios/**


### PR DESCRIPTION
# Why

As `pnpm-lock.yaml` is YAML, it is supported by prettier that will fomat it on save.

# How

- Add `pnpm-lock.yaml` to `.prettierignore`

# Test Plan

- `pnpm prettier pnpm-lock.yaml --write` should result in no change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
