### PR TITLE
chore(cli): Update to `lan-network@^0.2.1`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Add `react-native-web` to autolinking module resolution modules ([#44160](https://github.com/expo/expo/pull/44160) by [@kitten](https://github.com/kitten))
 - Limit `/open-stack-frame` to paths within server root ([#44039](https://github.com/expo/expo/pull/44039) by [@kitten](https://github.com/kitten))
 - Use `@expo/require-utils` for ngrok resolution ([#44236](https://github.com/expo/expo/pull/44236) by [@kitten](https://github.com/kitten))
+- Update to `lan-network@^0.2.1` ([#44587](https://github.com/expo/expo/pull/44587) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -85,7 +85,7 @@
     "fetch-nodeshim": "^0.4.6",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",
-    "lan-network": "^0.2.0",
+    "lan-network": "^0.2.1",
     "multitars": "^0.2.3",
     "node-forge": "^1.3.3",
     "npm-package-arg": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1755,8 +1755,8 @@ importers:
         specifier: ^13.0.0
         version: 13.0.6
       lan-network:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.2.1
+        version: 0.2.1
       multitars:
         specifier: ^0.2.3
         version: 0.2.4
@@ -12230,8 +12230,8 @@ packages:
     resolution: {integrity: sha512-mnIlAEMu4OyEvUNdzco9xpuB9YVcPkQec+QsgycBCtPZvEqWPCDPfbAE4OJMdBBWpZWtpCn1xw9jJYlwjWI5zQ==}
     hasBin: true
 
-  lan-network@0.2.0:
-    resolution: {integrity: sha512-EZgbsXMrGS+oK+Ta12mCjzBFse+SIewGdwrSTr5g+MSymnjpox2x05ceI20PQejJOFvOgzcXrfDk/SdY7dSCtw==}
+  lan-network@0.2.1:
+    resolution: {integrity: sha512-ONPnazC96VKDntab9j9JKwIWhZ4ZUceB4A9Epu4Ssg0hYFmtHZSeQ+n15nIwTFmcBUKtExOer8WTJ4GF9MO64A==}
     hasBin: true
 
   lazy-cache@1.0.4:
@@ -23382,7 +23382,7 @@ snapshots:
 
   lan-network@0.1.7: {}
 
-  lan-network@0.2.0: {}
+  lan-network@0.2.1: {}
 
   lazy-cache@1.0.4: {}
 


### PR DESCRIPTION
# Summary

Resolves #44580

See: https://github.com/kitten/lan-network/blob/main/CHANGELOG.md#021

# Test Plan

- CI should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
