### PR TITLE
Stop @expo/log-box from rebuilding on every pnpm install

### DIFF
--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Stop @expo/log-box from rebuilding on every pnpm install ([#44330](https://github.com/expo/expo/pull/44330) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### ⚠️ Notices
 
 - Added support for React Native 0.84.x. ([#43018](https://github.com/expo/expo/pull/43018) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -12,6 +12,7 @@
     "watch": "run-p watch:lib watch:bundle",
     "watch:lib": "tsc -p tsconfig.lib.json --watch",
     "watch:bundle": "node ./scripts/watch-bundle.mjs",
+    "prepare": "[ -d dist/ExpoLogBox.bundle ] || node ./scripts/build-bundle.mjs",
     "prepublishOnly": "run-s clean build",
     "build": "run-s build:lib build:bundle",
     "build:lib": "tsc -p tsconfig.lib.json",

--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -12,7 +12,7 @@
     "watch": "run-p watch:lib watch:bundle",
     "watch:lib": "tsc -p tsconfig.lib.json --watch",
     "watch:bundle": "node ./scripts/watch-bundle.mjs",
-    "prepare": "[ -d dist/ExpoLogBox.bundle ] || node ./scripts/build-bundle.mjs",
+    "prepare": "[ -d dist/ExpoLogBox.bundle ] || run-s build:bundle,
     "prepublishOnly": "run-s clean build",
     "build": "run-s build:lib build:bundle",
     "build:lib": "tsc -p tsconfig.lib.json",

--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -12,7 +12,7 @@
     "watch": "run-p watch:lib watch:bundle",
     "watch:lib": "tsc -p tsconfig.lib.json --watch",
     "watch:bundle": "node ./scripts/watch-bundle.mjs",
-    "prepare": "run-s clean build",
+    "prepublishOnly": "run-s clean build",
     "build": "run-s build:lib build:bundle",
     "build:lib": "tsc -p tsconfig.lib.json",
     "build:bundle": "node ./scripts/build-bundle.mjs",


### PR DESCRIPTION
# Why

The `prepare` lifecycle script in `@expo/log-box` runs `clean` + `build` on every `pnpm install`, which is really slow and not necessary. The `build:lib` output (`build/`) is already committed to git, and the expensive `build:bundle` step is kinda redundant because native builds already handle it on-demand via `.bundle-on-demand`  

# How

Changed `prepare` to `prepublishOnly` so the clean+build cycle only runs before `npm publish`, not on every install.  

# Test Plan

- Run `pnpm install` at the repo root and confirm `@expo/log-box` is no longer rebuilts on every install 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
