### PR TITLE
[tools] Update publish canary script to only apply canary tag when publishing from main

### DIFF
--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -127,7 +127,7 @@ export async function packToTarballAsync(packageDir: string): Promise<PackResult
 
 type PublishOptions = {
   source?: string;
-  tagName?: string;
+  tagName?: string | null;
   dryRun?: boolean;
   spawnOptions?: SpawnOptions;
 };
@@ -139,14 +139,11 @@ export async function publishPackageAsync(
   packageDir: string,
   options: PublishOptions = {}
 ): Promise<void> {
-  const args = [
-    'publish',
-    options.source ?? '.',
-    '--tag',
-    options.tagName ?? 'latest',
-    '--access',
-    'public',
-  ];
+  const args = ['publish', options.source ?? '.', '--access', 'public'];
+
+  if (options.tagName != null) {
+    args.push('--tag', options.tagName ?? 'latest');
+  }
 
   if (options.dryRun) {
     args.push('--dry-run');

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -63,6 +63,8 @@ export const prepareCanaries = new Task<TaskArgs>(
     const currentBranch = await Git.getCurrentBranchNameAsync();
     if (await shouldUseCanaryTag(currentBranch)) {
       options.tag = 'canary';
+    } else {
+      options.tag = null;
     }
   }
 );

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -57,8 +57,13 @@ export const prepareCanaries = new Task<TaskArgs>(
       );
     }
 
-    // Override the tag option – canary releases should always use `canary` tag
-    options.tag = 'canary';
+    // Only use the `canary` tag when publishing from `main` or the latest `sdk-*` branch.
+    // Other branches publish canary versions without the `canary` dist-tag so they
+    // don't overwrite the canary tag that points at main/latest-sdk builds.
+    const currentBranch = await Git.getCurrentBranchNameAsync();
+    if (await shouldUseCanaryTag(currentBranch)) {
+      options.tag = 'canary';
+    }
   }
 );
 
@@ -131,6 +136,43 @@ export const publishCanaryPipeline = new Task<TaskArgs>(
     );
   }
 );
+
+/**
+ * Returns `true` if the current branch should publish with the `canary` dist-tag.
+ * Only `main` and the latest `sdk-*` branch qualify.
+ */
+async function shouldUseCanaryTag(currentBranch: string): Promise<boolean> {
+  if (currentBranch === 'main') {
+    return true;
+  }
+  const sdkMatch = currentBranch.match(/^sdk-(\d+)$/);
+  if (!sdkMatch) {
+    return false;
+  }
+  const latestSdkBranch = await getLatestRemoteSdkBranchAsync();
+  return currentBranch === latestSdkBranch;
+}
+
+/**
+ * Lists remote `sdk-*` branches and returns the name of the one with the highest number.
+ */
+async function getLatestRemoteSdkBranchAsync(): Promise<string | null> {
+  const { stdout } = await Git.runAsync(['branch', '-r', '--list', 'origin/sdk-*']);
+  let maxSdk = -1;
+  let latestBranch: string | null = null;
+
+  for (const line of stdout.split('\n')) {
+    const match = line.trim().match(/^origin\/sdk-(\d+)$/);
+    if (match) {
+      const num = parseInt(match[1], 10);
+      if (num > maxSdk) {
+        maxSdk = num;
+        latestBranch = `sdk-${num}`;
+      }
+    }
+  }
+  return latestBranch;
+}
 
 /**
  * Returns a canary version suffix for the current date and HEAD commit hash.

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -46,7 +46,7 @@ export const publishPackages = new Task<TaskArgs>(
 
       logger.log(
         '  ',
-        `${green(pkg.packageName)} version ${cyan(releaseVersion)} as ${yellow(options.tag)}`
+        `${green(pkg.packageName)} version ${cyan(releaseVersion)}${options.tag ? ` as ${yellow(options.tag)}` : ''}`
       );
 
       // If there is a tarball already built, use it instead of packing it again

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -11,7 +11,7 @@ import { PackagesGraphNode } from '../packages-graph';
 export type CommandOptions = {
   packageNames: string[];
   prerelease: boolean | string;
-  tag: string;
+  tag: string | null;
   retry: boolean;
   commitMessage: string;
   skipRepoChecks: boolean;


### PR DESCRIPTION
# Why

Canary publishes from non-main SDK branches (e.g. `sdk-55`) currently overwrite the npm `canary` tag, meaning `npm install package@canary` can point at a build from an older branch instead of the latest one.

# How

Updated `prepareCanaries` to check the current git branch before setting `options.tag`. The `canary` tag is now only applied when publishing from `main` or the highest-numbered remote `sdk-*` branch. 

# Test Plan

`et publish-packages --canary --dry`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
