### PR TITLE
[docs] Remove hardcoded Expo AV internal links

### DIFF
--- a/docs/components/plugins/api/APIStaticData.ts
+++ b/docs/components/plugins/api/APIStaticData.ts
@@ -207,12 +207,7 @@ export const hardcodedTypeLinks: Record<string, string> = {
   Asset: '/versions/latest/sdk/asset/#asset',
   AsyncIterableIterator:
     'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AsyncIterator',
-  AudioSampleCallback: '/versions/latest/sdk/av/#avplaybackstatustoset',
   AuthSessionOpenOptions: '/versions/latest/sdk/webbrowser/#authsessionopenoptions',
-  AVMetadata: '/versions/latest/sdk/av/#avmetadata',
-  AVPlaybackSource: '/versions/latest/sdk/av/#avplaybacksource',
-  AVPlaybackStatus: '/versions/latest/sdk/av/#avplaybackstatus',
-  AVPlaybackStatusToSet: '/versions/latest/sdk/av/#avplaybackstatustoset',
   Blob: 'https://developer.mozilla.org/en-US/docs/Web/API/Blob',
   CameraPosition: '/versions/latest/sdk/maps/#cameraposition-2',
   ColorValue: 'https://reactnative.dev/docs/colors',
@@ -261,7 +256,6 @@ export const hardcodedTypeLinks: Record<string, string> = {
   Partial: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype',
   Pick: 'https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys',
   Platform: 'https://reactnative.dev/docs/platform',
-  Playback: '/versions/latest/sdk/av/#playback',
   ProcessedColorValue: 'https://reactnative.dev/docs/colors',
   Promise:
     'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Remove hardcoded Expo AV internal links since Expo AV has been deprecated and removed from latest SDK docs.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove links from `hardcodedTypeLinks`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
