### PR TITLE
[core] fix findView for fabric

### DIFF
--- a/apps/native-component-list/src/screens/Video/VideoFullscreenScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoFullscreenScreen.tsx
@@ -26,16 +26,21 @@ export default function VideoFullscreenScreen() {
   });
 
   const toggleFullscreen = useCallback(() => {
-    if (!isFullscreen) {
-      ref.current?.enterFullscreen();
+    const current = ref.current;
+    if (current) {
+      if (!isFullscreen) {
+        ref.current?.enterFullscreen().catch(addNewHistoryEntry);
+      } else {
+        ref.current?.exitFullscreen().catch(addNewHistoryEntry);
+      }
     } else {
-      ref.current?.exitFullscreen();
+      addNewHistoryEntry('current video ref was null!');
     }
   }, [player]);
 
   const addNewHistoryEntry = (entry: string) => {
     const newIdx = Object.keys(eventHistory).length;
-    const history = eventHistory;
+    const history = { ...eventHistory };
     history[newIdx] = entry;
     setEventHistory(history);
   };

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed view lookup in bridgeless mode by using `ExpoHostWrapper` instead of `reactBridge.uiManager`. ([#44375](https://github.com/expo/expo/pull/44375) by [@vonovak](https://github.com/vonovak))
 - [Android] Added support for CSS `rgb(...)` and `rgba(...)` color strings when converting JS color values to `android.graphics.Color`. ([#44023](https://github.com/expo/expo/pull/44023) by [@dileepapeiris](https://github.com/dileepapeiris))
 - [Android] Fixed Compose view clipping that caused Material ripple effects to be cut off (e.g., Switch thumb ripple). ([#43656](https://github.com/expo/expo/pull/43656) by [@vonovak](https://github.com/vonovak))
 - [iOS] Fix memory leak due to retain cycle in SwiftUI views. ([#43468](https://github.com/expo/expo/pull/43468) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -184,8 +184,8 @@ public final class AppContext: NSObject, @unchecked Sendable {
 
   // MARK: - UI
 
-  public func findView<ViewType>(withTag viewTag: Int, ofType type: ViewType.Type) -> ViewType? {    
-    return reactBridge?.uiManager.view(forReactTag: NSNumber(value: viewTag)) as? ViewType
+  public func findView<ViewType>(withTag viewTag: Int, ofType type: ViewType.Type) -> ViewType? {
+    return hostWrapper?.findView(withTag: viewTag) as? ViewType
   }
 
   // MARK: - Running on specific queues


### PR DESCRIPTION
# Why

#44248 (SPM refactoring) replaced `hostWrapper?.findView(withTag:)` with `reactBridge?.uiManager.view(forReactTag:)` in `AppContext.findView`. In bridgeless/new-arch mode, `reactBridge` is nil, so all view functions (caught by expo-video e2e tests) fail with "Unable to find the view with tag".

# How

Restore the `hostWrapper?.findView(withTag:)` call, which uses `RCTComponentViewRegistry` (Fabric) instead of the legacy Paper `uiManager`.

# Test Plan

1. Open bare-expo (new arch enabled) on iOS.
2. Navigate to the Video > Fullscreen screen in NCL.
3. Tap "Enter Fullscreen" — verify fullscreen enters without error.
4. Exit fullscreen — verify it exits cleanly.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
