### PR TITLE
[dev-launcher] fix deep links not reaching the app

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed deep links not reaching the app because `EXDevLauncherController.isAppRunning` always returned `false`. ([#44609](https://github.com/expo/expo/pull/44609) by [@vonovak](https://github.com/vonovak))
 - [Android] Fix `DevLauncherErrorActivity` dark theme. ([#44529](https://github.com/expo/expo/pull/44529) by [@zoontek](https://github.com/zoontek))
 - [iOS] Fix issue when using `fullScreenModal` with `expo-router`. ([#43520](https://github.com/expo/expo/pull/43520) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix missing navigation bar padding ([#43672](https://github.com/expo/expo/pull/43672) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -41,7 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface EXDevLauncherController : RCTDefaultReactNativeFactoryDelegate <RCTBridgeDelegate, EXUpdatesExternalInterfaceDelegate>
 
-@property (nonatomic, weak) RCTBridge * _Nullable appBridge;
 @property (nonatomic, weak) EXAppContext * _Nullable appContext;
 @property (nonatomic, strong) EXDevLauncherPendingDeepLinkRegistry *pendingDeepLinkRegistry;
 @property (nonatomic, strong) EXDevLauncherRecentlyOpenedAppsRegistry *recentlyOpenedAppsRegistry;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -228,7 +228,6 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 {
   NSAssert([NSThread isMainThread], @"This function must be called on main thread");
 
-  [_appBridge invalidate];
   [self invalidateDevMenuApp];
 
   self.networkInterceptor = nil;
@@ -539,11 +538,7 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
 
 - (BOOL)isAppRunning
 {
-  if([_appBridge isProxy]){
-    return [self.delegate isReactInstanceValid];
-  }
-
-  return [_appBridge isValid];
+  return [self.delegate isReactInstanceValid];
 }
 
 #if !TARGET_OS_OSX

--- a/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
+++ b/packages/expo-dev-launcher/ios/Errors/EXDevLauncherUncaughtExceptionHandler.swift
@@ -54,7 +54,7 @@ public class EXDevLauncherUncaughtExceptionHandler: NSObject {
     // URL structure replicates
     // https://github.com/facebook/react-native/blob/0.69-stable/Libraries/Utilities/HMRClient.js#L164
     // but URLSessionWebSocketTask will crash if the scheme is not `ws` or `wss`
-    guard let appUrl = controller.appBridge?.bundleURL else {
+    guard let appUrl = controller.sourceUrl() else {
       return nil
     }
     guard let socketUrl = URL.init(string: "hot", relativeTo: appUrl) else {

--- a/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
+++ b/packages/expo-dev-launcher/ios/ReactDelegateHandler/ExpoDevLauncherReactDelegateHandler.swift
@@ -115,7 +115,6 @@ public class ExpoDevLauncherReactDelegateHandler: ExpoReactDelegateHandler, EXDe
       initialProps: self.rootViewInitialProperties,
       launchOptions: developmentClientController.getLaunchOptions()
     )
-    developmentClientController.appBridge = RCTBridge.current()
 
     let targetVC: UIViewController
 #if !os(macOS)


### PR DESCRIPTION
# Why

On the new architecture (bridgeless), `EXDevLauncherController.isAppRunning` always returned `false` because it relied on the removed `RCTBridge` (`_appBridge` was always nil). This caused the dev launcher to swallow deep link URLs instead of letting them through to `RCTLinkingManager`, so deep links never reached JS (when the app was running).

# How

- Removed the `appBridge` (`RCTBridge`) property and all its usages from `EXDevLauncherController`.
- `isAppRunning` now delegates to `self.delegate.isReactInstanceValid()`.
- `EXDevLauncherUncaughtExceptionHandler.getWebSocketUrl` now uses `controller.sourceUrl()` instead of `appBridge.bundleURL`

# Test Plan

1. Build bare-expo with dev client on iOS.
2. With the app running, execute `xcrun simctl openurl booted "bareexpo://components/video/fullscreen"`.
3. Verify the app navigates to the Video Fullscreen screen.
4. Verify cold-start deep links still work: kill the app, then run the same `openurl` command.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)