### PR TITLE
fix(router-e2e): Add missing deps

### DIFF
--- a/apps/router-e2e/package.json
+++ b/apps/router-e2e/package.json
@@ -82,9 +82,11 @@
     "react-native-webview": "13.16.0"
   },
   "devDependencies": {
+    "@types/react": "~19.2.0",
     "compression": "^1.8.0",
     "esbuild": "^0.25.8",
     "express": "^5.1.0",
+    "getenv": "^2.0.0",
     "morgan": "^1.10.0",
     "tailwindcss": "^3.3.5",
     "tiny": "^0.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1353,6 +1353,9 @@ importers:
         specifier: 13.16.0
         version: 13.16.0(react-native@0.85.0-rc.5(@babel/core@7.29.0)(@react-native/jest-preset@0.85.0-rc.5(@babel/core@7.29.0)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
     devDependencies:
+      '@types/react':
+        specifier: ~19.2.0
+        version: 19.2.14
       compression:
         specifier: ^1.8.0
         version: 1.8.1
@@ -1362,6 +1365,9 @@ importers:
       express:
         specifier: ^5.1.0
         version: 5.2.1
+      getenv:
+        specifier: ^2.0.0
+        version: 2.0.0
       morgan:
         specifier: ^1.10.0
         version: 1.10.1


### PR DESCRIPTION
# Why

Minor missing dependencies

# How

- Add `getenv`
- Add `@types/react`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
