### PR TITLE
[file-system][android] Optimize cross-backend copy/move performance

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 - Deprecate `modificationTime` in favor of new `lastModified`, compatible with web `File` interface. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - Deprecate `File.pickFileAsync(arg1, arg2)` in favour of new `File.pickFileAsync(options)`. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
-- [Android] Optimized performance of copy and move operations. ([#44357](https://github.com/expo/expo/pull/44357) by [@barthap](https://github.com/barthap))
+- [Android] Optimized performance of copy and move operations. ([#44357](https://github.com/expo/expo/pull/44357), [#44358](https://github.com/expo/expo/pull/44358) by [@barthap](https://github.com/barthap))
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/DestinationSink.kt
@@ -62,7 +62,7 @@ sealed class DestinationSink(val spec: DestinationSpec) {
           target.mkdir()
           copyDirectoryViaStream(source, target)
         }
-        else -> copyFileViaStream(source, target)
+        else -> copyFileWithChannelFallback(source, target)
       }
       return target.uri
     }
@@ -91,7 +91,7 @@ sealed class DestinationSink(val spec: DestinationSpec) {
         } else {
           target
         }
-        copyFileViaStream(source, actualDest)
+        copyFileWithChannelFallback(source, actualDest)
         return actualDest.uri
       }
     }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/NioUtilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/NioUtilities.kt
@@ -12,13 +12,8 @@ import java.nio.file.StandardCopyOption
  * avoiding user-space buffering.
  *
  * These functions are only for local file-to-local file operations (JavaFile).
- * SAF/ContentProvider/Asset backends must continue using stream-based copy
- * since they only guarantee InputStream/OutputStream via ContentResolver.
- *
- * TODO: SAF files could potentially use ContentResolver.openFileDescriptor()
- * → FileChannel.transferTo() for zero-copy, with fallback to streams when
- * the provider doesn't support file descriptors. FileSystemFileHandle already
- * demonstrates this pattern (forContentURI opens FileChannel via openFileDescriptor).
+ * SAF/ContentProvider backends use FileChannel via copyFileWithChannelFallback
+ * (see Utilities.kt) with stream-based fallback.
  */
 
 @RequiresApi(Build.VERSION_CODES.O)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -30,6 +30,27 @@ internal fun copyFileViaStream(
 }
 
 /**
+ * Repeatedly transfers bytes until [size] is reached or the transfer stops
+ * making progress.
+ *
+ * Returns `true` only when all bytes were transferred.
+ */
+internal fun copyChannelContents(
+  size: Long,
+  transferTo: (position: Long, count: Long) -> Long
+): Boolean {
+  var position = 0L
+  while (position < size) {
+    val transferred = transferTo(position, size - position)
+    if (transferred <= 0L) {
+      return false
+    }
+    position += transferred
+  }
+  return true
+}
+
+/**
  * Attempt to copy a file using FileChannel.transferTo() for zero-copy.
  * Returns true if the channel-based copy succeeded, false if either side
  * doesn't support file descriptors (caller should fall back to streams).
@@ -47,10 +68,10 @@ internal fun copyFileViaChannel(
       dstPfd.use { dst ->
         FileInputStream(src.fileDescriptor).channel.use { inCh ->
           FileOutputStream(dst.fileDescriptor).channel.use { outCh ->
-            var position = 0L
-            val size = inCh.size()
-            while (position < size) {
-              position += inCh.transferTo(position, size - position, outCh)
+            if (!copyChannelContents(inCh.size()) { position, count ->
+                inCh.transferTo(position, count, outCh)
+              }) {
+              return false
             }
           }
         }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -42,16 +42,24 @@ internal fun copyFileViaChannel(
   val dstPfd = dest.openFileDescriptor("w")
     ?: run { srcPfd.close(); return false }
 
-  srcPfd.use { src ->
-    dstPfd.use { dst ->
-      FileInputStream(src.fileDescriptor).channel.use { inCh ->
-        FileOutputStream(dst.fileDescriptor).channel.use { outCh ->
-          inCh.transferTo(0, inCh.size(), outCh)
+  return try {
+    srcPfd.use { src ->
+      dstPfd.use { dst ->
+        FileInputStream(src.fileDescriptor).channel.use { inCh ->
+          FileOutputStream(dst.fileDescriptor).channel.use { outCh ->
+            var position = 0L
+            val size = inCh.size()
+            while (position < size) {
+              position += inCh.transferTo(position, size - position, outCh)
+            }
+          }
         }
       }
     }
+    true
+  } catch (_: Exception) {
+    false
   }
-  return true
 }
 
 /**
@@ -107,7 +115,7 @@ internal fun copyDirectoryViaStream(
  *
  * @param source Source directory
  * @param dest Destination directory (must exist)
- * @param copyFile Function to copy a single file. Defaults to [copyFileViaStream].
+ * @param copyFile Function to copy a single file. Defaults to [copyFileWithChannelFallback].
  *   Callers can pass an NIO-based alternative for local-to-local copies.
  * @param parallelism Maximum number of concurrent file copies
  */

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -2,6 +2,8 @@ package expo.modules.filesystem.fsops
 
 import expo.modules.filesystem.unifiedfile.UnifiedFileInterface
 import expo.modules.kotlin.exception.Exceptions
