### PR TITLE
[templates] added support for agent files in templates

### DIFF
--- a/packages/create-expo/src/Examples.ts
+++ b/packages/create-expo/src/Examples.ts
@@ -132,7 +132,7 @@ export async function downloadAndExtractExampleAsync(root: string, name: string)
   }
 
   await pipeline(
-    Readable.fromWeb(response.body),
+    Readable.fromWeb(response.body as any),
     tarExtract(
       {
         cwd: root,

--- a/packages/create-expo/src/__tests__/agents.test.ts
+++ b/packages/create-expo/src/__tests__/agents.test.ts
@@ -1,0 +1,250 @@
+import { vol } from 'memfs';
+import prompts from 'prompts';
+
+import {
+  AGENTS,
+  resolveAgents,
+  setupAgentsAsync,
+  promptAgentsAsync,
+  AgentContext,
+} from '../agents';
+import { env } from '../utils/env';
+
+jest.mock('fs');
+jest.mock('prompts');
+
+const defaultContext: AgentContext = { packageManager: 'npm' };
+
+describe(resolveAgents, () => {
+  it('parses a comma-separated string of agent ids', async () => {
+    const result = await resolveAgents('claude,cursor', false);
+    expect(result).toEqual(['claude', 'cursor']);
+  });
+
+  it('filters out invalid agent ids with warning', async () => {
+    const result = await resolveAgents('claude,invalid', false);
+    expect(result).toEqual(['claude']);
+  });
+
+  it('returns empty array for empty string', async () => {
+    const result = await resolveAgents('', false);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array when --yes is set and no --agents flag', async () => {
+    const result = await resolveAgents(undefined, true);
+    expect(result).toEqual([]);
+  });
+
+  it('returns empty array in CI mode with no --agents flag', async () => {
+    const spy = jest.spyOn(env, 'CI', 'get').mockReturnValue(true);
+    const result = await resolveAgents(undefined, false);
+    expect(result).toEqual([]);
+    spy.mockRestore();
+  });
+
+  it('prompts in interactive mode with no flags', async () => {
+    const spy = jest.spyOn(env, 'CI', 'get').mockReturnValue(false);
+    jest.mocked(prompts).mockResolvedValue({ answer: ['windsurf'] });
+    const result = await resolveAgents(undefined, false);
+    expect(result).toEqual(['windsurf']);
+    spy.mockRestore();
+  });
+});
+
+describe(promptAgentsAsync, () => {
+  it('returns selected agents', async () => {
+    jest.mocked(prompts).mockResolvedValue({ answer: ['claude', 'copilot'] });
+    const result = await promptAgentsAsync();
+    expect(result).toEqual(['claude', 'copilot']);
+    expect(prompts).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'multiselect',
+        choices: AGENTS.map((a) => ({ title: a.name, value: a.id })),
+      })
+    );
+  });
+
+  it('returns empty array when user presses Escape', async () => {
+    jest.mocked(prompts).mockResolvedValue({ answer: undefined });
+    const result = await promptAgentsAsync();
+    expect(result).toEqual([]);
+  });
+});
+
+describe(setupAgentsAsync, () => {
+  afterEach(() => vol.reset());
+
+  it('deletes config files for unselected agents and keeps AGENTS.md', async () => {
+    vol.fromJSON({
+      '/project/AGENTS.md': '# {{projectName}}',
+      '/project/CLAUDE.md': 'claude config',
+      '/project/.claude/settings.json': '{}',
+      '/project/.cursor/rules/expo.mdc': 'cursor config',
+      '/project/.windsurf/rules/expo.md': 'windsurf config',
+      '/project/package.json': '{"name":"test-app","dependencies":{"expo":"~55.0.0"}}',
+    });
+
+    await setupAgentsAsync('/project', { agents: 'claude' }, defaultContext);
+
+    // Shared AGENTS.md should remain (at least one agent selected)
+    expect(vol.existsSync('/project/AGENTS.md')).toBe(true);
+
+    // Claude files should remain
+    expect(vol.existsSync('/project/CLAUDE.md')).toBe(true);
+    expect(vol.existsSync('/project/.claude/settings.json')).toBe(true);
+
+    // Other agent files should be deleted
+    expect(vol.existsSync('/project/.cursor')).toBe(false);
+    expect(vol.existsSync('/project/.windsurf')).toBe(false);
+  });
+
+  it('deletes all agent configs including AGENTS.md when --yes with no --agents', async () => {
+    vol.fromJSON({
+      '/project/AGENTS.md': '# shared',
+      '/project/CLAUDE.md': 'claude config',
+      '/project/.claude/settings.json': '{}',
+      '/project/.cursor/rules/expo.mdc': 'cursor config',
+      '/project/.windsurf/rules/expo.md': 'windsurf config',
+    });
+
+    await setupAgentsAsync('/project', { yes: true }, defaultContext);
+
+    expect(vol.existsSync('/project/AGENTS.md')).toBe(false);
+    expect(vol.existsSync('/project/CLAUDE.md')).toBe(false);
+    expect(vol.existsSync('/project/.claude')).toBe(false);
+    expect(vol.existsSync('/project/.cursor')).toBe(false);
+    expect(vol.existsSync('/project/.windsurf')).toBe(false);
+  });
+
+  it('handles missing config files gracefully', async () => {
+    vol.fromJSON({
+      '/project/package.json': '{}',
+    });
+
+    // Should not throw even if no agent config files exist
+    await expect(
+      setupAgentsAsync('/project', { agents: 'claude' }, defaultContext)
+    ).resolves.not.toThrow();
+  });
+
+  it('replaces placeholders in AGENTS.md and tool-specific files', async () => {
+    vol.fromJSON({
+      '/project/AGENTS.md':
+        '# {{projectName}}\n\nSDK {{sdkVersion}}. PM: {{packageManager}}.\n\n`{{packageRunCommand}} start`',
+      '/project/CLAUDE.md': 'skills only',
+      '/project/.claude/settings.json': '{}',
+      '/project/package.json': '{"name":"my-app","dependencies":{"expo":"~55.0.0"}}',
+    });
+
+    await setupAgentsAsync('/project', { agents: 'claude' }, { packageManager: 'npm' });
+
+    const content = vol.readFileSync('/project/AGENTS.md', 'utf-8') as string;
+    expect(content).toContain('# my-app');
+    expect(content).toContain('SDK 55');
+    expect(content).toContain('PM: npm');
+    expect(content).toContain('`npm run start`');
+    expect(content).not.toContain('{{');
+  });
+
+  it('replaces placeholders with yarn package manager', async () => {
+    vol.fromJSON({
+      '/project/AGENTS.md':
+        '# {{projectName}}\n\nPM: {{packageManager}}.\n\n`{{packageRunCommand}} start`',
+      '/project/CLAUDE.md': 'skills',
+      '/project/.claude/settings.json': '{}',
+      '/project/package.json': '{"name":"yarn-app","dependencies":{"expo":"^54.1.0"}}',
+    });
+
+    await setupAgentsAsync('/project', { agents: 'claude' }, { packageManager: 'yarn' });
+
+    const content = vol.readFileSync('/project/AGENTS.md', 'utf-8') as string;
+    expect(content).toContain('# yarn-app');
+    expect(content).toContain('PM: yarn');
+    expect(content).toContain('`yarn start`');
+  });
+
+  it('replaces placeholders in nested directory files', async () => {
+    vol.fromJSON({
+      '/project/AGENTS.md': '# {{projectName}}',
+      '/project/.cursor/rules/expo.mdc': 'Use `{{packageManager}} install` for deps',
+      '/project/package.json': '{"name":"test","dependencies":{"expo":"~55.0.0"}}',
+    });
+
+    await setupAgentsAsync('/project', { agents: 'cursor' }, { packageManager: 'pnpm' });
+
+    const content = vol.readFileSync('/project/.cursor/rules/expo.mdc', 'utf-8') as string;
+    expect(content).toContain('Use `pnpm install` for deps');
+  });
+
+  it('keeps AGENTS.md and copilot-instructions.md when copilot is the only selected agent', async () => {
+    vol.fromJSON({
+      '/project/AGENTS.md': '# {{projectName}}\n\nPM: {{packageManager}}.',
+      '/project/CLAUDE.md': 'claude',
+      '/project/.claude/settings.json': '{}',
+      '/project/.cursor/rules/expo.mdc': 'cursor',
+      '/project/.windsurf/rules/expo.md': 'windsurf',
+      '/project/.github/copilot-instructions.md': 'Read AGENTS.md',
+      '/project/package.json': '{"name":"copilot-app","dependencies":{"expo":"~55.0.0"}}',
+    });
+
+    await setupAgentsAsync('/project', { agents: 'copilot' }, { packageManager: 'npm' });
+
+    // AGENTS.md should remain and have placeholders replaced
+    expect(vol.existsSync('/project/AGENTS.md')).toBe(true);
+    const content = vol.readFileSync('/project/AGENTS.md', 'utf-8') as string;
+    expect(content).toContain('# copilot-app');
+    expect(content).toContain('PM: npm');
+
+    // Copilot instructions should remain
+    expect(vol.existsSync('/project/.github/copilot-instructions.md')).toBe(true);
+
+    // All other tool-specific files should be removed
+    expect(vol.existsSync('/project/CLAUDE.md')).toBe(false);
+    expect(vol.existsSync('/project/.cursor')).toBe(false);
+    expect(vol.existsSync('/project/.windsurf')).toBe(false);
+  });
+
+  it('removes copilot-instructions.md but keeps .github/ when copilot is not selected', async () => {
+    vol.fromJSON({
+      '/project/AGENTS.md': '# {{projectName}}',
+      '/project/CLAUDE.md': 'claude',
+      '/project/.claude/settings.json': '{}',
+      '/project/.github/copilot-instructions.md': 'Read AGENTS.md',
+      '/project/.github/workflows/ci.yml': 'name: CI',
+      '/project/package.json': '{"name":"test-app","dependencies":{"expo":"~55.0.0"}}',
+    });
+
+    await setupAgentsAsync('/project', { agents: 'claude' }, { packageManager: 'npm' });
+
+    // Copilot instructions should be removed
+    expect(vol.existsSync('/project/.github/copilot-instructions.md')).toBe(false);
+
+    // .github directory and other files in it should remain
+    expect(vol.existsSync('/project/.github/workflows/ci.yml')).toBe(true);
+  });
+
+  it('keeps AGENTS.md when "other" is the only selected agent', async () => {
+    vol.fromJSON({
+      '/project/AGENTS.md': '# {{projectName}}\n\nPM: {{packageManager}}.',
+      '/project/CLAUDE.md': 'claude',
+      '/project/.claude/settings.json': '{}',
+      '/project/.cursor/rules/expo.mdc': 'cursor',
+      '/project/.windsurf/rules/expo.md': 'windsurf',
+      '/project/package.json': '{"name":"other-app","dependencies":{"expo":"~55.0.0"}}',
+    });
+
+    await setupAgentsAsync('/project', { agents: 'other' }, { packageManager: 'bun' });
+
+    // AGENTS.md should remain and have placeholders replaced
+    expect(vol.existsSync('/project/AGENTS.md')).toBe(true);
+    const content = vol.readFileSync('/project/AGENTS.md', 'utf-8') as string;
+    expect(content).toContain('# other-app');
+    expect(content).toContain('PM: bun');
+
+    // All tool-specific files should be removed
+    expect(vol.existsSync('/project/CLAUDE.md')).toBe(false);
+    expect(vol.existsSync('/project/.cursor')).toBe(false);
+    expect(vol.existsSync('/project/.windsurf')).toBe(false);
+  });
+});

