### PR TITLE
[docs] Add expo-module skill to Expo Skills

### DIFF
--- a/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
+++ b/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
@@ -2,9 +2,9 @@
   "source": {
     "repo": "expo/skills",
     "url": "https://api.github.com/repos/expo/skills/contents/plugins/expo/skills",
-    "fetchedAt": "2026-03-25T20:39:13.112Z"
+    "fetchedAt": "2026-04-02T10:41:54.890Z"
   },
-  "totalSkills": 11,
+  "totalSkills": 12,
   "skills": [
     {
       "name": "building-native-ui",
@@ -30,6 +30,11 @@
       "name": "expo-dev-client",
       "description": "Build and distribute Expo development clients locally or via TestFlight.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-dev-client/SKILL.md"
+    },
+    {
+      "name": "expo-module",
+      "description": "Guide for writing Expo native modules and views using the Expo Modules API (Swift, Kotlin, TypeScript). Covers module definition DSL, native views, shared objects, config plugins, lifecycle hooks, autolinking, and type system. Use when building or modifying native modules for Expo.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-module/SKILL.md"
     },
     {
       "name": "expo-tailwind-setup",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/skills/pull/37

Add expo-module skill to Expo Skills

# How

<!--
How did you build this feature or fix this bug and why?
-->

Run `yarn run expo-skills-sync`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2334" height="1934" alt="CleanShot 2026-04-02 at 16 13 38@2x" src="https://github.com/user-attachments/assets/c851f7fa-8d6a-4bc5-b39c-f76a27389e4d" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
