### PR TITLE
[ios][precompile] add prebuilt expo-camera

### DIFF
--- a/packages/expo-camera/spm.config.json
+++ b/packages/expo-camera/spm.config.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "../../tools/src/prebuilds/schemas/spm.config.schema.json",
+  "products": [
+    {
+      "name": "ExpoCamera",
+      "podName": "ExpoCamera",
+      "platforms": [
+        "iOS(.v15)"
+      ],
+      "externalDependencies": [
+        "ReactNativeDependencies",
+        "React",
+        "Hermes",
+        "expo-modules-core/ExpoModulesCore"
+      ],
+      "spmPackages": [
+        {
+          "url": "https://github.com/zxingify/zxingify-objc.git",
+          "productName": "ZXingObjC",
+          "version": {
+            "exact": "3.6.9"
+          }
+        }
+      ],
+      "targets": [
+        {
+          "type": "swift",
+          "name": "ExpoCamera",
+          "path": "ios",
+          "pattern": "**/*.swift",
+          "dependencies": [
+            "ReactNativeDependencies",
+            "React",
+            "Hermes",
+            "expo-modules-core/ExpoModulesCore",
+            "ZXingObjC"
+          ],
+          "linkedFrameworks": [
+            "Foundation",
+            "UIKit",
+            "AVFoundation"
+          ],
+          "compilerFlags": {
+            "swift": [
+              "-DZXINGOBJC_USE_SUBSPECS",
+              "-DZXINGOBJC_PDF417",
+              "-DZXINGOBJC_ONED"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Why

Expo-camera is itself not a big module, but the ZXingObjC library is big and should be prebuilt.

# How

This PR prebuilds ZXingObjC and expo-camera.

# Test Plan

Build with precompiled modules. Improves build time.
