### PR TITLE
[docs] Add missing `isBeta` frontmatter tag in Expo Symbols

### DIFF
--- a/docs/pages/versions/unversioned/sdk/symbols.mdx
+++ b/docs/pages/versions/unversioned/sdk/symbols.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-symbols'
 packageName: 'expo-symbols'
 iconUrl: '/static/images/packages/expo-symbols.png'
 platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
+isBeta: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/symbols.mdx
+++ b/docs/pages/versions/unversioned/sdk/symbols.mdx
@@ -12,7 +12,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-> **warning** This library is currently in [beta](/more/release-statuses/#beta) and subject to breaking changes.
+> **important** This library is currently in [beta](/more/release-statuses/#beta) and subject to breaking changes.
 
 `expo-symbols` provides access to native symbol libraries across platforms. On iOS and tvOS, it uses [SF Symbols](https://developer.apple.com/sf-symbols/). On Android and web, it uses [Material Symbols](https://fonts.google.com/icons).
 

--- a/docs/pages/versions/v55.0.0/sdk/symbols.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/symbols.mdx
@@ -5,6 +5,7 @@ sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-symbols'
 packageName: 'expo-symbols'
 iconUrl: '/static/images/packages/expo-symbols.png'
 platforms: ['android', 'ios', 'tvos', 'web', 'expo-go']
+isBeta: true
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/v55.0.0/sdk/symbols.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/symbols.mdx
@@ -12,7 +12,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-> **warning** This library is currently in [beta](/more/release-statuses/#beta) and subject to breaking changes.
+> **important** This library is currently in [beta](/more/release-statuses/#beta) and subject to breaking changes.
 
 `expo-symbols` provides access to native symbol libraries across platforms. On iOS and tvOS, it uses [SF Symbols](https://developer.apple.com/sf-symbols/). On Android and web, it uses [Material Symbols](https://fonts.google.com/icons).
 


### PR DESCRIPTION
# Why

Fix ENG-20511

# How

- Add `isBeta: true` to the frontmatter in `pages/versions/v55.0.0/sdk/symbols.mdx` and  `pages/versions/unversioned/sdk/symbols.mdx` so the sidebar renders the beta tag for the current version.
- Change the beta callout from `**warning**` to `**important**` in both pages to use the correct callout type

# Test Plan

Navigate to the SDK Symbols page in the docs sidebar and confirm the "BETA" tag appears next to "Symbols" in both the v55.0.0 and unversioned versions.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
