### PR TITLE
Refactor permission checks for camera access

### DIFF
--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
@@ -280,25 +280,13 @@ class ImagePickerModule : Module() {
 
     permissions.askForPermissions(
       { permissionsResponse ->
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-          if (permissionsResponse[Manifest.permission.CAMERA]?.status == PermissionsStatus.GRANTED) {
-            continuation.resume(Unit)
-          } else {
-            continuation.resumeWithException(UserRejectedPermissionsException())
-          }
-        } else if (
-          permissionsResponse[Manifest.permission.WRITE_EXTERNAL_STORAGE]?.status == PermissionsStatus.GRANTED &&
-          permissionsResponse[Manifest.permission.CAMERA]?.status == PermissionsStatus.GRANTED
-        ) {
+         if (permissionsResponse[Manifest.permission.CAMERA]?.status == PermissionsStatus.GRANTED) {
           continuation.resume(Unit)
         } else {
           continuation.resumeWithException(UserRejectedPermissionsException())
         }
       },
-      *listOfNotNull(
-        Manifest.permission.WRITE_EXTERNAL_STORAGE.takeIf { Build.VERSION.SDK_INT < Build.VERSION_CODES.Q },
-        Manifest.permission.CAMERA
-      ).toTypedArray()
+     Manifest.permission.CAMERA
     )
   }
 


### PR DESCRIPTION
Title: Simplified permission handling for camera access by removing checks for WRITE_EXTERNAL_STORAGE on Android Q and above.

# Why

On Android, launchCameraAsync saves photos to the app's internal cache directory via FileProvider, which does not require WRITE_EXTERNAL_STORAGE. The previous implementation checked for both CAMERA and WRITE_EXTERNAL_STORAGE on Android < Q (API 29), but this was unnecessary because FileProvider uses content:// URIs with granted URI permissions — no broad storage access is needed on any API level.

This also caused a concrete bug: if an app explicitly removes WRITE_EXTERNAL_STORAGE from its merged manifest (e.g. via tools:node="remove" to minimize permissions), ensureCameraPermissionsAreGranted() would always fail with UserRejectedPermissionsException on Android < Q, even though the camera itself works fine.

# How

Simplified ensureCameraPermissionsAreGranted() to only request and check Manifest.permission.CAMERA, removing the conditional WRITE_EXTERNAL_STORAGE check for Build.VERSION.SDK_INT < Build.VERSION_CODES.Q. The camera output path (cacheDirectory → FileProvider.getUriForFile()) is unchanged and does not depend on storage permissions.

# Test Plan

Tested on Android 8.0 (API 26) emulator: launchCameraAsync successfully opens the camera and returns the captured photo with only CAMERA permission granted, no WRITE_EXTERNAL_STORAGE in manifest.
Tested on Android 14 (API 34) device: camera works identically to before the change.
Verified the captured photo URI is a content:// URI from FileProvider, confirming no storage permission is needed for the write path.
# Checklist


I added a
changelog.md
entry and rebuilt the package sources according to
[this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)

This diff will work correctly for
npx expo prebuild
& EAS Build (eg: updated a module plugin).

Conforms with the
[Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)