### PR TITLE
[docs] Remove axios dependency, use native fetch in schema-sync

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -103,7 +103,6 @@
     "@types/turndown": "^5.0.6",
     "@vvago/vale": "3.12.0",
     "acorn": "^8.16.0",
-    "axios": "^1.12.2",
     "cheerio": "^1.2.0",
     "eslint": "^9.39.2",
     "eslint-config-next": "^16.1.6",

--- a/docs/scripts/schema-sync.js
+++ b/docs/scripts/schema-sync.js
@@ -19,6 +19,7 @@ async function run() {
   }
 
   if (version === 'unversioned') {
+    console.log('Fetching schema for unversioned from production...');
     const response = await fetch(
       `http://exp.host/--/api/v2/project/configuration/schema/UNVERSIONED`
     );

--- a/docs/scripts/schema-sync.js
+++ b/docs/scripts/schema-sync.js
@@ -6,7 +6,6 @@
  */
 
 import parser from '@apidevtools/json-schema-ref-parser';
-import axios from 'axios';
 import fs from 'fs-extra';
 import path from 'node:path';
 
@@ -20,10 +19,11 @@ async function run() {
   }
 
   if (version === 'unversioned') {
-    const response = await axios.get(
+    const response = await fetch(
       `http://exp.host/--/api/v2/project/configuration/schema/UNVERSIONED`
     );
-    const schema = await preprocessSchema(response.data.data.schema);
+    const responseJson = await response.json();
+    const schema = await preprocessSchema(responseJson.data.schema);
 
     await fs.writeFile(
       `public/static/schemas/unversioned/app-config-schema.json`,
@@ -47,10 +47,11 @@ async function fetchAndWriteSchema(version, staging) {
 
   const hostname = staging ? 'staging.exp.host' : 'exp.host';
 
-  const response = await axios.get(
+  const response = await fetch(
     `http://${hostname}/--/api/v2/project/configuration/schema/${version}.0.0`
   );
-  const schema = await preprocessSchema(response.data.data.schema);
+  const responseJson = await response.json();
+  const schema = await preprocessSchema(responseJson.data.schema);
 
   await fs.writeFile(schemaPath, JSON.stringify(schema.properties), 'utf8');
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -5517,7 +5517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.12.2, axios@npm:^1.4.0":
+"axios@npm:^1.4.0":
   version: 1.12.2
   resolution: "axios@npm:1.12.2"
   dependencies:
@@ -8110,7 +8110,6 @@ __metadata:
     "@vvago/vale": "npm:3.12.0"
     "@xyflow/react": "npm:^12.10.1"
     acorn: "npm:^8.16.0"
-    axios: "npm:^1.12.2"
     cheerio: "npm:^1.2.0"
     clipboard-copy: "npm:^4.0.1"
     cmdk: "npm:^0.2.1"


### PR DESCRIPTION
# Why

The `schema-sync.js` script was the only file in the docs codebase using `axios` for HTTP requests. Every other fetch script (`fetch-versions-schema.js`, `fetch-react-navigation-options.js`, `prune-cloudflare-deployments.mjs`) already uses the native `fetch` API.

# How

- Replace `axios.get()` calls in `scripts/schema-sync.js` with native `fetch()` and `response.json()`. Since axios wraps responses in `response.data`, the access path changed from `response.data.data.schema` to `responseJson.data.schema`.
- Add missing `console.log` for the unversioned schema fetch to match the versioned path's logging behavior.

# Test Plan

Run `yarn run schema-sync unversioned` and `yarn run schema-sync 55` and confirm both fetch and write the schema JSON files successfully. Verify the console output includes the "Fetching schema" log for both versioned and unversioned runs.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
