### PR TITLE
[tools] Bump patch version in canaries from sdk branch

### DIFF
--- a/tools/src/publish-packages/tasks/publishCanary.test.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { computeCanaryVersion } from './publishCanary';
+
+describe('computeCanaryVersion', () => {
+  describe('on main', () => {
+    const isMain = true;
+
+    it('bumps SDK-versioned packages to next major', () => {
+      assert.equal(computeCanaryVersion('55.0.9', 55, isMain, '56.0.0'), '56.0.0');
+    });
+
+    it('bumps SDK-versioned packages with higher patch to next major', () => {
+      assert.equal(computeCanaryVersion('55.0.13', 55, isMain, '56.0.0'), '56.0.0');
+    });
+
+    it('returns null for non-SDK-versioned packages', () => {
+      assert.equal(computeCanaryVersion('2.0.9', 55, isMain, '56.0.0'), null);
+    });
+
+    it('returns null for packages on a different major', () => {
+      assert.equal(computeCanaryVersion('54.0.5', 55, isMain, '56.0.0'), null);
+    });
+  });
+
+  describe('on SDK branch', () => {
+    const isMain = false;
+
+    it('patch-bumps SDK-versioned packages', () => {
+      assert.equal(computeCanaryVersion('55.0.9', 55, isMain, '56.0.0'), '55.0.10');
+    });
+
+    it('patch-bumps SDK-versioned packages with higher patch', () => {
+      assert.equal(computeCanaryVersion('55.0.13', 55, isMain, '56.0.0'), '55.0.14');
+    });
+
+    it('returns null for non-SDK-versioned packages', () => {
+      assert.equal(computeCanaryVersion('2.0.9', 55, isMain, '56.0.0'), null);
+    });
+
+    it('returns null for packages on a different major', () => {
+      assert.equal(computeCanaryVersion('54.0.5', 55, isMain, '56.0.0'), null);
+    });
+  });
+});

--- a/tools/src/publish-packages/tasks/publishCanary.test.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.test.ts
@@ -11,10 +11,6 @@ describe('computeCanaryVersion', () => {
       assert.equal(computeCanaryVersion('55.0.9', 55, isMain, '56.0.0'), '56.0.0');
     });
 
-    it('bumps SDK-versioned packages with higher patch to next major', () => {
-      assert.equal(computeCanaryVersion('55.0.13', 55, isMain, '56.0.0'), '56.0.0');
-    });
-
     it('returns null for non-SDK-versioned packages', () => {
       assert.equal(computeCanaryVersion('2.0.9', 55, isMain, '56.0.0'), null);
     });
