### PR TITLE
[ios][precompile] Fix computing output path for 3rd party deps

### DIFF
--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -239,6 +239,29 @@ export const Frameworks = {
   hasSharedSPMDepFramework: (productName: string, buildType: BuildFlavor): boolean => {
     return fs.existsSync(Frameworks.getSharedSPMDepFrameworkPath(productName, buildType));
   },
+
+  /**
+   * Computes the output version prefix for a dependency package, given the building
+   * package's version prefix and the dependency's package version.
+   *
+   * Version prefixes have the format: <packageVersion>/<reactNativeVersion>/<hermesVersion>
+   * The RN and Hermes version parts are shared across all external packages in a build,
+   * so we extract them from the building package's prefix and combine with the dep's version.
+   *
+   * @param buildingPkgVersionPrefix The building package's outputVersionPrefix (e.g. "4.2.2/0.85.0/1.0.0")
+   * @param depPackageVersion The dependency package's version (e.g. "0.16.0")
+   * @returns The computed version prefix for the dependency (e.g. "0.16.0/0.85.0/1.0.0")
+   */
+  computeVersionPrefixForDependency: (
+    buildingPkgVersionPrefix: string,
+    depPackageVersion: string
+  ): string => {
+    // Split prefix into parts: [packageVersion, rnVersion, hermesVersion]
+    const parts = buildingPkgVersionPrefix.split(path.sep);
+    // Replace the first part (building package's version) with the dep's version
+    // Keep the RN and Hermes version parts (index 1 and beyond)
+    return path.join(depPackageVersion, ...parts.slice(1));
+  },
 };
 
 /**

--- a/tools/src/prebuilds/PathBuilders.test.ts
+++ b/tools/src/prebuilds/PathBuilders.test.ts
@@ -405,3 +405,50 @@ describe('Shared SPM dependency path functions', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// computeVersionPrefixForDependency
+// ---------------------------------------------------------------------------
+
+describe('computeVersionPrefixForDependency', () => {
+  it('replaces the building package version with dependency version', () => {
+    const buildingPrefix = path.join('4.2.2', '0.85.0', '1.0.0');
+    const result = Frameworks.computeVersionPrefixForDependency(buildingPrefix, '0.16.0');
+    assert.equal(result, path.join('0.16.0', '0.85.0', '1.0.0'));
+  });
+
+  it('preserves RN and Hermes versions from building package', () => {
+    const buildingPrefix = path.join('1.0.0', '0.83.0', '2.0.0');
+    const result = Frameworks.computeVersionPrefixForDependency(buildingPrefix, '3.5.1');
+    assert.equal(result, path.join('3.5.1', '0.83.0', '2.0.0'));
+  });
+
+  it('produces correct xcframework path when combined with getFrameworkPath', () => {
+    const buildingPrefix = path.join('4.2.2', '0.85.0-rc.5', '0.16.0');
+    const depVersion = '0.16.0';
+    const depBuildPath = '/repo/packages/precompile/.build/react-native-worklets';
+    const depVersionPrefix = Frameworks.computeVersionPrefixForDependency(
+      buildingPrefix,
+      depVersion
+    );
+    const result = Frameworks.getFrameworkPath(
+      depBuildPath,
+      'RNWorklets',
+      'Debug',
+      depVersionPrefix
+    );
+    assert.equal(
+      result,
+      path.join(
+        depBuildPath,
+        'output',
+        '0.16.0',
+        '0.85.0-rc.5',
+        '0.16.0',
+        'debug',
+        'xcframeworks',
+        'RNWorklets.xcframework'
+      )
+    );
+  });
+});

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -1267,11 +1267,22 @@ async function buildPackageSwiftContext(
     // This handles dependencies between external packages in node_modules
     const externalPkg = getExternalPackageByProductName(depName);
     if (externalPkg) {
+      // Compute the dependency's version prefix from the building package's prefix.
+      // The building package (pkg) has outputVersionPrefix set (e.g. "4.2.2/0.85.0-rc.5/0.16.0"),
+      // but the fresh ExternalPackage from getExternalPackageByProductName doesn't.
+      // We reuse the RN/Hermes version parts and substitute the dep's own package version.
+      const depVersionPrefix = pkg.outputVersionPrefix
+        ? Frameworks.computeVersionPrefixForDependency(
+            pkg.outputVersionPrefix,
+            externalPkg.packageVersion
+          )
+        : undefined;
+
       const xcframeworkPath = Frameworks.getFrameworkPath(
         externalPkg.buildPath,
         depName,
         buildType,
-        externalPkg.outputVersionPrefix
+        depVersionPrefix
       );
 
       if (await fs.pathExists(xcframeworkPath)) {
@@ -1289,7 +1300,7 @@ async function buildPackageSwiftContext(
         xcframeworkPaths.set(depName, {
           buildPath: externalPkg.buildPath,
           productName: depName,
-          versionPrefix: externalPkg.outputVersionPrefix,
+          versionPrefix: depVersionPrefix,
         });
         continue;
       } else {

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -19,7 +19,7 @@ import { getPackageByName } from '../../Packages';
 import { Artifacts } from '../Artifacts';
 import { Dependencies } from '../Dependencies';
 import type { SPMPackageSource } from '../ExternalPackage';
-import { isExternalPackage } from '../ExternalPackage';
+import { getExternalPackageByProductName, isExternalPackage } from '../ExternalPackage';
 import { Frameworks } from '../Frameworks';
 import type { BuildFlavor } from '../Prebuilder.types';
 import { buildSharedSPMDependencyAsync } from '../SPMBuild';
@@ -204,6 +204,59 @@ export function sortPackagesByDependencies(packages: SPMPackageSource[]): Topolo
 }
 
 // ---------------------------------------------------------------------------
+// Helper: frameworkExistsAtAnyVersion
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks if an xcframework exists at either a non-versioned or versioned output path.
+ * Versioned paths have the format: output/<packageVersion>/<rnVersion>/<hermesVersion>/<flavor>/xcframeworks/
+ * Non-versioned paths have the format: output/<flavor>/xcframeworks/
+ */
+function frameworkExistsAtAnyVersion(
+  buildPath: string,
+  productName: string,
+  buildType: BuildFlavor
+): boolean {
+  // Check non-versioned path first (quick check)
+  if (fs.existsSync(Frameworks.getFrameworkPath(buildPath, productName, buildType))) {
+    return true;
+  }
+
+  // Check versioned paths by scanning the output directory
+  const outputDir = path.join(buildPath, 'output');
+  if (!fs.existsSync(outputDir)) {
+    return false;
+  }
+
+  const flavor = buildType.toLowerCase();
+  const xcframeworkName = `${productName}.xcframework`;
+
+  // Scan top-level entries in output/ — version directories are non-flavor names
+  try {
+    for (const entry of fs.readdirSync(outputDir)) {
+      if (entry === 'debug' || entry === 'release') continue;
+      // Walk a known depth: <ver>/<rnVer>/<hermesVer>/<flavor>/xcframeworks/
+      const verDir = path.join(outputDir, entry);
+      if (!fs.statSync(verDir).isDirectory()) continue;
+      for (const rnVer of fs.readdirSync(verDir)) {
+        const rnDir = path.join(verDir, rnVer);
+        if (!fs.statSync(rnDir).isDirectory()) continue;
+        for (const hermesVer of fs.readdirSync(rnDir)) {
+          const candidate = path.join(rnDir, hermesVer, flavor, 'xcframeworks', xcframeworkName);
+          if (fs.existsSync(candidate)) {
+            return true;
+          }
+        }
+      }
+    }
+  } catch {
+    // If we can't read the directory, assume not found
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // Helper: expandWithUnbuiltDependencies
 // ---------------------------------------------------------------------------
 
@@ -235,25 +288,36 @@ export function expandWithUnbuiltDependencies(packages: SPMPackageSource[]): SPM
         if (!product.externalDependencies) continue;
 
         for (const dep of product.externalDependencies) {
-          if (!dep.includes('/')) continue;
+          let depPackageName: string;
+          let depProductName: string;
 
-          // Parse package name and product name (handle scoped: @expo/ui/ExpoUI)
-          const parts = dep.split('/');
-          const isScoped = parts[0].startsWith('@');
-          const depPackageName = isScoped ? `${parts[0]}/${parts[1]}` : parts[0];
-          const depProductName = isScoped ? parts[2] : parts[1];
+          if (dep.includes('/')) {
+            // Parse package name and product name (handle scoped: @expo/ui/ExpoUI)
+            const parts = dep.split('/');
+            const isScoped = parts[0].startsWith('@');
+            depPackageName = isScoped ? `${parts[0]}/${parts[1]}` : parts[0];
+            depProductName = isScoped ? parts[2] : parts[1];
+          } else {
+            // Bare product name (e.g., "RNWorklets")
+            // Resolve to package via external package configs
+            const externalPkg = getExternalPackageByProductName(dep);
+            if (!externalPkg) continue;
+            depPackageName = externalPkg.packageName;
+            depProductName = dep;
+          }
 
           // Skip cache deps and deps already in the build set
           if (CACHE_DEPS.has(depPackageName)) continue;
           if (packagesByName.has(depPackageName) || added.has(depPackageName)) continue;
 
           // Check if the xcframework already exists (for both debug and release)
+          // Check both non-versioned and versioned paths (versioned: output/<ver>/<rn>/<hermes>/<flavor>/xcframeworks/)
           const depBuildPath = path.join(getPrecompileDir(), '.build', depPackageName);
-          const debugExists = fs.existsSync(
-            Frameworks.getFrameworkPath(depBuildPath, depProductName, 'Debug')
-          );
-          const releaseExists = fs.existsSync(
-            Frameworks.getFrameworkPath(depBuildPath, depProductName, 'Release')
+          const debugExists = frameworkExistsAtAnyVersion(depBuildPath, depProductName, 'Debug');
+          const releaseExists = frameworkExistsAtAnyVersion(
+            depBuildPath,
+            depProductName,
+            'Release'
           );
 
           if (debugExists && releaseExists) continue;


### PR DESCRIPTION
# Why

When building react-native-reanimated we have a dependency on react-native-worklets. To link woth the RNWorklets xcframework we need to compute its path with the version pattern. This was failing after we added support for version folders.

# How

This PR fixes this by adding a compute function for getting the output path based on versions.

# Test Plan

Verify that building react-native-reanimated works:

`et prebuild react-native-reanimated`
