### PR TITLE
[docs] Fix broken MDX imports and add import/no-unresolved to lint

### DIFF
--- a/docs/eslint.config.mjs
+++ b/docs/eslint.config.mjs
@@ -226,6 +226,7 @@ export default defineConfig([
     },
     rules: {
       ...mdx.flat.rules,
+      'import/no-unresolved': 'error',
       'no-unused-vars': ['warn', { vars: 'all', args: 'none', ignoreRestSiblings: true }],
       'no-unused-expressions': 'off',
       'no-useless-escape': 'off',

--- a/docs/pages/workflow/android-studio-emulator.mdx
+++ b/docs/pages/workflow/android-studio-emulator.mdx
@@ -3,9 +3,9 @@ title: Android Studio Emulator
 description: Learn how to set up the Android Emulator to test your app on a virtual Android device.
 ---
 
-import AndroidEmulatorInstructions from 'scenes/get-started/set-up-your-environment/instructions/_androidEmulatorInstructions.mdx';
-import AndroidStudioEnvironmentInstructions from 'scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx';
-import AndroidStudioInstructions from 'scenes/get-started/set-up-your-environment/instructions/_androidStudioInstructions.mdx';
+import AndroidEmulatorInstructions from '~/scenes/get-started/set-up-your-environment/instructions/_androidEmulatorInstructions.mdx';
+import AndroidStudioEnvironmentInstructions from '~/scenes/get-started/set-up-your-environment/instructions/_androidStudioEnvironmentInstructions.mdx';
+import AndroidStudioInstructions from '~/scenes/get-started/set-up-your-environment/instructions/_androidStudioInstructions.mdx';
 
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -4,7 +4,7 @@ description: Learn how you can install the iOS Simulator on your Mac and use it 
 ---
 
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
-import XcodeInstructions from 'scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx';
+import XcodeInstructions from '~/scenes/get-started/set-up-your-environment/instructions/_xcodeInstructions.mdx';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The production build fails with "Module not found" errors in `pages/workflow/android-studio-emulator.mdx` and `pages/workflow/ios-simulator.mdx`. These files import from `'scenes/...'` instead of `'~/scenes/...'`, which webpack cannot resolve since the `~/` alias (mapped via tsconfig paths) is required for project-root imports.

<img width="1868" height="1492" alt="CleanShot 2026-04-03 at 16 48 44@2x" src="https://github.com/user-attachments/assets/19450eaf-6cbe-49b1-b121-61067c4275a3" />

This class of bug was not caught at the lint stage, only surfacing during the Next.js production build.

# How

- Fix 4 broken imports in `pages/workflow/android-studio-emulator.mdx` and `pages/workflow/ios-simulator.mdx` by adding the `~/` prefix.
- Add `'import/no-unresolved': 'error'` to the MDX rules block in `eslint.config.mjs` so ESLint catches unresolvable imports in MDX files at lint time. This uses the already-installed `eslint-import-resolver-typescript` to resolve the `~/` alias from tsconfig.

# Test Plan

Run `yarn lint` and confirm it passes. To verify the rule works, temporarily remove the `~/` prefix from one of the fixed imports and run ESLint on that file to confirm it reports an `import/no-unresolved` error.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
