### PR TITLE
[ui][iOS] Don't add hostingController if parent is UITabBarController

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [iOS] Make access to module registry thread safe. ([#44042](https://github.com/expo/expo/pull/44042) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fixed runtime setup crashing in the old bridge module. ([#44121](https://github.com/expo/expo/pull/44121) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Resolve `react-native-worklets` from existing podspec, falling back to peer resolution ([#44232](https://github.com/expo/expo/pull/44232) by [@kitten](https://github.com/kitten))
+- [iOS] Fixed adding SwiftUI views to tabs BottomAccessory. ([#44247](https://github.com/expo/expo/pull/44247) by [@t0maboro](https://github.com/t0maboro))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIHostingView.swift
@@ -224,9 +224,10 @@ extension ExpoSwiftUI {
 
       if window != nil, let parentController = reactViewController() {
         #if !os(macOS)
-        if parentController as? UINavigationController == nil {
+        if parentController as? UINavigationController == nil && parentController as? UITabBarController == nil {
           // Swift automatically adds the hostingController in the correct place when the parentController
-          // is UINavigationController, since it's children are supposed to be only screens
+          // is UINavigationController, since it's children are supposed to be only screens.
+          // Similarly, for UITabBarController we expect its children to be only tabs.
           parentController.addChild(hostingController)
         }
         #else


### PR DESCRIPTION
# Why

When using `react-native-screens` and the `UIHostingController` is placed inside our `BottomAccessory`, it gets attached underneath the `RNSTabBarController`, which leads to an unexpected view hierarchy and results in an instant crash.
Only `RNSTabsScreenViewControllers` should be attached at this level, based on our current assumptions: https://github.com/software-mansion/react-native-screens/blob/4.24.0/ios/tabs/host/RNSTabBarController.mm#L123 .

# How

Similarly to https://github.com/expo/expo/pull/36305 , don't add `hostingController` to `UITabBarController`.

# Test Plan

Test:
```tsx
import { NavigationContainer, useNavigation } from '@react-navigation/native';
import { createNativeBottomTabNavigator } from '@react-navigation/bottom-tabs/unstable';
import { Gauge, Host } from '@expo/ui/swift-ui';
import { gaugeStyle, tint } from '@expo/ui/swift-ui/modifiers';
import React, { createContext, useContext, useState, useEffect } from 'react';
import { StyleSheet, Text, View, ScrollView } from 'react-native';

type AccessoryState = {
  isReaderFocused: boolean;
  setReaderFocused: (v: boolean) => void;
  isShowingContent: boolean;
  setShowingContent: (v: boolean) => void;
};

export const AccessoryContext = createContext<AccessoryState>({
  isReaderFocused: false,
  setReaderFocused: () => {},
  isShowingContent: false,
  setShowingContent: () => {},
});

export const useAccessory = () => useContext(AccessoryContext);

const Tab = createNativeBottomTabNavigator();

function HomeScreen() {
  return (
    <View style={screenStyles.container}>
      <Text style={screenStyles.title}>Home Tab</Text>
      <Text style={screenStyles.body}>
        Tap the "Reader" tab to mount the BottomAccessory.{'\n'}
        Then switch back here to unmount it.
      </Text>
    </View>
  );
}

function ReaderScreen() {
  const navigation = useNavigation();
  const { setReaderFocused, setShowingContent } = useAccessory();

  useEffect(() => {
    const unsubFocus = navigation.addListener('focus', () => setReaderFocused(true));
    const unsubBlur = navigation.addListener('blur', () => setReaderFocused(false));

    return () => {
      unsubFocus();
      unsubBlur();
    };
  }, [navigation, setReaderFocused]);

  useEffect(() => {
    const timer = setTimeout(() => setShowingContent(true), 100);
    return () => clearTimeout(timer);
  }, [setShowingContent]);

  return (
    <ScrollView contentContainerStyle={screenStyles.scrollContainer}>
      <Text style={screenStyles.title}>Reader Tab</Text>
      <Text style={screenStyles.body}>
        The BottomAccessory should appear below.{'\n\n'}
        Switch tabs rapidly to trigger the race condition.
      </Text>
      {Array.from({ length: 30 }, (_, i) => (
        <Text key={i} style={screenStyles.verse}>
          {i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing elit.
        </Text>
      ))}
    </ScrollView>
  );
}

export default function App() {
  const [isReaderFocused, setReaderFocused] = useState(false);
  const [isShowingContent, setShowingContent] = useState(false);

  const showAccessory = isReaderFocused && isShowingContent;

  const renderAccessory = () => (
    <View style={styles.accessory}>
      <View style={styles.gaugeContainer}>
        <Host style={styles.host}>
          <Gauge value={0.42} modifiers={[gaugeStyle('linearCapacity'), tint('#4A90D9')]} />
        </Host>
      </View>
      <Text style={styles.accessoryText}>42%</Text>
    </View>
  );

  return (
    <AccessoryContext.Provider
      value={{
        isReaderFocused,
        setReaderFocused,
        isShowingContent,
        setShowingContent,
      }}>
      <NavigationContainer>
        <Tab.Navigator
          screenOptions={{
            bottomAccessory: showAccessory ? renderAccessory : undefined,
          }}>
          <Tab.Screen
            name="Home"
            component={HomeScreen}
            options={{
              title: 'Home',
            }}
          />
          <Tab.Screen
            name="Reader"
            component={ReaderScreen}
            options={{
              title: 'Reader',
            }}
          />
        </Tab.Navigator>
      </NavigationContainer>
    </AccessoryContext.Provider>
  );
}

const styles = StyleSheet.create({
  accessory: {
    height: 56,
    flexDirection: 'row',
    alignItems: 'center',
    paddingHorizontal: 16,
    gap: 12,
  },
  gaugeContainer: {
    flex: 1,
  },
  host: {
    flex: 1,
    height: 6,
  },
  accessoryText: {
    fontSize: 14,
    fontWeight: '600',
    color: '#666',
  },
});

const screenStyles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    padding: 24,
  },
  scrollContainer: {
    padding: 24,
    paddingBottom: 100,
  },
  title: {
    fontSize: 24,
    fontWeight: 'bold',
    marginBottom: 16,
  },
  body: {
    fontSize: 15,
    textAlign: 'center',
    color: '#666',
    lineHeight: 22,
    marginBottom: 24,
  },
  verse: {
    fontSize: 16,
    lineHeight: 26,
    marginBottom: 12,
    color: '#333',
  },
});
```

Before:

https://github.com/user-attachments/assets/2c7885c6-23c0-492a-b0f3-9b933a2ce600

After:

https://github.com/user-attachments/assets/f7dd2352-fb09-4cba-aedf-9cf860878715

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
