### PR TITLE
[location]: make foreground service notification icon fall back to notification_icon

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -96,7 +96,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'androidForegroundServiceIcon',
       platform: 'android',
       description:
-        'Local path to an image to use as the icon for the foreground service started by `startLocationUpdatesAsync`. 96x96 all-white png with transparency. If not set, the app icon will be used.',
+        'Local path to an image to use as the icon for the foreground service started by `startLocationUpdatesAsync`. 96x96 all-white png with transparency. If not set, falls back to the `notification_icon` drawable (configured via `notification.icon` in **app.json**, shared with `expo-notifications`), then to the app launcher icon. The launcher icon is full-color and may render as a solid white square since Android requires notification icons to be monochrome.',
     },
   ]}
 />

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -96,7 +96,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'androidForegroundServiceIcon',
       platform: 'android',
       description:
-        'Local path to an image to use as the icon for the foreground service started by `startLocationUpdatesAsync`. 96x96 all-white png with transparency. If not set, falls back to the `notification_icon` drawable (configured via `notification.icon` in **app.json**, shared with `expo-notifications`), then to the app launcher icon. The launcher icon is full-color and may render as a solid white square since Android requires notification icons to be monochrome.',
+        'Local path to an image to use as the icon for the foreground service started by `startLocationUpdatesAsync`. 96x96 all-white png with transparency. If not set, falls back to the `notification_icon` drawable (configured via app config's `notification.icon`, shared with `expo-notifications`), then to the app launcher icon. The launcher icon is full-color and may render as a solid white square since Android requires notification icons to be monochrome.',
     },
   ]}
 />

--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -96,7 +96,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'androidForegroundServiceIcon',
       platform: 'android',
       description:
