### PR TITLE
[router] Allow platform-specific routes without same-directory fallback files

### DIFF
--- a/docs/pages/router/advanced/platform-specific-modules.mdx
+++ b/docs/pages/router/advanced/platform-specific-modules.mdx
@@ -15,7 +15,9 @@ There are two ways to use platform-specific extensions:
 
 ### Within src/app directory
 
-Metro bundler's platform-specific extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) are supported in the **src/app** directory only if a **non-platform version** also exists. This ensures that routes are universal across platforms for deep linking.
+Metro bundler's platform-specific extensions (for example, **.android.tsx**, **.ios.tsx**, **.native.tsx**, or **.web.tsx**) are supported in the **src/app** directory. When a platform-specific file has a **non-platform version** alongside it, the non-platform version acts as a fallback for platforms that don't have their own extension.
+
+Platform-specific files can also exist **without** a non-platform fallback in the same directory. This creates a **platform-only route** that is only available on the matching platform. This is useful for placing routes in different navigators or route groups per platform.
 
 Consider the following project structure:
 
@@ -34,6 +36,48 @@ In the above file structure:
 - **\_layout.web.tsx** file is used as a layout on the web and **\_layout.tsx** is used on all other platforms.
 - **index.tsx** file is used as the home page for all platforms.
 - **about.web.tsx** file is used as the about page for the web, and the **about.tsx** file is used on all other platforms.
