### PR TITLE
[ios][precompile] skip generating vfs template if it exists.

### DIFF
--- a/tools/src/prebuilds/SPMBuild.test.ts
+++ b/tools/src/prebuilds/SPMBuild.test.ts
@@ -5,11 +5,11 @@
  *  - findFirstExisting
  *  - findXCFrameworkInDir
  */
+import fs from 'fs-extra';
 import assert from 'node:assert/strict';
 import { describe, it, before, after } from 'node:test';
-import fs from 'fs-extra';
-import path from 'path';
 import os from 'os';
+import path from 'path';
 
 import {
   derivePackageName,
@@ -31,10 +31,7 @@ describe('derivePackageName', () => {
   });
 
   it('works without .git suffix', () => {
-    assert.equal(
-      derivePackageName('https://github.com/airbnb/lottie-spm'),
-      'lottie-spm'
-    );
+    assert.equal(derivePackageName('https://github.com/airbnb/lottie-spm'), 'lottie-spm');
   });
 
   it('handles scoped / deeply nested URLs', () => {
@@ -63,10 +60,7 @@ describe('formatVersionRequirement', () => {
   });
 
   it('formats revision version', () => {
-    assert.equal(
-      formatVersionRequirement({ revision: 'abc123' }),
-      'revision: "abc123"'
-    );
+    assert.equal(formatVersionRequirement({ revision: 'abc123' }), 'revision: "abc123"');
   });
 
   it('throws for invalid version', () => {
@@ -139,18 +133,12 @@ describe('findXCFrameworkInDir', () => {
 
   it('finds an xcframework nested in subdirectories', async () => {
     const result = await findXCFrameworkInDir(tmpDir, 'Lottie');
-    assert.equal(
-      result,
-      path.join(tmpDir, 'lottie-spm', 'Lottie', 'Lottie.xcframework')
-    );
+    assert.equal(result, path.join(tmpDir, 'lottie-spm', 'Lottie', 'Lottie.xcframework'));
   });
 
   it('finds a different xcframework', async () => {
     const result = await findXCFrameworkInDir(tmpDir, 'Other');
-    assert.equal(
-      result,
-      path.join(tmpDir, 'other-pkg', 'Other', 'Other.xcframework')
-    );
+    assert.equal(result, path.join(tmpDir, 'other-pkg', 'Other', 'Other.xcframework'));
   });
 
   it('returns null when xcframework does not exist', async () => {

--- a/tools/src/prebuilds/SPMBuild.ts
+++ b/tools/src/prebuilds/SPMBuild.ts
@@ -6,7 +6,12 @@ import path from 'path';
 import type { SPMPackageSource } from './ExternalPackage';
 import { Frameworks } from './Frameworks';
 import { BuildFlavor } from './Prebuilder.types';
-import { BuildPlatform, ProductPlatform, SPMPackageDependencyConfig, SPMProduct } from './SPMConfig.types';
+import {
+  BuildPlatform,
+  ProductPlatform,
+  SPMPackageDependencyConfig,
+  SPMProduct,
+} from './SPMConfig.types';
 import { SPMGenerator } from './SPMGenerator';
 import { createAsyncSpinner } from './Utils';
 import { spawnXcodeBuildWithSpinner } from './XCodeRunner';
@@ -542,7 +547,12 @@ async function patchCheckoutWithSharedDeps(
     content = content.replace(pkgPattern, `.package(path: "${relativePath}")`);
 
     // Binary targets don't expose C headers automatically — collect -I flags
-    const headersDir = path.join(xcframeworkPath, 'ios-arm64', `${productName}.framework`, 'Headers');
+    const headersDir = path.join(
+      xcframeworkPath,
+      'ios-arm64',
+      `${productName}.framework`,
+      'Headers'
+    );
     if (await fs.pathExists(headersDir)) {
       headerSearchFlags.push(`"-I", "${headersDir}"`);
     }
@@ -552,10 +562,7 @@ async function patchCheckoutWithSharedDeps(
   if (headerSearchFlags.length > 0) {
     const flagsStr = `.unsafeFlags([${headerSearchFlags.join(', ')}])`;
     if (content.includes('cSettings:')) {
-      content = content.replace(
-        /cSettings:\s*\[/,
-        `cSettings: [\n                ${flagsStr},`
-      );
+      content = content.replace(/cSettings:\s*\[/, `cSettings: [\n                ${flagsStr},`);
     } else {
       // Add cSettings before the closing `)` of the main .target
       content = content.replace(
@@ -591,7 +598,9 @@ async function enrichFrameworkWithHeaders(
   // Find the `.target(` block that contains `name: "<productName>"` by matching
   // from `.target(` through to `publicHeadersPath` or the closing `)`.
   const targetBlockMatch = checkoutPkgSwift.match(
-    new RegExp(`\\.target\\(\\s*\\n[\\s\\S]*?name:\\s*"${productName}"[\\s\\S]*?(?=\\.target\\(|\\.testTarget\\(|\\.binaryTarget\\(|\\]\\s*[\\n\\r])`)
+    new RegExp(
+      `\\.target\\(\\s*\\n[\\s\\S]*?name:\\s*"${productName}"[\\s\\S]*?(?=\\.target\\(|\\.testTarget\\(|\\.binaryTarget\\(|\\]\\s*[\\n\\r])`
+    )
   );
   const targetBlock = targetBlockMatch ? targetBlockMatch[0] : '';
   const targetPathMatch = targetBlock.match(/\bpath:\s*"([^"]+)"/);
@@ -600,9 +609,7 @@ async function enrichFrameworkWithHeaders(
 
   const headersCandidates = [
     // Explicit publicHeadersPath relative to target path
-    ...(publicHeadersMatch
-      ? [path.join(checkoutDir, targetPath, publicHeadersMatch[1])]
-      : []),
+    ...(publicHeadersMatch ? [path.join(checkoutDir, targetPath, publicHeadersMatch[1])] : []),
     // Default SPM conventions
     path.join(checkoutDir, productName, 'include', productName),
     path.join(checkoutDir, productName, 'include'),
@@ -618,16 +625,30 @@ async function enrichFrameworkWithHeaders(
     // Copy .h files preserving subdirectory structure (e.g., avif/avif.h).
     // Use -L to follow symlinks (some packages symlink umbrella headers from other dirs).
     // --include='*/' keeps subdirectories, --include='*.h' keeps headers, --exclude='*' drops the rest.
-    execSync(`rsync -aL --include='*/' --include='*.h' --exclude='*' "${headersDir}/" "${destHeaders}/"`, { stdio: 'pipe' });
+    execSync(
+      `rsync -aL --include='*/' --include='*.h' --exclude='*' "${headersDir}/" "${destHeaders}/"`,
+      { stdio: 'pipe' }
+    );
   }
 
   // 2. Copy the generated module map
   const modulemapPaths = [
-    path.join(derivedDataPath, 'Build', 'Intermediates.noindex',
-      `GeneratedModuleMaps-${buildFolderPrefix}`, `${productName}.modulemap`),
-    path.join(derivedDataPath, 'Build', 'Intermediates.noindex',
-      `${productName}.build`, `${buildType}-${buildFolderPrefix}`,
-      `${productName}.build`, `${productName}.modulemap`),
+    path.join(
+      derivedDataPath,
+      'Build',
+      'Intermediates.noindex',
+      `GeneratedModuleMaps-${buildFolderPrefix}`,
+      `${productName}.modulemap`
+    ),
+    path.join(
+      derivedDataPath,
+      'Build',
+      'Intermediates.noindex',
+      `${productName}.build`,
+      `${buildType}-${buildFolderPrefix}`,
+      `${productName}.build`,
+      `${productName}.modulemap`
+    ),
   ];
   const modulemapPath = await findFirstExisting(modulemapPaths);
   if (modulemapPath) {
@@ -642,10 +663,7 @@ async function enrichFrameworkWithHeaders(
 
     // The xcodebuild-generated modulemap uses `module X` but inside a .framework
     // bundle it must be `framework module X` so Clang resolves headers from Headers/.
-    modulemapContent = modulemapContent.replace(
-      /^module /m,
-      'framework module '
-    );
+    modulemapContent = modulemapContent.replace(/^module /m, 'framework module ');
 
     if (modulemapContent.includes('umbrella header')) {
       // Single umbrella header — rewrite to just the filename
@@ -671,32 +689,41 @@ async function enrichFrameworkWithHeaders(
       }
     } else {
       // Directory-based umbrella — rewrite to point to the framework's Headers/ dir
-      modulemapContent = modulemapContent.replace(
-        /umbrella "[^"]+"/,
-        'umbrella "Headers"'
-      );
+      modulemapContent = modulemapContent.replace(/umbrella "[^"]+"/, 'umbrella "Headers"');
     }
     await fs.writeFile(path.join(destModules, 'module.modulemap'), modulemapContent, 'utf-8');
   }
 
   // 3. Copy Swift module interfaces if they exist (for Swift packages)
-  const swiftmoduleDir = path.join(derivedDataPath, 'Build', 'Intermediates.noindex',
-    `${productName}.build`, `${buildType}-${buildFolderPrefix}`,
-    `${productName}.build`, 'Objects-normal');
+  const swiftmoduleDir = path.join(
+    derivedDataPath,
+    'Build',
+    'Intermediates.noindex',
+    `${productName}.build`,
+    `${buildType}-${buildFolderPrefix}`,
+    `${productName}.build`,
+    'Objects-normal'
+  );
   if (await fs.pathExists(swiftmoduleDir)) {
     for (const arch of await fs.readdir(swiftmoduleDir)) {
       const swiftinterface = path.join(swiftmoduleDir, arch, `${productName}.swiftinterface`);
       if (await fs.pathExists(swiftinterface)) {
         const destSwiftmodule = path.join(frameworkPath, 'Modules', `${productName}.swiftmodule`);
         await fs.mkdirp(destSwiftmodule);
-        await fs.copy(swiftinterface, path.join(destSwiftmodule, `${arch}-apple-ios.swiftinterface`));
+        await fs.copy(
+          swiftinterface,
+          path.join(destSwiftmodule, `${arch}-apple-ios.swiftinterface`)
+        );
       }
     }
   }
 }
 
 /** Recursively searches a directory for an xcframework with the given product name. */
-export async function findXCFrameworkInDir(dir: string, productName: string): Promise<string | null> {
+export async function findXCFrameworkInDir(
+  dir: string,
+  productName: string
+): Promise<string | null> {
   const target = `${productName}.xcframework`;
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
@@ -811,9 +838,7 @@ export async function buildSharedSPMDependencyAsync(
 
   // Check if already built
   if (Frameworks.hasSharedSPMDepFramework(productName, buildType)) {
-    logger.info(
-      `⏭️  Shared SPM dep ${chalk.cyan(productName)} already exists for ${buildType}`
-    );
+    logger.info(`⏭️  Shared SPM dep ${chalk.cyan(productName)} already exists for ${buildType}`);
     return;
   }
 
@@ -841,7 +866,7 @@ export async function buildSharedSPMDependencyAsync(
   const packageSwiftContent = generateStandaloneSPMPackageSwift(dep);
   const packageSwiftPath = path.join(buildDir, 'Package.swift');
 
-  const existingPackageSwift = await fs.pathExists(packageSwiftPath)
+  const existingPackageSwift = (await fs.pathExists(packageSwiftPath))
     ? await fs.readFile(packageSwiftPath, 'utf-8')
     : null;
   const needsResolve = existingPackageSwift !== packageSwiftContent;
@@ -870,7 +895,7 @@ export async function buildSharedSPMDependencyAsync(
   if (!(await fs.pathExists(checkoutSource))) {
     throw new Error(
       `Checkout not found for ${productName} at ${checkoutSource}. ` +
-      `Available: ${(await fs.readdir(checkoutsDir)).join(', ')}`
+        `Available: ${(await fs.readdir(checkoutsDir)).join(', ')}`
     );
   }
 
@@ -888,12 +913,16 @@ export async function buildSharedSPMDependencyAsync(
         await fs.mkdirp(path.dirname(destPath));
         await fs.remove(destPath);
         execSync(`rsync -a "${xcframeworkPath}/" "${destPath}/"`, { stdio: 'pipe' });
-        logger.info(`✅ Copied binary SPM dep ${chalk.cyan(productName)} → ${path.relative(process.cwd(), destPath)}`);
+        logger.info(
+          `✅ Copied binary SPM dep ${chalk.cyan(productName)} → ${path.relative(process.cwd(), destPath)}`
+        );
         // Keep buildDir for caching — resolved artifacts persist for reuse
         return;
       }
     }
-    logger.warn(`⚠️  ${productName} has .binaryTarget but xcframework not found in artifacts, falling back to build`);
+    logger.warn(
+      `⚠️  ${productName} has .binaryTarget but xcframework not found in artifacts, falling back to build`
+    );
   }
 
   // Copy checkout to a clean location so xcodebuild can resolve its own dependencies.
@@ -961,11 +990,16 @@ export async function buildSharedSPMDependencyAsync(
 
   for (const platform of platforms) {
     const args = [
-      '-scheme', productName,
-      '-destination', `generic/platform=${platform}`,
-      '-derivedDataPath', derivedDataPath,
-      '-clonedSourcePackagesDirPath', sharedSourcePackages,
-      '-configuration', buildType,
+      '-scheme',
+      productName,
+      '-destination',
+      `generic/platform=${platform}`,
+      '-derivedDataPath',
+      derivedDataPath,
+      '-clonedSourcePackagesDirPath',
+      sharedSourcePackages,
+      '-configuration',
+      buildType,
       'SKIP_INSTALL=NO',
       'BUILD_LIBRARY_FOR_DISTRIBUTION=YES',
       ...(buildType === 'Release'
@@ -1006,9 +1040,7 @@ export async function buildSharedSPMDependencyAsync(
     ];
 
     const frameworkPath = await findFirstExisting(candidatePaths);
-    const dsymPath = await findFirstExisting(
-      candidatePaths.map((p) => `${p}.dSYM`)
-    );
+    const dsymPath = await findFirstExisting(candidatePaths.map((p) => `${p}.dSYM`));
 
     if (frameworkPath) {
       // SPM's PackageFrameworks/ output doesn't include Headers/ or Modules/ —
@@ -1053,7 +1085,7 @@ export async function buildSharedSPMDependencyAsync(
 
       logger.warn(
         `⚠️  Framework not found for ${productName} at platform ${platform}. Checked:\n` +
-        candidatePaths.map((p) => `      ${p}`).join('\n')
+          candidatePaths.map((p) => `      ${p}`).join('\n')
       );
     }
   }
@@ -1071,9 +1103,7 @@ export async function buildSharedSPMDependencyAsync(
   );
 
   if (code !== 0) {
-    throw new Error(
-      `Failed to compose xcframework for ${productName}:\n${composeError}`
-    );
+    throw new Error(`Failed to compose xcframework for ${productName}:\n${composeError}`);
   }
 
   // Keep the build directory for caching — resolved checkouts persist so
@@ -1081,5 +1111,7 @@ export async function buildSharedSPMDependencyAsync(
   // Only DerivedData is cleaned since it's large and not reusable across builds.
   await fs.remove(derivedDataPath);
 
-  logger.info(`✅ Built shared SPM dep ${chalk.cyan(productName)} → ${path.relative(process.cwd(), destPath)}`);
+  logger.info(
+    `✅ Built shared SPM dep ${chalk.cyan(productName)} → ${path.relative(process.cwd(), destPath)}`
+  );
 }

--- a/tools/src/prebuilds/TransformReactXCFramework.test.ts
+++ b/tools/src/prebuilds/TransformReactXCFramework.test.ts
@@ -38,21 +38,30 @@ describe('isVFSGenerated', () => {
 
   it('returns false when template exists but no version stamp file', () => {
     fs.writeFileSync(path.join(outputPath, 'React-VFS-template.yaml'), 'content');
-    fs.writeFileSync(path.join(rnSourcePath, 'package.json'), JSON.stringify({ version: '0.77.0' }));
+    fs.writeFileSync(
+      path.join(rnSourcePath, 'package.json'),
+      JSON.stringify({ version: '0.77.0' })
+    );
     assert.equal(isVFSGenerated(outputPath, rnSourcePath), false);
   });
 
   it('returns true when version stamp matches current RN version', () => {
     fs.writeFileSync(path.join(outputPath, 'React-VFS-template.yaml'), 'content');
     VersionStamp.write(outputPath, { reactNativeVersion: '0.77.0' }, '.vfs-version-stamp');
-    fs.writeFileSync(path.join(rnSourcePath, 'package.json'), JSON.stringify({ version: '0.77.0' }));
+    fs.writeFileSync(
+      path.join(rnSourcePath, 'package.json'),
+      JSON.stringify({ version: '0.77.0' })
+    );
     assert.equal(isVFSGenerated(outputPath, rnSourcePath), true);
   });
 
   it('returns false when version stamp does not match current RN version', () => {
     fs.writeFileSync(path.join(outputPath, 'React-VFS-template.yaml'), 'content');
     VersionStamp.write(outputPath, { reactNativeVersion: '0.76.0' }, '.vfs-version-stamp');
-    fs.writeFileSync(path.join(rnSourcePath, 'package.json'), JSON.stringify({ version: '0.77.0' }));
+    fs.writeFileSync(
+      path.join(rnSourcePath, 'package.json'),
+      JSON.stringify({ version: '0.77.0' })
+    );
     assert.equal(isVFSGenerated(outputPath, rnSourcePath), false);
   });
 });

--- a/tools/src/prebuilds/TransformReactXCFramework.ts
+++ b/tools/src/prebuilds/TransformReactXCFramework.ts
@@ -48,6 +48,32 @@ export async function transformReactXCFrameworkAsync(options: TransformOptions):
     throw new Error(`Headers directory not found in xcframework: ${headersDir}`);
   }
 
+  // RN 0.85+ ships React-VFS-template.yaml inside the xcframework with fully nested headers.
+  // When present, use it directly instead of generating our own.
+  const bundledTemplatePath = path.join(xcframeworkPath, 'React-VFS-template.yaml');
+  if (fs.existsSync(bundledTemplatePath)) {
+    logger.info('  Using bundled React-VFS-template.yaml from xcframework (RN 0.85+)');
+
+    // Copy bundled template to expected location (where resolveVFSOverlayTemplate reads it)
+    fs.copyFileSync(bundledTemplatePath, path.join(outputPath, 'React-VFS-template.yaml'));
+
+    // Clean up stale staging directory (no longer needed with bundled nested headers)
+    const stagingDir = path.join(outputPath, 'React-extra-headers');
+    if (fs.existsSync(stagingDir)) {
+      fs.removeSync(stagingDir);
+      logger.info('  Removed stale React-extra-headers/ directory');
+    }
+
+    // Write version stamp for cache invalidation
+    const rnVersion = JSON.parse(
+      fs.readFileSync(path.join(reactNativePath, 'package.json'), 'utf8')
+    ).version;
+    VersionStamp.write(outputPath, { reactNativeVersion: rnVersion }, VFS_STAMP_FILENAME);
+
+    logger.info('  VFS overlay setup complete (using bundled template).');
+    return;
+  }
+
   logger.info('  Collecting header mappings from podspecs...');
   const headerMappings = getHeaderFilesFromPodspecs(reactNativePath);
 

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from 'async_hooks';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import { glob } from 'glob';
@@ -16,16 +17,6 @@ import {
 import { SPMProduct } from './SPMConfig.types';
 import { resolvePackagePath } from './resolvePackage';
 
-let _forceNonInteractive = false;
-
-export function isNonInteractive(): boolean {
-  return _forceNonInteractive || process.env.CI != null || process.stdout.isTTY === false;
-}
-
-export function setForceNonInteractive(value: boolean): void {
-  _forceNonInteractive = value;
-}
-
 /**
  * Async-context-local log prefix for spinner output.
  *
@@ -37,7 +28,16 @@ export function setForceNonInteractive(value: boolean): void {
  * Use `runWithLogPrefix(prefix, fn)` to set the prefix for all code running
  * inside `fn`, including nested async calls.
  */
-import { AsyncLocalStorage } from 'async_hooks';
+
+let _forceNonInteractive = false;
+
+export function isNonInteractive(): boolean {
+  return _forceNonInteractive || process.env.CI != null || process.stdout.isTTY === false;
+}
+
+export function setForceNonInteractive(value: boolean): void {
+  _forceNonInteractive = value;
+}
 
 const _logPrefixStorage = new AsyncLocalStorage<string>();
 
@@ -530,24 +530,16 @@ export const createAsyncSpinner = (
   if (isNonInteractive()) {
     return {
       succeed: (text?: string) => {
-        logger.log(
-          `${Prefix} ${chalk.green('✔')} ${effectivePrefix(chalk.green)}${text ?? ''}`
-        );
+        logger.log(`${Prefix} ${chalk.green('✔')} ${effectivePrefix(chalk.green)}${text ?? ''}`);
       },
       fail: (text?: string) => {
-        logger.log(
-          `${Prefix} ${chalk.red('✖')} ${effectivePrefix(chalk.red)}${text ?? ''}`
-        );
+        logger.log(`${Prefix} ${chalk.red('✖')} ${effectivePrefix(chalk.red)}${text ?? ''}`);
       },
       warn: (text?: string) => {
-        logger.log(
-          `${Prefix} ${chalk.yellow('⚠')} ${effectivePrefix(chalk.yellow)}${text ?? ''}`
-        );
+        logger.log(`${Prefix} ${chalk.yellow('⚠')} ${effectivePrefix(chalk.yellow)}${text ?? ''}`);
       },
       info: (text?: string) => {
-        logger.log(
-          `${Prefix} ${chalk.blue('ℹ')} ${effectivePrefix(chalk.green)}${text ?? ''}`
-        );
+        logger.log(`${Prefix} ${chalk.blue('ℹ')} ${effectivePrefix(chalk.green)}${text ?? ''}`);
       },
     };
   }
@@ -561,14 +553,10 @@ export const createAsyncSpinner = (
     text: spinnerPrefix + initialText,
   }).start();
   return {
-    succeed: (text?: string) =>
-      spinner.succeed(effectivePrefix(chalk.green) + (text ?? '')),
-    fail: (text?: string) =>
-      spinner.fail(effectivePrefix(chalk.red) + (text ?? '')),
-    warn: (text?: string) =>
-      spinner.warn(effectivePrefix(chalk.yellow) + (text ?? '')),
-    info: (text: string) =>
-      (spinner.text = effectivePrefix(chalk.green) + text),
+    succeed: (text?: string) => spinner.succeed(effectivePrefix(chalk.green) + (text ?? '')),
+    fail: (text?: string) => spinner.fail(effectivePrefix(chalk.red) + (text ?? '')),
+    warn: (text?: string) => spinner.warn(effectivePrefix(chalk.yellow) + (text ?? '')),
+    info: (text: string) => (spinner.text = effectivePrefix(chalk.green) + text),
   };
 };
 

--- a/tools/src/prebuilds/pipeline/Reporter.ts
+++ b/tools/src/prebuilds/pipeline/Reporter.ts
@@ -26,7 +26,9 @@ export function logPackageBanner(
   artifactsPath: string
 ): void {
   const flavorInfo = flavors.length > 1 ? ` [${flavors.join(' + ')}]` : ` [${flavors[0]}]`;
-  logger.info(`\n📦 [${chalk.dim(`${index + 1}/${total}`)}] ${chalk.green(pkg.packageName)}${flavorInfo}`);
+  logger.info(
+    `\n📦 [${chalk.dim(`${index + 1}/${total}`)}] ${chalk.green(pkg.packageName)}${flavorInfo}`
+  );
   logger.info(`${'─'.repeat(60)}`);
   const relPath = (p: string) => path.relative(process.cwd(), p);
   logger.info(`   ・Package:      ${chalk.dim(relPath(pkg.path))}`);

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -389,9 +389,7 @@ export interface SharedSPMDependency {
  * Dependencies are deduplicated by productName — the first encountered version wins.
  * Also tracks which packages use each dependency.
  */
-export function collectSharedSPMDependencies(
-  packages: SPMPackageSource[]
-): SharedSPMDependency[] {
+export function collectSharedSPMDependencies(packages: SPMPackageSource[]): SharedSPMDependency[] {
   const seen = new Map<string, SharedSPMDependency>();
 
   for (const pkg of packages) {
@@ -445,9 +443,7 @@ export const prepareSharedSPMDepsStep: Step<PrebuildContext> = {
       `📦 Found ${shared.length} shared SPM ${shared.length === 1 ? 'dependency' : 'dependencies'}:`
     );
     for (const { dep, usedBy } of shared) {
-      logger.info(
-        `   ${chalk.cyan(dep.productName)} ← ${usedBy.join(', ')}`
-      );
+      logger.info(`   ${chalk.cyan(dep.productName)} ← ${usedBy.join(', ')}`);
     }
 
     // When --clean is passed, wipe shared SPM dep build dirs and xcframeworks

--- a/tools/src/prebuilds/pipeline/Scheduler.test.ts
+++ b/tools/src/prebuilds/pipeline/Scheduler.test.ts
@@ -169,12 +169,8 @@ describe('runPackagesInParallel', () => {
   });
 
   it('handles empty package list', async () => {
-    const results = await runPackagesInParallel(
-      [],
-      new Map(),
-      4,
-      new AbortController(),
-      async () => successResult('never')
+    const results = await runPackagesInParallel([], new Map(), 4, new AbortController(), async () =>
+      successResult('never')
     );
     assert.deepEqual(results, []);
   });

--- a/tools/src/prebuilds/pipeline/Scheduler.ts
+++ b/tools/src/prebuilds/pipeline/Scheduler.ts
@@ -16,10 +16,7 @@ export interface PackageResult {
   stopRun: boolean;
 }
 
-type ExecutePackageFn = (
-  pkg: SPMPackageSource,
-  signal: AbortSignal
-) => Promise<PackageResult>;
+type ExecutePackageFn = (pkg: SPMPackageSource, signal: AbortSignal) => Promise<PackageResult>;
 
 /**
  * Runs packages in parallel, respecting the dependency DAG and concurrency limit.
@@ -82,11 +79,7 @@ export async function runPackagesInParallel(
 
   while (readyQueue.length > 0 || running.size > 0) {
     // Launch ready packages up to concurrency limit (unless aborted)
-    while (
-      readyQueue.length > 0 &&
-      running.size < concurrency &&
-      !abortController.signal.aborted
-    ) {
+    while (readyQueue.length > 0 && running.size < concurrency && !abortController.signal.aborted) {
       const pkg = readyQueue.shift()!;
       const promise = executePackage(pkg, abortController.signal).then((result) => ({
         name: pkg.packageName,


### PR DESCRIPTION
# Why

for RN 0.85 where Meta ships a built-in VFS template, this pipeline would generate a duplicate/competing one. On sdk-55 with RN 0.83 that's fine — there's no built-in one, so the pipeline creates it correctly.


# How

This commit fixes this by checking if the file already exists.
Also ran lint (since we hadn't done that in a while) and it included a few other files with lint fixes
