### PR TITLE
[expo-widgets] support AccessoryWidgetBackground in widget rendering

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### 🐛 Bug fixes
 
-- Add support for `AccessoryWidgetBackground` views from `@expo/ui` in widget rendering.
+- Add support for `AccessoryWidgetBackground` views from `@expo/ui` in widget rendering. ([#44499](https://github.com/expo/expo/pull/44499) by [@cinques](https://github.com/cinques))
 - Fix `ExpoWidgets.bundle` not copied to widget extension when `use_frameworks` is active. ([#44065](https://github.com/expo/expo/pull/44065) by [@marvwhere](https://github.com/marvwhere))
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
 - [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### 🐛 Bug fixes
 
+- Add support for `AccessoryWidgetBackground` views from `@expo/ui` in widget rendering.
 - Fix `ExpoWidgets.bundle` not copied to widget extension when `use_frameworks` is active. ([#44065](https://github.com/expo/expo/pull/44065) by [@marvwhere](https://github.com/marvwhere))
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))
 - [plugin] Fix reading undefined when config is not provided. ([#43568](https://github.com/expo/expo/pull/43568) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -65,6 +65,8 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
       render(CircleView.self, CircleViewProps.self)
     case "ImageView":
       render(ImageView.self, ImageViewProps.self)
+    case "AccessoryWidgetBackgroundView":
+      render(AccessoryWidgetBackgroundView.self, AccessoryWidgetBackgroundProps.self)
     case "DividerView":
       render(DividerView.self, DividerProps.self)
     case "EllipseView":


### PR DESCRIPTION
## Summary

This adds `AccessoryWidgetBackgroundView` to the set of view types supported by `WidgetsDynamicView` in `expo-widgets`.

## Why

`@expo/ui` already exports `AccessoryWidgetBackground` and registers its native SwiftUI view, but `expo-widgets` does not handle the corresponding `AccessoryWidgetBackgroundView` node when rendering widget layouts.

In practice, using `AccessoryWidgetBackground` inside an `expo-widgets` widget causes the widget renderer to fall back to the "Unable to get the view for ..." path instead of rendering the lock screen accessory background.

## Validation

- Reproduced with a lock screen `accessoryCircular` widget using `AccessoryWidgetBackground` from `@expo/ui`
- Verified the missing runtime case in `WidgetsDynamicView`
- Ran `git diff --check`
