### PR TITLE
[iOS] Add legacy resolver to Promise for compatibility

### DIFF
--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -40,7 +40,7 @@ public class AudioModule: Module {
       #if os(iOS)
       appContext?.permissions?.askForPermission(
         usingRequesterClass: AudioRecordingRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
       #else
@@ -52,7 +52,7 @@ public class AudioModule: Module {
       #if os(iOS)
       appContext?.permissions?.getPermissionUsingRequesterClass(
         AudioRecordingRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
       #else

--- a/packages/expo-brightness/ios/BrightnessModule.swift
+++ b/packages/expo-brightness/ios/BrightnessModule.swift
@@ -22,7 +22,7 @@ public class BrightnessModule: Module {
       }
       permissions.getPermissionUsingRequesterClass(
         BrightnessPermissionsRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -33,7 +33,7 @@ public class BrightnessModule: Module {
       }
       permissions.askForPermission(
         usingRequesterClass: BrightnessPermissionsRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }

--- a/packages/expo-calendar/ios/CalendarModule.swift
+++ b/packages/expo-calendar/ios/CalendarModule.swift
@@ -276,7 +276,7 @@ public class CalendarModule: Module {
     AsyncFunction("getCalendarPermissionsAsync") { (promise: Promise) in
       appContext?.permissions?.getPermissionUsingRequesterClass(
         CalendarPermissionsRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -284,7 +284,7 @@ public class CalendarModule: Module {
     AsyncFunction("requestCalendarPermissionsAsync") { (promise: Promise) in
       appContext?.permissions?.askForPermission(
         usingRequesterClass: CalendarPermissionsRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -292,7 +292,7 @@ public class CalendarModule: Module {
     AsyncFunction("getRemindersPermissionsAsync") { (promise: Promise) in
       appContext?.permissions?.getPermissionUsingRequesterClass(
         RemindersPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -300,8 +300,9 @@ public class CalendarModule: Module {
     AsyncFunction("requestRemindersPermissionsAsync") { (promise: Promise) in
       appContext?.permissions?.askForPermission(
         usingRequesterClass: RemindersPermissionRequester.self,
-        resolve: promise.resolver,
-        reject: promise.legacyRejecter)
+        resolve: promise.legacyResolver,
+        reject: promise.legacyRejecter
+      )
     }
 
     AsyncFunction("createEventInCalendarAsync") { (event: Event, promise: Promise) in

--- a/packages/expo-calendar/ios/Next/CalendarNextModule.swift
+++ b/packages/expo-calendar/ios/Next/CalendarNextModule.swift
@@ -139,7 +139,7 @@ public final class CalendarNextModule: Module {
     AsyncFunction("getCalendarPermissions") { (promise: Promise) in
       appContext?.permissions?.getPermissionUsingRequesterClass(
         CalendarPermissionsRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -147,7 +147,7 @@ public final class CalendarNextModule: Module {
     AsyncFunction("requestCalendarPermissions") { (promise: Promise) in
       appContext?.permissions?.askForPermission(
         usingRequesterClass: CalendarPermissionsRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -155,7 +155,7 @@ public final class CalendarNextModule: Module {
     AsyncFunction("getRemindersPermissions") { (promise: Promise) in
       appContext?.permissions?.getPermissionUsingRequesterClass(
         RemindersPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -163,7 +163,7 @@ public final class CalendarNextModule: Module {
     AsyncFunction("requestRemindersPermissions") { (promise: Promise) in
       appContext?.permissions?.askForPermission(
         usingRequesterClass: RemindersPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter)
     }
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -355,7 +355,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
         self.appContext?.permissions,
         withRequester: CameraOnlyPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -364,7 +364,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       EXPermissionsMethodsDelegate.askForPermission(
         withPermissionsManager: self.appContext?.permissions,
         withRequester: CameraOnlyPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -373,7 +373,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
         self.appContext?.permissions,
         withRequester: CameraMicrophonePermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -382,7 +382,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       EXPermissionsMethodsDelegate.askForPermission(
         withPermissionsManager: self.appContext?.permissions,
         withRequester: CameraMicrophonePermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }

--- a/packages/expo-contacts/ios/ContactsModule.swift
+++ b/packages/expo-contacts/ios/ContactsModule.swift
@@ -347,7 +347,7 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
     AsyncFunction("getPermissionsAsync") { (promise: Promise) in
       appContext?.permissions?.getPermissionUsingRequesterClass(
         ContactsPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -355,7 +355,7 @@ public class ContactsModule: Module, OnContactPickingResultHandler {
     AsyncFunction("requestPermissionsAsync") { (promise: Promise) in
       appContext?.permissions?.askForPermission(
         usingRequesterClass: ContactsPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }

--- a/packages/expo-contacts/ios/next/ContactsNextModule.swift
+++ b/packages/expo-contacts/ios/next/ContactsNextModule.swift
@@ -388,7 +388,7 @@ public class ContactsNextModule: Module {
       StaticAsyncFunction("getPermissionsAsync") { (promise: Promise) in
         appContext?.permissions?.getPermissionUsingRequesterClass(
           ContactsPermissionRequester.self,
-          resolve: promise.resolver,
+          resolve: promise.legacyResolver,
           reject: promise.legacyRejecter
         )
       }
@@ -396,7 +396,7 @@ public class ContactsNextModule: Module {
       StaticAsyncFunction("requestPermissionsAsync") { (promise: Promise) in
         appContext?.permissions?.askForPermission(
           usingRequesterClass: ContactsPermissionRequester.self,
-          resolve: promise.resolver,
+          resolve: promise.legacyResolver,
           reject: promise.legacyRejecter
         )
       }

--- a/packages/expo-file-system/ios/Legacy/FileSystemLegacyModule.swift
+++ b/packages/expo-file-system/ios/Legacy/FileSystemLegacyModule.swift
@@ -51,9 +51,19 @@ public final class FileSystemLegacyModule: Module {
       let optionsDict = options.toDictionary(appContext: appContext)
       switch url.scheme {
       case "file":
-        EXFileSystemLocalFileHandler.getInfoForFile(url, withOptions: optionsDict, resolver: promise.resolver, rejecter: promise.legacyRejecter)
+        EXFileSystemLocalFileHandler.getInfoForFile(
+          url,
+          withOptions: optionsDict,
+          resolver: promise.legacyResolver,
+          rejecter: promise.legacyRejecter
+        )
       case "assets-library", "ph":
-        EXFileSystemAssetLibraryHandler.getInfoForFile(url, withOptions: optionsDict, resolver: promise.resolver, rejecter: promise.legacyRejecter)
+        EXFileSystemAssetLibraryHandler.getInfoForFile(
+          url,
+          withOptions: optionsDict,
+          resolver: promise.legacyResolver,
+          rejecter: promise.legacyRejecter
+        )
       default:
         throw UnsupportedSchemeException(url.scheme)
       }
@@ -143,9 +153,19 @@ public final class FileSystemLegacyModule: Module {
       try ensurePathPermission(appContext, path: toUrl.path, flag: .write)
 
       if fromUrl.scheme == "file" {
-        EXFileSystemLocalFileHandler.copy(from: fromUrl, to: toUrl, resolver: promise.resolver, rejecter: promise.legacyRejecter)
+        EXFileSystemLocalFileHandler.copy(
+          from: fromUrl,
+          to: toUrl,
+          resolver: promise.legacyResolver,
+          rejecter: promise.legacyRejecter
+        )
       } else if ["ph", "assets-library"].contains(fromUrl.scheme) {
-        EXFileSystemAssetLibraryHandler.copy(from: fromUrl, to: toUrl, resolver: promise.resolver, rejecter: promise.legacyRejecter)
+        EXFileSystemAssetLibraryHandler.copy(
+          from: fromUrl,
+          to: toUrl,
+          resolver: promise.legacyResolver,
+          rejecter: promise.legacyRejecter
+        )
       } else {
         throw InvalidFileUrlException(fromUrl)
       }
@@ -175,14 +195,19 @@ public final class FileSystemLegacyModule: Module {
 
       if sourceUrl.isFileURL {
         try ensurePathPermission(appContext, path: sourceUrl.path, flag: .read)
-        EXFileSystemLocalFileHandler.copy(from: sourceUrl, to: localUrl, resolver: promise.resolver, rejecter: promise.legacyRejecter)
+        EXFileSystemLocalFileHandler.copy(
+          from: sourceUrl,
+          to: localUrl,
+          resolver: promise.legacyResolver,
+          rejecter: promise.legacyRejecter
+        )
         return
       }
       let session = options.sessionType == .background ? backgroundSession : foregroundSession
       let request = createUrlRequest(url: sourceUrl, headers: options.headers)
       let downloadTask = session.downloadTask(with: request)
       let taskDelegate = EXSessionDownloadTaskDelegate(
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter,
         localUrl: localUrl,
         shouldCalculateMd5: options.md5
@@ -201,7 +226,7 @@ public final class FileSystemLegacyModule: Module {
       }
       let session = options.sessionType == .background ? backgroundSession : foregroundSession
       let task = try createUploadTask(session: session, targetUrl: targetUrl, sourceUrl: localUrl, options: options)
-      let taskDelegate = EXSessionUploadTaskDelegate(resolve: promise.resolver, reject: promise.legacyRejecter)
+      let taskDelegate = EXSessionUploadTaskDelegate(resolve: promise.legacyResolver, reject: promise.legacyRejecter)
 
       sessionTaskDispatcher.register(taskDelegate, for: task)
       task.resume()
@@ -220,7 +245,7 @@ public final class FileSystemLegacyModule: Module {
         ])
       }
       let taskDelegate = EXSessionCancelableUploadTaskDelegate(
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter,
         onSendCallback: onSend,
         resumableManager: taskHandlersManager,
@@ -257,7 +282,7 @@ public final class FileSystemLegacyModule: Module {
       }
 
       let taskDelegate = EXSessionResumableDownloadTaskDelegate(
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter,
         localUrl: localUrl,
         shouldCalculateMd5: options.md5,

--- a/packages/expo-gl/ios/ExpoGLModule.swift
+++ b/packages/expo-gl/ios/ExpoGLModule.swift
@@ -10,7 +10,7 @@ public final class ExpoGLModule: Module {
       EXGLObjectManager.shared.takeSnapshot(
         withContextId: contextId as NSNumber,
         andOptions: options,
-        resolver: promise.resolver,
+        resolver: promise.legacyResolver,
         rejecter: promise.legacyRejecter
       )
     }
@@ -34,7 +34,7 @@ public final class ExpoGLModule: Module {
     AsyncFunction("destroyContextAsync") { (contextId: UInt, promise: Promise) in
       EXGLObjectManager.shared.destroyContext(
         withId: contextId as NSNumber,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -42,7 +42,7 @@ public final class ExpoGLModule: Module {
     AsyncFunction("destroyObjectAsync") { (objectId: UInt, promise: Promise) in
       EXGLObjectManager.shared.destroyObjectAsync(
         objectId as NSNumber,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -55,7 +55,7 @@ public final class ExpoGLModule: Module {
       EXGLObjectManager.shared.createTextureForContext(
         withId: contextId as NSNumber,
         cameraView: cameraView,
-        resolver: promise.resolver,
+        resolver: promise.legacyResolver,
         rejecter: promise.legacyRejecter
       )
     }

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -75,8 +75,8 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
       return promise.reject(PermissionsModuleNotFoundException())
     }
     switch operationType {
-    case .get: permissions.getPermissionUsingRequesterClass(requesterClass, resolve: promise.resolver, reject: promise.legacyRejecter)
-    case .ask: permissions.askForPermission(usingRequesterClass: requesterClass, resolve: promise.resolver, reject: promise.legacyRejecter)
+    case .get: permissions.getPermissionUsingRequesterClass(requesterClass, resolve: promise.legacyResolver, reject: promise.legacyRejecter)
+    case .ask: permissions.askForPermission(usingRequesterClass: requesterClass, resolve: promise.legacyResolver, reject: promise.legacyRejecter)
     }
   }
 

--- a/packages/expo-location/ios/LocationUtils.swift
+++ b/packages/expo-location/ios/LocationUtils.swift
@@ -64,7 +64,7 @@ internal func getPermissionUsingRequester<Requester: EXPermissionsRequester>(
   EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
     permissionsManager,
     withRequester: Requester.self,
-    resolve: promise.resolver,
+    resolve: promise.legacyResolver,
     reject: promise.legacyRejecter
   )
 }
@@ -80,7 +80,7 @@ internal func askForPermissionUsingRequester<Requester: EXPermissionsRequester>(
   EXPermissionsMethodsDelegate.askForPermission(
     withPermissionsManager: permissionsManager,
     withRequester: Requester.self,
-    resolve: promise.resolver,
+    resolve: promise.legacyResolver,
     reject: promise.legacyRejecter
   )
 }

--- a/packages/expo-maps/ios/MapsModule.swift
+++ b/packages/expo-maps/ios/MapsModule.swift
@@ -19,7 +19,7 @@ public class MapsModule: Module {
       }
       permissionsManager.getPermissionUsingRequesterClass(
         MapPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -30,7 +30,7 @@ public class MapsModule: Module {
       }
       permissionsManager.askForPermission(
         usingRequesterClass: MapPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }

--- a/packages/expo-media-library/ios/MediaLibraryModule.swift
+++ b/packages/expo-media-library/ios/MediaLibraryModule.swift
@@ -52,7 +52,7 @@ public class MediaLibraryModule: Module, PhotoLibraryObserverHandler {
         .permissions?
         .getPermissionUsingRequesterClass(
           requesterClass(writeOnly),
-          resolve: promise.resolver,
+          resolve: promise.legacyResolver,
           reject: promise.legacyRejecter
         )
     }
@@ -63,7 +63,7 @@ public class MediaLibraryModule: Module, PhotoLibraryObserverHandler {
         .permissions?
         .askForPermission(
           usingRequesterClass: requesterClass(writeOnly),
-          resolve: promise.resolver,
+          resolve: promise.legacyResolver,
           reject: promise.legacyRejecter
         )
     }

--- a/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
+++ b/packages/expo-media-library/ios/next/MediaLibraryNextModule.swift
@@ -210,7 +210,7 @@ public final class MediaLibraryNextModule: Module {
         .permissions?
         .getPermissionUsingRequesterClass(
           requesterClass(writeOnly),
-          resolve: promise.resolver,
+          resolve: promise.legacyResolver,
           reject: promise.legacyRejecter
         )
     }
@@ -220,7 +220,7 @@ public final class MediaLibraryNextModule: Module {
         .permissions?
         .askForPermission(
           usingRequesterClass: requesterClass(writeOnly),
-          resolve: promise.resolver,
+          resolve: promise.legacyResolver,
           reject: promise.legacyRejecter
         )
     }

--- a/packages/expo-modules-core/ios/Core/Promise.swift
+++ b/packages/expo-modules-core/ios/Core/Promise.swift
@@ -9,6 +9,16 @@ public struct Promise: AnyArgument, Sendable {
   public var rejecter: RejectClosure
 
   /**
+   The resolver that is compatible with the legacy `EXPromiseResolveBlock`.
+   Necessary in some places not converted to Swift, such as `EXPermissionsMethodsDelegate`.
+   */
+  public var legacyResolver: EXPromiseResolveBlock {
+    return { value in
+      resolve(value)
+    }
+  }
+
+  /**
    The rejecter that is compatible with the legacy `EXPromiseRejectBlock`.
    Necessary in some places not converted to Swift, such as `EXPermissionsMethodsDelegate`.
    */

--- a/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Permissions/PermissionsModule.swift
@@ -21,7 +21,7 @@ public class PermissionsModule: Module {
         .permissions?
         .getPermissionUsingRequesterClass(
           ExpoNotificationsPermissionsRequester.self,
-          resolve: promise.resolver,
+          resolve: promise.legacyResolver,
           reject: promise.legacyRejecter
         )
     }
@@ -39,7 +39,7 @@ public class PermissionsModule: Module {
       // Expo Go notifications permissions are not scoped
       let resolver: EXPromiseResolveBlock = { result in
         if let permission = result as? [AnyHashable: Any] {
-          promise.resolver(EXPermissionsService.parsePermission(fromRequester: permission))
+          promise.legacyResolver(EXPermissionsService.parsePermission(fromRequester: permission))
         } else {
           promise.legacyRejecter("ERR_PERMISSIONS_REQUEST_NOTIFICATIONS", "Unexpected permission result type", nil)
         }

--- a/packages/expo-sensors/ios/DeviceMotionModule.swift
+++ b/packages/expo-sensors/ios/DeviceMotionModule.swift
@@ -35,7 +35,7 @@ public final class DeviceMotionModule: Module {
       }
       permissionsManager.getPermissionUsingRequesterClass(
         EXMotionPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -46,7 +46,7 @@ public final class DeviceMotionModule: Module {
       }
       permissionsManager.askForPermission(
         usingRequesterClass: EXMotionPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }

--- a/packages/expo-sensors/ios/PedometerModule.swift
+++ b/packages/expo-sensors/ios/PedometerModule.swift
@@ -46,7 +46,7 @@ public final class PedometerModule: Module {
       }
       permissionsManager.getPermissionUsingRequesterClass(
         EXMotionPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -57,7 +57,7 @@ public final class PedometerModule: Module {
       }
       permissionsManager.askForPermission(
         usingRequesterClass: EXMotionPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }

--- a/packages/expo-tracking-transparency/ios/TrackingTransparencyModule.swift
+++ b/packages/expo-tracking-transparency/ios/TrackingTransparencyModule.swift
@@ -18,7 +18,7 @@ public class TrackingTransparencyModule: Module {
       EXPermissionsMethodsDelegate.getPermissionWithPermissionsManager(
         self.appContext?.permissions,
         withRequester: TrackingTransparencyPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }
@@ -28,7 +28,7 @@ public class TrackingTransparencyModule: Module {
       EXPermissionsMethodsDelegate.askForPermission(
         withPermissionsManager: self.appContext?.permissions,
         withRequester: TrackingTransparencyPermissionRequester.self,
-        resolve: promise.resolver,
+        resolve: promise.legacyResolver,
         reject: promise.legacyRejecter
       )
     }


### PR DESCRIPTION
# Why

This is basically extracted from #44337 where we have to change the signature of `promise.resolver` to take `any JavaScriptRepresentable` instead of `Any` type. Most of the functions related to permissions are legacy and in Objective-C and the new `JavaScriptRepresentable` cannot be represented in Objective-C.
Ideally if we can migrate these permissions-related utils to Swift in this cycle, but for now I need to apply this change to reduce the scope of #44337 

# How

Added `legacyResolver` function that has a signature `(Any?) -> Void` (aka `EXPromiseResolveBlock`) that is compatible with Objective-C.

# Test Plan

It's very straightforward change that doesn't change the existing behavior.

<!-- disable:changelog-checks -->