### PR TITLE
[docs] Fix app config example invalid syntax in ImagePicker

### DIFF
--- a/docs/pages/versions/unversioned/sdk/imagepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/imagepicker.mdx
@@ -43,6 +43,7 @@ By default `expo-image-picker` will add `RECORD_AUDIO` permission on Android. Yo
 
 <ConfigPluginExample>
 
+{/* prettier-ignore */}
 ```json app.json
 {
   "expo": {
@@ -50,13 +51,13 @@ By default `expo-image-picker` will add `RECORD_AUDIO` permission on Android. Yo
       [
         "expo-image-picker",
         {
-          "photosPermission": "The app accesses your photos to let you share them with your friends."
+          "photosPermission": "The app accesses your photos to let you share them with your friends.",
           "colors": {
-            "cropToolbarColor": "#000000",
+            "cropToolbarColor": "#000000"
           },
           "dark": {
             "colors": {
-              "cropToolbarColor": "#000000",
+              "cropToolbarColor": "#000000"
             }
           }
         }

--- a/docs/pages/versions/v55.0.0/sdk/imagepicker.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/imagepicker.mdx
@@ -43,6 +43,7 @@ By default `expo-image-picker` will add `RECORD_AUDIO` permission on Android. Yo
 
 <ConfigPluginExample>
 
+{/* prettier-ignore */}
 ```json app.json
 {
   "expo": {
@@ -50,13 +51,13 @@ By default `expo-image-picker` will add `RECORD_AUDIO` permission on Android. Yo
       [
         "expo-image-picker",
         {
-          "photosPermission": "The app accesses your photos to let you share them with your friends."
+          "photosPermission": "The app accesses your photos to let you share them with your friends.",
           "colors": {
-            "cropToolbarColor": "#000000",
+            "cropToolbarColor": "#000000"
           },
           "dark": {
             "colors": {
-              "cropToolbarColor": "#000000",
+              "cropToolbarColor": "#000000"
             }
           }
         }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/44282

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix app config example invalid syntax in ImagePicker reference for unversioned and SDK 55.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
