### PR TITLE
[Android] Fix Spotless formatting violations

### DIFF
--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
@@ -57,7 +57,8 @@ class DevMenuDefaultPreferences(
 
   private val fabDefault: Boolean = try {
     val ai = application.packageManager.getApplicationInfo(
-      application.packageName, PackageManager.GET_META_DATA
+      application.packageName,
+      PackageManager.GET_META_DATA
     )
     ai.metaData?.getString("EXDevMenuShowFloatingActionButton")?.toBoolean() ?: true
   } catch (_: Exception) {

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
@@ -69,7 +69,8 @@ class ExpoCropImageActivity : CropImageActivity() {
     // Inset the crop view margins so it doesn't overlap with system bars or display cutouts
     ViewCompat.setOnApplyWindowInsetsListener(cropImageView) { view, insets ->
       val values = insets.getInsets(
-        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+      )
 
       view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
         setMargins(values.left, values.top, values.right, values.bottom)
@@ -131,13 +132,16 @@ class ExpoCropImageActivity : CropImageActivity() {
       decorView.setBackgroundColor(activityBackgroundColor)
 
       // Add the status bar view with zero initial height (will be sized by insets listener below)
-      addContentView(statusBarView,
-        ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0))
+      addContentView(
+        statusBarView,
+        ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0)
+      )
 
       // Dynamically resize the status bar view to match the actual status bar / display cutout height
       ViewCompat.setOnApplyWindowInsetsListener(decorView) { _, insets ->
         val values = insets.getInsets(
-          WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout())
+          WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout()
+        )
         statusBarView.updateLayoutParams { height = values.top }
         insets
       }

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
@@ -79,6 +79,7 @@ interface UpdatesStateChangeSubscription {
    * Call this to remove the subscription and stop receiving state change events
    */
   fun remove()
+
   /*
    * When updates is enabled, returns the current state context as an instance of UpdatesNativeInterfaceStateContext
    */


### PR DESCRIPTION
# Why

Spotless lint check is failing on `main` for `expo-dev-menu`, `expo-image-picker`, and `expo-updates-interface` (see [recent CI runs](https://github.com/expo/expo/actions/runs/23770981944)).

**Note:** Depends on #44389 — the CI workflow needs to install react-native submodule deps before Gradle tasks can run.

# How

Ran `./gradlew spotlessApply` for the affected packages.

# Test Plan

CI — `spotlessCheck` should pass after #44389 is merged.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

<!-- disable:changelog-checks -->