### PR TITLE
fix(cli): Fix typings for removed `jsEngine` config type property

### DIFF
--- a/packages/@expo/cli/src/export/exportHermes.ts
+++ b/packages/@expo/cli/src/export/exportHermes.ts
@@ -33,7 +33,7 @@ function getLiteralHermesSettingFromPodfile(content: string): boolean | null {
 
 export async function assertEngineMismatchAsync(
   projectRoot: string,
-  exp: Pick<ExpoConfig, 'ios' | 'android' | 'jsEngine'>,
+  exp: Pick<ExpoConfig, 'ios' | 'android'>,
   platform: Platform
 ) {
   const isHermesManaged = isEnableHermesManaged(exp, platform);
@@ -48,15 +48,17 @@ export async function assertEngineMismatchAsync(
 }
 
 export function isEnableHermesManaged(
-  expoConfig: Partial<Pick<ExpoConfig, 'ios' | 'android' | 'jsEngine'>>,
+  expoConfig: Partial<Pick<ExpoConfig, 'ios' | 'android'>>,
   platform: string
 ): boolean {
   switch (platform) {
     case 'android': {
-      return (expoConfig.android?.jsEngine ?? expoConfig.jsEngine) !== 'jsc';
+      // NOTE(@kitten): `jsEngine` was deprecated, but we're preserving the check
+      return ((expoConfig.android as any)?.jsEngine ?? (expoConfig as any).jsEngine) !== 'jsc';
     }
     case 'ios': {
-      return (expoConfig.ios?.jsEngine ?? expoConfig.jsEngine) !== 'jsc';
+      // NOTE(@kitten): `jsEngine` was deprecated, but we're preserving the check
+      return ((expoConfig.ios as any)?.jsEngine ?? (expoConfig as any).jsEngine) !== 'jsc';
     }
     default:
       return false;


### PR DESCRIPTION
# Why

Related to #44542

The update removes the previously deprecated `jsEngine`. However, we should probably still preserve the check for a little bit longer.

# How

- Remove `jsEngine` type references, since this has been removed from `@expo/config-types`

Not adding a changelog entry, since none of these changes are user-facing.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
