### PR TITLE
fix(expo-updates): Fix use_dev_client in iOS podspec

### DIFF
--- a/packages/expo-updates/ios/EXUpdates.podspec
+++ b/packages/expo-updates/ios/EXUpdates.podspec
@@ -14,7 +14,8 @@ use_dev_client = false
 begin
   # No dev client if we are using native debug
   if ENV['EX_UPDATES_NATIVE_DEBUG'] != '1'
-    use_dev_client = `node --print "require('expo-dev-client/package.json').version" 2>/dev/null`.length > 0
+    project_root = ENV['PROJECT_ROOT'] || Pod::Config.instance.installation_root.to_s
+    use_dev_client = File.dirname(`node --print "require.resolve('expo-dev-client/package.json', { paths: ['#{__dir__}', '#{project_root}'] })"`).length > 0
   end
 rescue
   use_dev_client = false


### PR DESCRIPTION
# Why

Fix the detection of expo-dev-client dependency in the expo-updates podspec. This is required for updates to be downloadable in the dev launcher.How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

This fixes the updates E2E dev client test in CI.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)