### PR TITLE
[iOS][core] Add async/await overload for StaticAsyncFunction

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Add async/await overload for StaticAsyncFunction ([#44471](https://github.com/expo/expo/pull/44471) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fixed looking up the `EXConstants.bundle` from the main bundle to allow running with precompiled XCFrameworks. ([#44551](https://github.com/expo/expo/pull/44551) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider. ([#44550](https://github.com/expo/expo/pull/44550) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed view lookup in bridgeless mode by using `ExpoHostWrapper` instead of `reactBridge.uiManager`. ([#44375](https://github.com/expo/expo/pull/44375) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/ios/Api/Factories/StaticFunctionFactories.swift
+++ b/packages/expo-modules-core/ios/Api/Factories/StaticFunctionFactories.swift
@@ -59,3 +59,33 @@ public func StaticAsyncFunction<R, A0: AnyArgument, each A: AnyArgument>(
     closure
   )
 }
+
+/**
+ Static asynchronous function without arguments.
+ */
+public func StaticAsyncFunction<R>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping () async throws -> R
+) -> StaticConcurrentFunctionDefinition<(), Void, R> {
+  return StaticConcurrentFunctionDefinition(
+    name,
+    firstArgType: Void.self,
+    dynamicArgumentTypes: [],
+    closure
+  )
+}
+
+/**
+ Static asynchronous function with one or more arguments.
+ */
+public func StaticAsyncFunction<R, A0: AnyArgument, each A: AnyArgument>(
+  _ name: String,
+  @_implicitSelfCapture _ closure: @escaping (A0, repeat each A) async throws -> R
+) -> StaticConcurrentFunctionDefinition<(A0, repeat each A), A0, R> {
+  return StaticConcurrentFunctionDefinition(
+    name,
+    firstArgType: A0.self,
+    dynamicArgumentTypes: buildDynamicTypes(A0.self, repeat (each A).self),
+    closure
+  )
+}

--- a/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
@@ -14,7 +14,7 @@ internal protocol AnyConcurrentFunctionDefinition: AnyFunctionDefinition {
  Represents a concurrent function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
  As opposed to `AsyncFunctionDefinition`, it can leverage the new Swift's concurrency model and take the async/await closure.
  */
-public final class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>: AnyConcurrentFunctionDefinition, @unchecked Sendable {
+public class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>: AnyConcurrentFunctionDefinition, @unchecked Sendable {
   typealias ClosureType = (Args) async throws -> ReturnType
 
   let body: ClosureType

--- a/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/StaticFunctionDefinition.swift
@@ -42,3 +42,20 @@ public final class StaticAsyncFunctionDefinition<Args, FirstArgType, ReturnType>
     return super.call(by: nil, withArguments: args, appContext: appContext, callback: callback)
   }
 }
+
+/**
+ Represents a static function that can only be called asynchronously, thus its JavaScript equivalent returns a Promise.
+ */
+public final class StaticConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>:
+  ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>, AnyStaticFunctionDefinition, @unchecked Sendable {
+  let isStatic = true
+
+  override func call(
+    by owner: AnyObject?,
+    withArguments args: [Any],
+    appContext: AppContext,
+    callback: @Sendable @escaping (FunctionCallResult) -> Void
+  ) {
+    return super.call(by: nil, withArguments: args, appContext: appContext, callback: callback)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/ClassDefinitionTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ClassDefinitionTests.swift
@@ -264,6 +264,23 @@ struct ClassDefinitionTests {
       #expect(object.getObject().getProperty("currentValue").getInt() == initialValue)
     }
 
+    @Test
+    func `initializes the shared object from static concurrent function`() async throws {
+      let initialValue = Int.random(in: 1..<100)
+      try runtime
+        .eval(
+          "expo.modules.TestModule.Counter.createConcurrently(\(initialValue)).then((result) => { globalThis.result = result; })"
+        )
+
+      try await waitUntil(timeout: 4.0) {
+        safeBoolEval("globalThis.result != null")
+      }
+      let object = try runtime.eval("object = globalThis.result")
+
+      #expect(object.kind == .object)
+      #expect(object.getObject().getProperty("currentValue").getInt() == initialValue)
+    }
+
     private func safeBoolEval(_ js: String) -> Bool {
       var result = false
       do {
@@ -392,6 +409,10 @@ fileprivate final class ModuleWithCounterClass: Module {
 
       StaticAsyncFunction("createAsync") { (initialValue: Int, p: Promise) in
         p.resolve(Counter(initialValue: initialValue))
+      }
+
+      StaticAsyncFunction("createConcurrently") { (initialValue: Int) async throws in
+        Counter(initialValue: initialValue)
       }
 
       Function("increment") { (counter, value: Int) in


### PR DESCRIPTION
# Why
`StaticAsyncFunction` only supports non-async closures, whereas `AsyncFunction` has overloads for async/await.

# How
Added the exact same pattern that `AsyncFunction` uses across `AsyncFunctionFactories.swift` and `ConcurrentFunctionFactories.swift` for `StaticAsyncFunction`.

# Test Plan
Added a test to native tests ✅
Tested on bare expo (contacts@next, media-library@next) ✅