### PR TITLE
[docs] Fix style order in GestureDetector example

### DIFF
--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -184,7 +184,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
         <Animated.Image
           source={stickerSource}
           resizeMode="contain"
-          style={/* @tutinfo Modify the <CODE>style</CODE> prop on the <CODE>Animated.Image</CODE> to pass the <CODE>imageStyle</CODE>. */[imageStyle, { width: imageSize, height: imageSize }]/* @end */}
+          style={/* @tutinfo Modify the <CODE>style</CODE> prop on the <CODE>Animated.Image</CODE> to pass the <CODE>imageStyle</CODE>. */[{ width: imageSize, height: imageSize }, imageStyle]/* @end */}
         />
       /* @tutinfo */
       </GestureDetector>

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -326,7 +326,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
           <Animated.Image
             source={stickerSource}
             resizeMode="contain"
-            style={[imageStyle, { width: imageSize, height: imageSize }]}
+            style={[{ width: imageSize, height: imageSize }, imageStyle]}
           />
         </GestureDetector>
       </Animated.View>


### PR DESCRIPTION
# Why

If the style is `[imageStyle, { width: imageSize, height: imageSize }]`, our animated `imageStyle` will be overridden by the latter width and height. So I think maybe it's more accurate to put `imageStyle` in the end.

# How

Fix a style order error in GestureDetector example.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