+import java.io.FileInputStream
+import java.io.FileOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -24,6 +26,44 @@ internal fun copyFileViaStream(
     dest.outputStream().use { output ->
       input.copyTo(output, bufferSize = 65_536) // 64KB — reduces syscall overhead vs 8KB default
     }
+  }
+}
+
+/**
+ * Attempt to copy a file using FileChannel.transferTo() for zero-copy.
+ * Returns true if the channel-based copy succeeded, false if either side
+ * doesn't support file descriptors (caller should fall back to streams).
+ */
+internal fun copyFileViaChannel(
+  source: UnifiedFileInterface,
+  dest: UnifiedFileInterface
+): Boolean {
+  val srcPfd = source.openFileDescriptor("r") ?: return false
+  val dstPfd = dest.openFileDescriptor("w")
+    ?: run { srcPfd.close(); return false }
+
+  srcPfd.use { src ->
+    dstPfd.use { dst ->
+      FileInputStream(src.fileDescriptor).channel.use { inCh ->
+        FileOutputStream(dst.fileDescriptor).channel.use { outCh ->
+          inCh.transferTo(0, inCh.size(), outCh)
+        }
+      }
+    }
+  }
+  return true
+}
+
+/**
+ * Copy a file using FileChannel if possible, falling back to stream-based copy.
+ * Drop-in replacement for [copyFileViaStream] at all non-NIO call sites.
+ */
+internal fun copyFileWithChannelFallback(
+  source: UnifiedFileInterface,
+  dest: UnifiedFileInterface
+) {
+  if (!copyFileViaChannel(source, dest)) {
+    copyFileViaStream(source, dest)
   }
 }
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -35,7 +35,7 @@ internal fun copyFileViaStream(
  *
  * Returns `true` only when all bytes were transferred.
  */
-internal fun copyChannelContents(
+internal inline fun copyChannelContents(
   size: Long,
   transferTo: (position: Long, count: Long) -> Long
 ): Boolean {
@@ -61,16 +61,20 @@ internal fun copyFileViaChannel(
 ): Boolean {
   val srcPfd = source.openFileDescriptor("r") ?: return false
   val dstPfd = dest.openFileDescriptor("w")
-    ?: run { srcPfd.close(); return false }
+    ?: run {
+      srcPfd.close()
+      return false
+    }
 
-  return try {
+  return runCatching {
     srcPfd.use { src ->
       dstPfd.use { dst ->
         FileInputStream(src.fileDescriptor).channel.use { inCh ->
           FileOutputStream(dst.fileDescriptor).channel.use { outCh ->
             if (!copyChannelContents(inCh.size()) { position, count ->
                 inCh.transferTo(position, count, outCh)
-              }) {
+              }
+            ) {
               return false
             }
           }
@@ -78,9 +82,7 @@ internal fun copyFileViaChannel(
       }
     }
     true
-  } catch (_: Exception) {
-    false
-  }
+  }.getOrElse { false }
 }
 
 /**

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -30,27 +30,6 @@ internal fun copyFileViaStream(
 }
 
 /**
- * Repeatedly transfers bytes until [size] is reached or the transfer stops
- * making progress.
- *
- * Returns `true` only when all bytes were transferred.
- */
-internal inline fun copyChannelContents(
-  size: Long,
-  transferTo: (position: Long, count: Long) -> Long
-): Boolean {
-  var position = 0L
-  while (position < size) {
-    val transferred = transferTo(position, size - position)
-    if (transferred <= 0L) {
-      return false
-    }
-    position += transferred
-  }
-  return true
-}
-
-/**
  * Attempt to copy a file using FileChannel.transferTo() for zero-copy.
  * Returns true if the channel-based copy succeeded, false if either side
  * doesn't support file descriptors (caller should fall back to streams).
@@ -71,18 +50,35 @@ internal fun copyFileViaChannel(
       dstPfd.use { dst ->
         FileInputStream(src.fileDescriptor).channel.use { inCh ->
           FileOutputStream(dst.fileDescriptor).channel.use { outCh ->
-            if (!copyChannelContents(inCh.size()) { position, count ->
-                inCh.transferTo(position, count, outCh)
-              }
-            ) {
-              return false
+            copyChannelContents(inCh.size()) { position, count ->
+              inCh.transferTo(position, count, outCh)
             }
           }
         }
       }
     }
-    true
   }.getOrElse { false }
+}
+
+/**
+ * Repeatedly transfers bytes until [size] is reached or the transfer stops
+ * making progress.
+ *
+ * Returns `true` only when all bytes were transferred.
+ */
+private inline fun copyChannelContents(
+  size: Long,
+  transferTo: (position: Long, count: Long) -> Long
+): Boolean {
+  var position = 0L
+  while (position < size) {
+    val transferred = transferTo(position, size - position)
+    if (transferred <= 0L) {
+      return false
+    }
+    position += transferred
+  }
+  return true
 }
 
 /**

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -39,15 +39,10 @@ internal fun copyFileViaChannel(
   dest: UnifiedFileInterface
 ): Boolean {
   val srcPfd = source.openFileDescriptor("r") ?: return false
-  val dstPfd = dest.openFileDescriptor("w")
-    ?: run {
-      srcPfd.close()
-      return false
-    }
-
-  return runCatching {
-    srcPfd.use { src ->
-      dstPfd.use { dst ->
+  return srcPfd.use { src ->
+    val dstPfd = dest.openFileDescriptor("w") ?: return false
+    dstPfd.use { dst ->
+      runCatching {
         FileInputStream(src.fileDescriptor).channel.use { inCh ->
           FileOutputStream(dst.fileDescriptor).channel.use { outCh ->
             copyChannelContents(inCh.size()) { position, count ->
@@ -55,9 +50,9 @@ internal fun copyFileViaChannel(
             }
           }
         }
-      }
+      }.getOrElse { false }
     }
-  }.getOrElse { false }
+  }
 }
 
 /**

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -61,7 +61,7 @@ internal fun copyFileViaChannel(
  *
  * Returns `true` only when all bytes were transferred.
  */
-private inline fun copyChannelContents(
+internal inline fun copyChannelContents(
   size: Long,
   transferTo: (position: Long, count: Long) -> Long
 ): Boolean {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/fsops/Utilities.kt
@@ -93,7 +93,7 @@ internal fun copyDirectoryViaStream(
     } else {
       val childDest = dest.createFile(child.type ?: "*/*", childName)
         ?: throw Exceptions.IllegalStateException("Failed to create file: $childName")
-      copyFileViaStream(child, childDest)
+      copyFileWithChannelFallback(child, childDest)
     }
   }
 }
@@ -114,7 +114,7 @@ internal fun copyDirectoryViaStream(
 internal suspend fun copyDirectoryParallel(
   source: UnifiedFileInterface,
   dest: UnifiedFileInterface,
-  copyFile: (UnifiedFileInterface, UnifiedFileInterface) -> Unit = ::copyFileViaStream,
+  copyFile: (UnifiedFileInterface, UnifiedFileInterface) -> Unit = ::copyFileWithChannelFallback,
   parallelism: Int = 4
 ) = coroutineScope {
   require(source.isDirectory()) { "Source must be directory" }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/ContentProviderFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/ContentProviderFile.kt
@@ -2,6 +2,7 @@ package expo.modules.filesystem.unifiedfile
 
 import android.content.Context
 import android.net.Uri
+import android.os.ParcelFileDescriptor
 import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
 import expo.modules.filesystem.fsops.CopyMoveStrategy
@@ -81,6 +82,9 @@ class ContentProviderFile(
     return context.contentResolver.openInputStream(uri)
       ?: throw Exceptions.IllegalStateException("Unable to open input stream for URI: $uri")
   }
+
+  override fun openFileDescriptor(mode: String): ParcelFileDescriptor? =
+    runCatching { context.contentResolver.openFileDescriptor(uri, mode) }.getOrNull()
 
   override fun length(): Long {
     queryColumn(OpenableColumns.SIZE)?.toLongOrNull()?.let { size ->

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/JavaFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/JavaFile.kt
@@ -2,6 +2,7 @@ package expo.modules.filesystem.unifiedfile
 
 import android.net.Uri
 import android.os.Build
+import android.os.ParcelFileDescriptor
 import android.webkit.MimeTypeMap
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
@@ -76,6 +77,17 @@ class JavaFile(override val uri: Uri) : UnifiedFileInterface, File(URI.create(ur
   override fun inputStream(): InputStream {
     return FileInputStream(this)
   }
+
+  override fun openFileDescriptor(mode: String): ParcelFileDescriptor? = runCatching {
+    val pfdMode = when (mode) {
+      "r" -> ParcelFileDescriptor.MODE_READ_ONLY
+      "w" -> ParcelFileDescriptor.MODE_WRITE_ONLY or
+        ParcelFileDescriptor.MODE_CREATE or
+        ParcelFileDescriptor.MODE_TRUNCATE
+      else -> return null
+    }
+    ParcelFileDescriptor.open(this, pfdMode)
+  }.getOrNull()
 
   override fun walkTopDown(): Sequence<JavaFile> {
     return walk(direction = FileWalkDirection.TOP_DOWN).map { JavaFile(it.toUri()) }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/JavaFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/JavaFile.kt
@@ -81,9 +81,10 @@ class JavaFile(override val uri: Uri) : UnifiedFileInterface, File(URI.create(ur
   override fun openFileDescriptor(mode: String): ParcelFileDescriptor? = runCatching {
     val pfdMode = when (mode) {
       "r" -> ParcelFileDescriptor.MODE_READ_ONLY
-      "w" -> ParcelFileDescriptor.MODE_WRITE_ONLY or
-        ParcelFileDescriptor.MODE_CREATE or
-        ParcelFileDescriptor.MODE_TRUNCATE
+      "w" ->
+        ParcelFileDescriptor.MODE_WRITE_ONLY or
+          ParcelFileDescriptor.MODE_CREATE or
+          ParcelFileDescriptor.MODE_TRUNCATE
       else -> return null
     }
     ParcelFileDescriptor.open(this, pfdMode)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/SAFDocumentFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/SAFDocumentFile.kt
@@ -2,6 +2,7 @@ package expo.modules.filesystem.unifiedfile
 
 import android.content.Context
 import android.net.Uri
+import android.os.ParcelFileDescriptor
 import androidx.documentfile.provider.DocumentFile
 import expo.modules.filesystem.fsops.CopyMoveStrategy
 import expo.modules.kotlin.AppContext
@@ -81,6 +82,9 @@ class SAFDocumentFile(private val context: Context, override val uri: Uri) : Uni
     return context.contentResolver.openInputStream(uri)
       ?: throw IllegalStateException("Unable to open input stream for URI: $uri")
   }
+
+  override fun openFileDescriptor(mode: String): ParcelFileDescriptor? =
+    runCatching { context.contentResolver.openFileDescriptor(uri, mode) }.getOrNull()
 
   override fun length(): Long {
     return documentFile?.length() ?: 0

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/UnifiedFileInterface.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/unifiedfile/UnifiedFileInterface.kt
@@ -1,6 +1,7 @@
 package expo.modules.filesystem.unifiedfile
 
 import android.net.Uri
+import android.os.ParcelFileDescriptor
 import expo.modules.filesystem.fsops.DestinationSpec
 import expo.modules.filesystem.fsops.CopyMoveStrategy
 import expo.modules.kotlin.AppContext
@@ -23,6 +24,15 @@ interface UnifiedFileInterface {
   fun getContentUri(appContext: AppContext): Uri
   fun outputStream(append: Boolean = false): java.io.OutputStream
   fun inputStream(): java.io.InputStream
+
+  /**
+   * Opens a [ParcelFileDescriptor] for this file.
+   * Returns `null` if the backend does not support file descriptors.
+   *
+   * @param mode "r" for read, "w" for write (follows ContentResolver conventions)
+   */
+  fun openFileDescriptor(mode: String): ParcelFileDescriptor? = null
+
   fun length(): Long
   fun walkTopDown(): Sequence<UnifiedFileInterface>
 

--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/fsops/UtilitiesTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/fsops/UtilitiesTest.kt
@@ -1,0 +1,40 @@
+package expo.modules.filesystem.fsops
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UtilitiesTest {
+  @Test
+  fun copyChannelContents_stopsWhenTransferMakesNoProgress() {
+    var calls = 0
+
+    val result = copyChannelContents(4_096L) { _, _ ->
+      calls += 1
+      when (calls) {
+        1 -> 2_048L
+        else -> 0L
+      }
+    }
+
+    assertFalse(result)
+    assertTrue("The loop should stop after the first zero-progress transfer", calls == 2)
+  }
+
+  @Test
+  fun copyChannelContents_supportsLargeSizes() {
+    val size = Int.MAX_VALUE.toLong() + 8_192L
+    var calls = 0
+
+    val result = copyChannelContents(size) { _, remaining ->
+      calls += 1
+      when (calls) {
+        1 -> Int.MAX_VALUE.toLong()
+        else -> remaining
+      }
+    }
+
+    assertTrue(result)
+    assertTrue("The loop should finish in two transfers", calls == 2)
+  }
+}

--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/fsops/UtilitiesTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/fsops/UtilitiesTest.kt
@@ -9,10 +9,10 @@ class UtilitiesTest {
   fun copyChannelContents_stopsWhenTransferMakesNoProgress() {
     var calls = 0
 
-    val result = copyChannelContents(4_096L) { _, _ ->
+    val result = copyChannelContents(4096L) { _, _ ->
       calls += 1
       when (calls) {
-        1 -> 2_048L
+        1 -> 2048L
         else -> 0L
       }
     }
@@ -23,7 +23,7 @@ class UtilitiesTest {
 
   @Test
   fun copyChannelContents_supportsLargeSizes() {
-    val size = Int.MAX_VALUE.toLong() + 8_192L
+    val size = Int.MAX_VALUE.toLong() + 8192L
     var calls = 0
 
     val result = copyChannelContents(size) { _, remaining ->


### PR DESCRIPTION
# Why

The previous PR (#44357) added NIO and parallel directory copies for local-to-local paths, but SAF and ContentProvider file copies still go through buffered streams, missing the opportunity for zero-copy transfers via `FileChannel.transferTo()`.

# How

- Added `openFileDescriptor(mode)` to `UnifiedFileInterface` with implementations for `JavaFile`, `SAFDocumentFile`, and `ContentProviderFile`.
- Added `copyFileViaChannel()` using `FileChannel.transferTo()` with a loop for large files and a fallback when the transfer stalls.
- Added `copyFileWithChannelFallback()` as a drop-in replacement for `copyFileViaStream()` — tries FileChannel first, falls back to streams if either side doesn't support file descriptors.
- Used `copyFileWithChannelFallback` for all non-NIO copy paths (SAF-to-SAF, SAF-to-local, local-to-SAF, ContentProvider, and sequential directory copy).

# Test Plan

- NCL
- Android instrumented tests
- added new unit tests

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)