### PR TITLE
[ios][precompile] fix artifacts folder

### DIFF
--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: xcframeworks-${{ matrix.flavor }}
-          path: packages/precompile/.build/*/output/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
+          path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
           if-no-files-found: error
           retention-days: 14
           include-hidden-files: true


### PR DESCRIPTION
# Why

After adding versioning of 3rd party libs we also need to extend the artifacts glob to include the nested folder structure.

# How

This commit fixes this by changing */output/debug/ → */output/**/debug/ in the upload glob.

This should also capture the full version folder names.

# Test Plan

Run workflow - should go green

