### PR TITLE
[modules-core] Exclude ExpoModulesMacros.swift from SPM prebuild

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [Android] Added broader colors support to convertibles. ([#44041](https://github.com/expo/expo/pull/44041) by [@kudo](https://github.com/kudo))
 - [iOS] Added `@OptimizedFunction` macros support for Expo modules. ([#44262](https://github.com/expo/expo/pull/44262) by [@kudo](https://github.com/kudo))
 - [iOS] Remove legacy `EXNativeModulesProxy` ([#42672](https://github.com/expo/expo/pull/42672) by [@tsapeta](https://github.com/tsapeta))
+- Exclude ExpoModulesMacros.swift from SPM prebuild ([#44354](https://github.com/expo/expo/pull/44354) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -122,7 +122,8 @@
             "Tests/**",
             "BridgeModule/**",
             "Views/**",
-            "Worklets/**"
+            "Worklets/**",
+            "Core/ExpoModulesMacros.swift"
           ],
           "dependencies": [
             "Hermes",


### PR DESCRIPTION
# Why

`et prebuild expo-modules-core` command  is currently failing with:

```
❌ (ExpoModulesCore/Core/ExpoModulesMacros.swift:6:19)
@_exported import ExpoModulesMacros
^ Unable to find module dependency: 'ExpoModulesMacros'
```

This is happening because `ExpoModulesMacros.swift` re-exports the `@expo/expo-modules-macros-plugin` Swift macro package. 
 
Updating the macro plugin to export products properly would require adding `import CompilerPluginSupport` to the generator, bumping the generated `swift-tools-version` from `5.9` to `6.2`, and wiring up a library target wrapper around the `.macro` target (the standard SPM pattern for vending macros). This would be a larger change, which I'm not that sure about. If you guys prefer this other approach, we can close this PR and follow up with a new one  

Since Swift macros expand at compile time, the prebuilt xcframework already contains the fully expanded code and does not need the `@_exported import`. Consumers building from source still get the macro through CocoaPods (`s.dependency 'ExpoModulesMacros'` in the podspec).

# How

Excluded `Core/ExpoModulesMacros.swift` from the Swift target's source files in `packages/expo-modules-core/spm.config.json`.

# Test Plan

Run `et prebuild expo-modules-core` and verify the build succeeds  


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