--- a/packages/create-expo/src/__tests__/createFileTransformer.test.ts
+++ b/packages/create-expo/src/__tests__/createFileTransformer.test.ts
@@ -33,6 +33,38 @@ describe(modifyFileDuringPipe, () => {
       }).path
     ).toEqual('_package/.vscode/foo/_vscode/settings.json');
   });
+  it(`renames _claude to .claude`, () => {
+    expect(
+      modifyFileDuringPipe({
+        path: 'package/_claude/settings.json',
+        type: 'File',
+      }).path
+    ).toEqual('package/.claude/settings.json');
+  });
+  it(`renames _windsurf to .windsurf`, () => {
+    expect(
+      modifyFileDuringPipe({
+        path: 'package/_windsurf/rules/expo.md',
+        type: 'File',
+      }).path
+    ).toEqual('package/.windsurf/rules/expo.md');
+  });
+  it(`renames _cursor to .cursor`, () => {
+    expect(
+      modifyFileDuringPipe({
+        path: 'package/_cursor/rules/expo.mdc',
+        type: 'File',
+      }).path
+    ).toEqual('package/.cursor/rules/expo.mdc');
+  });
+  it(`renames _github to .github`, () => {
+    expect(
+      modifyFileDuringPipe({
+        path: 'package/_github/copilot-instructions.md',
+        type: 'File',
+      }).path
+    ).toEqual('package/.github/copilot-instructions.md');
+  });
 });
 
 describe(createGlobFilter, () => {

--- a/packages/create-expo/src/agents.ts
+++ b/packages/create-expo/src/agents.ts
@@ -1,0 +1,216 @@
+import fs from 'fs';
+import path from 'path';
+import prompts from 'prompts';
+
+import { Log } from './log';
+import { PackageManagerName } from './resolvePackageManager';
+import { env } from './utils/env';
+import { withSectionLog } from './utils/log';
+
+const debug = require('debug')('expo:init:agents') as typeof console.log;
+
+/** Shared file read by all AI coding tools (Claude Code, Cursor, Windsurf, Copilot, Codex, etc.) */
+const SHARED_AGENT_FILE = 'AGENTS.md';
+
+export const AGENTS = [
+  { id: 'claude', name: 'Claude Code', paths: ['CLAUDE.md', '.claude'] },
+  { id: 'cursor', name: 'Cursor', paths: ['.cursor'] },
+  { id: 'windsurf', name: 'Windsurf', paths: ['.windsurf'] },
+  { id: 'copilot', name: 'GitHub Copilot', paths: ['.github/copilot-instructions.md'] },
+  { id: 'other', name: 'Other (installs AGENTS.md)', paths: [] },
+] as const;
+
+export type AgentId = (typeof AGENTS)[number]['id'];
+
+export type AgentContext = {
+  packageManager: PackageManagerName;
+};
+
+function getRunCommand(packageManager: PackageManagerName): string {
+  switch (packageManager) {
+    case 'yarn':
+      return 'yarn';
+    case 'npm':
+      return 'npm run';
+    case 'pnpm':
+      return 'pnpm';
+    case 'bun':
+      return 'bun run';
+  }
+}
+
+async function readProjectInfo(projectRoot: string): Promise<{ name: string; sdkVersion: string }> {
+  try {
+    const pkgJson = JSON.parse(
+      await fs.promises.readFile(path.join(projectRoot, 'package.json'), 'utf-8')
+    );
+    const name = pkgJson.name || path.basename(projectRoot);
+    const expoVersion = pkgJson.dependencies?.expo || '';
+    // Extract major version: "~55.0.0" → "55", "^55.1.2" → "55"
+    const sdkVersion = expoVersion.replace(/^[~^]/, '').split('.')[0] || 'latest';
+    return { name, sdkVersion };
+  } catch {
+    return { name: path.basename(projectRoot), sdkVersion: 'latest' };
+  }
+}
+
+function replacePlaceholders(content: string, vars: Record<string, string>): string {
+  return content.replace(/\{\{(\w+)\}\}/g, (match, key) => vars[key] ?? match);
+}
+
+const TEXT_EXTENSIONS = new Set(['.md', '.mdc', '.txt', '.json']);
+
+async function replaceInFile(filePath: string, vars: Record<string, string>) {
+  try {
+    const content = await fs.promises.readFile(filePath, 'utf-8');
+    const replaced = replacePlaceholders(content, vars);
+    if (replaced !== content) {
+      await fs.promises.writeFile(filePath, replaced, 'utf-8');
+    }
+  } catch (error: any) {
+    if (error.code !== 'ENOENT') {
+      debug(`Error processing %s: %O`, filePath, error);
+    }
+  }
+}
+
+async function replaceInDirectory(dirPath: string, vars: Record<string, string>) {
+  let entries;
+  try {
+    entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+  } catch (error: any) {
+    if (error.code !== 'ENOENT') {
+      debug(`Error reading directory %s: %O`, dirPath, error);
+    }
+    return;
+  }
+  for (const entry of entries) {
+    const fullPath = path.join(dirPath, entry.name);
+    if (entry.isDirectory()) {
+      await replaceInDirectory(fullPath, vars);
+    } else if (entry.isFile() && TEXT_EXTENSIONS.has(path.extname(entry.name))) {
+      await replaceInFile(fullPath, vars);
+    }
+  }
+}
+
+async function replaceInAgentFiles(projectRoot: string, vars: Record<string, string>) {
+  await replaceInFile(path.join(projectRoot, SHARED_AGENT_FILE), vars);
+
+  for (const agent of AGENTS) {
+    for (const p of agent.paths) {
+      const fullPath = path.join(projectRoot, p);
+      if (path.extname(fullPath)) {
+        await replaceInFile(fullPath, vars);
+      } else {
+        await replaceInDirectory(fullPath, vars);
+      }
+    }
+  }
+}
+
+async function removeFileOrDirectory(fullPath: string) {
+  try {
+    await fs.promises.rm(fullPath, { recursive: true, force: true });
+  } catch (error: any) {
+    debug(`Error removing %s: %O`, fullPath, error);
+  }
+}
+
+export async function setupAgentsAsync(
+  projectRoot: string,
+  options: { agents?: string | true; yes?: boolean },
+  context: AgentContext
+): Promise<void> {
+  const selected = await resolveAgents(options.agents, options.yes);
+
+  await withSectionLog(
+    async () => {
+      const unselected = AGENTS.filter((a) => !selected.includes(a.id));
+      for (const agent of unselected) {
+        for (const p of agent.paths) {
+          await removeFileOrDirectory(path.join(projectRoot, p));
+        }
+      }
+
+      if (selected.length === 0) {
+        await removeFileOrDirectory(path.join(projectRoot, SHARED_AGENT_FILE));
+      }
+
+      if (selected.length > 0) {
+        const { name, sdkVersion } = await readProjectInfo(projectRoot);
+        const vars: Record<string, string> = {
+          packageManager: context.packageManager,
+          packageRunCommand: getRunCommand(context.packageManager),
+          projectName: name,
+          sdkVersion,
+        };
+        await replaceInAgentFiles(projectRoot, vars);
+
+        const names = selected.map((id) => AGENTS.find((a) => a.id === id)!.name).join(', ');
+        Log.log(`  Configured: ${names}`);
+      }
+    },
+    {
+      pending: 'Configuring AI coding agents.',
+      success: 'Configured AI coding agents.',
+      error: (error) => `Error configuring AI coding agents: ${error.message}`,
+    }
+  );
+}
+
+export async function resolveAgents(
+  agentsArg: string | true | undefined,
+  yes?: boolean
+): Promise<AgentId[]> {
+  // --agents claude,cursor (explicit list)
+  if (typeof agentsArg === 'string') {
+    return parseAgentIds(agentsArg);
+  }
+
+  // --yes with no --agents → skip (remove all)
+  if (yes) {
+    return [];
+  }
+
+  // Non-interactive → skip
+  if (env.CI) {
+    return [];
+  }
+
+  // Interactive mode → prompt
+  return await promptAgentsAsync();
+}
+
+function parseAgentIds(input: string): AgentId[] {
+  const validIds = AGENTS.map((a) => a.id);
+  const ids = input.split(',').map((s) => s.trim().toLowerCase());
+  const invalid = ids.filter((id) => !validIds.includes(id as AgentId));
+  if (invalid.length > 0) {
+    Log.log(
+      `Warning: Unknown agent(s): ${invalid.join(', ')}. Valid options: ${validIds.join(', ')}`
+    );
+  }
+  return ids.filter((id) => validIds.includes(id as AgentId)) as AgentId[];
+}
+
+export async function promptAgentsAsync(): Promise<AgentId[]> {
+  const { answer } = await prompts({
+    type: 'multiselect',
+    name: 'answer',
+    message: 'Which AI coding agents do you use?',
+    choices: AGENTS.map((agent) => ({
+      title: agent.name,
+      value: agent.id,
+    })),
+    hint: 'Space to toggle, Enter to confirm, Esc to skip',
+    instructions: false,
+  });
+
+  // User pressed Escape or Ctrl+C
+  if (answer === undefined) {
+    return [];
+  }
+
+  return answer;
+}

--- a/packages/create-expo/src/cli.ts
+++ b/packages/create-expo/src/cli.ts
@@ -42,6 +42,7 @@ async function run() {
         `    --no-install      Skip installing npm packages or CocoaPods`,
         chalk`-t, --template {gray [pkg]}  NPM template to use: default, blank, blank-typescript, tabs, bare-minimum. Default: default`,
         chalk`-e, --example {gray [name]}  Example name from {underline https://github.com/expo/examples}.`,
+        chalk`-a, --agents {gray <list>}   Configure AI coding agents (claude,cursor,windsurf,copilot)`,
         `-v, --version         Version number`,
         `-h, --help            Usage info`,
       ].join('\n'),
@@ -73,8 +74,12 @@ async function run() {
     const parsed = await resolveStringOrBooleanArgsAsync(argv, rawArgsMap, {
       '--template': Boolean,
       '--example': Boolean,
+      '--agents': Boolean,
       '-t': '--template',
       '-e': '--example',
+      '-a': '--agents',
+      // Note: --agents is only in extraArgs (not rawArgsMap) so it's
+      // treated as string-or-boolean via resolveStringOrBooleanArgsAsync
     });
 
     debug(`Default args:\n%O`, args);
@@ -85,6 +90,7 @@ async function run() {
       yes: !!args['--yes'],
       template: parsed.args['--template'],
       example: parsed.args['--example'],
+      agents: parsed.args['--agents'],
       install: !args['--no-install'],
     });
 

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -11,6 +11,7 @@ import {
   promptExamplesAsync,
 } from './Examples';
 import * as Template from './Template';
+import { setupAgentsAsync } from './agents';
 import { promptTemplateAsync } from './legacyTemplates';
 import { Log } from './log';
 import {
@@ -35,6 +36,7 @@ export type Options = {
   install: boolean;
   template?: string | true;
   example?: string | true;
+  agents?: string | true;
   yes: boolean;
 };
 
@@ -55,9 +57,12 @@ async function resolveProjectRootArgAsync(
   }
 }
 
-async function setupDependenciesAsync(projectRoot: string, props: Pick<Options, 'install'>) {
+async function setupDependenciesAsync(
+  projectRoot: string,
+  props: Pick<Options, 'install'>,
+  packageManager: PackageManagerName
+) {
   const shouldInstall = props.install;
-  const packageManager = resolvePackageManager();
 
   // Configure package manager, which is unrelated to installing or not
   await configureNodeDependenciesAsync(projectRoot, packageManager);
@@ -136,7 +141,19 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     }
   );
 
-  await setupDependenciesAsync(projectRoot, props);
+  const packageManager = resolvePackageManager();
+
+  try {
+    await setupAgentsAsync(
+      projectRoot,
+      { agents: props.agents, yes: props.yes },
+      { packageManager }
+    );
+  } catch (error: any) {
+    debug(`Error setting up agents: %O`, error);
+  }
+
+  await setupDependenciesAsync(projectRoot, props, packageManager);
 
   // for now, we will just init a git repo if they have git installed and the
   // project is not inside an existing git tree, and do it silently. we should
@@ -218,7 +235,19 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
       `Something went wrong in downloading and extracting the example files: ${error.message}`,
   });
 
