### PR TITLE
Add expoStatusBarHidden and expoNavigationBarHidden attributes

### DIFF
--- a/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
@@ -15,9 +15,7 @@ import {
 } from '~/ui/components/ConfigSection';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-navigation-bar` enables you to modify and observe the native navigation bar on Android devices. Due to some Android platform restrictions, parts of this API overlap with the `expo-status-bar` API.
-
-The APIs in this package have no impact when "Gesture Navigation" is enabled on the Android device. There is currently no native Android API to detect if "Gesture Navigation" is enabled or not.
+`expo-navigation-bar` provides a component and an imperative API for controlling the app's navigation bar on Android devices, allowing you to change the color of its buttons or hide it.
 
 ## Installation
 
@@ -53,7 +51,7 @@ You can configure `expo-navigation-bar` using its built-in [config plugin](/conf
     {
       name: 'enforceContrast',
       description:
-        'Determines whether the operating system should keep the navigation bar translucent to provide contrast between the navigation buttons and app content.',
+        'Determines whether the operating system should keep the navigation bar translucent to provide contrast between the navigation buttons and app content. Has no effect on Android 9 and below.',
       default: 'true',
       platform: 'android',
     },

--- a/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/navigation-bar.mdx
@@ -78,13 +78,13 @@ You can configure `expo-navigation-bar` using its built-in [config plugin](/conf
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using a native **android** project manually, then you need to add the following configuration to your native project:
 
-- To hide the status bar on **Android**, add `expo_navigation_bar_visibility` to **android/app/src/main/res/values/strings.xml**:
+- To hide the navigation bar on **Android**, add `expoNavigationBarHidden` to **android/app/src/main/res/values/styles.xml**:
 
   ```xml
-  <resources>
+  <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
     <!-- ... -->
-    <string name="expo_navigation_bar_visibility" translatable="false">hidden</string>
-  </resources>
+    <item name="expoNavigationBarHidden">true</item>
+  </style>
   ```
 
 </ConfigReactNative>

--- a/docs/pages/versions/unversioned/sdk/status-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/status-bar.mdx
@@ -77,13 +77,13 @@ You can configure `expo-status-bar` using its built-in [config plugin](/config-p
 
 If you're not using Continuous Native Generation ([CNG](/workflow/continuous-native-generation/)) or you're using a native project manually, then you need to add the following configuration to your native project:
 
-- To hide the status bar on **Android**, add `expo_status_bar_visibility` to **android/app/src/main/res/values/strings.xml**:
+- To hide the status bar on **Android**, add `expoStatusBarHidden` to **android/app/src/main/res/values/styles.xml**:
 
   ```xml
-  <resources>
+  <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
     <!-- ... -->
-    <string name="expo_status_bar_visibility" translatable="false">hidden</string>
-  </resources>
+    <item name="expoStatusBarHidden">true</item>
+  </style>
   ```
 
 - To hide the status bar on **iOS**, set the following keys in your **ios/&lt;project&gt;/Info.plist**:

--- a/docs/pages/versions/unversioned/sdk/status-bar.mdx
+++ b/docs/pages/versions/unversioned/sdk/status-bar.mdx
@@ -18,7 +18,7 @@ import {
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { SnackInline } from '~/ui/components/Snippet';
 
-`expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, background color, hide it, make it translucent or opaque, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
+`expo-status-bar` gives you a component and imperative interface to control the app status bar to change its text color, hide it, and apply animations to any of these changes. Exactly what you are able to do with the `StatusBar` component depends on the platform you're using.
 
 > **tvOS and web support**
 >

--- a/packages/expo-navigation-bar/CHANGELOG.md
+++ b/packages/expo-navigation-bar/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 💡 Others
 
