### PR TITLE
[ci] update expo-video tests

### DIFF
--- a/apps/bare-expo/e2e/expo-video/player-output-test.yaml
+++ b/apps/bare-expo/e2e/expo-video/player-output-test.yaml
@@ -8,6 +8,9 @@ jsEngine: graaljs
     visible: 'Players ready'
     timeout: 10000
 - tapOn: 'Move player 1 to the next video view'
+# Wait for the video surface to render in the new view
+- waitForAnimationToEnd:
+    timeout: 3000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -18,6 +21,8 @@ jsEngine: graaljs
     text: 'Move player 2 to the next video view'
     repeat: 2
 - tapOn: 'Move player 1 to the next video view'
+- waitForAnimationToEnd:
+    timeout: 3000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -26,6 +31,8 @@ jsEngine: graaljs
       mode: 'keep-originals'
 - tapOn: 'Move player 1 to first video view'
 - tapOn: 'Move player 2 to first video view'
+- waitForAnimationToEnd:
+    timeout: 3000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:
@@ -40,6 +47,8 @@ jsEngine: graaljs
 - tapOn:
     text: 'Move player 1 to the next video view'
     repeat: 2
+- waitForAnimationToEnd:
+    timeout: 3000
 - runFlow:
     file: ../_nested-flows/viewshot-comparison.yaml
     env:

--- a/apps/native-component-list/src/screens/Video/VideoChangePlayerOutputScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoChangePlayerOutputScreen.tsx
@@ -36,29 +36,29 @@ export default function VideoChangePlayerOutputScreen() {
 
   const [viewPlayers, setViewPlayers] = useState([player, player2, null, null]);
 
+  const movePlayerTo = useCallback(
+    (playerIndex: number, newViewIndex: number) => {
+      const currentIndex = players.current[playerIndex].viewIndex;
+      setViewPlayers((prev) => {
+        const newViewPlayers = [...prev];
+        if (!useIncorrectReplace) {
+          newViewPlayers[currentIndex] = null;
+        }
+        newViewPlayers[newViewIndex] = players.current[playerIndex].ref;
+        return newViewPlayers;
+      });
+      players.current[playerIndex].viewIndex = newViewIndex;
+    },
+    [useIncorrectReplace]
+  );
+
   const advancePlayer = useCallback(
     (playerIndex: number) => {
       const currentIndex = players.current[playerIndex].viewIndex;
       const newIndex = (currentIndex + 1) % 4;
       movePlayerTo(playerIndex, newIndex);
     },
-    [viewPlayers, useIncorrectReplace]
-  );
-
-  const movePlayerTo = useCallback(
-    (playerIndex: number, newViewIndex: number) => {
-      const currentIndex = players.current[playerIndex].viewIndex;
-      const newViewPlayers = [...viewPlayers];
-
-      if (!useIncorrectReplace) {
-        newViewPlayers[currentIndex] = null;
-      }
-      newViewPlayers[newViewIndex] = players.current[playerIndex].ref;
-      setViewPlayers(newViewPlayers);
-
-      players.current[playerIndex].viewIndex = newViewIndex;
-    },
-    [viewPlayers, useIncorrectReplace]
+    [movePlayerTo]
   );
 
   return (


### PR DESCRIPTION
# Why

sdk-55 expo video tests fail pretty regularly. I'd pick the `VideoChangePlayerOutputScreen` changes to main too.

I do believe this uncovers some issues in the VideoChangePlayerOutputScreen.tsx (now uses `setViewPlayers` with the callback syntax to avoid missing a pending update) and the waits - not a fan of them but if it helps.

# How

refactor exisitng code

# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
