### PR TITLE
[build-properties] Add usePrecompiledModules option for iOS

### DIFF
--- a/apps/bare-expo/ios/Podfile
+++ b/apps/bare-expo/ios/Podfile
@@ -8,6 +8,7 @@ ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NET
 ENV['RCT_USE_RN_DEP'] ||= '0' if podfile_properties['ios.buildReactNativeFromSource'] == 'true'
 ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= '0' if podfile_properties['ios.buildReactNativeFromSource'] == 'true'
+ENV['EXPO_USE_PRECOMPILED_MODULES'] ||= '1' if podfile_properties['EXPO_USE_PRECOMPILED_MODULES'] == '1'
 
 platform :ios, podfile_properties['ios.deploymentTarget'] || '16.4'
 

--- a/apps/minimal-tester/ios/Podfile
+++ b/apps/minimal-tester/ios/Podfile
@@ -16,6 +16,7 @@ ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NET
 ENV['RCT_USE_RN_DEP'] ||= '0' if podfile_properties['ios.buildReactNativeFromSource'] == 'true'
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= '0' if podfile_properties['ios.buildReactNativeFromSource'] == 'true'
 ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
+ENV['EXPO_USE_PRECOMPILED_MODULES'] ||= '1' if podfile_properties['EXPO_USE_PRECOMPILED_MODULES'] == '1'
 platform :ios, podfile_properties['ios.deploymentTarget'] || '16.4'
 
 prepare_react_native_project!

--- a/packages/expo-build-properties/build/ios.js
+++ b/packages/expo-build-properties/build/ios.js
@@ -40,6 +40,10 @@ exports.withIosBuildProperties = createBuildPodfilePropsConfigPlugin([
         propName: 'expo.useHermesV1',
         propValueGetter: (config) => (0, pluginConfig_1.resolveConfigValue)(config, 'ios', 'useHermesV1')?.toString(),
     },
+    {
+        propName: 'EXPO_USE_PRECOMPILED_MODULES',
+        propValueGetter: (config) => (config.ios?.usePrecompiledModules ?? false).toString(),
+    },
 ], 'withIosBuildProperties');
 const withIosDeploymentTarget = (config, props) => {
     const deploymentTarget = props.ios?.deploymentTarget;

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -352,6 +352,14 @@ export interface PluginConfigTypeIos extends SharedBuildConfigFields {
      * and [Apple's documentation on Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
      */
     privacyManifestAggregationEnabled?: boolean;
+    /**
+     * Enable using precompiled Expo modules (XCFrameworks) instead of building from source.
+     * When enabled, sets the `EXPO_USE_PRECOMPILED_MODULES` environment variable to `1`
+     * during `pod install`, which causes matching modules to be linked as vendored frameworks.
+     *
+     * @default false
+     */
+    usePrecompiledModules?: boolean;
 }
 /**
  * Interface representing extra CocoaPods dependency.

--- a/packages/expo-build-properties/build/pluginConfig.js
+++ b/packages/expo-build-properties/build/pluginConfig.js
@@ -211,6 +211,7 @@ const schema = {
                     nullable: true,
                 },
                 useHermesV1: { type: 'boolean', nullable: true },
+                usePrecompiledModules: { type: 'boolean', nullable: true },
             },
             nullable: true,
         },

--- a/packages/expo-build-properties/src/ios.ts
+++ b/packages/expo-build-properties/src/ios.ts
@@ -49,6 +49,10 @@ export const withIosBuildProperties = createBuildPodfilePropsConfigPlugin<Plugin
       propName: 'expo.useHermesV1',
       propValueGetter: (config) => resolveConfigValue(config, 'ios', 'useHermesV1')?.toString(),
     },
+    {
+      propName: 'EXPO_USE_PRECOMPILED_MODULES',
+      propValueGetter: (config) => (config.ios?.usePrecompiledModules ?? false).toString(),
+    },
   ],
   'withIosBuildProperties'
 );

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -420,6 +420,15 @@ export interface PluginConfigTypeIos extends SharedBuildConfigFields {
    * and [Apple's documentation on Privacy manifest files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
    */
   privacyManifestAggregationEnabled?: boolean;
+
+  /**
+   * Enable using precompiled Expo modules (XCFrameworks) instead of building from source.
+   * When enabled, sets the `EXPO_USE_PRECOMPILED_MODULES` environment variable to `1`
+   * during `pod install`, which causes matching modules to be linked as vendored frameworks.
+   *
+   * @default false
+   */
+  usePrecompiledModules?: boolean;
 }
 
 /**
@@ -788,6 +797,7 @@ const schema: JSONSchema<PluginConfigType> = {
           nullable: true,
         },
         useHermesV1: { type: 'boolean', nullable: true },
+        usePrecompiledModules: { type: 'boolean', nullable: true },
       },
       nullable: true,
     },

--- a/templates/expo-template-bare-minimum/ios/Podfile
+++ b/templates/expo-template-bare-minimum/ios/Podfile
@@ -16,6 +16,7 @@ ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NET
 ENV['RCT_USE_RN_DEP'] ||= '0' if podfile_properties['ios.buildReactNativeFromSource'] == 'true'
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= '0' if podfile_properties['ios.buildReactNativeFromSource'] == 'true'
 ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
+ENV['EXPO_USE_PRECOMPILED_MODULES'] ||= '1' if podfile_properties['EXPO_USE_PRECOMPILED_MODULES'] == '1'
 platform :ios, podfile_properties['ios.deploymentTarget'] || '16.4'
 
 prepare_react_native_project!


### PR DESCRIPTION
# Why

Currently, to use precompiled modules on iOS, users must manually set `EXPO_USE_PRECOMPILED_MODULES=1` before running `pod install`. Which is kinda tricky for users using CNG

# How

Added a new `usePrecompiledModules` option to the `ios` config in `expo-build-properties`

# Test Plan

In sandbox app add the following to app.json

```json
"plugins": [
      [
        "expo-build-properties",
        {
          "ios": {
            "usePrecompiledModules": true, 
          },
        }
      ]
    ],
```

And run `npx expo prebuild` then install pods and config precompiled libs are build used 
 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
