### PR TITLE
[ci] install react-native submodule deps in Android unit tests workflow, run spotless

### DIFF
--- a/.github/workflows/android-unit-tests.yml
+++ b/.github/workflows/android-unit-tests.yml
@@ -66,6 +66,9 @@ jobs:
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 📦 Install node modules
         run: pnpm install --frozen-lockfile
+      - name: 📦 Install react-native submodule dependencies
+        run: yarn install
+        working-directory: react-native-lab/react-native
       - name: 💅 Run Spotless lint check
         working-directory: apps/expo-go/android
         run: ./gradlew spotlessCheck || { echo '::error Spotless lint failed. Run `./gradlew spotlessApply` from `apps/expo-go/android` to automatically fix formatting.' && exit 1; }

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
@@ -57,7 +57,8 @@ class DevMenuDefaultPreferences(
 
   private val fabDefault: Boolean = try {
     val ai = application.packageManager.getApplicationInfo(
-      application.packageName, PackageManager.GET_META_DATA
+      application.packageName,
+      PackageManager.GET_META_DATA
     )
     ai.metaData?.getString("EXDevMenuShowFloatingActionButton")?.toBoolean() ?: true
   } catch (_: Exception) {

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ExpoCropImageActivity.kt
@@ -69,7 +69,8 @@ class ExpoCropImageActivity : CropImageActivity() {
     // Inset the crop view margins so it doesn't overlap with system bars or display cutouts
     ViewCompat.setOnApplyWindowInsetsListener(cropImageView) { view, insets ->
       val values = insets.getInsets(
-        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+        WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+      )
 
       view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
         setMargins(values.left, values.top, values.right, values.bottom)
@@ -131,13 +132,16 @@ class ExpoCropImageActivity : CropImageActivity() {
       decorView.setBackgroundColor(activityBackgroundColor)
 
       // Add the status bar view with zero initial height (will be sized by insets listener below)
-      addContentView(statusBarView,
-        ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0))
+      addContentView(
+        statusBarView,
+        ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, 0)
+      )
 
       // Dynamically resize the status bar view to match the actual status bar / display cutout height
       ViewCompat.setOnApplyWindowInsetsListener(decorView) { _, insets ->
         val values = insets.getInsets(
-          WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout())
+          WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout()
+        )
         statusBarView.updateLayoutParams { height = values.top }
         insets
       }

--- a/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
+++ b/packages/expo-updates-interface/android/src/main/java/expo/modules/updatesinterface/UpdatesInterface.kt
@@ -79,6 +79,7 @@ interface UpdatesStateChangeSubscription {
    * Call this to remove the subscription and stop receiving state change events
    */
   fun remove()
+
   /*
    * When updates is enabled, returns the current state context as an instance of UpdatesNativeInterfaceStateContext
    */


### PR DESCRIPTION
# Why

The `Android Unit Tests` workflow has been failing on `main` since the [switch to pnpm](https://github.com/expo/expo/commit/c1e5df1f) (#44057). Previously, `yarn install` at the root would hoist dependencies that the `react-native-lab/react-native` submodule needed. After switching to pnpm, the submodule's internal workspace packages (like `@react-native/community-cli-plugin`) are no longer available because pnpm is stricter about isolation.

This causes `settings.gradle` line 28 (`autolinkLibrariesFromCommand`) to fail — it runs `react-native.config.js` which requires `@react-native/community-cli-plugin`, a workspace package inside the RN submodule that isn't installed by `pnpm install`.

```
Process 'command 'node'' finished with non-zero exit value 1
```

Last passing run: [March 24](https://github.com/expo/expo/actions/runs/23498507032). All runs since have been cancelled or failed.

# How

Added a `yarn install` step for the react-native submodule before any Gradle tasks run. The submodule uses yarn workspaces and needs its own install to link its internal packages.

**Note:** CI for this PR will get past the `settings.gradle` failure but will still fail on Spotless formatting violations — those are fixed in #44388.

# Test Plan

This PR modifies the CI workflow itself — the Android Unit Tests job should pass after this change and #44388 are merged.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

<!-- disable:changelog-checks -->