### PR TITLE
[sdk-55] fix(expo-modules-core): Replace adhoc `react-native-worklets` resolution with pod/peer resolution

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Resolve `react-native-worklets` from existing podspec, falling back to peer resolution ([#44232](https://github.com/expo/expo/pull/44232) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.21 — 2026-04-07

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -108,9 +108,16 @@ Pod::Spec.new do |s|
     ])
 
     if shouldEnableWorkletsIntegration
+      rn_worklets_dep = Pod::Config.instance.podfile.dependencies.find { |dep| dep.name == 'RNWorklets' }
+      rn_worklets_path = rn_worklets_dep&.external_source&.dig(:path)
+      react_native_worklets_dir_absolute = if rn_worklets_path
+        File.expand_path(rn_worklets_path, Pod::Config.instance.installation_root.to_s)
+      else
+        project_root = ENV['PROJECT_ROOT'] || Pod::Config.instance.installation_root.to_s
+        File.dirname(`node --print "require.resolve('react-native-worklets/package.json', { paths: ['#{__dir__}', '#{project_root}'] })"`)
+      end
+
       pods_root = Pod::Config.instance.project_pods_root
-      react_native_worklets_node_modules_dir = File.join(File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native-worklets/package.json')"`), '..')
-      react_native_worklets_dir_absolute = File.join(react_native_worklets_node_modules_dir, 'react-native-worklets')
       workletsPath = Pathname.new(react_native_worklets_dir_absolute).relative_path_from(pods_root).to_s
 
       header_search_paths.concat([

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -60,7 +60,13 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-worklets": "^0.7.4 || ^0.8.0"
+  },
+  "peerDependenciesMeta": {
+    "react-native-worklets": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.0",


### PR DESCRIPTION
# Why

**Backport of #44232 to SDK 55**

# How

Manually targeted changes to `ExpoModulesCore.podspec`

# Test Plan

- CI should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
