### PR TITLE
fix(expo-updates): cache state machine events for native interface

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Cache state machine events for native interface. ([#44256](https://github.com/expo/expo/pull/44256) by [@douglowder](https://github.com/douglowder))
+
 ### 💡 Others
 
 - Remove pin on `arg` dependency ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -4,6 +4,8 @@ import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.easclient.EASClientID
@@ -349,6 +351,12 @@ class EnabledUpdatesController(
   override fun subscribeToUpdatesStateChanges(listener: UpdatesStateChangeListener): UpdatesStateChangeSubscription {
     val subscriptionId = UUID.randomUUID().toString()
     stateChangeListenerMap[subscriptionId] = listener
+    val cachedEvents = getRecentStateChangeEventsForNativeInterface()
+    Handler(Looper.getMainLooper()).postDelayed({
+      cachedEvents.forEach { event ->
+        listener.updatesStateDidChange(event)
+      }
+    }, 200)
     return EnabledUpdatesStateChangeSubscription(subscriptionId = subscriptionId)
   }
 
@@ -356,6 +364,10 @@ class EnabledUpdatesController(
     if (stateChangeListenerMap.containsKey(subscriptionId)) {
       stateChangeListenerMap.remove(subscriptionId)
     }
+  }
+
+  internal fun getRecentStateChangeEventsForNativeInterface(): List<Map<String, Any>> {
+    return stateMachine.nativeInterfaceCache.events()
   }
 
   override val isEnabled: Boolean = true

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -10,6 +10,7 @@ import expo.modules.updatesinterface.UpdatesControllerRegistry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import java.util.Date
+import kotlin.math.floor
 
 /**
  * The Updates state machine class. There should be only one instance of this class
@@ -68,22 +69,29 @@ class UpdatesStateMachine(
     sendContextToJS()
   }
 
+  // Accessed by updates controller native interface implementation
+  val nativeInterfaceCache = UpdatesStateMachineNativeInterfaceCache()
+
   private fun toMap(event: UpdatesStateEvent): Map<String, Any> {
+    val base = mutableMapOf(
+      "type" to event.type.type,
+      "timestamp" to floor(System.currentTimeMillis().toDouble()).toLong()
+    )
     return when (event) {
-      is UpdatesStateEvent.DownloadCompleteWithUpdate -> mapOf("type" to "downloadCompleteWithUpdate", "manifest" to event.manifest.toMap())
-      is UpdatesStateEvent.CheckCompleteWithUpdate -> mapOf("type" to "checkCompleteWithUpdate", "manifest" to event.manifest.toMap())
-      is UpdatesStateEvent.CheckCompleteWithRollback -> mapOf("type" to "checkCompleteWithRollback")
-      is UpdatesStateEvent.CheckError -> mapOf("type" to "checkError", "errorMessage" to event.error.message)
-      is UpdatesStateEvent.DownloadError -> mapOf("type" to "downloadError", "errorMessage" to event.error.message)
-      is UpdatesStateEvent.DownloadProgress -> mapOf("type" to "downloadProgress", "progress" to event.progress)
-      is UpdatesStateEvent.Check -> mapOf("type" to event.type.type)
-      is UpdatesStateEvent.CheckCompleteUnavailable -> mapOf("type" to event.type.type)
-      is UpdatesStateEvent.Download -> mapOf("type" to event.type.type)
-      is UpdatesStateEvent.DownloadComplete -> mapOf("type" to event.type.type)
-      is UpdatesStateEvent.DownloadCompleteWithRollback -> mapOf("type" to event.type.type)
-      is UpdatesStateEvent.Restart -> mapOf("type" to event.type.type)
-      is UpdatesStateEvent.StartStartup -> mapOf("type" to event.type.type)
-      is UpdatesStateEvent.EndStartup -> mapOf("type" to event.type.type)
+      is UpdatesStateEvent.DownloadCompleteWithUpdate -> base + mapOf("type" to "downloadCompleteWithUpdate", "manifest" to event.manifest.toMap())
+      is UpdatesStateEvent.CheckCompleteWithUpdate -> base + mapOf("type" to "checkCompleteWithUpdate", "manifest" to event.manifest.toMap())
+      is UpdatesStateEvent.CheckCompleteWithRollback -> base + mapOf("type" to "checkCompleteWithRollback")
+      is UpdatesStateEvent.CheckError -> base + mapOf("type" to "checkError", "errorMessage" to event.error.message)
+      is UpdatesStateEvent.DownloadError -> base + mapOf("type" to "downloadError", "errorMessage" to event.error.message)
+      is UpdatesStateEvent.DownloadProgress -> base + mapOf("type" to "downloadProgress", "progress" to event.progress)
+      is UpdatesStateEvent.Check -> base
+      is UpdatesStateEvent.CheckCompleteUnavailable -> base
+      is UpdatesStateEvent.Download -> base
+      is UpdatesStateEvent.DownloadComplete -> base
+      is UpdatesStateEvent.DownloadCompleteWithRollback -> base
+      is UpdatesStateEvent.Restart -> base
+      is UpdatesStateEvent.StartStartup -> base
+      is UpdatesStateEvent.EndStartup -> base
     }
   }
 
@@ -96,14 +104,7 @@ class UpdatesStateMachine(
       if (event !is UpdatesStateEvent.DownloadProgress) {
         logger.info("Updates state change: ${event.type}, context = ${context.json}")
       }
-      UpdatesControllerRegistry.controller?.get()?.let {
-        if (it is EnabledUpdatesController) {
-          // Notify the controller state change listener
-          it.stateChangeListenerMap.keys.forEach { key ->
-            it.stateChangeListenerMap[key]?.updatesStateDidChange(toMap(event))
-          }
-        }
-      }
+      notifyStateChangeListener(event)
       sendContextToJS()
     }
   }
@@ -124,6 +125,24 @@ class UpdatesStateMachine(
     }
     state = newStateValue
     return true
+  }
+
+  /**
+   * Notify the state change listener in the native interface
+   */
+  private fun notifyStateChangeListener(event: UpdatesStateEvent) {
+    UpdatesControllerRegistry.controller?.get()?.let {
+      if (it is EnabledUpdatesController) {
+        val nativeInterfaceEvent = toMap(event)
+        // Don't cache the download progress events
+        if (event !is UpdatesStateEvent.DownloadProgress) {
+          nativeInterfaceCache.add(nativeInterfaceEvent)
+        }
+        it.stateChangeListenerMap.keys.forEach { key ->
+          it.stateChangeListenerMap[key]?.updatesStateDidChange(nativeInterfaceEvent)
+        }
+      }
+    }
   }
 
   fun sendContextToJS() {
@@ -239,5 +258,22 @@ class UpdatesStateMachine(
         )
       }
     }
+  }
+}
+
+// State machine native interface event cache
+class UpdatesStateMachineNativeInterfaceCache {
+  private val cachedEvents: MutableList<Map<String, Any>> = mutableListOf()
+  private val maxSize = 50
+
+  fun add(event: Map<String, Any>) {
+    cachedEvents.add(event)
+    if (cachedEvents.size > maxSize) {
+      cachedEvents.removeAt(0)
+    }
+  }
+
+  fun events(): List<Map<String, Any>> {
+    return cachedEvents.toList().sortedBy { (it["timestamp"] as? Double) ?: 0.0 }
   }
 }

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -179,8 +179,14 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesInterf
   public func subscribeToUpdatesStateChanges(_ listener: any UpdatesStateChangeListener) -> UpdatesStateChangeSubscription {
     let subscriptionId = UUID().uuidString
     let subscription = EnabledUpdatesStateChangeSubscription(subscriptionId)
-
     stateChangeListeners[subscriptionId] = listener
+
+    // Send cached events to the listener
+    let cachedEvents = getRecentStateChangeEventsForNativeInterface()
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+      cachedEvents.forEach { listener.updatesStateDidChange($0) }
+    }
+
     return subscription
   }
 
