### PR TITLE
[autolinking] Remove ReactCodegen build phase workaround for fixed upstream RN issue 54066

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 💡 Others
 
-- [iOS] removed fix for FB 54066 which is now merged and ready to be used. Introduced in #40219.
+- [iOS] removed fix for FB 54066 which is now merged and ready to be used. Introduced in #40219. ([#44290](https://github.com/expo/expo/pull/44290) by [@chrfalch](https://github.com/chrfalch))
 - Add `package.json:exports` with no-op reexport paths ([#44002](https://github.com/expo/expo/pull/44002) by [@kitten](https://github.com/kitten), [@hassankhan](https://github.com/hassankhan))
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 💡 Others
 
+- [iOS] removed fix for FB 54066 which is now merged and ready to be used. Introduced in #40219.
 - Add `package.json:exports` with no-op reexport paths ([#44002](https://github.com/expo/expo/pull/44002) by [@kitten](https://github.com/kitten), [@hassankhan](https://github.com/hassankhan))
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -22,91 +22,9 @@ module Pod
   class Installer
     private
 
-    _original_perform_post_install_actions = instance_method(:perform_post_install_actions)
     _original_run_podfile_pre_install_hooks = instance_method(:run_podfile_pre_install_hooks)
-    _script_phase_name = '[Expo Autolinking] Run Codegen with autolinking'
 
     public
-
-    define_method(:perform_post_install_actions) do
-
-      # Call original implementation first
-      _original_perform_post_install_actions.bind(self).()
-
-      # Next we'll perform an Expo workaround for Codegen in React Native where it uses the wrong output path for
-      # the generated files. This can be remove when the following PR is merged and released upstream:
-      # https://github.com/facebook/react-native/pull/54066
-      # TODO: chrfalch - remove when RN PR is released
-      # Find the ReactCodegen pod target in the pods project
-      react_codegen_native_target = self.pods_project.targets.find { |target| target.name == 'ReactCodegen' }
-
-      if react_codegen_native_target
-        # Check if the build phase already exists
-        already_exists = react_codegen_native_target.build_phases.any? do |phase|
-          phase.is_a?(Xcodeproj::Project::Object::PBXShellScriptBuildPhase) && phase.name == _script_phase_name
-        end
-
-        if !already_exists
-          Pod::UI.puts "[Expo] ".blue + "Adding '#{_script_phase_name}' build phase to ReactCodegen"
-
-          # Create the new shell script build phase
-          phase = react_codegen_native_target.new_shell_script_build_phase(_script_phase_name)
-          phase.shell_path = '/bin/sh'
-          phase.shell_script = <<~SH
-            # Remove this step when the fix is merged and released.
-            # See: https://github.com/facebook/react-native/pull/54066
-
-            # This re-runs Codegen without the broken "scripts/react_native_pods_utils/script_phases.sh" script, causing Codegen to run without autolinking.
-            # Instead of using "script_phases.sh" which always runs inside DerivedData, we run it in the normal "/ios" folder
-            # See: https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/react_native_pods_utils/script_phases.sh
-            pushd "$PODS_ROOT/../" > /dev/null
-              RCT_SCRIPT_POD_INSTALLATION_ROOT="$PODS_ROOT/.."
-            popd >/dev/null
-
-            export RCT_SCRIPT_RN_DIR="$REACT_NATIVE_PATH" # This is set by Expo
-            export RCT_SCRIPT_APP_PATH="$RCT_SCRIPT_POD_INSTALLATION_ROOT/.."
-            export RCT_SCRIPT_OUTPUT_DIR="$RCT_SCRIPT_POD_INSTALLATION_ROOT"
-            export RCT_SCRIPT_TYPE="withCodegenDiscovery"
-
-            # This is the broken script that runs inside DerivedData, meaning it can't find the autolinking result in `ios/build/generated/autolinking.json`.
-            # Resulting in Codegen running with it's own autolinking, not discovering transitive peer dependencies.
-            # export SCRIPT_PHASES_SCRIPT="$RCT_SCRIPT_RN_DIR/scripts/react_native_pods_utils/script_phases.sh"
-            export WITH_ENVIRONMENT="$RCT_SCRIPT_RN_DIR/scripts/xcode/with-environment.sh"
-
-            # Start of workaround code
-
-            # Load the $NODE_BINARY from the "with-environment.sh" script
-            source "$WITH_ENVIRONMENT"
-
-            # Run this script directly in the right folders:
-            # https://github.com/facebook/react-native/blob/3f7f9d8fb8beb41408d092870a7c7cac58029a4d/packages/react-native/scripts/react_native_pods_utils/script_phases.sh#L96-L101
-            pushd "$RCT_SCRIPT_RN_DIR" >/dev/null || exit 1
-              set -x
-              "$NODE_BINARY" "scripts/generate-codegen-artifacts.js" --path "$RCT_SCRIPT_APP_PATH" --outputPath "$RCT_SCRIPT_OUTPUT_DIR" --targetPlatform "ios"
-              set +x
-            popd >/dev/null || exit 1
-
-            # End of workaround code
-          SH
-
-          # Find the index of the "Compile Sources" phase (PBXSourcesBuildPhase)
-          compile_sources_index = react_codegen_native_target.build_phases.find_index do |p|
-            p.is_a?(Xcodeproj::Project::Object::PBXSourcesBuildPhase)
-          end
-
-          if compile_sources_index
-            # Remove the phase from its current position (it was added at the end)
-            react_codegen_native_target.build_phases.delete(phase)
-            # Insert it before the "Compile Sources" phase
-            react_codegen_native_target.build_phases.insert(compile_sources_index, phase)
-          else
-            Pod::UI.puts "[Expo] ".yellow + "Could not find 'Compile Sources' phase, build phase added at default position"
-          end
-        end
-      else
-        Pod::UI.puts "[Expo] ".yellow + "ReactCodegen target not found in pods project"
-      end
-    end
 
     define_method(:run_podfile_pre_install_hooks) do
       # Call original implementation first


### PR DESCRIPTION
# Why

The workaround for facebook/react-native#54066 is no longer needed now that the fix has been merged and released upstream.

# How

Removed the code that was added in #40219 now that the original PR in FB is merged.

# Test Plan

Build BareExpo multiple times.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