-  await setupDependenciesAsync(projectRoot, props);
+  const packageManager = resolvePackageManager();
+
+  try {
+    await setupAgentsAsync(
+      projectRoot,
+      { agents: props.agents, yes: props.yes },
+      { packageManager }
+    );
+  } catch (error: any) {
+    debug(`Error setting up agents: %O`, error);
+  }
+
+  await setupDependenciesAsync(projectRoot, props, packageManager);
 
   // for now, we will just init a git repo if they have git installed and the
   // project is not inside an existing git tree, and do it silently. we should

--- a/packages/create-expo/src/createFileTransform.ts
+++ b/packages/create-expo/src/createFileTransform.ts
@@ -12,7 +12,7 @@ export function sanitizedName(name: string) {
 }
 
 // Directories that can be added to the template with an underscore instead of a dot, e.g. `.vscode` and be added with `_vscode`.
-const SUPPORTED_DIRECTORIES = ['eas', 'vscode', 'github', 'cursor'];
+const SUPPORTED_DIRECTORIES = ['eas', 'vscode', 'github', 'cursor', 'claude', 'windsurf'];
 const SUPPORTED_DIRECTORIES_PATTERN = new RegExp(
   `(^|/|\\\\)_(${SUPPORTED_DIRECTORIES.join('|')})(/|\\\\|$)`
 );

