### PR TITLE
Refactor AlertDialog component usage in documentation

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/alertdialog.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/alertdialog.mdx
@@ -31,26 +31,15 @@ export default function BasicAlertDialogExample() {
       <Button onClick={() => setVisible(true)}>
         <Text>Show Alert</Text>
       </Button>
-      {visible && (
-        <AlertDialog onDismissRequest={() => setVisible(false)}>
-          <AlertDialog.Title>
-            <Text>Confirm Action</Text>
-          </AlertDialog.Title>
-          <AlertDialog.Text>
-            <Text>Are you sure you want to proceed?</Text>
-          </AlertDialog.Text>
-          <AlertDialog.ConfirmButton>
-            <TextButton onClick={() => setVisible(false)}>
-              <Text>Confirm</Text>
-            </TextButton>
-          </AlertDialog.ConfirmButton>
-          <AlertDialog.DismissButton>
-            <TextButton onClick={() => setVisible(false)}>
-              <Text>Cancel</Text>
-            </TextButton>
-          </AlertDialog.DismissButton>
-        </AlertDialog>
-      )}
+      <AlertDialog
+        visible={visible}
+        title="Confirm Action"
+        dismissButtonText="Cancel"
+        confirmButtonText="Confirm"
+        text="Are you sure you want to proceed?"
+        onConfirmPressed={() => setVisible(false)}
+        onDismissPressed={() => setVisible(false)}
+      />
     </Host>
   );
 }


### PR DESCRIPTION
30th March, 2026. Being in alpha, the implementation in the documentation for @expo/ui/jetpack-compose AlertDialog is outdated. That is what worked for me.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
