### PR TITLE
[expo-splash-screen] SurfaceControl.checkNotReleased crash mitigation

### DIFF
--- a/packages/expo-splash-screen/CHANGELOG.md
+++ b/packages/expo-splash-screen/CHANGELOG.md
@@ -12,7 +12,11 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Mitigate `SurfaceControl.checkNotReleased` crash on API 31-33 by cancelling splash exit animation on activity stop. ([#44584](https://github.com/expo/expo/pull/44584) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
+
+- [Android] Updated `androidx.core:core-splashscreen` from `1.2.0-alpha02` to `1.2.0`. ([#44584](https://github.com/expo/expo/pull/44584) by [@zoontek](https://github.com/zoontek))
 
 - Make `backgroundColor` plugin prop optional, defaulting to `#ffffff`. ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
 - [iOS] Use `internal import React` and reduce public API surface to internal access level. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-splash-screen/android/build.gradle
+++ b/packages/expo-splash-screen/android/build.gradle
@@ -16,6 +16,6 @@ android {
 
 dependencies {
   implementation 'androidx.appcompat:appcompat:1.7.1'
-  implementation "androidx.core:core-splashscreen:1.2.0-alpha02"
+  implementation "androidx.core:core-splashscreen:1.2.0"
   implementation "com.facebook.react:react-android"
 }

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
@@ -95,6 +95,7 @@ object SplashScreenManager {
 
         override fun onActivityStopped(activity: Activity) {
           if (activity == mainActivity) {
+            runCatching { mainActivity.splashScreen.clearOnExitAnimationListener() }
             splashScreenViewRef?.get()?.animate()?.cancel()
             splashScreenViewRef = null
             application.unregisterActivityLifecycleCallbacks(this)

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
@@ -1,7 +1,9 @@
 package expo.modules.splashscreen
 
 import android.app.Activity
+import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Build
+import android.os.Bundle
 import android.view.View
 import android.view.ViewTreeObserver.OnPreDrawListener
 import android.view.animation.AccelerateInterpolator
@@ -10,11 +12,13 @@ import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarkerConstants
+import java.lang.ref.WeakReference
 
 object SplashScreenManager {
   private var keepSplashScreenOnScreen = true
   var preventAutoHideCalled: Boolean = false
   private lateinit var splashScreen: SplashScreen
+  private var splashScreenViewRef: WeakReference<View>? = null
 
   private val contentAppearedListener = ReactMarker.MarkerListener { name, _, _ ->
     if (name == ReactMarkerConstants.CONTENT_APPEARED) {
@@ -35,12 +39,16 @@ object SplashScreenManager {
 
     splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
       val splashScreenView = splashScreenViewProvider.view
+      splashScreenViewRef = WeakReference(splashScreenView)
+
       splashScreenView
         .animate()
         .setDuration(duration)
         .alpha(0.0f)
         .setInterpolator(AccelerateInterpolator())
         .withEndAction {
+          splashScreenViewRef = null
+
           if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             splashScreenViewProvider.remove()
           } else {
@@ -51,13 +59,13 @@ object SplashScreenManager {
     }
   }
 
-  fun registerOnActivity(activity: Activity) {
-    splashScreen = activity.installSplashScreen()
+  fun registerOnActivity(mainActivity: Activity) {
+    splashScreen = mainActivity.installSplashScreen()
     ReactMarker.addListener(contentAppearedListener)
 
     // Using `splashScreen.setKeepOnScreenCondition()` does not work on apis below 33
     // so we need to implement this ourselves.
-    val contentView = activity.findViewById<View>(android.R.id.content)
+    val contentView = mainActivity.findViewById<View>(android.R.id.content)
     val observer = contentView.viewTreeObserver
     observer.addOnPreDrawListener(object : OnPreDrawListener {
       override fun onPreDraw(): Boolean {
@@ -70,6 +78,30 @@ object SplashScreenManager {
     })
 
     configureSplashScreen()
+
+    // Mitigate race where splash exit listener may fire after activity stop,
+    // causing SurfaceControl.checkNotReleased() crash on API 31-33
+    // https://issuetracker.google.com/issues/242118185
+    if (Build.VERSION.SDK_INT in Build.VERSION_CODES.S..Build.VERSION_CODES.TIRAMISU) {
+      val application = mainActivity.application
+
+      application.registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
+        override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+        override fun onActivityDestroyed(activity: Activity) {}
+        override fun onActivityPaused(activity: Activity) {}
+        override fun onActivityResumed(activity: Activity) {}
+        override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+        override fun onActivityStarted(activity: Activity) {}
+
+        override fun onActivityStopped(activity: Activity) {
+          if (activity == mainActivity) {
+            splashScreenViewRef?.get()?.animate()?.cancel()
+            splashScreenViewRef = null
+            application.unregisterActivityLifecycleCallbacks(this)
+          }
+        }
+      })
+    }
   }
 
   fun hide() {

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenManager.kt
@@ -12,13 +12,11 @@ import androidx.core.splashscreen.SplashScreen
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import com.facebook.react.bridge.ReactMarker
 import com.facebook.react.bridge.ReactMarkerConstants
-import java.lang.ref.WeakReference
 
 object SplashScreenManager {
   private var keepSplashScreenOnScreen = true
   var preventAutoHideCalled: Boolean = false
   private lateinit var splashScreen: SplashScreen
-  private var splashScreenViewRef: WeakReference<View>? = null
 
   private val contentAppearedListener = ReactMarker.MarkerListener { name, _, _ ->
     if (name == ReactMarkerConstants.CONTENT_APPEARED) {
@@ -39,16 +37,12 @@ object SplashScreenManager {
 
     splashScreen.setOnExitAnimationListener { splashScreenViewProvider ->
       val splashScreenView = splashScreenViewProvider.view
-      splashScreenViewRef = WeakReference(splashScreenView)
-
       splashScreenView
         .animate()
         .setDuration(duration)
         .alpha(0.0f)
         .setInterpolator(AccelerateInterpolator())
         .withEndAction {
-          splashScreenViewRef = null
-
           if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
             splashScreenViewProvider.remove()
           } else {
@@ -96,8 +90,6 @@ object SplashScreenManager {
         override fun onActivityStopped(activity: Activity) {
           if (activity == mainActivity) {
             runCatching { mainActivity.splashScreen.clearOnExitAnimationListener() }
-            splashScreenViewRef?.get()?.animate()?.cancel()
-            splashScreenViewRef = null
             application.unregisterActivityLifecycleCallbacks(this)
           }
         }


### PR DESCRIPTION
# Why

Related PR: https://github.com/expo/expo/pull/44243

On Android 12-13 (API 31-33), there's a platform bug where the splash screen exit animation listener can fire after the activity has stopped, causing a `SurfaceControl.checkNotReleased` crash. This is a known Android issue: https://issuetracker.google.com/issues/242118185

# How

- Added an `ActivityLifecycleCallbacks` that cancels the splash screen exit animation when the activity stops on API 31-33, preventing the crash from occurring

#### Why not simply remove `setOnExitAnimationListener`?

Removing the listener entirely would fix the crash but introduce two regressions:

1. **Forced system fade**: without the listener, the system uses its own default fade to dismiss the splash. Users who set `fade: false` (e.g. to animate individual splash screen parts) would see an unwanted fade regardless.
2. **System bars race condition**: inside the listener, we call `(splashScreenView as SplashScreenView).remove()` instead of `splashScreenViewProvider.remove()` on API >= 31 to avoid triggering `applyThemesSystemBarAppearance`, which races with React Native / Expo system bar appearance management. Skipping the listener would re-introduces this issue on Android 12-13.

**This is a mitigation, not a total fix.** The underlying bug is in the Android platform itself and cannot be fully fixed on our side. This change reduces the window in which the crash can occur by cancelling the animation on activity stop, but edge cases with very tight timing may still slip through. It should reduce error occurrences, allowing remaining rare reports to be safely ignored.

# Test Plan

Tested on Android 12-13 devices by rapidly backgrounding the app during splash screen animation.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
