### PR TITLE
chore(@expo/config-types): remove Branch config

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -381,15 +381,6 @@ export interface IOS {
      */
     config?: {
         /**
-         * [Branch](https://branch.io/) key to hook up Branch linking services.
-         */
-        branch?: {
-            /**
-             * Your Branch API key
-             */
-            apiKey?: string;
-        };
-        /**
          * Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.
          */
         usesNonExemptEncryption?: boolean;
@@ -646,15 +637,6 @@ export interface Android {
      * Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.
      */
     config?: {
-        /**
-         * [Branch](https://branch.io/) key to hook up Branch linking services.
-         */
-        branch?: {
-            /**
-             * Your Branch API key
-             */
-            apiKey?: string;
-        };
         /**
          * [Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.
          */

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -389,15 +389,6 @@ export interface IOS {
    */
   config?: {
     /**
-     * [Branch](https://branch.io/) key to hook up Branch linking services.
-     */
-    branch?: {
-      /**
-       * Your Branch API key
-       */
-      apiKey?: string;
-    };
-    /**
      * Sets `ITSAppUsesNonExemptEncryption` in the standalone ipa's Info.plist to the given boolean value.
      */
     usesNonExemptEncryption?: boolean;
@@ -654,15 +645,6 @@ export interface Android {
    * Note: This property key is not included in the production manifest and will evaluate to `undefined`. It is used internally only in the build process, because it contains API keys that some may want to keep private.
    */
   config?: {
-    /**
-     * [Branch](https://branch.io/) key to hook up Branch linking services.
-     */
-    branch?: {
-      /**
-       * Your Branch API key
-       */
-      apiKey?: string;
-    };
     /**
      * [Google Maps Android SDK](https://developers.google.com/maps/documentation/android-api/signup) configuration for your standalone app.
      */


### PR DESCRIPTION
# Why

The options for `@config-plugins/react-native-branch` should be set in the config plugin as opposed to the main Expo config.

Closes https://github.com/expo/expo/pull/28084

# How

Ran the `generate` package script in `@expo/config-types`.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
