### PR TITLE
[core][Android] Start using CT reflection

### DIFF
--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceTest.kt
@@ -5,6 +5,7 @@ import expo.modules.calendar.domain.event.records.input.RecurrenceRuleInput
 import expo.modules.kotlin.types.ConvertedValue
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.IncompatibleValue
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 import java.util.TimeZone
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -119,7 +120,7 @@ class EventRecurrenceUtilsTest {
 }
 
 private inline fun <reified L : Any, reified R : Any> eitherWithFirst(value: L): Either<L, R> {
-  val types = listOf(typeOf<L>(), typeOf<R>())
+  val types = listOf(typeDescriptorOf<L>(), typeDescriptorOf<R>())
 
   val deferredValue = mutableListOf(
     ConvertedValue(value),

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceTest.kt
@@ -11,7 +11,6 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class EventRecurrenceUtilsTest {
 

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,6 +230,8 @@ dependencies {
     implementation workletsProject
   }
 
+  implementation("io.github.lukmccall.pika:pika-api:0.0.3-2.1.20")
+
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'
   testImplementation 'io.mockk:mockk:1.14.9'

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
@@ -65,7 +65,7 @@ class ComposeViewProp(
     return this
   }
 
-  override val isNullable: Boolean = anyType.kType.isMarkedNullable
+  override val isNullable: Boolean = anyType.typeDescriptor.isNullable
 
   override val isStateProp: Boolean
     get() = _isStateProp

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -7,12 +7,12 @@ import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.modules.InternalModuleDefinitionBuilder
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.types.AnyType
-import expo.modules.kotlin.types.LazyKType
+import expo.modules.kotlin.types.descriptors.toTypeDescriptor
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 import expo.modules.kotlin.views.decorators.UseCSSProps
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 import kotlin.reflect.full.memberProperties
-import kotlin.reflect.typeOf
 
 /**
  * The name for the global event dispatcher
@@ -27,12 +27,12 @@ open class ModuleDefinitionBuilderWithCompose(
    * Also collects all compose view props and generates setters.
    */
   @JvmName("ComposeView")
-  inline fun <reified T : ExpoComposeView<P>, reified P : Any> View(viewClass: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit = {}) {
-    val viewDefinitionBuilder = ViewDefinitionBuilder(viewClass, LazyKType(classifier = T::class, kTypeProvider = { typeOf<T>() }))
+  inline fun <reified T : ExpoComposeView<P>, reified P : ComposeProps> View(viewClass: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit = {}) {
+    val viewDefinitionBuilder = ViewDefinitionBuilder(viewClass, typeDescriptorOf<T>())
     P::class.memberProperties.forEach { prop ->
       val kType = prop.returnType.arguments.first().type
       if (kType != null && viewDefinitionBuilder.props[prop.name] == null) {
-        viewDefinitionBuilder.props[prop.name] = ComposeViewProp(prop.name, AnyType(kType), prop)
+        viewDefinitionBuilder.props[prop.name] = ComposeViewProp(prop.name, AnyType(kType.toTypeDescriptor()), prop)
       }
     }
 
@@ -76,7 +76,7 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps>(
       viewType = ComposeFunctionHolder::class.java,
       props = propsClass.memberProperties.associate { prop ->
         val kType = prop.returnType
-        prop.name to ComposeViewProp(prop.name, AnyType(kType), prop)
+        prop.name to ComposeViewProp(prop.name, AnyType(kType.toTypeDescriptor()), prop)
       }
     )
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/classcomponent/ClassComponentBuilder.kt
@@ -69,7 +69,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
     val objectData = buildObject() + traits.map { t -> t.export(appContext) }.reduceOrNull { t1, t2 -> t1 + t2 }
 
     objectData.functions.forEach {
-      it.ownerType = ownerType.kType
+      it.ownerType = ownerType.typeDescriptor
       it.canTakeOwner = true
     }
 
@@ -84,7 +84,7 @@ class ClassComponentBuilder<SharedObjectType : Any>(
       toReturnType<Unit>()
     ) {}
     constructor.canTakeOwner = true
-    constructor.ownerType = ownerType.kType
+    constructor.ownerType = ownerType.typeDescriptor
 
     return ClassDefinitionData(
       name,
@@ -201,14 +201,14 @@ class ClassComponentBuilder<SharedObjectType : Any>(
    * Creates the read-only property whose getter takes the caller as an argument.
    */
   inline fun <reified T> Property(name: String, crossinline body: (owner: SharedObjectType) -> T): PropertyComponentBuilderWithThis<SharedObjectType> {
-    return PropertyComponentBuilderWithThis<SharedObjectType>(ownerType.kType, name).also {
+    return PropertyComponentBuilderWithThis<SharedObjectType>(ownerType.typeDescriptor, name).also {
       it.get(body)
       properties[name] = it
     }
   }
 
   override fun Property(name: String): PropertyComponentBuilderWithThis<SharedObjectType> {
-    return PropertyComponentBuilderWithThis<SharedObjectType>(ownerType.kType, name).also {
+    return PropertyComponentBuilderWithThis<SharedObjectType>(ownerType.typeDescriptor, name).also {
       properties[name] = it
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -2,6 +2,7 @@ package expo.modules.kotlin.exception
 
 import com.facebook.react.bridge.ReadableType
 import expo.modules.core.interfaces.DoNotStrip
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 import java.util.*
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
@@ -88,13 +89,13 @@ internal class EnumNoSuchValueException(
 )
 
 internal class MissingTypeConverter(
-  forType: KType
+  forType: TypeDescriptor
 ) : CodedException(
   message = "Cannot find type converter for '$forType'. Make sure the class implements `expo.modules.kotlin.records.Record` (i.e. `class MyObj : Record`)."
 )
 
 internal class InvalidExpectedType(
-  forType: KType
+  forType: TypeDescriptor
 ) : CodedException(
   message = "Cannot obtain ExpectedType form '$forType'."
 )
@@ -169,7 +170,7 @@ internal class OnViewDidUpdatePropsException(
 )
 
 internal class ArgumentCastException(
-  argDesiredType: KType,
+  argDesiredType: TypeDescriptor,
   argIndex: Int,
   providedType: String,
   cause: CodedException
@@ -199,7 +200,7 @@ internal class InvalidSharedObjectTypeException(
 )
 
 internal class IncorrectRefTypeException(
-  desiredType: KType,
+  desiredType: TypeDescriptor,
   receivedClass: Class<*>
 ) : CodedException(
   message = "Cannot convert received '$receivedClass' to the '$desiredType', because of the inner ref type mismatch"
@@ -211,7 +212,7 @@ internal class FieldCastException private constructor(
 ) : DecoratedException(message, cause) {
   constructor(
     fieldName: String,
-    fieldType: KType,
+    fieldType: TypeDescriptor,
     providedType: ReadableType,
     cause: CodedException
   ) : this(
@@ -222,7 +223,7 @@ internal class FieldCastException private constructor(
   constructor(
     fieldName: String,
     fieldType: KType,
-    recordType: KType,
+    recordType: TypeDescriptor,
     cause: CodedException
   ) : this(
     message = "Cannot cast value for field '$fieldName' ('$fieldType') in record '$recordType'.",
@@ -231,7 +232,7 @@ internal class FieldCastException private constructor(
 }
 
 internal class RecordCastException(
-  recordType: KType,
+  recordType: TypeDescriptor,
   cause: CodedException
 ) : DecoratedException(
   message = "Cannot create a record of the type: '$recordType'.",
@@ -239,8 +240,8 @@ internal class RecordCastException(
 )
 
 internal class CollectionElementCastException private constructor(
-  collectionType: KType,
-  elementType: KType,
+  collectionType: TypeDescriptor,
+  elementType: TypeDescriptor,
   providedType: String,
   cause: CodedException
 ) : DecoratedException(
@@ -248,15 +249,15 @@ internal class CollectionElementCastException private constructor(
   cause
 ) {
   constructor(
-    collectionType: KType,
-    elementType: KType,
+    collectionType: TypeDescriptor,
+    elementType: TypeDescriptor,
     providedType: ReadableType,
     cause: CodedException
   ) : this(collectionType, elementType, providedType.name, cause)
 
   constructor(
-    collectionType: KType,
-    elementType: KType,
+    collectionType: TypeDescriptor,
+    elementType: TypeDescriptor,
     providedType: KClass<*>,
     cause: CodedException
   ) : this(collectionType, elementType, providedType.toString(), cause)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -9,8 +9,7 @@ import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.JavaScriptObject
 import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.types.AnyType
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 /**
  * Base class of all exported functions
@@ -23,21 +22,21 @@ abstract class AnyFunction(
   internal var canTakeOwner: Boolean = false
 
   @PublishedApi
-  internal var ownerType: KType? = null
+  internal var ownerType: TypeDescriptor? = null
 
   internal var isEnumerable: Boolean = true
 
   internal val takesOwner: Boolean
     get() {
       if (canTakeOwner) {
-        val firstArgumentType = desiredArgsTypes.firstOrNull()?.kType?.classifier as? KClass<*>
+        val firstArgumentType = desiredArgsTypes.firstOrNull()?.typeDescriptor?.kClass
           ?: return false
 
         if (firstArgumentType == JavaScriptObject::class) {
           return true
         }
 
-        val ownerClass = ownerType?.classifier as? KClass<*> ?: return false
+        val ownerClass = ownerType?.typeInfo?.kClass ?: return false
 
         return firstArgumentType == ownerClass
       }
@@ -50,7 +49,7 @@ abstract class AnyFunction(
   private val requiredArgumentsCount = run {
     val nonNullableArgIndex = desiredArgsTypes
       .reversed()
-      .indexOfFirst { !it.kType.isMarkedNullable }
+      .indexOfFirst { !it.typeDescriptor.isNullable }
     if (nonNullableArgIndex < 0) {
       return@run 0
     }
@@ -79,7 +78,7 @@ abstract class AnyFunction(
       val element = args[index]
       val desiredType = desiredArgsTypes[index]
       exceptionDecorator({ cause ->
-        ArgumentCastException(desiredType.kType, index, element?.javaClass.toString(), cause)
+        ArgumentCastException(desiredType.typeDescriptor, index, element?.javaClass.toString(), cause)
       }) {
         finalArgs[index] = desiredType.convert(element, appContext, forceConversion)
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
@@ -2,8 +2,7 @@ package expo.modules.kotlin.jni
 
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.exception.InvalidExpectedType
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 /**
  * A basic class that represents metadata about the expected type.
@@ -185,9 +184,8 @@ class ExpectedType(
       SingleType(CppType.MAP, arrayOf(valueType))
     )
 
-    fun fromKType(type: KType): ExpectedType {
-      val kClass = type.classifier as? KClass<*>
-        ?: throw IllegalArgumentException("Cannot obtain KClass from '$type'")
+    fun fromTypeDescriptor(typeDescriptor: TypeDescriptor): ExpectedType {
+      val kClass = typeDescriptor.kClass
       when (kClass) {
         Int::class -> return ExpectedType(SingleType(CppType.INT))
         Long::class -> return ExpectedType(SingleType(CppType.LONG))
@@ -197,18 +195,18 @@ class ExpectedType(
         String::class -> return ExpectedType(SingleType(CppType.STRING))
       }
       if (kClass.java.isAssignableFrom(List::class.java)) {
-        val argType = type.arguments.firstOrNull()?.type
+        val argType = typeDescriptor.params.firstOrNull()
         if (argType != null) {
-          return forList(fromKType(argType))
+          return forList(fromTypeDescriptor(argType))
         }
       }
       if (kClass.java.isAssignableFrom(Map::class.java)) {
-        val argType = type.arguments.getOrNull(1)?.type
+        val argType = typeDescriptor.params.getOrNull(1)
         if (argType != null) {
-          return forMap(fromKType(argType))
+          return forMap(fromTypeDescriptor(argType))
         }
       }
-      throw InvalidExpectedType(type)
+      throw InvalidExpectedType(typeDescriptor)
     }
 
     fun merge(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptFunction.kt
@@ -4,16 +4,15 @@ import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.types.JSTypeConverterProvider
-import expo.modules.kotlin.types.LazyKType
 import expo.modules.kotlin.types.TypeConverterProviderImpl
-import kotlin.reflect.KType
-import kotlin.reflect.typeOf
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 
 @Suppress("KotlinJniMissingFunction")
 @DoNotStrip
 class JavaScriptFunction<ReturnType : Any?> @DoNotStrip private constructor(@DoNotStrip private val mHybridData: HybridData) : Destructible {
   @PublishedApi
-  internal var returnType: KType? = null
+  internal var returnType: TypeDescriptor? = null
 
   fun isValid() = mHybridData.isValid
 
@@ -27,11 +26,7 @@ class JavaScriptFunction<ReturnType : Any?> @DoNotStrip private constructor(@DoN
 
     val converter = TypeConverterProviderImpl
       .obtainTypeConverter(
-        returnType ?: LazyKType(
-          classifier = Unit::class,
-          isMarkedNullable = false,
-          kTypeProvider = { typeOf<Unit>() }
-        )
+        returnType ?: typeDescriptorOf<Unit>()
       )
 
     val expectedReturnType = converter.getCppRequiredTypes()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JavaScriptValue.kt
@@ -2,7 +2,7 @@ package expo.modules.kotlin.jni
 
 import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
-import kotlin.reflect.typeOf
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 
 /**
  * A Kotlin representation of jsi::Value.
@@ -39,14 +39,14 @@ class JavaScriptValue @DoNotStrip private constructor(@DoNotStrip private val mH
 
   inline fun <reified ReturnType : Any?> getFunction(): JavaScriptFunction<ReturnType> {
     return internalJniGetFunction<ReturnType>().apply {
-      returnType = typeOf<ReturnType>()
+      returnType = typeDescriptorOf<ReturnType>()
     }
   }
 
   @JvmName("getVoidFunction")
   fun getFunction(): JavaScriptFunction<Unit> {
     return internalJniGetFunction<Unit>().apply {
-      returnType = typeOf<Unit>()
+      returnType = typeDescriptorOf<Unit>()
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
@@ -187,7 +187,7 @@ class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible 
       }
 
       val constructor = constructor
-      val ownerClass = (constructor.ownerType?.classifier as? kotlin.reflect.KClass<*>)?.java
+      val ownerClass = constructor.ownerType?.kClass?.java
 
       registerClass(
         name,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleConvertersBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleConvertersBuilder.kt
@@ -7,16 +7,16 @@ import expo.modules.kotlin.types.NullableTypeConverter
 import expo.modules.kotlin.types.TypeConverter
 import expo.modules.kotlin.types.TypeConverterComponent
 import expo.modules.kotlin.types.TypeConverterProvider
-import expo.modules.kotlin.types.lazyTypeOf
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 import kotlin.reflect.KClass
-import kotlin.reflect.KType
 
 class ModuleConvertersBuilder {
   @PublishedApi
   internal var convertersComponent = mutableListOf<TypeConverterComponent<*>>()
 
   inline fun <reified T : Any> TypeConverter(classifier: KClass<T> = T::class): TypeConverterComponent<T> {
-    val converterComponent = TypeConverterComponent<T>(lazyTypeOf<T>())
+    val converterComponent = TypeConverterComponent<T>(typeDescriptorOf<T>())
     convertersComponent.add(converterComponent)
     return converterComponent
   }
@@ -37,19 +37,19 @@ class ModuleConvertersBuilder {
       .mapNotNull { it.build() }
 
     return object : TypeConverterProvider {
-      override fun obtainTypeConverter(type: KType): TypeConverter<*> {
-        val nonNullableTypeConverter = findNonNullableTypeConverter(type)
-          ?: throw MissingTypeConverter(type)
+      override fun obtainTypeConverter(typeDescriptor: TypeDescriptor): TypeConverter<*> {
+        val nonNullableTypeConverter = findNonNullableTypeConverter(typeDescriptor)
+          ?: throw MissingTypeConverter(typeDescriptor)
 
-        if (type.isMarkedNullable) {
+        if (typeDescriptor.isNullable) {
           return NullableTypeConverter(nonNullableTypeConverter)
         }
         return nonNullableTypeConverter
       }
 
-      private fun findNonNullableTypeConverter(type: KType): TypeConverter<*>? {
+      private fun findNonNullableTypeConverter(typeDescriptor: TypeDescriptor): TypeConverter<*>? {
         return converters.find { (converterType, _) ->
-          converterType.classifier == type.classifier && converterType.arguments == type.arguments
+          converterType.kClass == typeDescriptor.kClass && converterType.params == typeDescriptor.params
         }?.second
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleDefinitionBuilder.kt
@@ -16,16 +16,15 @@ import expo.modules.kotlin.events.EventName
 import expo.modules.kotlin.events.OnActivityResultPayload
 import expo.modules.kotlin.objects.ObjectDefinitionBuilder
 import expo.modules.kotlin.sharedobjects.SharedObject
-import expo.modules.kotlin.types.LazyKType
 import expo.modules.kotlin.types.TypeConverterProvider
 import expo.modules.kotlin.types.mergeWithDefault
 import expo.modules.kotlin.types.toAnyType
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 import expo.modules.kotlin.views.ModuleDefinitionBuilderWithCompose
 import expo.modules.kotlin.views.ViewDefinitionBuilder
 import expo.modules.kotlin.views.ViewManagerDefinition
 import expo.modules.kotlin.views.decorators.UseCSSProps
 import kotlin.reflect.KClass
-import kotlin.reflect.typeOf
 
 const val DEFAULT_MODULE_VIEW = "DEFAULT_MODULE_VIEW"
 
@@ -93,7 +92,7 @@ open class InternalModuleDefinitionBuilder(
   inline fun <reified T : View> View(viewClass: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit) {
     val viewDefinitionBuilder = ViewDefinitionBuilder(
       viewClass,
-      LazyKType(classifier = T::class, kTypeProvider = { typeOf<T>() }),
+      typeDescriptorOf<T>(),
       converters
     )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/PropertyComponentBuilder.kt
@@ -2,9 +2,9 @@ package expo.modules.kotlin.objects
 
 import expo.modules.kotlin.functions.SyncFunctionComponent
 import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 import expo.modules.kotlin.types.toAnyType
 import expo.modules.kotlin.types.toReturnType
-import kotlin.reflect.KType
 
 open class PropertyComponentBuilder(
   val name: String
@@ -32,7 +32,7 @@ open class PropertyComponentBuilder(
 }
 
 class PropertyComponentBuilderWithThis<ThisType>(
-  val thisType: KType,
+  val thisType: TypeDescriptor,
   name: String
 ) : PropertyComponentBuilder(name) {
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -16,24 +16,29 @@ import expo.modules.kotlin.recycle
 import expo.modules.kotlin.types.DynamicAwareTypeConverters
 import expo.modules.kotlin.types.TypeConverter
 import expo.modules.kotlin.types.TypeConverterProvider
+import expo.modules.kotlin.types.TypeConverterProviderImpl
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
+import expo.modules.kotlin.types.descriptors.toTypeDescriptor
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
-import kotlin.reflect.KType
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaField
+import kotlin.reflect.typeOf
 
 class RecordTypeConverter<T : Record>(
   private val converterProvider: TypeConverterProvider,
-  val type: KType
+  val typeDescriptor: TypeDescriptor
 ) : DynamicAwareTypeConverters<T>() {
   private val objectConstructorFactory = ObjectConstructorFactory()
   private val propertyDescriptors: Map<KProperty1<out Any, *>, PropertyDescriptor> by lazy {
-    (type.classifier as KClass<*>)
+    typeDescriptor.kClass
       .memberProperties
       .mapNotNull { property ->
         val fieldAnnotation = property.findAnnotation<Field>() ?: return@mapNotNull null
-        val typeConverter = converterProvider.obtainTypeConverter(property.returnType)
+        val typeConverter = converterProvider.obtainTypeConverter(
+          property.returnType.toTypeDescriptor()
+        )
 
         return@mapNotNull property to PropertyDescriptor(
           typeConverter,
@@ -45,7 +50,7 @@ class RecordTypeConverter<T : Record>(
   }
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T =
-    exceptionDecorator({ cause -> RecordCastException(type, cause) }) {
+    exceptionDecorator({ cause -> RecordCastException(typeDescriptor, cause) }) {
       val jsMap = value.asMap() ?: throw DynamicCastException(ReadableMap::class)
       return@exceptionDecorator convertFromReadableMap(jsMap, context, forceConversion)
     }
@@ -69,7 +74,7 @@ class RecordTypeConverter<T : Record>(
   override fun isTrivial(): Boolean = false
 
   private fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): T {
-    val kClass = type.classifier as KClass<*>
+    val kClass = typeDescriptor.kClass
     val instance = getObjectConstructor(kClass).construct()
 
     propertyDescriptors
@@ -87,7 +92,7 @@ class RecordTypeConverter<T : Record>(
         jsMap.getDynamic(jsKey).recycle {
           val javaField = property.javaField!!
 
-          val casted = exceptionDecorator({ cause -> FieldCastException(property.name, property.returnType, type, cause) }) {
+          val casted = exceptionDecorator({ cause -> FieldCastException(property.name, property.returnType, typeDescriptor, cause) }) {
             descriptor.typeConverter.convert(this, context, forceConversion)
           }
 
@@ -101,7 +106,7 @@ class RecordTypeConverter<T : Record>(
   }
 
   internal fun convertFromMap(map: Map<String, Any?>, context: AppContext? = null, forceConversion: Boolean = false): T {
-    val kClass = type.classifier as KClass<*>
+    val kClass = typeDescriptor.kClass
     val instance = getObjectConstructor(kClass).construct()
 
     propertyDescriptors
@@ -131,7 +136,7 @@ class RecordTypeConverter<T : Record>(
         }
         val javaField = property.javaField!!
 
-        val casted = exceptionDecorator({ cause -> FieldCastException(property.name, property.returnType, type, cause) }) {
+        val casted = exceptionDecorator({ cause -> FieldCastException(property.name, property.returnType, typeDescriptor, cause) }) {
           descriptor.typeConverter.convert(value, context, forceConversion)
         }
 
@@ -173,7 +178,7 @@ internal fun <T : Record> recordFromMap(map: Map<String, Any?>, converter: Recor
 }
 
 inline fun <reified T : Record> recordFromMap(map: Map<String, Any?>): T {
-  val converter = expo.modules.kotlin.types.TypeConverterProviderImpl.obtainTypeConverter(kotlin.reflect.typeOf<T>())
+  val converter = TypeConverterProviderImpl.obtainTypeConverter(typeOf<T>().toTypeDescriptor())
   @Suppress("UNCHECKED_CAST")
   return recordFromMap(map, converter as RecordTypeConverter<T>)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -8,12 +8,13 @@ import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.toStrongReference
 import expo.modules.kotlin.types.NonNullableTypeConverter
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.KTypeProjection
 
 class SharedObjectTypeConverter<T : SharedObject>(
-  val type: KType
+  val typeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<T>() {
   @Suppress("UNCHECKED_CAST")
   override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): T {
@@ -36,13 +37,13 @@ class SharedObjectTypeConverter<T : SharedObject>(
 }
 
 class SharedRefTypeConverter<T : SharedRef<*>>(
-  val type: KType
+  val typeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<T>() {
-  private val sharedObjectTypeConverter = SharedObjectTypeConverter<T>(type)
+  private val sharedObjectTypeConverter = SharedObjectTypeConverter<T>(typeDescriptor)
 
   val sharedRefType: KType? by lazy {
-    var currentClass: KClass<*>? = type.classifier as? KClass<*>
-    var currentType: KType? = type
+    var currentClass: KClass<*>? = typeDescriptor.kClass
+    var currentType: KType? = typeDescriptor.kType
     while (currentClass != null) {
       if (currentClass == SharedRef::class) {
         val firstArgument = currentType?.arguments?.first()
@@ -79,7 +80,7 @@ class SharedRefTypeConverter<T : SharedRef<*>>(
       return sharedRef
     }
 
-    throw IncorrectRefTypeException(type, sharedRef.javaClass)
+    throw IncorrectRefTypeException(typeDescriptor, sharedRef.javaClass)
   }
 
   override fun getCppRequiredTypes() = sharedObjectTypeConverter.getCppRequiredTypes()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -1,318 +1,31 @@
 package expo.modules.kotlin.types
 
-import android.net.Uri
 import com.facebook.react.bridge.Dynamic
-import com.facebook.react.bridge.ReadableArray
-import com.facebook.react.bridge.ReadableMap
-import expo.modules.core.arguments.ReadableArguments
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.ExpectedType
-import expo.modules.kotlin.jni.JavaScriptObject
-import expo.modules.kotlin.jni.JavaScriptValue
-import expo.modules.kotlin.typedarray.BigInt64Array
-import expo.modules.kotlin.typedarray.BigUint64Array
-import expo.modules.kotlin.typedarray.Float32Array
-import expo.modules.kotlin.typedarray.Float64Array
-import expo.modules.kotlin.typedarray.Int16Array
-import expo.modules.kotlin.typedarray.Int32Array
-import expo.modules.kotlin.typedarray.Int8Array
-import expo.modules.kotlin.typedarray.TypedArray
-import expo.modules.kotlin.typedarray.Uint16Array
-import expo.modules.kotlin.typedarray.Uint32Array
-import expo.modules.kotlin.typedarray.Uint8Array
-import expo.modules.kotlin.typedarray.Uint8ClampedArray
-import java.io.File
-import java.net.URI
-import java.net.URL
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
-import kotlin.reflect.KTypeProjection
-import kotlin.reflect.typeOf
-
-class LazyKType(
-  override val classifier: KClass<*>,
-  override val isMarkedNullable: Boolean = false,
-  val kTypeProvider: () -> KType
-) : KType {
-  private var _kType: KType? = null
-  private val kType: KType
-    get() {
-      if (_kType == null) {
-        _kType = kTypeProvider()
-      }
-      return _kType!!
-    }
-
-  override val annotations: List<Annotation>
-    get() = kType.annotations
-  override val arguments: List<KTypeProjection>
-    get() = kType.arguments
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other !is LazyKType) return this.kType == other
-
-    return classifier == other.classifier && isMarkedNullable == other.isMarkedNullable
-  }
-
-  override fun hashCode(): Int {
-    var result = classifier.hashCode()
-    result = 31 * result + isMarkedNullable.hashCode()
-    return result
-  }
-
-  override fun toString(): String {
-    return kType.toString()
-  }
-}
-
-class EmptyKType(
-  override val classifier: KClass<*>,
-  override val isMarkedNullable: Boolean = false
-) : KType {
-  override val annotations: List<Annotation>
-    get() = emptyList()
-  override val arguments: List<KTypeProjection>
-    get() = emptyList()
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other !is EmptyKType) return false
-
-    return classifier == other.classifier && isMarkedNullable == other.isMarkedNullable
-  }
-
-  override fun hashCode(): Int {
-    return 31 * classifier.hashCode() + isMarkedNullable.hashCode()
-  }
-}
-
-object AnyTypeProvider {
-  @PublishedApi
-  internal val typesMap = buildMap {
-    listOf(
-      Int::class,
-      Float::class,
-      Double::class,
-      Long::class,
-      Boolean::class,
-      String::class,
-
-      ByteArray::class,
-      LongArray::class,
-      IntArray::class,
-      BooleanArray::class,
-      FloatArray::class,
-      DoubleArray::class,
-
-      JavaScriptValue::class,
-      JavaScriptObject::class,
-
-      TypedArray::class,
-      Int8Array::class,
-      Int16Array::class,
-      Int32Array::class,
-      Uint8Array::class,
-      Uint8ClampedArray::class,
-      Uint16Array::class,
-      Uint32Array::class,
-      Float32Array::class,
-      Float64Array::class,
-      BigInt64Array::class,
-      BigUint64Array::class,
-
-      ReadableArray::class,
-      ReadableMap::class,
-
-      URL::class,
-      Uri::class,
-      URI::class,
-
-      File::class,
-
-      Any::class,
-      Unit::class,
-
-      ReadableArguments::class
-    ).forEach { klass ->
-      put((klass to false), AnyType(EmptyKType(klass, false)))
-      put((klass to true), AnyType(EmptyKType(klass, true)))
-    }
-  }
-}
-
-inline fun <reified T> AnyTypeProvider.cachedAnyType(): AnyType? {
-  val key = Pair(T::class, null is T)
-  return typesMap[key]
-}
-
-inline fun <reified T> lazyTypeOf() = { typeOf<T>() }.toLazyType<T>()
-
-inline fun <reified T> (() -> KType).toLazyType() =
-  LazyKType(
-    classifier = T::class,
-    isMarkedNullable = null is T,
-    kTypeProvider = this
-  )
-
-inline fun <reified T> (() -> KType).toAnyType(converterProvider: TypeConverterProvider? = null) =
-  AnyType(
-    LazyKType(
-      classifier = T::class,
-      isMarkedNullable = null is T,
-      kTypeProvider = this
-    ),
-    converterProvider
-  )
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 
 inline fun <reified T> toAnyType(converterProvider: TypeConverterProvider? = null): AnyType {
-  return AnyTypeProvider.cachedAnyType<T>() ?: { typeOf<T>() }.toAnyType<T>(converterProvider)
-}
+  val cachedAnyType = AnyTypeCache.cachedAnyType<T>()
+  if (cachedAnyType != null) {
+    return cachedAnyType
+  }
 
-@Suppress("UNUSED_PARAMETER")
-inline fun <reified P0> toArgsArray(
-  p0: Class<P0> = P0::class.java,
-  converterProvider: TypeConverterProvider? = null
-): Array<AnyType> {
-  return arrayOf(
-    toAnyType<P0>(converterProvider)
-  )
-}
-
-@Suppress("UNUSED_PARAMETER")
-inline fun <reified P0, reified P1> toArgsArray(
-  p0: Class<P0> = P0::class.java,
-  p1: Class<P1> = P1::class.java,
-  converterProvider: TypeConverterProvider? = null
-): Array<AnyType> {
-  return arrayOf(
-    toAnyType<P0>(converterProvider),
-    toAnyType<P1>(converterProvider)
-  )
-}
-
-@Suppress("UNUSED_PARAMETER")
-inline fun <reified P0, reified P1, reified P2> toArgsArray(
-  p0: Class<P0> = P0::class.java,
-  p1: Class<P1> = P1::class.java,
-  p2: Class<P2> = P2::class.java,
-  converterProvider: TypeConverterProvider? = null
-): Array<AnyType> {
-  return arrayOf(
-    toAnyType<P0>(converterProvider),
-    toAnyType<P1>(converterProvider),
-    toAnyType<P2>(converterProvider)
-  )
-}
-
-@Suppress("UNUSED_PARAMETER")
-inline fun <reified P0, reified P1, reified P2, reified P3> toArgsArray(
-  p0: Class<P0> = P0::class.java,
-  p1: Class<P1> = P1::class.java,
-  p2: Class<P2> = P2::class.java,
-  p3: Class<P3> = P3::class.java,
-  converterProvider: TypeConverterProvider? = null
-): Array<AnyType> {
-  return arrayOf(
-    toAnyType<P0>(converterProvider),
-    toAnyType<P1>(converterProvider),
-    toAnyType<P2>(converterProvider),
-    toAnyType<P3>(converterProvider)
-  )
-}
-
-@Suppress("UNUSED_PARAMETER")
-inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> toArgsArray(
-  p0: Class<P0> = P0::class.java,
-  p1: Class<P1> = P1::class.java,
-  p2: Class<P2> = P2::class.java,
-  p3: Class<P3> = P3::class.java,
-  p4: Class<P4> = P4::class.java,
-  converterProvider: TypeConverterProvider? = null
-): Array<AnyType> {
-  return arrayOf(
-    toAnyType<P0>(converterProvider),
-    toAnyType<P1>(converterProvider),
-    toAnyType<P2>(converterProvider),
-    toAnyType<P3>(converterProvider),
-    toAnyType<P4>(converterProvider)
-  )
-}
-
-@Suppress("UNUSED_PARAMETER")
-inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> toArgsArray(
-  p0: Class<P0> = P0::class.java,
-  p1: Class<P1> = P1::class.java,
-  p2: Class<P2> = P2::class.java,
-  p3: Class<P3> = P3::class.java,
-  p4: Class<P4> = P4::class.java,
-  p5: Class<P5> = P5::class.java,
-  converterProvider: TypeConverterProvider? = null
-): Array<AnyType> {
-  return arrayOf(
-    toAnyType<P0>(converterProvider),
-    toAnyType<P1>(converterProvider),
-    toAnyType<P2>(converterProvider),
-    toAnyType<P3>(converterProvider),
-    toAnyType<P4>(converterProvider),
-    toAnyType<P5>(converterProvider)
-  )
-}
-
-@Suppress("UNUSED_PARAMETER")
-inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> toArgsArray(
-  p0: Class<P0> = P0::class.java,
-  p1: Class<P1> = P1::class.java,
-  p2: Class<P2> = P2::class.java,
-  p3: Class<P3> = P3::class.java,
-  p4: Class<P4> = P4::class.java,
-  p5: Class<P5> = P5::class.java,
-  p6: Class<P6> = P6::class.java,
-  converterProvider: TypeConverterProvider? = null
-): Array<AnyType> {
-  return arrayOf(
-    toAnyType<P0>(converterProvider),
-    toAnyType<P1>(converterProvider),
-    toAnyType<P2>(converterProvider),
-    toAnyType<P3>(converterProvider),
-    toAnyType<P4>(converterProvider),
-    toAnyType<P5>(converterProvider),
-    toAnyType<P6>(converterProvider)
-  )
-}
-
-@Suppress("UNUSED_PARAMETER")
-inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> toArgsArray(
-  p0: Class<P0> = P0::class.java,
-  p1: Class<P1> = P1::class.java,
-  p2: Class<P2> = P2::class.java,
-  p3: Class<P3> = P3::class.java,
-  p4: Class<P4> = P4::class.java,
-  p5: Class<P5> = P5::class.java,
-  p6: Class<P6> = P6::class.java,
-  p7: Class<P7> = P7::class.java,
-  converterProvider: TypeConverterProvider? = null
-): Array<AnyType> {
-  return arrayOf(
-    toAnyType<P0>(converterProvider),
-    toAnyType<P1>(converterProvider),
-    toAnyType<P2>(converterProvider),
-    toAnyType<P3>(converterProvider),
-    toAnyType<P4>(converterProvider),
-    toAnyType<P5>(converterProvider),
-    toAnyType<P6>(converterProvider),
-    toAnyType<P7>(converterProvider)
+  val typeDescriptor = typeDescriptorOf<T>()
+  return AnyType(
+    typeDescriptor = typeDescriptor,
+    converterProvider = converterProvider
   )
 }
 
 class AnyType(
-  val kType: KType,
+  val typeDescriptor: TypeDescriptor,
   val converterProvider: TypeConverterProvider? = null
 ) {
-
   private val converter: TypeConverter<*> by lazy {
-    converterProvider?.obtainTypeConverter(kType)
-      ?: TypeConverterProviderImpl.obtainTypeConverter(kType)
+    converterProvider?.obtainTypeConverter(typeDescriptor)
+      ?: TypeConverterProviderImpl.obtainTypeConverter(typeDescriptor)
   }
 
   fun convert(value: Any?, appContext: AppContext? = null, forceConversion: Boolean = false): Any? {
@@ -327,8 +40,6 @@ class AnyType(
 }
 
 inline fun <reified T> AnyType.inheritFrom(): Boolean {
-  val kClass = kType.classifier as? KClass<*> ?: return false
-  val jClass = kClass.java
-
+  val jClass = typeDescriptor.kClass.java
   return T::class.java.isAssignableFrom(jClass)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeCache.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyTypeCache.kt
@@ -1,0 +1,107 @@
+package expo.modules.kotlin.types
+
+import android.net.Uri
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import expo.modules.core.arguments.ReadableArguments
+import expo.modules.kotlin.jni.JavaScriptObject
+import expo.modules.kotlin.jni.JavaScriptValue
+import expo.modules.kotlin.typedarray.BigInt64Array
+import expo.modules.kotlin.typedarray.BigUint64Array
+import expo.modules.kotlin.typedarray.Float32Array
+import expo.modules.kotlin.typedarray.Float64Array
+import expo.modules.kotlin.typedarray.Int16Array
+import expo.modules.kotlin.typedarray.Int32Array
+import expo.modules.kotlin.typedarray.Int8Array
+import expo.modules.kotlin.typedarray.TypedArray
+import expo.modules.kotlin.typedarray.Uint16Array
+import expo.modules.kotlin.typedarray.Uint32Array
+import expo.modules.kotlin.typedarray.Uint8Array
+import expo.modules.kotlin.typedarray.Uint8ClampedArray
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
+import java.io.File
+import java.net.URI
+import java.net.URL
+import kotlin.collections.get
+
+object AnyTypeCache {
+  @PublishedApi
+  internal val typesMap = mapOf(
+    (Int::class to false) to AnyType(typeDescriptorOf<Int>()),
+    (Float::class to false) to AnyType(typeDescriptorOf<Float>()),
+    (Double::class to false) to AnyType(typeDescriptorOf<Double>()),
+    (Long::class to false) to AnyType(typeDescriptorOf<Long>()),
+    (Boolean::class to false) to AnyType(typeDescriptorOf<Boolean>()),
+    (String::class to false) to AnyType(typeDescriptorOf<String>()),
+    (ByteArray::class to false) to AnyType(typeDescriptorOf<ByteArray>()),
+    (LongArray::class to false) to AnyType(typeDescriptorOf<LongArray>()),
+    (IntArray::class to false) to AnyType(typeDescriptorOf<IntArray>()),
+    (BooleanArray::class to false) to AnyType(typeDescriptorOf<BooleanArray>()),
+    (FloatArray::class to false) to AnyType(typeDescriptorOf<FloatArray>()),
+    (DoubleArray::class to false) to AnyType(typeDescriptorOf<DoubleArray>()),
+    (JavaScriptValue::class to false) to AnyType(typeDescriptorOf<JavaScriptValue>()),
+    (JavaScriptObject::class to false) to AnyType(typeDescriptorOf<JavaScriptObject>()),
+    (TypedArray::class to false) to AnyType(typeDescriptorOf<TypedArray>()),
+    (Int8Array::class to false) to AnyType(typeDescriptorOf<Int8Array>()),
+    (Int16Array::class to false) to AnyType(typeDescriptorOf<Int16Array>()),
+    (Int32Array::class to false) to AnyType(typeDescriptorOf<Int32Array>()),
+    (Uint8Array::class to false) to AnyType(typeDescriptorOf<Uint8Array>()),
+    (Uint8ClampedArray::class to false) to AnyType(typeDescriptorOf<Uint8ClampedArray>()),
+    (Uint16Array::class to false) to AnyType(typeDescriptorOf<Uint16Array>()),
+    (Uint32Array::class to false) to AnyType(typeDescriptorOf<Uint32Array>()),
+    (Float32Array::class to false) to AnyType(typeDescriptorOf<Float32Array>()),
+    (Float64Array::class to false) to AnyType(typeDescriptorOf<Float64Array>()),
+    (BigInt64Array::class to false) to AnyType(typeDescriptorOf<BigInt64Array>()),
+    (BigUint64Array::class to false) to AnyType(typeDescriptorOf<BigUint64Array>()),
+    (ReadableArray::class to false) to AnyType(typeDescriptorOf<ReadableArray>()),
+    (ReadableMap::class to false) to AnyType(typeDescriptorOf<ReadableMap>()),
+    (URL::class to false) to AnyType(typeDescriptorOf<URL>()),
+    (Uri::class to false) to AnyType(typeDescriptorOf<Uri>()),
+    (URI::class to false) to AnyType(typeDescriptorOf<URI>()),
+    (File::class to false) to AnyType(typeDescriptorOf<File>()),
+    (Any::class to false) to AnyType(typeDescriptorOf<Any>()),
+    (Unit::class to false) to AnyType(typeDescriptorOf<Unit>()),
+    (ReadableArguments::class to false) to AnyType(typeDescriptorOf<ReadableArguments>()),
+
+    (Int::class to true) to AnyType(typeDescriptorOf<Int?>()),
+    (Float::class to true) to AnyType(typeDescriptorOf<Float?>()),
+    (Double::class to true) to AnyType(typeDescriptorOf<Double?>()),
+    (Long::class to true) to AnyType(typeDescriptorOf<Long?>()),
+    (Boolean::class to true) to AnyType(typeDescriptorOf<Boolean?>()),
+    (String::class to true) to AnyType(typeDescriptorOf<String?>()),
+    (ByteArray::class to true) to AnyType(typeDescriptorOf<ByteArray?>()),
+    (LongArray::class to true) to AnyType(typeDescriptorOf<LongArray?>()),
+    (IntArray::class to true) to AnyType(typeDescriptorOf<IntArray?>()),
+    (BooleanArray::class to true) to AnyType(typeDescriptorOf<BooleanArray?>()),
+    (FloatArray::class to true) to AnyType(typeDescriptorOf<FloatArray?>()),
+    (DoubleArray::class to true) to AnyType(typeDescriptorOf<DoubleArray?>()),
+    (JavaScriptValue::class to true) to AnyType(typeDescriptorOf<JavaScriptValue?>()),
+    (JavaScriptObject::class to true) to AnyType(typeDescriptorOf<JavaScriptObject?>()),
+    (TypedArray::class to true) to AnyType(typeDescriptorOf<TypedArray?>()),
+    (Int8Array::class to true) to AnyType(typeDescriptorOf<Int8Array?>()),
+    (Int16Array::class to true) to AnyType(typeDescriptorOf<Int16Array?>()),
+    (Int32Array::class to true) to AnyType(typeDescriptorOf<Int32Array?>()),
+    (Uint8Array::class to true) to AnyType(typeDescriptorOf<Uint8Array?>()),
+    (Uint8ClampedArray::class to true) to AnyType(typeDescriptorOf<Uint8ClampedArray?>()),
+    (Uint16Array::class to true) to AnyType(typeDescriptorOf<Uint16Array?>()),
+    (Uint32Array::class to true) to AnyType(typeDescriptorOf<Uint32Array?>()),
+    (Float32Array::class to true) to AnyType(typeDescriptorOf<Float32Array?>()),
+    (Float64Array::class to true) to AnyType(typeDescriptorOf<Float64Array?>()),
+    (BigInt64Array::class to true) to AnyType(typeDescriptorOf<BigInt64Array?>()),
+    (BigUint64Array::class to true) to AnyType(typeDescriptorOf<BigUint64Array?>()),
+    (ReadableArray::class to true) to AnyType(typeDescriptorOf<ReadableArray?>()),
+    (ReadableMap::class to true) to AnyType(typeDescriptorOf<ReadableMap?>()),
+    (URL::class to true) to AnyType(typeDescriptorOf<URL?>()),
+    (Uri::class to true) to AnyType(typeDescriptorOf<Uri?>()),
+    (URI::class to true) to AnyType(typeDescriptorOf<URI?>()),
+    (File::class to true) to AnyType(typeDescriptorOf<File?>()),
+    (Any::class to true) to AnyType(typeDescriptorOf<Any?>()),
+    (Unit::class to true) to AnyType(typeDescriptorOf<Unit?>()),
+    (ReadableArguments::class to true) to AnyType(typeDescriptorOf<ReadableArguments?>())
+  )
+}
+
+inline fun <reified T> AnyTypeCache.cachedAnyType(): AnyType? {
+  val key = Pair(T::class, null is T)
+  return typesMap[key]
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -8,15 +8,14 @@ import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class ArrayTypeConverter(
   converterProvider: TypeConverterProvider,
-  private val arrayType: KType
+  private val arrayType: TypeDescriptor
 ) : DynamicAwareTypeConverters<Array<*>>() {
   private val arrayElementConverter = converterProvider.obtainTypeConverter(
-    requireNotNull(arrayType.arguments.firstOrNull()?.type) {
+    requireNotNull(arrayType.params.firstOrNull()) {
       "The array type should contain the type of the elements."
     }
   )
@@ -29,7 +28,7 @@ class ArrayTypeConverter(
         .getDynamic(i)
         .recycle {
           exceptionDecorator({ cause ->
-            CollectionElementCastException(arrayType, arrayType.arguments.first().type!!, type, cause)
+            CollectionElementCastException(arrayType, arrayType.params.first(), type, cause)
           }) {
             arrayElementConverter.convert(this, context, forceConversion)
           }
@@ -46,7 +45,7 @@ class ArrayTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(
             arrayType,
-            arrayType.arguments.first().type!!,
+            arrayType.params.first(),
             it!!::class,
             cause
           )
@@ -58,7 +57,7 @@ class ArrayTypeConverter(
   }
 
   /**
-   * We can't use a Array<Any?> here. We have to create a typed array.
+   * We can't use an Array<Any?> here. We have to create a typed array.
    * Otherwise, cast which is done before calling lambda provided by the user will always fail.
    * For JVM, Array<String> is a different type than Array<Any?>.
    * The first one is translated to `[Ljava.lang.String;` but the second one is translated to `[java.lang.Object;`.
@@ -66,7 +65,7 @@ class ArrayTypeConverter(
   @Suppress("UNCHECKED_CAST")
   private fun createTypedArray(size: Int): Array<Any?> {
     return java.lang.reflect.Array.newInstance(
-      (arrayType.arguments.first().type!!.classifier as KClass<*>).java,
+      (arrayType.params.first().kClass).java,
       size
     ) as Array<Any?>
   }
@@ -77,8 +76,8 @@ class ArrayTypeConverter(
   override fun isTrivial() = arrayElementConverter.isTrivial()
 }
 
-internal fun isPrimitiveArray(type: KType, clazz: Class<*>): Boolean {
-  return when (clazz) {
+internal fun isPrimitiveArray(typeDescriptor: TypeDescriptor): Boolean {
+  return when (typeDescriptor.kClass.java) {
     BooleanArray::class.java,
     ByteArray::class.java,
     CharArray::class.java,
@@ -86,7 +85,7 @@ internal fun isPrimitiveArray(type: KType, clazz: Class<*>): Boolean {
     IntArray::class.java,
     LongArray::class.java,
     FloatArray::class.java,
-    DoubleArray::class.java -> type.arguments.isEmpty()
+    DoubleArray::class.java -> typeDescriptor.params.isEmpty()
     else -> false
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Either.kt
@@ -5,10 +5,10 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 import expo.modules.kotlin.unwrap
 import java.lang.ref.WeakReference
 import kotlin.reflect.KClass
-import kotlin.reflect.KType
 
 sealed class DeferredValue
 
@@ -47,7 +47,7 @@ inline fun <reified T : Any> toKClass(): KClass<T> = T::class
 open class Either<FirstType : Any, SecondType : Any>(
   private val bareValue: Any,
   private val deferredValue: MutableList<DeferredValue>,
-  private val types: List<KType>
+  private val types: List<TypeDescriptor>
 
 ) {
   internal fun `is`(index: Int): Boolean {
@@ -108,7 +108,7 @@ open class Either<FirstType : Any, SecondType : Any>(
 open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
   bareValue: Any,
   deferredValue: MutableList<DeferredValue>,
-  types: List<KType>
+  types: List<TypeDescriptor>
 ) : Either<FirstType, SecondType>(bareValue, deferredValue, types) {
   @JvmName("isThirdType")
   fun `is`(@Suppress("UNUSED_PARAMETER") type: KClass<ThirdType>): Boolean = `is`(2)
@@ -123,7 +123,7 @@ open class EitherOfThree<FirstType : Any, SecondType : Any, ThirdType : Any>(
 class EitherOfFour<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
   bareValue: Any,
   deferredValue: MutableList<DeferredValue>,
-  types: List<KType>
+  types: List<TypeDescriptor>
 ) : EitherOfThree<FirstType, SecondType, ThirdType>(bareValue, deferredValue, types) {
   @JvmName("isFourthType")
   fun `is`(@Suppress("UNUSED_PARAMETER") type: KClass<FourthType>): Boolean = `is`(3)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EitherTypeConverter.kt
@@ -3,7 +3,7 @@ package expo.modules.kotlin.types
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.ExpectedType
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 private fun createDeferredValue(
   value: Any,
@@ -46,7 +46,7 @@ private fun createDeferredValues(
   value: Any,
   context: AppContext?,
   list: List<Pair<ExpectedType, TypeConverter<*>>>,
-  typeList: List<KType>
+  typeList: List<TypeDescriptor>
 ): List<DeferredValue> {
   var wasConverted = false
   val result = list.map { (expectedType, converter) ->
@@ -67,10 +67,10 @@ private fun createDeferredValues(
 
 class EitherTypeConverter<FirstType : Any, SecondType : Any>(
   converterProvider: TypeConverterProvider,
-  eitherType: KType
+  eitherTypeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<Either<FirstType, SecondType>>() {
-  private val firstJavaType = requireNotNull(eitherType.arguments.getOrNull(0)?.type)
-  private val secondJavaType = requireNotNull(eitherType.arguments.getOrNull(1)?.type)
+  private val firstJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(0))
+  private val secondJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(1))
   private val firstTypeConverter = converterProvider.obtainTypeConverter(
     firstJavaType
   )
@@ -108,11 +108,11 @@ class EitherTypeConverter<FirstType : Any, SecondType : Any>(
 
 class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : Any>(
   converterProvider: TypeConverterProvider,
-  eitherType: KType
+  eitherTypeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<EitherOfThree<FirstType, SecondType, ThirdType>>() {
-  private val firstJavaType = requireNotNull(eitherType.arguments.getOrNull(0)?.type)
-  private val secondJavaType = requireNotNull(eitherType.arguments.getOrNull(1)?.type)
-  private val thirdJavaType = requireNotNull(eitherType.arguments.getOrNull(2)?.type)
+  private val firstJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(0))
+  private val secondJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(1))
+  private val thirdJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(2))
   private val firstTypeConverter = converterProvider.obtainTypeConverter(
     firstJavaType
   )
@@ -154,12 +154,12 @@ class EitherOfThreeTypeConverter<FirstType : Any, SecondType : Any, ThirdType : 
 
 class EitherOfFourTypeConverter<FirstType : Any, SecondType : Any, ThirdType : Any, FourthType : Any>(
   converterProvider: TypeConverterProvider,
-  eitherType: KType
+  eitherTypeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<EitherOfFour<FirstType, SecondType, ThirdType, FourthType>>() {
-  private val firstJavaType = requireNotNull(eitherType.arguments.getOrNull(0)?.type)
-  private val secondJavaType = requireNotNull(eitherType.arguments.getOrNull(1)?.type)
-  private val thirdJavaType = requireNotNull(eitherType.arguments.getOrNull(2)?.type)
-  private val fourthJavaType = requireNotNull(eitherType.arguments.getOrNull(3)?.type)
+  private val firstJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(0))
+  private val secondJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(1))
+  private val thirdJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(2))
+  private val fourthJavaType = requireNotNull(eitherTypeDescriptor.params.getOrNull(3))
   private val firstTypeConverter = converterProvider.obtainTypeConverter(
     firstJavaType
   )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JavaScriptFunctionTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JavaScriptFunctionTypeConverter.kt
@@ -4,15 +4,15 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.JavaScriptFunction
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class JavaScriptFunctionTypeConverter<T : Any>(
-  val type: KType
+  val typeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<JavaScriptFunction<T>>() {
   override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): JavaScriptFunction<T> {
     @Suppress("UNCHECKED_CAST")
     val jsFunction = value as JavaScriptFunction<T>
-    jsFunction.returnType = requireNotNull(type.arguments.first().type)
+    jsFunction.returnType = requireNotNull(typeDescriptor.params.first())
     return jsFunction
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ListTypeConverter.kt
@@ -9,14 +9,14 @@ import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class ListTypeConverter(
   converterProvider: TypeConverterProvider,
-  private val listType: KType
+  private val listType: TypeDescriptor
 ) : DynamicAwareTypeConverters<List<*>>() {
   private val elementConverter = converterProvider.obtainTypeConverter(
-    requireNotNull(listType.arguments.first().type) {
+    requireNotNull(listType.params.first()) {
       "The list type should contain the type of elements."
     }
   )
@@ -27,7 +27,7 @@ class ListTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(
             listType,
-            listType.arguments.first().type!!,
+            listType.params.first(),
             value::class,
             cause
           )
@@ -49,7 +49,7 @@ class ListTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(
             listType,
-            listType.arguments.first().type!!,
+            listType.params.first(),
             it!!::class,
             cause
           )
@@ -66,7 +66,7 @@ class ListTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(
             listType,
-            listType.arguments.first().type!!,
+            listType.params.first(),
             type,
             cause
           )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -9,20 +9,20 @@ import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class MapTypeConverter(
   converterProvider: TypeConverterProvider,
-  private val mapType: KType
+  private val mapType: TypeDescriptor
 ) : DynamicAwareTypeConverters<Map<*, *>>() {
   init {
-    require(mapType.arguments.first().type?.classifier == String::class) {
-      "The map key type should be String, but received ${mapType.arguments.first()}."
+    require(mapType.params.first().kClass == String::class) {
+      "The map key type should be String, but received ${mapType.params.first()}."
     }
   }
 
   private val valueConverter = converterProvider.obtainTypeConverter(
-    requireNotNull(mapType.arguments.getOrNull(1)?.type) {
+    requireNotNull(mapType.params.getOrNull(1)) {
       "The map type should contain the key type."
     }
   )
@@ -40,7 +40,7 @@ class MapTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(
             mapType,
-            mapType.arguments[1].type!!,
+            mapType.params[1],
             v!!::class,
             cause
           )
@@ -57,7 +57,7 @@ class MapTypeConverter(
     jsMap.entryIterator.forEach { (key, value) ->
       DynamicFromObject(value).recycle {
         exceptionDecorator({ cause ->
-          CollectionElementCastException(mapType, mapType.arguments[1].type!!, type, cause)
+          CollectionElementCastException(mapType, mapType.params[1], type, cause)
         }) {
           result[key] = valueConverter.convert(this, context, forceConversion)
         }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/PairTypeConverter.kt
@@ -10,20 +10,20 @@ import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
 import expo.modules.kotlin.recycle
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class PairTypeConverter(
   converterProvider: TypeConverterProvider,
-  private val pairType: KType
+  private val pairType: TypeDescriptor
 ) : DynamicAwareTypeConverters<Pair<*, *>>() {
   private val converters = listOf(
     converterProvider.obtainTypeConverter(
-      requireNotNull(pairType.arguments.getOrNull(0)?.type) {
+      requireNotNull(pairType.params.getOrNull(0)) {
         "The pair type should contain the type of the first parameter."
       }
     ),
     converterProvider.obtainTypeConverter(
-      requireNotNull(pairType.arguments.getOrNull(1)?.type) {
+      requireNotNull(pairType.params.getOrNull(1)) {
         "The pair type should contain the type of the second parameter."
       }
     )
@@ -52,7 +52,7 @@ class PairTypeConverter(
   private fun convertElement(context: AppContext?, array: ReadableArray, index: Int, forceConversion: Boolean): Any? {
     return array.getDynamic(index).recycle {
       exceptionDecorator({ cause ->
-        CollectionElementCastException(pairType, pairType.arguments[index].type!!, type, cause)
+        CollectionElementCastException(pairType, pairType.params[index], type, cause)
       }) {
         converters[index].convert(this, context, forceConversion)
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/SetTypeConverter.kt
@@ -8,14 +8,14 @@ import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.recycle
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class SetTypeConverter(
   converterProvider: TypeConverterProvider,
-  private val setType: KType
+  private val setType: TypeDescriptor
 ) : DynamicAwareTypeConverters<Set<*>>() {
   private val elementConverter = converterProvider.obtainTypeConverter(
-    requireNotNull(setType.arguments.first().type) {
+    requireNotNull(setType.params.first()) {
       "The set type should contain the type of elements."
     }
   )
@@ -33,7 +33,7 @@ class SetTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(
             setType,
-            setType.arguments.first().type!!,
+            setType.params.first(),
             it!!::class,
             cause
           )
@@ -50,7 +50,7 @@ class SetTypeConverter(
         exceptionDecorator({ cause ->
           CollectionElementCastException(
             setType,
-            setType.arguments.first().type!!,
+            setType.params.first(),
             type,
             cause
           )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
@@ -6,11 +6,10 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.MissingTypeConverter
 import expo.modules.kotlin.exception.toCodedException
 import expo.modules.kotlin.jni.ExpectedType
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
-import kotlin.reflect.typeOf
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 
-class TypeConverterComponent<Type : Any>(val desireType: KType) {
+class TypeConverterComponent<Type : Any>(val desireType: TypeDescriptor) {
   val desireTypeConverter = lazy { TypeConverterCollection<Type>(desireType) }
 
   inline fun <reified P0 : Any> from(crossinline body: (p0: P0) -> Type): TypeConverterComponent<Type> {
@@ -18,7 +17,7 @@ class TypeConverterComponent<Type : Any>(val desireType: KType) {
     return this
   }
 
-  fun build(): Pair<KType, TypeConverter<*>>? {
+  fun build(): Pair<TypeDescriptor, TypeConverter<*>>? {
     if (desireTypeConverter.isInitialized()) {
       val typeConverter = TypeConverterCollection<Type>(desireType)
       typeConverter.converters = desireTypeConverter.value.converters
@@ -29,13 +28,13 @@ class TypeConverterComponent<Type : Any>(val desireType: KType) {
 }
 
 class TypeConverterCollection<Type : Any>(
-  val type: KType
+  val type: TypeDescriptor
 ) : NonNullableTypeConverter<Type>() {
   @PublishedApi
-  internal var converters: MutableMap<KType, (Any?) -> Type> = mutableMapOf()
+  internal var converters: MutableMap<TypeDescriptor, (Any?) -> Type> = mutableMapOf()
 
   inline fun <reified P0> from(crossinline body: (p0: P0) -> Type): TypeConverterCollection<Type> {
-    converters[typeOf<P0>()] = { value ->
+    converters[typeDescriptorOf<P0>()] = { value ->
       enforceType<P0>(value)
       body(value)
     }
@@ -46,10 +45,7 @@ class TypeConverterCollection<Type : Any>(
   override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Type {
     val possibleConverters = converters
       .map { (key, converter) -> key to converter }
-      .filter { (key, _) ->
-        val kClass = key.classifier as? KClass<*>
-        kClass?.isInstance(value) == true
-      }
+      .filter { (key, _) -> key.kClass.isInstance(value) }
 
     if (possibleConverters.isEmpty()) {
       // We don't have a converter for Dynamic, but we can try to convert it to ExpoDynamic
@@ -93,7 +89,7 @@ class TypeConverterCollection<Type : Any>(
   override fun getCppRequiredTypes(): ExpectedType {
     return ExpectedType.merge(
       *converters.keys.map { key ->
-        ExpectedType.fromKType(key)
+        ExpectedType.fromTypeDescriptor(key)
       }.toTypedArray()
     )
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -36,6 +36,9 @@ import expo.modules.kotlin.typedarray.Uint16Array
 import expo.modules.kotlin.typedarray.Uint32Array
 import expo.modules.kotlin.typedarray.Uint8Array
 import expo.modules.kotlin.typedarray.Uint8ClampedArray
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
+import expo.modules.kotlin.types.descriptors.toTypeDescriptor
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 import expo.modules.kotlin.types.io.FileTypeConverter
 import expo.modules.kotlin.types.io.PathTypeConverter
 import expo.modules.kotlin.types.net.JavaURITypeConverter
@@ -51,30 +54,29 @@ import java.nio.file.Path
 import java.time.LocalDate
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
-import kotlin.reflect.typeOf
 import kotlin.time.Duration
 
 interface TypeConverterProvider {
-  fun obtainTypeConverter(type: KType): TypeConverter<*>
+  fun obtainTypeConverter(typeDescriptor: TypeDescriptor): TypeConverter<*>
 }
 
 inline fun <reified T : Any> obtainTypeConverter(): TypeConverter<T> {
   @Suppress("UNCHECKED_CAST")
-  return TypeConverterProviderImpl.obtainTypeConverter(typeOf<T>()) as TypeConverter<T>
+  return TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>()) as TypeConverter<T>
 }
 
 inline fun <reified T> convert(value: Dynamic): T {
-  val converter = TypeConverterProviderImpl.obtainTypeConverter(typeOf<T>())
+  val converter = TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>())
   return converter.convert(value) as T
 }
 
 inline fun <reified T> convert(value: Any?): T {
-  val converter = TypeConverterProviderImpl.obtainTypeConverter(typeOf<T>())
+  val converter = TypeConverterProviderImpl.obtainTypeConverter(typeDescriptorOf<T>())
   return converter.convert(value) as T
 }
 
 fun convert(value: Dynamic, type: KType): Any? {
-  val converter = TypeConverterProviderImpl.obtainTypeConverter(type)
+  val converter = TypeConverterProviderImpl.obtainTypeConverter(type.toTypeDescriptor())
   return converter.convert(value)
 }
 
@@ -84,52 +86,52 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
   private val cachedRecordConverters = mutableMapOf<KType, TypeConverter<*>>()
 
-  private fun getCachedConverter(inputType: KType): TypeConverter<*>? {
-    return cachedConverters[inputType.classifier]
+  private fun getCachedConverter(inputType: TypeDescriptor): TypeConverter<*>? {
+    return cachedConverters[inputType.kClass]
   }
-  private fun getCachedPrimitiveArrayConverter(inputType: KType): TypeConverter<*>? {
-    return cachedPrimitiveArrayConverters[inputType.classifier]
+  private fun getCachedPrimitiveArrayConverter(typeDescriptor: TypeDescriptor): TypeConverter<*>? {
+    return cachedPrimitiveArrayConverters[typeDescriptor.kClass]
   }
 
-  override fun obtainTypeConverter(type: KType): TypeConverter<*> {
-    val nonNullableTypeConverter = obtainNonNullableTypeConverter(type)
-    return if (type.isMarkedNullable) {
+  override fun obtainTypeConverter(typeDescriptor: TypeDescriptor): TypeConverter<*> {
+    val nonNullableTypeConverter = obtainNonNullableTypeConverter(typeDescriptor)
+    return if (typeDescriptor.isNullable) {
       NullableTypeConverter(nonNullableTypeConverter)
     } else {
       nonNullableTypeConverter
     }
   }
 
-  fun obtainNonNullableTypeConverter(type: KType): TypeConverter<*> {
-    getCachedConverter(type)?.let {
+  fun obtainNonNullableTypeConverter(typeDescriptor: TypeDescriptor): TypeConverter<*> {
+    getCachedConverter(typeDescriptor)?.let {
       return it
     }
 
-    val kClass = type.classifier as? KClass<*> ?: throw MissingTypeConverter(type)
+    val kClass = typeDescriptor.kClass
     val jClass = kClass.java
 
     if (jClass.isArray || Array::class.java.isAssignableFrom(jClass)) {
-      return if (isPrimitiveArray(type, jClass)) {
-        getCachedPrimitiveArrayConverter(type) ?: throw MissingTypeConverter(type)
+      return if (isPrimitiveArray(typeDescriptor)) {
+        getCachedPrimitiveArrayConverter(typeDescriptor) ?: throw MissingTypeConverter(typeDescriptor)
       } else {
-        ArrayTypeConverter(this, type)
+        ArrayTypeConverter(this, typeDescriptor)
       }
     }
 
     if (List::class.java.isAssignableFrom(jClass)) {
-      return ListTypeConverter(this, type)
+      return ListTypeConverter(this, typeDescriptor)
     }
 
     if (Map::class.java.isAssignableFrom(jClass)) {
-      return MapTypeConverter(this, type)
+      return MapTypeConverter(this, typeDescriptor)
     }
 
     if (Pair::class.java.isAssignableFrom(jClass)) {
-      return PairTypeConverter(this, type)
+      return PairTypeConverter(this, typeDescriptor)
     }
 
     if (Set::class.java.isAssignableFrom(jClass)) {
-      return SetTypeConverter(this, type)
+      return SetTypeConverter(this, typeDescriptor)
     }
 
     if (jClass.isEnum) {
@@ -137,50 +139,51 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       return EnumTypeConverter(kClass as KClass<Enum<*>>)
     }
 
-    val cachedConverter = cachedRecordConverters[type]
+    val cachedConverter = cachedRecordConverters[typeDescriptor.kType]
     if (cachedConverter != null) {
       return cachedConverter
     }
 
     if (Record::class.java.isAssignableFrom(jClass)) {
-      val converter = RecordTypeConverter<Record>(this, type)
-      cachedRecordConverters[type] = converter
+      val converter = RecordTypeConverter<Record>(this, typeDescriptor)
+      cachedRecordConverters[typeDescriptor.kType] = converter
       return converter
     }
 
     if (View::class.java.isAssignableFrom(jClass)) {
-      return ViewTypeConverter<View>(type)
+      return ViewTypeConverter<View>(typeDescriptor)
     }
 
     if (SharedRef::class.java.isAssignableFrom(jClass)) {
-      return SharedRefTypeConverter<SharedRef<*>>(type)
+      return SharedRefTypeConverter<SharedRef<*>>(typeDescriptor)
     }
 
     if (SharedObject::class.java.isAssignableFrom(jClass)) {
-      return SharedObjectTypeConverter<SharedObject>(type)
+      return SharedObjectTypeConverter<SharedObject>(typeDescriptor)
     }
 
     if (JavaScriptFunction::class.java.isAssignableFrom(jClass)) {
-      return JavaScriptFunctionTypeConverter<Any>(type)
+      return JavaScriptFunctionTypeConverter<Any>(typeDescriptor)
     }
 
     if (ValueOrUndefined::class.java.isAssignableFrom(jClass)) {
-      return ValueOrUndefinedTypeConverter(this, type)
+      return ValueOrUndefinedTypeConverter(this, typeDescriptor)
     }
 
-    return handelEither(type, jClass)
-      ?: throw MissingTypeConverter(type)
+    return handelEither(typeDescriptor)
+      ?: throw MissingTypeConverter(typeDescriptor)
   }
 
-  private fun handelEither(type: KType, jClass: Class<*>): TypeConverter<*>? {
+  private fun handelEither(typeDescriptor: TypeDescriptor): TypeConverter<*>? {
+    val jClass = typeDescriptor.kClass.java
     if (Either::class.java.isAssignableFrom(jClass)) {
       if (EitherOfFour::class.java.isAssignableFrom(jClass)) {
-        return EitherOfFourTypeConverter<Any, Any, Any, Any>(this, type)
+        return EitherOfFourTypeConverter<Any, Any, Any, Any>(this, typeDescriptor)
       }
       if (EitherOfThree::class.java.isAssignableFrom(jClass)) {
-        return EitherOfThreeTypeConverter<Any, Any, Any>(this, type)
+        return EitherOfThreeTypeConverter<Any, Any, Any>(this, typeDescriptor)
       }
-      return EitherTypeConverter<Any, Any>(this, type)
+      return EitherTypeConverter<Any, Any>(this, typeDescriptor)
     }
 
     return null
@@ -340,16 +343,16 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 class MergedTypeConverterProvider(
   private val providers: List<TypeConverterProvider>
 ) : TypeConverterProvider {
-  override fun obtainTypeConverter(type: KType): TypeConverter<*> {
+  override fun obtainTypeConverter(typeDescriptor: TypeDescriptor): TypeConverter<*> {
     for (provider in providers) {
       try {
-        return provider.obtainTypeConverter(type)
+        return provider.obtainTypeConverter(typeDescriptor)
       } catch (_: MissingTypeConverter) {
         // Ignore and try next provider
       }
     }
 
-    throw MissingTypeConverter(type)
+    throw MissingTypeConverter(typeDescriptor)
   }
 }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefinedTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ValueOrUndefinedTypeConverter.kt
@@ -4,14 +4,14 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class ValueOrUndefinedTypeConverter(
   converterProvider: TypeConverterProvider,
-  innerType: KType
+  typeDescriptor: TypeDescriptor
 ) : TypeConverter<ValueOrUndefined<*>> {
   private val innerTypeConverter = converterProvider.obtainTypeConverter(
-    requireNotNull(innerType.arguments.first().type) {
+    requireNotNull(typeDescriptor.params.first()) {
       "The ValueOrUndefined type should contain the argument type."
     }
   )

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/TypeDescriptor.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/TypeDescriptor.kt
@@ -1,0 +1,81 @@
+package expo.modules.kotlin.types.descriptors
+
+import kotlin.reflect.KClass
+import kotlin.reflect.KType
+
+sealed interface RawTypeDescriptor {
+  val kClass: KClass<*>
+  val isNullable: Boolean
+
+  data class Simple(
+    override val kClass: KClass<*>,
+    override val isNullable: Boolean
+  ) : RawTypeDescriptor
+
+  data class Parameterized(
+    override val kClass: KClass<*>,
+    override val isNullable: Boolean,
+    val params: List<RawTypeDescriptor>
+  ) : RawTypeDescriptor
+}
+
+class TypeDescriptor(
+  val typeInfo: RawTypeDescriptor,
+  private val kTypeProvider: () -> KType
+) {
+  private var _kType: KType? = null
+  val kType: KType
+    get() {
+      if (_kType == null) {
+        _kType = kTypeProvider()
+      }
+      return _kType!!
+    }
+
+  inline val isNullable: Boolean
+    get() = typeInfo.isNullable
+
+  inline val kClass: KClass<*>
+    get() = typeInfo.kClass
+
+  inline val params: List<TypeDescriptor>
+    get() = when (typeInfo) {
+      is RawTypeDescriptor.Simple -> emptyList()
+      is RawTypeDescriptor.Parameterized -> typeInfo.params.mapIndexed { index, descriptor ->
+        TypeDescriptor(
+          typeInfo = descriptor,
+          kTypeProvider = { kType.arguments[index].type ?: error("Type argument is missing") }
+        )
+      }
+    }
+
+  override fun toString(): String {
+    val paramsString = if (params.isNotEmpty()) {
+      params.joinToString(", ", "<", ">") { it.toString() }
+    } else {
+      ""
+    }
+    return "$kClass$paramsString${if (isNullable) "?" else ""}"
+  }
+}
+
+// TODO(@lukmccall): Remove if possible
+fun KType.toTypeDescriptor(): TypeDescriptor {
+  val classifier = this.classifier as? KClass<*> ?: error("Unsupported type: $this")
+  val isNullable = this.isMarkedNullable
+  val params = this.arguments.map { arg ->
+    val argType = arg.type ?: error("Type argument is missing for $this")
+    argType.toTypeDescriptor()
+  }
+
+  val rawTypeDescriptor = if (params.isEmpty()) {
+    RawTypeDescriptor.Simple(classifier, isNullable)
+  } else {
+    RawTypeDescriptor.Parameterized(classifier, isNullable, params.map { it.typeInfo })
+  }
+
+  return TypeDescriptor(
+    typeInfo = rawTypeDescriptor,
+    kTypeProvider = { this }
+  )
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/typeDescriptorOf.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/typeDescriptorOf.kt
@@ -1,0 +1,46 @@
+package expo.modules.kotlin.types.descriptors
+
+import android.util.Log
+import io.github.lukmccall.pika.TypeInfo
+import io.github.lukmccall.pika.typeInfo
+import kotlin.reflect.typeOf
+
+@PublishedApi
+internal fun TypeInfo.toRawTypeDescriptor(): RawTypeDescriptor {
+  return when (this) {
+    is TypeInfo.Simple -> RawTypeDescriptor.Simple(
+      kClass,
+      isNullable
+    )
+
+    is TypeInfo.Parameterized -> RawTypeDescriptor.Parameterized(
+      kClass,
+      isNullable,
+      typeArguments.map { it.toRawTypeDescriptor() }
+    )
+
+    TypeInfo.Star -> error("Star projections are not supported")
+  }
+}
+
+@PublishedApi
+internal inline fun <reified T> cpTypeDescriptorOf(): TypeDescriptor {
+  return TypeDescriptor(
+    typeInfo = typeInfo<T>().toRawTypeDescriptor(),
+    kTypeProvider = { typeOf<T>() }
+  )
+}
+
+inline fun <reified T> typeDescriptorOf(): TypeDescriptor {
+  val typeDescriptor = runCatching { cpTypeDescriptorOf<T>() }
+    .onFailure {
+      Log.e("ExpoModulesCore", "Failed to get type info for ${T::class.java.name}", it)
+    }
+    .getOrNull()
+
+  if (typeDescriptor != null) {
+    return typeDescriptor
+  }
+
+  return typeOf<T>().toTypeDescriptor()
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/toArgsArray.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/toArgsArray.kt
@@ -1,0 +1,137 @@
+package expo.modules.kotlin.types
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  converterProvider: TypeConverterProvider? = null
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(converterProvider)
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  converterProvider: TypeConverterProvider? = null
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider)
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  converterProvider: TypeConverterProvider? = null
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider)
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  converterProvider: TypeConverterProvider? = null
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider)
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  p4: Class<P4> = P4::class.java,
+  converterProvider: TypeConverterProvider? = null
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider),
+    toAnyType<P4>(converterProvider)
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  p4: Class<P4> = P4::class.java,
+  p5: Class<P5> = P5::class.java,
+  converterProvider: TypeConverterProvider? = null
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider),
+    toAnyType<P4>(converterProvider),
+    toAnyType<P5>(converterProvider)
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  p4: Class<P4> = P4::class.java,
+  p5: Class<P5> = P5::class.java,
+  p6: Class<P6> = P6::class.java,
+  converterProvider: TypeConverterProvider? = null
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider),
+    toAnyType<P4>(converterProvider),
+    toAnyType<P5>(converterProvider),
+    toAnyType<P6>(converterProvider)
+  )
+}
+
+@Suppress("UNUSED_PARAMETER")
+inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified P6, reified P7> toArgsArray(
+  p0: Class<P0> = P0::class.java,
+  p1: Class<P1> = P1::class.java,
+  p2: Class<P2> = P2::class.java,
+  p3: Class<P3> = P3::class.java,
+  p4: Class<P4> = P4::class.java,
+  p5: Class<P5> = P5::class.java,
+  p6: Class<P6> = P6::class.java,
+  p7: Class<P7> = P7::class.java,
+  converterProvider: TypeConverterProvider? = null
+): Array<AnyType> {
+  return arrayOf(
+    toAnyType<P0>(converterProvider),
+    toAnyType<P1>(converterProvider),
+    toAnyType<P2>(converterProvider),
+    toAnyType<P3>(converterProvider),
+    toAnyType<P4>(converterProvider),
+    toAnyType<P5>(converterProvider),
+    toAnyType<P6>(converterProvider),
+    toAnyType<P7>(converterProvider)
+  )
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ConcreteViewProp.kt
@@ -31,7 +31,7 @@ open class ConcreteViewProp<ViewType : View, PropType>(
     }
   }
 
-  override val isNullable: Boolean = propType.kType.isMarkedNullable
+  override val isNullable: Boolean = propType.typeDescriptor.isNullable
 
   override val isStateProp: Boolean
     get() = _isStateProp

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
@@ -48,7 +48,7 @@ class GroupViewManagerWrapper(
   override fun getNativeProps(): MutableMap<String, String> {
     val props = super.getNativeProps()
     viewWrapperDelegate.props.forEach { (key, prop) ->
-      props[key] = prop.type.kType.classifier.toString()
+      props[key] = prop.type.typeDescriptor.kClass.toString()
     }
     return props
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
@@ -46,7 +46,7 @@ class SimpleViewManagerWrapper(
   override fun getNativeProps(): MutableMap<String, String> {
     val props = super.getNativeProps()
     viewWrapperDelegate.props.forEach { (key, prop) ->
-      props[key] = prop.type.kType.classifier.toString()
+      props[key] = prop.type.typeDescriptor.kClass.toString()
     }
     return props
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewDefinitionBuilder.kt
@@ -13,23 +13,23 @@ import expo.modules.kotlin.component7
 import expo.modules.kotlin.component8
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.UnexpectedException
-import expo.modules.kotlin.functions.AsyncFunctionComponent
 import expo.modules.kotlin.functions.AsyncFunctionBuilder
+import expo.modules.kotlin.functions.AsyncFunctionComponent
 import expo.modules.kotlin.functions.AsyncFunctionWithPromiseComponent
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.functions.createAsyncFunctionComponent
 import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.types.TypeConverterProvider
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 import expo.modules.kotlin.types.enforceType
 import expo.modules.kotlin.types.toAnyType
 import expo.modules.kotlin.types.toArgsArray
 import kotlin.reflect.KClass
-import kotlin.reflect.KType
 
 @DefinitionMarker
 class ViewDefinitionBuilder<T : View>(
   @PublishedApi internal val viewClass: KClass<T>,
-  @PublishedApi internal val viewType: KType,
+  @PublishedApi internal val viewType: TypeDescriptor,
   @PublishedApi internal val converters: TypeConverterProvider? = null
 ) {
   @PublishedApi

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
@@ -7,11 +7,10 @@ import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.toStrongReference
 import expo.modules.kotlin.types.NonNullableTypeConverter
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
 
 class ViewTypeConverter<T : View>(
-  val type: KType
+  val typeDescriptor: TypeDescriptor
 ) : NonNullableTypeConverter<T>() {
   override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): T {
     val appContext = context.toStrongReference()
@@ -19,7 +18,7 @@ class ViewTypeConverter<T : View>(
 
     val viewTag = value as Int
     val view = appContext.findView<T>(viewTag)
-      ?: throw Exceptions.ViewNotFound(type.classifier as KClass<*>, viewTag)
+      ?: throw Exceptions.ViewNotFound(typeDescriptor.kClass, viewTag)
 
     return view
   }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -140,8 +140,8 @@ class KotlinInteropModuleRegistryTest {
         JavaOnlyArray().apply { pushMap(JavaOnlyMap().apply { putInt("string", 10) }) }
       ) to """
         Call to function 'test-1.f2' has been rejected.
-        → Caused by: The 1st argument cannot be cast to type expo.modules.kotlin.TestRecord (received class com.facebook.react.bridge.JavaOnlyMap)
-        → Caused by: Cannot cast 'Number' for field 'string' ('kotlin.String').
+        → Caused by: The 1st argument cannot be cast to type class expo.modules.kotlin.TestRecord (received class com.facebook.react.bridge.JavaOnlyMap)
+        → Caused by: Cannot cast value for field 'string' ('kotlin.String') in record 'class expo.modules.kotlin.TestRecord'.
         → Caused by: java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.lang.String (java.lang.Double and java.lang.String are in module java.base of loader 'bootstrap')
       """.trimIndent()
     )

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -9,10 +9,9 @@ import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.ArgumentCastException
 import expo.modules.kotlin.exception.InvalidArgsNumberException
 import expo.modules.kotlin.types.AnyType
-import expo.modules.kotlin.types.toAnyType
+import expo.modules.kotlin.types.toArgsArray
 import io.mockk.mockk
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class AnyFunctionTest {
   class MockedAnyFunctionComponent(
@@ -26,7 +25,7 @@ class AnyFunctionTest {
 
   @Test
   fun `call should throw if pass more arguments then expected`() {
-    val method = MockedAnyFunctionComponent(arrayOf({ typeOf<Int>() }.toAnyType<Int>()))
+    val method = MockedAnyFunctionComponent(toArgsArray<Int>())
     val promise = PromiseMock()
 
     assertThrows<InvalidArgsNumberException>("Received 2 arguments, but 1 was expected") {
@@ -42,7 +41,7 @@ class AnyFunctionTest {
 
   @Test
   fun `call should throw if pass less arguments then expected`() {
-    val method = MockedAnyFunctionComponent(arrayOf({ typeOf<Int>() }.toAnyType<Int>(), { typeOf<Int>() }.toAnyType<Int>()))
+    val method = MockedAnyFunctionComponent(toArgsArray<Int, Int>())
     val promise = PromiseMock()
 
     assertThrows<InvalidArgsNumberException>("Received 1 arguments, but 2 was expected") {
@@ -58,12 +57,12 @@ class AnyFunctionTest {
 
   @Test
   fun `call should throw if cannot convert args`() {
-    val method = MockedAnyFunctionComponent(arrayOf({ typeOf<Int>() }.toAnyType<Int>()))
+    val method = MockedAnyFunctionComponent(toArgsArray<Int>())
     val promise = PromiseMock()
 
     assertThrows<ArgumentCastException>(
       """
-      The 1st argument cannot be cast to type kotlin.Int (received class java.lang.String)
+      The 1st argument cannot be cast to type class kotlin.Int (received class java.lang.String)
       → Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer (java.lang.String and java.lang.Integer are in module java.base of loader 'bootstrap')
       """.trimIndent()
     ) {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ExpectedTypeTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ExpectedTypeTest.kt
@@ -4,14 +4,13 @@ import com.google.common.truth.Truth
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.jni.SingleType
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 internal class ExpectedTypeTest {
   @Test
   fun `should return expected type for Int`() {
-    val type = typeOf<Int>()
-    val expectedType = ExpectedType.fromKType(type)
+    val expectedType = ExpectedType.fromTypeDescriptor(typeDescriptorOf<Int>())
 
     Truth.assertThat(expectedType).isInstanceOf(ExpectedType::class.java)
     Truth.assertThat(expectedType.getPossibleTypes().size).isEqualTo(1)
@@ -22,8 +21,7 @@ internal class ExpectedTypeTest {
 
   @Test
   fun `should return expected type for Float`() {
-    val type = typeOf<Float>()
-    val expectedType = ExpectedType.fromKType(type)
+    val expectedType = ExpectedType.fromTypeDescriptor(typeDescriptorOf<Float>())
     val anticipatedExpectedType = ExpectedType(SingleType(CppType.FLOAT))
 
     Truth.assertThat(expectedType).isEqualTo(anticipatedExpectedType)
@@ -31,8 +29,8 @@ internal class ExpectedTypeTest {
 
   @Test
   fun `should return expected type for List of Ints`() {
-    val type = typeOf<List<Int>>()
-    val expectedType = ExpectedType.fromKType(type)
+    val expectedType = ExpectedType.fromTypeDescriptor(typeDescriptorOf<List<Int>>())
+
     val anticipatedExpectedType = ExpectedType(SingleType(CppType.LIST, arrayOf(ExpectedType(SingleType(CppType.INT)))))
 
     Truth.assertThat(expectedType).isEqualTo(anticipatedExpectedType)
@@ -40,8 +38,7 @@ internal class ExpectedTypeTest {
 
   @Test
   fun `should return expected type for Map of Lists of Doubles`() {
-    val type = typeOf<Map<String, List<Double>>>()
-    val expectedType = ExpectedType.fromKType(type)
+    val expectedType = ExpectedType.fromTypeDescriptor(typeDescriptorOf<Map<String, List<Double>>>())
     val anticipatedExpectedType = ExpectedType(SingleType(CppType.MAP, arrayOf(ExpectedType(SingleType(CppType.LIST, arrayOf(ExpectedType(SingleType(CppType.DOUBLE))))))))
 
     Truth.assertThat(expectedType).isEqualTo(anticipatedExpectedType)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
@@ -9,7 +9,6 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.toAnyType
 import io.mockk.mockk
 import org.junit.Test
-import kotlin.reflect.typeOf
 
 class ConcreteViewPropTest {
   @Test
@@ -18,7 +17,7 @@ class ConcreteViewPropTest {
     var providedValue = -1
     var providedView: View? = null
 
-    val prop = ConcreteViewProp<View, Int>("name", { typeOf<Int>() }.toAnyType<Int>()) { view, value ->
+    val prop = ConcreteViewProp<View, Int>("name", toAnyType<Int>()) { view, value ->
       providedValue = value
       providedView = view
     }
@@ -42,7 +41,7 @@ class ConcreteViewPropTest {
     val mockedView = mockk<View>()
     var providedValue: MyRecord? = null
 
-    val prop = ConcreteViewProp<View, MyRecord>("name", { typeOf<MyRecord>() }.toAnyType<MyRecord>()) { _, value ->
+    val prop = ConcreteViewProp<View, MyRecord>("name", toAnyType<MyRecord>()) { _, value ->
       providedValue = value
     }
 

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.0.4-2.1.20")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
@@ -21,6 +21,8 @@ abstract class ExpoModulesGradlePlugin : Plugin<Project> {
 
     with(project) {
       applyDefaultPlugins()
+      applyPikaPlugin()
+
       applyKotlin(kotlinVersion, kspVersion)
       applyDefaultDependencies()
       applyDefaultAndroidSdkVersions()

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -30,6 +30,12 @@ internal fun Project.applyDefaultPlugins() {
   }
 }
 
+internal fun Project.applyPikaPlugin() {
+  if (!plugins.hasPlugin("io.github.lukmccall.pika")) {
+    plugins.apply("io.github.lukmccall.pika")
+  }
+}
+
 internal fun Project.applyKotlin(kotlinVersion: String, kspVersion: String) {
   extra.set("kotlinVersion", kotlinVersion)
   extra.set("kspVersion", kspVersion)


### PR DESCRIPTION
# Why

Started using the Kotlin compiler plugin, which generates type information at compile time, so we no longer have to rely on reflection

See https://github.com/lukmccall/pika.

# How

Instead of using KType, I've migrated the code to use `TypeDescriptor`, which is built on the `TypeInfo` from the Pika plugin. There are still some places where we're relying on reflection. I'm going to eliminate those in future PRs. There are still a lot of things that I would love to include in the compiler plugin.

# Test Plan

- bare-expo
  - debug ✅ 
  - release ✅  

- Startup Performance                                                                                                                                                                                        
                                                                                                                                                                                                                   
  | Metric | Before | After | Change |                                                                                                                                                                             
  |--------|--------|-------|--------|                                                                                                                                                                             
  | **Cold Start (avg)** | 718ms | 572ms | **-146ms (-20.3%)** |                                                                                                                                                   
  | **Cold Start (min)** | 666ms | 535ms | -131ms |                                                                                                                                                                
  | **Cold Start (max)** | 798ms | 630ms | -168ms |                                                                                                                                                                
  | **Hot Start (avg)** | 42ms | ~40ms | ~same |   