### PR TITLE
[expo-image][android] Apply ApplicationVersionSignature to local resource URIs

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Apply `ApplicationVersionSignature` to local resource URIs (`res:/` scheme) to prevent stale cached images after app updates. by [@linkeryoon](https://github.com/linkeryoon)
+- [Android] Apply `ApplicationVersionSignature` to local resource URIs (`res:/` scheme) to prevent stale cached images after app updates. by [@linkeryoon](https://github.com/linkeryoon) ([#44355](https://github.com/expo/expo/pull/44355) by [@Yoon-Hae-Min](https://github.com/Yoon-Hae-Min))
 - Added `tintColor` option to `ImageLoadOptions`. This resolves [#42007](https://github.com/expo/expo/issues/42007). ([#42821](https://github.com/expo/expo/pull/42821)) by [@HubertBer](https://github.com/HubertBer).
 
 ### 💡 Others

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Apply `ApplicationVersionSignature` to local resource URIs (`res:/` scheme) to prevent stale cached images after app updates. by [@linkeryoon](https://github.com/linkeryoon)
 - Added `tintColor` option to `ImageLoadOptions`. This resolves [#42007](https://github.com/expo/expo/issues/42007). ([#42821](https://github.com/expo/expo/pull/42821)) by [@HubertBer](https://github.com/HubertBer).
 
 ### 💡 Others

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -146,7 +146,7 @@ data class SourceMap(
       // Override the size for local assets (apart from SVGs). This ensures that
       // resizeMode "center" displays the image in the correct size.
       override((width * scale).toInt(), (height * scale).toInt())
-    }.customize(`when` = isResourceUri()) {
+    }.customize(`when` = isResourceUri() || isLocalResourceUri()) {
       // Every local resource (drawable) in Android has its own unique numeric id, which are
       // generated at build time. Although these ids are unique, they are not guaranteed unique
       // across builds. The underlying glide implementation caches these resources. To make


### PR DESCRIPTION
# Why

`computeLocalUri()` → `ResourceIdHelper.getResourceUri()` →
React Native's `ResourceDrawableIdHelper` produces URIs with the `res:/` scheme.

In `createGlideOptions()`, `ApplicationVersionSignature` is applied
only when `isResourceUri()` matches (`android.resource://` scheme).

But `res:/` URIs match `isLocalResourceUri()`, not `isResourceUri()`.
So the version signature is never applied to locally bundled images.

# How

Extend the condition in `createGlideOptions()` from `isResourceUri()`
to `isResourceUri() || isLocalResourceUri()`.

# Test Plan

1. Build and install an app with local asset images on an Android device
2. Modify, add, or remove image assets, then rebuild
3. Install the update over the existing app (without uninstalling)
4. Verify images display correctly