### PR TITLE
[expo-dev-launcher][fix] Fix typo in `package.json`, add scripts

### DIFF
--- a/packages/expo-dev-launcher/package.json
+++ b/packages/expo-dev-launcher/package.json
@@ -8,6 +8,10 @@
     "url": "https://github.com/expo/expo.git",
     "directory": "packages/expo-dev-launcher"
   },
+  "scripts": {
+    "build:plugin": "expo-module build plugin",
+    "expo-module": "expo-module"
+  },
   "keywords": [
     "react-native"
   ],
@@ -19,11 +23,11 @@
     "expo-dev-menu": "workspace:55.0.9",
     "expo-manifests": "workspace:~55.0.9"
   },
-  "devDepecencies": {
-    "@types/node": "^22.14.0"
-  },
   "peerDependencies": {
     "expo": "workspace:*",
     "react-native": "*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3825,6 +3825,10 @@ importers:
       react-native:
         specifier: 0.85.0-rc.5
         version: 0.85.0-rc.5(@babel/core@7.29.0)(@react-native/jest-preset@0.85.0-rc.5(@babel/core@7.29.0)(react@19.2.3))(@types/react@19.2.14)(react@19.2.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.19.15
 
   packages/expo-dev-menu:
     dependencies:


### PR DESCRIPTION
# Why
There is a typo in `package.json` and you cannot build plugins because of it. Also the package lacks scripts to build plugins.
# How
Fixed the typo and added `build:plugin` script.
# Test Plan
Checked that plugins build correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
