### PR TITLE
[ci] improve filesystem test stability

### DIFF
--- a/apps/test-suite/tests/FileSystem.ts
+++ b/apps/test-suite/tests/FileSystem.ts
@@ -1539,13 +1539,14 @@ export async function test({ describe, expect, it, ...t }) {
       });
 
       it('can cancel a download with AbortSignal', async () => {
-        // Use a large file to ensure we have time to cancel
-        const url = 'https://httpbingo.org/bytes/5242880';
+        // Use a slow-streaming endpoint to ensure the download is still in-flight when we cancel.
+        // Note: httpbingo.org/bytes has a 524288 byte limit and returns 400 for larger values.
+        const url = 'https://httpbingo.org/drip?numbytes=51200&duration=5&delay=0';
         const file = new File(testDirectory, 'cancel_test.bin');
         const controller = new AbortController();
 
-        // Cancel after a short delay
-        setTimeout(() => controller.abort(), 50);
+        // Cancel after a short delay — the /drip endpoint streams over 5s so this is safe.
+        setTimeout(() => controller.abort(), 100);
 
         let error: any;
         try {
@@ -1582,7 +1583,8 @@ export async function test({ describe, expect, it, ...t }) {
       });
 
       it('can use onProgress and signal together', async () => {
-        const url = 'https://httpbingo.org/bytes/524288';
+        // /drip streams data over 5s, so progress events fire before the download completes.
+        const url = 'https://httpbingo.org/drip?numbytes=51200&duration=5&delay=0';
         const file = new File(testDirectory, 'progress_and_cancel.bin');
         const controller = new AbortController();
         const progressUpdates: { bytesWritten: number; totalBytes: number }[] = [];


### PR DESCRIPTION
# Why

The `expo-file-system` download abort tests flake on iOS CI. .

# How

- Switch both abort-related tests from `/bytes` (instant response) to `/drip` (streams data over 5 seconds), guaranteeing the download is still in-flight when the abort fires.
- Bump the abort timer from 50ms to 100ms for more headroom on loaded CI runners.

# Test Plan



1. Verify CI passes on this branch.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)