### PR TITLE
[dev-launcher] Add option to disable tools buttons

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - [Android] Add NDS service discovery.
-- [plugin] Add option to disable tools button by default.
+- [plugin] Add option to disable tools button by default. ([#44251](https://github.com/expo/expo/pull/44251) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - [Android] Add NDS service discovery.
+- [plugin] Add option to disable tools button by default.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -3,14 +3,6 @@
   "title": "Expo Development Launcher",
   "version": "55.0.10",
   "description": "Pre-release version of the Expo development launcher package for testing.",
-  "scripts": {
-    "build": "expo-module build",
-    "clean": "expo-module clean",
-    "lint": "expo-module lint",
-    "test": "expo-module test",
-    "prepublishOnly": "expo-module prepublishOnly",
-    "expo-module": "expo-module"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git",

--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -3,6 +3,14 @@
   "title": "Expo Development Launcher",
   "version": "55.0.10",
   "description": "Pre-release version of the Expo development launcher package for testing.",
+  "scripts": {
+    "build": "expo-module build",
+    "clean": "expo-module clean",
+    "lint": "expo-module lint",
+    "test": "expo-module test",
+    "prepublishOnly": "expo-module prepublishOnly",
+    "expo-module": "expo-module"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/expo/expo.git",

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -37,7 +37,7 @@ export type PluginConfigOptions = {
      */
     launchModeExperimental?: 'most-recent' | 'launcher';
     /**
-     * Whether to show the floating action button by default.
+     * Whether to show the tools button by default.
      *
      * @default true
      */

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -36,6 +36,12 @@ export type PluginConfigOptions = {
      * @deprecated use the `launchMode` property instead
      */
     launchModeExperimental?: 'most-recent' | 'launcher';
+    /**
+     * Whether to show the floating action button by default.
+     *
+     * @default true
+     */
+    floatingButton?: boolean;
 };
 /**
  * @ignore

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -41,7 +41,7 @@ export type PluginConfigOptions = {
      *
      * @default true
      */
-    floatingButton?: boolean;
+    toolsButton?: boolean;
 };
 /**
  * @ignore

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -16,7 +16,7 @@ const schema = {
             enum: ['most-recent', 'launcher'],
             nullable: true,
         },
-        floatingButton: {
+        toolsButton: {
             type: 'boolean',
             nullable: true,
         },
@@ -33,7 +33,7 @@ const schema = {
                     enum: ['most-recent', 'launcher'],
                     nullable: true,
                 },
-                floatingButton: {
+                toolsButton: {
                     type: 'boolean',
                     nullable: true,
                 },
@@ -53,7 +53,7 @@ const schema = {
                     enum: ['most-recent', 'launcher'],
                     nullable: true,
                 },
-                floatingButton: {
+                toolsButton: {
                     type: 'boolean',
                     nullable: true,
                 },

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -16,6 +16,10 @@ const schema = {
             enum: ['most-recent', 'launcher'],
             nullable: true,
         },
+        floatingButton: {
+            type: 'boolean',
+            nullable: true,
+        },
         android: {
             type: 'object',
             properties: {
@@ -27,6 +31,10 @@ const schema = {
                 launchModeExperimental: {
                     type: 'string',
                     enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+                floatingButton: {
+                    type: 'boolean',
                     nullable: true,
                 },
             },
@@ -43,6 +51,10 @@ const schema = {
                 launchModeExperimental: {
                     type: 'string',
                     enum: ['most-recent', 'launcher'],
+                    nullable: true,
+                },
+                floatingButton: {
+                    type: 'boolean',
                     nullable: true,
                 },
             },

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -102,6 +102,13 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
             return config;
         });
     }
+    const iOSFloatingButton = props.ios?.floatingButton ?? props.floatingButton;
+    if (iOSFloatingButton !== undefined) {
+        config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
+            config.modResults['EXDevMenuShowFloatingActionButton'] = iOSFloatingButton;
+            return config;
+        });
+    }
     const androidLaunchMode = props.android?.launchMode ??
         props.launchMode ??
         props.android?.launchModeExperimental ??
@@ -110,6 +117,14 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
             const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
             config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE', false?.toString());
+            return config;
+        });
+    }
+    const androidFloatingButton = props.android?.floatingButton ?? props.floatingButton;
+    if (androidFloatingButton !== undefined) {
+        config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+            const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'EXDevMenuShowFloatingActionButton', String(androidFloatingButton));
             return config;
         });
     }

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -102,10 +102,10 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
             return config;
         });
     }
-    const iOSFloatingButton = props.ios?.floatingButton ?? props.floatingButton;
-    if (iOSFloatingButton !== undefined) {
+    const iOSToolsButton = props.ios?.toolsButton ?? props.toolsButton;
+    if (iOSToolsButton !== undefined) {
         config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
-            config.modResults['EXDevMenuShowFloatingActionButton'] = iOSFloatingButton;
+            config.modResults['EXDevMenuShowFloatingActionButton'] = iOSToolsButton;
             return config;
         });
     }
@@ -120,11 +120,11 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
             return config;
         });
     }
-    const androidFloatingButton = props.android?.floatingButton ?? props.floatingButton;
-    if (androidFloatingButton !== undefined) {
+    const androidToolsButton = props.android?.toolsButton ?? props.toolsButton;
+    if (androidToolsButton !== undefined) {
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
             const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
-            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'EXDevMenuShowFloatingActionButton', String(androidFloatingButton));
+            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'EXDevMenuShowFloatingActionButton', String(androidToolsButton));
             return config;
         });
     }

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -45,7 +45,7 @@ export type PluginConfigOptions = {
    *
    * @default true
    */
-  floatingButton?: boolean;
+  toolsButton?: boolean;
 };
 
 const schema: JSONSchema<PluginConfigType> = {
@@ -62,7 +62,7 @@ const schema: JSONSchema<PluginConfigType> = {
       enum: ['most-recent', 'launcher'],
       nullable: true,
     },
-    floatingButton: {
+    toolsButton: {
       type: 'boolean',
       nullable: true,
     },
@@ -79,7 +79,7 @@ const schema: JSONSchema<PluginConfigType> = {
           enum: ['most-recent', 'launcher'],
           nullable: true,
         },
-        floatingButton: {
+        toolsButton: {
           type: 'boolean',
           nullable: true,
         },
@@ -99,7 +99,7 @@ const schema: JSONSchema<PluginConfigType> = {
           enum: ['most-recent', 'launcher'],
           nullable: true,
         },
-        floatingButton: {
+        toolsButton: {
           type: 'boolean',
           nullable: true,
         },

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -41,7 +41,7 @@ export type PluginConfigOptions = {
    */
   launchModeExperimental?: 'most-recent' | 'launcher';
   /**
-   * Whether to show the floating action button by default.
+   * Whether to show the tools button by default.
    *
    * @default true
    */

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -40,6 +40,12 @@ export type PluginConfigOptions = {
    * @deprecated use the `launchMode` property instead
    */
   launchModeExperimental?: 'most-recent' | 'launcher';
+  /**
+   * Whether to show the floating action button by default.
+   *
+   * @default true
+   */
+  floatingButton?: boolean;
 };
 
 const schema: JSONSchema<PluginConfigType> = {
@@ -56,6 +62,10 @@ const schema: JSONSchema<PluginConfigType> = {
       enum: ['most-recent', 'launcher'],
       nullable: true,
     },
+    floatingButton: {
+      type: 'boolean',
+      nullable: true,
+    },
     android: {
       type: 'object',
       properties: {
@@ -67,6 +77,10 @@ const schema: JSONSchema<PluginConfigType> = {
         launchModeExperimental: {
           type: 'string',
           enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+        floatingButton: {
+          type: 'boolean',
           nullable: true,
         },
       },
@@ -83,6 +97,10 @@ const schema: JSONSchema<PluginConfigType> = {
         launchModeExperimental: {
           type: 'string',
           enum: ['most-recent', 'launcher'],
+          nullable: true,
+        },
+        floatingButton: {
+          type: 'boolean',
           nullable: true,
         },
       },

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -130,6 +130,14 @@ export default createRunOncePlugin<PluginConfigType>(
       });
     }
 
+    const iOSFloatingButton = props.ios?.floatingButton ?? props.floatingButton;
+    if (iOSFloatingButton !== undefined) {
+      config = withInfoPlist(config, (config) => {
+        config.modResults['EXDevMenuShowFloatingActionButton'] = iOSFloatingButton;
+        return config;
+      });
+    }
+
     const androidLaunchMode =
       props.android?.launchMode ??
       props.launchMode ??
@@ -143,6 +151,20 @@ export default createRunOncePlugin<PluginConfigType>(
           mainApplication,
           'DEV_CLIENT_TRY_TO_LAUNCH_LAST_BUNDLE',
           false?.toString()
+        );
+        return config;
+      });
+    }
+
+    const androidFloatingButton = props.android?.floatingButton ?? props.floatingButton;
+    if (androidFloatingButton !== undefined) {
+      config = withAndroidManifest(config, (config) => {
+        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+          mainApplication,
+          'EXDevMenuShowFloatingActionButton',
+          String(androidFloatingButton)
         );
         return config;
       });

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -130,10 +130,10 @@ export default createRunOncePlugin<PluginConfigType>(
       });
     }
 
-    const iOSFloatingButton = props.ios?.floatingButton ?? props.floatingButton;
-    if (iOSFloatingButton !== undefined) {
+    const iOSToolsButton = props.ios?.toolsButton ?? props.toolsButton;
+    if (iOSToolsButton !== undefined) {
       config = withInfoPlist(config, (config) => {
-        config.modResults['EXDevMenuShowFloatingActionButton'] = iOSFloatingButton;
+        config.modResults['EXDevMenuShowFloatingActionButton'] = iOSToolsButton;
         return config;
       });
     }
@@ -156,15 +156,15 @@ export default createRunOncePlugin<PluginConfigType>(
       });
     }
 
-    const androidFloatingButton = props.android?.floatingButton ?? props.floatingButton;
-    if (androidFloatingButton !== undefined) {
+    const androidToolsButton = props.android?.toolsButton ?? props.toolsButton;
+    if (androidToolsButton !== undefined) {
       config = withAndroidManifest(config, (config) => {
         const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
 
         AndroidConfig.Manifest.addMetaDataItemToMainApplication(
           mainApplication,
           'EXDevMenuShowFloatingActionButton',
-          String(androidFloatingButton)
+          String(androidToolsButton)
         );
         return config;
       });

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- [plugin] Add option to disable tools button by default. ([#44251](https://github.com/expo/expo/pull/44251) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 🐛 Bug fixes
 
 - [iOS] Fix support for react-native 0.84 ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
@@ -3,6 +3,7 @@ package expo.modules.devmenu
 import android.app.Application
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
+import android.content.pm.PackageManager
 import expo.modules.devmenu.helpers.preferences
 
 private const val DEV_SETTINGS_PREFERENCES = "expo.modules.devmenu.sharedpreferences"
@@ -54,6 +55,15 @@ class DevMenuDefaultPreferences(
 ) : DevMenuPreferences {
   private val sharedPreferences = application.getSharedPreferences(DEV_SETTINGS_PREFERENCES, MODE_PRIVATE)
 
+  private val fabDefault: Boolean = try {
+    val ai = application.packageManager.getApplicationInfo(
+      application.packageName, PackageManager.GET_META_DATA
+    )
+    ai.metaData?.getString("EXDevMenuShowFloatingActionButton")?.toBoolean() ?: true
+  } catch (_: Exception) {
+    true
+  }
+
   private val listeners = mutableListOf<() -> Unit>()
 
   // The preference manager does not currently store a strong reference to the listener.
@@ -89,5 +99,5 @@ class DevMenuDefaultPreferences(
     by preferences(sharedPreferences, false)
 
   override var showFab: Boolean
-    by preferences(sharedPreferences, true)
+    by preferences(sharedPreferences, fabDefault)
 }

--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -26,6 +26,8 @@ public class DevMenuPreferences: Module {
    and applying some preferences to static classes like interceptors.
    */
   static func setup() {
+    let fabDefault = Bundle.main.object(forInfoDictionaryKey: showFloatingActionButtonKey) as? Bool
+
     #if os(tvOS)
     UserDefaults.standard.register(defaults: [
       motionGestureEnabledKey: false,
@@ -33,7 +35,7 @@ public class DevMenuPreferences: Module {
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: true,
-      showFloatingActionButtonKey: false
+      showFloatingActionButtonKey: fabDefault ?? false
     ])
     #else
     UserDefaults.standard.register(defaults: [
@@ -42,7 +44,7 @@ public class DevMenuPreferences: Module {
       keyCommandsEnabledKey: true,
       showsAtLaunchKey: false,
       isOnboardingFinishedKey: false,
-      showFloatingActionButtonKey: true
+      showFloatingActionButtonKey: fabDefault ?? true
     ])
     #endif
 


### PR DESCRIPTION
# Why
Closes #44234
Adds option to the plugin to decide whether show the tools button by default or not

# How
Add option to the plist and to the android manifest

# Test Plan
Sandbox
