### PR TITLE
fix(expo/winter): Remove `original*` global copies for globals with getters

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent `original*` globals from being enumerable or from being created for globals with getters, since these may be side-effectful ([#44407](https://github.com/expo/expo/pull/44407) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Decouple web entry files from `react-native-web` by adding web-specific forks for `registerRootComponent`, `AppRegistry`, `AppEntryNotFound`, and `DevLoadingView`. ([#44298](https://github.com/expo/expo/pull/44298) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo/build/winter/installGlobal.d.ts.map
+++ b/packages/expo/build/winter/installGlobal.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"installGlobal.d.ts","sourceRoot":"","sources":["../../src/winter/installGlobal.ts"],"names":[],"mappings":"AAAA;;;;;;;;;GASG;AAyDH;;;;;;;;;;;;GAYG;AACH,wBAAgB,aAAa,CAAC,CAAC,SAAS,MAAM,EAAE,IAAI,EAAE,MAAM,EAAE,QAAQ,EAAE,MAAM,CAAC,GAAG,IAAI,CA6BrF"}
+{"version":3,"file":"installGlobal.d.ts","sourceRoot":"","sources":["../../src/winter/installGlobal.ts"],"names":[],"mappings":"AAAA;;;;;;;;;GASG;AAyDH;;;;;;;;;;;;GAYG;AACH,wBAAgB,aAAa,CAAC,CAAC,SAAS,MAAM,EAAE,IAAI,EAAE,MAAM,EAAE,QAAQ,EAAE,MAAM,CAAC,GAAG,IAAI,CAmCrF"}

--- a/packages/expo/build/winter/installGlobal.d.ts.map
+++ b/packages/expo/build/winter/installGlobal.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"installGlobal.d.ts","sourceRoot":"","sources":["../../src/winter/installGlobal.ts"],"names":[],"mappings":"AAAA;;;;;;;;;GASG;AAyDH;;;;;;;;;;;;GAYG;AACH,wBAAgB,aAAa,CAAC,CAAC,SAAS,MAAM,EAAE,IAAI,EAAE,MAAM,EAAE,QAAQ,EAAE,MAAM,CAAC,GAAG,IAAI,CAmCrF"}
+{"version":3,"file":"installGlobal.d.ts","sourceRoot":"","sources":["../../src/winter/installGlobal.ts"],"names":[],"mappings":"AAAA;;;;;;;;;GASG;AAyDH;;;;;;;;;;;;GAYG;AACH,wBAAgB,aAAa,CAAC,CAAC,SAAS,MAAM,EAAE,IAAI,EAAE,MAAM,EAAE,QAAQ,EAAE,MAAM,CAAC,GAAG,IAAI,CAkCrF"}

--- a/packages/expo/src/winter/installGlobal.ts
+++ b/packages/expo/src/winter/installGlobal.ts
@@ -81,8 +81,14 @@ export function installGlobal<T extends object>(name: string, getValue: () => T)
   // @ts-ignore: globalThis is not defined in all environments
   const object = typeof global !== 'undefined' ? global : globalThis;
   const descriptor = Object.getOwnPropertyDescriptor(object, name);
-  if (__DEV__ && descriptor) {
+
+  // NOTE(@kitten): We have to exclude descriptors with getters here
+  // When two calls of a "lazy getter" conflict, accessing the original will override the global again
+  // (e.g. `globalThis.originalURL` in react-native will set URL back to its own value)
+  if (__DEV__ && descriptor && !descriptor.get) {
     const backupName = `original${name[0] ?? ''.toUpperCase()}${name.slice(1)}`;
+    // NOTE(@kitten): We don't want the global to be enumerably different in development
+    descriptor.enumerable = false;
     Object.defineProperty(object, backupName, descriptor);
   }
 

--- a/packages/expo/src/winter/installGlobal.ts
+++ b/packages/expo/src/winter/installGlobal.ts
@@ -88,8 +88,7 @@ export function installGlobal<T extends object>(name: string, getValue: () => T)
   if (__DEV__ && descriptor && !descriptor.get) {
     const backupName = `original${name[0] ?? ''.toUpperCase()}${name.slice(1)}`;
     // NOTE(@kitten): We don't want the global to be enumerably different in development
-    descriptor.enumerable = false;
-    Object.defineProperty(object, backupName, descriptor);
+    Object.defineProperty(object, backupName, { ...descriptor, enumerable: false });
   }
 
   const { enumerable, writable, configurable = false } = descriptor || {};


### PR DESCRIPTION
# Why

Resolves #44343

It's unclear why we've copied this over or this was retained (even for react-native's version), so it seems safe to remove.

Accessing `global.originalURL`, for example, will trigger react-native's side-effect on its getter, which then subsequently sets `global.URL` to React Native's version temporarily, which is never intended to be loaded in the first place. This is dangerous and confusing.

# How

- Don't set `original*` copies for descriptors with `get` getter
- Force `enumerable = false` on copies, since we shouldn't make the global obviously appear different in development and production

# Test Plan

- Manually tested with provided reproduction

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
