### PR TITLE
[et] Bundle main expo packages iOS prebuilds in npm package

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -14,7 +14,8 @@ concurrency:
 
 jobs:
   publish-canaries:
-    runs-on: ubuntu-24.04
+    runs-on: macos-15
+    timeout-minutes: 120
     env:
       NODE_AUTH_TOKEN: ${{ secrets.EXPO_BOT_NPM_TOKEN }}
     steps:
@@ -22,6 +23,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'schedule' && 'sdk-56' || github.ref }}
+          submodules: true
+      - name: 🔨 Switch to Xcode 26.2
+        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Add bin to GITHUB_PATH
+        run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -38,7 +44,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: 📦 Install dependencies
-        run: pnpm install --ignore-scripts --frozen-lockfile
+        run: pnpm install --frozen-lockfile
       - name: 📦 Publish canaries
         run: pnpm expotools publish-packages --canary ${{ github.event_name != 'workflow_dispatch' && '--dry' || '' }}
         env:

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add `include` option to `package.json:expo.autolinking` and per-platform configurations. This allows the verification and deduplication checks to also apply to additional packages that aren't otherwise recognized as native modules, which is useful to detect or deduplicate additional packages with singleton state, for example. ([#43724](https://github.com/expo/expo/pull/43724) by [@kitten](https://github.com/kitten))
+- Add support for loading precompiled frameworks from npm. ([#44360](https://github.com/expo/expo/pull/44360) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -1009,9 +1009,10 @@ module Expo
 
         if repo_root
           scan_spm_configs(repo_root)
-        elsif custom_modules_path
-          # Standalone project with EXPO_PRECOMPILED_MODULES_PATH:
-          # discover spm.config.json from node_modules instead of packages/
+        else
+          # Standalone project: discover spm.config.json from node_modules instead of packages/.
+          # Prebuilds are resolved from EXPO_PRECOMPILED_MODULES_PATH if set,
+          # otherwise from prebuilds/ bundled inside each package directory.
           project_root = File.dirname(Dir.pwd) # Dir.pwd is ios/ during pod install
           scan_node_modules_configs(project_root)
         end
@@ -1102,6 +1103,12 @@ module Expo
           codegen_name = installed_codegen_name || product['codegenName']
           build_output_dir = File.join(base_dir, npm_package, 'output')
 
+          # Fallback: check for prebuilds bundled inside the package directory (shipped in npm)
+          bundled_output_dir = File.join(package_root, 'prebuilds', 'output')
+          if !File.directory?(build_output_dir) && File.directory?(bundled_output_dir)
+            build_output_dir = bundled_output_dir
+          end
+
           targets = (product['targets'] || [])
             .select { |t| t['type'] != 'framework' && !t['path']&.start_with?('.build/') }
             .map { |t| { name: t['name'], path: t['path'] } }
@@ -1163,6 +1170,13 @@ module Expo
         codegen_name = resolve_codegen_name(product, pod_name, npm_package, type, repo_root)
         base_dir = custom_modules_path || File.join(repo_root, 'packages', 'precompile', PRECOMPILE_BUILD_DIR)
         build_output_dir = File.join(base_dir, npm_package, 'output')
+
+        # Fallback: check for prebuilds bundled inside the package directory (shipped in npm)
+        bundled_output_dir = File.join(package_dir, 'prebuilds', 'output')
+        if !File.directory?(build_output_dir) && File.directory?(bundled_output_dir)
+          build_output_dir = bundled_output_dir
+        end
+
         package_root, podspec_dir = resolve_package_paths(pod_name, package_dir, npm_package, type, repo_root)
 
         targets = (product['targets'] || [])

--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -8,16 +8,24 @@ import {
 } from '../prebuilds/pipeline/Index';
 import type { PrebuildCliOptions } from '../prebuilds/pipeline/Index';
 
-async function runPrebuildPackagesAsync(packageNames: string[], options: PrebuildCliOptions) {
+export async function runPrebuildPackagesAsync(
+  packageNames: string[],
+  options: PrebuildCliOptions
+) {
   const request = createRequest(packageNames, options);
   const ctx = createContext(request);
   const removeHandlers = installSignalHandlers(ctx);
+
   try {
-    const result = await runPrebuildPipeline(ctx);
-    process.exit(result.exitCode);
+    return await runPrebuildPipeline(ctx);
   } finally {
     removeHandlers();
   }
+}
+
+async function main(packageNames: string[], options: PrebuildCliOptions) {
+  const result = await runPrebuildPackagesAsync(packageNames, options);
+  process.exit(result.exitCode);
 }
 
 export default (program: Command) => {
@@ -91,5 +99,5 @@ export default (program: Command) => {
       'Maximum number of packages to build in parallel. Defaults to CPU core count.',
       (val: string) => parseInt(val, 10)
     )
-    .asyncAction(runPrebuildPackagesAsync);
+    .asyncAction(main);
 };

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -63,7 +63,8 @@ export const Frameworks = {
     product: SPMProduct,
     buildType: BuildFlavor,
     platform?: BuildPlatform,
-    signing?: SigningOptions
+    signing?: SigningOptions,
+    options?: { bundleSharedDeps?: boolean }
   ): Promise<void> => {
     const spmConfig = pkg.getSwiftPMConfiguration();
 
@@ -132,7 +133,7 @@ export const Frameworks = {
     // Copy SPM dependency xcframeworks (e.g., Lottie.xcframework for lottie-react-native)
     // These are pre-built binary frameworks that the product dynamically links against
     // and must be embedded in the app bundle at runtime.
-    await copySPMDependencyXCFrameworksAsync(pkg, product, buildType);
+    await copySPMDependencyXCFrameworksAsync(pkg, product, buildType, options?.bundleSharedDeps);
 
     // Sign the XCFramework if a signing identity is provided
     if (signing?.identity) {
@@ -140,7 +141,7 @@ export const Frameworks = {
     }
 
     // Create tarball containing the product xcframework and any SPM dependency xcframeworks
-    await createProductTarballAsync(pkg, product, buildType);
+    await createProductTarballAsync(pkg, product, buildType, options?.bundleSharedDeps);
   },
 
   /**
@@ -405,7 +406,8 @@ const copyResourceBundlesIntoXCFrameworkAsync = async (
 const copySPMDependencyXCFrameworksAsync = async (
   pkg: SPMPackageSource,
   product: SPMProduct,
-  buildType: BuildFlavor
+  buildType: BuildFlavor,
+  bundleSharedDeps?: boolean
 ): Promise<void> => {
   // Check if this product has SPM package dependencies
   const spmPackages = product.spmPackages;
@@ -421,12 +423,26 @@ const copySPMDependencyXCFrameworksAsync = async (
     const packageName = spmPkg.packageName || path.basename(spmPkg.url, '.git');
     const productName = spmPkg.productName;
 
-    // Skip deps that are shared — they were built as standalone xcframeworks
-    // and will be vendored separately at pod install time
+    // Shared deps are normally skipped — they were built as standalone xcframeworks
+    // and vendored separately at pod install time. When bundleSharedDeps is true
+    // (npm bundling mode), copy them from the shared location into the output dir
+    // so they end up in the product tarball.
     if (Frameworks.hasSharedSPMDepFramework(productName, buildType)) {
+      if (!bundleSharedDeps) {
+        logger.info(
+          `⏭️  Skipping shared SPM dep ${chalk.cyan(productName)} (already at shared location)`
+        );
+        continue;
+      }
+
+      const sharedPath = Frameworks.getSharedSPMDepFrameworkPath(productName, buildType);
+      const destPath = path.join(outputDir, `${productName}.xcframework`);
       logger.info(
-        `⏭️  Skipping shared SPM dep ${chalk.cyan(productName)} (already at shared location)`
+        `📦 Copying shared SPM dep ${chalk.cyan(productName)} from shared location → ${path.relative(pkg.path, destPath)}`
       );
+      await fs.remove(destPath);
+      execSync(`rsync -a --delete "${sharedPath}/" "${destPath}/"`, { stdio: 'pipe' });
+      logger.info(`✅ Bundled shared dep ${productName}.xcframework`);
       continue;
     }
 
@@ -540,7 +556,8 @@ const copySPMDependencyXCFrameworksAsync = async (
 const createProductTarballAsync = async (
   pkg: SPMPackageSource,
   product: SPMProduct,
-  buildType: BuildFlavor
+  buildType: BuildFlavor,
+  bundleSharedDeps?: boolean
 ): Promise<void> => {
   const outputDir = Frameworks.getFrameworksOutputPath(pkg.buildPath, buildType);
   const tarballPath = Frameworks.getTarballPath(pkg.buildPath, product.name, buildType);
@@ -549,13 +566,12 @@ const createProductTarballAsync = async (
   const xcframeworkEntries = [`${product.name}.xcframework`];
 
   // Include SPM dependency xcframeworks (e.g., Lottie.xcframework for lottie-react-native)
-  // Skip deps that exist at the shared location — they are distributed independently
+  // Skip shared deps unless bundleSharedDeps is true (npm bundling mode)
   const spmPackages = product.spmPackages;
   if (spmPackages && spmPackages.length > 0) {
     for (const spmPkg of spmPackages) {
       const depName = spmPkg.productName;
-      // Skip shared deps — they live at .spm-deps/ and are vendored separately
-      if (Frameworks.hasSharedSPMDepFramework(depName, buildType)) {
+      if (!bundleSharedDeps && Frameworks.hasSharedSPMDepFramework(depName, buildType)) {
         continue;
       }
       const depXcframework = `${depName}.xcframework`;

--- a/tools/src/prebuilds/pipeline/Context.ts
+++ b/tools/src/prebuilds/pipeline/Context.ts
@@ -20,7 +20,7 @@ import type { UnitError, UnitStatus } from './Types';
 
 export type PrebuildCliOptions = {
   reactNativeVersion?: string;
-  hermesVersion: string;
+  hermesVersion?: string;
   clean: boolean;
   cleanCache: boolean;
   flavor?: BuildFlavor;
@@ -66,7 +66,7 @@ export interface PrebuildRequest {
     readonly reactNativeDependencies?: string;
   };
   readonly reactNativeVersionOverride?: string;
-  readonly hermesVersionOverride: string;
+  readonly hermesVersionOverride?: string;
   readonly concurrency: number;
 }
 

--- a/tools/src/prebuilds/pipeline/Context.ts
+++ b/tools/src/prebuilds/pipeline/Context.ts
@@ -39,6 +39,7 @@ export type PrebuildCliOptions = {
   noTimestamp?: boolean;
   verbose: boolean;
   concurrency?: number;
+  bundleSharedDeps?: boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -60,6 +61,7 @@ export interface PrebuildRequest {
   readonly includeExternal: boolean;
   readonly signing?: SigningOptions;
   readonly verbose: boolean;
+  readonly bundleSharedDeps: boolean;
   readonly localTarballTemplates: {
     readonly reactNative?: string;
     readonly hermes?: string;
@@ -141,6 +143,7 @@ export function createRequest(
     },
     reactNativeVersionOverride: options.reactNativeVersion,
     hermesVersionOverride: options.hermesVersion,
+    bundleSharedDeps: options.bundleSharedDeps ?? false,
     concurrency: options.concurrency ?? Math.ceil(os.cpus().length / 3),
   };
 }

--- a/tools/src/prebuilds/pipeline/ProductSteps.ts
+++ b/tools/src/prebuilds/pipeline/ProductSteps.ts
@@ -156,7 +156,8 @@ export const composeStep: Step<PrebuildContext> = {
       product,
       flavor,
       ctx.request.platformFilter,
-      ctx.request.signing
+      ctx.request.signing,
+      { bundleSharedDeps: ctx.request.bundleSharedDeps }
     );
 
     setStage(ctx, 'compose', 'success');

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -14,9 +14,7 @@ import { Parcel, TaskArgs } from '../types';
  */
 const IOS_PREBUILD_PACKAGES = [
   'expo-modules-core',
-  'expo-image',
   'expo-image-manipulator',
-  'expo-camera',
   'expo-video',
   'expo-contacts',
   'expo-file-system',
@@ -29,7 +27,6 @@ const IOS_PREBUILD_PACKAGES = [
   'expo-live-photo',
   'expo-brownfield',
   'expo-ui',
-  'expo-screen-orientation',
 ];
 
 const PRECOMPILE_BUILD_DIR = path.join(PACKAGES_DIR, 'precompile', '.build');

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -12,7 +12,25 @@ import { Parcel, TaskArgs } from '../types';
 /**
  * Packages whose iOS prebuilt xcframeworks should be bundled into the npm tarball.
  */
-const IOS_PREBUILD_PACKAGES = ['expo-modules-core'];
+const IOS_PREBUILD_PACKAGES = [
+  'expo-modules-core',
+  'expo-image',
+  'expo-image-manipulator',
+  'expo-camera',
+  'expo-video',
+  'expo-contacts',
+  'expo-file-system',
+  'expo-media-library',
+  'expo-location',
+  'expo-maps',
+  'expo-print',
+  'expo-sensors',
+  'expo-font',
+  'expo-live-photo',
+  'expo-brownfield',
+  'expo-ui',
+  'expo-screen-orientation',
+];
 
 const PRECOMPILE_BUILD_DIR = path.join(PACKAGES_DIR, 'precompile', '.build');
 const FLAVORS = ['debug', 'release'] as const;
@@ -46,6 +64,7 @@ export const bundleIOSPrebuilds = new Task<TaskArgs>(
       skipCompose: false,
       skipVerify: false,
       verbose: false,
+      bundleSharedDeps: true,
     });
 
     if (result.exitCode !== 0) {

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -28,7 +28,16 @@ export const bundleIOSPrebuilds = new Task<TaskArgs>(
   },
   async (parcels: Parcel[]) => {
     logger.log('\n📱 Building iOS prebuilds...');
-    const result = await runPrebuildPackagesAsync(IOS_PREBUILD_PACKAGES, {
+
+    const relevantParcels = IOS_PREBUILD_PACKAGES.filter((name) =>
+      parcels.some((p) => p.pkg.packageName === name)
+    );
+    if (relevantParcels.length === 0) {
+      logger.log('No iOS prebuild packages in publish set, skipping');
+      return;
+    }
+
+    const result = await runPrebuildPackagesAsync(relevantParcels, {
       clean: false,
       cleanCache: false,
       skipGenerate: false,
@@ -44,7 +53,14 @@ export const bundleIOSPrebuilds = new Task<TaskArgs>(
       if (result.errorLogPath) {
         logger.error(`Error log: ${result.errorLogPath}`);
       }
-      throw new Error('iOS prebuild pipeline failed');
+
+      const errorDetails = result.errors
+        .map((e) => `  - [${e.packageName}/${e.productName}] ${e.stage}: ${e.error.message}`)
+        .join('\n');
+      const errorMessage = errorDetails
+        ? `iOS prebuild pipeline failed:\n${errorDetails}`
+        : 'iOS prebuild pipeline failed';
+      throw new Error(errorMessage);
     }
 
     // Copy built tarballs into each package's prebuilds/ directory

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -27,7 +27,7 @@ const IOS_PREBUILD_PACKAGES = [
   'expo-modules-core',
   'expo-print',
   'expo-sensors',
-  'expo-ui',
+  '@expo/ui',
   'expo-video',
 ];
 

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -1,0 +1,96 @@
+import fs from 'fs';
+import path from 'path';
+
+import { loadRequestedParcels } from './loadRequestedParcels';
+import { PACKAGES_DIR } from '../../Constants';
+import { runPrebuildPackagesAsync } from '../../commands/PrebuildPackages';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { runWithSpinner } from '../../Utils';
+import { Parcel, TaskArgs } from '../types';
+
+/**
+ * Packages whose iOS prebuilt xcframeworks should be bundled into the npm tarball.
+ */
+const IOS_PREBUILD_PACKAGES = ['expo-modules-core'];
+
+const PRECOMPILE_BUILD_DIR = path.join(PACKAGES_DIR, 'precompile', '.build');
+const FLAVORS = ['debug', 'release'] as const;
+
+/**
+ * Builds iOS xcframeworks for selected packages and copies the output tarballs
+ * into each package's `prebuilds/output/` directory so they are included in `npm pack`.
+ */
+export const bundleIOSPrebuilds = new Task<TaskArgs>(
+  {
+    name: 'bundleIOSPrebuilds',
+    dependsOn: [loadRequestedParcels],
+  },
+  async (parcels: Parcel[]) => {
+    logger.log('\n📱 Building iOS prebuilds...');
+    const result = await runPrebuildPackagesAsync(IOS_PREBUILD_PACKAGES, {
+      clean: false,
+      cleanCache: false,
+      skipGenerate: false,
+      skipArtifacts: false,
+      skipBuild: false,
+      skipCompose: false,
+      skipVerify: false,
+      verbose: false,
+    });
+
+    if (result.exitCode !== 0) {
+      logger.error(`iOS prebuild failed with exit code ${result.exitCode}`);
+      if (result.errorLogPath) {
+        logger.error(`Error log: ${result.errorLogPath}`);
+      }
+      throw new Error('iOS prebuild pipeline failed');
+    }
+
+    // Copy built tarballs into each package's prebuilds/ directory
+    for (const pkgName of IOS_PREBUILD_PACKAGES) {
+      const parcel = parcels.find((p) => p.pkg.packageName === pkgName);
+      if (!parcel) {
+        logger.warn(`Package ${pkgName} not found in parcels, skipping prebuild bundling`);
+        continue;
+      }
+
+      await runWithSpinner(
+        `Bundling iOS prebuilds into ${pkgName}`,
+        async () => {
+          for (const flavor of FLAVORS) {
+            const srcDir = path.join(
+              PRECOMPILE_BUILD_DIR,
+              pkgName,
+              'output',
+              flavor,
+              'xcframeworks'
+            );
+            const destDir = path.join(
+              parcel.pkg.path,
+              'prebuilds',
+              'output',
+              flavor,
+              'xcframeworks'
+            );
+
+            if (!fs.existsSync(srcDir)) {
+              logger.warn(`  No ${flavor} xcframeworks found at ${srcDir}`);
+              continue;
+            }
+
+            await fs.promises.mkdir(destDir, { recursive: true });
+
+            const files = await fs.promises.readdir(srcDir);
+            for (const file of files) {
+              if (file.endsWith('.tar.gz')) {
+                await fs.promises.copyFile(path.join(srcDir, file), path.join(destDir, file));
+              }
+            }
+          }
+        },
+        `Bundled iOS prebuilds into ${pkgName}`
+      );
+    }
+  }
+);

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -3,10 +3,10 @@ import path from 'path';
 
 import { loadRequestedParcels } from './loadRequestedParcels';
 import { PACKAGES_DIR } from '../../Constants';
-import { runPrebuildPackagesAsync } from '../../commands/PrebuildPackages';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
+import { runPrebuildPackagesAsync } from '../../commands/PrebuildPackages';
 import { Parcel, TaskArgs } from '../types';
 
 /**

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -13,20 +13,22 @@ import { Parcel, TaskArgs } from '../types';
  * Packages whose iOS prebuilt xcframeworks should be bundled into the npm tarball.
  */
 const IOS_PREBUILD_PACKAGES = [
-  'expo-modules-core',
-  'expo-image-manipulator',
-  'expo-video',
+  'expo-brownfield',
+  'expo-camera',
   'expo-contacts',
   'expo-file-system',
-  'expo-media-library',
+  'expo-font',
+  'expo-image',
+  'expo-image-manipulator',
+  'expo-live-photo',
   'expo-location',
   'expo-maps',
+  'expo-media-library',
+  'expo-modules-core',
   'expo-print',
   'expo-sensors',
-  'expo-font',
-  'expo-live-photo',
-  'expo-brownfield',
   'expo-ui',
+  'expo-video',
 ];
 
 const PRECOMPILE_BUILD_DIR = path.join(PACKAGES_DIR, 'precompile', '.build');

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -19,6 +19,7 @@ import { runWithSpinner } from '../../Utils';
 import { resolveReleaseTypeAndVersion } from '../helpers';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
 import { addTemplateTarball } from './addTemplateTarball';
+import { bundleIOSPrebuilds } from './bundleIOSPrebuilds';
 import { updateAndroidProjects } from './updateAndroidProjects';
 
 const { cyan } = chalk;
@@ -99,7 +100,7 @@ export const cleanWorkingTree = new Task<TaskArgs>(
         await Git.cleanAsync({
           recursive: true,
           force: true,
-          paths: ['packages/**/*.tgz', 'packages/**/local-maven-repo/**', 'templates/**/*.tgz'],
+          paths: ['packages/**/*.tgz', 'packages/**/local-maven-repo/**', 'packages/**/prebuilds/**', 'templates/**/*.tgz'],
         });
       },
       'Cleaned up the working tree'
@@ -125,6 +126,7 @@ export const publishCanaryPipeline = new Task<TaskArgs>(
       updateAndroidProjects,
       publishAndroidArtifacts,
       addTemplateTarball,
+      bundleIOSPrebuilds,
       packPackageToTarball,
       publishPackages,
       cleanWorkingTree,

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -100,7 +100,12 @@ export const cleanWorkingTree = new Task<TaskArgs>(
         await Git.cleanAsync({
           recursive: true,
           force: true,
-          paths: ['packages/**/*.tgz', 'packages/**/local-maven-repo/**', 'packages/**/prebuilds/**', 'templates/**/*.tgz'],
+          paths: [
+            'packages/**/*.tgz',
+            'packages/**/local-maven-repo/**',
+            'packages/**/prebuilds/**',
+            'templates/**/*.tgz',
+          ],
         });
       },
       'Cleaned up the working tree'


### PR DESCRIPTION
# Why

With the current approach, users can only use iOS precompiled artifacts if they have them stored in a separate local folder. This works great in environments like EAS, but it is not really practical for normal users. By shipping the prebuilt debug + release tarballs inside the npm package itself, any consumer gets prebuilds out of the box.

We can start by adding prebuild artifacts just to expo-module-core for testing, and in the future we can expand this to other packages if necessary.

expo-modules-core npm tarball with precompiles is **~28,8 mb**, so it should be ok to publish on npm

Update: We're now prebuilding the following packages: 
```
[
  'expo-modules-core',
  'expo-image-manipulator',
  'expo-video',
  'expo-contacts',
  'expo-file-system',
  'expo-media-library',
  'expo-location',
  'expo-maps',
  'expo-print',
  'expo-sensors',
  'expo-font',
  'expo-live-photo',
  'expo-brownfield',
  'expo-ui',
]
```

# How

- Add a new `bundleIOSPrebuilds` publish task that runs `et prebuild` for a list of predetermined packages (currently `['expo-modules-core']`), then copies the output tarballs so they're included in `npm pack`.
- Updated `precompiled_modules.rb` script to check for a `prebuilds/output/` directory inside the package directory itself when the outer build path doesn't exist. `EXPO_PRECOMPILED_MODULES_PATH` still takes precedence.
- Adjusted publish-canaries workflow to use a `macos` runner, since the pipeline now runs `xcodebuild`
- Made `hermesVersion` explicitly optional in `PrebuildCliOptions`, (invoking et prepublish would already pass empty hermes version) 

# Test Plan

- Run `et publish-packages --canary --dry` on macOS and verify the `bundleIOSPrebuilds` task builds xcframeworks and copies them into `packages/expo-modules-core/prebuilds/output/`
- Run `cd packages/expo-modules-core && npm pack --dry-run` and verify `prebuilds/output/{debug,release}/xcframeworks/ExpoModulesCore.tar.gz` are listed
- In a standalone project, run `EXPO_USE_PRECOMPILED_MODULES=1 pod install` and verify ExpoModulesCore resolves from the bundled prebuilds path without needing `EXPO_PRECOMPILED_MODULES_PATH` 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
