### PR TITLE
[expo-navigation-bar] Update NavigationBar background color on Android < Q

### DIFF
--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `setStyle` on Android < Q by setting an explicit navigation bar color for proper button contrast. ([#44477](https://github.com/expo/expo/pull/44477) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 - Deprecated `setVisibilityAsync`, `getVisibilityAsync`, `useVisibility`, `addVisibilityListener`, and top-level `setStyle` in favor of the `NavigationBar` component and its static methods. ([#44327](https://github.com/expo/expo/pull/44327) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -45,6 +45,14 @@ class NavigationBarModule : Module() {
     }
 
     AsyncFunction("setStyle") { style: String ->
+      // android:enforceNavigationBarContrast is not available below Android Q.
+      // This means the navigation bar is always semi-opaque, but the button style
+      // is not automatically adjusted for contrast. We prevent changing
+      // it to avoid "light on light" or "dark on dark" navigation bar style.
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        return@AsyncFunction
+      }
+
       val window = currentActivity.window
 
       WindowInsetsControllerCompat(window, window.decorView).run {

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -1,5 +1,6 @@
 package expo.modules.navigationbar
 
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.view.View
@@ -9,6 +10,15 @@ import androidx.core.view.WindowInsetsControllerCompat
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+
+// The light scrim color used in the platform API 29+
+// https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/com/android/internal/policy/DecorView.java;drc=6ef0f022c333385dba2c294e35b8de544455bf19;l=142
+internal val LightNavigationBarColor = Color.argb(0xe6, 0xFF, 0xFF, 0xFF)
+
+// The dark scrim color used in the platform.
+// https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/res/res/color/system_bar_background_semi_transparent.xml
+// https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/res/remote_color_resources_res/values/colors.xml;l=67
+internal val DarkNavigationBarColor = Color.argb(0x80, 0x1b, 0x1b, 0x1b)
 
 class NavigationBarModule : Module() {
   private val currentActivity get() = appContext.throwingActivity
@@ -45,21 +55,23 @@ class NavigationBarModule : Module() {
     }
 
     AsyncFunction("setStyle") { style: String ->
-      // android:enforceNavigationBarContrast is not available below Android Q.
-      // This means the navigation bar is always semi-opaque, but the button style
-      // is not automatically adjusted for contrast. We prevent changing
-      // it to avoid "light on light" or "dark on dark" navigation bar style.
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+      // isAppearanceLightNavigationBars is not available below Android O.
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
         return@AsyncFunction
       }
 
       val window = currentActivity.window
+      val light = style == "dark" // dark content -> light background
+
+      // android:enforceNavigationBarContrast is not available below Android Q.
+      // This means the button style is not automatically adjusted for contrast,
+      // so we set an explicit navigation bar color to avoid invisible buttons.
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        window.navigationBarColor = if (light) LightNavigationBarColor else DarkNavigationBarColor
+      }
 
       WindowInsetsControllerCompat(window, window.decorView).run {
-        when (style) {
-          "dark" -> isAppearanceLightNavigationBars = true
-          "light" -> isAppearanceLightNavigationBars = false
-        }
+        isAppearanceLightNavigationBars = light
       }
 
       return@AsyncFunction

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarModule.kt
@@ -54,6 +54,7 @@ class NavigationBarModule : Module() {
       }
     }
 
+    @Suppress("DEPRECATION")
     AsyncFunction("setStyle") { style: String ->
       // isAppearanceLightNavigationBars is not available below Android O.
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
@@ -61,17 +62,17 @@ class NavigationBarModule : Module() {
       }
 
       val window = currentActivity.window
-      val light = style == "dark" // dark content -> light background
+      val hasLightBackground = style == "dark" // dark content -> light background
 
       // android:enforceNavigationBarContrast is not available below Android Q.
       // This means the button style is not automatically adjusted for contrast,
       // so we set an explicit navigation bar color to avoid invisible buttons.
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
-        window.navigationBarColor = if (light) LightNavigationBarColor else DarkNavigationBarColor
+        window.navigationBarColor = if (hasLightBackground) LightNavigationBarColor else DarkNavigationBarColor
       }
 
       WindowInsetsControllerCompat(window, window.decorView).run {
-        isAppearanceLightNavigationBars = light
+        isAppearanceLightNavigationBars = hasLightBackground
       }
 
       return@AsyncFunction


### PR DESCRIPTION
# Why

On Android < Q (API 29), `android:enforceNavigationBarContrast` is not available. This means the navigation bar button style is not automatically adjusted for contrast, which can result in invisible buttons ("light on light" or "dark on dark").

Additionally, `isAppearanceLightNavigationBars` is not available below Android O (API 26), so `setStyle` should no-op entirely on those devices.

# How

- Added an early return for Android < O, where `isAppearanceLightNavigationBars` is not supported.
- On Android O–P (API 26–28), we now set an explicit navigation bar color using the same light/dark scrim colors used by the platform on API 29+. This ensures proper contrast between the bar background and its buttons.

# Test Plan

- Run on an Android < O emulator/device, call `NavigationBar.setStyle("dark")`, verify it no-ops.
- Run on an Android O–P device, call `NavigationBar.setStyle("dark")` / `NavigationBar.setStyle("light")`, verify the navigation bar color changes to provide proper contrast.
- Run on an Android >= Q device, call `NavigationBar.setStyle("dark")` / `NavigationBar.setStyle("light")`, verify the style updates correctly as before.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

# Screenshots

## Current behavior

<img width="514" height="962" alt="Android 9 - style= light" src="https://github.com/user-attachments/assets/723d285b-46e1-48a1-bba3-49c2f67238a2" />
