### PR TITLE
[auth-session] Add support for specifying timeout for requests

### DIFF
--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added `timeout` option to `TokenRequestConfig` and `RevokeTokenRequestConfig` for aborting token requests after a specified duration in milliseconds. ([#44476](https://github.com/expo/expo/pull/44476) by [@dulmandakh](https://github.com/dulmandakh))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-auth-session/src/Fetch.ts
+++ b/packages/expo-auth-session/src/Fetch.ts
@@ -9,6 +9,7 @@ export type FetchRequest = {
   body?: Record<string, string>;
   dataType?: string;
   method?: string;
+  signal?: AbortSignal;
 };
 
 export async function requestAsync<T>(requestUrl: string, fetchRequest: FetchRequest): Promise<T> {
@@ -20,6 +21,7 @@ export async function requestAsync<T>(requestUrl: string, fetchRequest: FetchReq
     method: fetchRequest.method,
     mode: 'cors',
     headers,
+    signal: fetchRequest.signal,
   };
 
   const isJsonDataType = fetchRequest.dataType?.toLowerCase() === 'json';

--- a/packages/expo-auth-session/src/TokenRequest.ts
+++ b/packages/expo-auth-session/src/TokenRequest.ts
@@ -157,6 +157,15 @@ export class Request<T, B> {
     throw new Error('getQueryBody must be extended');
   }
 }
+function createTimeoutSignal(timeout?: number): AbortSignal | undefined {
+  if (!timeout) {
+    return undefined;
+  }
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeout);
+  return controller.signal;
+}
+
 function sanitizeExtraHeaders(
   extra: Record<string, string> | undefined,
   hasClientSecret: boolean
@@ -187,6 +196,7 @@ export class TokenRequest<T extends TokenRequestConfig>
   readonly scopes?: string[];
   readonly extraParams?: Record<string, string>;
   readonly extraHeaders?: Record<string, string>;
+  readonly timeout?: number;
 
   constructor(
     request: T,
@@ -197,6 +207,7 @@ export class TokenRequest<T extends TokenRequestConfig>
     this.clientSecret = request.clientSecret;
     this.extraParams = request.extraParams;
     this.scopes = request.scopes;
+    this.timeout = request.timeout;
     this.extraHeaders = sanitizeExtraHeaders(
       request.extraHeaders,
       typeof request.clientSecret !== 'undefined'
@@ -233,6 +244,7 @@ export class TokenRequest<T extends TokenRequestConfig>
         method: 'POST',
         headers: this.getHeaders(),
         body: this.getQueryBody(),
+        signal: createTimeoutSignal(this.timeout),
       }
     );
 
@@ -397,6 +409,7 @@ export class RevokeTokenRequest
   readonly token: string;
   readonly tokenTypeHint?: TokenTypeHint;
   readonly extraHeaders?: Record<string, string>;
+  readonly timeout?: number;
 
   constructor(request: RevokeTokenRequestConfig) {
     super(request);
@@ -405,6 +418,7 @@ export class RevokeTokenRequest
     this.clientSecret = request.clientSecret;
     this.token = request.token;
     this.tokenTypeHint = request.tokenTypeHint;
+    this.timeout = request.timeout;
     this.extraHeaders = sanitizeExtraHeaders(
       request.extraHeaders,
       typeof request.clientSecret !== 'undefined'
@@ -442,6 +456,7 @@ export class RevokeTokenRequest
       method: 'POST',
       headers: this.getHeaders(),
       body: this.getQueryBody(),
+      signal: createTimeoutSignal(this.timeout),
     });
 
     return true;

--- a/packages/expo-auth-session/src/TokenRequest.ts
+++ b/packages/expo-auth-session/src/TokenRequest.ts
@@ -162,7 +162,8 @@ function createTimeoutSignal(timeout?: number): AbortSignal | undefined {
     return undefined;
   }
   const controller = new AbortController();
-  setTimeout(() => controller.abort(), timeout);
+  const timer = setTimeout(() => controller.abort(), timeout);
+  controller.signal.addEventListener('abort', () => clearTimeout(timer), { once: true });
   return controller.signal;
 }
 

--- a/packages/expo-auth-session/src/TokenRequest.types.ts
+++ b/packages/expo-auth-session/src/TokenRequest.types.ts
@@ -63,6 +63,11 @@ export type TokenRequestConfig = {
    * [Section 3.3](https://tools.ietf.org/html/rfc6749#section-3.3)
    */
   scopes?: string[];
+  /**
+   * Timeout for the token request in milliseconds. If the request takes longer than this,
+   * it will be aborted and the promise will reject with a `TimeoutError`.
+   */
+  timeout?: number;
 };
 
 // @needsAudit


### PR DESCRIPTION
# Why

Token requests in `expo-auth-session` have no way to time out. If an identity provider's token endpoint is slow or unreachable, `exchangeCodeAsync`, `refreshAsync`, and `revokeAsync` hang indefinitely. This is a problem on mobile where network conditions are unpredictable and users expect responsive UIs.

# How

Adds an optional `timeout` (in milliseconds) to `TokenRequestConfig` and `RevokeTokenRequestConfig`. When set, the underlying `fetch` is aborted after the  specified duration via `AbortController` + `setTimeout` (rather than `AbortSignal.timeout()` for compatibility with all Hermes versions).

# Test Plan

Call `exchangeCodeAsync`, `refreshAsync`, and `revokeAsync` with a short timeout against a slow endpoint to confirm the request rejects.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
