### PR TITLE
@expo/log-box: Use OkHttpClientProvider instead of raw OkHttpClient

### DIFF
--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Add native no-op for `renderInShadowRoot` to avoid `react-dom` resolution errors on native platforms. ([#43893](https://github.com/expo/expo/issues/43893)) ([#44190](https://github.com/expo/expo/pull/44190) by [@mvincentong](https://github.com/mvincentong))
+- Use OkHttpClientProvider instead of raw OkHttpClient ([#44416](https://github.com/expo/expo/pull/44416)) by [@cortinico](https://github.com/cortinico)
 
 ### 💡 Others
 

--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -11,10 +11,10 @@
 ### 🐛 Bug fixes
 
 - Add native no-op for `renderInShadowRoot` to avoid `react-dom` resolution errors on native platforms. ([#43893](https://github.com/expo/expo/issues/43893)) ([#44190](https://github.com/expo/expo/pull/44190) by [@mvincentong](https://github.com/mvincentong))
-- Use OkHttpClientProvider instead of raw OkHttpClient ([#44416](https://github.com/expo/expo/pull/44416)) by [@cortinico](https://github.com/cortinico)
 
 ### 💡 Others
 
+- Use `OkHttpClientProvider` instead of raw `OkHttpClient` ([#44416](https://github.com/expo/expo/pull/44416)) by [@cortinico](https://github.com/cortinico)
 - Stop @expo/log-box from rebuilding on every pnpm install ([#44330](https://github.com/expo/expo/pull/44330) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### ⚠️ Notices

--- a/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxSurfaceDelegate.kt
+++ b/packages/@expo/log-box/android/src/main/expo/modules/logbox/ExpoLogBoxSurfaceDelegate.kt
@@ -6,11 +6,11 @@ import android.widget.FrameLayout
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.SurfaceDelegate
+import com.facebook.react.modules.network.OkHttpClientProvider
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
@@ -103,7 +103,7 @@ class ExpoLogBoxSurfaceDelegate(private val devSupportManager: DevSupportManager
       onResult: (String) -> Unit,
       onFailure: (Exception) -> Unit
     ->
-    val client = OkHttpClient()
+    val client = OkHttpClientProvider.getOkHttpClient()
 
     val requestBody = if (method.uppercase() != "GET") {
       body.toRequestBody("application/json; charset=utf-8".toMediaTypeOrNull())


### PR DESCRIPTION
# Why

Replace direct OkHttpClient instantiation with OkHttpClientProvider.getOkHttpClient() in ExpoLogBoxSurfaceDelegate to use the shared HTTP client that React Native is exposing.

# How

Tested in my local deployment of Expo.

# Test Plan

N/A

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
