### PR TITLE
[ios][precompile] moved 3rd party spm config files to expo-modules-autolinking

### DIFF
--- a/packages/expo-modules-autolinking/external-configs/ios/@react-native-async-storage/async-storage/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/@react-native-async-storage/async-storage/spm.config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNCAsyncStorage",

--- a/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNSkia",

--- a/packages/expo-modules-autolinking/external-configs/ios/README.md
+++ b/packages/expo-modules-autolinking/external-configs/ios/README.md
@@ -6,13 +6,13 @@ This document explains how to add support for third-party React Native packages 
 
 When a user asks you to add SPM prebuild support for an external package, you need to:
 
-1. Create an `spm.config.json` file in `packages/external/<package-name>/`
+1. Create an `spm.config.json` file in `packages/expo-modules-autolinking/external-configs/ios/<package-name>/`
 2. Potentially create a patch file if the package source needs modifications
 3. Ensure the codegen module is properly excluded from ReactCodegen
 
 ## Supported External Packages
 
-Configs live in `packages/external/<package-name>/spm.config.json`:
+Configs live in `packages/expo-modules-autolinking/external-configs/ios/<package-name>/spm.config.json`:
 
 | Package | Product Name |
 |---------|-------------|
@@ -29,11 +29,11 @@ Configs live in `packages/external/<package-name>/spm.config.json`:
 
 ## Key Concepts
 
