### PR TITLE
[iOS][JSI] Additions to JavaScriptArrayBuffer

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -7,6 +7,7 @@
 #include <hermes/hermes.h>
 #include "HostFunctionClosure.h"
 #include "CppError.h"
+#include "MemoryBuffer.h"
 #include "NativeState.h"
 
 namespace jsi = facebook::jsi;
@@ -102,12 +103,56 @@ inline jsi::Value callAsConstructor(jsi::Runtime &runtime, const jsi::Function &
 
 // MARK: - ArrayBuffer
 
+/**
+ * Converts a `jsi::ArrayBuffer` to a `jsi::Value`. Needed because Swift/C++ interop
+ * does not implicitly upcast `ArrayBuffer` to `Object` for the `Value` constructor.
+ */
+inline jsi::Value valueFromArrayBuffer(jsi::Runtime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
+  return jsi::Value(runtime, arrayBuffer);
+}
+
+/**
+ * Returns the size of the array buffer storage in bytes.
+ */
 inline size_t arrayBufferSize(jsi::Runtime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
   return arrayBuffer.size(runtime);
 }
 
+/**
+ * Returns a pointer to the underlying data of the array buffer.
+ */
 inline uint8_t *arrayBufferData(jsi::Runtime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
   return arrayBuffer.data(runtime);
+}
+
+/**
+ * Creates a new array buffer of the given size with zero-initialized memory.
+ */
+inline jsi::ArrayBuffer createArrayBuffer(jsi::Runtime &runtime, size_t size) {
+  uint8_t *data = new uint8_t[size]();
+  auto buffer = std::make_shared<MemoryBuffer>(data, size, [data]() { delete[] data; });
+  return jsi::ArrayBuffer(runtime, std::move(buffer));
+}
+
+/**
+ * Creates a new array buffer that wraps the given native data pointer.
+ * The cleanup function is called (with the cleanup context) when the ArrayBuffer is deallocated.
+ */
+inline jsi::ArrayBuffer createArrayBuffer(
+  jsi::Runtime &runtime,
+  uint8_t *data,
+  size_t size,
+  void *_Nonnull cleanupContext,
+  void (* _Nonnull cleanupFunction)(void * _Nonnull)
+) {
+  // The cleanup context must not be null — the cleanup function is never called without it,
+  // which would leak the data. The Swift caller always provides a retained Unmanaged pointer.
+  assert(cleanupContext != nullptr && "cleanupContext must not be null; cleanup would be skipped and data leaked");
+
+  auto buffer = std::make_shared<MemoryBuffer>(data, size, [cleanupContext, cleanupFunction]() {
+    cleanupFunction(cleanupContext);
+  });
+  return jsi::ArrayBuffer(runtime, std::move(buffer));
 }
 
 // MARK: - Native state

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/MemoryBuffer.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/MemoryBuffer.h
@@ -1,0 +1,51 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#pragma once
+#ifdef __cplusplus
+
+#include <functional>
+#include <jsi/jsi.h>
+
+namespace expo {
+
+using CleanupFunc = std::function<void()>;
+
+/**
+ * A JSI-compatible mutable buffer that allows creating JSI ArrayBuffers from natively-managed memory.
+ * Since ArrayBuffers created from native memory don't automatically deallocate during GC,
+ * this class handles deallocation through a custom cleanup function.
+ */
+class MemoryBuffer final : public facebook::jsi::MutableBuffer {
+public:
+  MemoryBuffer(uint8_t *data, size_t size, CleanupFunc &&cleanupFunc)
+    : data_(data), size_(size), cleanupFunc_(std::move(cleanupFunc)) {}
+
+  // Non-copyable and non-movable to prevent double-free of the underlying data.
+  MemoryBuffer(const MemoryBuffer &) = delete;
+  MemoryBuffer &operator=(const MemoryBuffer &) = delete;
+  MemoryBuffer(MemoryBuffer &&) = delete;
+  MemoryBuffer &operator=(MemoryBuffer &&) = delete;
+
+  ~MemoryBuffer() override {
+    if (cleanupFunc_ != nullptr) {
+      cleanupFunc_();
+    }
+  }
+
+  uint8_t *data() override {
+    return data_;
+  }
+
+  [[nodiscard]] size_t size() const override {
+    return size_;
+  }
+
+private:
+  uint8_t *data_;
+  size_t size_;
+  CleanupFunc cleanupFunc_;
+};
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/CleanupContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/CleanupContext.swift
@@ -1,0 +1,17 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/**
+ A box that holds a cleanup closure and invokes it on deallocation.
+ Used to bridge Swift closures to C++ cleanup callbacks via `Unmanaged` pointers.
+ */
+internal final class CleanupContext: Sendable {
+  let cleanup: @Sendable () -> Void
+
+  init(_ cleanup: @escaping @Sendable () -> Void) {
+    self.cleanup = cleanup
+  }
+
+  deinit {
+    cleanup()
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -152,6 +152,28 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return JavaScriptObject(self, hostObject)
   }
 
+  // MARK: - Creating array buffers
+
+  /**
+   Creates a new array buffer of the given size with zero-initialized memory.
+   */
+  public func createArrayBuffer(size: Int) -> JavaScriptArrayBuffer {
+    let jsiArrayBuffer = expo.createArrayBuffer(pointee, size)
+    return JavaScriptArrayBuffer(self, jsiArrayBuffer)
+  }
+
+  /**
+   Creates a new array buffer that wraps the given native data pointer.
+   The cleanup closure is called when the array buffer is garbage collected.
+   */
+  public func createArrayBuffer(data: UnsafeMutablePointer<UInt8>, size: Int, cleanup: @escaping @Sendable () -> Void) -> JavaScriptArrayBuffer {
+    let context = Unmanaged.passRetained(CleanupContext(cleanup)).toOpaque()
+    let jsiArrayBuffer = expo.createArrayBuffer(pointee, data, size, context) { context in
+      Unmanaged<CleanupContext>.fromOpaque(context).release()
+    }
+    return JavaScriptArrayBuffer(self, jsiArrayBuffer)
+  }
+
   // MARK: - Creating arrays
 
   /**

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArrayBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArrayBuffer.swift
@@ -4,7 +4,7 @@ internal import jsi
 internal import ExpoModulesJSI_Cxx
 
 /**
- A Swift representation of a JavaScript `ArrayBuffer`. Provides access to the
+ A Swift representation of a JavaScript array buffer. Provides access to the
  underlying raw data pointer and size of the buffer.
  */
 public struct JavaScriptArrayBuffer: ~Copyable {
@@ -17,7 +17,7 @@ public struct JavaScriptArrayBuffer: ~Copyable {
   }
 
   /**
-   Returns the size of the `ArrayBuffer` storage in bytes.
+   Returns the size of the array buffer storage in bytes.
    This is not affected by overriding the `byteLength` property.
    */
   public var size: Int {
@@ -28,13 +28,38 @@ public struct JavaScriptArrayBuffer: ~Copyable {
   }
 
   /**
-   Returns a pointer to the underlying data of the `ArrayBuffer`.
+   Returns a pointer to the underlying data of the array buffer.
    */
   public func data() -> UnsafeMutablePointer<UInt8> {
     guard let runtime else {
       FatalError.runtimeLost()
     }
     return expo.arrayBufferData(runtime.pointee, pointee)
+  }
+
+  /**
+   Creates a new array buffer with a copy of this buffer's data.
+   */
+  public func copy() -> JavaScriptArrayBuffer {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    let byteCount = size
+    let newBuffer = runtime.createArrayBuffer(size: byteCount)
+    memcpy(newBuffer.data(), data(), byteCount)
+    return newBuffer
+  }
+
+  // MARK: - Conversions
+
+  /**
+   Returns this array buffer as a `JavaScriptValue`.
+   */
+  public func asValue() -> JavaScriptValue {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    return JavaScriptValue(runtime, expo.valueFromArrayBuffer(runtime.pointee, pointee))
   }
 
   // MARK: - Providing JavaScriptObject API

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayBufferTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayBufferTests.swift
@@ -1,0 +1,193 @@
+import Testing
+import ExpoModulesJSI
+
+@Suite
+@JavaScriptActor
+struct JavaScriptArrayBufferTests {
+  let runtime = JavaScriptRuntime()
+
+  // MARK: - Creation
+
+  @Test
+  func `create array buffer with specified size`() {
+    let buffer = runtime.createArrayBuffer(size: 64)
+    #expect(buffer.size == 64)
+  }
+
+  @Test
+  func `create array buffer with zero size`() {
+    let buffer = runtime.createArrayBuffer(size: 0)
+    #expect(buffer.size == 0)
+  }
+
+  @Test
+  func `create array buffer has zero-initialized memory`() {
+    let buffer = runtime.createArrayBuffer(size: 8)
+    let ptr = buffer.data()
+    for i in 0..<8 {
+      #expect(ptr[i] == 0)
+    }
+  }
+
+  @Test
+  func `create array buffer wrapping native data`() {
+    nonisolated(unsafe) let data = UnsafeMutablePointer<UInt8>.allocate(capacity: 4)
+    data[0] = 10
+    data[1] = 20
+    data[2] = 30
+    data[3] = 40
+
+    let buffer = runtime.createArrayBuffer(data: data, size: 4) {
+      data.deallocate()
+    }
+
+    #expect(buffer.size == 4)
+    #expect(buffer.data()[0] == 10)
+    #expect(buffer.data()[1] == 20)
+    #expect(buffer.data()[2] == 30)
+    #expect(buffer.data()[3] == 40)
+  }
+
+  @Test
+  func `create array buffer from JavaScript`() throws {
+    let value = try runtime.eval("new ArrayBuffer(32)")
+    let object = value.getObject()
+
+    #expect(object.isArrayBuffer() == true)
+
+    let buffer = object.getArrayBuffer()
+    #expect(buffer.size == 32)
+  }
+
+  // MARK: - Data access
+
+  @Test
+  func `read and write through data pointer`() {
+    let buffer = runtime.createArrayBuffer(size: 4)
+    let ptr = buffer.data()
+
+    ptr[0] = 0xDE
+    ptr[1] = 0xAD
+    ptr[2] = 0xBE
+    ptr[3] = 0xEF
+
+    #expect(ptr[0] == 0xDE)
+    #expect(ptr[1] == 0xAD)
+    #expect(ptr[2] == 0xBE)
+    #expect(ptr[3] == 0xEF)
+  }
+
+  @Test
+  func `native writes are visible from JavaScript`() throws {
+    let buffer = runtime.createArrayBuffer(size: 4)
+    buffer.data()[0] = 42
+
+    runtime.global().setProperty("buf", value: buffer.asValue())
+    let result = try runtime.eval("new Uint8Array(buf)[0]")
+
+    #expect(result.getInt() == 42)
+  }
+
+  @Test
+  func `JavaScript writes are visible from native`() throws {
+    let buffer = runtime.createArrayBuffer(size: 4)
+    runtime.global().setProperty("buf", value: buffer.asValue())
+
+    try runtime.eval("new Uint8Array(buf)[0] = 99")
+
+    #expect(buffer.data()[0] == 99)
+  }
+
+  // MARK: - Copy
+
+  @Test
+  func `copy creates independent buffer`() {
+    let original = runtime.createArrayBuffer(size: 4)
+    original.data()[0] = 42
+
+    let copied = original.copy()
+
+    #expect(copied.size == 4)
+    #expect(copied.data()[0] == 42)
+
+    // Mutating the copy does not affect the original
+    copied.data()[0] = 99
+    #expect(original.data()[0] == 42)
+    #expect(copied.data()[0] == 99)
+  }
+
+  @Test
+  func `copy preserves all data`() {
+    let original = runtime.createArrayBuffer(size: 8)
+    let ptr = original.data()
+    for i: UInt8 in 0..<8 {
+      ptr[Int(i)] = i * 10
+    }
+
+    let copied = original.copy()
+    let copiedPtr = copied.data()
+
+    for i: UInt8 in 0..<8 {
+      #expect(copiedPtr[Int(i)] == i * 10)
+    }
+  }
+
+  // MARK: - Conversions
+
+  @Test
+  func `asValue returns a valid JavaScript value`() {
+    let buffer = runtime.createArrayBuffer(size: 16)
+    let value = buffer.asValue()
+
+    #expect(value.isObject() == true)
+    #expect(value.getObject().isArrayBuffer() == true)
+  }
+
+  @Test
+  func `asValue preserves buffer identity`() throws {
+    let buffer = runtime.createArrayBuffer(size: 8)
+    buffer.data()[0] = 123
+
+    runtime.global().setProperty("buf", value: buffer.asValue())
+    let readBack = try runtime.eval("new Uint8Array(buf)[0]")
+
+    #expect(readBack.getInt() == 123)
+  }
+
+  // MARK: - Properties
+
+  @Test
+  func `getProperty reads byteLength`() {
+    let buffer = runtime.createArrayBuffer(size: 64)
+    let byteLength = buffer.getProperty("byteLength")
+
+    #expect(byteLength.isNumber() == true)
+    #expect(byteLength.getInt() == 64)
+  }
+
+  // MARK: - Cleanup
+
+  @Test
+  func `cleanup is called when buffer is collected`() async throws {
+    var cleanupCalled = false
+    nonisolated(unsafe) let flag = UnsafeMutablePointer<Bool>.allocate(capacity: 1)
+    flag.initialize(to: false)
+
+    do {
+      nonisolated(unsafe) let data = UnsafeMutablePointer<UInt8>.allocate(capacity: 8)
+      _ = runtime.createArrayBuffer(data: data, size: 8) {
+        data.deallocate()
+        flag.pointee = true
+      }
+      // Buffer goes out of scope here
+    }
+
+    // Hermes gc() is synchronous, so the buffer should be collected immediately.
+    try runtime.eval("gc()")
+
+    cleanupCalled = flag.pointee
+    flag.deallocate()
+
+    #expect(cleanupCalled)
+  }
+}


### PR DESCRIPTION
Extends `JavaScriptArrayBuffer` in `expo-modules-jsi` with the ability to **create**, **copy**, and **convert** array buffers — capabilities needed for the `expo-modules-core` ArrayBuffer integration.

### C++ layer

- **`MemoryBuffer`** — new header-only `jsi::MutableBuffer` subclass that wraps natively-managed memory with a cleanup callback, used to create JSI ArrayBuffers from native data
- **`JSIUtils.h`** — added helpers:
  - `valueFromArrayBuffer` — converts `jsi::ArrayBuffer` to `jsi::Value` (needed because Swift/C++ interop doesn't implicitly upcast `ArrayBuffer` → `Object`)
  - `createArrayBuffer(runtime, size)` — allocates a new zero-initialized buffer
  - `createArrayBuffer(runtime, data, size, cleanupContext, cleanupFunction)` — wraps existing native memory with a C-style cleanup callback
  - Doc comments added to all ArrayBuffer-related functions

### Swift layer

- **`JavaScriptRuntime.createArrayBuffer(size:)`** — creates a new zero-initialized ArrayBuffer
- **`JavaScriptRuntime.createArrayBuffer(data:size:cleanup:)`** — wraps existing native data, calling the cleanup closure when the JS ArrayBuffer is garbage collected
- **`JavaScriptArrayBuffer.copy()`** — creates a new ArrayBuffer with an independent copy of the data
- **`JavaScriptArrayBuffer.asValue()`** — converts to `JavaScriptValue` for returning to JavaScript
- **`CleanupContext`** — internal helper that bridges Swift `@Sendable` closures to C++ cleanup callbacks via `Unmanaged` pointers

### Tests

- Added `JavaScriptArrayBufferTests` covering creation (sized, zero-sized, wrapping native data, from JS), data access (read/write, native↔JS visibility), copy independence, conversions (`asValue`), property access, and cleanup behavior.
