### PR TITLE
major(babel-preset-expo): Rename and enable `transformImportMeta` everywhere

### DIFF
--- a/packages/babel-preset-expo/CHANGELOG.md
+++ b/packages/babel-preset-expo/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Enable `import.meta` transform by default and rename option to `transformImportMeta` ([#44239](https://github.com/expo/expo/pull/44239) by [@kitten](https://github.com/kitten))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/babel-preset-expo/README.md
+++ b/packages/babel-preset-expo/README.md
@@ -152,11 +152,11 @@ If `undefined` (default), this will be set automatically via `caller.supportsSta
 
 Changes the engine preset in `@react-native/babel-preset` based on the JavaScript engine that is being targeted. In Expo SDK 50 and greater, this is automatically set based on the [`jsEngine`](https://docs.expo.dev/versions/latest/config/app/#jsengine) option in your `app.json`.
 
-### `unstable_transformImportMeta`
+### `transformImportMeta`
 
-Enable that transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`, defaults to `false` in client bundles and `true` for server bundles.
+Enable transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`. Defaults to `true`.
 
-> **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
+> **Note:** If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
 
 ### `enableBabelRuntime`
 

--- a/packages/babel-preset-expo/build/import-meta-transform-plugin.js
+++ b/packages/babel-preset-expo/build/import-meta-transform-plugin.js
@@ -15,7 +15,7 @@ function expoImportMetaTransformPluginFactory(pluginEnabled) {
                     if (node.meta.name === 'import' && node.property.name === 'meta') {
                         if (!pluginEnabled) {
                             if (platform !== 'web') {
-                                throw path.buildCodeFrameError('`import.meta` is not supported in Hermes. Enable the polyfill `unstable_transformImportMeta` in babel-preset-expo to use this syntax.');
+                                throw path.buildCodeFrameError('`import.meta` is not supported in Hermes. Enable the polyfill `transformImportMeta` in babel-preset-expo to use this syntax.');
                             }
                             return;
                         }

--- a/packages/babel-preset-expo/build/index.d.ts
+++ b/packages/babel-preset-expo/build/index.d.ts
@@ -33,11 +33,11 @@ type BabelPresetExpoPlatformOptions = {
     /**
      * Enable that transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`.
      *
-     * > **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
+     * > **Note:** If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
      *
-     * @default `false` on client and `true` on server.
+     * @default `true`
      */
-    unstable_transformImportMeta?: boolean;
+    transformImportMeta?: boolean;
 };
 export type BabelPresetExpoOptions = BabelPresetExpoPlatformOptions & {
     /** Web-specific settings. */

--- a/packages/babel-preset-expo/build/index.js
+++ b/packages/babel-preset-expo/build/index.js
@@ -223,7 +223,7 @@ function babelPresetExpo(api, options = {}) {
     if (platformOptions.disableImportExportTransform) {
         extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
     }
-    const polyfillImportMeta = platformOptions.unstable_transformImportMeta ?? isServerEnv;
+    const polyfillImportMeta = platformOptions.transformImportMeta !== false;
     extraPlugins.push((0, import_meta_transform_plugin_1.expoImportMetaTransformPluginFactory)(polyfillImportMeta === true));
     return {
         presets: [

--- a/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
+++ b/packages/babel-preset-expo/src/__tests__/import-meta-transform-plugin.test.ts
@@ -32,27 +32,16 @@ it(`transforms import.meta.url to globalThis.__ExpoImportMetaRegistry.url when u
   );
 });
 
-it(`should throw an error when trying to transform import.meta by default for native platforms`, () => {
-  ['android', 'ios'].forEach((platform) => {
-    const options = {
-      ...DEF_OPTIONS,
-      caller: getCaller({ name: 'metro', engine: 'hermes', platform, isDev: true }),
-    };
-
-    const sourceCode = `var url = import.meta.url;`;
-    expect(() => babel.transform(sourceCode, options)).toThrow(
-      /`import.meta` is not supported in Hermes. Enable the polyfill `unstable_transformImportMeta` in babel-preset-expo to use this syntax./
-    );
-  });
-});
-it(`should not transform import.meta by default for web platforms`, () => {
+it(`should transform import.meta by default for web platforms`, () => {
   const options = {
     ...DEF_OPTIONS,
     caller: getCaller({ name: 'metro', engine: 'hermes', platform: 'web', isDev: true }),
   };
 
   const sourceCode = `var url = import.meta.url;`;
-  expect(babel.transform(sourceCode, options).code).toEqual(`var url = import.meta.url;`);
+  expect(babel.transform(sourceCode, options).code).toEqual(
+    `var url = globalThis.__ExpoImportMetaRegistry.url;`
+  );
 });
 
 it(`should transform import.meta by default for server bundles`, () => {

--- a/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
+++ b/packages/babel-preset-expo/src/import-meta-transform-plugin.ts
@@ -18,7 +18,7 @@ export function expoImportMetaTransformPluginFactory(pluginEnabled: boolean) {
             if (!pluginEnabled) {
               if (platform !== 'web') {
                 throw path.buildCodeFrameError(
-                  '`import.meta` is not supported in Hermes. Enable the polyfill `unstable_transformImportMeta` in babel-preset-expo to use this syntax.'
+                  '`import.meta` is not supported in Hermes. Enable the polyfill `transformImportMeta` in babel-preset-expo to use this syntax.'
                 );
               }
               return;

--- a/packages/babel-preset-expo/src/index.ts
+++ b/packages/babel-preset-expo/src/index.ts
@@ -71,11 +71,11 @@ type BabelPresetExpoPlatformOptions = {
   /**
    * Enable that transform that converts `import.meta` to `globalThis.__ExpoImportMetaRegistry`.
    *
-   * > **Note:** Use this option at your own risk. If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
+   * > **Note:** If the JavaScript engine supports `import.meta` natively, this transformation may interfere with the native implementation.
    *
-   * @default `false` on client and `true` on server.
+   * @default `true`
    */
-  unstable_transformImportMeta?: boolean;
+  transformImportMeta?: boolean;
 };
 
 export type BabelPresetExpoOptions = BabelPresetExpoPlatformOptions & {
@@ -338,7 +338,7 @@ function babelPresetExpo(api: ConfigAPI, options: BabelPresetExpoOptions = {}): 
     extraPlugins.push([require('./detect-dynamic-exports').detectDynamicExports]);
   }
 
-  const polyfillImportMeta = platformOptions.unstable_transformImportMeta ?? isServerEnv;
+  const polyfillImportMeta = platformOptions.transformImportMeta !== false;
 
   extraPlugins.push(expoImportMetaTransformPluginFactory(polyfillImportMeta === true));
 


### PR DESCRIPTION
# Why

We're ready to promote this option to stable and enable it by default. Since we don't run in an ESM context that supports `import.meta` in any case, this is safe to enable, since by default, there won't be any conflicts. Without this option, many libraries can fail when they use `import.meta` otherwise.

# How

- Rename option from `unstable_transformImportMeta` to `transformImportMeta`
- Enable option by default for all environments

# Test Plan

- Unit tests were updated to reflect this change

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
