### PR TITLE
[ui] fix RNHostView re-parent exception

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -64,6 +64,7 @@
 - [Android] Added `RNHostView` to improve RN component layout inside Compose views. ([#43495](https://github.com/expo/expo/pull/43495) by [@nishan](https://github.com/intergalacticspacehighway))
 - [Android] Fix `ContextMenu` not expanding when triggered by `IconButton`. ([#43592](https://github.com/expo/expo/pull/43592) by [@nishan](https://github.com/intergalacticspacehighway))
 - [android] fix modifiers export ([#43639](https://github.com/expo/expo/pull/43639) by [@Ubax](https://github.com/Ubax))
+- [jetpack-compose] Fixed `RNHostView` re-parenting exception. ([#44522](https://github.com/expo/expo/pull/44522) by [@kudo](https://github.com/kudo))
 
 ### 💡 Others
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
@@ -88,19 +88,21 @@ internal class RNHostView(context: Context, appContext: AppContext) :
 
     wrapperState.value?.let { wrapper ->
       val childView = childViewState.value ?: return@let
-      if (matchContents) {
-        AndroidView(
-          factory = { wrapper },
-          modifier = applySizeFromYogaNodeModifier(childView)
-        )
+      val modifier = if (matchContents) {
+        applySizeFromYogaNodeModifier(childView)
       } else {
-        AndroidView(
-          factory = { wrapper },
-          modifier = Modifier
-            .fillMaxSize()
-            .then(reportSizeToYogaNodeModifier())
-        )
+        Modifier
+          .fillMaxSize()
+          .then(reportSizeToYogaNodeModifier())
       }
+
+      AndroidView(
+        factory = {
+          (wrapper.parent as? ViewGroup)?.removeView(wrapper)
+          wrapper
+        },
+        modifier = modifier
+      )
     }
   }
 


### PR DESCRIPTION
# Why

fixed the other error: `java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.`

# How

remove parent first

# Test Plan

```jsx
import { Host, LazyColumn, RNHostView, Text } from '@expo/ui/jetpack-compose';
import { useState } from 'react';
import { Button, View } from 'react-native';

export default function CrashTest() {
  const [show, setShow] = useState(true);

  return (
    <View style={{ flex: 1, paddingTop: 80 }}>
      <Button
        title={show ? 'Hide middle item' : 'Show middle item'}
        onPress={() => setShow((v) => !v)}
      />
      <Host style={{ flex: 1 }}>
        <LazyColumn>
          <Text>Item A</Text>
          {show && <Text>Item B (conditional)</Text>}
          <RNHostView matchContents>
            <View style={{ padding: 20, backgroundColor: '#E3F2FD' }}>
              <Button title="I'm an RN View in RNHostView" onPress={() => {}} />
            </View>
          </RNHostView>
        </LazyColumn>
      </Host>
    </View>
  );
}
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