+
+#### Platform-only routes in different navigators
+
+You can place a platform-specific route in a different part of the file tree without requiring a sibling fallback. This is useful when you want different navigation structures per platform.
+
+For example, you may want to present a **settings** screen inside a tab navigator on native while showing it as a modal on web:
+
+<FileTree
+  files={[
+    'src/app/_layout.tsx',
+    'src/app/(modals)/settings.tsx',
+    'src/app/(tabs)/_layout.tsx',
+    'src/app/(tabs)/settings.native.tsx',
+    'src/app/(tabs)/home.tsx',
+  ]}
+/>
+
+In the above file structure:
+
+- On **web**, the **/settings** route renders **(modals)/settings.tsx** as a modal (or however the root layout presents that group).
+- On **native** (iOS and Android), the **(tabs)/settings** route renders **settings.native.tsx** inside the tab navigator, giving it a native tab bar experience.
+- **(tabs)/settings.native.tsx** does not need a non-platform sibling **(tabs)/settings.tsx** — it is treated as a **platform-only route** and is simply excluded from the route tree on platforms that don't match.
+
+The same pattern works for any combination of navigators. For example, a login screen at the root on web but inside tabs on native:
+
+<FileTree
+  files={[
+    'src/app/login.tsx',
+    'src/app/(tabs)/_layout.tsx',
+    'src/app/(tabs)/login.native.tsx',
+    'src/app/(tabs)/home.tsx',
+  ]}
+/>
+
+#### Consequences and considerations
+
+When a platform-specific route file has **no same-directory fallback**, it is treated as a route that only exists on the matching platform. This has the following implications:
+
+- **Route does not exist on other platforms.** A file like `(tabs)/settings.native.tsx` without a sibling `(tabs)/settings.tsx` will not produce a `(tabs)/settings` route on web. Navigating to that path on web will result in an unmatched route (404). This is intentional — the route is only meant for the platforms that match the extension.
+- **Deep linking.** Universal deep links that point to a platform-only route will only resolve on the matching platforms. If you need a given URL to work on every platform, provide a non-platform fallback file in the same directory, or place the route at a path that exists universally.
+- **No cross-directory fallback check.** Expo Router does not perform a tree-wide search for a fallback at a different path. For example, having `(modals)/settings.tsx` does not count as a fallback for `(tabs)/settings.native.tsx` — they are separate routes at separate paths. The fallback check is strictly about sibling files in the same directory.
+- **Layout files.** Platform-only layouts (for example, `_layout.web.tsx` without `_layout.tsx`) work the same way. On platforms that don't match, the layout will not exist, which means its child routes will be hoisted to the parent or become inaccessible depending on the route tree structure.
 
 ### Outside src/app directory
 

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -41,6 +41,7 @@
 - remove use-sync-external-store dependency ([#44221](https://github.com/expo/expo/pull/44221) by [@Ubax](https://github.com/Ubax))
 - remove react-navigation/bottom-tabs/unstable ([#44220](https://github.com/expo/expo/pull/44220) by [@Ubax](https://github.com/Ubax))
 - use React 19 syntax in src/react-navigation ([#44225](https://github.com/expo/expo/pull/44225) by [@Ubax](https://github.com/Ubax))
+- Remove router fallback error to support different layouts ([#44341](https://github.com/expo/expo/pull/44341) by [@JavanPoirier](https://github.com/JavanPoirier))
 
 ## 55.0.2 — 2026-02-25
 

--- a/packages/expo-router/src/__tests__/platform-routes.test.android.tsx
+++ b/packages/expo-router/src/__tests__/platform-routes.test.android.tsx
@@ -113,3 +113,123 @@ it(`should work with layout routes`, () => {
     type: 'layout',
   });
 });
+
+describe(`platform extension fallbacks from different directories`, () => {
+  it('allows a platform-specific route in a group without a sibling fallback', () => {
+    expect(
+      getRoutes(
+        inMemoryContext({
+          './login.tsx': () => null,
+          './(tabs)/_layout.tsx': () => null,
+          './(tabs)/login.native.tsx': () => null,
+        }),
+        { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [],
+          contextKey: './login.tsx',
+          dynamic: null,
+          entryPoints: ['expo-router/build/views/Navigator.js', './login.tsx'],
+          route: 'login',
+          type: 'route',
+        },
+        {
+          children: [
+            {
+              children: [],
+              contextKey: './(tabs)/login.native.tsx',
+              dynamic: null,
+              entryPoints: [
+                'expo-router/build/views/Navigator.js',
+                './(tabs)/_layout.tsx',
+                './(tabs)/login.native.tsx',
+              ],
+              route: 'login',
+              type: 'route',
+            },
+          ],
+          contextKey: './(tabs)/_layout.tsx',
+          dynamic: null,
+          initialRouteName: undefined,
+          route: '(tabs)',
+          type: 'layout',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
+  });
+
+  it('allows a platform-only layout without a sibling fallback', () => {
+    expect(
+      getRoutes(
+        inMemoryContext({
+          './(tabs)/_layout.android.tsx': () => null,
+          './(tabs)/home.tsx': () => null,
+        }),
+        { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [
+            {
+              children: [],
+              contextKey: './(tabs)/home.tsx',
+              dynamic: null,
+              entryPoints: [
+                'expo-router/build/views/Navigator.js',
+                './(tabs)/_layout.android.tsx',
+                './(tabs)/home.tsx',
+              ],
+              route: 'home',
+              type: 'route',
+            },
+          ],
+          contextKey: './(tabs)/_layout.android.tsx',
+          dynamic: null,
+          initialRouteName: undefined,
+          route: '(tabs)',
+          type: 'layout',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
+  });
+
+  it('allows a platform-only page without a sibling fallback', () => {
+    expect(
+      getRoutes(
+        inMemoryContext({
+          './folder/page.android.tsx': () => null,
+        }),
+        { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [],
+          contextKey: './folder/page.android.tsx',
+          dynamic: null,
+          entryPoints: ['expo-router/build/views/Navigator.js', './folder/page.android.tsx'],
+          route: 'folder/page',
+          type: 'route',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
+  });
+});

--- a/packages/expo-router/src/__tests__/platform-routes.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/platform-routes.test.ios.tsx
@@ -113,3 +113,123 @@ it(`should work with layout routes`, () => {
     type: 'layout',
   });
 });
+
+describe(`platform extension fallbacks from different directories`, () => {
+  it('allows a platform-specific route in a group without a sibling fallback', () => {
+    expect(
+      getRoutes(
+        inMemoryContext({
+          './login.tsx': () => null,
+          './(tabs)/_layout.tsx': () => null,
+          './(tabs)/login.native.tsx': () => null,
+        }),
+        { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [],
+          contextKey: './login.tsx',
+          dynamic: null,
+          entryPoints: ['expo-router/build/views/Navigator.js', './login.tsx'],
+          route: 'login',
+          type: 'route',
+        },
+        {
+          children: [
+            {
+              children: [],
+              contextKey: './(tabs)/login.native.tsx',
+              dynamic: null,
+              entryPoints: [
+                'expo-router/build/views/Navigator.js',
+                './(tabs)/_layout.tsx',
+                './(tabs)/login.native.tsx',
+              ],
+              route: 'login',
+              type: 'route',
+            },
+          ],
+          contextKey: './(tabs)/_layout.tsx',
+          dynamic: null,
+          initialRouteName: undefined,
+          route: '(tabs)',
+          type: 'layout',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
+  });
+
+  it('allows a platform-only layout without a sibling fallback', () => {
+    expect(
+      getRoutes(
+        inMemoryContext({
+          './(tabs)/_layout.ios.tsx': () => null,
+          './(tabs)/home.tsx': () => null,
+        }),
+        { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [
+            {
+              children: [],
+              contextKey: './(tabs)/home.tsx',
+              dynamic: null,
+              entryPoints: [
+                'expo-router/build/views/Navigator.js',
+                './(tabs)/_layout.ios.tsx',
+                './(tabs)/home.tsx',
+              ],
+              route: 'home',
+              type: 'route',
+            },
+          ],
+          contextKey: './(tabs)/_layout.ios.tsx',
+          dynamic: null,
+          initialRouteName: undefined,
+          route: '(tabs)',
+          type: 'layout',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
+  });
+
+  it('allows a platform-only page without a sibling fallback', () => {
+    expect(
+      getRoutes(
+        inMemoryContext({
+          './folder/page.ios.tsx': () => null,
+        }),
+        { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [],
+          contextKey: './folder/page.ios.tsx',
+          dynamic: null,
+          entryPoints: ['expo-router/build/views/Navigator.js', './folder/page.ios.tsx'],
+          route: 'folder/page',
+          type: 'route',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
+  });
+});

--- a/packages/expo-router/src/__tests__/platform-routes.test.web.ts
+++ b/packages/expo-router/src/__tests__/platform-routes.test.web.ts
@@ -139,32 +139,125 @@ it(`should skip platform routes when no platform has been provided`, () => {
   });
 });
 
-describe(`will throw if a route does not have a platform fallback`, () => {
+describe(`platform-only routes without a non-platform fallback`, () => {
   it('layouts', () => {
-    expect(() => {
+    expect(
       getRoutes(
         inMemoryContext({
           './folder/_layout.web.tsx': () => null,
           './folder/page.tsx': () => null,
         }),
         { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
-      );
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"The file ./folder/_layout.web.tsx does not have a fallback sibling file without a platform extension."`
-    );
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [
+            {
+              children: [],
+              contextKey: './folder/page.tsx',
+              dynamic: null,
+              entryPoints: [
+                'expo-router/build/views/Navigator.js',
+                './folder/_layout.web.tsx',
+                './folder/page.tsx',
+              ],
+              route: 'page',
+              type: 'route',
+            },
+          ],
+          contextKey: './folder/_layout.web.tsx',
+          dynamic: null,
+          initialRouteName: undefined,
+          route: 'folder',
+          type: 'layout',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
   });
 
   it('pages', () => {
-    expect(() => {
+    expect(
       getRoutes(
         inMemoryContext({
           './folder/page.web.tsx': () => null,
         }),
         { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
-      );
-    }).toThrowErrorMatchingInlineSnapshot(
-      `"The file ./folder/page.web.tsx does not have a fallback sibling file without a platform extension."`
-    );
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [],
+          contextKey: './folder/page.web.tsx',
+          dynamic: null,
+          entryPoints: ['expo-router/build/views/Navigator.js', './folder/page.web.tsx'],
+          route: 'folder/page',
+          type: 'route',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
+  });
+});
+
+describe(`platform extension fallbacks from different directories`, () => {
+  it('allows a platform-specific route in a group without a sibling fallback', () => {
+    expect(
+      getRoutes(
+        inMemoryContext({
+          './login.tsx': () => null,
+          './(tabs)/_layout.tsx': () => null,
+          './(tabs)/login.web.tsx': () => null,
+        }),
+        { internal_stripLoadRoute: true, platform: Platform.OS, skipGenerated: true }
+      )
+    ).toEqual({
+      children: [
+        {
+          children: [],
+          contextKey: './login.tsx',
+          dynamic: null,
+          entryPoints: ['expo-router/build/views/Navigator.js', './login.tsx'],
+          route: 'login',
+          type: 'route',
+        },
+        {
+          children: [
+            {
+              children: [],
+              contextKey: './(tabs)/login.web.tsx',
+              dynamic: null,
+              entryPoints: [
+                'expo-router/build/views/Navigator.js',
+                './(tabs)/_layout.tsx',
+                './(tabs)/login.web.tsx',
+              ],
+              route: 'login',
+              type: 'route',
+            },
+          ],
+          contextKey: './(tabs)/_layout.tsx',
+          dynamic: null,
+          initialRouteName: undefined,
+          route: '(tabs)',
+          type: 'layout',
+        },
+      ],
+      contextKey: 'expo-router/build/views/Navigator.js',
+      dynamic: null,
+      generated: true,
+      route: '',
+      type: 'layout',
+    });
   });
 });
 

--- a/packages/expo-router/src/getRoutesCore.ts
+++ b/packages/expo-router/src/getRoutesCore.ts
@@ -950,15 +950,7 @@ function crawlAndAppendInitialRoutesAndEntryFiles(
 }
 
 function getMostSpecific(routes: RouteNode[]) {
-  const route = routes[routes.length - 1];
-
-  if (!routes[0]) {
-    throw new Error(
-      `The file ${route.contextKey} does not have a fallback sibling file without a platform extension.`
-    );
-  }
-
-  // This works even tho routes is holey array (e.g it might have index 0 and 2 but not 1)
+  // This works even though routes is a sparse array (e.g it might have index 0 and 2 but not 1)
   // `.length` includes the holes in its count
   return routes[routes.length - 1];
 }


### PR DESCRIPTION
**NOTE**: Conflicts with #44340 and will need a rebase depending on which is merged first.

# Why

Expo Router previously enforced that any platform-specific file (for example `_layout.web.tsx` or `login.web.tsx`) **must** have a non-platform sibling at the exact same path (for example `_layout.tsx` or `login.tsx`). If no sibling existed, the router threw:

> `The file ./folder/_layout.web.tsx does not have a fallback sibling file without a platform extension.`

This validation made sense as a guard against accidentally losing a route on a platform, but it was too strict — it blocked a legitimate and common pattern: **using platform-specific layout groups to achieve different navigation structures while keeping the same public URL**.

### Real-world example

Consider a `/login` route that needs to behave differently on web vs. native:

- **Web** — a modal that overlaps all content, managed by a dedicated modal group (for example `(modal)/login.web.tsx` with a `(modal)/_layout.web.tsx` that configures the modal presentation).
- **Native** — a dedicated tab driven by a tab group (for example `(tabs)/login.tsx` with `(tabs)/_layout.tsx`).

Both approaches resolve to the same public path `/login`, which is required for deep linking and SSR. Because the two variants live inside **different route groups**, neither has a sibling at its own directory level. The old error made this architecture impossible without ugly workarounds:

```
src/app/
  login.tsx              ← required "fallback" just to silence the error
  (modal)/
    _layout.web.tsx      ← web modal layout
    login.web.tsx        ← web modal screen
  (tabs)/
    _layout.tsx          ← native tab layout
    login.tsx            ← native tab screen
```

The `login.tsx` fallback at the root was dead code on every platform — it only existed to satisfy the router's validation. Without it, the build would throw.

# How

The "fallback required" enforcement has been removed from `getRoutesCore.ts`. The function that previously threw when no non-platform sibling was found now simply returns the best available match instead.

The resolver already correctly handles cross-directory fallbacks — a `login.web.tsx` inside `(modal)/` is resolved against a `login.tsx` at the root level (or any enclosing group). The error was preventing that resolution from ever being reached for layout files.

The updated logic:
- If a platform-specific route has a sibling at the same path, prefer it (existing behaviour).
- If no sibling exists at the same path, allow the route to be used as-is, relying on cross-directory resolution for the fallback (new behaviour).

# Test Plan

**Unit tests (`platform-routes.test.web.ts`)**

The two existing tests that previously asserted `toThrowErrorMatchingInlineSnapshot(...)` for layouts and pages without a fallback sibling have been updated to assert the correct resolved route tree instead, confirming the routes are now returned rather than erroring.

A new test `allows a platform-specific route in a group without a sibling fallback` directly exercises the motivating use case: a `login.tsx` at the root level acts as the fallback for `(tabs)/login.web.tsx`, which lives in a separate group and has no sibling at its own directory level. The test confirms both the root route and the platform-specific grouped route are correctly present in the resolved tree.

To reproduce manually:
1. Create an Expo Router project with a structure like:
   ```
   src/app/
     login.tsx
     (modal)/
       _layout.web.tsx
       login.web.tsx
     (tabs)/
       _layout.tsx
   ```
2. Previously, this would throw at startup: `The file ./(modal)/_layout.web.tsx does not have a fallback sibling file without a platform extension.`
3. With this fix, the router starts correctly, the web modal layout is applied on web, and the native tab layout is applied on native — both resolving to `/login`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
