### PR TITLE
[file-system][android] Optimize local files copy/move performance

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Deprecate `modificationTime` in favor of new `lastModified`, compatible with web `File` interface. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - Deprecate `File.pickFileAsync(arg1, arg2)` in favour of new `File.pickFileAsync(options)`. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
+- [Android] Optimized performance of copy and move operations. ([#44357](https://github.com/expo/expo/pull/44357) by [@barthap](https://github.com/barthap))
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/expo-file-system/android/build.gradle
+++ b/packages/expo-file-system/android/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   api "androidx.documentfile:documentfile:1.1.0"
 
   testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:4.16'
 
   if (project.findProject(':expo-modules-test-core')) {
     androidTestImplementation project(':expo-modules-test-core')

--- a/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/CopyMoveOperationsTest.kt
+++ b/packages/expo-file-system/android/src/androidTest/java/expo/modules/filesystem/CopyMoveOperationsTest.kt
@@ -11,6 +11,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import java.io.File
 
@@ -45,7 +46,7 @@ class CopyMoveOperationsTest {
   private fun File.toUri(): Uri = Uri.parse(this.toURI().toString())
 
   @Test
-  fun testCopyLocalFile_ToLocalFile() {
+  fun testCopyLocalFile_ToLocalFile() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("test content") }
@@ -62,7 +63,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopyLocalFile_ToLocalDirectory() {
+  fun testCopyLocalFile_ToLocalDirectory() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("test content") }
@@ -79,7 +80,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopyLocalDirectory_ToLocalDirectory() {
+  fun testCopyLocalDirectory_ToLocalDirectory() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }
@@ -101,7 +102,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopySAFFile_ToSAFFile() {
+  fun testCopySAFFile_ToSAFFile() = runBlocking {
     val safRootDir = getSAFRootDir()
 
     val srcDoc = safRootDir.createFile("text/plain", "source.txt")
@@ -123,7 +124,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopySAFFile_ToSAFDirectory() {
+  fun testCopySAFFile_ToSAFDirectory() = runBlocking {
     val safRootDir = getSAFRootDir()
 
     val srcDoc = safRootDir.createFile("text/plain", "source.txt")!!
@@ -143,7 +144,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopySAFDirectory_ToSAFDirectory() {
+  fun testCopySAFDirectory_ToSAFDirectory() = runBlocking {
     val safRootDir = getSAFRootDir()
 
     val srcDir = safRootDir.createDirectory("srcDir")!!
@@ -168,7 +169,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopySAFFile_ToLocalFile() {
+  fun testCopySAFFile_ToLocalFile() = runBlocking {
     val safRootDir = getSAFRootDir()
     val localTestDir = getLocalTestDir()
 
@@ -187,7 +188,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopySAFFile_ToLocalDirectory() {
+  fun testCopySAFFile_ToLocalDirectory() = runBlocking {
     val safRootDir = getSAFRootDir()
     val localTestDir = getLocalTestDir()
 
@@ -207,7 +208,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopyLocalFile_ToSAFDirectory() {
+  fun testCopyLocalFile_ToSAFDirectory() = runBlocking {
     val safRootDir = getSAFRootDir()
     val localTestDir = getLocalTestDir()
 
@@ -226,7 +227,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopyLocalDirectory_ToSAFDirectory() {
+  fun testCopyLocalDirectory_ToSAFDirectory() = runBlocking {
     val safRootDir = getSAFRootDir()
     val localTestDir = getLocalTestDir()
 
@@ -251,7 +252,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testMoveLocalFile_ToLocalFile() {
+  fun testMoveLocalFile_ToLocalFile() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("move content") }
@@ -269,7 +270,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testMoveLocalFile_ToLocalDirectory() {
+  fun testMoveLocalFile_ToLocalDirectory() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("move content") }
@@ -287,7 +288,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testMoveSAFFile_ToLocalDirectory() {
+  fun testMoveSAFFile_ToLocalDirectory() = runBlocking {
     val safRootDir = getSAFRootDir()
     val localTestDir = getLocalTestDir()
 
@@ -311,7 +312,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testMoveLocalFile_ToSAFDirectory() {
+  fun testMoveLocalFile_ToSAFDirectory() = runBlocking {
     val safRootDir = getSAFRootDir()
     val localTestDir = getLocalTestDir()
 
@@ -331,7 +332,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopy_ThrowsWhenDestinationExists_AndOverwriteIsFalse() {
+  fun testCopy_ThrowsWhenDestinationExists_AndOverwriteIsFalse() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("source") }
@@ -350,7 +351,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopy_OverwritesDestination_WhenOverwriteIsTrue() {
+  fun testCopy_OverwritesDestination_WhenOverwriteIsTrue() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("new content") }
@@ -365,7 +366,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testMove_ThrowsWhenDestinationExists_AndOverwriteIsFalse() {
+  fun testMove_ThrowsWhenDestinationExists_AndOverwriteIsFalse() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("source") }
@@ -384,7 +385,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testMove_OverwritesDestination_WhenOverwriteIsTrue() {
+  fun testMove_OverwritesDestination_WhenOverwriteIsTrue() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("new content") }
@@ -400,7 +401,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopy_ThrowsWhenCopyingDirectoryToFile() {
+  fun testCopy_ThrowsWhenCopyingDirectoryToFile() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }
@@ -418,7 +419,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopy_ThrowsWhenDestinationParentDoesNotExist() {
+  fun testCopy_ThrowsWhenDestinationParentDoesNotExist() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("content") }
@@ -436,7 +437,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopy_FileToNonexistentDirectory_Throws() {
+  fun testCopy_FileToNonexistentDirectory_Throws() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcFile = File(localTestDir, "source.txt").apply { writeText("content") }
@@ -454,7 +455,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopyDirectory_ToExistingDirectory_CreatesChildDirectory() {
+  fun testCopyDirectory_ToExistingDirectory_CreatesChildDirectory() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }
@@ -473,7 +474,7 @@ class CopyMoveOperationsTest {
   }
 
   @Test
-  fun testCopyDirectory_ToNonexistentDirectory_RenamesIfParentExists() {
+  fun testCopyDirectory_ToNonexistentDirectory_RenamesIfParentExists() = runBlocking {
     val localTestDir = getLocalTestDir()
 
     val srcDir = File(localTestDir, "srcDir").apply { mkdirs() }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -12,6 +12,8 @@ import expo.modules.filesystem.unifiedfile.JavaFile
 import expo.modules.filesystem.unifiedfile.SAFDocumentFile
 import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
 import expo.modules.kotlin.exception.Exceptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
 import expo.modules.kotlin.services.FilePermissionService
 import expo.modules.kotlin.sharedobjects.SharedObject
 import java.io.File
@@ -151,7 +153,9 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     validatePermission(FilePermissionService.Permission.READ)
     to.validatePermission(FilePermissionService.Permission.WRITE)
 
-    file.copyTo(to.asCopyOrMoveDestination(options.overwrite))
+    runBlocking(Dispatchers.IO) {
+      file.copyTo(to.asCopyOrMoveDestination(options.overwrite))
+    }
   }
 
   fun move(to: FileSystemPath, options: RelocationOptions) {
@@ -161,7 +165,9 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     to.validatePermission(FilePermissionService.Permission.WRITE)
 
     // moveTo returns the URI of where the file was actually moved to
-    val finalUri = file.moveTo(to.asCopyOrMoveDestination(options.overwrite))
+    val finalUri = runBlocking(Dispatchers.IO) {
+      file.moveTo(to.asCopyOrMoveDestination(options.overwrite))
+    }
 
     // Update URI to reflect the new location
     uri = finalUri

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
@@ -2,6 +2,7 @@ package expo.modules.filesystem.fsops
 
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.provider.DocumentsContract
 import androidx.core.net.toUri
 import expo.modules.filesystem.CopyOrMoveDirectoryToFileException
@@ -93,9 +94,20 @@ sealed class CopyMoveStrategy(
     }
 
     override fun tryNativeMove(resolved: DestinationSink): Uri? {
-      if (resolved is DestinationSink.LocalFile) {
-        if (file.renameTo(resolved.target)) return resolved.target.uri
+      if (resolved !is DestinationSink.LocalFile) return null
+
+      // Fast path: atomic rename (same filesystem)
+      if (file.renameTo(resolved.target)) return resolved.target.uri
+
+      // NIO fallback: Files.move handles cross-filesystem moves internally
+      // (copy+delete under the hood, but lets the JVM pick the optimal strategy)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        return runCatching {
+          moveFileNio(file.toPath(), resolved.target.toPath())
+          resolved.target.uri
+        }.getOrNull()
       }
+
       return null
     }
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
@@ -29,11 +29,11 @@ sealed class CopyMoveStrategy(
   protected open val file: UnifiedFileInterface
 ) {
 
-  open fun copyTo(spec: DestinationSpec) {
+  open suspend fun copyTo(spec: DestinationSpec) {
     spec.resolve(file).receiveFrom(file)
   }
 
-  open fun moveTo(spec: DestinationSpec): Uri {
+  open suspend fun moveTo(spec: DestinationSpec): Uri {
     val resolved = spec.resolve(file)
     return tryNativeMove(resolved) ?: run {
       resolved.receiveFrom(file).also {
@@ -170,7 +170,7 @@ sealed class CopyMoveStrategy(
       return DestinationSink.ContentResource(spec)
     }
 
-    override fun moveTo(spec: DestinationSpec): Uri {
+    override suspend fun moveTo(spec: DestinationSpec): Uri {
       throw UnableToMoveException("Content provider file cannot be moved (provider-dependent)")
     }
   }
@@ -181,7 +181,7 @@ sealed class CopyMoveStrategy(
       return DestinationSink.Asset(spec)
     }
 
-    override fun moveTo(spec: DestinationSpec): Uri {
+    override suspend fun moveTo(spec: DestinationSpec): Uri {
       throw UnableToMoveException("Assets cannot be moved (provider-dependent)")
     }
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
@@ -94,10 +94,14 @@ sealed class CopyMoveStrategy(
     }
 
     override fun tryNativeMove(resolved: DestinationSink): Uri? {
-      if (resolved !is DestinationSink.LocalFile) return null
+      if (resolved !is DestinationSink.LocalFile) {
+        return null
+      }
 
       // Fast path: atomic rename (same filesystem)
-      if (file.renameTo(resolved.target)) return resolved.target.uri
+      if (file.renameTo(resolved.target)) {
+        return resolved.target.uri
+      }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         return runCatching {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/CopyMoveStrategy.kt
@@ -99,8 +99,6 @@ sealed class CopyMoveStrategy(
       // Fast path: atomic rename (same filesystem)
       if (file.renameTo(resolved.target)) return resolved.target.uri
 
-      // NIO fallback: Files.move handles cross-filesystem moves internally
-      // (copy+delete under the hood, but lets the JVM pick the optimal strategy)
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         return runCatching {
           moveFileNio(file.toPath(), resolved.target.toPath())

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
@@ -48,10 +48,9 @@ sealed class DestinationSink(val spec: DestinationSpec) {
             }
           }
         }
-        // Non-local sources (SAF, ContentProvider, Asset): keep sequential.
-        // SAF ContentResolver operations are provider-dependent and may not be
-        // thread-safe for parallel reads. Parallel non-local source copies can
-        // be explored in a future follow-up after testing with common providers.
+        // Non-local sources (SAF, ContentProvider, Asset) should stay sequential.
+        // SAF ContentResolver operations are provider-dependent and may not be thread-safe
+        // for parallel reads.
         source.isDirectory() -> {
           target.mkdir()
           copyDirectoryViaStream(source, target)
@@ -73,10 +72,6 @@ sealed class DestinationSink(val spec: DestinationSpec) {
         } else {
           target
         }
-        // SAF ContentResolver operations are provider-dependent and may not be
-        // thread-safe. Parallel copies could cause issues with some document
-        // providers. Use sequential copy for SAF; consider parallelism in a
-        // future follow-up after testing with common providers.
         copyDirectoryViaStream(source, actualDest)
         return actualDest.uri
       } else {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
@@ -1,6 +1,7 @@
 package expo.modules.filesystem.fsops
 
 import android.net.Uri
+import android.os.Build
 import expo.modules.filesystem.UnableToCopyException
 import expo.modules.filesystem.unifiedfile.JavaFile
 import expo.modules.filesystem.unifiedfile.SAFDocumentFile
@@ -29,7 +30,28 @@ sealed class DestinationSink(val spec: DestinationSpec) {
   class LocalFile(spec: DestinationSpec, val target: JavaFile) : DestinationSink(spec) {
     override suspend fun receiveFrom(source: UnifiedFileInterface): Uri {
       when {
-        source is JavaFile -> source.copyRecursively(target, overwrite = spec.overwrite)
+        source is JavaFile -> {
+          if (source.isDirectory()) {
+            target.mkdir()
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+              copyDirectoryParallel(source, target, copyFile = { src, dst ->
+                copyFileNio((src as JavaFile).toPath(), (dst as JavaFile).toPath())
+              })
+            } else {
+              copyDirectoryParallel(source, target)
+            }
+          } else {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+              copyFileNio(source.toPath(), target.toPath())
+            } else {
+              copyFileViaStream(source, target)
+            }
+          }
+        }
+        // Non-local sources (SAF, ContentProvider, Asset): keep sequential.
+        // SAF ContentResolver operations are provider-dependent and may not be
+        // thread-safe for parallel reads. Parallel non-local source copies can
+        // be explored in a future follow-up after testing with common providers.
         source.isDirectory() -> {
           target.mkdir()
           copyDirectoryViaStream(source, target)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
@@ -34,9 +34,16 @@ sealed class DestinationSink(val spec: DestinationSpec) {
           if (source.isDirectory()) {
             target.mkdir()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-              copyDirectoryParallel(source, target, copyFile = { src, dst ->
-                copyFileNio((src as JavaFile).toPath(), (dst as JavaFile).toPath())
-              })
+              copyDirectoryParallel(
+                source,
+                target,
+                copyFile = { src, dst ->
+                  copyFileNio(
+                    (src as JavaFile).toPath(),
+                    (dst as JavaFile).toPath()
+                  )
+                }
+              )
             } else {
               copyDirectoryParallel(source, target)
             }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
@@ -24,10 +24,10 @@ sealed class DestinationSink(val spec: DestinationSpec) {
    * @param source The source file/directory to copy from
    * @return The URI of the resulting copied file/directory
    */
-  abstract fun receiveFrom(source: UnifiedFileInterface): Uri
+  abstract suspend fun receiveFrom(source: UnifiedFileInterface): Uri
 
   class LocalFile(spec: DestinationSpec, val target: JavaFile) : DestinationSink(spec) {
-    override fun receiveFrom(source: UnifiedFileInterface): Uri {
+    override suspend fun receiveFrom(source: UnifiedFileInterface): Uri {
       when {
         source is JavaFile -> source.copyRecursively(target, overwrite = spec.overwrite)
         source.isDirectory() -> {
@@ -41,7 +41,7 @@ sealed class DestinationSink(val spec: DestinationSpec) {
   }
 
   class SAF(spec: DestinationSpec, val target: SAFDocumentFile, val isContainer: Boolean = false) : DestinationSink(spec) {
-    override fun receiveFrom(source: UnifiedFileInterface): Uri {
+    override suspend fun receiveFrom(source: UnifiedFileInterface): Uri {
       if (source.isDirectory()) {
         val actualDest = if (isContainer) {
           val dirName = source.fileName
@@ -51,6 +51,10 @@ sealed class DestinationSink(val spec: DestinationSpec) {
         } else {
           target
         }
+        // SAF ContentResolver operations are provider-dependent and may not be
+        // thread-safe. Parallel copies could cause issues with some document
+        // providers. Use sequential copy for SAF; consider parallelism in a
+        // future follow-up after testing with common providers.
         copyDirectoryViaStream(source, actualDest)
         return actualDest.uri
       } else {
@@ -70,13 +74,13 @@ sealed class DestinationSink(val spec: DestinationSpec) {
   }
 
   class ContentResource(spec: DestinationSpec) : DestinationSink(spec) {
-    override fun receiveFrom(source: UnifiedFileInterface): Uri {
+    override suspend fun receiveFrom(source: UnifiedFileInterface): Uri {
       throw UnableToCopyException("Cannot copy to read-only destination")
     }
   }
 
   class Asset(spec: DestinationSpec) : DestinationSink(spec) {
-    override fun receiveFrom(source: UnifiedFileInterface): Uri {
+    override suspend fun receiveFrom(source: UnifiedFileInterface): Uri {
       throw UnableToCopyException("Cannot copy to read-only destination")
     }
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/NioUtilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/NioUtilities.kt
@@ -1,0 +1,32 @@
+package expo.modules.filesystem.fsops
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * NIO-based file operations for local files on API 26+.
+ * Uses kernel-level zero-copy (sendfile syscall) where possible,
+ * avoiding user-space buffering.
+ *
+ * These functions are only for local file-to-local file operations (JavaFile).
+ * SAF/ContentProvider/Asset backends must continue using stream-based copy
+ * since they only guarantee InputStream/OutputStream via ContentResolver.
+ *
+ * TODO: SAF files could potentially use ContentResolver.openFileDescriptor()
+ * → FileChannel.transferTo() for zero-copy, with fallback to streams when
+ * the provider doesn't support file descriptors. FileSystemFileHandle already
+ * demonstrates this pattern (forContentURI opens FileChannel via openFileDescriptor).
+ */
+
+@RequiresApi(Build.VERSION_CODES.O)
+internal fun copyFileNio(source: Path, dest: Path) {
+  Files.copy(source, dest, StandardCopyOption.REPLACE_EXISTING)
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+internal fun moveFileNio(source: Path, dest: Path) {
+  Files.move(source, dest, StandardCopyOption.REPLACE_EXISTING)
+}

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -2,6 +2,11 @@ package expo.modules.filesystem.fsops
 
 import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
 import expo.modules.kotlin.exception.Exceptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 
 /**
  * Copy file contents via streams.
@@ -52,4 +57,52 @@ internal fun copyDirectoryViaStream(
       copyFileViaStream(child, childDest)
     }
   }
+}
+
+/**
+ * Copy directory recursively with parallel file copies.
+ *
+ * Directory structure is created sequentially (parent before child) to maintain
+ * ordering guarantees. File data copies are dispatched in parallel on [Dispatchers.IO]
+ * with bounded concurrency via [Semaphore].
+ *
+ * @param source Source directory
+ * @param dest Destination directory (must exist)
+ * @param copyFile Function to copy a single file. Defaults to [copyFileViaStream].
+ *   Callers can pass an NIO-based alternative for local-to-local copies.
+ * @param parallelism Maximum number of concurrent file copies
+ */
+internal suspend fun copyDirectoryParallel(
+  source: UnifiedFileInterface,
+  dest: UnifiedFileInterface,
+  copyFile: (UnifiedFileInterface, UnifiedFileInterface) -> Unit = ::copyFileViaStream,
+  parallelism: Int = 4
+) = coroutineScope {
+  require(source.isDirectory()) { "Source must be directory" }
+  require(dest.isDirectory()) { "Dest must be directory" }
+
+  val semaphore = Semaphore(parallelism)
+
+  suspend fun walk(src: UnifiedFileInterface, dst: UnifiedFileInterface) {
+    src.listFilesAsUnified().forEach { child ->
+      val childName = child.fileName
+        ?: throw Exceptions.IllegalArgument("Child has no file name")
+
+      if (child.isDirectory()) {
+        val childDest = dst.createDirectory(childName)
+          ?: throw Exceptions.IllegalStateException("Failed to create directory: $childName")
+        walk(child, childDest) // Sequential — preserves parent-before-child ordering
+      } else {
+        val childDest = dst.createFile(child.type ?: "*/*", childName)
+          ?: throw Exceptions.IllegalStateException("Failed to create file: $childName")
+        launch(Dispatchers.IO) {
+          semaphore.withPermit {
+            copyFile(child, childDest)
+          }
+        }
+      }
+    }
+  }
+
+  walk(source, dest)
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -92,9 +92,8 @@ internal suspend fun copyDirectoryParallel(
           ?: throw Exceptions.IllegalStateException("Failed to create directory: $childName")
         walk(child, childDest) // Sequential — preserves parent-before-child ordering
       } else {
-        // Acquire before launching so traversal itself backpressures when the
-        // concurrency limit is reached. This keeps active work, queued jobs,
-        // and pre-created destination files bounded.
+        // Acquire before launching so traversal itself backpressures when the concurrency limit
+        // is reached. This keeps active work, queued jobs, and pre-created destination files bounded.
         semaphore.acquire()
         var launched = false
         try {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
-import kotlinx.coroutines.sync.withPermit
 
 /**
  * Copy file contents via streams.
@@ -93,11 +92,25 @@ internal suspend fun copyDirectoryParallel(
           ?: throw Exceptions.IllegalStateException("Failed to create directory: $childName")
         walk(child, childDest) // Sequential — preserves parent-before-child ordering
       } else {
-        val childDest = dst.createFile(child.type ?: "*/*", childName)
-          ?: throw Exceptions.IllegalStateException("Failed to create file: $childName")
-        launch(Dispatchers.IO) {
-          semaphore.withPermit {
-            copyFile(child, childDest)
+        // Acquire before launching so traversal itself backpressures when the
+        // concurrency limit is reached. This keeps active work, queued jobs,
+        // and pre-created destination files bounded.
+        semaphore.acquire()
+        var launched = false
+        try {
+          val childDest = dst.createFile(child.type ?: "*/*", childName)
+            ?: throw Exceptions.IllegalStateException("Failed to create file: $childName")
+          launch(Dispatchers.IO) {
+            try {
+              copyFile(child, childDest)
+            } finally {
+              semaphore.release()
+            }
+          }
+          launched = true
+        } finally {
+          if (!launched) {
+            semaphore.release()
           }
         }
       }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -18,7 +18,7 @@ internal fun copyFileViaStream(
 
   source.inputStream().use { input ->
     dest.outputStream().use { output ->
-      input.copyTo(output)
+      input.copyTo(output, bufferSize = 65_536) // 64KB — reduces syscall overhead vs 8KB default
     }
   }
 }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/UnifiedFileInterface.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/UnifiedFileInterface.kt
@@ -27,6 +27,6 @@ interface UnifiedFileInterface {
   fun walkTopDown(): Sequence<UnifiedFileInterface>
 
   val copyMoveStrategy: CopyMoveStrategy
-  fun copyTo(dest: DestinationSpec) = copyMoveStrategy.copyTo(dest)
-  fun moveTo(dest: DestinationSpec): Uri = copyMoveStrategy.moveTo(dest)
+  suspend fun copyTo(dest: DestinationSpec) = copyMoveStrategy.copyTo(dest)
+  suspend fun moveTo(dest: DestinationSpec): Uri = copyMoveStrategy.moveTo(dest)
 }

--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/fsops/CopyDirectoryParallelTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/fsops/CopyDirectoryParallelTest.kt
@@ -1,0 +1,81 @@
+package expo.modules.filesystem.fsops
+
+import android.os.Build
+import android.net.Uri
+import expo.modules.filesystem.unifiedfile.JavaFile
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class CopyDirectoryParallelTest {
+  private lateinit var sourceDir: File
+  private lateinit var destinationDir: File
+
+  @After
+  fun tearDown() {
+    if (::sourceDir.isInitialized) {
+      sourceDir.deleteRecursively()
+    }
+    if (::destinationDir.isInitialized) {
+      destinationDir.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun `copyDirectoryParallel backpressures traversal after the concurrency limit is reached`() {
+    sourceDir = Files.createTempDirectory("expo-file-system-copy-source").toFile().apply {
+      repeat(8) { index ->
+        File(this, "file-$index.txt").writeText("file-$index")
+      }
+    }
+    destinationDir = Files.createTempDirectory("expo-file-system-copy-dest").toFile()
+
+    val firstCopyStarted = CountDownLatch(1)
+    val releaseFirstCopy = CountDownLatch(1)
+    val failure = AtomicReference<Throwable?>(null)
+
+    val worker = thread(name = "copyDirectoryParallel-test") {
+      try {
+        runBlocking {
+          copyDirectoryParallel(
+            source = JavaFile(Uri.fromFile(sourceDir)),
+            dest = JavaFile(Uri.fromFile(destinationDir)),
+            parallelism = 1,
+            copyFile = { _, _ ->
+              firstCopyStarted.countDown()
+              if (!releaseFirstCopy.await(5, TimeUnit.SECONDS)) {
+                throw AssertionError("Timed out waiting to release the blocked copy")
+              }
+            }
+          )
+        }
+      } catch (throwable: Throwable) {
+        failure.set(throwable)
+      }
+    }
+
+    assertTrue(firstCopyStarted.await(5, TimeUnit.SECONDS))
+    assertEquals(1, destinationDir.listFiles()?.size ?: 0)
+
+    releaseFirstCopy.countDown()
+    worker.join(5_000)
+    assertFalse(worker.isAlive)
+    failure.get()?.let { throw it }
+
+    assertEquals(8, destinationDir.listFiles()?.size ?: 0)
+  }
+}


### PR DESCRIPTION
# Why

Android file copy/move operations in `expo-file-system` use basic stream-based I/O with small (8KB) buffers and sequential directory traversal, leaving performance on the table for local-to-local file operations.

# How

- Use NIO `Files.copy()`/`Files.move()` on API 26+ for local file operations, enabling kernel-level zero-copy via sendfile syscall.
- Increase stream copy buffer from 8KB to 64KB for pre-API 26 and non-local paths.
- Copy directory contents in parallel (bounded by a semaphore with backpressure) instead of sequentially.
- Fall back to NIO `Files.move()` when `renameTo()` fails (e.g., cross-filesystem moves).
- Make `copyTo`/`moveTo` chain `suspend` with `runBlocking` bridge at the module boundary (made these async in later PR).

# Test Plan

- NCL
- existing `CopyMoveOperationsTest` instrumented tests — wrapped them in `runBlocking` for the new suspend signatures.
- added a native unit test checking parallelism/backpressure logic

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
