### PR TITLE
[docs] Fix Algolia 404s with broken links and missing redirects

### DIFF
--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -606,4 +606,10 @@ const RENAMED_PAGES: Record<string, string> = {
     '/versions/latest/sdk/ui/jetpack-compose/progress/',
   '/versions/latest/sdk/ui/jetpack-compose/circularprogress/':
     '/versions/latest/sdk/ui/jetpack-compose/progress/',
+
+  // Based on Algolia 404 report 2026-04-01
+  '/versions/latest/sdk/secure-store/': '/versions/latest/sdk/securestore/',
+  '/versions/latest/sdk/av/': '/versions/latest/sdk/audio/',
+  '/versions/latest/sdk/ui/jetpack-compose/floatingactionbutton/':
+    '/versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton/',
 };

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -70,7 +70,7 @@ At this time, TV applications work with the following libraries and APIs listed 
 - [Audio](/versions/latest/sdk/audio)
 - [Asset](/versions/latest/sdk/asset/)
 - [AsyncStorage](/versions/latest/sdk/async-storage/)
-- [AV](/versions/latest/sdk/av/)
+- [AV](/versions/v54.0.0/sdk/av/)
 - [BackgroundTask](/versions/latest/sdk/background-task/)
 - [BlurView](/versions/latest/sdk/blur-view/)
 - [BuildProperties](/versions/latest/sdk/build-properties/)

--- a/docs/pages/guides/using-clerk.mdx
+++ b/docs/pages/guides/using-clerk.mdx
@@ -16,7 +16,7 @@ Clerk provides hooks, UI, and control components so you can build completely cus
 ## Features
 
 - **Authentication flows:** Sign-up and sign-in with email verification code, magic links, passwords, social providers (20+), passkeys, phone number verification, SAML, OpenID Connect, Web3 (MetaMask), and authenticator apps for multi-factor authentication.
-- **Session management:** Secure token handling with [`expo-secure-store`](/versions/latest/sdk/secure-store/).
+- **Session management:** Secure token handling with [`expo-secure-store`](/versions/latest/sdk/securestore/).
 - **User management:** Profile data, account settings, and organization membership for multi-tenant apps.
 
 ## Get started

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -356,3 +356,8 @@
 /versions/latest/sdk/ui/jetpack-compose/picker /versions/latest/sdk/ui/jetpack-compose/segmentedbutton 301
 /versions/unversioned/sdk/ui/jetpack-compose/picker /versions/unversioned/sdk/ui/jetpack-compose/segmentedbutton 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/picker /versions/v55.0.0/sdk/ui/jetpack-compose/segmentedbutton 301
+
+# Based on Algolia 404 report 2026-04-01
+/versions/latest/sdk/secure-store /versions/latest/sdk/securestore 301
+/versions/latest/sdk/av /versions/latest/sdk/audio 301
+/versions/latest/sdk/ui/jetpack-compose/floatingactionbutton /versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton 301


### PR DESCRIPTION
# Why

Fix ENG-20421

# How

**Fixed broken links in guide pages:**
- Fixed `/versions/latest/sdk/secure-store/` to `/versions/latest/sdk/securestore/` in `using-clerk.mdx` (file is `securestore.mdx`, no hyphen)
- Fixed `/versions/latest/sdk/av/` to `/versions/v54.0.0/sdk/av/` in `building-for-tv.mdx` (AV page was removed in v55, v54 is the last version with it. Audio already listed separately)

**Added server-side redirects in `_redirects`:**
- `/versions/latest/sdk/secure-store` -> `/versions/latest/sdk/securestore`
- `/versions/latest/sdk/av` -> `/versions/latest/sdk/audio`
- `/versions/latest/sdk/ui/jetpack-compose/floatingactionbutton` -> `/versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton` (page exists in unversioned only, not yet in v55)

**Added matching client-side redirects in `client-redirects.ts`** for the same three paths.

# Test Plan

Verify the following URLs redirect correctly after deploy:
- `/versions/latest/sdk/secure-store` should redirect to `/versions/latest/sdk/securestore/`
- `/versions/latest/sdk/av` should redirect to `/versions/latest/sdk/audio/`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