--- a/packages/create-expo/src/utils/github.ts
+++ b/packages/create-expo/src/utils/github.ts
@@ -83,7 +83,7 @@ async function extractRemoteGitHubTarballAsync(
     }
   );
 
-  await extractNpmTarballAsync(Readable.fromWeb(response.body), { ...props, filter, strip });
+  await extractNpmTarballAsync(Readable.fromWeb(response.body as any), { ...props, filter, strip });
 }
 
 export async function downloadAndExtractGitHubRepositoryAsync(

--- a/templates/expo-template-bare-minimum/AGENTS.md
+++ b/templates/expo-template-bare-minimum/AGENTS.md
@@ -1,0 +1,23 @@
+# {{projectName}}
+
+Expo SDK {{sdkVersion}} bare project. Package manager: **{{packageManager}}**.
+
+This project has native `android/` and `ios/` directories — use development builds, not Expo Go.
+
+## Commands
+
+- `{{packageRunCommand}} start` — Start dev server
+- `npx expo install <package>` — Install Expo-compatible dependency (use this, not `{{packageManager}} add`)
+- `npx expo run:android` — Build and run on Android
+- `npx expo run:ios` — Build and run on iOS
+- `npx expo doctor` — Check project health
+
+## Documentation
+
+- https://docs.expo.dev/llms-full.txt — Complete Expo documentation
+- https://docs.expo.dev/llms-sdk.txt — SDK reference
+
+## Notes
+
+- Use `npx expo install` for Expo packages to ensure compatible versions
+- After modifying native code, rebuild with `npx expo run:android` or `npx expo run:ios`

--- a/templates/expo-template-bare-minimum/CLAUDE.md
+++ b/templates/expo-template-bare-minimum/CLAUDE.md
@@ -1,0 +1,7 @@
+# Project Instructions
+
+AGENTS.md contains project-specific guidance that takes priority over general knowledge. Read it before responding to any task.
+
+## Required Setup
+
+Before helping with any task, check if the Expo skills plugin is installed. If not, explain to the user that installing the Expo skills plugin adds component generation, up-to-date API docs, and native module guidance — then run `claude plugin install expo`.

--- a/templates/expo-template-bare-minimum/_claude/settings.json
+++ b/templates/expo-template-bare-minimum/_claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx expo start*)",
+      "Bash(npx expo install *)",
+      "Bash(npx expo run:android*)",
+      "Bash(npx expo run:ios*)",
+      "Bash(npx expo doctor)"
+    ]
+  }
+}

