### PR TITLE
[docs] Update EAS CLI reference to 18.5.0

### DIFF
--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.4.0
+cliVersion: 18.5.0
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-03-17T10:19:56.588Z",
-    "cliVersion": "18.4.0"
+    "fetchedAt": "2026-04-04T06:57:27.992Z",
+    "cliVersion": "18.5.0"
   },
   "totalCommands": 102,
   "commands": [
@@ -329,12 +329,12 @@
     {
       "command": "eas metadata:pull",
       "description": "generate the local store configuration from the app stores",
-      "usage": "USAGE\n  $ eas metadata:pull [-e <value>]\n\nFLAGS\n  -e, --profile=<value>  Name of the submit profile from eas.json. Defaults to \"production\" if defined in eas.json.\n\nDESCRIPTION\n  generate the local store configuration from the app stores"
+      "usage": "USAGE\n  $ eas metadata:pull [-e <value>] [--non-interactive]\n\nFLAGS\n  -e, --profile=<value>  Name of the submit profile from eas.json. Defaults to \"production\" if defined in eas.json.\n      --non-interactive  Run the command in non-interactive mode.\n\nDESCRIPTION\n  generate the local store configuration from the app stores"
     },
     {
       "command": "eas metadata:push",
       "description": "sync the local store configuration to the app stores",
-      "usage": "USAGE\n  $ eas metadata:push [-e <value>]\n\nFLAGS\n  -e, --profile=<value>  Name of the submit profile from eas.json. Defaults to \"production\" if defined in eas.json.\n\nDESCRIPTION\n  sync the local store configuration to the app stores"
+      "usage": "USAGE\n  $ eas metadata:push [-e <value>] [--non-interactive]\n\nFLAGS\n  -e, --profile=<value>  Name of the submit profile from eas.json. Defaults to \"production\" if defined in eas.json.\n      --non-interactive  Run the command in non-interactive mode.\n\nDESCRIPTION\n  sync the local store configuration to the app stores"
     },
     {
       "command": "eas new [PATH]",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update the EAS CLI reference to 18.5.0 to update `eas metadata:pull` and `eas metadata:push` descriptions with `--non-interactive` option.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Run `yarn run eas-cli-sync`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2394" height="1722" alt="CleanShot 2026-04-04 at 12 30 43@2x" src="https://github.com/user-attachments/assets/fb943084-9b88-43bd-9326-b93e098a009d" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
