### PR TITLE
docs(expo-router): document suspense fallbacks

### DIFF
--- a/docs/pages/router/error-handling.mdx
+++ b/docs/pages/router/error-handling.mdx
@@ -1,11 +1,11 @@
 ---
-title: Error handling
-description: Learn how to handle unmatched routes and errors in your app when using Expo Router.
+title: Error handling and loading states
+description: Learn how to handle unmatched routes, errors, and loading states in your app when using Expo Router.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-This guide specifies how to handle unmatched routes and errors in your app when using Expo Router.
+This guide specifies how to handle unmatched routes, errors, and loading states in your app when using Expo Router.
 
 ## Unmatched routes
 
@@ -81,3 +81,52 @@ When `ErrorBoundary` is not present, the error will be thrown to the nearest par
 ### Work in progress
 
 React Native LogBox needs to be presented less aggressively to develop with errors. Currently, it shows for `console.error` and `console.warn`. However, it should ideally only show for uncaught errors.
+
+## Loading states with Suspense fallback
+
+Expo Router wraps each route in a [React Suspense](https://react.dev/reference/react/Suspense) boundary. You can export a [`SuspenseFallback`](/versions/unversioned/sdk/router/#suspensefallback) component from a layout file to customize the loading UI shown while any child route is suspended:
+
+```tsx src/app/_layout.tsx
+import { ActivityIndicator, View } from 'react-native';
+import { Stack } from 'expo-router';
+
+export function SuspenseFallback() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}
+
+export default function RootLayout() {
+  return <Stack />;
+}
+```
+
+> When multiple parent layouts define a fallback, the nearest parent takes precedence.
+
+### Accessing route parameters
+
+The [`SuspenseFallback`](/versions/unversioned/sdk/router/#suspensefallback) component receives `route` and `params` props. You can use `params` to display context-specific loading states for dynamic routes, for example:
+
+```tsx src/app/(app)/_layout.tsx
+import { ActivityIndicator, Text, View } from 'react-native';
+import { Stack, type SuspenseFallbackProps } from 'expo-router';
+
+export function SuspenseFallback({ params }: SuspenseFallbackProps) {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Loading profile {params.id}...</Text>
+      <ActivityIndicator size="large" />
+    </View>
+  );
+}
+
+export default function AppLayout() {
+  return <Stack />;
+}
+```
+
+### Limitations
+
+- [Async routes](/router/web/async-routes) do not support custom Suspense fallbacks.

--- a/docs/pages/router/web/async-routes.mdx
+++ b/docs/pages/router/web/async-routes.mdx
@@ -93,6 +93,6 @@ All initial routes, defined with `unstable_settings = { initialRouteName: '...' 
 
 Async Routes represents an early preview of how we plan to support [React Server Components](https://react.dev/blog/2023/03/22/react-labs-what-we-have-been-working-on-march-2023#react-server-components) in the future. As such, there are some caveats to be aware of:
 
-- Async Routes do not support native production apps yet.
+- Async routes do not support native production apps yet.
 - In development, the runtime JavaScript is lazily bundled so you may encounter cases where the HTML doesn't match the available JavaScript.
-- The loading state cannot be customized at this time.
+- Custom [`SuspenseFallback`](/router/error-handling/#loading-states-with-suspense-fallback) exports do not work with async routes.


### PR DESCRIPTION
# Why

Documents the new Suspense fallbacks feature added in https://github.com/expo/expo/pull/43885

# How

Updated `async-routes.mdx` and `error-handling.mdx` with information on how to use layout-level Suspense fallbacks.

# Test Plan

None required

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
