### PR TITLE
Fix permission check for camera on Android

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -675,3 +675,8 @@ _This version does not introduce any user-facing changes._
 
 - Skip asking for camera permissions on web with `ImagePicker.getCameraPermissionsAsync`. ([#8475](https://github.com/expo/expo/pull/8475) by [@EvanBacon](https://github.com/EvanBacon))
 - Fixed exception when calling `ImagePicker.getCameraPermissionsAsync` on Web. ([#7498](https://github.com/expo/expo/pull/7498) by [@IjzerenHein](https://github.com/IjzerenHein))
+## Unpublished
+
+### 🐛 Bug fixes
+
+- Removed unnecessary `WRITE_EXTERNAL_STORAGE` permission check in `ensureCameraPermissionsAreGranted()` for Android < Q. Camera uses `FileProvider` which does not require storage permissions. ([#44439](https://github.com/expo/expo/pull/44439) by [@double-in](https://github.com/double-in))


### PR DESCRIPTION
Removed unnecessary WRITE_EXTERNAL_STORAGE permission check for Android < Q in ensureCameraPermissionsAreGranted().

# Why

On Android, `launchCameraAsync` saves photos to the app's internal cache directory via `FileProvider`, which does not require `WRITE_EXTERNAL_STORAGE`. The previous implementation checked for both `CAMERA` and `WRITE_EXTERNAL_STORAGE` on Android < Q (API 29), but this was unnecessary because `FileProvider` uses `content://` URIs with granted URI permissions — no broad storage access is needed on any API level.

This also caused a concrete bug: if an app explicitly removes `WRITE_EXTERNAL_STORAGE` from its merged manifest (e.g. via `tools:node="remove"` to minimize permissions), `ensureCameraPermissionsAreGranted()` would always fail with `UserRejectedPermissionsException` on Android < Q, even though the camera itself works fine.

# How

Simplified `ensureCameraPermissionsAreGranted()` to only request and check `Manifest.permission.CAMERA`, removing the conditional `WRITE_EXTERNAL_STORAGE` check for `Build.VERSION.SDK_INT < Build.VERSION_CODES.Q`. The camera output path (`cacheDirectory` → `FileProvider.getUriForFile()`) is unchanged and does not depend on storage permissions.

# Test Plan

- Tested on Android 8.0 (API 26) emulator: `launchCameraAsync` successfully opens the camera and returns the captured photo with only `CAMERA` permission granted, no `WRITE_EXTERNAL_STORAGE` in manifest.
- Tested on Android 14 (API 34) device: camera works identically to before the change.
- Verified the captured photo URI is a `content://` URI from `FileProvider`, confirming no storage permission is needed for the write path.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)