### PR TITLE
[docs] Revert system bars page changes

### DIFF
--- a/docs/pages/develop/user-interface/system-bars.mdx
+++ b/docs/pages/develop/user-interface/system-bars.mdx
@@ -62,21 +62,25 @@ export default function RootLayout() {
 
 To control the `StatusBar` visibility, you can set the [`hidden`](/versions/latest/sdk/status-bar/#hidden) property to `true` or use the [`setStatusBarHidden`](/versions/latest/sdk/status-bar/#statusbarsetstatusbarhiddenhidden-animation) method.
 
+**With edge-to-edge enabled on Android, features from `expo-status-bar` that depend on an opaque status bar [are unavailable](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge)**. It's only possible to customize the style and visibility. Other properties will no-op and warn.
+
 ### Navigation bar configuration (Android only)
 
 On Android devices, the Navigation Bar appears at the bottom of the screen. You can customize it using the [`expo-navigation-bar`](/versions/latest/sdk/navigation-bar) library. It provides a `NavigationBar` component that you can use to set the style of the navigation bar using the [`setStyle`](/versions/latest/sdk/navigation-bar/#navigationbarsetstylestyle) method:
 
 ```tsx src/app/_layout.tsx
-import { NavigationBar } from 'expo-navigation-bar';
+import { Platform } from 'react-native';
+import * as NavigationBar from 'expo-navigation-bar';
+import { useEffect } from 'react';
 
-export default function RootLayout() {
-  return (
-    <>
-      {/* Set the navigation bar style */}
-      <NavigationBar style="dark" />
-    </>
-  );
-}
+useEffect(() => {
+  if (Platform.OS === 'android') {
+    // Set the navigation bar style
+    NavigationBar.setStyle('dark');
+  }
+}, []);
 ```
 
-To control the `NavigationBar` visibility, you can use the [`hidden`](/versions/latest/sdk/navigation-bar/#hidden) prop or the [`NavigationBar.setHidden`](/versions/latest/sdk/navigation-bar/#navigationbarsethiddenhidden) method.
+To control the `NavigationBar` visibility, you can use the [`setVisibilityAsync`](/versions/latest/sdk/navigation-bar/#navigationbarsetvisibilityasyncvisibility) method.
+
+**With edge-to-edge enabled on Android, features from `expo-navigation-bar` that depend on an opaque navigation bar [are unavailable](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge)**. It's only possible to customize the style and visibility. Other properties will no-op and warn.


### PR DESCRIPTION
# Why

According to https://github.com/expo/expo/pull/44327#discussion_r3010081818, this page is not versioned. So it must be rolled back until the new SDK release.

# How

- Rollback `system-bars.mdx` documentation page

# Test Plan

None

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
