### PR TITLE
[ui] improve Children performance

### DIFF
--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.RecomposeScope
 import androidx.compose.runtime.currentRecomposeScope
+import androidx.compose.runtime.key
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -107,9 +108,11 @@ abstract class ExpoComposeView<T : ComposeProps>(
     recomposeScope = currentRecomposeScope
     for (index in 0..<this.size) {
       val child = getChildAt(index) as? ExpoComposeView<*> ?: continue
-      with(composableScope ?: ComposableScope()) {
-        with(child) {
-          Content()
+      key(child) {
+        with(composableScope ?: ComposableScope()) {
+          with(child) {
+            Content()
+          }
         }
       }
     }
@@ -123,9 +126,11 @@ abstract class ExpoComposeView<T : ComposeProps>(
       if (!filter(child)) {
         continue
       }
-      with(composableScope ?: ComposableScope()) {
-        with(child) {
-          Content()
+      key(child) {
+        with(composableScope ?: ComposableScope()) {
+          with(child) {
+            Content()
+          }
         }
       }
     }
@@ -135,9 +140,11 @@ abstract class ExpoComposeView<T : ComposeProps>(
   fun Child(composableScope: ComposableScope, index: Int) {
     recomposeScope = currentRecomposeScope
     val child = getChildAt(index) as? ExpoComposeView<*> ?: return
-    with(composableScope) {
-      with(child) {
-        Content()
+    key(child) {
+      with(composableScope) {
+        with(child) {
+          Content()
+        }
       }
     }
   }

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -70,6 +70,7 @@
 - [iOS] Add `AsyncFunction` support in `ExpoUIView` definition function. ([#43669](https://github.com/expo/expo/pull/43669) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Introduce `SlotView` to replace structural child view types with a single generic slot. ([#43607](https://github.com/expo/expo/pull/43607) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Make RNHostView SwiftUI view ([#43570](https://github.com/expo/expo/pull/43570) by [@nishan](https://github.com/intergalacticspacehighway))
+- [jetpack-compose] Use view hash code as key for `Children`. ([#44521](https://github.com/expo/expo/pull/44521) by [@kudo](https://github.com/kudo))
 
 ## 55.0.1 — 2026-02-25
 


### PR DESCRIPTION
# Why

improve jetpack-compose Children performance

# How

use `key(child)` than the default index

# Test Plan

NCL

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
