### PR TITLE
[expo-video][android] Hide surface until first frame after source replace

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [iOS] Fix crashes when `VideoTrack` properties are non-finite. ([#44108](https://github.com/expo/expo/pull/44108) by [@behenate](https://github.com/behenate))
 - [Android] Fix PiP exiting immediately after auto-entering from fullscreen. ([#44157](https://github.com/expo/expo/pull/44157) by [@behenate](https://github.com/behenate))
 - [Android] Fix broken layout after returning from PiP when auto-enter if off. ([#44163](https://github.com/expo/expo/pull/44163) by [@behenate](https://github.com/behenate))
+- [Android] Hide the surface until the first frame after replacing the video source so the previous stream does not remain visible when switching to a different resolution. ([#44385](https://github.com/expo/expo/issues/44385))
 
 ### 💡 Others
 

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [iOS] Fix crashes when `VideoTrack` properties are non-finite. ([#44108](https://github.com/expo/expo/pull/44108) by [@behenate](https://github.com/behenate))
 - [Android] Fix PiP exiting immediately after auto-entering from fullscreen. ([#44157](https://github.com/expo/expo/pull/44157) by [@behenate](https://github.com/behenate))
 - [Android] Fix broken layout after returning from PiP when auto-enter if off. ([#44163](https://github.com/expo/expo/pull/44163) by [@behenate](https://github.com/behenate))
-- [Android] Hide the surface until the first frame after replacing the video source so the previous stream does not remain visible when switching to a different resolution. ([#44385](https://github.com/expo/expo/issues/44385))
+- [Android] Hide the surface until the first frame after replacing the video source so the previous stream does not remain visible when switching to a different resolution. ([#44385](https://github.com/expo/expo/issues/44385)) ([#44467](https://github.com/expo/expo/pull/44467) by [@vj2303](https://github.com/vj2303))
 
 ### 💡 Others
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoView.kt
@@ -288,6 +288,17 @@ open class VideoView(context: Context, appContext: AppContext, useTextureView: B
     listeners.retainAll { it.get() != listener }
   }
 
+  override fun onSourceChanged(player: VideoPlayer, source: VideoSource?, oldSource: VideoSource?) {
+    // When replacing the media on the same player, keep the surface hidden until the first frame of
+    // the new item is rendered. Otherwise the previous stream can remain visible (often mis-scaled)
+    // while the new stream buffers — e.g. switching from a higher-resolution URL to a lower one.
+    // See https://github.com/expo/expo/issues/44385
+    if (player == videoPlayer && oldSource != null) {
+      shouldHideSurfaceView = true
+      applySurfaceViewVisibility()
+    }
+  }
+
   override fun onVideoSourceLoaded(
     player: VideoPlayer,
     videoSource: VideoSource?,


### PR DESCRIPTION
## Summary

Fixes [#44385](https://github.com/expo/expo/issues/44385): when replacing the video URL/stream on the same `VideoPlayer` (e.g. switching from an HD to an SD source), Android could show the previous stream on the `SurfaceView` until the new stream rendered its first frame.

This PR resets `VideoView` surface visibility on `onSourceChanged` so the surface is hidden during source replacement and shown again on first frame.

## Scope

This branch is cut from current `main` and includes only `expo-video` changes.

## Test plan

- [ ] CI
- [ ] Android repro from issue: switch HD -> SD source on same player and verify no ghosting / stale frame overlay

Made with [Cursor](https://cursor.com)