### PR TITLE
[docs] Link experimental callout to release statuses in inline module pages

### DIFF
--- a/docs/pages/modules/inline-modules-reference.mdx
+++ b/docs/pages/modules/inline-modules-reference.mdx
@@ -5,7 +5,7 @@ description: A reference of Expo inline modules.
 
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 
-> **warning** **Warning:** Inline modules are currently experimental. The API is subject to breaking changes.
+> **warning** Inline modules are [experimental](/more/release-statuses/#experimental). The API is subject to breaking changes.
 
 Inline modules let you write native module code (Kotlin and Swift) directly in your Expo project directory,
 without creating a separate Expo module package. Expo discovers these files automatically and includes them in the build.

--- a/docs/pages/modules/inline-modules-tutorial.mdx
+++ b/docs/pages/modules/inline-modules-tutorial.mdx
@@ -10,7 +10,7 @@ import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-> **warning** **Warning:** Inline modules are currently experimental. The API is subject to breaking changes.
+> **warning** Inline modules are [experimental](/more/release-statuses/#experimental). The API is subject to breaking changes.
 
 In this tutorial, you will create an example native module and a native view directly inside your Expo project's **app** directory using inline modules.
 Unlike the standard Expo Modules, inline modules don't require a separate package or `create-expo-module` scaffolding.


### PR DESCRIPTION


# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/44376

# How

<!--
How did you build this feature or fix this bug and why?
-->

Link "experimental" callout to release statuses in inline module pages.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