@@ -29,10 +25,6 @@ describe('computeCanaryVersion', () => {
 
     it('patch-bumps SDK-versioned packages', () => {
       assert.equal(computeCanaryVersion('55.0.9', 55, isMain, '56.0.0'), '55.0.10');
-    });
-
-    it('patch-bumps SDK-versioned packages with higher patch', () => {
-      assert.equal(computeCanaryVersion('55.0.13', 55, isMain, '56.0.0'), '55.0.14');
     });
 
     it('returns null for non-SDK-versioned packages', () => {

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -36,16 +36,21 @@ export const prepareCanaries = new Task<TaskArgs>(
     const canarySuffix = await getCurrentCanaryVersionSuffix();
     const currentSdkVersion = await sdkVersionAsync();
     const currentSdkMajor = semver.major(currentSdkVersion);
-    const nextSdkVersion = await getNextSdkVersion();
+    const currentBranch = await Git.getCurrentBranchNameAsync();
+    const isMain = currentBranch === 'main';
 
     for (const parcel of parcels) {
       const { pkg, state, pkgView } = parcel;
-      // Packages whose major version matches the current SDK should be bumped
-      // to the next SDK version for canary releases (e.g. 55.0.2 → 56.0.0-canary-...).
-      const baseVersion =
-        semver.major(pkg.packageVersion) === currentSdkMajor
-          ? nextSdkVersion
-          : (await resolveReleaseTypeAndVersion(parcel, options)).releaseVersion;
+      // On `main`, SDK-versioned packages are bumped to the next major for canary releases
+      // (e.g. 55.0.2 → 56.0.0-canary-...) since main represents next-SDK development.
+      // On `sdk-*` branches, they get a patch bump (e.g. 55.0.2 → 55.0.3-canary-...)
+      // since these are fixes for an already-released SDK.
+      let baseVersion: string;
+      if (semver.major(pkg.packageVersion) === currentSdkMajor) {
+        baseVersion = isMain ? await getNextSdkVersion() : semver.inc(pkg.packageVersion, 'patch')!;
+      } else {
+        baseVersion = (await resolveReleaseTypeAndVersion(parcel, options)).releaseVersion;
+      }
 
       // Strip any pre-release tag from the baseVersion
       // For example, convert "5.0.0-rc.0" or "5.0.0-preview.0" to "5.0.0"
@@ -61,7 +66,6 @@ export const prepareCanaries = new Task<TaskArgs>(
     // Only use the `canary` tag when publishing from `main` or the latest `sdk-*` branch.
     // Other branches publish canary versions without the `canary` dist-tag so they
     // don't overwrite the canary tag that points at main/latest-sdk builds.
-    const currentBranch = await Git.getCurrentBranchNameAsync();
     if (await shouldUseCanaryTag(currentBranch)) {
       options.tag = 'canary';
     } else {

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -45,12 +45,14 @@ export const prepareCanaries = new Task<TaskArgs>(
       // (e.g. 55.0.2 → 56.0.0-canary-...) since main represents next-SDK development.
       // On `sdk-*` branches, they get a patch bump (e.g. 55.0.2 → 55.0.3-canary-...)
       // since these are fixes for an already-released SDK.
-      let baseVersion: string;
-      if (semver.major(pkg.packageVersion) === currentSdkMajor) {
-        baseVersion = isMain ? await getNextSdkVersion() : semver.inc(pkg.packageVersion, 'patch')!;
-      } else {
-        baseVersion = (await resolveReleaseTypeAndVersion(parcel, options)).releaseVersion;
-      }
+      const sdkBaseVersion = computeCanaryVersion(
+        pkg.packageVersion,
+        currentSdkMajor,
+        isMain,
+        await getNextSdkVersion()
+      );
+      const baseVersion =
+        sdkBaseVersion ?? (await resolveReleaseTypeAndVersion(parcel, options)).releaseVersion;
 
       // Strip any pre-release tag from the baseVersion
       // For example, convert "5.0.0-rc.0" or "5.0.0-preview.0" to "5.0.0"
@@ -204,6 +206,32 @@ async function getCurrentCanaryVersionSuffix() {
   });
 
   return `canary-${year}${month}${day}-${shortCommitHash}`;
+}
+
+/**
+ * Computes the base version for a canary release of an SDK-versioned package.
+ * Returns `null` if the package is not SDK-versioned.
+ *
+ * - On `main`: bumps to the next major SDK version (e.g. 55.0.2 → 56.0.0)
+ * - On SDK branches: bumps the patch version (e.g. 55.0.2 → 55.0.3)
+ */
+export function computeCanaryVersion(
+  packageVersion: string,
+  currentSdkMajor: number,
+  isMainBranch: boolean,
+  nextSdkVersion: string
+): string | null {
+  if (semver.major(packageVersion) !== currentSdkMajor) {
+    return null;
+  }
+  if (isMainBranch) {
+    return nextSdkVersion;
+  }
+  const patchVersion = semver.inc(packageVersion, 'patch');
+  if (!patchVersion) {
+    throw new Error(`Unable to compute patch version for ${packageVersion}`);
+  }
+  return patchVersion;
 }
 
 /**


### PR DESCRIPTION
# Why
When publishing canaries from a sdk branch we don't want to bump the major version. That should only happen from main. sdk branches should just increment the patch version aswell as use the `canary-sdk-*` tag

# How
Check the branch we are publishing from. If it's main, bump the major, otherwise the patch

# Test Plan
Added tests