### PR TITLE
[docs] Hide headings in Tabs from TOC sidebar

### DIFF
--- a/docs/ui/components/Permalink/Permalink.tsx
+++ b/docs/ui/components/Permalink/Permalink.tsx
@@ -1,9 +1,10 @@
 import { Button, mergeClasses } from '@expo/styleguide';
-import { Children, isValidElement, type PropsWithChildren } from 'react';
+import { Children, isValidElement, useContext, type PropsWithChildren } from 'react';
 
 import { AdditionalProps } from '~/common/headingManager';
 import withHeadingManager, { HeadingManagerProps } from '~/common/withHeadingManager';
 import { PermalinkIcon } from '~/ui/components/Permalink/PermalinkIcon';
+import { InsideTabsContext } from '~/ui/components/Tabs/Tabs';
 
 import { PermalinkBase } from './PermalinkBase';
 
@@ -15,6 +16,8 @@ type Props = PropsWithChildren<{
 }>;
 
 const Permalink = withHeadingManager((props: Props & HeadingManagerProps) => {
+  const insideTabs = useContext(InsideTabsContext);
+
   // NOTE(jim): Not the greatest way to generate permalinks.
   // for now I've shortened the length of permalinks.
   const component = isValidElement<PropsWithChildren<{ className?: string }>>(props.children)
@@ -32,10 +35,14 @@ const Permalink = withHeadingManager((props: Props & HeadingManagerProps) => {
     return children;
   }
 
+  const additionalProps = insideTabs
+    ? { ...props.additionalProps, hideInSidebar: true }
+    : props.additionalProps;
+
   const heading = props.headingManager.addHeading(
     children,
     props.nestingLevel,
-    props.additionalProps,
+    additionalProps,
     props.id
   );
 

--- a/docs/ui/components/Permalink/Permalink.tsx
+++ b/docs/ui/components/Permalink/Permalink.tsx
@@ -4,7 +4,7 @@ import { Children, isValidElement, useContext, type PropsWithChildren } from 're
 import { AdditionalProps } from '~/common/headingManager';
 import withHeadingManager, { HeadingManagerProps } from '~/common/withHeadingManager';
 import { PermalinkIcon } from '~/ui/components/Permalink/PermalinkIcon';
-import { InsideTabsContext } from '~/ui/components/Tabs/Tabs';
+import { InsideTabsContext } from '~/ui/components/Tabs/InsideTabsContext';
 
 import { PermalinkBase } from './PermalinkBase';
 

--- a/docs/ui/components/Tabs/InsideTabsContext.ts
+++ b/docs/ui/components/Tabs/InsideTabsContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const InsideTabsContext = createContext(false);

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -2,7 +2,6 @@ import { mergeClasses } from '@expo/styleguide';
 import { TabList, TabPanels, Tabs as ReachTabs, TabsProps } from '@reach/tabs';
 import {
   Children,
-  createContext,
   Fragment,
   PropsWithChildren,
   ReactElement,
@@ -13,11 +12,10 @@ import {
   useMemo,
 } from 'react';
 
+import { InsideTabsContext } from './InsideTabsContext';
 import { Tab } from './Tab';
 import { TabButton } from './TabButton';
 import { SharedTabsContext } from './TabsGroup';
-
-export const InsideTabsContext = createContext(false);
 
 type Props = PropsWithChildren<TabsProps> & {
   tabs?: string[];
@@ -84,7 +82,7 @@ const InnerTabs = ({
           <TabButton key={index} active={index === tabIndex} label={title} layoutId={layoutId} />
         ))}
       </TabList>
-      <InsideTabsContext.Provider value={true}>
+      <InsideTabsContext.Provider value>
         <TabPanels
           className={mergeClasses(
             'px-5 py-4',

--- a/docs/ui/components/Tabs/Tabs.tsx
+++ b/docs/ui/components/Tabs/Tabs.tsx
@@ -2,6 +2,7 @@ import { mergeClasses } from '@expo/styleguide';
 import { TabList, TabPanels, Tabs as ReachTabs, TabsProps } from '@reach/tabs';
 import {
   Children,
+  createContext,
   Fragment,
   PropsWithChildren,
   ReactElement,
@@ -15,6 +16,8 @@ import {
 import { Tab } from './Tab';
 import { TabButton } from './TabButton';
 import { SharedTabsContext } from './TabsGroup';
+
+export const InsideTabsContext = createContext(false);
 
 type Props = PropsWithChildren<TabsProps> & {
   tabs?: string[];
@@ -81,15 +84,17 @@ const InnerTabs = ({
           <TabButton key={index} active={index === tabIndex} label={title} layoutId={layoutId} />
         ))}
       </TabList>
-      <TabPanels
-        className={mergeClasses(
-          'px-5 py-4',
-          '[&_ul]:mb-3',
-          '[&_figure:first-child]:mt-1 [&_pre:first-child]:mt-1',
-          '[&>div>*:last-child]:mb-0!'
-        )}>
-        {tabPanels}
-      </TabPanels>
+      <InsideTabsContext.Provider value={true}>
+        <TabPanels
+          className={mergeClasses(
+            'px-5 py-4',
+            '[&_ul]:mb-3',
+            '[&_figure:first-child]:mt-1 [&_pre:first-child]:mt-1',
+            '[&>div>*:last-child]:mb-0!'
+          )}>
+          {tabPanels}
+        </TabPanels>
+      </InsideTabsContext.Provider>
     </ReachTabs>
   );
 };


### PR DESCRIPTION
# Why

Fix ENG-20467

Markdown headings inside `<Tabs>` components appear in the "On this page" TOC sidebar. Since only one tab is visible at a time, this shows headings the reader can't see (e.g., both Android and iOS configuration headings listed simultaneously).

Visible on https://docs.expo.dev/brownfield/integrated-approach/ and any other page with headings inside Tabs: 

<img width="4068" height="2372" alt="CleanShot 2026-04-02 at 22 58 09@2x" src="https://github.com/user-attachments/assets/78a1a8e0-0c68-4c1c-b7a7-ee3aa0429176" />


# How

- Add `InsideTabsContext` (React context, defaults to `false`) in `ui/components/Tabs/Tabs.tsx`. Wrap `<TabPanels>` children with `<InsideTabsContext.Provider value={true}>`.
- In `ui/components/Permalink/Permalink.tsx`, read `InsideTabsContext`. When `true`, pass `hideInSidebar: true` to `headingManager.addHeading()`. Headings still render on the page with anchor links, they just don't appear in the TOC.
- Uses the existing `hideInSidebar` mechanism in `headingManager.ts` (already tested in `headingManager.test.ts`). 

# Test Plan

Open preview and visit "How to add Expo to a native app using the integrated approach" guide and see that TOC doesn't show Hx's in the sidebar from Tabs.

<img width="4070" height="2348" alt="CleanShot 2026-04-02 at 23 02 41@2x" src="https://github.com/user-attachments/assets/8a4f6d70-a8f9-4b04-9df6-10938f496145" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
