### PR TITLE
[clipboard][android] Don't export the ClipboardFileProvider, use `android:grantUriPermissions` instead

### DIFF
--- a/packages/expo-clipboard/CHANGELOG.md
+++ b/packages/expo-clipboard/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- [Android] Instead of exporting the `ClipboardFileProvider` use `android:grantUriPermissions` to share image files. ([#44556](https://github.com/expo/expo/pull/44556) by [@behenate](https://github.com/behenate))
+
 ## 55.0.8 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-clipboard/android/src/main/AndroidManifest.xml
+++ b/packages/expo-clipboard/android/src/main/AndroidManifest.xml
@@ -3,7 +3,8 @@
     <provider
       android:name=".ClipboardFileProvider"
       android:authorities="${applicationId}.ClipboardFileProvider"
-      android:exported="true">
+      android:exported="false"
+      android:grantUriPermissions="true">
       <meta-data
         android:name="expo.modules.clipboard.CLIPBOARD_FILE_PROVIDER_PATHS"
         android:resource="@xml/clipboard_provider_paths"/>

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardFileProvider.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardFileProvider.kt
@@ -22,19 +22,18 @@ import java.io.FileNotFoundException
 import java.io.IOException
 
 /**
- * This is a modified version of [FileProvider]
- * that facilitates exposing files associated with an app by creating
- * a `content://` uri without using Androids URI permission mechanism.
- * In contrast to [FileProvider], this provider _must_ be exported.
+ * A read-only [ContentProvider] that exposes clipboard image files via `content://` URIs
+ * using Android's standard URI permission delegation model.
  *
- * The difference is that [FileProvider] forbids provider to be _exported_
- * which means it cannot easily grant access to any app installed
- * on the device. This becomes even more problematic with API 31, when
- * [PackageManager.getInstalledApplications] doesn't return all
- * installed apps, so we cannot iterate and use [Context.grantUriPermission]
- * easily
+ * The provider is not exported. Access is granted automatically by the Android
+ * [android.content.ClipboardManager] system service: when an app calls
+ * [android.content.ClipboardManager.getPrimaryClip], the system grants it temporary
+ * read URI permission for any `content://` URI placed in the clipboard by
+ * [android.content.ClipboardManager.setPrimaryClip].
  *
- * For usage details, see [FileProvider] documentation
+ * This requires the provider to declare `android:grantUriPermissions="true"` in the manifest.
+ *
+ * For usage details, see [FileProvider] documentation.
  */
 class ClipboardFileProvider : ContentProvider() {
   private val defaultProjectionColumns = arrayOf(OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE)
@@ -52,11 +51,6 @@ class ClipboardFileProvider : ContentProvider() {
    */
   override fun attachInfo(context: Context, info: ProviderInfo) {
     super.attachInfo(context, info)
-
-    if (!info.exported) {
-      throw AssertionError("ClipboardFileProvider must be exported")
-    }
-
     strategy = getPathStrategy(context, info.authority)
   }
 


### PR DESCRIPTION
# Why

Closes ENG-20382

We are currently exporting the `ClipboardFileProvider` which may be dangerous if the attacker knows the exact SHA address of the clipboard file. Otherwise other issues reported there seem to be auto-generated and don't apply to our implementation: 

```
  Omitted existing mitigations — the report presented the provider as entirely unprotected, but the implementation already had meaningful defenses:                                                                                                                                             
  - Read-only (insert/update/delete all throw UnsupportedOperationException)                                                                                                                                                                                                                    
  - Restricted to .clipboard/ cache only — no access to the rest of the filesystem                                                                                                                                                                                                              
  - Path traversal protection via canonical path + startsWith(root) check                                                                                                                                                                                                                       
  - File names generated with SecureRandom + SHA-256 — an attacker can't enumerate or guess them without a brute-force attack                                                                                                                                                                   
  ``` 

# How

Do not export the provider, instead use android:grantUriPermissions in the provider.

# Test Plan

Tested by creating a new app and using BareExpo. Tested by copying images between the new app and BareExpo
