### PR TITLE
[auto-linking] Fix uuid collision and stale pods cache for precompiled

### DIFF
--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -33,6 +33,23 @@ module Pod
       # Call original implementation first
       _original_perform_post_install_actions.bind(self).()
 
+      # CocoaPods overrides generate_available_uuid_list to use a sequential counter
+      # starting from @generated_uuids.size (see Pod::Project#generate_available_uuid_list).
+      # After predictabilize_uuids runs earlier in the install pipeline, @generated_uuids
+      # is reset to @available_uuids (a small array), which resets the counter to near zero.
+      # New UUIDs generated here can then collide with existing deterministic UUIDs 
+      # like the root object's, corrupting Pods.xcodeproj.
+      # we pad @generated_uuids so the sequential counter starts past all existing UUIDs.
+      existing_count = self.pods_project.objects_by_uuid.size
+      generated = self.pods_project.instance_variable_get(:@generated_uuids) || []
+      if generated.size < existing_count
+        padding = existing_count - generated.size
+        self.pods_project.instance_variable_set(
+          :@generated_uuids,
+          generated + Array.new(padding, '')
+        )
+      end
+
       # Run all precompiled module post-install configuration
       Expo::PrecompiledModules.perform_post_install(self)
     end

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -33,21 +33,19 @@ module Pod
       # Call original implementation first
       _original_perform_post_install_actions.bind(self).()
 
-      # CocoaPods overrides generate_available_uuid_list to use a sequential counter
-      # starting from @generated_uuids.size (see Pod::Project#generate_available_uuid_list).
-      # After predictabilize_uuids runs earlier in the install pipeline, @generated_uuids
-      # is reset to @available_uuids (a small array), which resets the counter to near zero.
-      # New UUIDs generated here can then collide with existing deterministic UUIDs 
-      # like the root object's, corrupting Pods.xcodeproj.
-      # we pad @generated_uuids so the sequential counter starts past all existing UUIDs.
-      existing_count = self.pods_project.objects_by_uuid.size
-      generated = self.pods_project.instance_variable_get(:@generated_uuids) || []
-      if generated.size < existing_count
-        padding = existing_count - generated.size
-        self.pods_project.instance_variable_set(
-          :@generated_uuids,
-          generated + Array.new(padding, '')
-        )
+      # CocoaPods overrides generate_available_uuid_list to use a fast sequential counter
+      # (Pod::Project#generate_available_uuid_list) that skips collision checks. After
+      # predictabilize_uuids reassigns all UUIDs to deterministic values, the counter resets
+      # and new sequential UUIDs can collide with existing ones, corrupting Pods.xcodeproj.
+      # Fix: replace the sequential generator with collision-safe random UUIDs for any
+      # objects created after predictabilize_uuids has run.
+      project = self.pods_project
+      existing_uuids = project.objects_by_uuid.keys.to_set
+      project.define_singleton_method(:generate_available_uuid_list) do |count = 100|
+        new_uuids = (0..count).map { SecureRandom.hex(12).upcase }
+        uniques = new_uuids.reject { |u| existing_uuids.include?(u) || @generated_uuids.include?(u) }
+        @generated_uuids += uniques
+        @available_uuids += uniques
       end
 
       # Run all precompiled module post-install configuration

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -158,19 +158,45 @@ module Expo
       # Cache management
       # ──────────────────────────────────────────────────────────────────────
 
-      # Clears the CocoaPods external download cache for precompiled pods.
-      # Prevents stale cache entries (from previous failed installs) from persisting.
+      # Clears CocoaPods caches for precompiled pods to ensure specs are re-fetched
+      # and patched on every `pod install`. Without this, incremental installs reuse
+      # stale unpatched specs from `Pods/Local Podspecs/` and the external download
+      # cache, causing precompiled pods to fall back to source builds.
       def clear_cocoapods_cache
         return unless enabled?
 
         cache_root = File.join(Dir.home, 'Library', 'Caches', 'CocoaPods', 'Pods', 'External')
-        return unless File.directory?(cache_root)
+        pods_root = Pod::Config.instance.sandbox_root rescue nil
+        local_podspecs_dir = pods_root ? File.join(pods_root, 'Local Podspecs') : nil
 
         pod_lookup_map.each_key do |pod_name|
           next unless has_prebuilt_xcframework?(pod_name)
 
-          cache_dir = File.join(cache_root, pod_name)
-          FileUtils.rm_rf(cache_dir) if File.directory?(cache_dir)
+          # Clear the external download cache
+          if cache_root && File.directory?(cache_root)
+            cache_dir = File.join(cache_root, pod_name)
+            FileUtils.rm_rf(cache_dir) if File.directory?(cache_dir)
+          end
+
+          # Clear cached podspecs so store_podspec is called again on the next install,
+          # allowing the spec to be patched for precompiled xcframework usage.
+          if local_podspecs_dir && File.directory?(local_podspecs_dir)
+            cached_spec = File.join(local_podspecs_dir, "#{pod_name}.podspec.json")
+            FileUtils.rm_f(cached_spec) if File.exist?(cached_spec)
+          end
+
+          # Clear the pod's installed directory so CocoaPods re-downloads from the
+          # patched spec's source tarball instead of reusing stale source-build artifacts.
+          if pods_root
+            pod_dir = File.join(pods_root, pod_name)
+            if File.directory?(pod_dir)
+              product_name = pod_lookup_map[pod_name]&.dig(:product_name) || pod_name
+              xcfw_info = File.join(pod_dir, "#{product_name}.xcframework", 'Info.plist')
+              unless File.exist?(xcfw_info)
+                FileUtils.rm_rf(pod_dir)
+              end
+            end
+          end
         end
       end
 


### PR DESCRIPTION
# Why
https://exponent-internal.slack.com/archives/C0ADA9SMS23/p1775084736771279

# How
CocoaPods' overrides `generate_available_uuid_list` with a sequential counter that intentionally skips collision checks. When `predictabilize_uuids` runs, it resets `@generated_uuids` to `@available_uuids`, causing the sequential counter to restart from a low offset. Any objects created after this point, like the build phases we add in `perform_post_install_actions` get UUIDs that can collide with existing ids.

The fix replaces the sequential generator with random UUIDs for any objects created after `predictabilize_uuids` has run. 

Also fixes stale podspec caching for precompiled modules on second pod install. CocoaPods skips `store_podspec` for already cached pods, so the `patch_spec_for_prebuilt hook` never runs. We should also clear the Local Podspecs and stale pod directories for precompiled pods during cache cleanup, this ensures specs are re-fetched and patched on every install.

# Test Plan
Tested in a repro project 