-> For dependency cache details (location, env vars, clean flags), see [`packages/precompile/README.md` — Dependency Cache](../precompile/README.md#dependency-cache).
+> For dependency cache details (location, env vars, clean flags), see [`packages/precompile/README.md` — Dependency Cache](../../../precompile/README.md#dependency-cache).
 
 ### Source Resolution
 
-- **Config location**: `packages/external/<package-name>/spm.config.json`
+- **Config location**: `packages/expo-modules-autolinking/external-configs/ios/<package-name>/spm.config.json`
 - **Source location**: `node_modules/<package-name>/` (resolved at build time)
 - **Output location**: `packages/precompile/.build/<package-name>/output/<flavor>/xcframeworks/`
 
@@ -91,7 +91,7 @@ Every config uses the `products` format with a `$schema` reference:
 
 ```json
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "ProductName",
@@ -234,7 +234,7 @@ No Swift, no custom C++ shadow nodes — just codegen + ObjC/ObjC++ sources:
 
 ```json
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNGestureHandler",
@@ -295,7 +295,7 @@ Adds a `_common_cpp` target for custom shadow node implementations in `common/cp
 
 ```json
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNSVG",
@@ -364,7 +364,7 @@ Splits Swift and ObjC into separate targets, plus an SPM remote dependency:
 
 ```json
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "LottieReactNative",
@@ -486,8 +486,8 @@ npx patch-package <package-name>
 
 Before completing your work, verify:
 
-- [ ] `spm.config.json` exists at `packages/external/<package-name>/spm.config.json`
-- [ ] `$schema` field points to `"../../../tools/src/prebuilds/schemas/spm.config.schema.json"`
+- [ ] `spm.config.json` exists at `packages/expo-modules-autolinking/external-configs/ios/<package-name>/spm.config.json`
+- [ ] `$schema` field points to `"../../../../../tools/src/prebuilds/schemas/spm.config.schema.json"`
 - [ ] Product `podName` matches `s.name` from the podspec
 - [ ] Product `codegenName` matches `codegenConfig.name` from package.json (if applicable)
 - [ ] All codegen targets have `moduleName` matching the codegenName

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNReanimated",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-safe-area-context/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-safe-area-context/spm.config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNCSafeAreaContext",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNScreens",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-svg/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-svg/spm.config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNSVG",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+    "$schema": "../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
     "products": [
         {
             "name": "RNWorklets",

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -998,7 +998,7 @@ module Expo
       # Builds and caches a map from pod names to package information.
       # Scans all spm.config.json files in:
       #   - packages/*/spm.config.json (internal Expo packages)
-      #   - packages/external/*/spm.config.json (external packages)
+      #   - external-configs/ios/*/spm.config.json (3rd-party packages, bundled with autolinking)
       #
       # @return [Hash] Map of podName -> { type:, npm_package:, podspec_dir:, build_output_dir:, ... }
       def pod_lookup_map
@@ -1020,23 +1020,15 @@ module Expo
       end
 
       # Scans all spm.config.json files and populates @pod_lookup_map.
+      # Used in monorepo context where find_repo_root succeeds.
       def scan_spm_configs(repo_root)
-        # Internal packages: packages/*/spm.config.json
+        # Internal Expo packages: packages/*/spm.config.json
         Dir.glob(File.join(repo_root, 'packages', '*', 'spm.config.json')).each do |config_path|
-          next if config_path.include?('/external/')
           process_spm_config(config_path, :internal, repo_root)
         end
 
-        # External packages: packages/external/*/spm.config.json (non-scoped)
-        Dir.glob(File.join(repo_root, 'packages', 'external', '*', 'spm.config.json')).each do |config_path|
-          next if config_path.include?('/@')
-          process_spm_config(config_path, :external, repo_root)
-        end
-
-        # External packages: packages/external/@scope/*/spm.config.json (scoped)
-        Dir.glob(File.join(repo_root, 'packages', 'external', '@*', '*', 'spm.config.json')).each do |config_path|
-          process_spm_config(config_path, :external, repo_root)
-        end
+        # External 3rd-party packages: bundled in external-configs/ios/
+        scan_external_configs(repo_root)
       end
 
       # Scans node_modules for spm.config.json files in standalone projects.
@@ -1045,15 +1037,91 @@ module Expo
         node_modules = File.join(project_root, 'node_modules')
         return unless File.directory?(node_modules)
 
-        # Non-scoped: node_modules/*/spm.config.json
+        # Internal Expo packages: node_modules/*/spm.config.json
         Dir.glob(File.join(node_modules, '*', 'spm.config.json')).each do |config_path|
           process_spm_config(config_path, :internal, project_root)
         end
 
-        # Scoped: node_modules/@scope/*/spm.config.json
+        # Internal Expo scoped packages: node_modules/@scope/*/spm.config.json
         Dir.glob(File.join(node_modules, '@*', '*', 'spm.config.json')).each do |config_path|
           process_spm_config(config_path, :internal, project_root)
         end
+
+        # External 3rd-party packages: bundled in external-configs/ios/
+        scan_external_configs(project_root)
+      end
+
+      # Scans spm.config.json files from external-configs/ios/ for 3rd-party packages
+      # (e.g. react-native-screens, react-native-svg) that don't ship their own spm.config.json.
+      # Shared by both monorepo and standalone project paths.
+      #
+      # @param effective_root [String] The project or repo root used to locate node_modules
+      def scan_external_configs(effective_root)
+        external_configs_dir = File.join(__dir__, '..', '..', 'external-configs', 'ios')
+        return unless File.directory?(external_configs_dir)
+
+        node_modules = File.join(effective_root, 'node_modules')
+
+        # Non-scoped: external-configs/ios/*/spm.config.json
+        Dir.glob(File.join(external_configs_dir, '*', 'spm.config.json')).each do |config_path|
+          npm_package = File.basename(File.dirname(config_path))
+          process_external_config(config_path, npm_package, node_modules, effective_root)
+        end
+
+        # Scoped: external-configs/ios/@scope/*/spm.config.json
+        Dir.glob(File.join(external_configs_dir, '@*', '*', 'spm.config.json')).each do |config_path|
+          rel = config_path.sub("#{external_configs_dir}/", '')
+          npm_package = File.dirname(rel) # e.g. "@shopify/react-native-skia"
+          process_external_config(config_path, npm_package, node_modules, effective_root)
+        end
+      end
+
+      # Processes a single external spm.config.json for a 3rd-party package.
+      def process_external_config(config_path, npm_package, node_modules, effective_root)
+        config = JSON.parse(File.read(config_path))
+        products = config['products'] || []
+        package_root = File.join(node_modules, npm_package)
+
+        # Only process if the package is actually installed
+        return unless File.directory?(package_root)
+
+        # Prefer codegenConfig.name from the installed package.json
+        installed_codegen_name = nil
+        pkg_json_path = File.join(package_root, 'package.json')
+        if File.exist?(pkg_json_path)
+          installed_codegen_name = JSON.parse(File.read(pkg_json_path)).dig('codegenConfig', 'name')
+        end
+
+        base_dir = custom_modules_path || File.join(effective_root, 'packages', 'precompile', PRECOMPILE_BUILD_DIR)
+
+        products.each do |product|
+          pod_name = product['podName']
+          next unless pod_name
+
+          product_name = product['name'] || pod_name
+          codegen_name = installed_codegen_name || product['codegenName']
+          build_output_dir = File.join(base_dir, npm_package, 'output')
+
+          targets = (product['targets'] || [])
+            .select { |t| t['type'] != 'framework' && !t['path']&.start_with?('.build/') }
+            .map { |t| { name: t['name'], path: t['path'] } }
+
+          spm_dependency_frameworks = (product['spmPackages'] || []).map { |pkg| pkg['productName'] }.compact
+
+          @pod_lookup_map[pod_name] = {
+            type: :external,
+            npm_package: npm_package,
+            package_root: package_root,
+            podspec_dir: package_root,
+            build_output_dir: build_output_dir,
+            codegen_name: codegen_name,
+            product_name: product_name,
+            targets: targets,
+            spm_dependency_frameworks: spm_dependency_frameworks
+          }
+        end
+      rescue JSON::ParserError, StandardError => e
+        Pod::UI.warn "[Expo-precompiled] Failed to read external config at #{config_path}: #{e.message}"
       end
 
       # Processes a single spm.config.json file and adds entries to @pod_lookup_map.

--- a/packages/precompile/README.md
+++ b/packages/precompile/README.md
@@ -178,7 +178,7 @@ Each of these has an `spm.config.json` in its package root:
 | `react-native-svg` | `RNSVG` |
 | `react-native-worklets` | `RNWorklets` |
 
-For more details, see [`packages/external/README.md`](../../packages/external/README.md#supported-external-packages).
+For more details, see [`packages/expo-modules-autolinking/external-configs/ios/README.md`](../../packages/expo-modules-autolinking/external-configs/ios/README.md#supported-external-packages).
 
 ## Adding SPM Prebuild Support to Expo Packages
 
@@ -497,7 +497,7 @@ Compiler flags support multiple forms:
 
 Supported variable substitutions in flags: `${REACT_NATIVE_MINOR_VERSION}`, `${PACKAGE_VERSION}`.
 
-See [`packages/external/README.md` — Compiler Flags](../../packages/external/README.md#compiler-flags) for more details.
+See [`packages/expo-modules-autolinking/external-configs/ios/README.md` — Compiler Flags](../../packages/expo-modules-autolinking/external-configs/ios/README.md#compiler-flags) for more details.
 
 ---
 
@@ -666,7 +666,7 @@ et prebuild [options] <package-names...>
 | `--local-react-native-deps-tarball <path>`    | Path to React Native Dependencies tarball. Supports `{flavor}` placeholder|
 | `--react-native-version <version>`            | React Native version (auto-detected from bare-expo if not set)            |
 | `--hermes-version <version>`                  | Hermes version                                                            |
-| `--include-external`                          | Include external (third-party) packages from `packages/external/`        |
+| `--include-external`                          | Include external (third-party) packages from `external-configs/ios/`        |
 | `-s, --sign <identity>`                       | Code signing identity to sign XCFrameworks                                |
 | `--no-timestamp`                              | Disable secure timestamp when signing                                     |
 | `-j, --concurrency <number>`                  | Max packages to build in parallel (default: CPU cores / 3)               |

--- a/tools/src/Directories.ts
+++ b/tools/src/Directories.ts
@@ -23,7 +23,7 @@ export function getPackagesDir(): string {
 }
 
 export function getExternalPackagesDir(): string {
-  return path.join(getPackagesDir(), 'external');
+  return path.join(getPackagesDir(), 'expo-modules-autolinking', 'external-configs', 'ios');
 }
 
 export function getPrecompileDir(): string {

--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -74,7 +74,7 @@ export default (program: Command) => {
     )
     .option(
       '--include-external',
-      'Include external (third-party) packages from packages/external/ in discovery and building.',
+      'Include external (third-party) packages from external-configs/ios/ in discovery and building.',
       false
     )
     .option(

--- a/tools/src/prebuilds/ExternalPackage.test.ts
+++ b/tools/src/prebuilds/ExternalPackage.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for ExternalPackage discovery functions.
+ */
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  discoverExternalPackagesAsync,
+  getExternalPackageByName,
+  getExternalPackageByProductName,
+} from './ExternalPackage';
+
+describe('discoverExternalPackagesAsync', () => {
+  it('discovers all external packages with spm.config.json', async () => {
+    const packages = await discoverExternalPackagesAsync();
+    const names = packages.map((p) => p.packageName).sort();
+
+    assert.ok(packages.length >= 7, `Expected at least 7 packages, got ${packages.length}`);
+    assert.ok(names.includes('react-native-screens'), 'Should include react-native-screens');
+    assert.ok(names.includes('react-native-svg'), 'Should include react-native-svg');
+    assert.ok(names.includes('react-native-reanimated'), 'Should include react-native-reanimated');
+    assert.ok(
+      names.includes('react-native-safe-area-context'),
+      'Should include react-native-safe-area-context'
+    );
+    assert.ok(names.includes('react-native-worklets'), 'Should include react-native-worklets');
+  });
+});
+
+describe('getExternalPackageByName', () => {
+  it('returns a valid ExternalPackage for react-native-screens', () => {
+    const pkg = getExternalPackageByName('react-native-screens');
+    assert.ok(pkg, 'Should find react-native-screens');
+    assert.equal(pkg.packageName, 'react-native-screens');
+  });
+
+  it('returns null for a non-existent package', () => {
+    const pkg = getExternalPackageByName('non-existent-package');
+    assert.equal(pkg, null);
+  });
+});
+
+describe('getExternalPackageByProductName', () => {
+  it('finds react-native-screens by product name RNScreens', () => {
+    const pkg = getExternalPackageByProductName('RNScreens');
+    assert.ok(pkg, 'Should find package by product name RNScreens');
+    assert.equal(pkg.packageName, 'react-native-screens');
+  });
+
+  it('returns null for a non-existent product', () => {
+    const pkg = getExternalPackageByProductName('NonExistentProduct');
+    assert.equal(pkg, null);
+  });
+});

--- a/tools/src/prebuilds/ExternalPackage.ts
+++ b/tools/src/prebuilds/ExternalPackage.ts
@@ -45,11 +45,11 @@ export interface SPMPackageSource {
 
 /**
  * Represents an external (third-party) package that has an SPM configuration
- * in packages/external/ but whose source code lives in node_modules/.
+ * in external-configs/ios/ but whose source code lives in node_modules/.
  */
 export class ExternalPackage implements SPMPackageSource {
   /**
-   * Path to the config directory (packages/external/<package-name>/)
+   * Path to the config directory (external-configs/ios/<package-name>/)
    */
   configPath: string;
 
@@ -135,7 +135,7 @@ export class ExternalPackage implements SPMPackageSource {
 
 /**
  * Discovers all external packages that have spm.config.json files
- * in the packages/external/ directory.
+ * in the external-configs/ios/ directory.
  */
 export async function discoverExternalPackagesAsync(): Promise<ExternalPackage[]> {
   const externalDir = getExternalPackagesDir();
@@ -145,7 +145,7 @@ export async function discoverExternalPackagesAsync(): Promise<ExternalPackage[]
     return [];
   }
 
-  // Find all spm.config.json files in packages/external/
+  // Find all spm.config.json files in external-configs/ios/
   // Pattern matches both regular packages and scoped packages:
   // - react-native-svg/spm.config.json
   // - @shopify/react-native-skia/spm.config.json
@@ -162,7 +162,7 @@ export async function discoverExternalPackagesAsync(): Promise<ExternalPackage[]
 }
 
 /**
- * Gets an external package by name from packages/external/
+ * Gets an external package by name from external-configs/ios/
  * @param packageName The npm package name (e.g., 'react-native-svg')
  */
 export function getExternalPackageByName(packageName: string): ExternalPackage | null {
@@ -226,7 +226,7 @@ export function getExternalPackageByProductName(productName: string): ExternalPa
     return null;
   }
 
-  // Get all subdirectories in packages/external/
+  // Get all subdirectories in external-configs/ios/
   const entries = fs.readdirSync(externalDir, { withFileTypes: true });
 
   for (const entry of entries) {

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -108,7 +108,7 @@ const _packageVersionCache: Record<string, string> = {};
 
 /**
  * Resolves the package version from the package.json in the given path.
- * @param pkgPath Path to the package (e.g., /workspace/packages/external/react-native-worklets)
+ * @param pkgPath Path to the package (e.g., /workspace/external-configs/ios/react-native-worklets)
  * @returns The version string from package.json
  * @throws if the version cannot be resolved
  */

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -347,7 +347,7 @@ export const verifyAllPackagesAsync = async (
 
       throw new Error(
         `Package not found: ${chalk.red(name)}. ` +
-          `Make sure it exists in packages/ or has a config in packages/external/.`
+          `Make sure it exists in packages/ or has a config in external-configs/ios/.`
       );
     })
   );

--- a/tools/src/prebuilds/docs/convert-external-package.md
+++ b/tools/src/prebuilds/docs/convert-external-package.md
@@ -4,7 +4,7 @@ You are converting an external React Native package to support prebuilt XCFramew
 
 ## Rules
 
-- ONLY create/edit these files: `packages/external/<PACKAGE>/spm.config.json`, the podspec in `node_modules/`, and source files in `node_modules/` that need header fixes.
+- ONLY create/edit these files: `packages/expo-modules-autolinking/external-configs/ios/<PACKAGE>/spm.config.json`, the podspec in `node_modules/`, and source files in `node_modules/` that need header fixes.
 - NEVER create patch files manually. Run `npx patch-package <PACKAGE>` to generate them.
 - NEVER build or test the output. Do NOT run `et prebuild-packages` or `pod install`.
 - Keep output minimal — short CLI-style status messages only.
@@ -61,7 +61,7 @@ end
 
 ### 4. Create spm.config.json
 
-Write `packages/external/<PACKAGE>/spm.config.json`.
+Write `packages/expo-modules-autolinking/external-configs/ios/<PACKAGE>/spm.config.json`.
 
 **Schema path**: `"$schema": "../../../tools/src/prebuilds/schemas/spm.config.schema.json"`
 
@@ -91,8 +91,8 @@ STOP here. Do not proceed further.
 ## Reference: Existing Converted Packages
 
 Study these for target structure patterns:
-- `packages/external/react-native-gesture-handler/spm.config.json` — ObjC-only with codegen
-- `packages/external/react-native-svg/spm.config.json` — ObjC + custom C++ shadow nodes
-- `packages/external/lottie-react-native/spm.config.json` — Mixed Swift + ObjC + SPM dependency
-- `packages/external/react-native-screens/spm.config.json` — Mixed Swift + ObjC + C++ + codegen
-- `packages/external/react-native-safe-area-context/spm.config.json` — ObjC + C++ + codegen
+- `packages/expo-modules-autolinking/external-configs/ios/react-native-gesture-handler/spm.config.json` — ObjC-only with codegen
+- `packages/expo-modules-autolinking/external-configs/ios/react-native-svg/spm.config.json` — ObjC + custom C++ shadow nodes
+- `packages/expo-modules-autolinking/external-configs/ios/lottie-react-native/spm.config.json` — Mixed Swift + ObjC + SPM dependency
+- `packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json` — Mixed Swift + ObjC + C++ + codegen
+- `packages/expo-modules-autolinking/external-configs/ios/react-native-safe-area-context/spm.config.json` — ObjC + C++ + codegen


### PR DESCRIPTION
# Why

The precompiled modules script uses spm.config.json files to look up 3rd party libraries inside node_modules for inclusion. Without these files, running pod install will never include XCFrameworks for 3rd party libs. These spm.config.json files are located in ./packages/external, but never copied to any npm packages.

# How

Changed the location of the 3rd party spm.config.json files to under expo-modules-autolinking/external-configs/ios and updated tools, tests and ruby pipeline to use this instead when installing 3rd party libs.