### PR TITLE
[dev-client][Android] Use OkHttpClientProvider in DevMenuMetroClient

### DIFF
--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/websockets/DevMenuMetroClient.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/websockets/DevMenuMetroClient.kt
@@ -1,13 +1,13 @@
 package expo.modules.devmenu.websockets
 
 import androidx.core.net.toUri
+import com.facebook.react.modules.network.OkHttpClientProvider
 import expo.modules.devmenu.helpers.await
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 
 object DevMenuMetroClient {
-  private val httpClient by lazy { OkHttpClient() }
+  private val httpClient = OkHttpClientProvider.getOkHttpClient()
 
   suspend fun openJSInspector(metroHost: String, applicationId: String) {
     val url = "$metroHost/_expo/debugger".toUri()


### PR DESCRIPTION
# Why

Replace standalone OkHttpClient with React Native's OkHttpClientProvider so that custom HTTP headers are included in Metro
client requests.

# How

Tested in my local Expo deployment.

# Test Plan

N/a

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
