### PR TITLE
[ios][expo-ui] Add selectedSegmentTintColor modifier for segmented pickers

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### 🎉 New features
 
+- [iOS] Added `selectedSegmentTintColor` modifier for per-instance tinting of segmented pickers. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@fedeciancaglini](https://github.com/fedeciancaglini))
 - [android] Added `shape`, `border`, `selected`, `checked`, `onClick`, and `onCheckedChange` props to `Surface`, supporting clickable, selectable, and toggleable variants. ([#44079](https://github.com/expo/expo/pull/44079) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Added nested text support for Compose `Text` with style inheritance, custom fonts via `expo-font`, `background`, `shadow`, and `lineBreak` properties. ([#44094](https://github.com/expo/expo/pull/44094) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Added `outlined` variant to `TextInput` component. ([#43719](https://github.com/expo/expo/pull/43719) by [@benjaminkomen](https://github.com/benjaminkomen))

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ### 🎉 New features
 
-- [iOS] Added `selectedSegmentTintColor` modifier for per-instance tinting of segmented pickers. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@fedeciancaglini](https://github.com/fedeciancaglini))
+- [iOS] Added `selectedSegmentTintColor` modifier for per-instance tinting of segmented pickers. ([#44319](https://github.com/expo/expo/pull/44319) by [@fedeciancaglini](https://github.com/fedeciancaglini))
 - [android] Added `shape`, `border`, `selected`, `checked`, `onClick`, and `onCheckedChange` props to `Surface`, supporting clickable, selectable, and toggleable variants. ([#44079](https://github.com/expo/expo/pull/44079) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Added nested text support for Compose `Text` with style inheritance, custom fonts via `expo-font`, `background`, `shadow`, and `lineBreak` properties. ([#44094](https://github.com/expo/expo/pull/44094) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] Added `outlined` variant to `TextInput` component. ([#43719](https://github.com/expo/expo/pull/43719) by [@benjaminkomen](https://github.com/benjaminkomen))

--- a/packages/expo-ui/build/swift-ui/modifiers/index.d.ts
+++ b/packages/expo-ui/build/swift-ui/modifiers/index.d.ts
@@ -344,6 +344,12 @@ export declare const monospacedDigit: () => ModifierConfig;
  */
 export declare const tint: (color: Color) => ModifierConfig;
 /**
+ * Sets the selected segment tint color of a segmented picker.
+ * Unlike `tint()`, this works with `pickerStyle("segmented")` by targeting the underlying `UISegmentedControl`.
+ * @param color - The tint color (hex string). For example, `#FF0000`.
+ */
+export declare const selectedSegmentTintColor: (color: Color) => ModifierConfig;
+/**
  * Hides or shows a view.
  * @param hidden - Whether the view should be hidden.
  * @see Official [SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/hidden(_:)).

--- a/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
+++ b/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift
@@ -198,6 +198,72 @@ internal struct TintModifier: ViewModifier, Record {
   }
 }
 
+internal struct SelectedSegmentTintColorModifier: ViewModifier, Record {
+  @Field var color: Color?
+
+  func body(content: Content) -> some View {
+    if let color = color {
+      content.introspectSegmentedControl(color: UIColor(color))
+    } else {
+      content
+    }
+  }
+}
+
+private extension View {
+  func introspectSegmentedControl(color: UIColor) -> some View {
+    self.background(
+      SegmentedControlFinder(selectedColor: color)
+        .frame(width: 0, height: 0)
+        .allowsHitTesting(false)
+    )
+  }
+}
+
+#if !os(tvOS)
+private struct SegmentedControlFinder: UIViewRepresentable {
+  let selectedColor: UIColor
+
+  func makeUIView(context: Context) -> UIView {
+    let view = UIView()
+    view.isHidden = true
+    view.isUserInteractionEnabled = false
+    return view
+  }
+
+  func updateUIView(_ uiView: UIView, context: Context) {
+    DispatchQueue.main.async {
+      guard let segmented = uiView.findSuperview(ofType: UISegmentedControl.self) else { return }
+      segmented.selectedSegmentTintColor = selectedColor
+    }
+  }
+}
+
+private extension UIView {
+  func findSuperview<T: UIView>(ofType type: T.Type) -> T? {
+    var current: UIView? = superview
+    while let view = current {
+      if let match = view as? T { return match }
+      if let parent = view.superview {
+        for sibling in parent.subviews where sibling !== view {
+          if let match = sibling.findDescendant(ofType: type) { return match }
+        }
+      }
+      current = view.superview
+    }
+    return nil
+  }
+
+  func findDescendant<T: UIView>(ofType type: T.Type) -> T? {
+    if let match = self as? T { return match }
+    for child in subviews {
+      if let match = child.findDescendant(ofType: type) { return match }
+    }
+    return nil
+  }
+}
+#endif
+
 internal struct HiddenModifier: ViewModifier, Record {
   @Field var hidden: Bool = true
 
@@ -1556,6 +1622,10 @@ extension ViewModifierRegistry {
 
     register("tint") { params, appContext, _ in
       return try TintModifier(from: params, appContext: appContext)
+    }
+
+    register("selectedSegmentTintColor") { params, appContext, _ in
+      return try SelectedSegmentTintColorModifier(from: params, appContext: appContext)
     }
 
     register("hidden") { params, appContext, _ in

--- a/packages/expo-ui/src/swift-ui/modifiers/index.ts
+++ b/packages/expo-ui/src/swift-ui/modifiers/index.ts
@@ -423,6 +423,14 @@ export const monospacedDigit = () => createModifier('monospacedDigit', {});
 export const tint = (color: Color) => createModifier('tint', { color });
 
 /**
+ * Sets the selected segment tint color of a segmented picker.
+ * Unlike `tint()`, this works with `pickerStyle("segmented")` by targeting the underlying `UISegmentedControl`.
+ * @param color - The tint color (hex string). For example, `#FF0000`.
+ */
+export const selectedSegmentTintColor = (color: Color) =>
+  createModifier('selectedSegmentTintColor', { color });
+
+/**
  * Hides or shows a view.
  * @param hidden - Whether the view should be hidden.
  * @see Official [SwiftUI documentation](https://developer.apple.com/documentation/swiftui/view/hidden(_:)).


### PR DESCRIPTION
# Why

SwiftUI's `.tint()` modifier has no effect on `pickerStyle(.segmented)` because the segmented style renders via UIKit's `UISegmentedControl`, which uses `selectedSegmentTintColor` instead. This means there's currently no way to customize the selected segment color when using `@expo/ui`'s Picker with the segmented style.

# How

Added a new `selectedSegmentTintColor` modifier that uses view introspection to find the underlying `UISegmentedControl` and set its `selectedSegmentTintColor` property directly. This provides per-instance tinting without relying on global `UISegmentedControl.appearance()`.

The implementation:
- Embeds a hidden `UIViewRepresentable` as a background view
- On render, it walks the view hierarchy to locate the `UISegmentedControl`
- Sets `selectedSegmentTintColor` on that specific instance
- Wrapped in `#if !os(tvOS)` since `UISegmentedControl` is not available on tvOS

Usage:
```tsx
import { Picker } from '@expo/ui/swift-ui'
import { pickerStyle, selectedSegmentTintColor } from '@expo/ui/swift-ui/modifiers'

<Picker modifiers={[pickerStyle('segmented'), selectedSegmentTintColor('#FF3B30')]}>
  {/* ... */}
</Picker>
```

# Test Plan

Tested in a production Expo 55 app with a segmented Picker. Verified:
- Selected segment renders with the specified color
- Color updates reactively when the prop changes
- Multiple segmented pickers on the same screen can have different tint colors (per-instance, not global)
- No effect on non-segmented picker styles (modifier is a no-op when no UISegmentedControl is found)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)