### PR TITLE
fix(@expo/config-types): fix types drift from schema

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -69,7 +69,7 @@ export interface ExpoConfig {
      */
     icon?: string;
     /**
-     * Configuration for the status bar on Android. For more details please navigate to [Configuring StatusBar](https://docs.expo.dev/guides/configuring-statusbar/).
+     * Configuration for the status bar on Android. For more details navigate to [Configuring StatusBar](https://docs.expo.dev/guides/configuring-statusbar/).
      * @deprecated Use the `expo-status-bar` plugin configuration instead
      */
     androidStatusBar?: {
@@ -89,35 +89,6 @@ export interface ExpoConfig {
          * When false, the system status bar pushes the content of your app down (similar to `position: relative`). When true, the status bar floats above the content in your app (similar to `position: absolute`). Defaults to `true` to match the iOS status bar behavior (which can only float above content). Explicitly setting this property to `true` will add `android:windowTranslucentStatus` to `styles.xml` and may cause unexpected keyboard behavior on Android when using the `softwareKeyboardLayoutMode` set to `resize`. In this case you will have to use `KeyboardAvoidingView` to manage the keyboard layout.
          */
         translucent?: boolean;
-    };
-    /**
-     * Configuration for the bottom navigation bar on Android. Can be used to configure the `expo-navigation-bar` module in EAS Build.
-     * @deprecated Use the `expo-navigation-bar` plugin configuration instead
-     */
-    androidNavigationBar?: {
-        /**
-         * Determines how and when the navigation bar is shown. [Learn more](https://developer.android.com/training/system-ui/immersive). Requires `expo-navigation-bar` be installed in your project. Valid values: `leanback`, `immersive`, `sticky-immersive`
-         *
-         *  `leanback` results in the navigation bar being hidden until the first touch gesture is registered.
-         *
-         *  `immersive` results in the navigation bar being hidden until the user swipes up from the edge where the navigation bar is hidden.
-         *
-         *  `sticky-immersive` is identical to `'immersive'` except that the navigation bar will be semi-transparent and will be hidden again after a short period of time.
-         */
-        visible?: 'leanback' | 'immersive' | 'sticky-immersive';
-        /**
-         * Configure the navigation bar icons to have a light or dark color. Supported on Android Oreo and newer. Valid values: `'light-content'`, `'dark-content'`
-         */
-        barStyle?: 'light-content' | 'dark-content';
-        /**
-         * Specifies the background color of the navigation bar.
-         */
-        backgroundColor?: string;
-        /**
-         * Determines whether the operating system should keep the navigation bar translucent to provide contrast between the navigation buttons and app content.
-         * Defaults to true.
-         */
-        enforceContrast?: boolean;
     };
     /**
      * Settings that apply specifically to running this app in a development client
@@ -198,12 +169,12 @@ export interface ExpoConfig {
          */
         useNativeDebug?: boolean;
         /**
-         * Enable support for downloading and applying asset patches using the BSDiff format. Defaults to false. Set to true to enable downloading asset patches instead of full assets when a server offers patch responses.
+         * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to false.
          */
         enableBsdiffPatchSupport?: boolean;
     };
     /**
-     * Provide overrides by locale for application name and System Dialog prompts like Permissions Boxes. [Learn more](https://docs.expo.dev/guides/localization/#translating-app-metadata).
+     * Provide per-locale values for System Dialog prompts such as Permissions Boxes, and create Localizable.strings file to localize (for example) push notifications. Platform-specific locale strings should be nested under `ios` and `android` keys.
      */
     locales?: {
         [k: string]: string | {
@@ -218,11 +189,6 @@ export interface ExpoConfig {
      * Config plugins for adding extra functionality to your project. [Learn more](https://docs.expo.dev/guides/config-plugins/).
      */
     plugins?: (string | [] | [string] | [string, any])[];
-    splash?: Splash;
-    /**
-     * @deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for Android apps. Defaults to `hermes`. Valid values: `hermes`, `jsc`.
-     */
-    jsEngine?: 'hermes' | 'jsc';
     /**
      * Enable downloading cached builds from remote.
      */
@@ -261,6 +227,10 @@ export interface ExpoConfig {
          */
         supportsTVOnly?: boolean;
         /**
+         * Enable React-based CSS support for native platforms. Only supports a subset of CSS properties, class names selectors, and has no cascading.
+         */
+        functionalCSS?: boolean;
+        /**
          * Enable tsconfig/jsconfig `compilerOptions.paths` and `compilerOptions.baseUrl` support for import aliases in Metro.
          */
         tsconfigPaths?: boolean;
@@ -274,7 +244,6 @@ export interface ExpoConfig {
         turboModules?: boolean;
         /**
          * Experimentally use a vendored canary build of React for testing upcoming features.
-         * @deprecated React 19 is enabled by default. Remove unused experiments.reactCanary flag.
          */
         reactCanary?: boolean;
         /**
@@ -296,7 +265,7 @@ export interface ExpoConfig {
             /**
              * List of directories watched for inline modules.
              */
-            watchedDirectories: [string];
+            watchedDirectories: string[];
         };
     };
     /**
@@ -311,24 +280,6 @@ export interface ExpoConfig {
         };
         [k: string]: any;
     };
-}
-/**
- * Configuration for loading and splash screen for standalone apps.
- */
-export interface Splash {
-    /**
-     * Color to fill the loading screen background
-     */
-    backgroundColor?: string;
-    /**
-     * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.
-     */
-    resizeMode?: 'cover' | 'contain';
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-     */
-    image?: string;
-    [k: string]: any;
 }
 /**
  * Configuration that is specific to the iOS platform.
@@ -363,7 +314,7 @@ export interface IOS {
      */
     scheme?: string | string[];
     /**
-     * Local path or remote URL to an image to use for your app's icon on iOS. Alternatively, an object specifying different icons for various system appearances (e.g., dark, tinted) can be provided. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency.
+     * Local path or remote URL to an image to use for your app's icon on iOS. Alternatively, an object specifying different icons for various system appearances (e.g., dark, tinted) can be provided. You can also provide a path to a .icon directory. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency.
      *
      * Expo will generate the other required sizes. This icon will appear on the home screen and within the Expo Go app.
      */
@@ -397,14 +348,6 @@ export interface IOS {
          * [Google Maps iOS SDK](https://developers.google.com/maps/documentation/ios-sdk/start) key for your standalone app.
          */
         googleMapsApiKey?: string;
-        /**
-         * [Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID.
-         */
-        googleMobileAdsAppId?: string;
-        /**
-         * A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)
-         */
-        googleMobileAdsAutoInit?: boolean;
     };
     /**
      * [Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.
@@ -493,54 +436,6 @@ export interface IOS {
      * A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.
      */
     accessesContactNotes?: boolean;
-    /**
-     * Configuration for loading and splash screen for standalone iOS apps.
-     */
-    splash?: {
-        /**
-         * Color to fill the loading screen background
-         */
-        backgroundColor?: string;
-        /**
-         * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.
-         */
-        resizeMode?: 'cover' | 'contain';
-        /**
-         * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-         */
-        image?: string;
-        /**
-         * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-         */
-        tabletImage?: string;
-        /**
-         * Configuration for loading and splash screen for standalone iOS apps in dark mode.
-         */
-        dark?: {
-            /**
-             * Color to fill the loading screen background
-             */
-            backgroundColor?: string;
-            /**
-             * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.
-             */
-            resizeMode?: 'cover' | 'contain';
-            /**
-             * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-             */
-            image?: string;
-            /**
-             * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-             */
-            tabletImage?: string;
-            [k: string]: any;
-        };
-        [k: string]: any;
-    };
-    /**
-     * @deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for iOS apps. Not supported in Expo Go. Defaults to `hermes`. Valid values: `hermes`, `jsc`.
-     */
-    jsEngine?: 'hermes' | 'jsc';
     /**
      * Property indicating compatibility between an iOS build's native code and an OTA update for the iOS platform. If provided, this will override the value of the top level `runtimeVersion` key on iOS.
      */
@@ -664,110 +559,6 @@ export interface Android {
              */
             apiKey?: string;
         };
-        /**
-         * [Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID.
-         */
-        googleMobileAdsAppId?: string;
-        /**
-         * A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)
-         */
-        googleMobileAdsAutoInit?: boolean;
-    };
-    /**
-     * Configuration for loading and splash screen for managed and standalone Android apps.
-     */
-    splash?: {
-        /**
-         * Color to fill the loading screen background
-         */
-        backgroundColor?: string;
-        /**
-         * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.
-         */
-        resizeMode?: 'cover' | 'contain' | 'native';
-        /**
-         * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-         */
-        image?: string;
-        /**
-         * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-         *
-         *  `Natural sized image (baseline)`
-         */
-        mdpi?: string;
-        /**
-         * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-         *
-         *  `Scale 1.5x`
-         */
-        hdpi?: string;
-        /**
-         * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-         *
-         *  `Scale 2x`
-         */
-        xhdpi?: string;
-        /**
-         * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-         *
-         *  `Scale 3x`
-         */
-        xxhdpi?: string;
-        /**
-         * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-         *
-         *  `Scale 4x`
-         */
-        xxxhdpi?: string;
-        /**
-         * Configuration for loading and splash screen for managed and standalone Android apps in dark mode.
-         */
-        dark?: {
-            /**
-             * Color to fill the loading screen background
-             */
-            backgroundColor?: string;
-            /**
-             * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.
-             */
-            resizeMode?: 'cover' | 'contain' | 'native';
-            /**
-             * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-             */
-            image?: string;
-            /**
-             * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-             *
-             *  `Natural sized image (baseline)`
-             */
-            mdpi?: string;
-            /**
-             * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-             *
-             *  `Scale 1.5x`
-             */
-            hdpi?: string;
-            /**
-             * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-             *
-             *  `Scale 2x`
-             */
-            xhdpi?: string;
-            /**
-             * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-             *
-             *  `Scale 3x`
-             */
-            xxhdpi?: string;
-            /**
-             * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-             *
-             *  `Scale 4x`
-             */
-            xxxhdpi?: string;
-            [k: string]: any;
-        };
-        [k: string]: any;
     };
     /**
      * Configuration for setting an array of custom intent filters in Android manifest. [Learn more](https://developer.android.com/guide/components/intents-filters)
@@ -789,10 +580,6 @@ export interface Android {
      * Determines how the software keyboard will impact the layout of your application. This maps to the `android:windowSoftInputMode` property. Defaults to `resize`. Valid values: `resize`, `pan`.
      */
     softwareKeyboardLayoutMode?: 'resize' | 'pan';
-    /**
-     * @deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for Android apps. Defaults to `hermes`. Valid values: `hermes`, `jsc`.
-     */
-    jsEngine?: 'hermes' | 'jsc';
     /**
      * Property indicating compatibility between a Android build's native code and an OTA update for the Android platform. If provided, this will override the value of top level `runtimeVersion` key on Android.
      */
@@ -833,15 +620,6 @@ export interface AndroidIntentFiltersData {
      * Prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`
      */
     pathPrefix?: string;
-    /**
-     * Suffix for paths that should be matched by the filter, e.g. `.pdf` will match `/docs/file.pdf`
-     */
-    pathSuffix?: string;
-    /**
-     * Advanced pattern for paths, available in API 31+ (Android 12 and later),
-     * supports regular expressions. Example: `/records/[0-9]+`
-     */
-    pathAdvancedPattern?: string;
     /**
      * MIME type for URLs that should be matched by the filter
      */

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -71,7 +71,7 @@ export interface ExpoConfig {
    */
   icon?: string;
   /**
-   * Configuration for the status bar on Android. For more details please navigate to [Configuring StatusBar](https://docs.expo.dev/guides/configuring-statusbar/).
+   * Configuration for the status bar on Android. For more details navigate to [Configuring StatusBar](https://docs.expo.dev/guides/configuring-statusbar/).
    * @deprecated Use the `expo-status-bar` plugin configuration instead
    */
   androidStatusBar?: {
@@ -91,35 +91,6 @@ export interface ExpoConfig {
      * When false, the system status bar pushes the content of your app down (similar to `position: relative`). When true, the status bar floats above the content in your app (similar to `position: absolute`). Defaults to `true` to match the iOS status bar behavior (which can only float above content). Explicitly setting this property to `true` will add `android:windowTranslucentStatus` to `styles.xml` and may cause unexpected keyboard behavior on Android when using the `softwareKeyboardLayoutMode` set to `resize`. In this case you will have to use `KeyboardAvoidingView` to manage the keyboard layout.
      */
     translucent?: boolean;
-  };
-  /**
-   * Configuration for the bottom navigation bar on Android. Can be used to configure the `expo-navigation-bar` module in EAS Build.
-   * @deprecated Use the `expo-navigation-bar` plugin configuration instead
-   */
-  androidNavigationBar?: {
-    /**
-     * Determines how and when the navigation bar is shown. [Learn more](https://developer.android.com/training/system-ui/immersive). Requires `expo-navigation-bar` be installed in your project. Valid values: `leanback`, `immersive`, `sticky-immersive`
-     *
-     *  `leanback` results in the navigation bar being hidden until the first touch gesture is registered.
-     *
-     *  `immersive` results in the navigation bar being hidden until the user swipes up from the edge where the navigation bar is hidden.
-     *
-     *  `sticky-immersive` is identical to `'immersive'` except that the navigation bar will be semi-transparent and will be hidden again after a short period of time.
-     */
-    visible?: 'leanback' | 'immersive' | 'sticky-immersive';
-    /**
-     * Configure the navigation bar icons to have a light or dark color. Supported on Android Oreo and newer. Valid values: `'light-content'`, `'dark-content'`
-     */
-    barStyle?: 'light-content' | 'dark-content';
-    /**
-     * Specifies the background color of the navigation bar.
-     */
-    backgroundColor?: string;
-    /**
-     * Determines whether the operating system should keep the navigation bar translucent to provide contrast between the navigation buttons and app content.
-     * Defaults to true.
-     */
-    enforceContrast?: boolean;
   };
   /**
    * Settings that apply specifically to running this app in a development client
@@ -200,12 +171,12 @@ export interface ExpoConfig {
      */
     useNativeDebug?: boolean;
     /**
-     * Enable support for downloading and applying asset patches using the BSDiff format. Defaults to false. Set to true to enable downloading asset patches instead of full assets when a server offers patch responses.
+     * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to false.
      */
     enableBsdiffPatchSupport?: boolean;
   };
   /**
-   * Provide overrides by locale for application name and System Dialog prompts like Permissions Boxes. [Learn more](https://docs.expo.dev/guides/localization/#translating-app-metadata).
+   * Provide per-locale values for System Dialog prompts such as Permissions Boxes, and create Localizable.strings file to localize (for example) push notifications. Platform-specific locale strings should be nested under `ios` and `android` keys.
    */
   locales?: {
     [k: string]:
@@ -222,11 +193,6 @@ export interface ExpoConfig {
    * Config plugins for adding extra functionality to your project. [Learn more](https://docs.expo.dev/guides/config-plugins/).
    */
   plugins?: (string | [] | [string] | [string, any])[];
-  splash?: Splash;
-  /**
-   * @deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for Android apps. Defaults to `hermes`. Valid values: `hermes`, `jsc`.
-   */
-  jsEngine?: 'hermes' | 'jsc';
   /**
    * Enable downloading cached builds from remote.
    */
@@ -269,6 +235,10 @@ export interface ExpoConfig {
      */
     supportsTVOnly?: boolean;
     /**
+     * Enable React-based CSS support for native platforms. Only supports a subset of CSS properties, class names selectors, and has no cascading.
+     */
+    functionalCSS?: boolean;
+    /**
      * Enable tsconfig/jsconfig `compilerOptions.paths` and `compilerOptions.baseUrl` support for import aliases in Metro.
      */
     tsconfigPaths?: boolean;
@@ -282,7 +252,6 @@ export interface ExpoConfig {
     turboModules?: boolean;
     /**
      * Experimentally use a vendored canary build of React for testing upcoming features.
-     * @deprecated React 19 is enabled by default. Remove unused experiments.reactCanary flag.
      */
     reactCanary?: boolean;
     /**
@@ -304,7 +273,7 @@ export interface ExpoConfig {
       /**
        * List of directories watched for inline modules.
        */
-      watchedDirectories: [string];
+      watchedDirectories: string[];
     };
   };
   /**
@@ -319,24 +288,6 @@ export interface ExpoConfig {
     };
     [k: string]: any;
   };
-}
-/**
- * Configuration for loading and splash screen for standalone apps.
- */
-export interface Splash {
-  /**
-   * Color to fill the loading screen background
-   */
-  backgroundColor?: string;
-  /**
-   * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.
-   */
-  resizeMode?: 'cover' | 'contain';
-  /**
-   * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-   */
-  image?: string;
-  [k: string]: any;
 }
 /**
  * Configuration that is specific to the iOS platform.
@@ -371,7 +322,7 @@ export interface IOS {
    */
   scheme?: string | string[];
   /**
-   * Local path or remote URL to an image to use for your app's icon on iOS. Alternatively, an object specifying different icons for various system appearances (e.g., dark, tinted) can be provided. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency.
+   * Local path or remote URL to an image to use for your app's icon on iOS. Alternatively, an object specifying different icons for various system appearances (e.g., dark, tinted) can be provided. You can also provide a path to a .icon directory. If specified, this overrides the top-level `icon` key. Use a 1024x1024 icon which follows Apple's interface guidelines for icons, including color profile and transparency.
    *
    * Expo will generate the other required sizes. This icon will appear on the home screen and within the Expo Go app.
    */
@@ -405,14 +356,6 @@ export interface IOS {
      * [Google Maps iOS SDK](https://developers.google.com/maps/documentation/ios-sdk/start) key for your standalone app.
      */
     googleMapsApiKey?: string;
-    /**
-     * [Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID.
-     */
-    googleMobileAdsAppId?: string;
-    /**
-     * A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Go and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`.](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)
-     */
-    googleMobileAdsAutoInit?: boolean;
   };
   /**
    * [Firebase Configuration File](https://support.google.com/firebase/answer/7015592) Location of the `GoogleService-Info.plist` file for configuring Firebase.
@@ -501,54 +444,6 @@ export interface IOS {
    * A Boolean value that indicates whether the app may access the notes stored in contacts. You must [receive permission from Apple](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes) before you can submit your app for review with this capability.
    */
   accessesContactNotes?: boolean;
-  /**
-   * Configuration for loading and splash screen for standalone iOS apps.
-   */
-  splash?: {
-    /**
-     * Color to fill the loading screen background
-     */
-    backgroundColor?: string;
-    /**
-     * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.
-     */
-    resizeMode?: 'cover' | 'contain';
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-     */
-    image?: string;
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-     */
-    tabletImage?: string;
-    /**
-     * Configuration for loading and splash screen for standalone iOS apps in dark mode.
-     */
-    dark?: {
-      /**
-       * Color to fill the loading screen background
-       */
-      backgroundColor?: string;
-      /**
-       * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover` or `contain`, defaults to `contain`.
-       */
-      resizeMode?: 'cover' | 'contain';
-      /**
-       * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-       */
-      image?: string;
-      /**
-       * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-       */
-      tabletImage?: string;
-      [k: string]: any;
-    };
-    [k: string]: any;
-  };
-  /**
-   * @deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for iOS apps. Not supported in Expo Go. Defaults to `hermes`. Valid values: `hermes`, `jsc`.
-   */
-  jsEngine?: 'hermes' | 'jsc';
   /**
    * Property indicating compatibility between an iOS build's native code and an OTA update for the iOS platform. If provided, this will override the value of the top level `runtimeVersion` key on iOS.
    */
@@ -672,110 +567,6 @@ export interface Android {
        */
       apiKey?: string;
     };
-    /**
-     * [Google Mobile Ads App ID](https://support.google.com/admob/answer/6232340) Google AdMob App ID.
-     */
-    googleMobileAdsAppId?: string;
-    /**
-     * A boolean indicating whether to initialize Google App Measurement and begin sending user-level event data to Google immediately when the app starts. The default in Expo (Client and in standalone apps) is `false`. [Sets the opposite of the given value to the following key in `Info.plist`](https://developers.google.com/admob/ios/eu-consent#delay_app_measurement_optional)
-     */
-    googleMobileAdsAutoInit?: boolean;
-  };
-  /**
-   * Configuration for loading and splash screen for managed and standalone Android apps.
-   */
-  splash?: {
-    /**
-     * Color to fill the loading screen background
-     */
-    backgroundColor?: string;
-    /**
-     * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.
-     */
-    resizeMode?: 'cover' | 'contain' | 'native';
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-     */
-    image?: string;
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-     *
-     *  `Natural sized image (baseline)`
-     */
-    mdpi?: string;
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-     *
-     *  `Scale 1.5x`
-     */
-    hdpi?: string;
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-     *
-     *  `Scale 2x`
-     */
-    xhdpi?: string;
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-     *
-     *  `Scale 3x`
-     */
-    xxhdpi?: string;
-    /**
-     * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-     *
-     *  `Scale 4x`
-     */
-    xxxhdpi?: string;
-    /**
-     * Configuration for loading and splash screen for managed and standalone Android apps in dark mode.
-     */
-    dark?: {
-      /**
-       * Color to fill the loading screen background
-       */
-      backgroundColor?: string;
-      /**
-       * Determines how the `image` will be displayed in the splash loading screen. Must be one of `cover`, `contain` or `native`, defaults to `contain`.
-       */
-      resizeMode?: 'cover' | 'contain' | 'native';
-      /**
-       * Local path or remote URL to an image to fill the background of the loading screen. Image size and aspect ratio are up to you. Must be a .png.
-       */
-      image?: string;
-      /**
-       * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-       *
-       *  `Natural sized image (baseline)`
-       */
-      mdpi?: string;
-      /**
-       * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-       *
-       *  `Scale 1.5x`
-       */
-      hdpi?: string;
-      /**
-       * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-       *
-       *  `Scale 2x`
-       */
-      xhdpi?: string;
-      /**
-       * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-       *
-       *  `Scale 3x`
-       */
-      xxhdpi?: string;
-      /**
-       * Local path or remote URL to an image to fill the background of the loading screen in "native" mode. Image size and aspect ratio are up to you. [Learn more]( https://developer.android.com/training/multiscreen/screendensities)
-       *
-       *  `Scale 4x`
-       */
-      xxxhdpi?: string;
-      [k: string]: any;
-    };
-    [k: string]: any;
   };
   /**
    * Configuration for setting an array of custom intent filters in Android manifest. [Learn more](https://developer.android.com/guide/components/intents-filters)
@@ -797,10 +588,6 @@ export interface Android {
    * Determines how the software keyboard will impact the layout of your application. This maps to the `android:windowSoftInputMode` property. Defaults to `resize`. Valid values: `resize`, `pan`.
    */
   softwareKeyboardLayoutMode?: 'resize' | 'pan';
-  /**
-   * @deprecated This field will be removed in a future release. When it is removed, you can continue using JavaScriptCore instead of Hermes by following the instructions in [@react-native-community/javascriptcore](https://github.com/react-native-community/javascriptcore). Specifies the JavaScript engine for Android apps. Defaults to `hermes`. Valid values: `hermes`, `jsc`.
-   */
-  jsEngine?: 'hermes' | 'jsc';
   /**
    * Property indicating compatibility between a Android build's native code and an OTA update for the Android platform. If provided, this will override the value of top level `runtimeVersion` key on Android.
    */
@@ -841,15 +628,6 @@ export interface AndroidIntentFiltersData {
    * Prefix for paths that should be matched by the filter, e.g. `/records/` will match `/records/123`
    */
   pathPrefix?: string;
-  /**
-   * Suffix for paths that should be matched by the filter, e.g. `.pdf` will match `/docs/file.pdf`
-   */
-  pathSuffix?: string;
-  /**
-   * Advanced pattern for paths, available in API 31+ (Android 12 and later),
-   * supports regular expressions. Example: `/records/[0-9]+`
-   */
-  pathAdvancedPattern?: string;
   /**
    * MIME type for URLs that should be matched by the filter
    */


### PR DESCRIPTION
# Why

Synchronizes the JSON schema from `expo/universe` with the types here in `@expo/config-types`

# How

`pnpm generate --path ../../../universe/server/www/xdl-schemas/UNVERSIONED-schema.json` in `packages/config-types`.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
