### PR TITLE
feat(expo-doctor): Print version output on `--verbose`

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add version to the `--verbose` output ([#44592](https://github.com/expo/expo/pull/44592) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/index.ts
+++ b/packages/expo-doctor/src/index.ts
@@ -46,6 +46,9 @@ async function run() {
     }
   });
 
+  if (showVerboseTestResults) {
+    console.log(`expo-doctor: v${packageJson().version}`);
+  }
   await actionAsync(projectRoot, showVerboseTestResults);
 }
 


### PR DESCRIPTION
# Why

Small QoL improvement. When users post the output from `--verbose`, I'd love to see whether they've actually run the latest version, just in case the latest isn't resolved or a cached version is used. This makes the output a little more trustworthy and reliable in the future.

# How

- Add `expo-doctor: v0.0.0` output to `--verbose`

# Test Plan

- Run `expo-doctor`; NOTE: There's a build error right now that'll need to be resolved first

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
