### PR TITLE
chore(cli): Bump to `fetch-nodeshim@^0.4.10`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Limit `/open-stack-frame` to paths within server root ([#44039](https://github.com/expo/expo/pull/44039) by [@kitten](https://github.com/kitten))
 - Use `@expo/require-utils` for ngrok resolution ([#44236](https://github.com/expo/expo/pull/44236) by [@kitten](https://github.com/kitten))
 - Update to `lan-network@^0.2.1` ([#44587](https://github.com/expo/expo/pull/44587) by [@kitten](https://github.com/kitten))
+- Update to `fetch-nodeshim@^0.4.10` ([#44588](https://github.com/expo/expo/pull/44588) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -82,7 +82,7 @@
     "debug": "^4.3.4",
     "dnssd-advertise": "^1.1.3",
     "expo-server": "workspace:^55.0.5",
-    "fetch-nodeshim": "^0.4.6",
+    "fetch-nodeshim": "^0.4.10",
     "getenv": "^2.0.0",
     "glob": "^13.0.0",
     "lan-network": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1746,8 +1746,8 @@ importers:
         specifier: workspace:^55.0.5
         version: link:../../expo-server
       fetch-nodeshim:
-        specifier: ^0.4.6
-        version: 0.4.9
+        specifier: ^0.4.10
+        version: 0.4.10
       getenv:
         specifier: ^2.0.0
         version: 2.0.0
@@ -10959,8 +10959,8 @@ packages:
       picomatch:
         optional: true
 
-  fetch-nodeshim@0.4.9:
-    resolution: {integrity: sha512-XIQWlB2A4RZ7NebXWGxS0uDMdvRHkiUDTghBVJKFg9yEOd45w/PP8cZANuPf2H08W6Cor3+2n7Q6TTZgAS3Fkw==}
+  fetch-nodeshim@0.4.10:
+    resolution: {integrity: sha512-m6I8ALe4L4XpdETy7MJZWs6L1IVMbjs99bwbpIKphxX+0CTns4IKDWJY0LWfr4YsFjfg+z1TjzTMU8lKl8rG0w==}
 
   fetch-retry@4.1.1:
     resolution: {integrity: sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==}
@@ -21711,7 +21711,7 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
-  fetch-nodeshim@0.4.9: {}
+  fetch-nodeshim@0.4.10: {}
 
   fetch-retry@4.1.1: {}
 


### PR DESCRIPTION
# Summary

See: https://github.com/kitten/fetch-nodeshim/blob/main/CHANGELOG.md#0410

# Test Plan

- CI should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
