### PR TITLE
[expo-updates-interface][expo-updates] Extend native interface with state context

### DIFF
--- a/packages/expo-updates-interface/CHANGELOG.md
+++ b/packages/expo-updates-interface/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Native interface access to state machine context. ([#44361](https://github.com/expo/expo/pull/44361) by [@douglowder](https://github.com/douglowder))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
@@ -79,4 +79,32 @@ interface UpdatesStateChangeSubscription {
    * Call this to remove the subscription and stop receiving state change events
    */
   fun remove()
+  /*
+   * When updates is enabled, returns the current state context as an instance of UpdatesNativeInterfaceStateContext
+   */
+  fun getContext(): Any?
+}
+
+/**
+ * Expose the state machine context to the native interface.
+ */
+data class UpdatesNativeInterfaceStateContext(
+  val isUpdateAvailable: Boolean,
+  val isUpdatePending: Boolean,
+  val isChecking: Boolean,
+  val isDownloading: Boolean,
+  val isRestarting: Boolean,
+  val restartCount: Int,
+  val latestManifest: Map<String, Any>?,
+  val downloadedManifest: Map<String, Any>?,
+  val rollback: Rollback?,
+  val checkError: Map<String, String>?,
+  val downloadError: Map<String, String>?,
+  val downloadProgress: Double,
+  val lastCheckForUpdateTime: java.util.Date?,
+  val sequenceNumber: Int,
+  val downloadStartTime: java.util.Date?,
+  val downloadFinishTime: java.util.Date?
+) {
+  data class Rollback(val commitTime: java.util.Date)
 }

--- a/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesInterface.swift
+++ b/packages/expo-updates-interface/ios/EXUpdatesInterface/UpdatesInterface.swift
@@ -85,4 +85,73 @@ public protocol UpdatesStateChangeSubscription {
    * Call this to remove the subscription and stop receiving state change events
    */
   func remove()
+  /*
+   * When updates is enabled, returns the current state context as an instance of UpdatesNativeInterfaceStateContext
+   */
+  func getContext() -> Any?
+}
+
+/**
+ Expose the state machine context to the native interface.
+ */
+public struct UpdatesNativeInterfaceStateContext {
+  public struct Rollback {
+    public let commitTime: Date
+
+    public init(commitTime: Date) {
+      self.commitTime = commitTime
+    }
+  }
+  public let isUpdateAvailable: Bool
+  public let isUpdatePending: Bool
+  public let isChecking: Bool
+  public let isDownloading: Bool
+  public let isRestarting: Bool
+  public let restartCount: Int
+  public let latestManifest: [String: Any]?
+  public let downloadedManifest: [String: Any]?
+  public let rollback: Rollback?
+  public let checkError: [String: String]?
+  public let downloadError: [String: String]?
+  public let downloadProgress: Double
+  public let lastCheckForUpdateTime: Date?
+  public let sequenceNumber: Int
+  public let downloadStartTime: Date?
+  public let downloadFinishTime: Date?
+
+  public init(
+    isUpdateAvailable: Bool,
+    isUpdatePending: Bool,
+    isChecking: Bool,
+    isDownloading: Bool,
+    isRestarting: Bool,
+    restartCount: Int,
+    latestManifest: [String : Any]?,
+    downloadedManifest: [String : Any]?,
+    rollback: Rollback?,
+    checkError: [String : String]?,
+    downloadError: [String : String]?,
+    downloadProgress: Double,
+    lastCheckForUpdateTime: Date?,
+    sequenceNumber: Int,
+    downloadStartTime: Date?,
+    downloadFinishTime: Date?
+  ) {
+    self.isUpdateAvailable = isUpdateAvailable
+    self.isUpdatePending = isUpdatePending
+    self.isChecking = isChecking
+    self.isDownloading = isDownloading
+    self.isRestarting = isRestarting
+    self.restartCount = restartCount
+    self.latestManifest = latestManifest
+    self.downloadedManifest = downloadedManifest
+    self.rollback = rollback
+    self.checkError = checkError
+    self.downloadError = downloadError
+    self.downloadProgress = downloadProgress
+    self.lastCheckForUpdateTime = lastCheckForUpdateTime
+    self.sequenceNumber = sequenceNumber
+    self.downloadStartTime = downloadStartTime
+    self.downloadFinishTime = downloadFinishTime
+  }
 }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
+- Native interface access to state machine context. ([#44361](https://github.com/expo/expo/pull/44361) by [@douglowder](https://github.com/douglowder))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -358,6 +358,10 @@ class EnabledUpdatesController(
     }
   }
 
+  internal fun getNativeInterfaceContext(): expo.modules.updatesinterface.UpdatesNativeInterfaceStateContext {
+    return stateMachine.context.nativeInterfaceContext
+  }
+
   override val isEnabled: Boolean = true
 
   companion object {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesStateChangeSubscription.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesStateChangeSubscription.kt
@@ -4,11 +4,17 @@ import expo.modules.updatesinterface.UpdatesStateChangeSubscription
 
 class DisabledUpdatesStateChangeSubscription : UpdatesStateChangeSubscription {
   override fun remove() {}
+  override fun getContext(): Any? = null
 }
 
 class EnabledUpdatesStateChangeSubscription(val subscriptionId: String) : UpdatesStateChangeSubscription {
   override fun remove() {
     val updatesController: EnabledUpdatesController? = UpdatesController.instance as? EnabledUpdatesController
     updatesController?.unsubscribeFromUpdatesStateChanges(subscriptionId)
+  }
+
+  override fun getContext(): Any? {
+    val updatesController: EnabledUpdatesController? = UpdatesController.instance as? EnabledUpdatesController
+    return updatesController?.getNativeInterfaceContext()
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateContext.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateContext.kt
@@ -24,7 +24,9 @@ class UpdatesStateContext private constructor(
   val downloadError: UpdatesStateError? = null,
   val downloadProgress: Double = 0.0,
   val lastCheckForUpdateTime: Date? = null,
-  val sequenceNumber: Int
+  val sequenceNumber: Int,
+  val downloadStartTime: Date? = null,
+  val downloadFinishTime: Date? = null
 ) {
   constructor(
     isStartupProcedureRunning: Boolean = false,
@@ -40,7 +42,9 @@ class UpdatesStateContext private constructor(
     checkError: UpdatesStateError? = null,
     downloadError: UpdatesStateError? = null,
     downloadProgress: Double = 0.0,
-    lastCheckForUpdateTime: Date? = null
+    lastCheckForUpdateTime: Date? = null,
+    downloadStartTime: Date? = null,
+    downloadFinishTime: Date? = null
   ) : this(
     isStartupProcedureRunning = isStartupProcedureRunning,
     isUpdateAvailable = isUpdateAvailable,
@@ -56,7 +60,9 @@ class UpdatesStateContext private constructor(
     downloadError = downloadError,
     downloadProgress = downloadProgress,
     lastCheckForUpdateTime = lastCheckForUpdateTime,
-    sequenceNumber = 0
+    sequenceNumber = 0,
+    downloadStartTime = downloadStartTime,
+    downloadFinishTime = downloadFinishTime
   )
 
   fun copyAndIncrementSequenceNumber(
@@ -73,7 +79,9 @@ class UpdatesStateContext private constructor(
     rollback: UpdatesStateContextRollback? = this.rollback,
     checkError: UpdatesStateError? = this.checkError,
     downloadError: UpdatesStateError? = this.downloadError,
-    lastCheckForUpdateTime: Date? = this.lastCheckForUpdateTime
+    lastCheckForUpdateTime: Date? = this.lastCheckForUpdateTime,
+    downloadStartTime: Date? = this.downloadStartTime,
+    downloadFinishTime: Date? = this.downloadFinishTime
   ): UpdatesStateContext = UpdatesStateContext(
     isStartupProcedureRunning = isStartupProcedureRunning,
     isUpdateAvailable = isUpdateAvailable,
@@ -89,13 +97,37 @@ class UpdatesStateContext private constructor(
     downloadError = downloadError,
     downloadProgress = downloadProgress,
     lastCheckForUpdateTime = lastCheckForUpdateTime,
-    sequenceNumber = this.sequenceNumber + 1
+    sequenceNumber = this.sequenceNumber + 1,
+    downloadStartTime = downloadStartTime,
+    downloadFinishTime = downloadFinishTime
   )
 
   fun resetCopyWithIncrementedRestartCountAndSequenceNumber(): UpdatesStateContext = UpdatesStateContext(
     restartCount = this.restartCount + 1,
     sequenceNumber = this.sequenceNumber + 1
   )
+
+  val nativeInterfaceContext: expo.modules.updatesinterface.UpdatesNativeInterfaceStateContext
+    get() = expo.modules.updatesinterface.UpdatesNativeInterfaceStateContext(
+      isUpdateAvailable = isUpdateAvailable,
+      isUpdatePending = isUpdatePending,
+      isChecking = isChecking,
+      isDownloading = isDownloading,
+      isRestarting = isRestarting,
+      restartCount = restartCount,
+      latestManifest = latestManifest?.let { jsonToMap(it) },
+      downloadedManifest = downloadedManifest?.let { jsonToMap(it) },
+      rollback = rollback?.let {
+        expo.modules.updatesinterface.UpdatesNativeInterfaceStateContext.Rollback(commitTime = it.commitTime)
+      },
+      checkError = checkError?.let { mapOf("message" to it.message) },
+      downloadError = downloadError?.let { mapOf("message" to it.message) },
+      downloadProgress = downloadProgress,
+      lastCheckForUpdateTime = lastCheckForUpdateTime,
+      sequenceNumber = sequenceNumber,
+      downloadStartTime = downloadStartTime,
+      downloadFinishTime = downloadFinishTime
+    )
 
   val json: Map<String, Any>
     get() {
@@ -127,6 +159,12 @@ class UpdatesStateContext private constructor(
       }
       if (lastCheckForUpdateTime != null) {
         map["lastCheckForUpdateTime"] = lastCheckForUpdateTime
+      }
+      if (downloadStartTime != null) {
+        map["downloadStartTime"] = downloadStartTime.time
+      }
+      if (downloadFinishTime != null) {
+        map["downloadFinishTime"] = downloadFinishTime.time
       }
       return map
     }
@@ -183,6 +221,16 @@ class UpdatesStateContext private constructor(
       SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US).apply {
         timeZone = java.util.TimeZone.getTimeZone("GMT")
       }
+    }
+
+    private fun jsonToMap(json: JSONObject): Map<String, Any> {
+      val map = mutableMapOf<String, Any>()
+      val keys = json.keys()
+      while (keys.hasNext()) {
+        val key = keys.next()
+        map[key] = json.get(key)
+      }
+      return map
     }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/statemachine/UpdatesStateMachine.kt
@@ -205,7 +205,9 @@ class UpdatesStateMachine(
         )
         is UpdatesStateEvent.Download -> context.copyAndIncrementSequenceNumber(
           downloadProgress = 0.0,
-          isDownloading = true
+          isDownloading = true,
+          downloadStartTime = Date(),
+          downloadFinishTime = null
         )
         is UpdatesStateEvent.DownloadProgress -> context.copyAndIncrementSequenceNumber(
           downloadProgress = event.progress
@@ -214,12 +216,16 @@ class UpdatesStateMachine(
           isDownloading = false,
           downloadError = null,
           isUpdatePending = true,
-          downloadProgress = 1.0
+          downloadProgress = 1.0,
+          downloadStartTime = null,
+          downloadFinishTime = null
         )
         is UpdatesStateEvent.DownloadCompleteWithRollback -> context.copyAndIncrementSequenceNumber(
           isDownloading = false,
           downloadError = null,
-          isUpdatePending = true
+          isUpdatePending = true,
+          downloadStartTime = null,
+          downloadFinishTime = null
         )
         is UpdatesStateEvent.DownloadCompleteWithUpdate -> context.copyAndIncrementSequenceNumber(
           isDownloading = false,
@@ -228,11 +234,14 @@ class UpdatesStateMachine(
           downloadedManifest = event.manifest,
           rollback = null,
           isUpdatePending = true,
-          isUpdateAvailable = true
+          isUpdateAvailable = true,
+          downloadFinishTime = Date()
         )
         is UpdatesStateEvent.DownloadError -> context.copyAndIncrementSequenceNumber(
           isDownloading = false,
-          downloadError = event.error
+          downloadError = event.error,
+          downloadStartTime = null,
+          downloadFinishTime = null
         )
         is UpdatesStateEvent.Restart -> context.copyAndIncrementSequenceNumber(
           isRestarting = true

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -16,6 +16,7 @@ type NativeInterfaceState = {
   runtimeVersion: string;
   embeddedUpdateId: string;
   launchedUpdateId: string;
+  downloadTimeMs: number | null;
   type?: string | null;
   manifest?: ExpoUpdatesManifest | null;
 };
@@ -39,6 +40,7 @@ function useNativeInterfaceState() {
     runtimeVersion,
     embeddedUpdateId,
     launchedUpdateId,
+    downloadTimeMs: null,
   });
   const listener = React.useCallback((event: any) => {
     setState({
@@ -47,6 +49,7 @@ function useNativeInterfaceState() {
       runtimeVersion,
       embeddedUpdateId,
       launchedUpdateId: ExpoUpdatesE2ETestModule.getLaunchedUpdateId(),
+      downloadTimeMs: ExpoUpdatesE2ETestModule.getDownloadTimeMs(),
     });
   }, []);
   React.useEffect(() => {
@@ -312,6 +315,10 @@ export default function App() {
       <TestValue
         testID="nativeInterfaceState.availableUpdateId"
         value={`${nativeInterfaceState.manifest?.id}`}
+      />
+      <TestValue
+        testID="nativeInterfaceState.downloadTimeMs"
+        value={`${nativeInterfaceState.downloadTimeMs}`}
       />
 
       <Text>Log messages</Text>

--- a/packages/expo-updates/e2e/fixtures/E2ETestModule.swift
+++ b/packages/expo-updates/e2e/fixtures/E2ETestModule.swift
@@ -59,6 +59,15 @@ public final class E2ETestModule: Module, UpdatesStateChangeListener {
       return updatesController?.runtimeVersion
     }
 
+    Function("getDownloadTimeMs") {
+      guard let context = subscription?.getContext() as? UpdatesNativeInterfaceStateContext,
+        let downloadStartTime = context.downloadStartTime,
+        let downloadFinishTime = context.downloadFinishTime else {
+        return nil as Int?
+      }
+      return Int(floor(downloadFinishTime.timeIntervalSince(downloadStartTime) * 1000.0))
+    }
+
     AsyncFunction("readInternalAssetsFolderAsync") { (promise: Promise) in
       guard let assetsFolder = AppController.sharedInstance.updatesDirectory else {
         promise.reject("ERR_UPDATES_E2E_READ", "No updatesDirectory initialized")

--- a/packages/expo-updates/e2e/fixtures/UpdatesE2ETestModule.kt
+++ b/packages/expo-updates/e2e/fixtures/UpdatesE2ETestModule.kt
@@ -7,8 +7,10 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.updatesinterface.UpdatesControllerRegistry
 import expo.modules.updatesinterface.UpdatesInterface
+import expo.modules.updatesinterface.UpdatesNativeInterfaceStateContext
 import expo.modules.updatesinterface.UpdatesStateChangeListener
 import expo.modules.updatesinterface.UpdatesStateChangeSubscription
+import kotlin.math.floor
 
 class UpdatesE2ETestModule : Module(), UpdatesStateChangeListener {
   private var hasListener: Boolean = false
@@ -51,6 +53,13 @@ class UpdatesE2ETestModule : Module(), UpdatesStateChangeListener {
 
     Function("getRuntimeVersion") {
       return@Function updatesController?.runtimeVersion
+    }
+
+    Function("getDownloadTimeMs") {
+      val context = subscription?.getContext() as? UpdatesNativeInterfaceStateContext ?: return@Function null
+      val startTime = context.downloadStartTime ?: return@Function null
+      val finishTime = context.downloadFinishTime ?: return@Function null
+      return@Function finishTime.time - startTime.time
     }
 
     AsyncFunction("clearInternalAssetsFolderAsync") { promise: Promise ->

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/jsapi_stateMachine.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/jsapi_stateMachine.yml
@@ -20,6 +20,12 @@ onFlowStart:
     condition: ${maestro.copiedText == "false"}
     label: Assert isUpdatePending is false
 - copyTextFrom:
+    label: Copy text from nativeInterface state type
+    id: nativeInterfaceState.downloadTimeMs
+- assertTrue:
+    condition: ${maestro.copiedText == "null"}
+    label: Assert download time is null
+- copyTextFrom:
     label: Copy text from isUpdateAvailable
     id: state.isUpdateAvailable
 - assertTrue:
@@ -132,6 +138,12 @@ onFlowStart:
 - assertTrue:
     condition: ${maestro.copiedText == "downloadCompleteWithUpdate"}
     label: Assert state is "downloadCompleteWithUpdate"
+- copyTextFrom:
+    label: Copy text from nativeInterface state type
+    id: nativeInterfaceState.downloadTimeMs
+- assertTrue:
+    condition: ${maestro.copiedText != "null"}
+    label: Assert download time is not null
 - copyTextFrom:
     label: Copy text from nativeInterface availableUpdateID
     id: nativeInterfaceState.availableUpdateID

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -5,6 +5,7 @@ import EXUpdatesInterface
 
 internal class DisabledUpdatesStateChangeSubscription: UpdatesStateChangeSubscription {
   func remove() {}
+  func getContext() -> Any? { return nil }
 }
 
 /**

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -16,6 +16,13 @@ internal class EnabledUpdatesStateChangeSubscription: UpdatesStateChangeSubscrip
       updatesController.unsubscribeFromUpdatesStateChanges(subscriptionId)
     }
   }
+
+  func getContext() -> Any? {
+    if let updatesController = AppController.sharedInstance as? EnabledAppController {
+      return updatesController.getNativeInterfaceContext()
+    }
+    return nil
+  }
 }
 
 /**
@@ -188,6 +195,10 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesInterf
     if stateChangeListeners[subscriptionId] != nil {
       stateChangeListeners.removeValue(forKey: subscriptionId)
     }
+  }
+
+  internal func getNativeInterfaceContext() -> UpdatesNativeInterfaceStateContext {
+    return stateMachine.context.nativeInterfaceContext
   }
 
   public var runtimeVersion: String? {

--- a/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesStateMachine.swift
@@ -1,6 +1,7 @@
 //  Copyright © 2023 650 Industries. All rights reserved.
 
 // swiftlint:disable no_grouping_extension
+// swiftlint:disable no_fallthrough_only
 
 import Foundation
 import EXUpdatesInterface
@@ -157,12 +158,39 @@ public struct UpdatesStateContext {
   public let downloadProgress: Double
   public let lastCheckForUpdateTime: Date?
   public let sequenceNumber: Int
+  public let downloadStartTime: Date?
+  public let downloadFinishTime: Date?
 
   private var lastCheckForUpdateTimeDateString: String? {
     guard let lastCheckForUpdateTime = lastCheckForUpdateTime else {
       return nil
     }
     return iso8601DateFormatter.string(from: lastCheckForUpdateTime)
+  }
+
+  var nativeInterfaceContext: UpdatesNativeInterfaceStateContext {
+    return UpdatesNativeInterfaceStateContext(
+      isUpdateAvailable: isUpdateAvailable,
+      isUpdatePending: isUpdatePending,
+      isChecking: isChecking,
+      isDownloading: isDownloading,
+      isRestarting: isRestarting,
+      restartCount: restartCount,
+      latestManifest: latestManifest,
+      downloadedManifest: downloadedManifest,
+      rollback: rollback != nil ?
+        UpdatesNativeInterfaceStateContext.Rollback(
+          commitTime: rollback?.commitTime ?? Date.now
+        ) :
+        nil,
+      checkError: checkError,
+      downloadError: downloadError,
+      downloadProgress: downloadProgress,
+      lastCheckForUpdateTime: lastCheckForUpdateTime,
+      sequenceNumber: sequenceNumber,
+      downloadStartTime: downloadStartTime,
+      downloadFinishTime: downloadFinishTime
+    )
   }
 
   var json: [String: Any?] {
@@ -181,7 +209,13 @@ public struct UpdatesStateContext {
       "downloadProgress": self.downloadProgress,
       "lastCheckForUpdateTimeString": lastCheckForUpdateTimeDateString,
       "rollback": rollback?.json,
-      "sequenceNumber": sequenceNumber
+      "sequenceNumber": sequenceNumber,
+      "downloadStartTime": downloadStartTime != nil
+        ? Int(floor(downloadStartTime?.timeIntervalSince1970 ?? 0.0 * 1000))
+        : nil,
+      "downloadFinishTime": downloadFinishTime != nil
+        ? Int(floor(downloadFinishTime?.timeIntervalSince1970 ?? 0.0 * 1000))
+        : nil
     ] as [String: Any?]
   }
 }
@@ -203,6 +237,8 @@ public extension UpdatesStateContext {
     self.lastCheckForUpdateTime = nil
     self.rollback = nil
     self.sequenceNumber = 0
+    self.downloadStartTime = nil
+    self.downloadFinishTime = nil
   }
 
   // struct copy, lets you overwrite specific variables retaining the value of the rest
@@ -233,6 +269,8 @@ public extension UpdatesStateContext {
     var downloadError: [String: String]?
     var lastCheckForUpdateTime: Date?
     var rollback: UpdatesStateContextRollback?
+    var downloadStartTime: Date?
+    var downloadFinishTime: Date?
 
     fileprivate init(original: UpdatesStateContext) {
       self.isStartupProcedureRunning = original.isStartupProcedureRunning
@@ -249,6 +287,8 @@ public extension UpdatesStateContext {
       self.downloadProgress = original.downloadProgress
       self.lastCheckForUpdateTime = original.lastCheckForUpdateTime
       self.rollback = original.rollback
+      self.downloadStartTime = original.downloadStartTime
+      self.downloadFinishTime = original.downloadFinishTime
     }
 
     fileprivate func toContext(newRestartCount: Int, newSequenceNumber: Int) -> UpdatesStateContext {
@@ -267,7 +307,9 @@ public extension UpdatesStateContext {
         downloadError: downloadError,
         downloadProgress: downloadProgress,
         lastCheckForUpdateTime: lastCheckForUpdateTime,
-        sequenceNumber: newSequenceNumber
+        sequenceNumber: newSequenceNumber,
+        downloadStartTime: downloadStartTime,
+        downloadFinishTime: downloadFinishTime
       )
     }
   }
@@ -444,6 +486,8 @@ internal class UpdatesStateMachine {
       return context.copyAndIncrementSequenceNumber {
         $0.downloadProgress = 0.0
         $0.isDownloading = true
+        $0.downloadStartTime = Date.now
+        $0.downloadFinishTime = nil
       }
     case let .downloadProgress(progress):
       return context.copyAndIncrementSequenceNumber {
@@ -455,12 +499,16 @@ internal class UpdatesStateMachine {
         $0.downloadError = nil
         $0.isUpdatePending = true
         $0.downloadProgress = 1.0
+        $0.downloadStartTime = nil
+        $0.downloadFinishTime = nil
       }
     case .downloadCompleteWithRollback:
       return context.copyAndIncrementSequenceNumber {
         $0.isDownloading = false
         $0.downloadError = nil
         $0.isUpdatePending = true
+        $0.downloadStartTime = nil
+        $0.downloadFinishTime = nil
       }
     case let .downloadCompleteWithUpdate(manifest):
       return context.copyAndIncrementSequenceNumber {
@@ -471,11 +519,14 @@ internal class UpdatesStateMachine {
         $0.rollback = nil
         $0.isUpdatePending = true
         $0.isUpdateAvailable = true
+        $0.downloadFinishTime = Date.now
       }
     case let .downloadError(errorMessage):
       return context.copyAndIncrementSequenceNumber {
         $0.isDownloading = false
         $0.downloadError = ["message": errorMessage]
+        $0.downloadStartTime = nil
+        $0.downloadFinishTime = nil
       }
     case .restart:
       return context.copyAndIncrementSequenceNumber {
@@ -525,4 +576,5 @@ internal class UpdatesStateMachine {
   ]
 }
 
+// swiftlint:enable no_fallthrough_only
 // swiftlint:enable no_grouping_extension


### PR DESCRIPTION
# Why

Code that uses the native interface in `expo-updates-interface` may need to know the current state of the updates system, in order to check status, compute metrics, etc. At the moment, the only information provided via the interface (besides a few constants) is sent by calling the state change event listener. Since this only happens after the updates system is started, the native interface will not be able to get information on OTA update downloads and other events that happen at startup.

In #44256 I proposed caching the events and sending events in the cache whenever a new subscription was created for the events. This works, but has some possible problems, since the cache has a limited size and there is still a possibility of missing events.

This PR solves the problem by instead allowing the native interface to have a read-only view of the state machine context. The changes here also include the addition of `downloadStartTime` and `downloadFinishTime` to the context, so that OTA download times can be calculated for metrics.

This PR does not introduce any breaking changes to the interface, so it is safe to cherry-pick for SDK 55.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Add a new method in `UpdatesStateChangeSubscription` to get a read-only copy of the context
    - On iOS, the context is returned as type `Any?` to keep Objective-C compatibility in the interface
    - New data struct type added in the native interface
- Add `downloadStartTime`and `downloadFinishTime` to the context
    - These will only be non-null after a `downloadCompleteWithUpdate` event. Other download events (`downloadError`, `downloadCompleteWithRollback`, etc., will set the times to null

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Tested manually with `UpdatesAPIDemo`
- New method added to E2E test module
- New test code added to the updates E2E (enabled) test in CI

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)