### PR TITLE
fix(expo-updates): E2E workflows should use pnpm

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/brownfield.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/brownfield.yml
@@ -12,7 +12,7 @@ on:
       - packages/expo-dev-menu/**
       - packages/expo-manifests/**
       - packages/expo-updates/**
-      - yarn.lock
+      - pnpm-lock.yaml
       - '!**/*.md'
       - '!**/__tests__/**'
       - '!**/__mocks__/**'
@@ -25,7 +25,7 @@ on:
       - packages/expo-dev-menu/**
       - packages/expo-manifests/**
       - packages/expo-updates/**
-      - yarn.lock
+      - pnpm-lock.yaml
       - '!**/*.md'
       - '!**/__tests__/**'
       - '!**/__mocks__/**'
@@ -33,11 +33,6 @@ on:
 concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
-
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
 
 jobs:
   detect_platform:
@@ -72,7 +67,7 @@ jobs:
       - uses: eas/use_npm_token
       - uses: eas/install_node_modules
       - name: Build Expo CLI
-        run: yarn workspace @expo/cli prepare
+        run: pnpm --filter @expo/cli prepare
       - name: Build and publish Android brownfield artifacts
         working_directory: ../brownfield-tester/expo-app
         run: |
@@ -95,7 +90,7 @@ jobs:
         with:
           platform: ios
       - name: Build Expo CLI
-        run: yarn workspace @expo/cli prepare
+        run: pnpm --filter @expo/cli prepare
       - name: Build iOS artifacts (Release)
         working_directory: ../brownfield-tester/expo-app
         run: |

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield.yml
@@ -18,11 +18,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   detect_platform:
     name: Detect platform changes

--- a/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/tv-compile.yml
@@ -74,11 +74,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   ios:
     runs_on: macos-large
@@ -102,15 +97,15 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-tv.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-eas-project-tv.ts
           ls -la ../updates-e2e
       - name: Prepare TV project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn ios:pod-install
+          pnpm run ios:pod-install
       - name: Compile TV project
         id: build
         working_directory: ../../../updates-e2e
         run: |
-          yarn tvos:build
+          pnpm run tvos:build

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-bricking-measures-disabled.yml
@@ -25,11 +25,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   ios:
     runs_on: macos-large
@@ -46,19 +41,19 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles ios test-update-1
-          yarn ios:pod-install
+          pnpm run generate-test-update-bundles ios test-update-1
+          pnpm run ios:pod-install
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:release:build
+          pnpm run maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
           device_identifier: iPhone 17
@@ -82,13 +77,13 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-bricking-measures-disabled-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles android test-update-1
+          pnpm run generate-test-update-bundles android test-update-1
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4
@@ -96,7 +91,7 @@ jobs:
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:release:build
+          pnpm run maestro:android:release:build
       - name: Run Maestro tests (release)
         id: testrelease
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-cli.yml
@@ -15,11 +15,6 @@ on:
   schedule:
     - cron: '0 18 * * SUN' # 18:00 UTC every Sunday
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
@@ -36,4 +31,4 @@ jobs:
         id: cli
         working_directory: ../../packages/expo-updates
         run: |
-          yarn test:e2e-cli --ci --runInBand
+          pnpm run test:e2e-cli --ci --runInBand

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-custom-init.yml
@@ -21,11 +21,6 @@ on:
   schedule:
     - cron: '0 19 * * SUN' # 22:00 UTC every Sunday
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
@@ -46,24 +41,24 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles ios
-          yarn ios:pod-install
+          pnpm run generate-test-update-bundles ios
+          pnpm run ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:debug:build
+          pnpm run maestro:ios:debug:build
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:release:build
+          pnpm run maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
           device_identifier: iPhone 17
@@ -94,13 +89,13 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-eas-project-custom-init.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles android
+          pnpm run generate-test-update-bundles android
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4
@@ -108,12 +103,12 @@ jobs:
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:debug:build
+          pnpm run maestro:android:debug:build
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:release:build
+          pnpm run maestro:android:release:build
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-dev-client.yml
@@ -31,11 +31,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   ios:
     runs_on: macos-large
@@ -60,19 +55,19 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles ios test-update-1
-          yarn ios:pod-install
+          pnpm run generate-test-update-bundles ios test-update-1
+          pnpm run ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:debug:build
+          pnpm run maestro:ios:debug:build
       - uses: eas/start_ios_simulator
         with:
           device_identifier: iPhone 17
