### PR TITLE
[expo-dev-client] Fix incorrect type import

### DIFF
--- a/packages/expo-dev-client/plugin/build/withDevClient.d.ts
+++ b/packages/expo-dev-client/plugin/build/withDevClient.d.ts
@@ -1,4 +1,4 @@
-import type { PluginConfigType } from 'expo-dev-launcher/plugin';
+import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
 export type DevClientPluginConfigType = PluginConfigType & {
     /**
      * Whether to register a custom URL scheme to open a project.

--- a/packages/expo-dev-client/plugin/src/withDevClient.ts
+++ b/packages/expo-dev-client/plugin/src/withDevClient.ts
@@ -2,7 +2,7 @@ import type { ExpoConfig } from 'expo/config';
 import { createRunOncePlugin } from 'expo/config-plugins';
 // @ts-expect-error missing types
 import withDevLauncher from 'expo-dev-launcher/app.plugin';
-import type { PluginConfigType } from 'expo-dev-launcher/plugin';
+import type { PluginConfigType } from 'expo-dev-launcher/plugin/build/pluginConfig';
 // @ts-expect-error missing types
 import withDevMenu from 'expo-dev-menu/app.plugin';
 

--- a/packages/expo-dev-launcher/plugin/build/index.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/index.d.ts
@@ -1,4 +1,3 @@
 import { PluginConfigType as Props } from './pluginConfig';
-export { PluginConfigType } from './pluginConfig';
 declare const _default: (props?: Props) => [string, Props];
 export default _default;

--- a/packages/expo-dev-launcher/plugin/src/index.ts
+++ b/packages/expo-dev-launcher/plugin/src/index.ts
@@ -1,5 +1,3 @@
 import { PluginConfigType as Props } from './pluginConfig';
 
-export { PluginConfigType } from './pluginConfig';
-
 export default (props: Props = {}): [string, Props] => ['expo-dev-launcher', props];


### PR DESCRIPTION
# Why

Fix incorrect type import after `exports` rollback on the typed plugins branch

# How

- Rollback import path, remove unused type export

# Test Plan

- The check packages CI step

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
