### PR TITLE
fix(cli): Fix `react-native-web` check having become unconditional

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Prevent out-of-monorepo `expo/expo` CLI detection to not mistrigger for user monorepos and update for pnpm compatibility ([#44101](https://github.com/expo/expo/pull/44101) by [@kitten](https://github.com/kitten))
 - Fix device being incorrectly tracked for `run:ios --device` invocation ([#43673](https://github.com/expo/expo/pull/43673) by [@kitten](https://github.com/kitten))
 - Fall back to name-based `.MainActivity` lookup when no runnable activity with `MAIN`/`LAUNCHER` intent filters exists in the manifest. ([#43702](https://github.com/expo/expo/pull/43702) by [@hwhh](https://github.com/hwhh))
+- Fix `react-native-web` install check being unconditional ([#44450](https://github.com/expo/expo/pull/44450) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
+++ b/packages/@expo/cli/src/start/doctor/web/WebSupportProjectPrerequisite.ts
@@ -61,11 +61,16 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
   }): Promise<boolean> {
     const requiredPackages: ResolvedPackage[] = [
       { file: 'react-dom/package.json', pkg: 'react-dom' },
+    ];
+    const hasReactNative = !!(
+      pkg.dependencies?.['react-native'] || pkg.devDependencies?.['react-native']
+    );
+    if (hasReactNative) {
       // react-native-web is recommended but not required to start a web project.
       // use react-native-web/package.json to skip node module cache issues when the user installs
       // the package and attempts to resolve the module in the same process.
-      { file: 'react-native-web/package.json', pkg: 'react-native-web' },
-    ];
+      requiredPackages.push({ file: 'react-native-web/package.json', pkg: 'react-native-web' });
+    }
 
     const bundler = getPlatformBundlers(this.projectRoot, exp).web;
     // Only include webpack-config if bundler is webpack.
@@ -95,8 +100,8 @@ export class WebSupportProjectPrerequisite extends ProjectPrerequisite {
       this.resetAssertion();
 
       // react-native-web is optional — if it's the only missing package, warn instead of blocking.
-      const hasReactDom = !!resolveFrom.silent(this.projectRoot, 'react-dom/package.json');
-      if (hasReactDom) {
+      const hasReactDOM = !!(pkg.dependencies?.['react-dom'] || pkg.devDependencies?.['react-dom']);
+      if (hasReactDOM) {
         Log.warn(
           chalk`{bold react-native-web} is not installed. Some React Native components may not work on web without it. Install it with: {bold npx expo install react-native-web}`
         );


### PR DESCRIPTION
# Why

The merge between #44300 and #44294 was incorrect and the resulting code now adds `react-native-web` to required packages unconditionally. However, if both `react-native-web` isn't installed and `react-dom` isn't resolving then the `react-native-web` error is passed on. The `react-native-web` requirement should be conditional on `react-native` itself to prevent this, since the `web-only` project demonstrates that it's still conditional on `react-native` itself.

# How

- Only add `react-native-web` requirement if `react-native` is in dependencies
- Update check to check for `package.json` contents instead

# Test Plan

- CI should pass

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
