### PR TITLE
[dev-launcher] Support loading embedded bundle

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
 - [Android] Add NDS service discovery.
 - [plugin] Add option to disable tools button by default. ([#44251](https://github.com/expo/expo/pull/44251) by [@alanjhughes](https://github.com/alanjhughes))
+- Support loading embedded bundles. ([#44396](https://github.com/expo/expo/pull/44396) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -35,6 +35,7 @@ import expo.modules.devlauncher.launcher.errors.DevLauncherAppError
 import expo.modules.devlauncher.launcher.errors.DevLauncherErrorActivity
 import expo.modules.devlauncher.launcher.errors.DevLauncherUncaughtExceptionHandler
 import expo.modules.devlauncher.launcher.loaders.DevLauncherAppLoaderFactory
+import expo.modules.devlauncher.launcher.loaders.DevLauncherEmbeddedAppLoader
 import expo.modules.devlauncher.launcher.manifest.DevLauncherManifestParser
 import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityNOPDelegate
 import expo.modules.devlauncher.react.activitydelegates.DevLauncherReactActivityRedirectDelegate
@@ -209,6 +210,54 @@ class DevLauncherController private constructor(
   override fun onAppLoadedWithError() {
     synchronized(this) {
       appIsLoading = false
+    }
+  }
+
+  fun hasEmbeddedBundle(): Boolean {
+    val enabled = getMetadataValue(context, "EXDevClientEmbeddedBundle", "false").toBoolean()
+    if (!enabled) {
+      return false
+    }
+
+    return try {
+      context.assets.open("index.android.bundle").use { true }
+    } catch (_: Exception) {
+      false
+    }
+  }
+
+  suspend fun loadEmbeddedBundle(mainActivity: ReactActivity? = null) {
+    synchronized(this) {
+      if (appIsLoading) {
+        return
+      }
+      appIsLoading = true
+    }
+
+    try {
+      ensureHostWasCleared(appHost, activityToBeInvalidated = mainActivity)
+
+      val appIntent = createAppIntent()
+      val appLoader = DevLauncherEmbeddedAppLoader(appHost, context, this)
+      useDeveloperSupport = false
+      manifest = null
+      manifestURL = null
+
+      val appLoaderListener = appLoader.createOnDelegateWillBeCreatedListener()
+      lifecycle.addListener(appLoaderListener)
+      mode = Mode.APP
+
+      if (appLoader.launch(appIntent)) {
+        latestLoadedApp = null
+        lifecycle.removeListener(appLoaderListener)
+      } else {
+        mode = Mode.LAUNCHER
+      }
+    } catch (e: Exception) {
+      synchronized(this) {
+        appIsLoading = false
+      }
+      throw e
     }
   }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -219,11 +219,9 @@ class DevLauncherController private constructor(
       return false
     }
 
-    return try {
+    return runCatching {
       context.assets.open("index.android.bundle").use { true }
-    } catch (_: Exception) {
-      false
-    }
+    }.getOrDefault(false)
   }
 
   suspend fun loadEmbeddedBundle(mainActivity: ReactActivity? = null) {
@@ -254,10 +252,12 @@ class DevLauncherController private constructor(
         mode = Mode.LAUNCHER
       }
     } catch (e: Exception) {
+      mode = Mode.LAUNCHER
+      throw e
+    } finally {
       synchronized(this) {
         appIsLoading = false
       }
-      throw e
     }
   }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/models/HomeViewModel.kt
@@ -33,6 +33,7 @@ sealed interface HomeAction {
   object ScanQRCode : HomeAction
   object ClearLoadingError : HomeAction
   object RefreshServers : HomeAction
+  object LoadEmbeddedBundle : HomeAction
 }
 
 data class HomeState(
@@ -40,7 +41,8 @@ data class HomeState(
   val recentlyOpenedApps: List<DevLauncherAppEntry> = emptyList(),
   val crashReport: DevLauncherErrorInstance? = null,
   val loadingError: String? = null,
-  val isRefreshing: Boolean = false
+  val isRefreshing: Boolean = false,
+  val hasEmbeddedBundle: Boolean = false
 )
 
 class HomeViewModel : ViewModel(), DefaultLifecycleObserver {
@@ -58,7 +60,8 @@ class HomeViewModel : ViewModel(), DefaultLifecycleObserver {
     HomeState(
       runningPackagers = filterPackagers(packagerService.runningPackagers.value),
       recentlyOpenedApps = devLauncherController.getRecentlyOpenedApps(),
-      crashReport = errorRegistryService.consumeException()
+      crashReport = errorRegistryService.consumeException(),
+      hasEmbeddedBundle = devLauncherController.hasEmbeddedBundle()
     )
   )
 
@@ -154,6 +157,17 @@ class HomeViewModel : ViewModel(), DefaultLifecycleObserver {
       is HomeAction.ClearLoadingError -> _state.value = _state.value.copy(loadingError = null)
 
       is HomeAction.RefreshServers -> refreshServers()
+
+      HomeAction.LoadEmbeddedBundle ->
+        devLauncherController.coroutineScope.launch {
+          try {
+            devLauncherController.loadEmbeddedBundle()
+          } catch (e: Exception) {
+            _state.value = _state.value.copy(
+              loadingError = e.message ?: "Failed to load embedded bundle"
+            )
+          }
+        }
 
       is HomeAction.NavigateToCrashReport -> throw IllegalStateException("Navigation action should be handled by the UI layer, not the ViewModel.")
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/HomeScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/HomeScreen.kt
@@ -26,6 +26,7 @@ import expo.modules.devlauncher.compose.ui.AppLoadingErrorDialog
 import expo.modules.devlauncher.compose.ui.DefaultScreenContainer
 import expo.modules.devlauncher.compose.ui.DevelopmentSessionActions
 import expo.modules.devlauncher.compose.ui.DevelopmentSessionSection
+import expo.modules.devlauncher.compose.ui.EmbeddedBundleButton
 import expo.modules.devlauncher.compose.ui.PullToRefreshContainer
 import expo.modules.devlauncher.compose.ui.RunningAppCard
 import expo.modules.devlauncher.compose.ui.rememberAnimatedItemsState
@@ -128,6 +129,11 @@ fun HomeScreen(
             )
           } else {
             DevelopmentSessionSection(state.isRefreshing, onAction)
+          }
+
+          if (state.hasEmbeddedBundle) {
+            Spacer(NewAppTheme.spacing.`3`)
+            EmbeddedBundleButton(onAction)
           }
 
           Spacer(NewAppTheme.spacing.`6`)

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/DevelopmentSession.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/DevelopmentSession.kt
@@ -4,13 +4,16 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.composeunstyled.Button
 import expo.modules.core.utilities.EmulatorUtilities
 import expo.modules.devlauncher.compose.models.HomeAction
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
@@ -113,6 +116,37 @@ fun DevelopmentSessionActions(isRefreshing: Boolean = false, showRefetchButton: 
       )
 
       ScanQRCodeButton(onAction)
+    }
+  }
+}
+
+@Composable
+fun EmbeddedBundleButton(
+  onAction: (HomeAction) -> Unit
+) {
+  RoundedSurface(
+    color = NewAppTheme.colors.background.element,
+    borderRadius = NewAppTheme.borderRadius.xl
+  ) {
+    Button(
+      onClick = {
+        onAction(HomeAction.LoadEmbeddedBundle)
+      }
+    ) {
+      Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(NewAppTheme.spacing.`3`)
+      ) {
+        NewText("Load embedded bundle")
+
+        LauncherIcons.Download(
+          size = 20.dp,
+          tint = NewAppTheme.colors.icon.quaternary
+        )
+      }
     }
   }
 }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherReactUtils.kt
@@ -93,9 +93,9 @@ private fun injectDebugServerHost(
 }
 
 @OptIn(UnstableReactNativeAPI::class)
-fun injectLocalBundleLoader(
+fun injectBundleLoader(
   reactHost: ReactHost,
-  bundlePath: String
+  jsBundleLoader: JSBundleLoader
 ): Boolean {
   return try {
     check(reactHost is ReactHostImpl)
@@ -107,8 +107,6 @@ fun injectLocalBundleLoader(
     mAllowPackagerServerAccessField.isAccessible = true
     mAllowPackagerServerAccessField[reactHost] = false
 
-    val newJsBundleLoader = JSBundleLoader.createFileLoader(bundlePath)
-
     // [1] Replace the ReactHostDelegate.jsBundlerLoader with our new loader
     val mReactHostDelegateField = reactHostClass.getDeclaredField("reactHostDelegate")
     mReactHostDelegateField.isAccessible = true
@@ -117,23 +115,30 @@ fun injectLocalBundleLoader(
       reactHostDelegate.javaClass.setPrivateDeclaredFieldValue(
         "_jsBundleLoader",
         reactHostDelegate,
-        newJsBundleLoader
+        jsBundleLoader
       )
     } else if (reactHostDelegate is DefaultReactHostDelegate) {
       DefaultReactHostDelegate::class.java.setPrivateDeclaredFieldValue(
         "jsBundleLoader",
         reactHostDelegate,
-        newJsBundleLoader
+        jsBundleLoader
       )
     } else {
-      throw IllegalStateException("[injectLocalBundleLoader] Unsupported reactHostDelegate: ${reactHostDelegate.javaClass}")
+      throw IllegalStateException("[injectBundleLoader] Unsupported reactHostDelegate: ${reactHostDelegate.javaClass}")
     }
 
     true
   } catch (e: Exception) {
-    Log.e("DevLauncher", "Unable to load local bundle file", e)
+    Log.e("DevLauncher", "Unable to inject bundle loader", e)
     false
   }
+}
+
+fun injectLocalBundleLoader(
+  reactHost: ReactHost,
+  bundlePath: String
+): Boolean {
+  return injectBundleLoader(reactHost, JSBundleLoader.createFileLoader(bundlePath))
 }
 
 fun injectDevServerHelper(context: Context, devSupportManager: DevSupportManager, controller: DevLauncherControllerInterface?) {

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherEmbeddedAppLoader.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/launcher/loaders/DevLauncherEmbeddedAppLoader.kt
@@ -1,0 +1,22 @@
+package expo.modules.devlauncher.launcher.loaders
+
+import android.content.Context
+import com.facebook.react.ReactHost
+import com.facebook.react.bridge.JSBundleLoader
+import expo.modules.devlauncher.helpers.injectBundleLoader
+import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
+
+/**
+ * Implementation of DevLauncherAppLoader which loads an embedded JS bundle
+ * from the app's assets directory (index.android.bundle).
+ */
+class DevLauncherEmbeddedAppLoader(
+  private val appHost: ReactHost,
+  private val context: Context,
+  controller: DevLauncherControllerInterface
+) : DevLauncherAppLoader(appHost, context, controller) {
+  override fun injectBundleLoader(): Boolean {
+    val loader = JSBundleLoader.createAssetLoader(context, "assets://index.android.bundle", true)
+    return injectBundleLoader(appHost, loader)
+  }
+}

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -61,6 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)loadApp:(NSURL *)expoUrl withProjectUrl:(NSURL  * _Nullable)projectUrl onSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError;
 
+- (void)loadLocalBundleOnSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError;
+
 - (void)clearRecentlyOpenedApps;
 
 - (NSDictionary *)getLaunchOptions;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -531,8 +531,6 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 
   RCTDevLoadingViewSetEnabled(NO);
   [self _initAppWithUrl:bundleUrl bundleUrl:bundleUrl manifest:nil];
-  // Clear manifestURL so that reload attempts don't try to load a file:// URL
-  // through the manifest parser path.
   self.manifestURL = nil;
   if (onSuccess) {
     onSuccess();

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -507,6 +507,38 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
   });
 }
 
+- (void)loadLocalBundleOnSuccess:(void (^ _Nullable)(void))onSuccess onError:(void (^ _Nullable)(NSError *error))onError
+{
+  NSNumber *embeddedBundleEnabled = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"EXDevClientEmbeddedBundle"];
+  if (![embeddedBundleEnabled boolValue]) {
+    if (onError) {
+      onError([NSError errorWithDomain:@"DevelopmentClient"
+                                  code:1
+                              userInfo:@{NSLocalizedDescriptionKey: @"Embedded bundle loading is not enabled. Set 'embeddedBundle: true' in your dev-client plugin config."}]);
+    }
+    return;
+  }
+
+  NSURL *bundleUrl = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  if (!bundleUrl) {
+    if (onError) {
+      onError([NSError errorWithDomain:@"DevelopmentClient"
+                                  code:1
+                              userInfo:@{NSLocalizedDescriptionKey: @"No embedded bundle found. Make sure a 'main.jsbundle' is included in the app bundle."}]);
+    }
+    return;
+  }
+
+  RCTDevLoadingViewSetEnabled(NO);
+  [self _initAppWithUrl:bundleUrl bundleUrl:bundleUrl manifest:nil];
+  // Clear manifestURL so that reload attempts don't try to load a file:// URL
+  // through the manifest parser path.
+  self.manifestURL = nil;
+  if (onSuccess) {
+    onSuccess();
+  }
+}
+
 - (BOOL)isAppRunning
 {
   if([_appBridge isProxy]){

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -52,6 +52,7 @@ class DevLauncherViewModel: ObservableObject {
   @Published var user: User?
   @Published var selectedAccountId: String?
   @Published var isLoadingServer: Bool = false
+  @Published var isLoadingLocalBundle: Bool = false
   @Published var permissionStatus: LocalNetworkPermissionStatus = .unknown
 
   @Published var devServers: [DevServer] = []
@@ -77,6 +78,13 @@ class DevLauncherViewModel: ObservableObject {
 
   var isLoggedIn: Bool {
     return isAuthenticated && user != nil
+  }
+
+  var hasEmbeddedBundle: Bool {
+    guard let enabled = Bundle.main.object(forInfoDictionaryKey: "EXDevClientEmbeddedBundle") as? Bool, enabled else {
+      return false
+    }
+    return Bundle.main.url(forResource: "main", withExtension: "jsbundle") != nil
   }
 
   init() {
@@ -164,6 +172,22 @@ class DevLauncherViewModel: ObservableObject {
   func clearRecentlyOpenedApps() {
     EXDevLauncherController.sharedInstance().clearRecentlyOpenedApps()
     self.recentlyOpenedApps = []
+  }
+
+  func loadLocalBundle() {
+    guard !isLoadingLocalBundle else { return }
+    isLoadingLocalBundle = true
+
+    EXDevLauncherController.sharedInstance().loadLocalBundle(onSuccess: { [weak self] in
+      DispatchQueue.main.async {
+        self?.isLoadingLocalBundle = false
+      }
+    }, onError: { [weak self] error in
+      DispatchQueue.main.async {
+        self?.isLoadingLocalBundle = false
+        self?.showErrorAlert(error.localizedDescription)
+      }
+    })
   }
 
   func isCompatibleRuntime(_ runtimeVersion: String) -> Bool {

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -59,6 +59,9 @@ struct DevServersView: View {
             }
           }
         }
+        if viewModel.hasEmbeddedBundle {
+          embeddedBundleRow
+        }
         enterUrl
       }
     }
@@ -119,6 +122,32 @@ struct DevServersView: View {
       Color.expoSecondarySystemBackground :
       Color.expoSystemBackground)
     .clipShape(RoundedRectangle(cornerRadius: 12))
+  }
+
+  private var embeddedBundleRow: some View {
+    Button {
+      viewModel.loadLocalBundle()
+    } label: {
+      HStack {
+        Image(systemName: "doc.fill")
+          .foregroundColor(.blue)
+          .frame(width: 12)
+        Text("Load embedded bundle")
+          .foregroundColor(.primary)
+        Spacer()
+        if viewModel.isLoadingLocalBundle {
+          ProgressView()
+        } else {
+          Image(systemName: "chevron.right")
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+      }
+      .padding()
+      .background(Color.expoSecondarySystemBackground)
+      .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+    .buttonStyle(PlainButtonStyle())
   }
 
   private var header: some View {

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -42,6 +42,14 @@ export type PluginConfigOptions = {
      * @default true
      */
     toolsButton?: boolean;
+    /**
+     * Whether to enable loading an embedded JS bundle from the dev launcher.
+     * When enabled and a bundle file is present in the app, a "Load embedded bundle"
+     * option appears in the dev launcher UI.
+     *
+     * @default false
+     */
+    embeddedBundle?: boolean;
 };
 /**
  * @ignore

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -20,6 +20,10 @@ const schema = {
             type: 'boolean',
             nullable: true,
         },
+        embeddedBundle: {
+            type: 'boolean',
+            nullable: true,
+        },
         android: {
             type: 'object',
             properties: {
@@ -34,6 +38,10 @@ const schema = {
                     nullable: true,
                 },
                 toolsButton: {
+                    type: 'boolean',
+                    nullable: true,
+                },
+                embeddedBundle: {
                     type: 'boolean',
                     nullable: true,
                 },
@@ -54,6 +62,10 @@ const schema = {
                     nullable: true,
                 },
                 toolsButton: {
+                    type: 'boolean',
+                    nullable: true,
+                },
+                embeddedBundle: {
                     type: 'boolean',
                     nullable: true,
                 },

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -109,6 +109,13 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
             return config;
         });
     }
+    const iOSEmbeddedBundle = props.ios?.embeddedBundle ?? props.embeddedBundle;
+    if (iOSEmbeddedBundle) {
+        config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
+            config.modResults['EXDevClientEmbeddedBundle'] = true;
+            return config;
+        });
+    }
     const androidLaunchMode = props.android?.launchMode ??
         props.launchMode ??
         props.android?.launchModeExperimental ??
@@ -125,6 +132,14 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
             const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
             config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'EXDevMenuShowFloatingActionButton', String(androidToolsButton));
+            return config;
+        });
+    }
+    const androidEmbeddedBundle = props.android?.embeddedBundle ?? props.embeddedBundle;
+    if (androidEmbeddedBundle) {
+        config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+            const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'EXDevClientEmbeddedBundle', String(true));
             return config;
         });
     }

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -46,6 +46,14 @@ export type PluginConfigOptions = {
    * @default true
    */
   toolsButton?: boolean;
+  /**
+   * Whether to enable loading an embedded JS bundle from the dev launcher.
+   * When enabled and a bundle file is present in the app, a "Load embedded bundle"
+   * option appears in the dev launcher UI.
+   *
+   * @default false
+   */
+  embeddedBundle?: boolean;
 };
 
 const schema: JSONSchema<PluginConfigType> = {
@@ -66,6 +74,10 @@ const schema: JSONSchema<PluginConfigType> = {
       type: 'boolean',
       nullable: true,
     },
+    embeddedBundle: {
+      type: 'boolean',
+      nullable: true,
+    },
     android: {
       type: 'object',
       properties: {
@@ -80,6 +92,10 @@ const schema: JSONSchema<PluginConfigType> = {
           nullable: true,
         },
         toolsButton: {
+          type: 'boolean',
+          nullable: true,
+        },
+        embeddedBundle: {
           type: 'boolean',
           nullable: true,
         },
@@ -100,6 +116,10 @@ const schema: JSONSchema<PluginConfigType> = {
           nullable: true,
         },
         toolsButton: {
+          type: 'boolean',
+          nullable: true,
+        },
+        embeddedBundle: {
           type: 'boolean',
           nullable: true,
         },

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -138,6 +138,14 @@ export default createRunOncePlugin<PluginConfigType>(
       });
     }
 
+    const iOSEmbeddedBundle = props.ios?.embeddedBundle ?? props.embeddedBundle;
+    if (iOSEmbeddedBundle) {
+      config = withInfoPlist(config, (config) => {
+        config.modResults['EXDevClientEmbeddedBundle'] = true;
+        return config;
+      });
+    }
+
     const androidLaunchMode =
       props.android?.launchMode ??
       props.launchMode ??
@@ -165,6 +173,20 @@ export default createRunOncePlugin<PluginConfigType>(
           mainApplication,
           'EXDevMenuShowFloatingActionButton',
           String(androidToolsButton)
+        );
+        return config;
+      });
+    }
+
+    const androidEmbeddedBundle = props.android?.embeddedBundle ?? props.embeddedBundle;
+    if (androidEmbeddedBundle) {
+      config = withAndroidManifest(config, (config) => {
+        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+          mainApplication,
+          'EXDevClientEmbeddedBundle',
+          String(true)
         );
         return config;
       });


### PR DESCRIPTION
# Why
Adds support for loading the embedded bundle

# How
- Added new option `embeddedBundle` to the config plugin
- Show an option in the UI to load the bundle if the config option is set and we can locate a valid bundle

There are some caveats to this. The bundle has to be created in release mode or the app will crash and the assets need to be created too. Both need to be added to the native projects manually. We currently do not have method to do this for users. This PR just adds support for loading the bundle in dev launcher if it is present.  

# Test Plan
https://github.com/user-attachments/assets/9a52d8cc-02ab-40c5-bf51-da9d078b83e6

https://github.com/user-attachments/assets/8a97df31-25e4-4320-932a-853cdbdfad2a
