### PR TITLE
[template] Remove react-navigation

### DIFF
--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -12,9 +12,6 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@react-navigation/bottom-tabs": "^7.15.5",
-    "@react-navigation/elements": "^2.9.10",
-    "@react-navigation/native": "^7.1.33",
     "expo": "~55.0.2",
     "expo-constants": "~55.0.7",
     "expo-device": "~55.0.9",

--- a/templates/expo-template-default/src/app/_layout.tsx
+++ b/templates/expo-template-default/src/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
+import { DarkTheme, DefaultTheme, ThemeProvider } from 'expo-router';
 import React from 'react';
 import { useColorScheme } from 'react-native';
 

--- a/templates/expo-template-tabs/app/_layout.tsx
+++ b/templates/expo-template-tabs/app/_layout.tsx
@@ -1,6 +1,5 @@
-import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
+import { DarkTheme, DefaultTheme, Stack, ThemeProvider } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 import 'react-native-reanimated';

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -11,7 +11,6 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@react-navigation/native": "^7.1.33",
     "expo": "~55.0.2",
     "expo-symbols": "~55.0.4",
     "expo-constants": "~55.0.7",


### PR DESCRIPTION
# Why

Expo Router no longer needs react-navigation.

# How

Remove dependencies and use imports from `expo-router`.

# Test Plan

Create apps using new templates.