@@ -81,7 +76,7 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           # start packager
-          yarn start:dev-client
+          pnpm run start:dev-client
           ./maestro/maestro-test-executor.sh ./maestro/tests/updates-e2e-dev-client.yml ios debug
   android:
     runs_on: linux-large-nested-virtualization
@@ -98,13 +93,13 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-dev-client-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles android test-update-1
+          pnpm run generate-test-update-bundles android test-update-1
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_9
@@ -113,12 +108,12 @@ jobs:
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:debug:build
+          pnpm run maestro:android:debug:build
       - name: Start packager
         id: startpackager
         working_directory: ../../../updates-e2e
         run: |
-          yarn start:dev-client
+          pnpm run start:dev-client
       - name: Run Maestro test (debug) (load update through dev client)
         id: testdebug1
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-disabled.yml
@@ -25,11 +25,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   ios:
     runs_on: macos-large
@@ -54,24 +49,24 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles ios test-update-1
-          yarn ios:pod-install
+          pnpm run generate-test-update-bundles ios test-update-1
+          pnpm run ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:debug:build
+          pnpm run maestro:ios:debug:build
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:release:build
+          pnpm run maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
           device_identifier: iPhone 17
@@ -100,13 +95,13 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-disabled-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles android test-update-1
+          pnpm run generate-test-update-bundles android test-update-1
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4
@@ -114,12 +109,12 @@ jobs:
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:debug:build
+          pnpm run maestro:android:debug:build
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:release:build
+          pnpm run maestro:android:release:build
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-enabled.yml
@@ -49,11 +49,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   ios:
     runs_on: macos-large
@@ -70,24 +65,24 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles ios
-          yarn ios:pod-install
+          pnpm run generate-test-update-bundles ios
+          pnpm run ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:debug:build
+          pnpm run maestro:ios:debug:build
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:release:build
+          pnpm run maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
           device_identifier: iPhone 17
@@ -116,13 +111,13 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles android
+          pnpm run generate-test-update-bundles android
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4
@@ -130,12 +125,12 @@ jobs:
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:debug:build
+          pnpm run maestro:android:debug:build
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:release:build
+          pnpm run maestro:android:release:build
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-error-recovery.yml
@@ -25,11 +25,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   ios:
     runs_on: macos-large
@@ -46,19 +41,19 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles ios test-update-crashing
-          yarn ios:pod-install
+          pnpm run generate-test-update-bundles ios test-update-crashing
+          pnpm run ios:pod-install
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:release:build
+          pnpm run maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
           device_identifier: iPhone 17
@@ -82,13 +77,13 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-error-recovery-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles android test-update-crashing
+          pnpm run generate-test-update-bundles android test-update-crashing
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4
@@ -96,7 +91,7 @@ jobs:
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:release:build
+          pnpm run maestro:android:release:build
       - name: Run Maestro tests (release)
         id: testrelease
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-fingerprint.yml
@@ -25,11 +25,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   ios:
     runs_on: macos-large
@@ -46,19 +41,19 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles ios test-update-1
-          yarn ios:pod-install
+          pnpm run generate-test-update-bundles ios test-update-1
+          pnpm run ios:pod-install
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:release:build
+          pnpm run maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
           device_identifier: iPhone 17
@@ -82,13 +77,13 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-fingerprint-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles android test-update-1
+          pnpm run generate-test-update-bundles android test-update-1
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4
@@ -97,11 +92,11 @@ jobs:
         working_directory: ../../../updates-e2e
         run: |
           rm -rf android/app/build
-          yarn maestro:android:release:build
+          pnpm run maestro:android:release:build
           # Regenerate bundles with correct fingerprint
-          yarn generate-test-update-bundles android test-update-1
+          pnpm run generate-test-update-bundles android test-update-1
           rm -rf android/app/build
-          yarn maestro:android:release:build
+          pnpm run maestro:android:release:build
       - name: Run Maestro tests (release)
         id: testrelease
         working_directory: ../../../updates-e2e

--- a/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/updates-e2e-startup.yml
@@ -25,11 +25,6 @@ concurrency:
   group: ${{ workflow.filename }}-${{ github.ref }}
   cancel_in_progress: true
 