@@ -188,6 +194,10 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesInterf
     if stateChangeListeners[subscriptionId] != nil {
       stateChangeListeners.removeValue(forKey: subscriptionId)
     }
+  }
+
+  internal func getRecentStateChangeEventsForNativeInterface() -> [[String: Any]] {
+    return stateMachine.nativeInterfaceCache.events()
   }
 
   public var runtimeVersion: String? {

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -1,6 +1,7 @@
 //  Copyright © 2023 650 Industries. All rights reserved.
 
 // swiftlint:disable no_grouping_extension
+// swiftlint:disable no_fallthrough_only
 
 import Foundation
 import EXUpdatesInterface
@@ -87,19 +88,20 @@ internal enum UpdatesStateEvent {
   }
 
   var toMap: [String: Any] {
+    let map = ["type": "\(type)", "timestamp": floor(Date.now.timeIntervalSince1970 * 1000)] as [String: Any]
     switch self {
     case .checkCompleteWithUpdate(manifest: let manifest):
-      return ["type": "checkCompleteWithUpdate", "manifest": manifest]
+      return map.merging(["type": "checkCompleteWithUpdate", "manifest": manifest]) { _, new in new }
     case .checkCompleteWithRollback:
-      return ["type": "checkCompleteWithRollback"]
+      return map.merging(["type": "checkCompleteWithRollback"]) { _, new in new }
     case .downloadCompleteWithUpdate(manifest: let manifest):
-      return ["type": "downloadCompleteWithUpdate", "manifest": manifest]
+      return map.merging(["type": "downloadCompleteWithUpdate", "manifest": manifest]) { _, new in new }
     case .checkError(errorMessage: let errorMessage):
-      return ["type": "checkError", "errorMessage": errorMessage]
+      return map.merging(["type": "checkError", "errorMessage": errorMessage]) { _, new in new }
     case .downloadError(errorMessage: let errorMessage):
-      return ["type": "downloadError", "errorMessage": errorMessage]
+      return map.merging(["type": "downloadError", "errorMessage": errorMessage]) { _, new in new }
     case .downloadProgress(progress: let progress):
-      return ["type": "downloadProgress", "progress": progress]
+      return map.merging(["type": "downloadProgress", "progress": progress]) { _, new in new }
     case .check:
       fallthrough
     case .checkCompleteUnavailable:
@@ -115,7 +117,7 @@ internal enum UpdatesStateEvent {
     case .startStartup:
       fallthrough
     case .endStartup:
-      return ["type": "\(type)"]
+      return map
     }
   }
 }
@@ -273,6 +275,30 @@ public extension UpdatesStateContext {
   }
 }
 
