### PR TITLE
[ci] fix failing expo go workflow

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
@@ -4,6 +4,7 @@
 #import <RCTAppSetupUtils.h>
 #import <React/CoreModulesPlugins.h>
 #import <ExpoModulesCore/EXRuntime.h>
+#import <ExpoModulesCore/EXHostWrapper.h>
 #import <ExpoModulesCore-Swift.h>
 
 


### PR DESCRIPTION
# Why

the workflow last failed with https://expo.dev/accounts/expo-ci/projects/unversioned-expo-go/workflows/019d3d2f-5363-77e9-8a35-1e3995e310c6#job-019d3d2f-5648-7c14-bcf7-1052cfb29224 


```
❌  (../expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm:55:32)

  53 |   // Inject and decorate the `global.expo` object
  54 |   appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
> 55 |   [appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
     |                                ^ receiver 'EXHostWrapper' for class message is a forward declaration
  56 | 
  57 |   [appContext registerNativeModules];
  58 | }


❌  (../expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm:55:31)

  53 |   // Inject and decorate the `global.expo` object
  54 |   appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
> 55 |   [appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
     |                               ^ receiver type 'EXHostWrapper' for instance message is a forward declaration
  56 | 
  57 |   [appContext registerNativeModules];
  58 | }
  ```

# How

add `EXHostWrapper` import to avoid "forward declaration" error

# Test Plan

- green CI 
- 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
