### PR TITLE
[ios][image] Fix contentPosition offset using unrounded layout size

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed `contentPosition` misalignment by using the unrounded cover/contain layout size for offset math. This resolves [#44466](https://github.com/expo/expo/issues/44466)
+- [iOS] Fixed `contentPosition` misalignment by using the unrounded cover/contain layout size for offset math. This resolves [#44466](https://github.com/expo/expo/issues/44466) ([#44497](https://github.com/expo/expo/pull/44497) by [@alicenoknow](https://github.com/alicenoknow))
 - [Android] Apply `ApplicationVersionSignature` to local resource URIs (`res:/` scheme) to prevent stale cached images after app updates. by [@linkeryoon](https://github.com/linkeryoon) ([#44355](https://github.com/expo/expo/pull/44355) by [@Yoon-Hae-Min](https://github.com/Yoon-Hae-Min))
 - Added `tintColor` option to `ImageLoadOptions`. This resolves [#42007](https://github.com/expo/expo/issues/42007). ([#42821](https://github.com/expo/expo/pull/42821)) by [@HubertBer](https://github.com/HubertBer).
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `contentPosition` misalignment by using the unrounded cover/contain layout size for offset math. This resolves [#44466](https://github.com/expo/expo/issues/44466)
 - [Android] Apply `ApplicationVersionSignature` to local resource URIs (`res:/` scheme) to prevent stale cached images after app updates. by [@linkeryoon](https://github.com/linkeryoon) ([#44355](https://github.com/expo/expo/pull/44355) by [@Yoon-Hae-Min](https://github.com/Yoon-Hae-Min))
 - Added `tintColor` option to `ImageLoadOptions`. This resolves [#42007](https://github.com/expo/expo/issues/42007). ([#42821](https://github.com/expo/expo/pull/42821)) by [@HubertBer](https://github.com/HubertBer).
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed `contentPosition` misalignment by using the unrounded cover/contain layout size for offset math. This resolves [#44466](https://github.com/expo/expo/issues/44466) ([#44497](https://github.com/expo/expo/pull/44497) by [@alicenoknow](https://github.com/alicenoknow))
+- [iOS] Fixed `contentPosition` misalignment by using the unrounded cover/contain layout size for offset math. ([#44497](https://github.com/expo/expo/pull/44497) by [@alicenoknow](https://github.com/alicenoknow))
 - [Android] Apply `ApplicationVersionSignature` to local resource URIs (`res:/` scheme) to prevent stale cached images after app updates. by [@linkeryoon](https://github.com/linkeryoon) ([#44355](https://github.com/expo/expo/pull/44355) by [@Yoon-Hae-Min](https://github.com/Yoon-Hae-Min))
 - Added `tintColor` option to `ImageLoadOptions`. This resolves [#42007](https://github.com/expo/expo/issues/42007). ([#42821](https://github.com/expo/expo/pull/42821)) by [@HubertBer](https://github.com/HubertBer).
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -91,6 +91,11 @@ public final class ImageView: ExpoView {
    */
   var imageIdealSize: CGSize = .zero
 
+  /**
+   `idealSize` before rounding, used only for `contentPosition` math so alignment matches true cover/contain geometry.
+   */
+  var imageLayoutSize: CGSize = .zero
+
   // MARK: - Events
 
   let onLoadStart = EventDispatcher()
@@ -139,7 +144,7 @@ public final class ImageView: ExpoView {
     if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
       // The mask layer we adjusted would be invaliated from `RCTViewComponentView.traitCollectionDidChange`.
       // After that we have to recalculate the mask layer in `applyContentPosition`.
-      applyContentPosition(contentSize: imageIdealSize, containerSize: frame.size)
+      applyContentPosition(contentSize: imageLayoutSize, containerSize: frame.size)
     }
   }
 
@@ -266,15 +271,16 @@ public final class ImageView: ExpoView {
       ])
 
       let scale = window?.screen.scale ?? UIScreen.main.scale
-      imageIdealSize = idealSize(
+      imageLayoutSize = idealSize(
         contentPixelSize: image.size * image.scale,
         containerSize: frame.size,
         scale: scale,
         contentFit: contentFit
-      ).rounded(.up)
+      )
+      imageIdealSize = imageLayoutSize.rounded(.up)
 
       let image = processImage(image, idealSize: imageIdealSize, scale: scale)
-      applyContentPosition(contentSize: imageIdealSize, containerSize: frame.size)
+      applyContentPosition(contentSize: imageLayoutSize, containerSize: frame.size)
       renderSourceImage(image)
     } else {
       displayPlaceholderIfNecessary()
@@ -310,14 +316,15 @@ public final class ImageView: ExpoView {
     ])
 
     let scale = window?.screen.scale ?? UIScreen.main.scale
-    imageIdealSize = idealSize(
+    imageLayoutSize = idealSize(
       contentPixelSize: image.size * image.scale,
       containerSize: frame.size,
       scale: scale,
       contentFit: contentFit
-    ).rounded(.up)
+    )
+    imageIdealSize = imageLayoutSize.rounded(.up)
 
-    applyContentPosition(contentSize: imageIdealSize, containerSize: frame.size)
+    applyContentPosition(contentSize: imageLayoutSize, containerSize: frame.size)
     renderSFSymbolImage(image)
   }
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -87,11 +87,6 @@ public final class ImageView: ExpoView {
   var isSFSymbolSource: Bool = false
 
   /**
-   The ideal image size that fills in the container size while maintaining the source aspect ratio.
-   */
-  var imageIdealSize: CGSize = .zero
-
-  /**
    `idealSize` before rounding, used only for `contentPosition` math so alignment matches true cover/contain geometry.
    */
   var imageLayoutSize: CGSize = .zero
@@ -277,8 +272,7 @@ public final class ImageView: ExpoView {
         scale: scale,
         contentFit: contentFit
       )
-      imageIdealSize = imageLayoutSize.rounded(.up)
-
+      let imageIdealSize = imageLayoutSize.rounded(.up)
       let image = processImage(image, idealSize: imageIdealSize, scale: scale)
       applyContentPosition(contentSize: imageLayoutSize, containerSize: frame.size)
       renderSourceImage(image)
@@ -322,7 +316,6 @@ public final class ImageView: ExpoView {
       scale: scale,
       contentFit: contentFit
     )
-    imageIdealSize = imageLayoutSize.rounded(.up)
 
     applyContentPosition(contentSize: imageLayoutSize, containerSize: frame.size)
     renderSFSymbolImage(image)


### PR DESCRIPTION
# Why

On iOS, `contentFit="cover"` with `contentPosition` could show a thin **white line / gap** at the container edge (layout depends on image and screen dimensions). See [#44466](https://github.com/expo/expo/issues/44466) and the repro in that issue.

Fixes https://github.com/expo/expo/issues/44466

# How

Positioning now uses the exact layout size from `idealSize`, only image resizing still rounds sizes up.

# Test Plan

- Ran tests and lint checks
- Verified on repro that the fix resolves the issue
- Build `bare-expo` app with the change and verified `contentPosition` logic works as expected for provided examples

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