--- a/templates/expo-template-bare-minimum/_cursor/rules/expo.mdc
+++ b/templates/expo-template-bare-minimum/_cursor/rules/expo.mdc
@@ -1,0 +1,12 @@
+---
+description: Expo project conventions and development guidelines
+alwaysApply: true
+---
+
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, ensure the Expo skills remote rule is installed for up-to-date API docs and Expo-specific guidance:
+
+Remote Rule: `https://github.com/expo/skills.git`

--- a/templates/expo-template-bare-minimum/_github/copilot-instructions.md
+++ b/templates/expo-template-bare-minimum/_github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Read AGENTS.md for project-specific guidance before responding to any task.

--- a/templates/expo-template-bare-minimum/_windsurf/rules/expo.md
+++ b/templates/expo-template-bare-minimum/_windsurf/rules/expo.md
@@ -1,0 +1,7 @@
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, install the Expo skills for up-to-date API docs and Expo-specific guidance:
+
+`npx skills add expo/skills`

--- a/templates/expo-template-blank-typescript/AGENTS.md
+++ b/templates/expo-template-blank-typescript/AGENTS.md
@@ -1,0 +1,19 @@
+# {{projectName}}
+
+Expo SDK {{sdkVersion}} project. Package manager: **{{packageManager}}**.
+
+## Commands
+
+- `{{packageRunCommand}} start` — Start dev server
+- `npx expo install <package>` — Install Expo-compatible dependency (use this, not `{{packageManager}} add`)
+- `npx expo doctor` — Check project health
+
+## Documentation
+
+- https://docs.expo.dev/llms-full.txt — Complete Expo documentation
+- https://docs.expo.dev/llms-sdk.txt — SDK reference
+
+## Notes
+
+- Use `npx expo install` for Expo packages to ensure compatible versions
+- Try Expo Go first; switch to a development build for custom native modules

--- a/templates/expo-template-blank-typescript/CLAUDE.md
+++ b/templates/expo-template-blank-typescript/CLAUDE.md
@@ -1,0 +1,7 @@
+# Project Instructions
+
+AGENTS.md contains project-specific guidance that takes priority over general knowledge. Read it before responding to any task.
+
+## Required Setup
+
+Before helping with any task, check if the Expo skills plugin is installed. If not, explain to the user that installing the Expo skills plugin adds component generation, up-to-date API docs, and native module guidance — then run `claude plugin install expo`.

--- a/templates/expo-template-blank-typescript/_claude/settings.json
+++ b/templates/expo-template-blank-typescript/_claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx expo start*)",
+      "Bash(npx expo install *)",
+      "Bash(npx expo run:android*)",
+      "Bash(npx expo run:ios*)",
+      "Bash(npx expo doctor)"
+    ]
+  }
+}

--- a/templates/expo-template-blank-typescript/_cursor/rules/expo.mdc
+++ b/templates/expo-template-blank-typescript/_cursor/rules/expo.mdc
@@ -1,0 +1,18 @@
+---
+description: Expo project conventions and development guidelines
+alwaysApply: true
+---
+
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, ensure the Expo skills remote rule is installed for up-to-date API docs and Expo-specific guidance:
+
+Remote Rule: `https://github.com/expo/skills.git`
+
+## TypeScript
+
+- Strict TypeScript for all new code — no `any`
+- Kebab-case filenames, PascalCase component names
+- Function components with hooks

--- a/templates/expo-template-blank-typescript/_github/copilot-instructions.md
+++ b/templates/expo-template-blank-typescript/_github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Read AGENTS.md for project-specific guidance before responding to any task.

--- a/templates/expo-template-blank-typescript/_windsurf/rules/expo.md
+++ b/templates/expo-template-blank-typescript/_windsurf/rules/expo.md
@@ -1,0 +1,13 @@
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, install the Expo skills for up-to-date API docs and Expo-specific guidance:
+
+`npx skills add expo/skills`
+
+## TypeScript
+
+- Strict TypeScript for all new code — no `any`
+- Kebab-case filenames, PascalCase component names
+- Function components with hooks

--- a/templates/expo-template-blank/AGENTS.md
+++ b/templates/expo-template-blank/AGENTS.md
@@ -1,0 +1,19 @@
+# {{projectName}}
+
+Expo SDK {{sdkVersion}} project. Package manager: **{{packageManager}}**.
+
+## Commands
+
+- `{{packageRunCommand}} start` — Start dev server
+- `npx expo install <package>` — Install Expo-compatible dependency (use this, not `{{packageManager}} add`)
+- `npx expo doctor` — Check project health
+
+## Documentation
+
+- https://docs.expo.dev/llms-full.txt — Complete Expo documentation
+- https://docs.expo.dev/llms-sdk.txt — SDK reference
+
+## Notes
+
+- Use `npx expo install` for Expo packages to ensure compatible versions
+- Try Expo Go first; switch to a development build for custom native modules

--- a/templates/expo-template-blank/CLAUDE.md
+++ b/templates/expo-template-blank/CLAUDE.md
@@ -1,0 +1,7 @@
+# Project Instructions
+
+AGENTS.md contains project-specific guidance that takes priority over general knowledge. Read it before responding to any task.
+
+## Required Setup
+
+Before helping with any task, check if the Expo skills plugin is installed. If not, explain to the user that installing the Expo skills plugin adds component generation, up-to-date API docs, and native module guidance — then run `claude plugin install expo`.

