### PR TITLE
[dev-launcher][Android] Bump Apollo Kotlin from 4.3.1 to 4.4.2

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### 💡 Others
 
 - Enforce transparent status bar and navigation bar on Android, remove unused `backgroundColor` / `translucent` options handling. ([#43518](https://github.com/expo/expo/pull/43518) by [@zoontek](https://github.com/zoontek))
+- [Android] Bump Apollo Kotlin from 4.3.1 to 4.4.2. ([#44386](https://github.com/expo/expo/pull/44386) by [@radko93](https://github.com/radko93))
 
 ### ⚠️ Notices
 

--- a/packages/expo-dev-launcher/android/build.gradle
+++ b/packages/expo-dev-launcher/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
   dependencies {
     classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${kotlinVersion}")
     classpath("org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin:${kotlinVersion}")
-    classpath("com.apollographql.apollo:apollo-gradle-plugin:4.3.1")
+    classpath("com.apollographql.apollo:apollo-gradle-plugin:4.4.2")
   }
 }
 
@@ -154,7 +154,7 @@ dependencies {
 
   debugOnly("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1")
 
-  debugOnly("com.apollographql.apollo:apollo-runtime:4.3.1")
+  debugOnly("com.apollographql.apollo:apollo-runtime:4.4.2")
 
   debugOnly("com.composables:core:1.43.1")
 


### PR DESCRIPTION
# Why

Bumps Apollo Kotlin dependency to the latest 4.x release (4.4.2). This also unblocks downstream consumers that use Apollo Kotlin in their own Expo modules from upgrading, since the Gradle plugin version must match across all modules in a build.

# How

Updated `apollo-gradle-plugin` and `apollo-runtime` from 4.3.1 to 4.4.2 in `packages/expo-dev-launcher/android/build.gradle`.

[Apollo Kotlin 4.4.2 changelog](https://github.com/apollographql/apollo-kotlin/releases/tag/v4.4.2)

# Test Plan

- Minor semver bump with no breaking changes in Apollo Kotlin 4.x
- Android build with dev-launcher enabled

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)