### PR TITLE
Fix download-dependencies.sh

### DIFF
--- a/apps/expo-go/README.md
+++ b/apps/expo-go/README.md
@@ -32,7 +32,7 @@ If you need to make native code changes to your Expo project, such as adding cus
 - Install [direnv](http://direnv.net/) and [Homebrew](https://brew.sh/).
 - Clone this repo; we recommend cloning it to a directory whose full path does not include any spaces (you should clone all the submodules with `git clone --recurse-submodules`).
 - Run `brew bundle` in the root directory.
-- Run `pnpm` in the root directory.
+- Run `pnpm install` in the root directory.
 - Run `pnpm setup:native` in the root directory.
 - Run `pnpm build` in the `packages/expo` directory.
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Expo",
   "license": "MIT",
   "scripts": {
-    "setup:docs": "./scripts/download-dependencies.sh",
-    "setup:native": "./scripts/download-dependencies.sh && ./scripts/setup-react-android.sh",
+    "setup:docs": "./scripts/download-dependencies.sh --docs",
+    "setup:native": "./scripts/download-dependencies.sh --native && ./scripts/setup-react-android.sh",
     "install:react-native-lab": "(([ \"$(ls -A react-native-lab/react-native)\" ] && (yarn --cwd react-native-lab/react-native install --frozen-lockfile || true)) || echo \"Skipping installing Node modules in react-native-lab/react-native (directory empty)\")",
     "lint": "eslint .",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1"

--- a/scripts/download-dependencies.sh
+++ b/scripts/download-dependencies.sh
@@ -10,9 +10,6 @@ require() {
 require node
 require npm
 require git-lfs
-# We can install yarn because `npm install` is cross-platform
-require yarn || npm install -g yarn
-
 require direnv
 
 # Set up submodules
@@ -22,5 +19,20 @@ git submodule foreach --recursive git checkout .
 # Pull the large git files
 git lfs pull
 
-# Install the dependencies
-yarn
+if [[ "$1" == "--native" ]]; then
+  # We can install pnpm because `npm install` is cross-platform
+  require pnpm || npm install -g pnpm
+
+  # Install the dependencies
+  pnpm install
+
+elif [[ "$1" == "--docs" ]]; then
+  # We can install yarn because `npm install` is cross-platform
+  require yarn || npm install -g yarn
+
+  # Install the dependencies
+  (cd ./docs && yarn)
+
+elif [[ -n "$1" ]]; then
+  echo "Unknown option: $1"
+fi


### PR DESCRIPTION
# Why

- Currently, `download-dependencies.sh` try to use `yarn` to install dependencies, not `pnpm`
- `yarn` is still needed for `docs`
- `yarn install` (when running `setup:docs`) should be ran in `./docs`, not at root

# How

- I updated the script to either pick `pnpm` or `yarn`

# Test Plan

- Run `setup:native` or `setup:docs` at root

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
