### PR TITLE
[ci] Fix hanging upload-artifact

### DIFF
--- a/.github/workflows/android-instrumentation-tests.yml
+++ b/.github/workflows/android-instrumentation-tests.yml
@@ -99,4 +99,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: packages/**/build/outputs/androidTest-results/**/*
+          path: packages/*/android/build/outputs/androidTest-results/**/*

--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -78,4 +78,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: test-results
-          path: packages/**/build/test-results/**/*xml
+          path: packages/*/android/build/test-results/**/*xml


### PR DESCRIPTION
# Why

There is a problem with a hanging upload-artifact step - highly likely because of the migration to pnpm (the filesystem hangs while trying to resolve symlinks in node_modules).
Example:
https://github.com/expo/expo/actions/runs/23752426979/job/69197919049
# How

I ran tests locally and searched for `test-results` directories. I found out that all paths follow this pattern: `packages/xyz/android/build` - therefore I replaced the old broad pattern with a new narrow one that omits node_modules. Same for android-instrumentation-tests

# Test Plan
Spotless seems to fail, but if the upload doesn't hang, we are good.