### PR TITLE
[docs] fix Popover example to use label prop on Button

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/popover.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/popover.mdx
@@ -33,7 +33,7 @@ export default function BasicPopoverExample() {
         isPresented={isPresented}
         onStateChange={({ isPresented }) => setIsPresented(isPresented)}>
         <Popover.Trigger>
-          <Button onPress={() => setIsPresented(true)}>Show Popover</Button>
+          <Button label="Show Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
         <Popover.Content>
           <VStack modifiers={[padding({ all: 16 })]}>
@@ -65,7 +65,7 @@ export default function AttachmentAnchorExample() {
         onStateChange={({ isPresented }) => setIsPresented(isPresented)}
         attachmentAnchor="trailing">
         <Popover.Trigger>
-          <Button onPress={() => setIsPresented(true)}>Show Popover</Button>
+          <Button label="Show Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
         <Popover.Content>
           <VStack modifiers={[padding({ all: 16 })]}>
@@ -97,7 +97,7 @@ export default function ArrowEdgeExample() {
         onStateChange={({ isPresented }) => setIsPresented(isPresented)}
         arrowEdge="top">
         <Popover.Trigger>
-          <Button onPress={() => setIsPresented(true)}>Show Popover</Button>
+          <Button label="Show Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
         <Popover.Content>
           <VStack modifiers={[padding({ all: 16 })]}>
@@ -129,7 +129,7 @@ export default function RNContentPopoverExample() {
         isPresented={isPresented}
         onStateChange={({ isPresented }) => setIsPresented(isPresented)}>
         <Popover.Trigger>
-          <Button onPress={() => setIsPresented(true)}>Show RN Popover</Button>
+          <Button label="Show RN Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
         <Popover.Content>
           <RNHostView matchContents>

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/popover.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/popover.mdx
@@ -33,7 +33,7 @@ export default function BasicPopoverExample() {
         isPresented={isPresented}
         onStateChange={({ isPresented }) => setIsPresented(isPresented)}>
         <Popover.Trigger>
-          <Button onPress={() => setIsPresented(true)}>Show Popover</Button>
+          <Button label="Show Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
         <Popover.Content>
           <VStack modifiers={[padding({ all: 16 })]}>
@@ -65,7 +65,7 @@ export default function AttachmentAnchorExample() {
         onStateChange={({ isPresented }) => setIsPresented(isPresented)}
         attachmentAnchor="trailing">
         <Popover.Trigger>
-          <Button onPress={() => setIsPresented(true)}>Show Popover</Button>
+          <Button label="Show Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
         <Popover.Content>
           <VStack modifiers={[padding({ all: 16 })]}>
@@ -97,7 +97,7 @@ export default function ArrowEdgeExample() {
         onStateChange={({ isPresented }) => setIsPresented(isPresented)}
         arrowEdge="top">
         <Popover.Trigger>
-          <Button onPress={() => setIsPresented(true)}>Show Popover</Button>
+          <Button label="Show Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
         <Popover.Content>
           <VStack modifiers={[padding({ all: 16 })]}>
@@ -129,7 +129,7 @@ export default function RNContentPopoverExample() {
         isPresented={isPresented}
         onStateChange={({ isPresented }) => setIsPresented(isPresented)}>
         <Popover.Trigger>
-          <Button onPress={() => setIsPresented(true)}>Show RN Popover</Button>
+          <Button label="Show RN Popover" onPress={() => setIsPresented(true)} />
         </Popover.Trigger>
         <Popover.Content>
           <RNHostView matchContents>


### PR DESCRIPTION
# Why

The current Popover documentation example passes the button label as a child instead of using the `label` prop. This is inconsistent with how `Button` is used everywhere else in `@expo/ui/swift-ui` docs.

# How

Updated the Popover examples to use `<Button label="Show Popover" onPress={...} />`

# Test Plan

Ran the docs site locally (`yarn dev`) and verified the Popover example renders with correct indentation and uses the `label` prop consistently with the rest of the SwiftUI Button documentation.

# Checklist


- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
