### PR TITLE
[docs] Add react-native-enriched-markdown references to rich text guide

### DIFF
--- a/docs/pages/guides/editing-richtext.mdx
+++ b/docs/pages/guides/editing-richtext.mdx
@@ -22,7 +22,7 @@ There is currently no default solution for that in the React Native ecosystem. H
 
 There are a lot of good options to display rich text:
 
-- For markdown content, you can use a markdown renderer such as [`react-native-markdown-display`](https://www.npmjs.com/package/react-native-markdown-display) or another.
+- For markdown content, you can use a markdown renderer such as [`react-native-enriched-markdown`](https://github.com/software-mansion-labs/react-native-enriched-markdown) or another.
 
 - For HTML content, you can use [`@expo/html-elements`](https://www.npmjs.com/package/@expo/html-elements) or a webview ([`react-native-webview`](/versions/latest/sdk/webview/)).
 
@@ -106,6 +106,7 @@ You can use a native Android or iOS rich text editor wrapped into a React Native
 - [`react-native-aztec`](https://github.com/WordPress/gutenberg/tree/trunk/packages/react-native-aztec)
 - [`gutenberg-mobile`](https://github.com/wordpress-mobile/gutenberg-mobile)
 - [`react-native-live-markdown`](https://github.com/Expensify/react-native-live-markdown)
+- [`react-native-enriched-markdown`](https://github.com/software-mansion-labs/react-native-enriched-markdown)
 - [`react-native-enriched`](https://github.com/software-mansion-labs/react-native-enriched)
 
 You can also wrap any native rich text editor using [Expo Modules API](/modules/overview/), but if you use different ones on each platform, you need to unify their APIs and input formats.


### PR DESCRIPTION
# Why

Replace [react-native-markdown-display](https://github.com/iamacup/react-native-markdown-display) with [react-native-enriched-markdown](https://github.com/software-mansion-labs/react-native-enriched-markdown) in the rich text guide. `react-native-markdown-display` is no longer maintained, while `react-native-enriched-markdown` is actively developed and offers both native markdown rendering and rich text input with markdown output.

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
