### PR TITLE
[ios][precompile][workflow] add missing expo_root_dir

### DIFF
--- a/.github/workflows/ios-prebuild-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-xcframeworks.yml
@@ -56,7 +56,6 @@ jobs:
 
       - name: Prebuild XCFrameworks (${{ matrix.flavor }})
         env:
-          EXPO_ROOT_DIR: ${{ github.workspace }}
           INPUT_PACKAGES: ${{ github.event.inputs.packages }}
           INPUT_INCLUDE_EXTERNAL: ${{ github.event.inputs.include-external }}
           INPUT_CONCURRENCY: ${{ github.event.inputs.concurrency }}

--- a/.github/workflows/ios-prebuild-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-xcframeworks.yml
@@ -86,3 +86,4 @@ jobs:
           path: packages/precompile/.build/*/output/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
           if-no-files-found: error
           retention-days: 14
+          include-hidden-files: true

--- a/.github/workflows/ios-prebuild-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-xcframeworks.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Prebuild XCFrameworks (${{ matrix.flavor }})
         env:
+          EXPO_ROOT_DIR: ${{ github.workspace }}
           INPUT_PACKAGES: ${{ github.event.inputs.packages }}
           INPUT_INCLUDE_EXTERNAL: ${{ github.event.inputs.include-external }}
           INPUT_CONCURRENCY: ${{ github.event.inputs.concurrency }}


### PR DESCRIPTION
# Why

To make the workflow see artifacts in the .build folder we need to set include-hidden-files: true

This PR fixes this.

The workflow is now green:
https://github.com/expo/expo/actions/runs/23642366693/job/68865948975

And the artifacts are here:
- xcframeworks-Debug (14.6 MB): https://github.com/expo/expo/actions/runs/23642366693/artifacts/6142137231    
- xcframeworks-Release (12.3 MB): https://github.com/expo/expo/actions/runs/23642366693/artifacts/6142118965     

