### PR TITLE
[docs] Add TypeScript tsconfig.json setup for Jest types in unit test

### DIFF
--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -47,6 +47,16 @@ Install `jest-expo` and other required dev dependencies in your project. Run the
 
 > **Note:** If your project is not using TypeScript, you can skip installing `@types/jest`.
 
+If your project uses TypeScript, add `"jest"` to the `types` array in your **tsconfig.json** to enable Jest's type definitions:
+
+```json tsconfig.json
+{
+  "compilerOptions": {
+    "types": ["jest"]
+  }
+}
+```
+
 </Step>
 
 <Step label="2">


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

When using Jest with TypeScript, the Jest global types (e.g., describe, it, expect) are not recognized by the TypeScript compiler unless "jest" is included in the types array in tsconfig.json. This adds that setup step to the unit testing docs so users don't run into type errors.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Added a note and code snippet in Step 1 of the unit testing guide, right after the @types/jest installation instruction, showing how to configure tsconfig.json with "types": ["jest"].

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified the docs page renders correctly with the new content by reviewing the MDX source.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [X] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [X] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [X] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
