### PR TITLE
[ios][dev-launcher] Fix deadlock in DevMenuPackagerConnectionHandler

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Fix support for react-native 0.84 ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fix crash in FabState coerceTo ([#43752](https://github.com/expo/expo/pull/43752) by [@kot331107](https://github.com/kot331107))
 - [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
+- [iOS] Fix deadlock in `DevMenuPackagerConnectionHandler.setup`.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [iOS] Fix support for react-native 0.84 ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fix crash in FabState coerceTo ([#43752](https://github.com/expo/expo/pull/43752) by [@kot331107](https://github.com/kot331107))
 - [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
-- [iOS] Fix deadlock in `DevMenuPackagerConnectionHandler.setup`.
+- [iOS] Fix deadlock in `DevMenuPackagerConnectionHandler.setup`. ([#44405](https://github.com/expo/expo/pull/44405) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
+++ b/packages/expo-dev-menu/ios/DevMenuPackagerConnectionHandler.swift
@@ -18,24 +18,28 @@ class DevMenuPackagerConnectionHandler {
 #if DEBUG
     self.swizzleRCTDevMenuShow()
 
-    let devSettings: RCTDevSettings? = self.manager?.currentAppContext?.nativeModule(named: "DevSettings")
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let manager = self.manager else { return }
+
+      let devSettings: RCTDevSettings? = manager.currentAppContext?.nativeModule(named: "DevSettings")
 // TODO(gabrieldonadel): Remove this once we bump react-native-macos to 0.84
 #if !os(macOS)
-    let packagerConnection = devSettings?.packagerConnection
+      let packagerConnection = devSettings?.packagerConnection
 #else
-    let packagerConnection: RCTPackagerConnection? = RCTPackagerConnection.shared()
+      let packagerConnection: RCTPackagerConnection? = RCTPackagerConnection.shared()
 #endif
-    packagerConnection?.addNotificationHandler(
-      self.sendDevCommandNotificationHandler,
-      queue: DispatchQueue.main,
-      forMethod: "sendDevCommand"
-    )
+      packagerConnection?.addNotificationHandler(
+        self.sendDevCommandNotificationHandler,
+        queue: DispatchQueue.main,
+        forMethod: "sendDevCommand"
+      )
 
-    packagerConnection?.addNotificationHandler(
-      self.devMenuNotificationHanlder,
-      queue: DispatchQueue.main,
-      forMethod: "devMenu"
-    )
+      packagerConnection?.addNotificationHandler(
+        self.devMenuNotificationHanlder,
+        queue: DispatchQueue.main,
+        forMethod: "devMenu"
+      )
+    }
 #endif
   }
 


### PR DESCRIPTION
# Why
While working on #44396 I ran into an issue where the app would consistently deadlock on the third bundle load.

# How
`DevMenuModule.OnCreate` calls `nativeModule(named: "DevSettings")` which triggers lazy TurboModule loading. When this runs on the main thread, it completes fine. When it runs on the JS thread (subsequent loads via didInitializeRuntime), TurboModule init needs the main thread. By the third cycle, the main thread is processing async teardown work from the previous host that can't complete because the old JS thread is gone.

The fix is move the `nativeModule` call to the main thread, so it runs after the thread finishes the whatever work is pending from clean up instead of deadlocking.

# Test Plan
Bare expo. Returning to the launcher and loading the bundle can be done repeatedly without issue