### PR TITLE
[ios][precompile] fixed expo-sqlite error in workflow build

### DIFF
--- a/packages/expo-sqlite/spm.config.json
+++ b/packages/expo-sqlite/spm.config.json
@@ -18,7 +18,7 @@
           "type": "cpp",
           "name": "ExpoSQLite_c",
           "moduleName": "ExpoSQLite",
-          "path": "ios",
+          "path": "vendor/sqlite3",
           "pattern": "**/*.{cpp,c}",
           "headerPattern": "**/*.h",
           "dependencies": [
@@ -39,10 +39,6 @@
             "-DSQLITE_ENABLE_FTS4=1",
             "-DSQLITE_ENABLE_FTS3_PARENTHESIS=1",
             "-DSQLITE_ENABLE_FTS5=1"
-          ],
-          "exclude": [
-            "libsql/**",
-            "libsql.xcframework/**"
           ]
         },
         {


### PR DESCRIPTION
# Why

Two files in the ios folder was copied there from pod install - which we're not running when doing et prebuild.

# How

Fix: change source for these files to the vendor folder.