### PR TITLE
[updates] change `writeErrorOrExceptionToLog` queue, fix failing tests

### DIFF
--- a/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
+++ b/packages/expo-modules-core/ios/Core/Logging/PersistentFileLog.swift
@@ -138,7 +138,7 @@ public class PersistentFileLog {
       try deleteFileSync()
       return
     }
-    try contents.joined(separator: "\n").write(toFile: filePath, atomically: true, encoding: .utf8)
+    try (contents.joined(separator: "\n") + "\n").write(toFile: filePath, atomically: true, encoding: .utf8)
   }
 
   private func deleteFileSync() throws {

--- a/packages/expo-modules-core/ios/Tests/PersistentFileLogTests.swift
+++ b/packages/expo-modules-core/ios/Tests/PersistentFileLogTests.swift
@@ -50,6 +50,21 @@ struct PersistentFileLogTests {
     #expect(entries[0] == "Test string 2")
   }
 
+  @Test
+  func `append after filter preserves separate entries`() async throws {
+    await clearEntriesAsync(log: log)
+    await appendEntryAsync(log: log, entry: "entry1")
+    await appendEntryAsync(log: log, entry: "entry2")
+    await filterEntriesAsync(log: log) { entry in
+      entry.contains("2")
+    }
+    await appendEntryAsync(log: log, entry: "entry3")
+    let entries = log.readEntries()
+    #expect(entries.count == 2)
+    #expect(entries[0] == "entry2")
+    #expect(entries[1] == "entry3")
+  }
+
   // MARK: - Helpers
 
   private func clearEntriesAsync(log: PersistentFileLog) async {

--- a/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
+++ b/packages/expo-updates/ios/EXUpdates/ErrorRecovery.swift
@@ -128,12 +128,12 @@ public final class ErrorRecovery: NSObject {
 
   public func handle(error: NSError) {
     startPipeline(withEncounteredError: error)
-    ErrorRecovery.writeErrorOrExceptionToLog(error, logger)
+    ErrorRecovery.writeErrorOrExceptionToLog(error, logger, dispatchQueue: errorRecoveryQueue)
   }
 
   public func handle(exception: NSException) {
     startPipeline(withEncounteredError: exception)
-    ErrorRecovery.writeErrorOrExceptionToLog(exception, logger)
+    ErrorRecovery.writeErrorOrExceptionToLog(exception, logger, dispatchQueue: errorRecoveryQueue)
   }
 
   public func notify(newRemoteLoadStatus newStatus: RemoteLoadStatus) {

--- a/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseTests.swift
+++ b/packages/expo-updates/ios/Tests/AppLauncherWithDatabaseTests.swift
@@ -111,7 +111,7 @@ class AppLauncherWithDatabaseTests {
     db.databaseQueue.sync {
       let sameUpdate = try! db.update(withId: testUpdate.updateId, config: config)
       #expect(yesterday != sameUpdate?.lastAccessed)
-      #expect(abs(sameUpdate!.lastAccessed.timeIntervalSinceNow) < 1)
+      #expect(abs(sameUpdate!.lastAccessed.timeIntervalSinceNow) < 3)
     }
   }
 }


### PR DESCRIPTION
# Why

failure 1:

There's some slowness in the CI env and our expectation seems to be too strict:
```
::error file=AppLauncherWithDatabaseTests.swift,line=114,col=7::Recorded an issue (Expectation failed: (abs(sameUpdate!.lastAccessed.timeIntervalSinceNow) → 1.100956916809082) < (1 → 1.0))
```

I increased the value from 1 to 3.

failure 2:

```
[07:30:50]: ▸ ::error file=ErrorRecoveryTests.swift,line=579,col=5::Recorded an issue (Expectation failed: (errorLog?.contains("TestDomain") → false) == true)
[07:30:50]: ▸ ::error file=ErrorRecoveryTests.swift,line=581,col=5::Recorded an issue (Expectation failed: (errorLog?.contains("TestLocalizedDescription") → false) == true)
[07:30:50]: ▸ ::error ::"error log consume" (0.011 seconds) 2 issue(s)
```

there's a dependency between tests:
`handle(error:)` and `handle(exception:)` dispatched the log write to `DispatchQueue.global()` while all other error recovery work used the serial `errorRecoveryQueue`.

In tests, `testQueue.flush()` only drained the serial queue, so log writes from previous tests could race with subsequent ones — a stale atomic write could overwrite the error log file, causing the `error log consume` test to read unexpected content.

The fix routes log writes through `errorRecoveryQueue`, so `testQueue.flush()` guarantees all work (pipeline + log write) completes before the test ends.


failure 3:

```
[10:57:11]: ▸ ::error file=UpdatesLogReaderTests.swift,line=46,col=5::Recorded an issue (Expectation   
failed: (entries3.count → 0) == 1)                                                                     
[10:57:11]: ▸ ::error ::PurgeOldLogs() (1.420 seconds) 1 issue(s)
```

added another test case to expose this more, and a fix that addresses that

# How

explained above

# Test Plan

- repeatedly green CI for iOS, mac is handled in https://github.com/expo/expo/pull/44380

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
