### PR TITLE
fix/chore(log-box) Fix typo from #44330 and move skip check to script

### DIFF
--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -12,7 +12,7 @@
     "watch": "run-p watch:lib watch:bundle",
     "watch:lib": "tsc -p tsconfig.lib.json --watch",
     "watch:bundle": "node ./scripts/watch-bundle.mjs",
-    "prepare": "[ -d dist/ExpoLogBox.bundle ] || run-s build:bundle,
+    "prepare": "run-s build:bundle",
     "prepublishOnly": "run-s clean build",
     "build": "run-s build:lib build:bundle",
     "build:lib": "tsc -p tsconfig.lib.json",

--- a/packages/@expo/log-box/scripts/build-bundle.mjs
+++ b/packages/@expo/log-box/scripts/build-bundle.mjs
@@ -5,6 +5,7 @@
 
 import spawn from '@expo/spawn-async';
 import { globSync } from 'glob';
+import { existsSync } from 'node:fs';
 import { rm, rename } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { join, dirname } from 'path';
@@ -21,6 +22,16 @@ const defaultDomComponentsBundle = 'www.bundle';
 const outputDir = join(__dirname, '../dist');
 const appBundlePath = join(outputDir, 'app.bundle');
 const indexHtmlPath = join(outputDir, defaultDomComponentsBundle, 'index.html');
+
+const forceArgvIdx = argv.findIndex((item) => item === '-f' || item === '--force');
+if (
+  forceArgvIdx === -1 &&
+  existsSync(join(outputDir, outputLogBoxBundle))
+) {
+  process.exit(0);
+} else if (forceArgvIdx !== -1) {
+  argv.splice(forceArgvIdx, 1);
+}
 
 await rm(outputDir, { recursive: true, force: true });
 


### PR DESCRIPTION
# Why

Fix typo introduced in #44330.
Also moves the skipping logic to the script itself

# How

- Skips if `-f|--force` isn't passed (filtered out of `argv`)
- and; if the bundle doesn't exist

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
