### PR TITLE
chore(cli): Bump to `dnssd-advertise@^1.1.4`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -47,6 +47,7 @@
 - Use `@expo/require-utils` for ngrok resolution ([#44236](https://github.com/expo/expo/pull/44236) by [@kitten](https://github.com/kitten))
 - Update to `lan-network@^0.2.1` ([#44587](https://github.com/expo/expo/pull/44587) by [@kitten](https://github.com/kitten))
 - Update to `fetch-nodeshim@^0.4.10` ([#44588](https://github.com/expo/expo/pull/44588) by [@kitten](https://github.com/kitten))
+- Update to `dnssd-advertise@^1.1.4` ([#44589](https://github.com/expo/expo/pull/44589) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -80,7 +80,7 @@
     "compression": "^1.7.4",
     "connect": "^3.7.0",
     "debug": "^4.3.4",
-    "dnssd-advertise": "^1.1.3",
+    "dnssd-advertise": "^1.1.4",
     "expo-server": "workspace:^55.0.5",
     "fetch-nodeshim": "^0.4.10",
     "getenv": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1734,8 +1734,8 @@ importers:
         specifier: ^4.3.4
         version: 4.4.3
       dnssd-advertise:
-        specifier: ^1.1.3
-        version: 1.1.3
+        specifier: ^1.1.4
+        version: 1.1.4
       expo:
         specifier: workspace:*
         version: link:../../expo
@@ -10372,8 +10372,8 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
-  dnssd-advertise@1.1.3:
-    resolution: {integrity: sha512-XENsHi3MBzWOCAXif3yZvU1Ah0l+nhJj1sjWL6TnOAYKvGiFhbTx32xHN7+wLMLUOCj7Nr0evADWG4R8JtqCDA==}
+  dnssd-advertise@1.1.4:
+    resolution: {integrity: sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -20741,7 +20741,7 @@ snapshots:
 
   dlv@1.1.3: {}
 
-  dnssd-advertise@1.1.3: {}
+  dnssd-advertise@1.1.4: {}
 
   doctrine@2.1.0:
     dependencies:


### PR DESCRIPTION
# Summary

Resolves #44097

See: https://github.com/kitten/dnssd-advertise/blob/main/CHANGELOG.md#114

# Test Plan

- CI should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
