### PR TITLE
fix(expo-doctor): Use independent native modules API call

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Resolve project config by spawning `expo config` CLI instead of importing `@expo/config` directly ([#44044](https://github.com/expo/expo/pull/44044) by [@entiendonull](https://github.com/entiendonull))
 - Include `@react-navigation/native` and `@react-navigation/core` in duplicates check ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
 - Include `web` platform in duplicate packages check ([#43724](https://github.com/expo/expo/pull/43724) by [@kitten](https://github.com/kitten))
+- Use independent native modules API call, instead of reusing `@expo/cli`'s implementation ([#44593](https://github.com/expo/expo/pull/44593) by [@kitten](https://github.com/kitten))
 
 ## 1.18.8 — 2026-02-25
 

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -33,7 +33,6 @@
     "prepublishOnly": "pnpm run clean && pnpm run build:prod"
   },
   "devDependencies": {
-    "@expo/cli": "workspace:*",
     "@expo/config": "workspace:*",
     "@expo/env": "workspace:*",
     "@expo/json-file": "workspace:*",

--- a/packages/expo-doctor/src/api/getNativeModuleVersionsAsync.ts
+++ b/packages/expo-doctor/src/api/getNativeModuleVersionsAsync.ts
@@ -1,0 +1,57 @@
+import resolveFrom from 'resolve-from';
+
+type BundledNativeModules = Record<string, string>;
+
+export async function getNativeModuleVersionsAsync(
+  projectRoot: string,
+  sdkVersion: string
+): Promise<BundledNativeModules> {
+  if (sdkVersion !== 'UNVERSIONED') {
+    try {
+      return await fetchNativeModuleVersionsAsync(sdkVersion);
+    } catch {}
+  }
+
+  return await readLocalBundledNativeModulesAsync(projectRoot);
+}
+
+async function fetchNativeModuleVersionsAsync(sdkVersion: string): Promise<BundledNativeModules> {
+  const url = new URL(`/v2/sdks/${sdkVersion}/native-modules`, getExpoApiBaseUrl()).toString();
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Unexpected response from Expo API: ${response.statusText}`);
+  }
+
+  const json: any = await response.json();
+  const data: { npmPackage: string; versionRange: string }[] = json?.data;
+  if (!data?.length) {
+    throw new Error('The bundled native module list from the Expo API is empty');
+  }
+
+  return Object.fromEntries(data.map((entry) => [entry.npmPackage, entry.versionRange]));
+}
+
+async function readLocalBundledNativeModulesAsync(
+  projectRoot: string
+): Promise<BundledNativeModules> {
+  const bundledNativeModulesPath = resolveFrom.silent(
+    projectRoot,
+    'expo/bundledNativeModules.json'
+  );
+  if (!bundledNativeModulesPath) {
+    throw new Error(
+      'The dependency map expo/bundledNativeModules.json cannot be found. Ensure you have the "expo" package installed in your project.'
+    );
+  }
+  return require(bundledNativeModulesPath);
+}
+
+function getExpoApiBaseUrl(): string {
+  if (process.env.EXPO_STAGING) {
+    return 'https://staging-api.expo.dev';
+  } else if (process.env.EXPO_LOCAL) {
+    return 'http://127.0.0.1:3000';
+  } else {
+    return 'https://api.expo.dev';
+  }
+}

--- a/packages/expo-doctor/src/utils/versionedNativeModules.ts
+++ b/packages/expo-doctor/src/utils/versionedNativeModules.ts
@@ -1,5 +1,4 @@
-import { getVersionedNativeModulesAsync } from '@expo/cli/src/start/doctor/dependencies/bundledNativeModules';
-
+import { getNativeModuleVersionsAsync } from '../api/getNativeModuleVersionsAsync';
 import { Log } from '../utils/log';
 
 export interface VersionedNativeModuleNamesCache {
@@ -15,7 +14,7 @@ export const getVersionedNativeModuleNamesAsync = (
 ): Promise<string[] | null> => {
   const _task = async () => {
     try {
-      const bundledNativeModules = await getVersionedNativeModulesAsync(
+      const bundledNativeModules = await getNativeModuleVersionsAsync(
         params.projectRoot,
         params.sdkVersion!
       );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3897,9 +3897,6 @@ importers:
 
   packages/expo-doctor:
     devDependencies:
-      '@expo/cli':
-        specifier: workspace:*
-        version: link:../@expo/cli
       '@expo/config':
         specifier: workspace:*
         version: link:../@expo/config


### PR DESCRIPTION
# Why

`@expo/cli`'s internal files aren't meant to be re-used. On `main`, this is now resulting in a build error since the `package.json:exports` don't allow this file to be reused. Since this was always meant to be a separate implementation, this PR adds a vendored API call for the native modules JSON.

# How

- Add `src/api/getNativeModuleVersionsAsync.ts` with slim native modules fetching
- Replace internal `@expo/cli` import path with it

# Test Plan

- CI should pass unchanged / manual run validates this

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
