### PR TITLE
[docs] Fix broken React Navigation drawer link

### DIFF
--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -19,7 +19,7 @@ A navigation drawer is a common pattern in mobile apps, it allows users to swipe
 <Tabs>
 <Tab label="SDK 54 and later">
 
-To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some additional dependencies if you do not have them already. On Android and iOS, the drawer navigator requires `react-native-reanimated` and `react-native-worklets` to drive its animations. On web, this is handled by CSS animations.
+To use [drawer navigator](https://reactnavigation.org/docs/drawer-navigator) you'll need to install some additional dependencies if you do not have them already. On Android and iOS, the drawer navigator requires `react-native-reanimated` and `react-native-worklets` to drive its animations. On web, this is handled by CSS animations.
 
 <Terminal
   cmd={[
@@ -30,7 +30,7 @@ To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigati
 </Tab>
 <Tab label="SDK 53 and earlier">
 
-To use [drawer navigator](https://reactnavigation.org/docs/drawer-based-navigation) you'll need to install some additional dependencies if you do not have them already. On Android and iOS, the drawer navigator requires `react-native-reanimated` and `react-native-gesture-handler` to drive its animations. On web, this is handled by CSS animations.
+To use [drawer navigator](https://reactnavigation.org/docs/drawer-navigator) you'll need to install some additional dependencies if you do not have them already. On Android and iOS, the drawer navigator requires `react-native-reanimated` and `react-native-gesture-handler` to drive its animations. On web, this is handled by CSS animations.
 
 <Terminal
   cmd={[


### PR DESCRIPTION
# Why

The React Navigation link in the Expo Router drawer documentation was pointing to a page that returned 404. This PR updates it to the correct working documentation page.

# How

Updated the broken React Navigation drawer documentation link in `docs/pages/router/advanced/drawer.mdx` to the correct URL:
`https://reactnavigation.org/docs/drawer-navigator`

# Test Plan

- Opened the previous link and confirmed it returned a 404 page
- Opened the updated link and confirmed it resolves to the correct React Navigation drawer documentation page

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