+- Replaced `expo_navigation_bar_visibility` string resource with `expoNavigationBarHidden` boolean theme attribute. ([#44536](https://github.com/expo/expo/pull/44536) by [@zoontek](https://github.com/zoontek))
 - Removed `androidNavigationBar` config overwrite (for Expo Go sync). ([#44469](https://github.com/expo/expo/pull/44469) by [@zoontek](https://github.com/zoontek))
 - Deprecated `setVisibilityAsync`, `getVisibilityAsync`, `useVisibility`, `addVisibilityListener`, and top-level `setStyle` in favor of the `NavigationBar` component and its static methods. ([#44327](https://github.com/expo/expo/pull/44327) by [@zoontek](https://github.com/zoontek))
 - Removed `react-native-is-edge-to-edge` dependency. ([#44196](https://github.com/expo/expo/pull/44196) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
+++ b/packages/expo-navigation-bar/android/src/main/java/expo/modules/navigationbar/NavigationBarReactActivityLifecycleListener.kt
@@ -1,26 +1,32 @@
 package expo.modules.navigationbar
 
 import android.app.Activity
+import android.content.res.Resources
 import android.os.Bundle
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
 class NavigationBarReactActivityLifecycleListener : ReactActivityLifecycleListener {
-  override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
-    // Execute static tasks before the JS engine starts.
-    // These values are defined via config plugins.
-    val visibility = activity.getString(R.string.expo_navigation_bar_visibility).lowercase()
+  private fun isNavigationBarHidden(theme: Resources.Theme): Boolean {
+    // This value is defined via config plugins
+    val attrs = intArrayOf(R.attr.expoNavigationBarHidden)
+    val typedArray = theme.obtainStyledAttributes(attrs)
 
-    if (visibility.isNotBlank()) {
+    return try {
+      typedArray.getBoolean(0, false)
+    } finally {
+      typedArray.recycle()
+    }
+  }
+
+  override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
+    // Execute static tasks before the JS engine starts
+    if (isNavigationBarHidden(activity.theme)) {
       val window = activity.window
 
-      WindowInsetsControllerCompat(window, window.decorView).run {
-        when (visibility) {
-          "hidden" -> hide(WindowInsetsCompat.Type.navigationBars())
-          "visible" -> show(WindowInsetsCompat.Type.navigationBars())
-        }
-      }
+      WindowInsetsControllerCompat(window, window.decorView)
+        .hide(WindowInsetsCompat.Type.navigationBars())
     }
   }
 }

--- a/packages/expo-navigation-bar/android/src/main/res/values/attrs.xml
+++ b/packages/expo-navigation-bar/android/src/main/res/values/attrs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <attr name="expoNavigationBarHidden" format="boolean" />
+</resources>

--- a/packages/expo-navigation-bar/android/src/main/res/values/strings.xml
+++ b/packages/expo-navigation-bar/android/src/main/res/values/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <string name="expo_navigation_bar_visibility" translatable="false"></string>
-
-</resources>

--- a/packages/expo-navigation-bar/plugin/build/withNavigationBar.d.ts
+++ b/packages/expo-navigation-bar/plugin/build/withNavigationBar.d.ts
@@ -25,8 +25,7 @@ export type Props = {
     visibility?: NavigationBarVisibility;
 };
 export declare function resolveProps(props: Props | undefined): Props | undefined;
-export declare function setStrings(strings: AndroidConfig.Resources.ResourceXML, { hidden }: Props): AndroidConfig.Resources.ResourceXML;
-export declare const setNavigationBarStyles: ({ style }: Props, styles: AndroidConfig.Resources.ResourceXML) => AndroidConfig.Resources.ResourceXML;
+export declare const setNavigationBarStyles: ({ hidden, style }: Props, styles: AndroidConfig.Resources.ResourceXML) => AndroidConfig.Resources.ResourceXML;
 export declare function applyEnforceNavigationBarContrast(config: ResourceXMLConfig, enforceNavigationBarContrast: boolean): ResourceXMLConfig;
 declare const _default: ConfigPlugin<Props | undefined>;
 export default _default;

--- a/packages/expo-navigation-bar/plugin/build/withNavigationBar.js
+++ b/packages/expo-navigation-bar/plugin/build/withNavigationBar.js
@@ -2,12 +2,9 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.setNavigationBarStyles = void 0;
 exports.resolveProps = resolveProps;
-exports.setStrings = setStrings;
 exports.applyEnforceNavigationBarContrast = applyEnforceNavigationBarContrast;
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('../../package.json');
-// strings.xml keys, this should not change.
-const VISIBILITY_KEY = 'expo_navigation_bar_visibility';
 function resolveProps(props) {
     if (props == null) {
         return;
@@ -39,38 +36,31 @@ const withNavigationBar = (config, _props) => {
     config.extra ??= {};
     config.extra[pkg.name] = props;
     // Use built-in styles instead of Expo custom properties, this makes the project hopefully a bit more predictable for bare users.
-    config = withNavigationBarStyles(config, props);
-    return (0, config_plugins_1.withStringsXml)(config, (config) => {
-        config.modResults = setStrings(config.modResults, props);
-        return config;
-    });
+    return withNavigationBarStyles(config, props);
 };
-function setStrings(strings, { hidden }) {
-    if (hidden == null) {
-        // Since we're using custom strings, we can remove them for convenience between prebuilds.
-        return config_plugins_1.AndroidConfig.Strings.removeStringItem(VISIBILITY_KEY, strings);
-    }
-    const item = config_plugins_1.AndroidConfig.Resources.buildResourceItem({
-        name: VISIBILITY_KEY,
-        value: hidden ? 'hidden' : 'visible',
-        translatable: false,
-    });
-    return config_plugins_1.AndroidConfig.Strings.setStringItem([item], strings);
-}
 const withNavigationBarStyles = (config, props) => {
     return (0, config_plugins_1.withAndroidStyles)(config, (config) => {
         config.modResults = (0, exports.setNavigationBarStyles)(props, config.modResults);
         return applyEnforceNavigationBarContrast(config, props.enforceContrast !== false);
     });
 };
-const setNavigationBarStyles = ({ style }, styles) => config_plugins_1.AndroidConfig.Styles.assignStylesValue(styles, {
-    // Adding means the buttons will be darker to account for a light background color.
-    // `setStyle('dark')` should do the same thing.
-    add: style != null,
-    parent: config_plugins_1.AndroidConfig.Styles.getAppThemeGroup(),
-    name: 'android:windowLightNavigationBar',
-    value: String(style === 'dark'),
-});
+const setNavigationBarStyles = ({ hidden, style }, styles) => {
+    styles = config_plugins_1.AndroidConfig.Styles.assignStylesValue(styles, {
+        add: hidden != null,
+        parent: config_plugins_1.AndroidConfig.Styles.getAppThemeGroup(),
+        name: 'expoNavigationBarHidden',
+        value: String(hidden),
+    });
+    styles = config_plugins_1.AndroidConfig.Styles.assignStylesValue(styles, {
+        // Adding means the buttons will be darker to account for a light background color.
+        // `setStyle('dark')` should do the same thing.
+        add: style != null,
+        parent: config_plugins_1.AndroidConfig.Styles.getAppThemeGroup(),
+        name: 'android:windowLightNavigationBar',
+        value: String(style === 'dark'),
+    });
+    return styles;
+};
 exports.setNavigationBarStyles = setNavigationBarStyles;
 function applyEnforceNavigationBarContrast(config, enforceNavigationBarContrast) {
     const enforceNavigationBarContrastItem = {

--- a/packages/expo-navigation-bar/plugin/src/__tests__/withNavigationBar-test.ts
+++ b/packages/expo-navigation-bar/plugin/src/__tests__/withNavigationBar-test.ts
@@ -2,7 +2,7 @@ import {
   applyEnforceNavigationBarContrast,
   resolveProps,
   ResourceXMLConfig,
-  setStrings,
+  setNavigationBarStyles,
 } from '../withNavigationBar';
 
 const exportedConfigWithPopsCommon = (modName: string = 'styles') => ({
@@ -22,18 +22,18 @@ const exportedConfigWithPopsCommon = (modName: string = 'styles') => ({
 });
 
 describe(resolveProps, () => {
-  it(`returns undefined for nullish or empty props`, () => {
+  it('returns undefined for nullish or empty props', () => {
     expect(resolveProps(undefined)).toBeUndefined();
     expect(resolveProps({})).toBeUndefined();
-    expect(resolveProps({ style: null })).toBeUndefined();
+    expect(resolveProps({ style: undefined })).toBeUndefined();
   });
 
-  it(`resolves props`, () => {
+  it('resolves props', () => {
     expect(resolveProps({ style: 'dark' })).toStrictEqual({ style: 'dark' });
     expect(resolveProps({ hidden: true })).toStrictEqual({ hidden: true });
   });
 
-  it(`maps deprecated props, preferring new ones`, () => {
+  it('maps deprecated props, preferring new ones', () => {
     expect(resolveProps({ barStyle: 'dark' })).toStrictEqual({ style: 'dark' });
     expect(resolveProps({ visibility: 'hidden' })).toStrictEqual({ hidden: true });
     expect(resolveProps({ visibility: 'visible' })).toStrictEqual({ hidden: false });
@@ -43,73 +43,70 @@ describe(resolveProps, () => {
   });
 });
 
-describe(setStrings, () => {
-  const getAllProps = () => ({ hidden: true, style: 'dark' }) as const;
+describe(setNavigationBarStyles, () => {
+  const parent = 'Theme.AppCompat.DayNight.NoActionBar';
 
-  it(`sets all strings`, () => {
-    expect(setStrings({ resources: {} }, getAllProps())).toStrictEqual({
-      resources: {
-        string: [
-          {
-            $: {
-              name: 'expo_navigation_bar_visibility',
-              translatable: 'false',
-            },
-            _: 'hidden',
-          },
-        ],
-      },
-    });
+  const baseStyles = () => ({
+    resources: { style: [{ $: { name: 'AppTheme', parent }, item: [] }] },
   });
 
-  it(`sets no strings`, () => {
-    expect(
-      setStrings(
-        {
-          resources: {
-            string: [],
-          },
-        },
-        {}
-      )
-    ).toStrictEqual({
-      resources: {
-        string: [],
-      },
-    });
+  const appTheme = (items: { name: string; value: string }[]) => ({
+    $: { name: 'AppTheme', parent },
+    item: items.map(({ name, value }) => ({ $: { name }, _: value })),
   });
 
-  it(`unsets string`, () => {
-    // Set all strings
-    const strings = setStrings({ resources: {} }, getAllProps());
+  it('sets all styles', () => {
+    const result = setNavigationBarStyles({ hidden: true, style: 'dark' }, baseStyles());
 
-    // Unset all strings
-    expect(setStrings(strings, {})).toStrictEqual({
-      resources: {
-        string: [],
-      },
-    });
+    expect(result.resources.style).toStrictEqual([
+      appTheme([
+        { name: 'expoNavigationBarHidden', value: 'true' },
+        { name: 'android:windowLightNavigationBar', value: 'true' },
+      ]),
+    ]);
   });
 
-  it(`redefines duplicates`, () => {
-    // Set all strings
-    const strings = setStrings({ resources: {} }, { hidden: true });
+  it('sets light style', () => {
+    const result = setNavigationBarStyles({ style: 'light' }, baseStyles());
 
-    expect(strings.resources.string).toStrictEqual([
-      {
-        $: { name: 'expo_navigation_bar_visibility', translatable: 'false' },
-        // Test an initial value
-        _: 'hidden',
-      },
+    expect(result.resources.style).toStrictEqual([
+      appTheme([{ name: 'android:windowLightNavigationBar', value: 'false' }]),
+    ]);
+  });
+
+  it('sets hidden only', () => {
+    const result = setNavigationBarStyles({ hidden: true }, baseStyles());
+
+    expect(result.resources.style).toStrictEqual([
+      appTheme([{ name: 'expoNavigationBarHidden', value: 'true' }]),
+    ]);
+  });
+
+  it('does nothing with empty props', () => {
+    const result = setNavigationBarStyles({}, baseStyles());
+
+    expect(result).toStrictEqual(baseStyles());
+  });
+
+  it('redefines duplicates', () => {
+    const styles = setNavigationBarStyles({ hidden: true }, baseStyles());
+
+    expect(styles.resources.style).toStrictEqual([
+      appTheme([{ name: 'expoNavigationBarHidden', value: 'true' }]),
     ]);
 
-    expect(setStrings(strings, { hidden: false }).resources.string).toStrictEqual([
-      {
-        $: { name: 'expo_navigation_bar_visibility', translatable: 'false' },
-        // Test a redefined value
-        _: 'visible',
-      },
+    const updated = setNavigationBarStyles({ hidden: false }, styles);
+
+    expect(updated.resources.style).toStrictEqual([
+      appTheme([{ name: 'expoNavigationBarHidden', value: 'false' }]),
     ]);
+  });
+
+  it('removes style when prop is unset', () => {
+    const styles = setNavigationBarStyles({ hidden: true, style: 'dark' }, baseStyles());
+    const result = setNavigationBarStyles({}, styles);
+
+    expect(result.resources.style).toStrictEqual([appTheme([])]);
   });
 });
 

--- a/packages/expo-navigation-bar/plugin/src/withNavigationBar.ts
+++ b/packages/expo-navigation-bar/plugin/src/withNavigationBar.ts
@@ -5,7 +5,6 @@ import {
   createRunOncePlugin,
   WarningAggregator,
   withAndroidStyles,
-  withStringsXml,
 } from 'expo/config-plugins';
 
 import { NavigationBarVisibility } from '../..';
@@ -39,9 +38,6 @@ export type Props = {
   /** @deprecated */
   visibility?: NavigationBarVisibility;
 };
-
-// strings.xml keys, this should not change.
-const VISIBILITY_KEY = 'expo_navigation_bar_visibility';
 
 export function resolveProps(props: Props | undefined): Props | undefined {
   if (props == null) {
@@ -90,31 +86,8 @@ const withNavigationBar: ConfigPlugin<Props | undefined> = (config, _props) => {
   config.extra[pkg.name] = props;
 
   // Use built-in styles instead of Expo custom properties, this makes the project hopefully a bit more predictable for bare users.
-  config = withNavigationBarStyles(config, props);
-
-  return withStringsXml(config, (config) => {
-    config.modResults = setStrings(config.modResults, props);
-    return config;
-  });
+  return withNavigationBarStyles(config, props);
 };
-
-export function setStrings(
-  strings: AndroidConfig.Resources.ResourceXML,
-  { hidden }: Props
-): AndroidConfig.Resources.ResourceXML {
-  if (hidden == null) {
-    // Since we're using custom strings, we can remove them for convenience between prebuilds.
-    return AndroidConfig.Strings.removeStringItem(VISIBILITY_KEY, strings);
-  }
-
-  const item = AndroidConfig.Resources.buildResourceItem({
-    name: VISIBILITY_KEY,
-    value: hidden ? 'hidden' : 'visible',
-    translatable: false,
-  });
-
-  return AndroidConfig.Strings.setStringItem([item], strings);
-}
 
 const withNavigationBarStyles: ConfigPlugin<Props> = (config, props) => {
   return withAndroidStyles(config, (config) => {
@@ -124,10 +97,17 @@ const withNavigationBarStyles: ConfigPlugin<Props> = (config, props) => {
 };
 
 export const setNavigationBarStyles = (
-  { style }: Props,
+  { hidden, style }: Props,
   styles: AndroidConfig.Resources.ResourceXML
-): AndroidConfig.Resources.ResourceXML =>
-  AndroidConfig.Styles.assignStylesValue(styles, {
+): AndroidConfig.Resources.ResourceXML => {
+  styles = AndroidConfig.Styles.assignStylesValue(styles, {
+    add: hidden != null,
+    parent: AndroidConfig.Styles.getAppThemeGroup(),
+    name: 'expoNavigationBarHidden',
+    value: String(hidden),
+  });
+
+  styles = AndroidConfig.Styles.assignStylesValue(styles, {
     // Adding means the buttons will be darker to account for a light background color.
     // `setStyle('dark')` should do the same thing.
     add: style != null,
@@ -135,6 +115,9 @@ export const setNavigationBarStyles = (
     name: 'android:windowLightNavigationBar',
     value: String(style === 'dark'),
   });
+
+  return styles;
+};
 
 export function applyEnforceNavigationBarContrast(
   config: ResourceXMLConfig,

--- a/packages/expo-status-bar/CHANGELOG.md
+++ b/packages/expo-status-bar/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
-- Added config plugin for Android and iOS status bar configuration. ([#43968](https://github.com/expo/expo/pull/43968) by [@zoontek](https://github.com/zoontek))
+- Added config plugin for Android and iOS status bar configuration. ([#43968](https://github.com/expo/expo/pull/43968), [#44536](https://github.com/expo/expo/pull/44536) by [@zoontek](https://github.com/zoontek))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-status-bar/android/src/main/java/expo/modules/statusbar/StatusBarReactActivityLifecycleListener.kt
+++ b/packages/expo-status-bar/android/src/main/java/expo/modules/statusbar/StatusBarReactActivityLifecycleListener.kt
@@ -1,26 +1,32 @@
 package expo.modules.statusbar
 
 import android.app.Activity
+import android.content.res.Resources
 import android.os.Bundle
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
 
 class StatusBarReactActivityLifecycleListener : ReactActivityLifecycleListener {
-  override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
-    // Execute static tasks before the JS engine starts.
-    // These values are defined via config plugins.
-    val visibility = activity.getString(R.string.expo_status_bar_visibility).lowercase()
+  private fun isStatusBarHidden(theme: Resources.Theme): Boolean {
+    // This value is defined via config plugins
+    val attrs = intArrayOf(R.attr.expoStatusBarHidden)
+    val typedArray = theme.obtainStyledAttributes(attrs)
 
-    if (visibility.isNotBlank()) {
+    return try {
+      typedArray.getBoolean(0, false)
+    } finally {
+      typedArray.recycle()
+    }
+  }
+
+  override fun onCreate(activity: Activity, savedInstanceState: Bundle?) {
+    // Execute static tasks before the JS engine starts
+    if (isStatusBarHidden(activity.theme)) {
       val window = activity.window
 
-      WindowInsetsControllerCompat(window, window.decorView).run {
-        when (visibility) {
-          "hidden" -> hide(WindowInsetsCompat.Type.statusBars())
-          "visible" -> show(WindowInsetsCompat.Type.statusBars())
-        }
-      }
+      WindowInsetsControllerCompat(window, window.decorView)
+        .hide(WindowInsetsCompat.Type.statusBars())
     }
   }
 }

--- a/packages/expo-status-bar/android/src/main/res/values/attrs.xml
+++ b/packages/expo-status-bar/android/src/main/res/values/attrs.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <attr name="expoStatusBarHidden" format="boolean" />
+</resources>

--- a/packages/expo-status-bar/android/src/main/res/values/strings.xml
+++ b/packages/expo-status-bar/android/src/main/res/values/strings.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-  <string name="expo_status_bar_visibility" translatable="false" />
-
-</resources>

--- a/packages/expo-status-bar/plugin/build/withStatusBar.d.ts
+++ b/packages/expo-status-bar/plugin/build/withStatusBar.d.ts
@@ -7,8 +7,7 @@ export type Props = {
     style?: StatusBarStyle;
 };
 export declare function resolveProps(props: Props | undefined): Props | undefined;
-export declare const setAndroidStatusBarStyles: (styles: AndroidConfig.Resources.ResourceXML, { style }: Props) => AndroidConfig.Resources.ResourceXML;
-export declare const setAndroidStrings: (strings: AndroidConfig.Resources.ResourceXML, { hidden }: Props) => AndroidConfig.Resources.ResourceXML;
+export declare const setAndroidStatusBarStyles: (styles: AndroidConfig.Resources.ResourceXML, { hidden, style }: Props) => AndroidConfig.Resources.ResourceXML;
 export declare const setIOSStatusBarInfoPlist: (plist: InfoPlist, { hidden, style }?: Props) => InfoPlist;
 declare const _default: ConfigPlugin<Props | undefined>;
 export default _default;

--- a/packages/expo-status-bar/plugin/build/withStatusBar.js
+++ b/packages/expo-status-bar/plugin/build/withStatusBar.js
@@ -1,11 +1,9 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.setIOSStatusBarInfoPlist = exports.setAndroidStrings = exports.setAndroidStatusBarStyles = void 0;
+exports.setIOSStatusBarInfoPlist = exports.setAndroidStatusBarStyles = void 0;
 exports.resolveProps = resolveProps;
 const config_plugins_1 = require("expo/config-plugins");
 const pkg = require('../../package.json');
-// strings.xml keys, this should not change.
-const VISIBILITY_KEY = 'expo_status_bar_visibility';
 const IOS_BAR_STYLE_MAP = {
     dark: 'UIStatusBarStyleDarkContent',
     light: 'UIStatusBarStyleLightContent',
@@ -23,37 +21,27 @@ function resolveProps(props) {
         return resolvedProps;
     }
 }
-const setAndroidStatusBarStyles = (styles, { style }) => config_plugins_1.AndroidConfig.Styles.assignStylesValue(styles, {
-    // Adding means the buttons will be darker to account for a light background color.
-    // `setStyle('dark')` should do the same thing.
-    add: style != null,
-    parent: config_plugins_1.AndroidConfig.Styles.getAppThemeGroup(),
-    name: 'android:windowLightStatusBar',
-    value: String(style === 'dark'),
-});
+const setAndroidStatusBarStyles = (styles, { hidden, style }) => {
+    styles = config_plugins_1.AndroidConfig.Styles.assignStylesValue(styles, {
+        add: hidden != null,
+        parent: config_plugins_1.AndroidConfig.Styles.getAppThemeGroup(),
+        name: 'expoStatusBarHidden',
+        value: String(hidden),
+    });
+    styles = config_plugins_1.AndroidConfig.Styles.assignStylesValue(styles, {
+        // Adding means the buttons will be darker to account for a light background color.
+        // `setStyle('dark')` should do the same thing.
+        add: style != null,
+        parent: config_plugins_1.AndroidConfig.Styles.getAppThemeGroup(),
+        name: 'android:windowLightStatusBar',
+        value: String(style === 'dark'),
+    });
+    return styles;
+};
 exports.setAndroidStatusBarStyles = setAndroidStatusBarStyles;
 const withAndroidStatusBarStyles = (config, props) => {
     return (0, config_plugins_1.withAndroidStyles)(config, (config) => {
         config.modResults = (0, exports.setAndroidStatusBarStyles)(config.modResults, props);
-        return config;
-    });
-};
-const setAndroidStrings = (strings, { hidden }) => {
-    if (hidden == null) {
-        // Since we're using custom strings, we can remove them for convenience between prebuilds.
-        return config_plugins_1.AndroidConfig.Strings.removeStringItem(VISIBILITY_KEY, strings);
-    }
-    const item = config_plugins_1.AndroidConfig.Resources.buildResourceItem({
-        name: VISIBILITY_KEY,
-        value: hidden ? 'hidden' : 'visible',
-        translatable: false,
-    });
-    return config_plugins_1.AndroidConfig.Strings.setStringItem([item], strings);
-};
-exports.setAndroidStrings = setAndroidStrings;
-const withAndroidStatusBarStringsXml = (config, props) => {
-    return (0, config_plugins_1.withStringsXml)(config, (config) => {
-        config.modResults = (0, exports.setAndroidStrings)(config.modResults, props);
         return config;
     });
 };
@@ -80,7 +68,6 @@ const withStatusBar = (config, _props) => {
     config.extra ??= {};
     config.extra[pkg.name] = props;
     config = withAndroidStatusBarStyles(config, props);
-    config = withAndroidStatusBarStringsXml(config, props);
     return withIOSStatusBarInfoPlist(config, props);
 };
 exports.default = (0, config_plugins_1.createRunOncePlugin)(withStatusBar, pkg.name, pkg.version);

--- a/packages/expo-status-bar/plugin/src/__tests__/withStatusBar-test.ts
+++ b/packages/expo-status-bar/plugin/src/__tests__/withStatusBar-test.ts
@@ -1,32 +1,36 @@
-import { resolveProps, setAndroidStrings, setIOSStatusBarInfoPlist } from '../withStatusBar';
+import {
+  resolveProps,
+  setAndroidStatusBarStyles,
+  setIOSStatusBarInfoPlist,
+} from '../withStatusBar';
 
 describe(setIOSStatusBarInfoPlist, () => {
-  it(`sets hidden and style`, () => {
+  it('sets hidden and style', () => {
     expect(setIOSStatusBarInfoPlist({}, { hidden: true, style: 'light' })).toStrictEqual({
       UIStatusBarHidden: true,
       UIStatusBarStyle: 'UIStatusBarStyleLightContent',
     });
   });
 
-  it(`sets dark style`, () => {
+  it('sets dark style', () => {
     expect(setIOSStatusBarInfoPlist({}, { style: 'dark' })).toStrictEqual({
       UIStatusBarStyle: 'UIStatusBarStyleDarkContent',
     });
   });
 
-  it(`sets hidden only`, () => {
+  it('sets hidden only', () => {
     expect(setIOSStatusBarInfoPlist({}, { hidden: true })).toStrictEqual({
       UIStatusBarHidden: true,
     });
   });
 
-  it(`overrides existing UIStatusBarHidden`, () => {
+  it('overrides existing UIStatusBarHidden', () => {
     expect(setIOSStatusBarInfoPlist({ UIStatusBarHidden: false }, { hidden: true })).toStrictEqual({
       UIStatusBarHidden: true,
     });
   });
 
-  it(`overrides existing UIStatusBarStyle`, () => {
+  it('overrides existing UIStatusBarStyle', () => {
     expect(
       setIOSStatusBarInfoPlist({ UIStatusBarStyle: 'UIStatusBarStyleDefault' }, { style: 'light' })
     ).toStrictEqual({
@@ -34,11 +38,11 @@ describe(setIOSStatusBarInfoPlist, () => {
     });
   });
 
-  it(`does nothing with empty props`, () => {
+  it('does nothing with empty props', () => {
     expect(setIOSStatusBarInfoPlist({}, {})).toStrictEqual({});
   });
 
-  it(`preserves existing infoPlist entries`, () => {
+  it('preserves existing infoPlist entries', () => {
     expect(setIOSStatusBarInfoPlist({ CFBundleName: 'MyApp' }, { style: 'dark' })).toStrictEqual({
       CFBundleName: 'MyApp',
       UIStatusBarStyle: 'UIStatusBarStyleDarkContent',
@@ -47,84 +51,81 @@ describe(setIOSStatusBarInfoPlist, () => {
 });
 
 describe(resolveProps, () => {
-  it(`returns undefined for nullish or empty props`, () => {
+  it('returns undefined for nullish or empty props', () => {
     expect(resolveProps(undefined)).toBeUndefined();
     expect(resolveProps({})).toBeUndefined();
-    expect(resolveProps({ style: null })).toBeUndefined();
+    expect(resolveProps({ style: undefined })).toBeUndefined();
   });
 
-  it(`resolves props`, () => {
+  it('resolves props', () => {
     expect(resolveProps({ style: 'dark' })).toStrictEqual({ style: 'dark' });
     expect(resolveProps({ hidden: true })).toStrictEqual({ hidden: true });
   });
 });
 
-describe(setAndroidStrings, () => {
-  const getAllProps = () => ({ hidden: true, style: 'dark' }) as const;
+describe(setAndroidStatusBarStyles, () => {
+  const parent = 'Theme.AppCompat.DayNight.NoActionBar';
 
-  it(`sets all strings`, () => {
-    expect(setAndroidStrings({ resources: {} }, getAllProps())).toStrictEqual({
-      resources: {
-        string: [
-          {
-            $: {
-              name: 'expo_status_bar_visibility',
-              translatable: 'false',
-            },
-            _: 'hidden',
-          },
-        ],
-      },
-    });
+  const baseStyles = () => ({
+    resources: { style: [{ $: { name: 'AppTheme', parent }, item: [] }] },
   });
 
-  it(`sets no strings`, () => {
-    expect(
-      setAndroidStrings(
-        {
-          resources: {
-            string: [],
-          },
-        },
-        {}
-      )
-    ).toStrictEqual({
-      resources: {
-        string: [],
-      },
-    });
+  const appTheme = (items: { name: string; value: string }[]) => ({
+    $: { name: 'AppTheme', parent },
+    item: items.map(({ name, value }) => ({ $: { name }, _: value })),
   });
 
-  it(`unsets string`, () => {
-    // Set all strings
-    const strings = setAndroidStrings({ resources: {} }, getAllProps());
+  it('sets all styles', () => {
+    const result = setAndroidStatusBarStyles(baseStyles(), { hidden: true, style: 'dark' });
 
-    // Unset all strings
-    expect(setAndroidStrings(strings, {})).toStrictEqual({
-      resources: {
-        string: [],
-      },
-    });
+    expect(result.resources.style).toStrictEqual([
+      appTheme([
+        { name: 'expoStatusBarHidden', value: 'true' },
+        { name: 'android:windowLightStatusBar', value: 'true' },
+      ]),
+    ]);
   });
 
-  it(`redefines duplicates`, () => {
-    // Set all strings
-    const strings = setAndroidStrings({ resources: {} }, { hidden: true });
+  it('sets light style', () => {
+    const result = setAndroidStatusBarStyles(baseStyles(), { style: 'light' });
 
-    expect(strings.resources.string).toStrictEqual([
-      {
-        $: { name: 'expo_status_bar_visibility', translatable: 'false' },
-        // Test an initial value
-        _: 'hidden',
-      },
+    expect(result.resources.style).toStrictEqual([
+      appTheme([{ name: 'android:windowLightStatusBar', value: 'false' }]),
+    ]);
+  });
+
+  it('sets hidden only', () => {
+    const result = setAndroidStatusBarStyles(baseStyles(), { hidden: true });
+
+    expect(result.resources.style).toStrictEqual([
+      appTheme([{ name: 'expoStatusBarHidden', value: 'true' }]),
+    ]);
+  });
+
+  it('does nothing with empty props', () => {
+    const result = setAndroidStatusBarStyles(baseStyles(), {});
+
+    expect(result).toStrictEqual(baseStyles());
+  });
+
+  it('redefines duplicates', () => {
+    const styles = setAndroidStatusBarStyles(baseStyles(), { hidden: true });
+
+    expect(styles.resources.style).toStrictEqual([
+      appTheme([{ name: 'expoStatusBarHidden', value: 'true' }]),
     ]);
 
-    expect(setAndroidStrings(strings, { hidden: false }).resources.string).toStrictEqual([
-      {
-        $: { name: 'expo_status_bar_visibility', translatable: 'false' },
-        // Test a redefined value
-        _: 'visible',
-      },
+    const updated = setAndroidStatusBarStyles(styles, { hidden: false });
+
+    expect(updated.resources.style).toStrictEqual([
+      appTheme([{ name: 'expoStatusBarHidden', value: 'false' }]),
     ]);
+  });
+
+  it('removes style when prop is unset', () => {
+    const styles = setAndroidStatusBarStyles(baseStyles(), { hidden: true, style: 'dark' });
+    const result = setAndroidStatusBarStyles(styles, {});
+
+    expect(result.resources.style).toStrictEqual([appTheme([])]);
   });
 });

--- a/packages/expo-status-bar/plugin/src/withStatusBar.ts
+++ b/packages/expo-status-bar/plugin/src/withStatusBar.ts
@@ -5,7 +5,6 @@ import {
   InfoPlist,
   withAndroidStyles,
   withInfoPlist,
-  withStringsXml,
 } from 'expo/config-plugins';
 
 const pkg = require('../../package.json');
@@ -18,9 +17,6 @@ export type Props = {
   /** Determines which style the status bar starts with. */
   style?: StatusBarStyle;
 };
-
-// strings.xml keys, this should not change.
-const VISIBILITY_KEY = 'expo_status_bar_visibility';
 
 const IOS_BAR_STYLE_MAP: Record<StatusBarStyle, string> = {
   dark: 'UIStatusBarStyleDarkContent',
@@ -46,9 +42,16 @@ export function resolveProps(props: Props | undefined): Props | undefined {
 
 export const setAndroidStatusBarStyles = (
   styles: AndroidConfig.Resources.ResourceXML,
-  { style }: Props
-): AndroidConfig.Resources.ResourceXML =>
-  AndroidConfig.Styles.assignStylesValue(styles, {
+  { hidden, style }: Props
+): AndroidConfig.Resources.ResourceXML => {
+  styles = AndroidConfig.Styles.assignStylesValue(styles, {
+    add: hidden != null,
+    parent: AndroidConfig.Styles.getAppThemeGroup(),
+    name: 'expoStatusBarHidden',
+    value: String(hidden),
+  });
+
+  styles = AndroidConfig.Styles.assignStylesValue(styles, {
     // Adding means the buttons will be darker to account for a light background color.
     // `setStyle('dark')` should do the same thing.
     add: style != null,
@@ -57,34 +60,12 @@ export const setAndroidStatusBarStyles = (
     value: String(style === 'dark'),
   });
 
+  return styles;
+};
+
 const withAndroidStatusBarStyles: ConfigPlugin<Props> = (config, props) => {
   return withAndroidStyles(config, (config) => {
     config.modResults = setAndroidStatusBarStyles(config.modResults, props);
-    return config;
-  });
-};
-
-export const setAndroidStrings = (
-  strings: AndroidConfig.Resources.ResourceXML,
-  { hidden }: Props
-): AndroidConfig.Resources.ResourceXML => {
-  if (hidden == null) {
-    // Since we're using custom strings, we can remove them for convenience between prebuilds.
-    return AndroidConfig.Strings.removeStringItem(VISIBILITY_KEY, strings);
-  }
-
-  const item = AndroidConfig.Resources.buildResourceItem({
-    name: VISIBILITY_KEY,
-    value: hidden ? 'hidden' : 'visible',
-    translatable: false,
-  });
-
-  return AndroidConfig.Strings.setStringItem([item], strings);
-};
-
-const withAndroidStatusBarStringsXml: ConfigPlugin<Props> = (config, props) => {
-  return withStringsXml(config, (config) => {
-    config.modResults = setAndroidStrings(config.modResults, props);
     return config;
   });
 };
@@ -120,7 +101,6 @@ const withStatusBar: ConfigPlugin<Props | undefined> = (config, _props) => {
   config.extra[pkg.name] = props;
 
   config = withAndroidStatusBarStyles(config, props);
-  config = withAndroidStatusBarStringsXml(config, props);
   return withIOSStatusBarInfoPlist(config, props);
 };
 


### PR DESCRIPTION
# Why

This PR replaces `expo_status_bar_visibility` / `expo_navigation_bar_visibility` (strings stored in `strings.xml`) with new theme attributes: `expoStatusBarHidden` and `expoNavigationBarHidden` (booleans stored in `styles.xml`).

The rationale is the following:

- This follows the same `expo*` attribute pattern used by `expo-image-picker`
- It will not affect users using CNG
- If you don't use CNG, currently you have to update both `styles.xml` (to set `android:navigationBarColor`, `android:enforceNavigationBarContrast`, `android:windowLightNavigationBar`…) and set `<string name="expo_navigation_bar_visibility" translatable="false">hidden</string>` in a separate file, `strings.xml` - which is weird. By switching to a boolean theme attribute, its value can be set in `styles.xml` alongside other Android theme attributes

# How

- Deleted `strings.xml` resource files from both `expo-status-bar` and `expo-navigation-bar` packages
- Added `attrs.xml` resource files declaring `expoStatusBarHidden` and `expoNavigationBarHidden` as boolean attributes
- Updated the Kotlin `ReactActivityLifecycleListener` implementations to read the boolean attribute from the theme using `obtainStyledAttributes`
- Updated the config plugins (`withStatusBar.ts`, `withNavigationBar.ts`) to write the value into `styles.xml` via `assignStylesValue`
- Updated existing documentation

# Test Plan

- Ran `npx expo prebuild` on a bare app with `expo-status-bar` and `expo-navigation-bar` configured with `hidden: true`
- Verified that the generated `styles.xml` contains `<item name="expoStatusBarHidden">true</item>` and `<item name="expoNavigationBarHidden">true</item>` under the app theme
- Built and ran the app on an Android device, confirmed both bars are hidden on startup

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