-defaults:
-  tools:
-    node: 22.14.0
-    yarn: 1.22.22
-
 jobs:
   ios:
     runs_on: macos-large
@@ -46,24 +41,24 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-startup-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-startup-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles ios test-update-1
-          yarn ios:pod-install
+          pnpm run generate-test-update-bundles ios test-update-1
+          pnpm run ios:pod-install
       - name: Build E2E test app (debug)
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:debug:build
+          pnpm run maestro:ios:debug:build
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:ios:release:build
+          pnpm run maestro:ios:release:build
       - uses: eas/start_ios_simulator
         with:
           device_identifier: iPhone 17
@@ -92,13 +87,13 @@ jobs:
           UPDATES_HOST: localhost
           UPDATES_PORT: '4747'
         run: |
-          yarn --silent ts-node --transpile-only ./packages/expo-updates/e2e/setup/create-startup-eas-project.ts
+          pnpm --silent ts-node ./packages/expo-updates/e2e/setup/create-startup-eas-project.ts
           ls -la ../updates-e2e
       - name: Prepare E2E project
         id: prepare
         working_directory: ../../../updates-e2e
         run: |
-          yarn generate-test-update-bundles android test-update-1
+          pnpm run generate-test-update-bundles android test-update-1
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4
@@ -106,12 +101,12 @@ jobs:
         id: builddebug
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:debug:build
+          pnpm run maestro:android:debug:build
       - name: Build E2E test app (release)
         id: buildrelease
         working_directory: ../../../updates-e2e
         run: |
-          yarn maestro:android:release:build
+          pnpm run maestro:android:release:build
       - name: Run Maestro tests (debug)
         id: testdebug
         working_directory: ../../../updates-e2e

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -367,6 +367,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
+        glob: "^11.0.0",
         'react-native': 'npm:react-native-tvos@0.85.0-0rc5',
         '@react-native-tvos/config-tv': '^0.1.5',
       },

--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -92,11 +92,7 @@ function getExpoDependencyNamesForDependencyChunks(expoDependencyChunks: string[
 
 const expoResolutions: { [key: string]: string } = {};
 
-function linkExpoDependency(
-  repoRoot: string,
-  projectRoot: string,
-  dependencyName: string
-) {
+function linkExpoDependency(repoRoot: string, projectRoot: string, dependencyName: string) {
   // Pack up the named Expo package into the destination folder
   const dependencyComponents = dependencyName.split('/');
   let dependencyPath: string;
@@ -326,7 +322,7 @@ async function preparePackageJson(
         'form-data': '^4.0.0',
         'resolve-from': '^5.0.0',
         'structured-headers': '^2.0.2',
-        'nullthrows': '^1.1.1',
+        nullthrows: '^1.1.1',
         prettier: '^2.8.1',
         'patch-package': '^8.0.0',
         'ts-node': '~10.9.2',
@@ -371,7 +367,7 @@ async function preparePackageJson(
       ...packageJson,
       dependencies: {
         ...packageJson.dependencies,
-        'react-native': 'npm:react-native-tvos@0.84.0-0',
+        'react-native': 'npm:react-native-tvos@0.85.0-0rc5',
         '@react-native-tvos/config-tv': '^0.1.5',
       },
       expo: {
@@ -505,7 +501,7 @@ function transformAppJsonForE2E(
       },
       experiments: {
         // NOTE(@kitten): Deduplicate `react` and native module code automatically as we're symlinking modules
-        autolinkingModuleResolution: true
+        autolinkingModuleResolution: true,
       },
       extra: {
         eas: {
@@ -657,7 +653,7 @@ export function transformAppJsonForUpdatesDisabledE2E(
       },
       experiments: {
         // NOTE(@kitten): Deduplicate `react` and native module code automatically as we're symlinking modules
-        autolinkingModuleResolution: true
+        autolinkingModuleResolution: true,
       },
       extra: {
         eas: {


### PR DESCRIPTION
# Why

EAS workflows for updates E2E testing should use pnpm.

Also bumping RNTV dependency for TV compile test.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Modify workflow YAML.

Add `glob` to the dependencies for the TV compile test, to work around an issue where the `config-tv` plugin has a dependency on `glob`, but pnpm does not install that package for some reason.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI should pass.