-        'Local path to an image to use as the icon for the foreground service started by `startLocationUpdatesAsync`. 96x96 all-white png with transparency. If not set, falls back to the `notification_icon` drawable (configured via app config's `notification.icon`, shared with `expo-notifications`), then to the app launcher icon. The launcher icon is full-color and may render as a solid white square since Android requires notification icons to be monochrome.',
+        'Local path to an image to use as the icon for the foreground service started by `startLocationUpdatesAsync`. 96x96 all-white png with transparency. If not set, falls back to the `notification_icon` drawable (if configured via `expo-notifications` config plugin), then to the app launcher icon. The launcher icon is full-color and may render as a solid white square since Android requires notification icons to be monochrome.',
     },
   ]}
 />

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Foreground service notification icon now falls back to `notification_icon` drawable before `applicationInfo.icon`. The launcher icon is full-color and renders as a solid white square in notifications. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@creatornader](https://github.com/creatornader))
 - [iOS] Ignore [`locationUnknown`](https://developer.apple.com/documentation/corelocation/clerror-swift.struct/locationunknown) errors in `watchPositionAsync`. ([#44027](https://github.com/expo/expo/pull/44027) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Foreground service notification icon now falls back to `notification_icon` drawable before `applicationInfo.icon`. The launcher icon is full-color and renders as a solid white square in notifications. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@creatornader](https://github.com/creatornader))
+- [Android] Foreground service notification icon now falls back to `notification_icon` drawable before `applicationInfo.icon`. The launcher icon is full-color and renders as a solid white square in notifications. ([#44309](https://github.com/expo/expo/pull/XXXX) by [@creatornader](https://github.com/creatornader))
 - [iOS] Ignore [`locationUnknown`](https://developer.apple.com/documentation/corelocation/clerror-swift.struct/locationunknown) errors in `watchPositionAsync`. ([#44027](https://github.com/expo/expo/pull/44027) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Foreground service notification icon now falls back to `notification_icon` drawable before `applicationInfo.icon`. The launcher icon is full-color and renders as a solid white square in notifications. ([#44309](https://github.com/expo/expo/pull/XXXX) by [@creatornader](https://github.com/creatornader))
+- [Android] Foreground service notification icon now falls back to `notification_icon` drawable before `applicationInfo.icon`. The launcher icon is full-color and renders as a solid white square in notifications. ([#44309](https://github.com/expo/expo/pull/44309) by [@creatornader](https://github.com/creatornader))
 - [iOS] Ignore [`locationUnknown`](https://developer.apple.com/documentation/corelocation/clerror-swift.struct/locationunknown) errors in `watchPositionAsync`. ([#44027](https://github.com/expo/expo/pull/44027) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
@@ -98,11 +98,17 @@ class LocationTaskService : Service() {
       if (ai.metaData?.containsKey(META_DATA_FOREGROUND_SERVICE_ICON_KEY) == true) {
         ai.metaData.getInt(META_DATA_FOREGROUND_SERVICE_ICON_KEY)
       } else {
-        applicationInfo.icon
+        // Fall back to the standard notification_icon drawable (configured via app.json
+        // notification.icon, used by expo-notifications). The previous fallback —
+        // applicationInfo.icon — is the full-color launcher icon, which Android renders
+        // as a solid white square in notifications (small icons must be monochrome).
+        mParentContext.resources.getIdentifier("notification_icon", "drawable", mParentContext.packageName)
+          .takeIf { it != 0 } ?: applicationInfo.icon
       }
     } catch (e: Exception) {
       android.util.Log.e("expo-location", "Could not fetch default notification icon.", e)
-      applicationInfo.icon
+      mParentContext.resources.getIdentifier("notification_icon", "drawable", mParentContext.packageName)
+        .takeIf { it != 0 } ?: applicationInfo.icon
     }
 
     return builder.setCategory(Notification.CATEGORY_SERVICE)

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
@@ -125,7 +125,7 @@ class LocationTaskService : Service() {
 
   /**
    * Returns the best available notification icon resource ID.
-   * Prefers the `notification_icon` drawable (configured via app.json notification.icon,
+   * Prefers the `notification_icon` drawable (configured via app config's `notification.icon`,
    * used by expo-notifications) over `applicationInfo.icon`. The launcher icon is
    * full-color and renders as a solid white square in notifications, since Android
    * requires small notification icons to be monochrome.

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
@@ -98,17 +98,11 @@ class LocationTaskService : Service() {
       if (ai.metaData?.containsKey(META_DATA_FOREGROUND_SERVICE_ICON_KEY) == true) {
         ai.metaData.getInt(META_DATA_FOREGROUND_SERVICE_ICON_KEY)
       } else {
-        // Fall back to the standard notification_icon drawable (configured via app.json
-        // notification.icon, used by expo-notifications). The previous fallback —
-        // applicationInfo.icon — is the full-color launcher icon, which Android renders
-        // as a solid white square in notifications (small icons must be monochrome).
-        mParentContext.resources.getIdentifier("notification_icon", "drawable", mParentContext.packageName)
-          .takeIf { it != 0 } ?: applicationInfo.icon
+        getDefaultNotificationIcon()
       }
     } catch (e: Exception) {
       android.util.Log.e("expo-location", "Could not fetch default notification icon.", e)
-      mParentContext.resources.getIdentifier("notification_icon", "drawable", mParentContext.packageName)
-        .takeIf { it != 0 } ?: applicationInfo.icon
+      getDefaultNotificationIcon()
     }
 
     return builder.setCategory(Notification.CATEGORY_SERVICE)
@@ -127,6 +121,18 @@ class LocationTaskService : Service() {
       channel.description = "Background location notification channel"
       notificationManager.createNotificationChannel(channel)
     }
+  }
+
+  /**
+   * Returns the best available notification icon resource ID.
+   * Prefers the `notification_icon` drawable (configured via app.json notification.icon,
+   * used by expo-notifications) over `applicationInfo.icon`. The launcher icon is
+   * full-color and renders as a solid white square in notifications, since Android
+   * requires small notification icons to be monochrome.
+   */
+  private fun getDefaultNotificationIcon(): Int {
+    return mParentContext.resources.getIdentifier("notification_icon", "drawable", mParentContext.packageName)
+      .takeIf { it != 0 } ?: applicationInfo.icon
   }
 
   private fun colorStringToInteger(color: String?): Int? {

--- a/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/services/LocationTaskService.kt
@@ -125,8 +125,7 @@ class LocationTaskService : Service() {
 
   /**
    * Returns the best available notification icon resource ID.
-   * Prefers the `notification_icon` drawable (configured via app config's `notification.icon`,
-   * used by expo-notifications) over `applicationInfo.icon`. The launcher icon is
+   * Prefers the `notification_icon` drawable (configured via configured via expo notifications config plugin ) over `applicationInfo.icon`. The launcher icon is
    * full-color and renders as a solid white square in notifications, since Android
    * requires small notification icons to be monochrome.
    */


### PR DESCRIPTION
## Summary

When `expo.modules.location.foreground_service_icon` metadata is not configured in the AndroidManifest, `LocationTaskService.buildServiceNotification()` falls back to `applicationInfo.icon` — the full-color launcher icon. Android requires notification small icons to be monochrome silhouettes, so this renders as a **solid white square**.

This PR fixes the fallback to check for the `notification_icon` drawable (configured via `app.json` `notification.icon`, used by `expo-notifications`) before falling back to `applicationInfo.icon`.

Related: #44308

## Changes

One file: `LocationTaskService.kt`

**Before:**
```kotlin
} else {
  applicationInfo.icon  // full-color launcher icon → white square
}
```

**After:**
```kotlin
} else {
  mParentContext.resources.getIdentifier("notification_icon", "drawable", mParentContext.packageName)
    .takeIf { it != 0 } ?: applicationInfo.icon
}
```

Same change applied to the `catch` fallback.

## Why this matters

Any app using `Location.startLocationUpdatesAsync()` with `foregroundService` on Android gets a white square notification icon unless they manually configure `expo.modules.location.foreground_service_icon` in the AndroidManifest (which isn't exposed via `app.json`). Most apps already have a proper monochrome `notification_icon` from `expo-notifications` — this PR makes `expo-location` use it.

Without this fix, the only workaround is ASM bytecode patching of the prebuilt AAR's `classes.jar` (`patch-package` on the Kotlin source doesn't work because expo-location ships prebuilt AARs in `local-maven-repo/`).

## Test Plan

1. Create an Expo app with `expo-notifications` configured (`notification.icon` in `app.json`)
2. Call `Location.startLocationUpdatesAsync()` with `foregroundService` options on Android
3. **Before this fix**: notification shows white square (launcher icon)
4. **After this fix**: notification shows the monochrome `notification_icon` drawable

Also verified: when neither `META_DATA_FOREGROUND_SERVICE_ICON_KEY` nor `notification_icon` drawable exists, falls back to `applicationInfo.icon` (same as current behavior).