### PR TITLE
docs: fix grammar in development builds page

### DIFF
--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -83,7 +83,7 @@ For detailed, step-by-step instructions, see our [EAS Tutorial](/tutorial/eas/in
 
 <Terminal cmd={['$ npx expo install expo-dev-client']} />
 
-<Collapsible summary="Are you using this library in a existing (bare) React Native apps?">
+<Collapsible summary="Are you using this library in an existing (bare) React Native app?">
 
 Apps that don't use [Continuous Native Generation](/workflow/continuous-native-generation/) or are created with `npx react-native`, require further configuration after installing this library. See steps 1 and 2 from [Install `expo-dev-client` in an existing React Native app](/bare/install-dev-builds-in-bare/).
 


### PR DESCRIPTION
## Summary
Fixes two grammar issues in the development builds documentation:

1. **"a existing" → "an existing"**: "existing" starts with a vowel sound, so the article should be "an"
2. **"apps?" → "app?"**: The sentence uses singular form ("this library"), so "app" should also be singular

**File:** `docs/pages/develop/development-builds/create-a-build.mdx`

## Test plan
- [x] Grammar fix only, no functional changes