### PR TITLE
[docs] Update React Compiler ESLint plugin to eslint-plugin-react-hooks

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -65,11 +65,11 @@ Toggle on the React Compiler experiment in your app config file:
 
 Additionally, you should use the ESLint plugin to continuously enforce the rules of React in your project.
 
-> **Note:** As of React Compiler 1.0, the compiler's lint rules have been merged into `eslint-plugin-react-hooks`. If you are on an older beta version of the compiler (SDK 53 and earlier), use `eslint-plugin-react-compiler` instead.
+> **Note:** React Compiler 1.0 moved its lint rules into `eslint-plugin-react-hooks`. If you are on an older beta version of the compiler (SDK 53 and earlier), use `eslint-plugin-react-compiler` instead.
 
 <Step label="1">
 
-Run [`npx expo lint`](/guides/using-eslint/#eslint) to ensure ESLint is setup in your app, then install the ESLint plugin:
+Run [`npx expo lint`](/guides/using-eslint/#eslint) to ensure ESLint is set up in your app, then install the ESLint plugin:
 
 <Terminal cmd={['$ npx expo install eslint-plugin-react-hooks -- -D']} />
 

--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -65,27 +65,29 @@ Toggle on the React Compiler experiment in your app config file:
 
 Additionally, you should use the ESLint plugin to continuously enforce the rules of React in your project.
 
+> **Note:** As of React Compiler 1.0, the compiler's lint rules have been merged into `eslint-plugin-react-hooks`. If you are on an older beta version of the compiler (SDK 53 and earlier), use `eslint-plugin-react-compiler` instead.
+
 <Step label="1">
 
-Run [`npx expo lint`](/guides/using-eslint/#eslint) to ensure ESLint is setup in your app, then install the ESLint plugin for React Compiler:
+Run [`npx expo lint`](/guides/using-eslint/#eslint) to ensure ESLint is setup in your app, then install the ESLint plugin:
 
-<Terminal cmd={['$ npx expo install eslint-plugin-react-compiler -- -D']} />
+<Terminal cmd={['$ npx expo install eslint-plugin-react-hooks -- -D']} />
 
 </Step>
 
 <Step label="2">
 
-Update your [ESLint configuration](/guides/using-eslint/) to include the plugin:
+Update your [ESLint configuration](/guides/using-eslint/) to enable the React Compiler rules:
 
 ```js .eslintrc.js
 // https://docs.expo.dev/guides/using-eslint/
 const { defineConfig } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
-const reactCompiler = require('eslint-plugin-react-compiler');
+const reactHooks = require('eslint-plugin-react-hooks');
 
 module.exports = defineConfig([
   expoConfig,
-  reactCompiler.configs.recommended,
+  reactHooks.configs['recommended-latest'],
   {
     ignores: ['dist/*'],
   },


### PR DESCRIPTION
# Why

The guide tells users to install `eslint-plugin-react-compiler`, but since React Compiler 1.0 those rules moved into `eslint-plugin-react-hooks` under the `recommended-latest` config. The standalone plugin is no longer the recommended path.

Closes #44237.

# How

Updated the install command to use `eslint-plugin-react-hooks` and updated the config example to use `reactHooks.configs['recommended-latest']`. Added a note for users on SDK 53 and earlier (beta compiler) who still need `eslint-plugin-react-compiler`.

Also fixed a pre-existing grammar error on the same line: `ESLint is setup` → `ESLint is set up`.

# Test Plan

Docs-only change.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)