### PR TITLE
Add error message guidelines to `.claude/CLAUDE.md`

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,3 +7,6 @@ When writing error messages, consider explaining what, why, and how:
 - **How:** tell the user what to do next, such as a fix, workaround, debugging step, or when to contact support. The user is usually a developer.
 
 Be specific, calm, and actionable. Do not stop at the symptom. Even when the exact fix is unknown, always provide a useful next step. Include diagnostic details only when they help troubleshooting, and label them clearly.
+
+Example error message:
+The JavaScript bundler couldn't bundle your code because it depends on a Node.js native addon (node_modules/example/example.node). Use a different package fully implemented in JavaScript, or see https://metrobundler.dev/docs/resolution/ if this package already provides one and the bundler may not be configured to resolve it.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,7 +3,7 @@
 When writing error messages, consider explaining what, why, and how:
 
 - **What:** clearly state what failed.
-- **Why:** explain the likely cause at a useful level of abstraction, not just the symptom.
+- **Why:** explain the likely cause at the user's level of abstraction, not just the symptom.
 - **How:** tell the user what to do next, such as a fix, workaround, debugging step, or when to contact support. The user is usually a developer.
 
 Be specific, calm, and actionable. Do not stop at the symptom. Even when the exact fix is unknown, always provide a useful next step. Include diagnostic details only when they help troubleshooting, and label them clearly.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,9 @@
+## Error messages
+
+When writing error messages, consider explaining what, why, and how:
+
+- **What:** clearly state what failed.
+- **Why:** explain the likely cause at a useful level of abstraction, not just the symptom.
+- **How:** tell the user what to do next, such as a fix, workaround, debugging step, or when to contact support. The user is usually a developer.
+
+Be specific, calm, and actionable. Do not stop at the symptom. Even when the exact fix is unknown, always provide a useful next step. Include diagnostic details only when they help troubleshooting, and label them clearly.


### PR DESCRIPTION
Why
===
There was no guidance for writing error messages, which led to inconsistent quality across the codebase. This mirrors the same guidelines added to the universe repo in expo/universe#26222.

How
===
Create `.claude/CLAUDE.md` with a "What, Why, How" framework for writing actionable, developer-friendly error messages: state what failed, explain the likely cause, and tell the user what to do next.

Test Plan
===
Read the rendered Markdown.
