### PR TITLE
[ios][expo-modules-core] Constants-provider fails unwrapping optional values to JS

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider.
 - [iOS] Fixed view lookup in bridgeless mode by using `ExpoHostWrapper` instead of `reactBridge.uiManager`. ([#44375](https://github.com/expo/expo/pull/44375) by [@vonovak](https://github.com/vonovak))
 - [Android] Added support for CSS `rgb(...)` and `rgba(...)` color strings when converting JS color values to `android.graphics.Color`. ([#44023](https://github.com/expo/expo/pull/44023) by [@dileepapeiris](https://github.com/dileepapeiris))
 - [Android] Fixed Compose view clipping that caused Material ripple effects to be cut off (e.g., Switch thumb ripple). ([#43656](https://github.com/expo/expo/pull/43656) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider.
+- [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider. ([#44550](https://github.com/expo/expo/pull/44550) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed view lookup in bridgeless mode by using `ExpoHostWrapper` instead of `reactBridge.uiManager`. ([#44375](https://github.com/expo/expo/pull/44375) by [@vonovak](https://github.com/vonovak))
 - [Android] Added support for CSS `rgb(...)` and `rgba(...)` color strings when converting JS color values to `android.graphics.Color`. ([#44023](https://github.com/expo/expo/pull/44023) by [@dileepapeiris](https://github.com/dileepapeiris))
 - [Android] Fixed Compose view clipping that caused Material ripple effects to be cut off (e.g., Switch thumb ripple). ([#43656](https://github.com/expo/expo/pull/43656) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/ios/Tests/ConstantsTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ConstantsTests.swift
@@ -36,4 +36,13 @@ struct ConstantsTests {
     #expect(consts["test"] as? Int == 123)
     #expect(consts["test2"] as? Int == 789)
   }
+
+  @Test
+  func `constants provider values are not double-wrapped optionals`() {
+    let constants = ConstantsProvider.shared.constants()
+    for (key, value) in constants {
+      let mirror = Mirror(reflecting: value)
+      #expect(mirror.displayStyle != .optional, "Value for key '\(key)' is a wrapped Optional — will bridge as null to JS")
+    }
+  }
 }

--- a/packages/expo-modules-core/ios/Tests/ConstantsTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ConstantsTests.swift
@@ -45,4 +45,16 @@ struct ConstantsTests {
       #expect(mirror.displayStyle != .optional, "Value for key '\(key)' is a wrapped Optional — will bridge as null to JS")
     }
   }
+
+  @Test
+  func `nested constants provider values are not double-wrapped optionals`() {
+    let constants = ConstantsProvider.shared.constants()
+    if let platform = constants["platform"] as? [String: Any],
+      let ios = platform["ios"] as? [String: Any] {
+      for (key, value) in ios {
+        let mirror = Mirror(reflecting: value)
+        #expect(mirror.displayStyle != .optional, "Value for key 'platform.ios.\(key)' is a wrapped Optional — will bridge as null to JS")
+      }
+    }
+  }
 }

--- a/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
+++ b/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
@@ -18,7 +18,7 @@ internal final class ConstantsProvider: EXConstantsInterface {
     let isDebugXcodeScheme = false
     #endif
 
-    return [
+    var result: [AnyHashable: Any] = [
       "sessionId": UUID().uuidString,
       "executionEnvironment": "bare",
       "statusBarHeight": statusBarHeight,
@@ -26,13 +26,18 @@ internal final class ConstantsProvider: EXConstantsInterface {
       "systemFonts": systemFonts,
       "debugMode": isDebugXcodeScheme,
       "isHeadless": false,
-      "manifest": getManifest(), // Deprecated, but still used internally.
       "platform": [
         "ios": [
-          "buildNumber": getBuildVersion()
+          "buildNumber": getBuildVersion() ?? ""
         ]
       ]
     ]
+    // Deprecated, but still used internally. We need to check if the manifest is set, otherwise it will result in 
+    // an error where the whole manifest is null since we cannot wrap an Optional null in JS correctly.
+    if let manifest = getManifest() {
+      result["manifest"] = manifest
+    }
+    return result
   }
 }
 


### PR DESCRIPTION
# Why

PR #41339 moved EXConstantsService from expo-constants to expo-modules-core as ConstantsProvider when rewriting to Swift.

The Swift code puts optional return values:

getManifest() → [String: Any]?, getBuildVersion() → String?) directly into a [String: Any] dictionary literal. This wraps the optional as Optional<T> typed as Any, creating a double-optional when accessed via subscript. The Expo modules bridge can't unwrap this and sends null to JS.

The old ObjC code used EXNullIfNil() which always returned a concrete type, avoiding this issue.

Partly fixes these issues (also need additional fix):  #44527,  #44528
Additional fix for above issues: https://github.com/expo/expo/pull/44551

# How

This commit fixes this by explicitly testing getManifest()'s result value before assigning it to the return value in the `constants` accessor.

In addition it unwraps getBuildNumber() with ?? "" to avoid the same issue there.

Also added test that fails with the old code and passes with the new code.

# Test Plan

- Added failing swift tests  for both manifest and buildNumber. Passes with these fixes.
- Also tested in the issue reproduction project: https://github.com/uniquedevs/expo-constants-null-repro-55

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).