### PR TITLE
Fix eslint / prettier negation patterns

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -25,7 +25,6 @@
 /docs/public/static/**
 pnpm-lock.yaml
 
-!packages/@expo/config-plugins/src/android/**
-!packages/@expo/config-plugins/src/ios/**
-!packages/expo-module-scripts/bin/**
-!packages/expo-symbols/src/android/**
+!packages/**/bin/**
+!packages/**/android/**
+!packages/**/ios/**


### PR DESCRIPTION
# Why

The current `.prettierignore` / `.eslintignore` includes `**/bin/**`, `**/ios/**` and `**/android/**` without enough negation patterns, resulting in all those files being ignored:

```
packages/@expo/cli/bin/**
packages/@expo/cli/src/run/android/**
packages/@expo/cli/src/run/ios/**
packages/@expo/cli/src/start/platforms/android/**
packages/@expo/cli/src/start/platforms/ios/**
packages/@expo/package-manager/src/ios/**
packages/expo-brownfield/plugin/src/android/**
packages/expo-brownfield/plugin/src/ios/**
packages/expo-modules-autolinking/src/platforms/android/**
packages/expo-sharing/plugin/src/android/**
packages/expo-sharing/plugin/src/ios/**
packages/install-expo-modules/src/plugins/android/**
packages/install-expo-modules/src/plugins/ios/**
```

# How

Replace the negation patterns with:

```
!packages/**/bin/**
!packages/**/android/**
!packages/**/ios/**
```

# Test Plan

- CI should be green

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
