### PR TITLE
[tools] Use `run` to forward args to scripts

### DIFF
--- a/tools/src/check-packages/runPackageScriptAsync.ts
+++ b/tools/src/check-packages/runPackageScriptAsync.ts
@@ -19,7 +19,7 @@ export default async function runPackageScriptAsync(
     logger.debug(`🤷‍♂️ ${cyan(scriptName)} script not found`);
     return;
   }
-  const spawnArgs = [scriptName, ...args];
+  const spawnArgs = args.length > 0 ? [scriptName, '--', ...args] : [scriptName];
 
   logger.log(`🏃‍♀️ Running ${cyan.italic(`pnpm ${spawnArgs.join(' ')}`)}`);
 

--- a/tools/src/check-packages/runPackageScriptAsync.ts
+++ b/tools/src/check-packages/runPackageScriptAsync.ts
@@ -19,7 +19,7 @@ export default async function runPackageScriptAsync(
     logger.debug(`🤷‍♂️ ${cyan(scriptName)} script not found`);
     return;
   }
-  const spawnArgs = args.length > 0 ? [scriptName, '--', ...args] : [scriptName];
+  const spawnArgs = ['run', scriptName, ...args];
 
   logger.log(`🏃‍♀️ Running ${cyan.italic(`pnpm ${spawnArgs.join(' ')}`)}`);
 


### PR DESCRIPTION
# Why
pnpm requires `--` when you want to pass arguments to a script, otherwise it will interpret the arguments as it's own and fail.
 
# How
~~Include `--` when we have multiple arguments~~
First attempt still had issues with scripts that included a `:`. Switching to `pnpm run` seems to be the best option

# Test Plan
`et cp` works without error locally
