### PR TITLE
Update gitignore to generalize env file patterns

### DIFF
--- a/templates/expo-template-default/gitignore
+++ b/templates/expo-template-default/gitignore
@@ -30,8 +30,8 @@ yarn-error.*
 .DS_Store
 *.pem
 
-# local env files
-.env*.local
+# env files
+.env*
 
 # typescript
 *.tsbuildinfo


### PR DESCRIPTION

This pull request updates the `.gitignore` file in the Expo template to better match common environment file patterns.

.gitignore improvements:

* Changed the `.env` ignore pattern from only local variants (`.env*.local`) to all environment files (`.env*`), ensuring all types of `.env` files are ignored.