### PR TITLE
[docs] Workflows: `on.app_store_connect` docs

### DIFF
--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -136,16 +136,14 @@ on:
       states:
         - ready_for_review
         - waiting_for_review
-    build_upload:
-      states:
-        - complete
   # @end #
 
 jobs:
-  build:
-    type: build
+  send_slack_notification:
+    type: slack
     params:
-      platform: ios
+      webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
+      message: "App version is ready for review or waiting for review."
 ```
 
 ### VS Code extension

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -143,7 +143,7 @@ jobs:
     type: slack
     params:
       webhook_url: ${{ env.SLACK_WEBHOOK_URL }}
-      message: "App version is ready for review or waiting for review."
+      message: 'App version is ready for review or waiting for review.'
 ```
 
 ### VS Code extension

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -121,7 +121,7 @@ You can also trigger workflows from App Store Connect events using [`on.app_stor
 Before using App Store Connect triggers, configure your App Store Connect connection in EAS dashboard:
 
 - Open EAS dashboard and select your project.
-- Navigate to **Project settings > General > Connections**.
+- Navigate to **[Project settings > General > Connections](https://expo.dev/accounts/[account]/projects/[project]/settings)**.
 - Connect your App Store Connect app.
 
 Example workflow:

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -118,7 +118,7 @@ on:
 
 You can also trigger workflows from App Store Connect events using [`on.app_store_connect`](/eas/workflows/syntax/#onapp_store_connect).
 
-Before using App Store Connect triggers, configure your App Store Connect connection in Expo dashboard:
+Before using App Store Connect triggers, configure your App Store Connect connection in your Expo project dashboard:
 
 - Open Expo dashboard and select your project.
 - Navigate to **Project settings > General > Connections**.

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -114,6 +114,40 @@ on:
         platform: ios
 ```
 
+### Trigger workflows from App Store Connect events
+
+You can also trigger workflows from App Store Connect events using [`on.app_store_connect`](/eas/workflows/syntax/#onapp_store_connect).
+
+Before using App Store Connect triggers, configure your App Store Connect connection in Expo dashboard:
+
+- Open Expo dashboard and select your project.
+- Navigate to **Project settings > General > Connections**.
+- Connect your App Store Connect app.
+
+Example workflow:
+
+```yaml .eas/workflows/app-store-connect-events.yml
+name: React to App Store Connect events
+
+# @info #
+on:
+  app_store_connect:
+    app_version:
+      states:
+        - ready_for_review
+        - waiting_for_review
+    build_upload:
+      states:
+        - complete
+  # @end #
+
+jobs:
+  build:
+    type: build
+    params:
+      platform: ios
+```
+
 ### VS Code extension
 
 Download the [Expo Tools VS Code extension](https://marketplace.visualstudio.com/items?itemName=expo.vscode-expo-tools) to get descriptions and autocompletions for your workflow files.

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -118,9 +118,9 @@ on:
 
 You can also trigger workflows from App Store Connect events using [`on.app_store_connect`](/eas/workflows/syntax/#onapp_store_connect).
 
-Before using App Store Connect triggers, configure your App Store Connect connection in your Expo project dashboard:
+Before using App Store Connect triggers, configure your App Store Connect connection in EAS dashboard:
 
-- Open Expo dashboard and select your project.
+- Open EAS dashboard and select your project.
 - Navigate to **Project settings > General > Connections**.
 - Connect your App Store Connect app.
 

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -68,7 +68,7 @@ Run on-demand using `eas workflow:run` command. Supports parameterized inputs fo
 
 Run when selected App Store Connect events occur (for example app version state changes, build upload states, external beta states, or beta feedback events).
 
-To use App Store Connect triggers, configure an App Store Connect connection in your Expo project dashboard: **Project settings > General > Connections**.
+To use App Store Connect triggers, configure an App Store Connect connection in the EAS dashboard: **Project settings > General > Connections**.
 
 See [`on.app_store_connect` syntax reference](/eas/workflows/syntax/#onapp_store_connect) for configuration details and supported values.
 

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -68,7 +68,7 @@ Run on-demand using `eas workflow:run` command. Supports parameterized inputs fo
 
 Run when selected App Store Connect events occur (for example app version state changes, build upload states, external beta states, or beta feedback events).
 
-To use App Store Connect triggers, configure an App Store Connect connection in the EAS dashboard: **Project settings > General > Connections**.
+To use App Store Connect triggers, configure an App Store Connect connection in the EAS dashboard: **[Project settings > General > Connections](https://expo.dev/accounts/[account]/projects/[project]/settings)**.
 
 See [`on.app_store_connect` syntax reference](/eas/workflows/syntax/#onapp_store_connect) for configuration details and supported values.
 

--- a/docs/pages/eas/workflows/introduction.mdx
+++ b/docs/pages/eas/workflows/introduction.mdx
@@ -64,6 +64,14 @@ Run on a cron schedule (for example, nightly builds or weekly regression tests).
 
 Run on-demand using `eas workflow:run` command. Supports parameterized inputs for flexible execution.
 
+### App Store Connect workflows
+
+Run when selected App Store Connect events occur (for example app version state changes, build upload states, external beta states, or beta feedback events).
+
+To use App Store Connect triggers, configure an App Store Connect connection in your Expo project dashboard: **Project settings > General > Connections**.
+
+See [`on.app_store_connect` syntax reference](/eas/workflows/syntax/#onapp_store_connect) for configuration details and supported values.
+
 ## When to use EAS Workflows
 
 | Scenario                                                                           | Recommendation |

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -173,10 +173,9 @@ on:
 
 Runs your workflow when one of the selected App Store Connect events occurs.
 
-> **important** To use this trigger, configure your App Store Connect connection in your Expo project dashboard: **Project settings > General > Connections**.
+> **info** To use this trigger, configure your App Store Connect connection in the EAS dashboard. For setup steps, see the [App Store Connect trigger setup](/eas/workflows/get-started/#trigger-workflows-from-app-store-connect-events) section.
 
-When `on.app_store_connect` is present, you must specify at least one event domain (`app_version`, `build_upload`, `external_beta`, or `beta_feedback`).
-Within a configured event domain, you can specify which states should trigger your workflow.
+When `on.app_store_connect` is present, you must specify at least one event domain (`app_version`, `build_upload`, `external_beta`, or `beta_feedback`). Within a configured event domain, you can specify which states should trigger your workflow.
 
 #### `on.app_store_connect.app_version.states`
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -173,7 +173,7 @@ on:
 
 Runs your workflow when one of the selected App Store Connect events occurs.
 
-> **info** To use this trigger, configure your App Store Connect connection in the EAS dashboard. For setup steps, see the [App Store Connect trigger setup](/eas/workflows/get-started/#trigger-workflows-from-app-store-connect-events) section.
+> **info** To use this trigger, configure your App Store Connect connection in the [EAS dashboard](https://expo.dev/accounts/[account]/projects/[project]/settings). For setup steps, see the [App Store Connect trigger setup](/eas/workflows/get-started/#trigger-workflows-from-app-store-connect-events) section.
 
 When `on.app_store_connect` is present, you must specify at least one event domain (`app_version`, `build_upload`, `external_beta`, or `beta_feedback`). Within a configured event domain, you can specify which states should trigger your workflow.
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -169,6 +169,105 @@ on:
     # other labels
 ```
 
+### `on.app_store_connect`
+
+Runs your workflow when one of the selected App Store Connect events occurs.
+
+> **important** To use this trigger, configure your App Store Connect connection in your Expo project dashboard: **Project settings > General > Connections**.
+
+When `on.app_store_connect` is present, you must specify at least one event domain (`app_version`, `build_upload`, `external_beta`, or `beta_feedback`).
+Within a configured event domain, you can specify which states should trigger your workflow.
+
+#### `on.app_store_connect.app_version.states`
+
+Filters app store app version state change events. Defaults to all supported app version states when not provided.
+
+Supported values:
+
+- `accepted`
+- `developer_rejected`
+- `in_review`
+- `invalid_binary`
+- `metadata_rejected`
+- `pending_apple_release`
+- `pending_developer_release`
+- `prepare_for_submission`
+- `processing_for_distribution`
+- `ready_for_distribution`
+- `ready_for_review`
+- `rejected`
+- `replaced_with_new_version`
+- `waiting_for_export_compliance`
+- `waiting_for_review`
+
+#### `on.app_store_connect.build_upload.states`
+
+Filters build upload events by state. Defaults to all supported build upload states when not provided.
+
+Supported values:
+
+- `complete`
+- `failed`
+- `processing`
+- `awaiting_upload`
+
+#### `on.app_store_connect.external_beta.states`
+
+Filters external beta events by state. Defaults to all supported external beta states when not provided.
+
+Supported values:
+
+- `processing`
+- `processing_exception`
+- `missing_export_compliance`
+- `ready_for_beta_testing`
+- `in_beta_testing`
+- `expired`
+- `ready_for_beta_submission`
+- `in_export_compliance_review`
+- `waiting_for_beta_review`
+- `in_beta_review`
+- `beta_rejected`
+- `beta_approved`
+
+#### `on.app_store_connect.beta_feedback.types`
+
+Filters beta feedback reported by testers by its type. Defaults to all supported beta feedback types when not provided.
+
+Supported values:
+
+- `crash`
+- `screenshot`
+
+All filter values must be lowercase and are case-sensitive.
+
+```yaml
+on:
+  app_store_connect:
+    app_version:
+      states:
+        - ready_for_review
+        - waiting_for_review
+    build_upload:
+      states:
+        - complete
+        - failed
+    external_beta:
+      states:
+        - ready_for_beta_testing
+        - beta_approved
+    beta_feedback:
+      types:
+        - crash
+```
+
+```yaml
+on:
+  app_store_connect:
+    app_version: {}
+    build_upload: {}
+```
+
 ### `on.schedule.cron`
 
 Runs your workflow on a schedule using [unix-cron](https://www.ibm.com/docs/en/db2/11.5?topic=task-unix-cron-format) syntax. You can use [crontab guru](https://crontab.guru/) and their [examples](https://crontab.guru/examples.html) to generate cron strings.

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -241,6 +241,11 @@ Supported values:
 All filter values must be lowercase and are case-sensitive.
 
 ```yaml
+# Triggers when:
+# - the app version enters review,
+# - a build upload completes or fails,
+# - an external beta build is ready for testing or approved,
+# - a tester reports a crash via TestFlight.
 on:
   app_store_connect:
     app_version:
@@ -261,6 +266,7 @@ on:
 ```
 
 ```yaml
+# Triggers on any app version or build upload state change.
 on:
   app_store_connect:
     app_version: {}


### PR DESCRIPTION
# Why

We're adding support for `on.app_store_connect` triggers to EAS workflows.

# How

Updated the docs for EAS workflows ("Introducion", "Get Started", "Syntax") with informations about the new features.

# Test Plan

Tested manually

<img width="1205" height="237" alt="image" src="https://github.com/user-attachments/assets/e12515c9-95ff-4e48-b07a-6b13bc8f6493" />

<img width="1202" height="748" alt="image" src="https://github.com/user-attachments/assets/cbfc0adf-f900-4c18-9545-bf76d0551529" />

<img width="1222" height="904" alt="image" src="https://github.com/user-attachments/assets/85d1a957-034d-493c-bc19-36a22149b03c" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
