### PR TITLE
[docs] Fix app config links in Age Range reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/age-range.mdx
+++ b/docs/pages/versions/unversioned/sdk/age-range.mdx
@@ -31,7 +31,7 @@ We strongly recommend testing the functionality on a real device, as simulator r
 
 ### Setup iOS project
 
-To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required. Add it to your [app config](./config/app/) file:
+To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required. Add it to your [app config](../config/app/) file:
 
 ```json app.json
 {

--- a/docs/pages/versions/v54.0.0/sdk/age-range.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/age-range.mdx
@@ -31,7 +31,7 @@ We strongly recommend testing the functionality on a real device, as simulator r
 
 ### Setup iOS project
 
-To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required. Add it to your [app config](./config/app/) file:
+To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required. Add it to your [app config](../config/app/) file:
 
 ```json app.json
 {

--- a/docs/pages/versions/v55.0.0/sdk/age-range.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/age-range.mdx
@@ -31,7 +31,7 @@ We strongly recommend testing the functionality on a real device, as simulator r
 
 ### Setup iOS project
 
-To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required. Add it to your [app config](./config/app/) file:
+To use the age range API on iOS, you need to build your project with Xcode 26.0 or later. The `com.apple.developer.declared-age-range` entitlement is required. Add it to your [app config](../config/app/) file:
 
 ```json app.json
 {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix 404 app config links in Age Range reference pages.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
