### PR TITLE
[canaries] Schedule publishing from main

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -22,7 +22,6 @@ jobs:
       - name: 👀 Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'schedule' && 'sdk-56' || github.ref }}
           submodules: true
       - name: 🔨 Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app


### PR DESCRIPTION
# Why
The scheduled publish is failing since the pnpm migration. We don't need to use sdk-56 branch anymore and can go back to publishing from main

