### PR TITLE
[docs] Fix broken same-page hash links in EAS Update debug page

### DIFF
--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -45,7 +45,7 @@ The following section describes common problems and how to fix them. Below is a 
   className="max-w-[600px]"
 />
 
-If the deployment channel is unexpected, it means our build was not built with the correct channel. To fix this, [configure our channel](/#configure-channel) and rebuild our app.
+If the deployment channel is unexpected, it means our build was not built with the correct channel. To fix this, [configure our channel](#configure-channel) and rebuild our app.
 
 ### Unexpected runtime version
 
@@ -55,7 +55,7 @@ If the deployment channel is unexpected, it means our build was not built with t
   className="max-w-[600px]"
 />
 
-If the deployment runtime version is unexpected, it means our build was not built with the correct runtime version. To fix this, [configure our runtime version](/#configure-runtime-version) and rebuild our app.
+If the deployment runtime version is unexpected, it means our build was not built with the correct runtime version. To fix this, [configure our runtime version](#configure-runtime-version) and rebuild our app.
 
 ### Unexpected branch
 
@@ -65,7 +65,7 @@ If the deployment runtime version is unexpected, it means our build was not buil
   className="max-w-[600px]"
 />
 
-If the deployment has an unexpected branch, we need to [map our channel to the correct branch](/#map-channel-to-branch).
+If the deployment has an unexpected branch, we need to [map our channel to the correct branch](#map-channel-to-branch).
 
 ### Missing updates
 
@@ -75,7 +75,7 @@ If the deployment has an unexpected branch, we need to [map our channel to the c
   className="max-w-[600px]"
 />
 
-The displayed deployment does not have any updates. To fix this, [publish an update to the branch](/#publish-update). If an update was already published, check the [Updates page](https://expo.dev/accounts/[account]/projects/[project]/updates) to make sure it matches the runtime version of our build.
+The displayed deployment does not have any updates. To fix this, [publish an update to the branch](#publish-update). If an update was already published, check the [Updates page](https://expo.dev/accounts/[account]/projects/[project]/updates) to make sure it matches the runtime version of our build.
 
 ### Missing branch
 
@@ -85,11 +85,11 @@ The displayed deployment does not have any updates. To fix this, [publish an upd
   className="max-w-[600px]"
 />
 
-The displayed deployment has the correct channel, but it is not linked to a branch. To fix this, [map the channel to the correct branch](/#map-channel-to-branch).
+The displayed deployment has the correct channel, but it is not linked to a branch. To fix this, [map the channel to the correct branch](#map-channel-to-branch).
 
 ### Missing deployment
 
-If our deployment is not displayed, it means our build is not configured properly for EAS Update. To fix this, [configure our channel](/#configure-channel), [configure our runtime version](/#configure-runtime-version) and verify our [general configuration](/eas-update/debug/#verifying-app-configuration). We'll need to rebuild our app after making these changes.
+If our deployment is not displayed, it means our build is not configured properly for EAS Update. To fix this, [configure our channel](#configure-channel), [configure our runtime version](#configure-runtime-version) and verify our [general configuration](/eas-update/debug/#verifying-app-configuration). We'll need to rebuild our app after making these changes.
 
 ### Automatic roll back when an update crashes
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20483

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix broken same-page hash links in docs/pages/eas-update/debug.mdx that used /#anchor format instead of #anchor

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)