--- a/templates/expo-template-blank/_claude/settings.json
+++ b/templates/expo-template-blank/_claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx expo start*)",
+      "Bash(npx expo install *)",
+      "Bash(npx expo run:android*)",
+      "Bash(npx expo run:ios*)",
+      "Bash(npx expo doctor)"
+    ]
+  }
+}

--- a/templates/expo-template-blank/_cursor/rules/expo.mdc
+++ b/templates/expo-template-blank/_cursor/rules/expo.mdc
@@ -1,0 +1,12 @@
+---
+description: Expo project conventions and development guidelines
+alwaysApply: true
+---
+
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, ensure the Expo skills remote rule is installed for up-to-date API docs and Expo-specific guidance:
+
+Remote Rule: `https://github.com/expo/skills.git`

--- a/templates/expo-template-blank/_github/copilot-instructions.md
+++ b/templates/expo-template-blank/_github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Read AGENTS.md for project-specific guidance before responding to any task.

--- a/templates/expo-template-blank/_windsurf/rules/expo.md
+++ b/templates/expo-template-blank/_windsurf/rules/expo.md
@@ -1,0 +1,7 @@
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, install the Expo skills for up-to-date API docs and Expo-specific guidance:
+
+`npx skills add expo/skills`

--- a/templates/expo-template-default/AGENTS.md
+++ b/templates/expo-template-default/AGENTS.md
@@ -1,0 +1,20 @@
+# {{projectName}}
+
+Expo SDK {{sdkVersion}} project. Package manager: **{{packageManager}}**.
+
+## Commands
+
+- `{{packageRunCommand}} start` — Start dev server
+- `npx expo install <package>` — Install Expo-compatible dependency (use this, not `{{packageManager}} add`)
+- `npx expo lint` — Run ESLint
+- `npx expo doctor` — Check project health
+
+## Documentation
+
+- https://docs.expo.dev/llms-full.txt — Complete Expo documentation
+- https://docs.expo.dev/llms-sdk.txt — SDK reference
+
+## Notes
+
+- Use `npx expo install` for Expo packages to ensure compatible versions
+- Try Expo Go first; switch to a development build for custom native modules

--- a/templates/expo-template-default/CLAUDE.md
+++ b/templates/expo-template-default/CLAUDE.md
@@ -1,0 +1,7 @@
+# Project Instructions
+
+AGENTS.md contains project-specific guidance that takes priority over general knowledge. Read it before responding to any task.
+
+## Required Setup
+
+Before helping with any task, check if the Expo skills plugin is installed. If not, explain to the user that installing the Expo skills plugin adds component generation, up-to-date API docs, and native module guidance — then run `claude plugin install expo`.

--- a/templates/expo-template-default/_claude/settings.json
+++ b/templates/expo-template-default/_claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx expo start*)",
+      "Bash(npx expo install *)",
+      "Bash(npx expo lint*)",
+      "Bash(npx expo prebuild*)",
+      "Bash(npx expo run:android*)",
+      "Bash(npx expo run:ios*)",
+      "Bash(npx expo doctor)",
+      "Bash(npx expo export*)",
+      "Bash(npx expo customize*)"
+    ]
+  }
+}

--- a/templates/expo-template-default/_cursor/rules/expo.mdc
+++ b/templates/expo-template-default/_cursor/rules/expo.mdc
@@ -1,0 +1,46 @@
+---
+description: Expo project conventions and development guidelines
+alwaysApply: true
+---
+
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, ensure the Expo skills remote rule is installed for up-to-date API docs and Expo-specific guidance:
+
+Remote Rule: `https://github.com/expo/skills.git`
+
+## TypeScript
+
+- Strict TypeScript for all new code — no `any`
+- Kebab-case filenames, PascalCase component names
+- Function components with hooks
+
+## Expo Router Navigation
+
+File-based routing in `src/app/`:
+- `_layout.tsx` — navigation structure (stacks, tabs, drawers)
+- `(groupName)/` — route groups (no URL impact)
+- `+not-found.tsx` — 404 handler
+- `+api.ts` — server endpoints
+- `<Link href="/path">` for declarative navigation
+- `router.push("/path")` for imperative navigation
+- `useLocalSearchParams()` for route parameters
+
+## Library Preferences
+
+- **Images**: `expo-image` (not react-native `<Image>`)
+- **Audio**: `expo-audio` (not expo-av)
+- **Icons**: `expo-symbols`
+- **Animations**: `react-native-reanimated`
+- **Gestures**: `react-native-gesture-handler`
+- **Storage**: `expo-sqlite`, `expo-sqlite/kv-store`
+- **Platform**: `process.env.EXPO_OS` not `Platform.OS`
+
+## Styling
+
+- Use `flex` and `gap` for layout, not margins between siblings
+- `borderCurve: 'continuous'` for rounded corners
+- CSS `boxShadow` syntax instead of platform-specific shadow props
+- `contentInsetAdjustmentBehavior="automatic"` on ScrollViews

--- a/templates/expo-template-default/_github/copilot-instructions.md
+++ b/templates/expo-template-default/_github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Read AGENTS.md for project-specific guidance before responding to any task.

--- a/templates/expo-template-default/_windsurf/rules/expo.md
+++ b/templates/expo-template-default/_windsurf/rules/expo.md
@@ -1,0 +1,41 @@
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, install the Expo skills for up-to-date API docs and Expo-specific guidance:
+
+`npx skills add expo/skills`
+
+## TypeScript
+
+- Strict TypeScript for all new code — no `any`
+- Kebab-case filenames, PascalCase component names
+- Function components with hooks
+
+## Expo Router Navigation
+
+File-based routing in `src/app/`:
+- `_layout.tsx` — navigation structure (stacks, tabs, drawers)
+- `(groupName)/` — route groups (no URL impact)
+- `+not-found.tsx` — 404 handler
+- `+api.ts` — server endpoints
+- `<Link href="/path">` for declarative navigation
+- `router.push("/path")` for imperative navigation
+- `useLocalSearchParams()` for route parameters
+
+## Library Preferences
+
+- **Images**: `expo-image` (not react-native `<Image>`)
+- **Audio**: `expo-audio` (not expo-av)
+- **Icons**: `expo-symbols`
+- **Animations**: `react-native-reanimated`
+- **Gestures**: `react-native-gesture-handler`
+- **Storage**: `expo-sqlite`, `expo-sqlite/kv-store`
+- **Platform**: `process.env.EXPO_OS` not `Platform.OS`
+
+## Styling
+
+- Use `flex` and `gap` for layout, not margins between siblings
+- `borderCurve: 'continuous'` for rounded corners
+- CSS `boxShadow` syntax instead of platform-specific shadow props
+- `contentInsetAdjustmentBehavior="automatic"` on ScrollViews