+// MARK: - State machine native interface event cache
+internal class UpdatesStateMachineNativeInterfaceCache {
+  private var cachedEvents: [[String: Any]] = []
+  private let MAX_SIZE = 50
+
+  internal func add(_ event: [String: Any]) {
+    cachedEvents.append(event)
+    if cachedEvents.count > MAX_SIZE {
+      cachedEvents.removeFirst()
+    }
+  }
+
+  internal func events() -> [[String: Any]] {
+    return cachedEvents
+      .sorted { event1, event2 in
+        if let ts1 = event1["timestamp"] as? Double,
+          let ts2 = event2["timestamp"] as? Double {
+          return ts1 < ts2
+        }
+        return false
+      }
+  }
+}
+
 // MARK: - State machine class
 
 /**
@@ -283,6 +309,9 @@ internal class UpdatesStateMachine {
   private let logger: UpdatesLogger
   private let eventManager: UpdatesEventManager
   private let validUpdatesStateValues: Set<UpdatesStateValue>
+
+  // Accessed by updates controller native interface implementation
+  let nativeInterfaceCache = UpdatesStateMachineNativeInterfaceCache()
 
   required init(logger: UpdatesLogger, eventManager: UpdatesEventManager, validUpdatesStateValues: Set<UpdatesStateValue>) {
     self.logger = logger
@@ -353,14 +382,7 @@ internal class UpdatesStateMachine {
       if event.type != .downloadProgress {
         logger.info(message: "Updates state change: state = \(state), event = \(event.type), context = \(context)")
       }
-      // Notify the controller state change listener
-      if let controller = UpdatesControllerRegistry.sharedInstance.controller as? EnabledAppController {
-        controller.stateChangeListeners.keys.forEach {subscriptionId in
-          if let listener = controller.stateChangeListeners[subscriptionId] {
-            listener.updatesStateDidChange(event.toMap)
-          }
-        }
-      }
+      notifyStateChangeListener(event)
       sendContextToJS()
     }
   }
@@ -387,6 +409,25 @@ internal class UpdatesStateMachine {
     // Successful transition
     state = newStateValue
     return true
+  }
+
+  /**
+   * Notify the state change listener in the native interface
+   */
+  private func notifyStateChangeListener(_ event: UpdatesStateEvent) {
+    // Notify the controller state change listener
+    if let controller = UpdatesControllerRegistry.sharedInstance.controller as? EnabledAppController {
+      let nativeInterfaceEvent = event.toMap
+      // Don't cache the download progress events
+      if event.type != .downloadProgress {
+        nativeInterfaceCache.add(nativeInterfaceEvent)
+      }
+      controller.stateChangeListeners.keys.forEach {subscriptionId in
+        if let listener = controller.stateChangeListeners[subscriptionId] {
+          listener.updatesStateDidChange(event.toMap)
+        }
+      }
+    }
   }
 
   /**
@@ -525,4 +566,5 @@ internal class UpdatesStateMachine {
   ]
 }
 
+// swiftlint:enable no_fallthrough_only
 // swiftlint:enable no_grouping_extension


### PR DESCRIPTION
# Why

This PR implements caching of state change events sent to state change listeners registered in `expo-updates-interface`. When new listeners subscribe to updates state changes, they now receive recent cached events to ensure they don't miss important state transitions that occurred before the subscription started.

This change is needed to support features like OTA update download time metrics, and should be cherry-picked for SDK 55.

No changes were made to `expo-updates-interface`methods or interfaces.

# How

Added a new `UpdatesStateMachineNativeInterfaceCache` class on both Android and iOS platforms that maintains a circular buffer of up to 50 recent state change events. The cache excludes download progress events to avoid noise. When a new listener subscribes via `subscribeToUpdatesStateChanges`, cached events are delivered after a 200ms delay on the main thread. All events now include timestamps for proper ordering.

# Test Plan

A test to demonstrate receipt of cached events will be added to the updates E2E (enabled) workflow.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)