### PR TITLE
fix(@expo/config-types): fix `generate` script

### DIFF
--- a/packages/@expo/config-types/package.json
+++ b/packages/@expo/config-types/package.json
@@ -36,8 +36,11 @@
     "build"
   ],
   "devDependencies": {
+    "chalk": "^4.1.2",
+    "commander": "^12.1.0",
     "expo-module-scripts": "workspace:*",
-    "json-schema-to-typescript": "^15.0.0"
+    "json-schema-to-typescript": "^15.0.0",
+    "semver": "^7.7.4"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2079,12 +2079,21 @@ importers:
 
   packages/@expo/config-types:
     devDependencies:
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
       expo-module-scripts:
         specifier: workspace:*
         version: link:../../expo-module-scripts
       json-schema-to-typescript:
         specifier: ^15.0.0
         version: 15.0.4
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
 
   packages/@expo/devtools:
     dependencies:
@@ -18835,7 +18844,7 @@ snapshots:
 
   '@types/eslint-scope@3.7.7':
     dependencies:
-      '@types/eslint': 9.6.1
+      '@types/eslint': 8.56.12
       '@types/estree': 1.0.8
 
   '@types/eslint@7.29.0':
@@ -18852,6 +18861,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
+    optional: true
 
   '@types/estree@1.0.8': {}
 
@@ -23239,7 +23249,7 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 22.19.15
       merge-stream: 2.0.0
       supports-color: 8.1.1
 


### PR DESCRIPTION
# Why

The `generate` package script in `@expo/config-types` was broken after https://github.com/expo/expo/pull/44057 was merged.

# How

Added missing `devDependencies` to `@expo/config-types`'s `package.json`.

# Test Plan

Tested by running the `generate` package script.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
