### PR TITLE
Remove DOM components experimental warning

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### 💡 Others
 
+- Remove dom components warning.
 - Add `@react-navigation/core` and `@react-navigation/native` to autolinking resolution ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Drop `expo-router/doctor` install check ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
 - Pass on `tls` options from Metro config to Metro `runServer` fork ([#43186](https://github.com/expo/expo/pull/43186) by [@cortinico](https://github.com/cortinico))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 ### 💡 Others
 
-- Remove dom components warning.
+- Remove dom components warning. ([#44253](https://github.com/expo/expo/pull/44253) by [@EvanBacon](https://github.com/EvanBacon))
 - Add `@react-navigation/core` and `@react-navigation/native` to autolinking resolution ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Drop `expo-router/doctor` install check ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
 - Pass on `tls` options from Metro config to Metro `runServer` fork ([#43186](https://github.com/expo/expo/pull/43186) by [@cortinico](https://github.com/cortinico))

--- a/packages/@expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/DomComponentsMiddleware.ts
@@ -3,7 +3,6 @@ import resolveFrom from 'resolve-from';
 
 import { createBundleUrlPath, ExpoMetroOptions } from './metroOptions';
 import type { ServerRequest, ServerResponse } from './server.types';
-import { Log } from '../../../log';
 import { toPosixPath } from '../../../utils/filePath';
 import { memoize } from '../../../utils/fn';
 import { fileURLToFilePath } from '../metro/createServerComponentsMiddleware';
@@ -11,10 +10,6 @@ import { fileURLToFilePath } from '../metro/createServerComponentsMiddleware';
 export type PickPartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;
 
 export const DOM_COMPONENTS_BUNDLE_DIR = 'www.bundle';
-
-const warnUnstable = memoize(() =>
-  Log.warn('Using experimental DOM Components API. Production exports may not work as expected.')
-);
 
 const checkWebViewInstalled = memoize((projectRoot: string) => {
   const webViewInstalled =
@@ -58,7 +53,6 @@ export function createDomComponentsMiddleware(
     }
 
     checkWebViewInstalled(projectRoot);
-    warnUnstable();
 
     // Generate a unique entry file for the webview.
     const generatedEntry = toPosixPath(file.startsWith('file://') ? fileURLToFilePath(file) : file);


### PR DESCRIPTION
## Summary
- Remove the experimental warning log shown when using DOM components (`"use dom"` directive)
- Clean up unused `memoize` import and `warnUnstable` function from `DomComponentsMiddleware.ts`

## Test plan
- Start a project using DOM components and verify no experimental warning is logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)