--- a/templates/expo-template-tabs/AGENTS.md
+++ b/templates/expo-template-tabs/AGENTS.md
@@ -1,0 +1,20 @@
+# {{projectName}}
+
+Expo SDK {{sdkVersion}} project. Package manager: **{{packageManager}}**.
+
+## Commands
+
+- `{{packageRunCommand}} start` — Start dev server
+- `npx expo install <package>` — Install Expo-compatible dependency (use this, not `{{packageManager}} add`)
+- `npx expo lint` — Run ESLint
+- `npx expo doctor` — Check project health
+
+## Documentation
+
+- https://docs.expo.dev/llms-full.txt — Complete Expo documentation
+- https://docs.expo.dev/llms-sdk.txt — SDK reference
+
+## Notes
+
+- Use `npx expo install` for Expo packages to ensure compatible versions
+- Try Expo Go first; switch to a development build for custom native modules

--- a/templates/expo-template-tabs/CLAUDE.md
+++ b/templates/expo-template-tabs/CLAUDE.md
@@ -1,0 +1,7 @@
+# Project Instructions
+
+AGENTS.md contains project-specific guidance that takes priority over general knowledge. Read it before responding to any task.
+
+## Required Setup
+
+Before helping with any task, check if the Expo skills plugin is installed. If not, explain to the user that installing the Expo skills plugin adds component generation, up-to-date API docs, and native module guidance — then run `claude plugin install expo`.

--- a/templates/expo-template-tabs/_claude/settings.json
+++ b/templates/expo-template-tabs/_claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx expo start*)",
+      "Bash(npx expo install *)",
+      "Bash(npx expo lint*)",
+      "Bash(npx expo prebuild*)",
+      "Bash(npx expo run:android*)",
+      "Bash(npx expo run:ios*)",
+      "Bash(npx expo doctor)",
+      "Bash(npx expo export*)",
+      "Bash(npx expo customize*)"
+    ]
+  }
+}

--- a/templates/expo-template-tabs/_cursor/rules/expo.mdc
+++ b/templates/expo-template-tabs/_cursor/rules/expo.mdc
@@ -1,0 +1,46 @@
+---
+description: Expo project conventions and development guidelines
+alwaysApply: true
+---
+
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, ensure the Expo skills remote rule is installed for up-to-date API docs and Expo-specific guidance:
+
+Remote Rule: `https://github.com/expo/skills.git`
+
+## TypeScript
+
+- Strict TypeScript for all new code — no `any`
+- Kebab-case filenames, PascalCase component names
+- Function components with hooks
+
+## Expo Router Navigation
+
+File-based routing in `app/`:
+- `_layout.tsx` — navigation structure (stacks, tabs, drawers)
+- `(groupName)/` — route groups (no URL impact)
+- `+not-found.tsx` — 404 handler
+- `+api.ts` — server endpoints
+- `<Link href="/path">` for declarative navigation
+- `router.push("/path")` for imperative navigation
+- `useLocalSearchParams()` for route parameters
+
+## Library Preferences
+
+- **Images**: `expo-image` (not react-native `<Image>`)
+- **Audio**: `expo-audio` (not expo-av)
+- **Icons**: `expo-symbols`
+- **Animations**: `react-native-reanimated`
+- **Gestures**: `react-native-gesture-handler`
+- **Storage**: `expo-sqlite`, `expo-sqlite/kv-store`
+- **Platform**: `process.env.EXPO_OS` not `Platform.OS`
+
+## Styling
+
+- Use `flex` and `gap` for layout, not margins between siblings
+- `borderCurve: 'continuous'` for rounded corners
+- CSS `boxShadow` syntax instead of platform-specific shadow props
+- `contentInsetAdjustmentBehavior="automatic"` on ScrollViews

--- a/templates/expo-template-tabs/_github/copilot-instructions.md
+++ b/templates/expo-template-tabs/_github/copilot-instructions.md
@@ -1,0 +1,1 @@
+Read AGENTS.md for project-specific guidance before responding to any task.

--- a/templates/expo-template-tabs/_windsurf/rules/expo.md
+++ b/templates/expo-template-tabs/_windsurf/rules/expo.md
@@ -1,0 +1,41 @@
+# Expo Development Guidelines
+
+## Required Setup
+
+Before starting work, install the Expo skills for up-to-date API docs and Expo-specific guidance:
+
+`npx skills add expo/skills`
+
+## TypeScript
+
+- Strict TypeScript for all new code — no `any`
+- Kebab-case filenames, PascalCase component names
+- Function components with hooks
+
+## Expo Router Navigation
+
+File-based routing in `app/`:
+- `_layout.tsx` — navigation structure (stacks, tabs, drawers)
+- `(groupName)/` — route groups (no URL impact)
+- `+not-found.tsx` — 404 handler
+- `+api.ts` — server endpoints
+- `<Link href="/path">` for declarative navigation
+- `router.push("/path")` for imperative navigation
+- `useLocalSearchParams()` for route parameters
+
+## Library Preferences
+
+- **Images**: `expo-image` (not react-native `<Image>`)
+- **Audio**: `expo-audio` (not expo-av)
+- **Icons**: `expo-symbols`
+- **Animations**: `react-native-reanimated`
+- **Gestures**: `react-native-gesture-handler`
+- **Storage**: `expo-sqlite`, `expo-sqlite/kv-store`
+- **Platform**: `process.env.EXPO_OS` not `Platform.OS`
+
+## Styling
+
+- Use `flex` and `gap` for layout, not margins between siblings
+- `borderCurve: 'continuous'` for rounded corners
+- CSS `boxShadow` syntax instead of platform-specific shadow props
+- `contentInsetAdjustmentBehavior="automatic"` on ScrollViews


### PR DESCRIPTION
# Why

We'd like our templates to include md-files for agents so that we can help the agent understand better how to get started using expo after running `npx create-expo-app`.

**This PR is a draft so far until our Skills plugin on the Claude marketplace is approved!**

This commit adds support for the template asking the user to select one or more agent too to add support for - and will write short and to-the-point agent files for the selected tools.

Main goal of the guides are to make sure we install expo skills.

# How

- Clean separation: AGENTS.md as the shared file all tools read, plus tool-specific config files (CLAUDE.md, .claude/, .cursor/, .windsurf/)
- Placeholder system ({{projectName}}, {{packageManager}}, etc.) with post-extraction replacement is a nice approach
- Interactive multiselect prompt with escape-to-skip, plus CLI flag --agents claude,cursor for scripted use
- Unselected agents' files get cleaned up; if no agents selected, AGENTS.md is removed too
- Tests cover the key paths well (selection, cleanup, placeholders, edge cases)

# Test Plan

Install templates and follow instructions - test that agent files are triggered after setup:

1. Start the agentic environment you are testing for
2. Ask something like - "I'm new to Expo, how should I get started"?
3. Ensure that Expo skills are downloaded and installed.

Tips: You can also ask the agent questions about triggering like this:
"I'm debugging my agents.md file, and would like you to tell me if you used it to help me in the previous question."

Test in
- Claude code
- Cursor
- Windsurf
- Copilot

<details>
<summary>
You can test this manually without publishing the templates using this script - it also ends with instructions on how to test it manually. Run in `packages/create-expo` folder.
</summary>

```bash
#!/bin/bash
set -e

REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
CREATE_EXPO="$REPO_ROOT/packages/create-expo"
TEMPLATES_DIR="$REPO_ROOT/templates"
TARBALLS_DIR="/tmp/expo-agent-test/tarballs"
PROJECTS_DIR="/tmp/expo-agent-test/projects"

# Clean up previous runs
rm -rf /tmp/expo-agent-test
mkdir -p "$TARBALLS_DIR" "$PROJECTS_DIR"

# Build create-expo
echo "==> Building create-expo..."
cd "$CREATE_EXPO" && yarn build

# Pack all templates
echo "==> Packing templates..."
for tpl in "$TEMPLATES_DIR"/expo-template-*; do
  name=$(basename "$tpl")
  echo "    $name"
  (cd "$tpl" && npm pack --pack-destination "$TARBALLS_DIR" 2>/dev/null)
done

resolve_tarball() {
  ls "$TARBALLS_DIR"/$1-*.tgz 2>/dev/null | head -1
}

run_test() {
  local name="$1"
  local template="$2"
  shift 2
  local tarball
  tarball=$(resolve_tarball "$template")
  if [ -z "$tarball" ]; then
    echo "SKIP: no tarball for $template"
    return
  fi
  echo ""
  echo "==> Test: $name (template: $template)"
  echo "    Args: $*"
  node "$CREATE_EXPO/build/index.js" "$PROJECTS_DIR/$name" --template "$tarball" --no-install "$@"
}

verify() {
  local project="$PROJECTS_DIR/$1"
  shift
  echo "    Checking $project..."
  local ok=true
  for spec in "$@"; do
    local expect="${spec:0:1}"
    local path="${spec:1}"
    if [ "$expect" = "+" ]; then
      if [ ! -e "$project/$path" ]; then
        echo "    FAIL: expected $path to exist"
        ok=false
      fi
    elif [ "$expect" = "-" ]; then
      if [ -e "$project/$path" ]; then
        echo "    FAIL: expected $path to NOT exist"
        ok=false
      fi
    fi
  done
  $ok && echo "    PASS"
}

verify_content() {
  local file="$PROJECTS_DIR/$1"
  local pattern="$2"
  if grep -q "$pattern" "$file" 2>/dev/null; then
    echo "    PASS: '$pattern' found in $1"
  else
    echo "    FAIL: '$pattern' NOT found in $1"
  fi
}

verify_no_content() {
  local file="$PROJECTS_DIR/$1"
  local pattern="$2"
  if grep -q "$pattern" "$file" 2>/dev/null; then
    echo "    FAIL: '$pattern' should NOT be in $1"
  else
    echo "    PASS: '$pattern' not in $1"
  fi
}

echo ""
echo "========================================"
echo "Test 1: --agents claude (only Claude)"
echo "========================================"
run_test "test-claude" "expo-template-default" --agents claude
verify "test-claude" \
  "+AGENTS.md" "+CLAUDE.md" "+.claude" \
  "-.cursor" "-.windsurf" "-.github/copilot-instructions.md"

echo ""
echo "========================================"
echo "Test 2: --agents claude,cursor"
echo "========================================"
run_test "test-multi" "expo-template-default" --agents claude,cursor
verify "test-multi" \
  "+AGENTS.md" "+CLAUDE.md" "+.claude" "+.cursor" \
  "-.windsurf" "-.github/copilot-instructions.md"

echo ""
echo "========================================"
echo "Test 3: --yes (skip agents, remove all)"
echo "========================================"
run_test "test-yes" "expo-template-default" --yes
verify "test-yes" \
  "-AGENTS.md" "-CLAUDE.md" "-.claude" "-.cursor" "-.windsurf" \
  "-.github/copilot-instructions.md"

echo ""
echo "========================================"
echo "Test 4: --agents copilot (AGENTS.md + copilot-instructions)"
echo "========================================"
run_test "test-copilot" "expo-template-default" --agents copilot
verify "test-copilot" \
  "+AGENTS.md" "+.github/copilot-instructions.md" \
  "-CLAUDE.md" "-.claude" "-.cursor" "-.windsurf"

echo ""
echo "========================================"
echo "Test 5: tabs template --agents windsurf"
echo "========================================"
run_test "test-tabs" "expo-template-tabs" --agents windsurf
verify "test-tabs" \
  "+AGENTS.md" "+.windsurf" \
  "-CLAUDE.md" "-.claude" "-.cursor" "-.github/copilot-instructions.md"

echo ""
echo "========================================"
echo "Test 6: --agents other (AGENTS.md only)"
echo "========================================"
run_test "test-other" "expo-template-default" --agents other
verify "test-other" \
  "+AGENTS.md" \
  "-CLAUDE.md" "-.claude" "-.cursor" "-.windsurf" "-.github/copilot-instructions.md"

echo ""
echo "========================================"
echo "Test 7: Placeholder replacement (npm)"
echo "========================================"
# npm is the default package manager when run via node directly
verify_content "test-claude/AGENTS.md" "Package manager: \*\*npm\*\*"
verify_content "test-claude/AGENTS.md" "npm run start"
verify_no_content "test-claude/AGENTS.md" "{{packageManager}}"
verify_no_content "test-claude/AGENTS.md" "{{projectName}}"

echo ""
echo "========================================"
echo "Test 8: CLAUDE.md references AGENTS.md and skills"
echo "========================================"
verify_content "test-claude/CLAUDE.md" "AGENTS.md"
verify_content "test-claude/CLAUDE.md" "claude plugin install expo"

echo ""
echo "========================================"
echo "Test 9: copilot-instructions.md references AGENTS.md"
echo "========================================"
verify_content "test-copilot/.github/copilot-instructions.md" "AGENTS.md"

echo ""
echo "========================================"
echo "All automated tests done!"
echo "========================================"
echo ""
echo "To test the interactive prompt manually:"
echo "  node $CREATE_EXPO/build/index.js /tmp/expo-agent-test/projects/test-interactive \\"
echo "    --template \$(ls $TARBALLS_DIR/expo-template-default-*.tgz) --no-install"
echo ""
echo "Clean up with: rm -rf /tmp/expo-agent-test"

```
</details>