### PR TITLE
[docs] List react-native-intlayer in localization doc

### DIFF
--- a/docs/pages/guides/localization.mdx
+++ b/docs/pages/guides/localization.mdx
@@ -165,6 +165,8 @@ Here is a non-exhaustive list of other libraries you can consider:
 
 - [React i18next](https://react.i18next.com/) is a stable, well-maintained library based on `i18next`.
 
+- [Intlayer](https://intlayer.org/doc/environment/react-native-and-expo) is per-component i18n library, with extractor, AI tools, focusing on bundle size and performance.
+
 ### Translating app metadata
 
 If you plan on shipping your app to different countries or regions or want it to support various languages, you can provide [localized](/versions/latest/sdk/localization) strings for things like the display name and system dialogs. This is easily set up [in the app config](/workflow/configuration) file. First, set `ios.infoPlist.CFBundleAllowMixedLocalizations: true`, then provide a list of file paths to `locales`.


### PR DESCRIPTION
# Why

Listing intlayer in l10n doc for react-native / expo i18n.

Intlayer offers a scoped i18n approach that simplifies content management and makes detecting missing translations easier.

Following up on https://github.com/expo/expo/pull/43830, the main doc was missing. 


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
