### PR TITLE
fix(expo-splash-screen): skip custom splash exit animation on Android 13

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] On Android 13 (API 33), skip `setOnExitAnimationListener` so dismissing the splash does not crash with `SurfaceControl.checkNotReleased()` when the app is backgrounded during the transition. ([#44243](https://github.com/expo/expo/pull/44243) by [@huextrat](https://github.com/huextrat))
+
 ### 💡 Others
 
 - Removed the `expo_splash_screen_status_bar_translucent` Android leftover attribute. ([#43514](https://github.com/expo/expo/pull/43514) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
@@ -31,14 +31,14 @@ object SplashScreenManager {
       return
     }
 
-    val duration = options.duration
-
     // Android 13 (API 33): custom exit animations via setOnExitAnimationListener can crash with
     // SurfaceControl.checkNotReleased() when the app is backgrounded during the transition.
     // https://issuetracker.google.com/issues/242118185
     if (Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU) {
       return
     }
+
+    val duration = options.duration
 
     splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
       val splashScreenView = splashScreenViewProvider.view

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
@@ -33,6 +33,13 @@ object SplashScreenManager {
 
     val duration = options.duration
 
+    // Android 13 (API 33): custom exit animations via setOnExitAnimationListener can crash with
+    // SurfaceControl.checkNotReleased() when the app is backgrounded during the transition.
+    // https://issuetracker.google.com/issues/242118185
+    if (Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU) {
+      return
+    }
+
     splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
       val splashScreenView = splashScreenViewProvider.view
       splashScreenView


### PR DESCRIPTION
# Why

On **Android 13 (API 33)**, apps using the SplashScreen API with a custom `setOnExitAnimationListener` can crash when the splash is dismissed in certain lifecycle conditions (commonly reported when the app is **backgrounded while the exit animation is still running**). The failure surfaces as a `NullPointerException` inside `SurfaceControl.checkNotReleased()` while the framework syncs the splash surface (`ActivityThread.syncTransferSplashscreenViewTransaction`).

This matches the platform issue tracked by Google: [Issue 242118185](https://issuetracker.google.com/issues/242118185). Similar reports exist in the ecosystem (e.g. [react-native-bootsplash#381](https://github.com/zoontek/react-native-bootsplash/issues/381)).

Example stack trace:

```
java.lang.NullPointerException: Attempt to invoke direct method 'void android.view.SurfaceControl.checkNotReleased()' on a null object reference
    at android.view.SurfaceControl.-$$Nest$mcheckNotReleased(:0)
    at android.view.SurfaceControl$Transaction.checkPreconditions(SurfaceControl.java:2941)
    at android.view.SurfaceControl$Transaction.hide(SurfaceControl.java:3124)
    at android.app.ActivityThread.syncTransferSplashscreenViewTransaction(ActivityThread.java:4360)
    at android.app.ActivityThread.-$$Nest$msyncTransferSplashscreenViewTransaction(:0)
    at android.app.ActivityThread$1.onDraw(ActivityThread.java:4337)
    at android.view.ViewTreeObserver.dispatchOnDraw(ViewTreeObserver.java:1132)
    at android.view.ViewRootImpl.draw(ViewRootImpl.java:4838)
    at android.view.ViewRootImpl.performDraw(ViewRootImpl.java:4609)
    at android.view.ViewRootImpl.performTraversals(ViewRootImpl.java:3775)
    at android.view.ViewRootImpl.doTraversal(ViewRootImpl.java:2469)
    at android.view.ViewRootImpl$TraversalRunnable.run(ViewRootImpl.java:9484)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1405)
    at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1413)
    at android.view.Choreographer.doCallbacks(Choreographer.java:1040)
    at android.view.Choreographer.doFrame(Choreographer.java:930)
    at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1388)
    at android.os.Handler.handleCallback(Handler.java:942)
    at android.os.Handler.dispatchMessage(Handler.java:99)
    at android.os.Looper.loopOnce(Looper.java:240)
    at android.os.Looper.loop(Looper.java:351)
    at android.app.ActivityThread.main(ActivityThread.java:8423)
    at java.lang.reflect.Method.invoke(Method.java)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:584)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1013)
```

`expo-splash-screen` registers a listener that runs a fade-out `ViewPropertyAnimator` and then removes the splash view. That path is what we avoid on API 33 only, to sidestep the buggy interaction without changing behavior on other supported API levels.

# How

In `SplashScreenManager.configureSplashScreen`, if `Build.VERSION.SDK_INT == Build.VERSION_CODES.TIRAMISU` (Android 13), return **before** calling `splashScreen.setOnExitAnimationListener`. The system then dismisses the splash using default behavior instead of our custom animated teardown.

**Trade-off:** On Android 13 only, the configurable **fade duration** from `SplashScreenOptions` no longer applies to the native exit path, because we no longer install that listener.

Changelog: entry under **Unpublished → Bug fixes** in `packages/expo-splash-screen/CHANGELOG.md`.

# Checklist

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
