### PR TITLE
[android][image] Switch to RNs OKHttpClient

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### 💡 Others
 
 - [iOS] Use `internal import SDWebImage` to hide third-party dependency from public module interface. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
+- [android] Use react natives `OKHttpClient`.
 
 ## 55.0.5 — 2026-02-25
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -18,7 +18,7 @@
 ### 💡 Others
 
 - [iOS] Use `internal import SDWebImage` to hide third-party dependency from public module interface. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
-- [android] Use react natives `OKHttpClient`.
+- [android] Use react natives `OKHttpClient`. ([#44431](https://github.com/expo/expo/pull/44431) by [@alanjhughes](https://github.com/alanjhughes))
 
 ## 55.0.5 — 2026-02-25
 

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -1,7 +1,6 @@
 package expo.modules.image.okhttp
 
 import android.content.Context
-import android.webkit.CookieManager
 import com.bumptech.glide.Glide
 import com.bumptech.glide.Registry
 import com.bumptech.glide.annotation.GlideModule
@@ -9,11 +8,8 @@ import com.bumptech.glide.integration.okhttp3.OkHttpUrlLoader
 import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.model.Headers
 import com.bumptech.glide.module.LibraryGlideModule
+import com.facebook.react.modules.network.OkHttpClientProvider
 import expo.modules.image.events.OkHttpProgressListener
-import okhttp3.Cookie
-import okhttp3.CookieJar
-import okhttp3.HttpUrl
-import okhttp3.OkHttpClient
 import java.io.InputStream
 
 /**
@@ -72,36 +68,12 @@ data class GlideUrlWrapper(val glideUrl: GlideUrl) {
   }
 }
 
-private object SharedCookieJar : CookieJar {
-  override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {
-    val cookieManager = getCookieManager() ?: return
-    val urlString = url.toString()
-    for (cookie in cookies) {
-      cookieManager.setCookie(urlString, cookie.toString())
-    }
-    cookieManager.flush()
-  }
-
-  override fun loadForRequest(url: HttpUrl): List<Cookie> {
-    val cookieManager = getCookieManager() ?: return emptyList()
-    val cookieString = cookieManager.getCookie(url.toString()) ?: return emptyList()
-    return cookieString.split(";").mapNotNull { Cookie.parse(url, it.trim()) }
-  }
-
-  private fun getCookieManager(): CookieManager? = runCatching {
-    CookieManager.getInstance()
-  }.getOrNull()
-}
-
 @GlideModule
 class ExpoImageOkHttpClientGlideModule : LibraryGlideModule() {
   override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
-    val client = OkHttpClient.Builder()
-      .cookieJar(SharedCookieJar)
-      .build()
+    val client = OkHttpClientProvider.createClient()
     // We don't use the `GlideUrl` directly but we want to replace the default okhttp loader anyway
-    // to make sure that the app will use only one client.
-    registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))
+    // to make sure that the app will use only one client.    registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))
     registry.prepend(GlideUrlWrapper::class.java, InputStream::class.java, GlideUrlWrapperLoader.Factory(client))
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -73,7 +73,8 @@ class ExpoImageOkHttpClientGlideModule : LibraryGlideModule() {
   override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
     val client = OkHttpClientProvider.createClient()
     // We don't use the `GlideUrl` directly but we want to replace the default okhttp loader anyway
-    // to make sure that the app will use only one client.    registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))
+    // to make sure that the app will use only one client.    
+    registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))
     registry.prepend(GlideUrlWrapper::class.java, InputStream::class.java, GlideUrlWrapperLoader.Factory(client))
   }
 }

--- a/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/okhttp/ExpoImageOkHttpClientGlideModule.kt
@@ -73,7 +73,7 @@ class ExpoImageOkHttpClientGlideModule : LibraryGlideModule() {
   override fun registerComponents(context: Context, glide: Glide, registry: Registry) {
     val client = OkHttpClientProvider.createClient()
     // We don't use the `GlideUrl` directly but we want to replace the default okhttp loader anyway
-    // to make sure that the app will use only one client.    
+    // to make sure that the app will use only one client.
     registry.replace(GlideUrl::class.java, InputStream::class.java, OkHttpUrlLoader.Factory(client))
     registry.prepend(GlideUrlWrapper::class.java, InputStream::class.java, GlideUrlWrapperLoader.Factory(client))
   }


### PR DESCRIPTION
# Why
Switching to RNs client allows us to share things like cookies etc. Similar change to #44416

# How
Instead of creating a new client use RNs `OkHttpClientProvider.createClient()`

# Test Plan
Bare expo. Everything seems to work the same as always
