### PR TITLE
[ci] fix failing snapshots

### DIFF
--- a/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/__tests__/__snapshots__/Maps-test.ts.snap
@@ -253,6 +253,7 @@ ENV['EX_DEV_CLIENT_NETWORK_INSPECTOR'] ||= podfile_properties['EX_DEV_CLIENT_NET
 ENV['RCT_USE_RN_DEP'] ||= '0' if podfile_properties['ios.buildReactNativeFromSource'] == 'true'
 ENV['RCT_USE_PREBUILT_RNCORE'] ||= '0' if podfile_properties['ios.buildReactNativeFromSource'] == 'true'
 ENV['RCT_HERMES_V1_ENABLED'] ||= '1' if podfile_properties['expo.useHermesV1'] == 'true'
+ENV['EXPO_USE_PRECOMPILED_MODULES'] ||= '1' if podfile_properties['EXPO_USE_PRECOMPILED_MODULES'] == '1'
 platform :ios, podfile_properties['ios.deploymentTarget'] || '16.4'
 
 prepare_react_native_project!

--- a/packages/eslint-config-universe/__tests__/default-test.js
+++ b/packages/eslint-config-universe/__tests__/default-test.js
@@ -29,9 +29,9 @@ it(`lints with the default config`, async () => {
     ['fixtures/*all*'],
   );
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);
 

--- a/packages/eslint-config-universe/__tests__/native-test.js
+++ b/packages/eslint-config-universe/__tests__/native-test.js
@@ -29,9 +29,9 @@ it(`lints with the React Native config`, async () => {
     ['fixtures/*all*', 'fixtures/*native*'],
   );
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);
 

--- a/packages/eslint-config-universe/__tests__/node-test.js
+++ b/packages/eslint-config-universe/__tests__/node-test.js
@@ -29,9 +29,9 @@ it(`lints with the Node config`, async () => {
     ['fixtures/*all*', 'fixtures/*node*'],
   );
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);
 

--- a/packages/eslint-config-universe/__tests__/typescript-analysis-test.js
+++ b/packages/eslint-config-universe/__tests__/typescript-analysis-test.js
@@ -22,8 +22,8 @@ it(`lints`, async () => {
   );
 
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);

--- a/packages/eslint-config-universe/__tests__/web-test.js
+++ b/packages/eslint-config-universe/__tests__/web-test.js
@@ -29,9 +29,9 @@ it(`lints with the web config`, async () => {
     ['fixtures/*all*', 'fixtures/*web*'],
   );
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);
 

--- a/packages/eslint-config-universe/flat/__tests__/default-test.js
+++ b/packages/eslint-config-universe/flat/__tests__/default-test.js
@@ -27,9 +27,9 @@ it(`lints with the default config`, async () => {
     ['fixtures/*all*'],
   );
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);
 

--- a/packages/eslint-config-universe/flat/__tests__/native-test.js
+++ b/packages/eslint-config-universe/flat/__tests__/native-test.js
@@ -27,9 +27,9 @@ it(`lints with the React Native config`, async () => {
     ['fixtures/*all*', 'fixtures/*native*'],
   );
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);
 

--- a/packages/eslint-config-universe/flat/__tests__/node-test.js
+++ b/packages/eslint-config-universe/flat/__tests__/node-test.js
@@ -27,9 +27,9 @@ it(`lints with the Node config`, async () => {
     ['fixtures/*all*', 'fixtures/*node*'],
   );
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);
 

--- a/packages/eslint-config-universe/flat/__tests__/typescript-analysis-test.js
+++ b/packages/eslint-config-universe/flat/__tests__/typescript-analysis-test.js
@@ -25,8 +25,8 @@ it(`lints`, async () => {
   );
 
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);

--- a/packages/eslint-config-universe/flat/__tests__/web-test.js
+++ b/packages/eslint-config-universe/flat/__tests__/web-test.js
@@ -27,9 +27,9 @@ it(`lints with the web config`, async () => {
     ['fixtures/*all*', 'fixtures/*web*'],
   );
   for (const result of results) {
-    const relativeFilePath = path.relative(__dirname, result.filePath);
+    const platformIndependentPath = path.relative(__dirname, result.filePath).replace(/\\/g, '/');
     delete result.filePath;
-    expect(result).toMatchSnapshot(relativeFilePath);
+    expect(result).toMatchSnapshot(platformIndependentPath);
   }
 }, 20000);
 


### PR DESCRIPTION
# Why



failures such as https://github.com/expo/expo/actions/runs/23949380922/job/69852927861 in eslint-config-universe (windows) and `packages/@expo/config-plugins`

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- fix snapshots

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- green CI on https://github.com/expo/expo/actions/runs/24024223807, except there's failure in `packages/expo-sqlite/dev-plugin-webui/package.json` on windows that can likely be reverted by the change from here, https://github.com/expo/expo/pull/41194/changes#diff-4717a41eabd2daca7296a3a4f3ac38d215463292480dd49fa6848bbb95af9a45 - just need to try it out

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)