### PR TITLE
[iOS][JSI] Add `withUnsafePointee` functions to access the underlying C++ pointers

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -59,11 +59,20 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   }
 
   /**
-   Raw pointer to the underlying JSI runtime. DO NOT USE IT!
+   Creates a runtime from a raw pointer to the underlying `facebook.jsi.Runtime`.
    */
-  @_spi(Unsafe)
-  public var unsafe_pointee: UnsafeMutableRawPointer {
-    return Unmanaged<facebook.jsi.Runtime>.passUnretained(pointee).toOpaque()
+  public init(unsafePointer: UnsafeMutableRawPointer) {
+    let runtime = unsafeBitCast(unsafePointer, to: facebook.jsi.Runtime.self)
+    self.pointee = runtime
+    self.scheduler = expo.RuntimeScheduler(runtime)
+  }
+
+  /**
+   Provides scoped access to a raw pointer to the underlying `facebook.jsi.Runtime`.
+   The pointer is valid only for the duration of the closure and must not be stored or escaped.
+   */
+  public func withUnsafePointee<R>(_ body: (UnsafeMutableRawPointer) throws -> R) rethrows -> R {
+    return try body(Unmanaged<facebook.jsi.Runtime>.passUnretained(pointee).toOpaque())
   }
 
   /**

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -89,6 +89,20 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     }
   }
 
+  /**
+   Provides scoped access to a raw pointer to the underlying `facebook.jsi.Value`.
+   The pointer is valid only for the duration of the closure and must not be stored or escaped.
+   */
+  public func withUnsafePointee<R>(_ body: (UnsafeRawPointer) throws -> R) rethrows -> R {
+    // Using `withUnsafePointer(to:)` crashes the SIL optimizer in release builds
+    // due to a Swift compiler bug with C++ interop value types.
+    return try withUnsafeBytes(of: pointee) { bytes in
+      // Force-unwrap is safe — baseAddress is only nil for zero-length buffers,
+      // which can't happen since facebook.jsi.Value has a non-zero size.
+      return try body(bytes.baseAddress!)
+    }
+  }
+
   // MARK: - Type checks
 
   public func isUndefined() -> Bool {

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -349,4 +349,37 @@ struct JavaScriptRuntimeTests {
     let klass = try runtime.createClass(name: "$_Foo123") { this, _ in this }
     #expect(klass.asObject().getProperty("name").getString() == "$_Foo123")
   }
+
+  // MARK: - Unsafe pointee access
+
+  @Test
+  func `withUnsafePointee returns non-null pointee`() {
+    runtime.withUnsafePointee { runtimePointee in
+      #expect(runtimePointee != UnsafeMutableRawPointer(bitPattern: 0))
+    }
+  }
+
+  @Test
+  func `withUnsafePointee returns value from closure`() {
+    let result = runtime.withUnsafePointee { _ in
+      return 42
+    }
+    #expect(result == 42)
+  }
+
+  @Test
+  func `withUnsafePointee returns same pointee across calls`() {
+    let pointee1 = runtime.withUnsafePointee { return $0 }
+    let pointee2 = runtime.withUnsafePointee { return $0 }
+    #expect(pointee1 == pointee2)
+  }
+
+  @Test
+  func `init from unsafePointer creates functional runtime`() throws {
+    let newRuntime = runtime.withUnsafePointee { runtimePointee in
+      return JavaScriptRuntime(unsafePointer: runtimePointee)
+    }
+    let result = try newRuntime.eval("1 + 2")
+    #expect(result.getInt() == 3)
+  }
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
@@ -470,4 +470,31 @@ struct JavaScriptValueTests {
       _ = try numberValue.asPromise()
     }
   }
+
+  // MARK: - Unsafe pointee access
+
+  @Test
+  func `withUnsafePointee returns non-null pointee`() {
+    let value = JavaScriptValue(runtime, 42)
+    value.withUnsafePointee { valuePointee in
+      #expect(valuePointee != UnsafeRawPointer(bitPattern: 0))
+    }
+  }
+
+  @Test
+  func `withUnsafePointee returns value from closure`() {
+    let value = JavaScriptValue(runtime, 42)
+    let result = value.withUnsafePointee { _ in
+      return "hello"
+    }
+    #expect(result == "hello")
+  }
+
+  @Test
+  func `withUnsafePointee returns same pointee across calls`() {
+    let value = JavaScriptValue(runtime, 42)
+    let pointee1 = value.withUnsafePointee { return $0 }
+    let pointee2 = value.withUnsafePointee { return $0 }
+    #expect(pointee1 == pointee2)
+  }
 }


### PR DESCRIPTION
# Why

For the integration with worklets, I need a way to get raw pointers to `jsi::Runtime` and `jsi::Value` to extract serializables and create worklet's runtime.
We had `unsafe_pointee` property, hidden behind "Unsafe" SPI, but I think we should expose it publicly. Otherwise it's going to be hard to interop with Objective-C 😞 

# How

Introduced `withUnsafePointee` on `JavaScriptRuntime` and `JavaScriptValue`. If that API works well, we could do a similar thing in other JS types too.

# Test Plan

Building `expo-modules-jsi` into xcframework succeeds and unit tests are passing (only locally, both are not run on the CI yet)