### PR TITLE
[brownfield] Use react-native prebuilds by default

### DIFF
--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -188,7 +188,7 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
       platform: 'ios',
       description:
         'Build React Native from source instead of using prebuilt frameworks. Turning this on significantly increases the build times.',
-      default: 'true',
+      default: 'false',
     },
     {
       name: 'android.group',

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [ios] enable optional usage of prebuilt RN frameworks ([#43356](https://github.com/expo/expo/pull/43356) by [@pmleczek](https://github.com/pmleczek))
 - align using custom components between the platforms ([#43633](https://github.com/expo/expo/pull/43633) by [@pmleczek](https://github.com/pmleczek))
 - [state] shared state implementation improvements ([#43279](https://github.com/expo/expo/pull/43279) by [@pmleczek](https://github.com/pmleczek))
+- Use react-native prebuilds by default ([#44332](https://github.com/expo/expo/pull/44332) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/e2e/plugin/__tests__/plugin-ios.test.ts
+++ b/packages/expo-brownfield/e2e/plugin/__tests__/plugin-ios.test.ts
@@ -30,7 +30,7 @@ describe('plugin for ios', () => {
 
   /**
    * Expected behavior:
-   * - Podfile properties includes: "ios.buildReactNativeFromSource" = "true"
+   * - Podfile properties includes: "ios.buildReactNativeFromSource" = "false"
    *   added via build properties plugin
    */
   it('modifies the build properties', async () => {

--- a/packages/expo-brownfield/e2e/plugin/__tests__/plugin-ios.test.ts
+++ b/packages/expo-brownfield/e2e/plugin/__tests__/plugin-ios.test.ts
@@ -57,7 +57,7 @@ describe('plugin for ios', () => {
    */
   it('modifies the podfile properties', async () => {
     validatePodfileProperties(TEMP_DIR, {
-      'ios.useFrameworks': 'static',
+      'ios.buildReactNativeFromSource': 'false',
     });
   });
 

--- a/packages/expo-brownfield/e2e/utils/ios.ts
+++ b/packages/expo-brownfield/e2e/utils/ios.ts
@@ -20,7 +20,7 @@ import { PluginProps } from './types';
  * Validates that build properties are properly set
  */
 export const validateBuildProperties = (projectRoot: string) => {
-  validatePodfileProperty(projectRoot, 'ios.buildReactNativeFromSource', 'true');
+  validatePodfileProperty(projectRoot, 'ios.buildReactNativeFromSource', 'false');
 };
 
 /**

--- a/packages/expo-brownfield/plugin/build/ios/utils/props.js
+++ b/packages/expo-brownfield/plugin/build/ios/utils/props.js
@@ -6,7 +6,7 @@ const getPluginConfig = (props, config) => {
     return {
         bundleIdentifier: getBundleIdentifier(props, config, targetName),
         targetName,
-        buildReactNativeFromSource: props?.buildReactNativeFromSource ?? true,
+        buildReactNativeFromSource: props?.buildReactNativeFromSource ?? false,
     };
 };
 exports.getPluginConfig = getPluginConfig;

--- a/packages/expo-brownfield/plugin/src/ios/utils/props.ts
+++ b/packages/expo-brownfield/plugin/src/ios/utils/props.ts
@@ -8,7 +8,7 @@ export const getPluginConfig = (props: PluginProps, config: ExpoConfig): PluginC
   return {
     bundleIdentifier: getBundleIdentifier(props, config, targetName),
     targetName,
-    buildReactNativeFromSource: props?.buildReactNativeFromSource ?? true,
+    buildReactNativeFromSource: props?.buildReactNativeFromSource ?? false,
   };
 };
 


### PR DESCRIPTION
# Why

Now that we're going to prebuild expo packages we should also use react-native prebuilds by default in expo-brownfield

# How

Change the default buildReactNativeFromSource plugin value to false and update docs 

# Test Plan

run `npx expo prebuild:ios` inside expo-app

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
