### PR TITLE
[android][go] Use SDK version to check update compatibility

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/UpdateRow.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/home/UpdateRow.kt
@@ -43,10 +43,10 @@ private fun openUpdateManifestPermalink(
 private fun UpdateRowContents(
   message: String?,
   createdAt: String?,
-  runtimeVersion: String?,
+  sdkVersion: String?,
   omitCompatibility: Boolean
 ) {
-  val isCompatible = isUpdateCompatible(runtimeVersion)
+  val isCompatible = isUpdateCompatible(sdkVersion)
 
   Text(
     text = message ?: "No message",
@@ -73,7 +73,7 @@ fun UpdateRow(
   omitCompatibility: Boolean = false
 ) {
   val uriHandler = LocalUriHandler.current
-  val isCompatible = isUpdateCompatible(update.updateData.runtimeVersion)
+  val isCompatible = isUpdateCompatible(update.updateData.expoGoSDKVersion)
 
   val modifier = if (isCompatible) {
     Modifier.clickable {
@@ -89,7 +89,7 @@ fun UpdateRow(
     UpdateRowContents(
       message = update.updateData.message,
       createdAt = update.updateData.createdAt as? String,
-      runtimeVersion = update.updateData.runtimeVersion,
+      sdkVersion = update.updateData.expoGoSDKVersion,
       omitCompatibility = omitCompatibility
     )
   }
@@ -101,7 +101,7 @@ fun UpdateRow(
   omitCompatibility: Boolean = false
 ) {
   val uriHandler = LocalUriHandler.current
-  val isCompatible = isUpdateCompatible(update.updateData.runtimeVersion)
+  val isCompatible = isUpdateCompatible(update.updateData.expoGoSDKVersion)
 
   val modifier = if (isCompatible) {
     Modifier.clickable {
@@ -117,7 +117,7 @@ fun UpdateRow(
     UpdateRowContents(
       message = update.updateData.message,
       createdAt = update.updateData.createdAt as? String,
-      runtimeVersion = update.updateData.runtimeVersion,
+      sdkVersion = update.updateData.expoGoSDKVersion,
       omitCompatibility = omitCompatibility
     )
   }

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix update compatibility check to use `expoGoSDKVersion` instead of `runtimeVersion` in Expo Go update list. ([#44429](https://github.com/expo/expo/pull/44429) by [@fschindler](https://github.com/fschindler))
 - Pass absolute path to CLI helpers when creating build manifest, since the underlying functions now handle entry file inputs properly, instead of applying `mainModuleName` semantics to them ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
 - [ios] Fix loading assets in brownfield ([#44724](https://github.com/expo/expo/pull/44724) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 


### PR DESCRIPTION
# Why

For Android the Expo Go home screen was using `runtimeVersion` to check whether an update is compatible with the current Expo Go client. However, `runtimeVersion` is a generic concept in Expo Updates and does not necessarily reflect the SDK version that Expo Go uses to determine compatibility. Using `expoGoSDKVersion` more accurately represents whether a given update can actually run in this version of Expo Go, since the compatibility check (isUpdateCompatible) compares major SDK versions against ExponentBuildConstants.TEMPORARY_SDK_VERSION.

# How

Replaced all usages of `update.updateData.runtimeVersion` with `update.updateData.expoGoSDKVersion` in `UpdateRow.kt`. The change affects both UpdateRow composable overloads and the UpdateRowContents helper, which now receives `sdkVersion` instead of `runtimeVersion` as a parameter name. The underlying `isUpdateCompatible` logic is unchanged — it still compares the major version component of the provided string against the build-constant SDK version.

# Test Plan

1. Build and run the Expo Go app on Android.
2. Open the home screen and navigate to a project's branch/update list.
3. Verify that updates whose `expoGoSDKVersion` matches the current Expo Go SDK major version are shown as compatible (tappable), and updates with a mismatched or missing `expoGoSDKVersion` are shown as incompatible (non-tappable / greyed out).
4. Confirm the behavior is correct for both a branch with updates on the current SDK and one with updates on a different SDK version.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
