### PR TITLE
[docs] Align typography with styleguide

### DIFF
--- a/docs/components/DocumentationNestedScrollLayout.tsx
+++ b/docs/components/DocumentationNestedScrollLayout.tsx
@@ -120,7 +120,7 @@ export default function DocumentationNestedScrollLayout({
                     </span>
                   </Button>
                 </Tooltip.Trigger>
-                <Tooltip.Content sideOffset={8} className="max-w-[260px] text-center text-xs">
+                <Tooltip.Content sideOffset={8} className="max-w-[260px] text-center text-sm">
                   Use Cmd/Ctrl + Shift + Enter to toggle immersive mode.
                 </Tooltip.Content>
               </Tooltip.Root>

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -116,7 +116,7 @@ export function Code({ className, children, title }: CodeProps) {
           {...attributes}>
           <div className="w-fit p-4">
             <code
-              className="text-2xs text-default"
+              className="text-default text-xs"
               dangerouslySetInnerHTML={{ __html: highlightedHtml.replace(/^@@@.+@@@/g, '') }}
             />
           </div>
@@ -140,7 +140,7 @@ export function Code({ className, children, title }: CodeProps) {
       {...attributes}>
       <div className="w-fit p-4">
         <code
-          className="text-2xs text-default"
+          className="text-default text-xs"
           dangerouslySetInnerHTML={{ __html: highlightedHtml }}
         />
       </div>
@@ -163,7 +163,7 @@ export const CodeBlock = ({ children, theme, className, inline = false }: CodeBl
       {...attributes}>
       <CODE
         className={mergeClasses(
-          'text-3xs! text-default',
+          'text-default text-xs!',
           inline && 'block w-full p-1.5!',
           className
         )}

--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -99,14 +99,14 @@ exports[`APISection expo-apple-authentication 1`] = `
       data-text="true"
     >
       <span
-        class="text-tertiary text-xs font-medium"
+        class="text-tertiary text-sm font-medium"
         data-text="true"
       >
         Type:
       </span>
        
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
         data-text="true"
       >
         React.Element
@@ -152,7 +152,7 @@ available via the provided properties.
           href="#appleauthenticationisavailableasync"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.isAvailableAsync()
@@ -161,7 +161,7 @@ available via the provided properties.
         
 resolves to 
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           true
@@ -169,7 +169,7 @@ resolves to
         . This component will render nothing if it is not available, and you will get
 a warning in development mode (
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           __DEV__ === true
@@ -184,7 +184,7 @@ a warning in development mode (
       >
         The properties of this component extend from 
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           View
@@ -192,21 +192,21 @@ a warning in development mode (
         ; however, you should not attempt to set
 
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           backgroundColor
         </code>
          or 
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           borderRadius
         </code>
          with the 
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           style
@@ -214,7 +214,7 @@ a warning in development mode (
          property. This will not work and is against
 the App Store Guidelines. Instead, you should use the 
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           buttonStyle
@@ -222,7 +222,7 @@ the App Store Guidelines. Instead, you should use the
          property to choose one of the
 predefined color styles and the 
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           cornerRadius
@@ -270,7 +270,7 @@ not appear on the screen.
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -300,7 +300,7 @@ for more details.
     </div>
     <div>
       <p
-        class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium"
+        class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-tertiary flex border-y px-4 py-2 text-xs font-medium"
         data-text="true"
       >
         <span
@@ -310,7 +310,7 @@ for more details.
         >
           AppleAuthenticationButtonProps
           <a
-            class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-2xs text-tertiary flex flex-row items-center gap-2 font-medium"
+            class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-tertiary flex flex-row items-center gap-2 text-xs font-medium"
             href="#appleauthenticationbuttonprops"
           >
             <span
@@ -401,12 +401,12 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
+          class="text-tertiary text-sm font-medium mx-4 mb-2.5"
         >
           Type:
            
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
@@ -482,12 +482,12 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
+          class="text-tertiary text-sm font-medium mx-4 mb-2.5"
         >
           Type:
            
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
@@ -563,13 +563,13 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
+          class="text-tertiary text-sm font-medium mx-4 mb-2.5"
         >
           Optional • 
           Type:
            
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
@@ -586,7 +586,7 @@ for more details.
             The border radius to use when rendering the button. This works similarly to
 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               style.borderRadius
@@ -648,12 +648,12 @@ for more details.
           </h3>
         </div>
         <div
-          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
+          class="text-tertiary text-sm font-medium mx-4 mb-2.5"
         >
           Type:
            
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
@@ -684,7 +684,7 @@ for more details.
               href="#appleauthenticationisavailableasync"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                 data-text="true"
               >
                 AppleAuthentication.signInAsync
@@ -748,13 +748,13 @@ in here.
           </h3>
         </div>
         <div
-          class="text-tertiary text-xs font-medium mx-4 mb-2.5"
+          class="text-tertiary text-sm font-medium mx-4 mb-2.5"
         >
           Optional • 
           Type:
            
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-md="type-sig"
             data-text="true"
           >
@@ -828,14 +828,14 @@ in here.
           >
             The custom style to apply to the button. Should not include 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               backgroundColor
             </code>
              or 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               borderRadius
@@ -896,7 +896,7 @@ properties.
             data-text="true"
           >
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               <a
@@ -1009,7 +1009,7 @@ properties.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -1018,17 +1018,17 @@ properties.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -1053,7 +1053,7 @@ properties.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -1093,7 +1093,7 @@ properties.
                 formatStyle
               </span>
               <span
-                class="text-3xs! text-tertiary flex"
+                class="text-tertiary flex text-xs!"
               >
                 (optional)
               </span>
@@ -1102,7 +1102,7 @@ properties.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -1168,13 +1168,13 @@ properties.
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           string
@@ -1252,7 +1252,7 @@ properties.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -1261,17 +1261,17 @@ properties.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -1296,7 +1296,7 @@ properties.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
@@ -1319,7 +1319,7 @@ This should come from the user field of an
                     href="#appleauthenticationcredentialstate"
                   >
                     <code
-                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                      class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                       data-text="true"
                     >
                       AppleAuthenticationCredential
@@ -1376,7 +1376,7 @@ This should come from the user field of an
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           
 
@@ -1423,13 +1423,13 @@ This should come from the user field of an
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -1476,7 +1476,7 @@ This should come from the user field of an
               href="#appleauthenticationcredentialstate"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                 data-text="true"
               >
                 AppleAuthenticationCredentialState
@@ -1577,13 +1577,13 @@ value depending on the state of the credential.
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -1621,14 +1621,14 @@ value depending on the state of the credential.
           >
             A promise that fulfills with 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               true
             </code>
              if the system supports Apple authentication, and 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               false
@@ -1695,7 +1695,7 @@ value depending on the state of the credential.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -1704,17 +1704,17 @@ value depending on the state of the credential.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -1739,7 +1739,7 @@ value depending on the state of the credential.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -1766,7 +1766,7 @@ value depending on the state of the credential.
                     href="#appleauthenticationrefreshoptions"
                   >
                     <code
-                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                      class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                       data-text="true"
                     >
                       AppleAuthenticationRefreshOptions
@@ -1818,13 +1818,13 @@ Calling this method will show the sign in modal before actually refreshing the u
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -1871,7 +1871,7 @@ Calling this method will show the sign in modal before actually refreshing the u
               href="#appleauthenticationcredential"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                 data-text="true"
               >
                 AppleAuthenticationCredential
@@ -1880,7 +1880,7 @@ Calling this method will show the sign in modal before actually refreshing the u
             
 object after a successful authentication, and rejects with 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               ERR_REQUEST_CANCELED
@@ -1948,7 +1948,7 @@ refresh operation.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -1957,17 +1957,17 @@ refresh operation.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -1988,7 +1988,7 @@ refresh operation.
                 options
               </span>
               <span
-                class="text-3xs! text-tertiary flex"
+                class="text-tertiary flex text-xs!"
               >
                 (optional)
               </span>
@@ -1997,7 +1997,7 @@ refresh operation.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -2024,7 +2024,7 @@ refresh operation.
                     href="#appleauthenticationsigninoptions"
                   >
                     <code
-                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                      class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                       data-text="true"
                     >
                       AppleAuthenticationSignInOptions
@@ -2081,7 +2081,7 @@ You can use
           href="#appleauthenticationcredential"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthenticationCredential.user
@@ -2117,13 +2117,13 @@ the user, since this remains the same for apps released by the same developer.
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -2170,7 +2170,7 @@ the user, since this remains the same for apps released by the same developer.
               href="#appleauthenticationcredential"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                 data-text="true"
               >
                 AppleAuthenticationCredential
@@ -2179,7 +2179,7 @@ the user, since this remains the same for apps released by the same developer.
             
 object after a successful authentication, and rejects with 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               ERR_REQUEST_CANCELED
@@ -2247,7 +2247,7 @@ sign-in operation.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -2256,17 +2256,17 @@ sign-in operation.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -2291,7 +2291,7 @@ sign-in operation.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -2318,7 +2318,7 @@ sign-in operation.
                     href="#appleauthenticationsignoutoptions"
                   >
                     <code
-                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                      class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                       data-text="true"
                     >
                       AppleAuthenticationSignOutOptions
@@ -2357,7 +2357,7 @@ from using
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             signInAsync
@@ -2369,7 +2369,7 @@ from using
           href="#appleauthenticationrefreshasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             refreshAsync
@@ -2404,13 +2404,13 @@ from using
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -2457,7 +2457,7 @@ from using
               href="#appleauthenticationcredential"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                 data-text="true"
               >
                 AppleAuthenticationCredential
@@ -2466,7 +2466,7 @@ from using
             
 object after a successful authentication, and rejects with 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               ERR_REQUEST_CANCELED
@@ -2574,7 +2574,7 @@ sign-out operation.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -2583,12 +2583,12 @@ sign-out operation.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
@@ -2613,7 +2613,7 @@ sign-out operation.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span
@@ -2660,13 +2660,13 @@ sign-out operation.
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           EventSubscription
@@ -2777,7 +2777,7 @@ sign-out operation.
       </p>
     </div>
     <p
-      class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium"
+      class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-tertiary flex border-y px-4 py-2 text-xs font-medium"
       data-text="true"
     >
       <span
@@ -2787,7 +2787,7 @@ sign-out operation.
       >
         Subscription Methods
         <a
-          class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-2xs text-tertiary flex flex-row items-center gap-2 font-medium"
+          class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-tertiary flex flex-row items-center gap-2 text-xs font-medium"
           href="#subscription-methods"
         >
           <span
@@ -2910,13 +2910,13 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="text-tertiary text-xs font-medium"
+              class="text-tertiary text-sm font-medium"
             >
               Returns:
             </span>
           </div>
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
             data-text="true"
           >
             void
@@ -3030,7 +3030,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -3043,7 +3043,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationrefreshasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.refreshAsync()
@@ -3055,7 +3055,7 @@ After calling this function, the listener will no longer receive any events from
           href="#appleauthenticationsignoutasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.signOutAsync()
@@ -3095,7 +3095,7 @@ which contains all of the pertinent user and credential information.
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -3130,7 +3130,7 @@ for more details.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -3139,17 +3139,17 @@ for more details.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -3173,7 +3173,7 @@ for more details.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3202,7 +3202,7 @@ for more details.
                   A short-lived session token used by your app for proof of authorization when interacting with
 the app's server counterpart. Unlike 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     user
@@ -3229,7 +3229,7 @@ the app's server counterpart. Unlike
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3257,7 +3257,7 @@ the app's server counterpart. Unlike
                 >
                   The user's email address. Might not be present if you didn't request the 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     EMAIL
@@ -3287,7 +3287,7 @@ an Apple domain.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3320,21 +3320,21 @@ an Apple domain.
                 >
                   The user's name. May be 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     null
                   </code>
                    or contain 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     null
                   </code>
                    values if you didn't request the 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     FULL_NAME
@@ -3363,7 +3363,7 @@ your app.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3411,7 +3411,7 @@ your app.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -3454,7 +3454,7 @@ your app.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3482,7 +3482,7 @@ your app.
                 >
                   An arbitrary string that your app provided as 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     state
@@ -3491,7 +3491,7 @@ your app.
 credential. Used to verify that the response was from the request you made. Can be used to
 avoid replay attacks. If you did not provide 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     state
@@ -3499,7 +3499,7 @@ avoid replay attacks. If you did not provide
                    when making the sign-in request, this field
 will be 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     null
@@ -3526,7 +3526,7 @@ will be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
@@ -3616,7 +3616,7 @@ developers.
         An object representing the tokenized portions of the user's full name. Any of all of the fields
 may be 
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           null
@@ -3631,7 +3631,7 @@ may be
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -3640,17 +3640,17 @@ may be
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -3674,7 +3674,7 @@ may be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3717,7 +3717,7 @@ may be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3760,7 +3760,7 @@ may be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3803,7 +3803,7 @@ may be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3846,7 +3846,7 @@ may be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3889,7 +3889,7 @@ may be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <span>
@@ -3976,12 +3976,12 @@ may be
       data-text="true"
     >
       <span
-        class="text-tertiary text-xs font-medium"
+        class="text-tertiary text-sm font-medium"
       >
         Literal Type: 
       </span>
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
         data-text="true"
       >
         string
@@ -4027,7 +4027,7 @@ may be
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -4056,13 +4056,13 @@ for more details.
       </blockquote>
     </div>
     <p
-      class="tracking-[-0.006rem] text-tertiary text-xs font-medium mx-4 mb-2.5 [table_&]:last:mb-0"
+      class="tracking-[-0.006rem] text-tertiary text-sm font-medium mx-4 mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
       Acceptable values are:
        
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'default'
@@ -4073,7 +4073,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'short'
@@ -4084,7 +4084,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'medium'
@@ -4095,7 +4095,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'long'
@@ -4106,7 +4106,7 @@ for more details.
          | 
       </span>
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'abbreviated'
@@ -4178,7 +4178,7 @@ for more details.
           href="#appleauthenticationrefreshasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.refreshAsync()
@@ -4218,7 +4218,7 @@ You must include the ID string of the user whose credentials you'd like to refre
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -4253,7 +4253,7 @@ for more details.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -4262,17 +4262,17 @@ for more details.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -4292,7 +4292,7 @@ for more details.
                 requestedScopes
               </span>
               <span
-                class="text-3xs! text-tertiary flex"
+                class="text-tertiary flex text-xs!"
               >
                 (optional)
               </span>
@@ -4301,7 +4301,7 @@ for more details.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -4327,7 +4327,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     null
@@ -4336,14 +4336,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     null
                   </code>
                   . Defaults to 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     []
@@ -4366,7 +4366,7 @@ requests they will be
                 state
               </span>
               <span
-                class="text-3xs! text-tertiary flex"
+                class="text-tertiary flex text-xs!"
               >
                 (optional)
               </span>
@@ -4375,7 +4375,7 @@ requests they will be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
@@ -4425,7 +4425,7 @@ OAuth 2.0 protocol
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
@@ -4510,7 +4510,7 @@ OAuth 2.0 protocol
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -4550,7 +4550,7 @@ None of these options are required.
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -4585,7 +4585,7 @@ for more details.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -4594,17 +4594,17 @@ for more details.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -4624,7 +4624,7 @@ for more details.
                 nonce
               </span>
               <span
-                class="text-3xs! text-tertiary flex"
+                class="text-tertiary flex text-xs!"
               >
                 (optional)
               </span>
@@ -4633,7 +4633,7 @@ for more details.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
@@ -4677,7 +4677,7 @@ for more details.
                 requestedScopes
               </span>
               <span
-                class="text-3xs! text-tertiary flex"
+                class="text-tertiary flex text-xs!"
               >
                 (optional)
               </span>
@@ -4686,7 +4686,7 @@ for more details.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -4712,7 +4712,7 @@ for more details.
 choose to deny your app access to any scope at the time of logging in. You will still need to
 handle 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     null
@@ -4721,14 +4721,14 @@ handle
 will only be provided to you the first time each user signs into your app; in subsequent
 requests they will be 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     null
                   </code>
                   . Defaults to 
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     []
@@ -4751,7 +4751,7 @@ requests they will be
                 state
               </span>
               <span
-                class="text-3xs! text-tertiary flex"
+                class="text-tertiary flex text-xs!"
               >
                 (optional)
               </span>
@@ -4760,7 +4760,7 @@ requests they will be
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
@@ -4862,7 +4862,7 @@ OAuth 2.0 protocol
           href="#appleauthenticationsignoutasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.signOutAsync()
@@ -4902,7 +4902,7 @@ You must include the ID string of the user to sign out.
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -4937,7 +4937,7 @@ for more details.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -4946,17 +4946,17 @@ for more details.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -4976,7 +4976,7 @@ for more details.
                 state
               </span>
               <span
-                class="text-3xs! text-tertiary flex"
+                class="text-tertiary flex text-xs!"
               >
                 (optional)
               </span>
@@ -4985,7 +4985,7 @@ for more details.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
@@ -5035,7 +5035,7 @@ OAuth 2.0 protocol
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 string
@@ -5160,7 +5160,7 @@ OAuth 2.0 protocol
           href="#appleauthenticationbutton"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -5222,7 +5222,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE ＝ 0
@@ -5291,7 +5291,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.WHITE_OUTLINE ＝ 1
@@ -5360,7 +5360,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonStyle.BLACK ＝ 2
@@ -5442,7 +5442,7 @@ OAuth 2.0 protocol
           href="#appleauthenticationbutton"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthenticationButton
@@ -5504,7 +5504,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_IN ＝ 0
@@ -5573,7 +5573,7 @@ OAuth 2.0 protocol
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonType.CONTINUE ＝ 1
@@ -5669,7 +5669,7 @@ OAuth 2.0 protocol
                 </g>
               </svg>
               <span
-                class="text-3xs! leading-none! font-normal whitespace-nowrap"
+                class="text-xs! leading-none! font-normal whitespace-nowrap"
               >
                 iOS 13.2+
               </span>
@@ -5678,7 +5678,7 @@ OAuth 2.0 protocol
         </div>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationButtonType.SIGN_UP ＝ 2
@@ -5760,7 +5760,7 @@ OAuth 2.0 protocol
           href="#appleauthenticationgetcredentialstateasyncuser"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.getCredentialStateAsync()
@@ -5799,7 +5799,7 @@ OAuth 2.0 protocol
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -5880,7 +5880,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationCredentialState.REVOKED ＝ 0
@@ -5942,7 +5942,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationCredentialState.AUTHORIZED ＝ 1
@@ -6004,7 +6004,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationCredentialState.NOT_FOUND ＝ 2
@@ -6066,7 +6066,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationCredentialState.TRANSFERRED ＝ 3
@@ -6184,7 +6184,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationOperation.IMPLICIT ＝ 0
@@ -6253,7 +6253,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGIN ＝ 1
@@ -6315,7 +6315,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationOperation.REFRESH ＝ 2
@@ -6377,7 +6377,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationOperation.LOGOUT ＝ 3
@@ -6452,7 +6452,7 @@ for more details.
           href="#appleauthenticationsigninasyncoptions"
         >
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             AppleAuthentication.signInAsync()
@@ -6493,7 +6493,7 @@ for more details.
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           
 
@@ -6539,7 +6539,7 @@ You will still need to handle null values for any fields you request.
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -6620,7 +6620,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationScope.FULL_NAME ＝ 0
@@ -6682,7 +6682,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationScope.EMAIL ＝ 1
@@ -6784,7 +6784,7 @@ for more details.
           </g>
         </svg>
         <div
-          class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+          class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
         >
           <p
             class="text-inherit font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem] mb-2.5 [table_&]:last:mb-0"
@@ -6865,7 +6865,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNSUPPORTED ＝ 0
@@ -6934,7 +6934,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.UNKNOWN ＝ 1
@@ -7003,7 +7003,7 @@ for more details.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         AppleAuthenticationUserDetectionStatus.LIKELY_REAL ＝ 2
@@ -7153,13 +7153,13 @@ exports[`APISection expo-pedometer 1`] = `
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -7267,7 +7267,7 @@ exports[`APISection expo-pedometer 1`] = `
               </g>
             </svg>
             <span
-              class="text-3xs! leading-none! font-normal whitespace-nowrap"
+              class="text-xs! leading-none! font-normal whitespace-nowrap"
             >
               iOS
             </span>
@@ -7279,7 +7279,7 @@ exports[`APISection expo-pedometer 1`] = `
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -7288,17 +7288,17 @@ exports[`APISection expo-pedometer 1`] = `
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -7323,7 +7323,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -7369,7 +7369,7 @@ exports[`APISection expo-pedometer 1`] = `
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -7437,13 +7437,13 @@ exports[`APISection expo-pedometer 1`] = `
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -7490,7 +7490,7 @@ exports[`APISection expo-pedometer 1`] = `
               href="#pedometerresult"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                 data-text="true"
               >
                 PedometerResult
@@ -7548,7 +7548,7 @@ exports[`APISection expo-pedometer 1`] = `
               </g>
             </svg>
             <div
-              class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+              class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
             >
               
 
@@ -7655,13 +7655,13 @@ a start date that is more than seven days in the past returns only the available
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -7699,7 +7699,7 @@ a start date that is more than seven days in the past returns only the available
           >
             Returns a promise that fulfills with a 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               boolean
@@ -7799,13 +7799,13 @@ available on this device.
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           <a
@@ -7889,7 +7889,7 @@ available on this device.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -7898,17 +7898,17 @@ available on this device.
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Parameter
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -7933,7 +7933,7 @@ available on this device.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 <a
@@ -7961,7 +7961,7 @@ provided with a single argument that is
                     href="#pedometerresult"
                   >
                     <code
-                      class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                      class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                       data-text="true"
                     >
                       PedometerResult
@@ -8012,13 +8012,13 @@ provided with a single argument that is
             </g>
           </svg>
           <span
-            class="text-tertiary text-xs font-medium"
+            class="text-tertiary text-sm font-medium"
           >
             Returns:
           </span>
         </div>
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           EventSubscription
@@ -8040,7 +8040,7 @@ provided with a single argument that is
               href="#subscription"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                 data-text="true"
               >
                 Subscription
@@ -8049,7 +8049,7 @@ provided with a single argument that is
              that enables you to call
 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
               data-text="true"
             >
               remove()
@@ -8089,7 +8089,7 @@ provided with a single argument that is
               </g>
             </svg>
             <div
-              class="text-default w-full last:mb-0 text-xs [&_code]:text-[90%] [&_p]:text-xs"
+              class="text-default w-full last:mb-0 text-sm [&_code]:text-[90%] [&_p]:text-sm"
             >
               
 
@@ -8106,7 +8106,7 @@ provided with a single argument that is
                   target="_blank"
                 >
                   <code
-                    class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                    class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                     data-text="true"
                   >
                     Health Connect API
@@ -8115,7 +8115,7 @@ provided with a single argument that is
                 .
 On iOS, the 
                 <code
-                  class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+                  class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
                   data-text="true"
                 >
                   getStepCountAsync
@@ -8233,7 +8233,7 @@ On iOS, the
       </p>
     </div>
     <p
-      class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium"
+      class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-tertiary flex border-y px-4 py-2 text-xs font-medium"
       data-text="true"
     >
       <span
@@ -8243,7 +8243,7 @@ On iOS, the
       >
         Subscription Methods
         <a
-          class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-2xs text-tertiary flex flex-row items-center gap-2 font-medium"
+          class="border border-solid rounded-full whitespace-nowrap border-button-quaternary bg-button-quaternary shadow-none hocus:bg-button-quaternary-hover active:scale-98 duration-default relative my-auto justify-center p-0 transition-all invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-visible:visible group-focus-visible:opacity-100 size-[22px] min-w-[22px] text-tertiary flex flex-row items-center gap-2 text-xs font-medium"
           href="#subscription-methods"
         >
           <span
@@ -8366,13 +8366,13 @@ After calling this function, the listener will no longer receive any events from
               </g>
             </svg>
             <span
-              class="text-tertiary text-xs font-medium"
+              class="text-tertiary text-sm font-medium"
             >
               Returns:
             </span>
           </div>
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
             data-text="true"
           >
             void
@@ -8483,7 +8483,7 @@ After calling this function, the listener will no longer receive any events from
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -8492,17 +8492,17 @@ After calling this function, the listener will no longer receive any events from
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -8526,7 +8526,7 @@ After calling this function, the listener will no longer receive any events from
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 number
@@ -8621,7 +8621,7 @@ After calling this function, the listener will no longer receive any events from
         class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
       >
         <table
-          class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+          class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
           <thead
             class="border-b-default bg-subtle border-b"
@@ -8630,12 +8630,12 @@ After calling this function, the listener will no longer receive any events from
               class="even:bg-subtle"
             >
               <th
-                class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+                class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
               >
                 Parameter
               </th>
               <th
-                class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+                class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
               >
                 Type
               </th>
@@ -8660,7 +8660,7 @@ After calling this function, the listener will no longer receive any events from
                 class="border-secondary border-r p-4 text-left last:border-r-0"
               >
                 <code
-                  class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                  class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                   data-text="true"
                 >
                   <a
@@ -8702,7 +8702,7 @@ After calling this function, the listener will no longer receive any events from
           </g>
         </svg>
         <span
-          class="text-tertiary text-xs font-medium"
+          class="text-tertiary text-sm font-medium"
         >
           Returns:
         </span>
@@ -8712,7 +8712,7 @@ After calling this function, the listener will no longer receive any events from
         data-text="true"
       >
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
           data-text="true"
         >
           void
@@ -8777,12 +8777,12 @@ After calling this function, the listener will no longer receive any events from
       data-text="true"
     >
       <span
-        class="text-tertiary text-xs font-medium"
+        class="text-tertiary text-sm font-medium"
       >
         Literal Type: 
       </span>
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
         data-text="true"
       >
         union
@@ -8799,13 +8799,13 @@ After calling this function, the listener will no longer receive any events from
       </p>
     </div>
     <p
-      class="tracking-[-0.006rem] text-tertiary text-xs font-medium mx-4 mb-2.5 [table_&]:last:mb-0"
+      class="tracking-[-0.006rem] text-tertiary text-sm font-medium mx-4 mb-2.5 [table_&]:last:mb-0"
       data-text="true"
     >
       Acceptable values are:
        
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         'never'
@@ -8816,7 +8816,7 @@ After calling this function, the listener will no longer receive any events from
          | 
       </span>
       <code
-        class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
+        class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 mb-px"
         data-text="true"
       >
         number
@@ -8892,7 +8892,7 @@ After calling this function, the listener will no longer receive any events from
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-xs [&_p]:text-xs [&_li]:text-xs [&_span]:text-xs [&_code_span]:text-inherit [&_strong]:text-xs [&_blockquote_div]:text-xs [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -8901,17 +8901,17 @@ After calling this function, the listener will no longer receive any events from
             class="even:bg-subtle"
           >
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Property
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Type
             </th>
             <th
-              class="border-secondary text-secondary border-r px-4 font-medium text-left text-3xs py-2 [&_code]:text-3xs [&_code]:text-secondary last:border-r-0"
+              class="border-secondary text-secondary border-r px-4 font-medium text-left py-2 text-xs [&_code]:text-secondary [&_code]:text-xs last:border-r-0"
             >
               Description
             </th>
@@ -8935,7 +8935,7 @@ After calling this function, the listener will no longer receive any events from
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 boolean
@@ -8975,7 +8975,7 @@ in order to enable/disable the permission.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 PermissionExpiration
@@ -9013,7 +9013,7 @@ in order to enable/disable the permission.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 boolean
@@ -9051,7 +9051,7 @@ in order to enable/disable the permission.
               class="border-secondary border-r p-4 text-left last:border-r-0"
             >
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5 [&>span]:text-inherit!"
                 data-text="true"
               >
                 PermissionStatus
@@ -9224,7 +9224,7 @@ in order to enable/disable the permission.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         PermissionStatus.DENIED ＝ "denied"
@@ -9293,7 +9293,7 @@ in order to enable/disable the permission.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         PermissionStatus.GRANTED ＝ "granted"
@@ -9362,7 +9362,7 @@ in order to enable/disable the permission.
         </h4>
       </div>
       <code
-        class="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere"
+        class="text-tertiary mb-2 inline-flex text-xs wrap-anywhere"
         data-text="true"
       >
         PermissionStatus.UNDETERMINED ＝ "undetermined"

--- a/docs/components/plugins/api/APISectionEnums.tsx
+++ b/docs/components/plugins/api/APISectionEnums.tsx
@@ -46,7 +46,7 @@ function APISectionEnum({ data: { name, children, comment } }: { data: EnumDefin
             </H4>
             <APISectionPlatformTags comment={enumValue.comment} disableFallback className="mb-1" />
           </div>
-          <MONOSPACE className="text-2xs text-tertiary mb-2 inline-flex wrap-anywhere">
+          <MONOSPACE className="text-tertiary mb-2 inline-flex text-xs wrap-anywhere">
             {`${name}.${enumValue.name} ＝ ${renderEnumValue(
               enumValue.type.value,
               enumValue.type.name

--- a/docs/components/plugins/api/APISectionMethods.tsx
+++ b/docs/components/plugins/api/APISectionMethods.tsx
@@ -162,7 +162,7 @@ export const renderMethod = (
         {hasOverloads && (
           <div className="text-tertiary px-4 pb-2">
             <BracketsEllipsesDuotoneIcon className="icon-xs mr-1 inline shrink-0" />
-            <span className="text-3xs">Overload #{overloadIndex + 1}</span>
+            <span className="text-xs">Overload #{overloadIndex + 1}</span>
           </div>
         )}
         {parameters && parameters.length > 0 && (

--- a/docs/components/plugins/api/components/APIBoxSectionHeader.tsx
+++ b/docs/components/plugins/api/components/APIBoxSectionHeader.tsx
@@ -28,10 +28,10 @@ export const APIBoxSectionHeader = ({
   return (
     <CALLOUT
       className={mergeClasses(
-        'border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium',
+        'border-palette-gray4 bg-subtle text-tertiary flex border-y px-4 py-2 text-xs font-medium',
         className
       )}>
-      <TextWrapper className="text-2xs text-tertiary flex flex-row items-center gap-2 font-medium">
+      <TextWrapper className="text-tertiary flex flex-row items-center gap-2 text-xs font-medium">
         {Icon && <Icon className="icon-sm text-icon-secondary" />}
         {text}
       </TextWrapper>

--- a/docs/components/plugins/api/components/APIParamDetailsBlock.tsx
+++ b/docs/components/plugins/api/components/APIParamDetailsBlock.tsx
@@ -19,7 +19,7 @@ export function APIParamDetailsBlock({ param, sdkVersion, className }: Props) {
   return (
     <div
       className={mergeClasses(
-        'border-secondary text-secondary flex flex-col gap-0.5 border-l-2 pl-2.5 text-xs',
+        'border-secondary text-secondary flex flex-col gap-0.5 border-l-2 pl-2.5 text-sm',
         className
       )}
       key={param.name}>

--- a/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
+++ b/docs/components/plugins/api/components/__snapshots__/APICommentTextBlock.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`APICommentTextBlock comment with example 1`] = `
             </g>
           </svg>
           <span
-            class="text-3xs! leading-none! font-normal whitespace-nowrap"
+            class="text-xs! leading-none! font-normal whitespace-nowrap"
           >
             Android
           </span>
@@ -68,7 +68,7 @@ exports[`APICommentTextBlock comment with example 1`] = `
         target="_blank"
       >
         <code
-          class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+          class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
           data-text="true"
         >
           Install Referrer API
@@ -81,11 +81,11 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
       class="mb-2.5 [table_&]:last:mb-0 [&>*:last-child]:mb-0!"
     >
       <p
-        class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-2xs text-tertiary flex border-y px-4 py-2 font-medium -mx-4 mt-1 mb-3"
+        class="tracking-[-0.006rem] border-palette-gray4 bg-subtle text-tertiary flex border-y px-4 py-2 text-xs font-medium -mx-4 mt-1 mb-3"
         data-text="true"
       >
         <span
-          class="tracking-[-0.006rem] text-2xs text-tertiary flex flex-row items-center gap-2 font-medium"
+          class="tracking-[-0.006rem] text-tertiary flex flex-row items-center gap-2 text-xs font-medium"
           data-text="true"
         >
           <svg
@@ -119,7 +119,7 @@ from the Google Play Store. In practice, the referrer URL may not be a complete,
           class="w-fit p-4"
         >
           <code
-            class="text-2xs text-default"
+            class="text-default text-xs"
           >
             <span
               class="token keyword"

--- a/docs/components/plugins/api/styles.tsx
+++ b/docs/components/plugins/api/styles.tsx
@@ -3,9 +3,9 @@ import { mergeClasses } from '@expo/styleguide';
 export const ELEMENT_SPACING = mergeClasses('mb-2.5 [table_&]:last:mb-0');
 export const VERTICAL_SPACING = mergeClasses('mx-4');
 
-export const STYLES_SECONDARY = mergeClasses('text-tertiary text-xs font-medium');
+export const STYLES_SECONDARY = mergeClasses('text-tertiary text-sm font-medium');
 
-export const STYLES_OPTIONAL = mergeClasses('text-3xs! text-tertiary flex');
+export const STYLES_OPTIONAL = mergeClasses('text-tertiary flex text-xs!');
 
 export const STYLES_APIBOX = mergeClasses(
   'border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs',

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -12,8 +12,14 @@ export default class DocsDocument extends Document {
 
   render() {
     return (
-      <Html lang="en">
-        <Head />
+      <Html lang="en" data-expo-theme>
+        <Head>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `(function(){if(window.matchMedia("(prefers-color-scheme:dark)").matches){document.documentElement.classList.add("dark-theme")}})()`,
+            }}
+          />
+        </Head>
         <body className="text-pretty">
           <Main />
           <NextScript />

--- a/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/unversioned/sdk/safe-area-context.mdx
@@ -58,7 +58,7 @@ function SomeComponent() {
 <PaddedAPIBox header="edges" headerNestingLevel={4}>
 
 {/* prettier-ignore */}
-<CALLOUT theme="tertiary" className="text-2xs">
+<CALLOUT theme="tertiary" className="text-xs">
   {'Optional\u2002•\u2002Type: '}
   <A href="#edge">
     <code>Edge[]</code>
@@ -74,7 +74,7 @@ Sets the edges to apply the safe area insets to.
 
 <PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4}>
 
-<CALLOUT theme="tertiary" className="text-2xs">
+<CALLOUT theme="tertiary" className="text-xs">
   {'Optional\u2002•\u2002Type: '}
   <code>boolean</code>
   {'\u2002•\u2002Default: '}

--- a/docs/pages/versions/v53.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/safe-area-context.mdx
@@ -58,7 +58,7 @@ function SomeComponent() {
 <PaddedAPIBox header="edges" headerNestingLevel={4}>
 
 {/* prettier-ignore */}
-<CALLOUT theme="tertiary" className="text-2xs">
+<CALLOUT theme="tertiary" className="text-xs">
   {'Optional\u2002•\u2002Type: '}
   <A href="#edge">
     <code>Edge[]</code>
@@ -74,7 +74,7 @@ Sets the edges to apply the safe area insets to.
 
 <PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4}>
 
-<CALLOUT theme="tertiary" className="text-2xs">
+<CALLOUT theme="tertiary" className="text-xs">
   {'Optional\u2002•\u2002Type: '}
   <code>boolean</code>
   {'\u2002•\u2002Default: '}

--- a/docs/pages/versions/v54.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/safe-area-context.mdx
@@ -58,7 +58,7 @@ function SomeComponent() {
 <PaddedAPIBox header="edges" headerNestingLevel={4}>
 
 {/* prettier-ignore */}
-<CALLOUT theme="tertiary" className="text-2xs">
+<CALLOUT theme="tertiary" className="text-xs">
   {'Optional\u2002•\u2002Type: '}
   <A href="#edge">
     <code>Edge[]</code>
@@ -74,7 +74,7 @@ Sets the edges to apply the safe area insets to.
 
 <PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4}>
 
-<CALLOUT theme="tertiary" className="text-2xs">
+<CALLOUT theme="tertiary" className="text-xs">
   {'Optional\u2002•\u2002Type: '}
   <code>boolean</code>
   {'\u2002•\u2002Default: '}

--- a/docs/pages/versions/v55.0.0/sdk/safe-area-context.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/safe-area-context.mdx
@@ -58,7 +58,7 @@ function SomeComponent() {
 <PaddedAPIBox header="edges" headerNestingLevel={4}>
 
 {/* prettier-ignore */}
-<CALLOUT theme="tertiary" className="text-2xs">
+<CALLOUT theme="tertiary" className="text-xs">
   {'Optional\u2002•\u2002Type: '}
   <A href="#edge">
     <code>Edge[]</code>
@@ -74,7 +74,7 @@ Sets the edges to apply the safe area insets to.
 
 <PaddedAPIBox header="emulateUnlessSupported" headerNestingLevel={4}>
 
-<CALLOUT theme="tertiary" className="text-2xs">
+<CALLOUT theme="tertiary" className="text-xs">
   {'Optional\u2002•\u2002Type: '}
   <code>boolean</code>
   {'\u2002•\u2002Default: '}

--- a/docs/scripts/generate-markdown-pages-utils.test.ts
+++ b/docs/scripts/generate-markdown-pages-utils.test.ts
@@ -557,7 +557,7 @@ describe('platform indicators', () => {
     const html = `<main>
       <div class="mb-2 inline-flex empty:hidden">
         <span data-text="true">
-          <span class="text-xs font-medium text-tertiary">Only for: </span>
+          <span class="text-sm font-medium text-tertiary">Only for: </span>
           <div data-md="platform-badge">
             <svg viewBox="0 0 24 24"><path/></svg>
             <span class="whitespace-nowrap">iOS</span>
@@ -1105,7 +1105,7 @@ describe('API returns section', () => {
       '<div data-md="api-returns" class="flex flex-row items-start gap-2">',
       '<div class="flex flex-row items-center gap-2">',
       '<svg viewBox="0 0 24 24"><path/></svg>',
-      '<span class="text-xs">Returns:</span>',
+      '<span class="text-sm">Returns:</span>',
       '</div>',
       '<code>Promise</code>',
       '</div></main>',

--- a/docs/styles/global.css
+++ b/docs/styles/global.css
@@ -1,6 +1,8 @@
 @import 'tailwindcss';
 @config '../tailwind.config.cjs';
 
+@import './tailwind-compat.css';
+
 @layer base {
   html {
     @apply bg-default;
@@ -149,7 +151,7 @@ div.tippy-box {
 /* Diff */
 
 .diff-unified {
-  @apply text-2xs;
+  @apply text-xs;
   border-collapse: collapse;
   white-space: pre-wrap;
   width: 100%;
@@ -177,7 +179,7 @@ div.tippy-box {
 }
 
 .diff-gutter {
-  @apply text-3xs px-1;
+  @apply px-1 text-xs;
   text-align: right;
   user-select: none;
 }

--- a/docs/styles/tailwind-compat.css
+++ b/docs/styles/tailwind-compat.css
@@ -1,0 +1,41 @@
+/*
+  Tailwind v4 Compatibility Overrides
+
+  Override TW4's default font size line-heights to match the styleguide.
+  The JS config sets font-size correctly, but TW4 uses separate CSS
+  variables for line-height that need to be explicitly overridden.
+  Values from @expo/styleguide/tailwind.js
+*/
+@theme {
+  --text-2xs--line-height: 1.6;
+  --text-xs--line-height: 1.6;
+  --text-sm--line-height: 1.6;
+  --text-base--line-height: 1.6;
+  --text-lg--line-height: 1.4;
+  --text-xl--line-height: 1.2;
+  --text-2xl--line-height: 1.2;
+}
+
+/*
+  TW4 changed default border color to currentcolor.
+  This restores the TW3 behavior.
+*/
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
+}
+
+/*
+  Reset TW4 preflight's --tw-leading on li elements.
+  TW4 sets --tw-leading: var(--leading-relaxed) on li, which overrides
+  the fallback line-height in text utilities. This restores correct
+  line-heights.
+*/
+li {
+  --tw-leading: initial;
+}

--- a/docs/tailwind.config.cjs
+++ b/docs/tailwind.config.cjs
@@ -1,17 +1,9 @@
 const expoTheme = require('@expo/styleguide/tailwind');
 const merge = require('lodash/merge');
 
-function getExpoTheme(extend = {}, plugins = [], themeOverrides = {}) {
+function getExpoTheme(extend = {}, plugins = []) {
   const customizedTheme = Object.assign({}, expoTheme);
-  customizedTheme.theme = Object.assign({}, merge(expoTheme.theme, themeOverrides));
-  // Shallow-replace fontSize and heading to prevent the styleguide's fontWeight
-  // values from bleeding into the docs' typography scale via deep merge.
-  if (themeOverrides.fontSize) {
-    customizedTheme.theme.fontSize = themeOverrides.fontSize;
-  }
-  if (themeOverrides.heading) {
-    customizedTheme.theme.heading = themeOverrides.heading;
-  }
+  customizedTheme.theme = Object.assign({}, expoTheme.theme);
   customizedTheme.theme.extend = Object.assign({}, merge(customizedTheme.theme.extend, extend));
   customizedTheme.plugins = [...expoTheme.plugins, ...plugins];
   return customizedTheme;
@@ -29,106 +21,44 @@ module.exports = {
     './node_modules/@expo/styleguide-search-ui/dist/**/*.{js,ts,jsx,tsx}',
     './node_modules/@expo/styleguide-cookie-consent/dist/**/*.{js,ts,jsx,tsx}',
   ],
-  ...getExpoTheme(
-    {
-      backgroundColor: {
-        'launch-party-red': '#D22323',
-        'launch-party-blue': '#006CFF',
-        'launch-party-yellow': '#F3AD0D',
-      },
-      borderColor: {
-        'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
-      },
-      backgroundImage: {
-        'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
-        'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",
-        'launch-party-banner': "url('/static/images/launch-party-banner-bg.svg')",
-        'launch-party-banner-mobile': "url('/static/images/launch-party-banner-bg.svg') 200px",
-      },
-      keyframes: {
-        wave: {
-          '0%, 100%': {
-            transform: 'rotate(0deg)',
-          },
-          '50%': {
-            transform: 'rotate(20deg)',
-          },
+  ...getExpoTheme({
+    backgroundColor: {
+      'launch-party-red': '#D22323',
+      'launch-party-blue': '#006CFF',
+      'launch-party-yellow': '#F3AD0D',
+    },
+    borderColor: {
+      'palette-orange3.5': 'hsl(from var(--orange-4) h calc(s - 5) calc(l + 5));',
+    },
+    backgroundImage: {
+      'cell-quickstart-pattern': "url('/static/images/home/QuickStartPattern.svg')",
+      'cell-tutorial-pattern': "url('/static/images/home/TutorialPattern.svg')",
+      'launch-party-banner': "url('/static/images/launch-party-banner-bg.svg')",
+      'launch-party-banner-mobile': "url('/static/images/launch-party-banner-bg.svg') 200px",
+    },
+    keyframes: {
+      wave: {
+        '0%, 100%': {
+          transform: 'rotate(0deg)',
         },
-        slideUpAndFadeIn: {
-          '0%': {
-            opacity: 0,
-            transform: 'translateY(16px)',
-          },
-          '100%': {
-            opacity: 1,
-            transform: 'translateY(0)',
-          },
+        '50%': {
+          transform: 'rotate(20deg)',
         },
       },
-      animation: {
-        slideUpAndFadeIn: 'slideUpAndFadeIn 0.25s ease-out',
-        wave: 'wave 0.25s ease-in-out 4',
+      slideUpAndFadeIn: {
+        '0%': {
+          opacity: 0,
+          transform: 'translateY(16px)',
+        },
+        '100%': {
+          opacity: 1,
+          transform: 'translateY(0)',
+        },
       },
     },
-    [],
-    {
-      fontSize: {
-        '3xl': ['31px', { lineHeight: 1.29, letterSpacing: '-0.021rem' }],
-        '2xl': ['25px', { lineHeight: 1.4, letterSpacing: '-0.021rem' }],
-        xl: ['20px', { lineHeight: 1.5, letterSpacing: '-0.017rem' }],
-        lg: ['18px', { lineHeight: 1.5, letterSpacing: '-0.014rem' }],
-        base: ['16px', { lineHeight: 1.625, letterSpacing: '-0.011rem' }],
-        sm: ['15px', { lineHeight: 1.6, letterSpacing: '-0.009rem' }],
-        xs: ['14px', { lineHeight: 1.57, letterSpacing: '-0.006rem' }],
-        '2xs': ['13px', { lineHeight: 1.61, letterSpacing: '-0.003rem' }],
-        '3xs': ['12px', { lineHeight: 1.58 }],
-      },
-      heading: {
-        '5xl': {
-          fontSize: '61px',
-          lineHeight: 1.2,
-          letterSpacing: '-0.022rem',
-        },
-        '4xl': {
-          fontSize: '49px',
-          lineHeight: 1.2,
-          letterSpacing: '-0.022rem',
-        },
-        '3xl': {
-          fontSize: '39px',
-          lineHeight: 1.3,
-          letterSpacing: '-0.022rem',
-        },
-        '2xl': {
-          fontSize: '31px',
-          lineHeight: 1.4,
-          letterSpacing: '-0.021rem',
-        },
-        xl: {
-          fontSize: '25px',
-          lineHeight: 1.5,
-          letterSpacing: '-0.017rem',
-        },
-        lg: {
-          fontSize: '20px',
-          lineHeight: 1.5,
-          letterSpacing: '-0.017rem',
-        },
-        base: {
-          fontSize: '16px',
-          lineHeight: 1.625,
-          letterSpacing: '-0.011rem',
-        },
-        sm: {
-          fontSize: '14.4px',
-          lineHeight: 1.61,
-          letterSpacing: '-0.003rem',
-        },
-        xs: {
-          fontSize: '12.8px',
-          lineHeight: 1.58,
-        },
-      },
-    }
-  ),
+    animation: {
+      slideUpAndFadeIn: 'slideUpAndFadeIn 0.25s ease-out',
+      wave: 'wave 0.25s ease-in-out 4',
+    },
+  }),
 };

--- a/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
+++ b/docs/ui/components/AppConfigSchemaTable/__snapshots__/AppConfigSchemaTable.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-text="true"
           >
             string
@@ -213,7 +213,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-text="true"
           >
             object
@@ -365,7 +365,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Type: 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               enum
@@ -374,7 +374,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             One of: 
             <span>
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
                 data-text="true"
               >
                 cover
@@ -383,7 +383,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             <span>
               , 
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
                 data-text="true"
               >
                 contain
@@ -468,7 +468,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               Type: 
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
                 data-text="true"
               >
                 boolean
@@ -554,7 +554,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Type: 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               string
@@ -589,7 +589,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           6 character long hex color string, eg: 
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 inline! py-0 wrap-break-word"
             data-text="true"
           >
             '#000000'
@@ -654,7 +654,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
         >
           Type: 
           <code
-            class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+            class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
             data-text="true"
           >
             array
@@ -763,7 +763,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           data-text="true"
         >
           <code
-            class="text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle rounded-md border px-1 py-0.5 text-3xs! text-default block w-full p-1.5!"
+            class="text-xs leading-[130%] font-normal border-secondary bg-subtle rounded-md border px-1 py-0.5 text-default text-xs! block w-full p-1.5!"
             data-text="true"
           >
             [
@@ -834,7 +834,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Type: 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               boolean
@@ -919,7 +919,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
           >
             Type: 
             <code
-              class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+              class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
               data-text="true"
             >
               array || object
@@ -997,7 +997,7 @@ exports[`AppConfigSchemaPropertiesTable correctly matches snapshot 1`] = `
             >
               Type: 
               <code
-                class="text-inherit text-[13px] leading-[130%] font-normal tracking-[-0.003rem] border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
+                class="text-inherit text-xs leading-[130%] font-normal border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5"
                 data-text="true"
               >
                 string

--- a/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
+++ b/docs/ui/components/AskPageAI/AskPageAIChatMessages.tsx
@@ -60,7 +60,7 @@ export function AskPageAIChatMessages({
     return (
       <div className="border-default bg-subtle rounded-md border px-3 py-2 shadow-xs">
         <FOOTNOTE className="text-default font-medium">AI Assistant</FOOTNOTE>
-        <div className="text-secondary mt-1 space-y-3 text-xs">
+        <div className="text-secondary mt-1 space-y-3 text-sm">
           I'm an SDK AI assistant — ask me a question about the{' '}
           <span className="text-default font-medium">
             {contextScope === 'page' ? 'current page' : 'Expo docs'}
@@ -130,7 +130,7 @@ export function AskPageAIChatMessages({
             </div>
             <div className="px-0">
               <FOOTNOTE className="text-default font-medium">AI Assistant</FOOTNOTE>
-              <div className="text-secondary mt-1 space-y-3 text-xs">
+              <div className="text-secondary mt-1 space-y-3 text-sm">
                 {answerForDisplay ? (
                   <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
                     {answerForDisplay}
@@ -147,7 +147,7 @@ export function AskPageAIChatMessages({
                     type="button"
                     theme="quaternary"
                     size="xs"
-                    className="border-default bg-subtle text-default hover:bg-element focus-visible:ring-palette-blue9 inline-flex items-center gap-2 rounded-md border px-3 py-1 text-xs font-medium shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                    className="border-default bg-subtle text-default hover:bg-element focus-visible:ring-palette-blue9 inline-flex items-center gap-2 rounded-md border px-3 py-1 text-sm font-medium shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
                     disabled={isBusy || hasTriggeredGlobalSearch || isPendingGlobal}
                     onClick={() => {
                       onSearchAcrossDocs(displayQuestion);
@@ -158,14 +158,14 @@ export function AskPageAIChatMessages({
                       : 'Search Expo docs'}
                   </Button>
                   {showSwitchingNotice ? (
-                    <FOOTNOTE theme="secondary" className="text-xs">
+                    <FOOTNOTE theme="secondary" className="text-sm">
                       {switchNoticeText}
                     </FOOTNOTE>
                   ) : null}
                 </div>
               ) : null}
               {canSubmitFeedback ? (
-                <div className="text-secondary mt-3 flex items-center gap-1 text-xs">
+                <div className="text-secondary mt-3 flex items-center gap-1 text-sm">
                   <span className="text-secondary">Was this helpful?</span>
                   <div className="flex items-center gap-1">
                     <Button
@@ -215,7 +215,7 @@ export function AskPageAIChatMessages({
               ) : null}
             </div>
             {sourcesForDisplay?.length ? (
-              <FOOTNOTE theme="secondary" className="ml-1 text-xs">
+              <FOOTNOTE theme="secondary" className="ml-1 text-sm">
                 Sources:{' '}
                 {sourcesForDisplay.map((source, sourceIdx, sources) => (
                   <span key={source.source_url}>

--- a/docs/ui/components/ConfigPluginHierarchy/index.tsx
+++ b/docs/ui/components/ConfigPluginHierarchy/index.tsx
@@ -98,8 +98,8 @@ const createNodeLabel = (data: NodeData, isHighlighted: boolean) => {
           {data.extraTitle}
         </div>
       )}
-      {data.subtitle && <div className={`text-xs ${styles.subtitleText}`}>{data.subtitle}</div>}
-      <div className={`mt-1 rounded-md px-2 py-1 text-xs ${styles.badge}`}>{data.badge}</div>
+      {data.subtitle && <div className={`text-sm ${styles.subtitleText}`}>{data.subtitle}</div>}
+      <div className={`mt-1 rounded-md px-2 py-1 text-sm ${styles.badge}`}>{data.badge}</div>
     </div>
   );
 };

--- a/docs/ui/components/ContentSpotlight/index.tsx
+++ b/docs/ui/components/ContentSpotlight/index.tsx
@@ -112,7 +112,7 @@ export function ContentSpotlight({
       {caption && (
         <figcaption
           className={mergeClasses(
-            'text-secondary mt-3.5 cursor-text px-8 py-2 text-center text-xs',
+            'text-secondary mt-3.5 cursor-text px-8 py-2 text-center text-sm',
             isVideo && 'bg-transparent'
           )}>
           {caption}

--- a/docs/ui/components/DownloadSlide/index.tsx
+++ b/docs/ui/components/DownloadSlide/index.tsx
@@ -37,7 +37,7 @@ export function DownloadSlide({ title, description, imageUrl, className }: Props
       <div className="bg-default flex flex-col justify-center gap-1 px-4 py-2">
         <p className="flex items-center gap-1.5 text-sm leading-normal font-medium">{title}</p>
         {description && (
-          <p className="text-secondary flex items-center gap-2 text-xs">{description}</p>
+          <p className="text-secondary flex items-center gap-2 text-sm">{description}</p>
         )}
       </div>
       <Download03Icon

--- a/docs/ui/components/EASCLIReference/index.tsx
+++ b/docs/ui/components/EASCLIReference/index.tsx
@@ -34,7 +34,7 @@ const ListSection = ({ entries }: { entries: ListEntry[] }) => {
     <UL className="mb-4">
       {entries.map(entry => (
         <LI key={entry.name}>
-          <CODE className="text-3xs">{entry.name}</CODE>
+          <CODE className="text-xs">{entry.name}</CODE>
           {entry.description &&
             (() => {
               const parsed = parseSubItems(entry.description);
@@ -46,7 +46,7 @@ const ListSection = ({ entries }: { entries: ListEntry[] }) => {
                     <UL className="mt-2">
                       {parsed.items.map(item => (
                         <LI key={`${entry.name}-${item.name}`}>
-                          <CODE className="text-3xs">{item.name}</CODE>
+                          <CODE className="text-xs">{item.name}</CODE>
                           {item.description ? (
                             <span> {renderInlineContent(formatSentence(item.description))}</span>
                           ) : null}

--- a/docs/ui/components/EASCLIReference/utils.tsx
+++ b/docs/ui/components/EASCLIReference/utils.tsx
@@ -188,7 +188,7 @@ function renderTextWithTokens(text: string): ReactNode[] {
     }
 
     nodes.push(
-      <CODE key={`token-${start}-${match[0]}`} className="text-3xs">
+      <CODE key={`token-${start}-${match[0]}`} className="text-xs">
         {match[0]}
       </CODE>
     );
@@ -267,7 +267,7 @@ export function renderInlineContent(text: string): ReactNode[] {
   parts.forEach((part, index) => {
     if (index % 2 === 1) {
       nodes.push(
-        <CODE key={`code-${index}`} className="text-3xs">
+        <CODE key={`code-${index}`} className="text-xs">
           {part}
         </CODE>
       );

--- a/docs/ui/components/FileTree/index.tsx
+++ b/docs/ui/components/FileTree/index.tsx
@@ -19,7 +19,7 @@ type FileObject = {
 export function FileTree({ files = [], ...rest }: FileTreeProps) {
   return (
     <div
-      className="border-default bg-default mb-4 overflow-x-auto rounded-md border p-2 pr-4 pb-4 text-xs whitespace-nowrap"
+      className="border-default bg-default mb-4 overflow-x-auto rounded-md border p-2 pr-4 pb-4 text-sm whitespace-nowrap"
       {...rest}>
       {renderStructure(generateStructure(files))}
     </div>

--- a/docs/ui/components/Footer/Footer.tsx
+++ b/docs/ui/components/Footer/Footer.tsx
@@ -119,12 +119,12 @@ export const Footer = ({
             {title && router?.pathname && <EditPageLink pathname={router.pathname} />}
             <LlmsTxtLink fullVersionHref={llmsFullHref} fullVersionLabel={llmsFullLabel} />
             {!isDev && shouldShowModifiedDate && modificationDate && (
-              <LI className="text-2xs! text-quaternary! mt-4!">
+              <LI className="text-quaternary! mt-4! text-xs!">
                 Last updated on <time dateTime={modificationDate}>{modificationDate}</time>
               </LI>
             )}
             {isDev && shouldShowModifiedDate && (
-              <LI className="text-2xs! text-quaternary! mt-4!">
+              <LI className="text-quaternary! mt-4! text-xs!">
                 Last updated data is not available in dev mode
               </LI>
             )}

--- a/docs/ui/components/Home/components/Header.tsx
+++ b/docs/ui/components/Home/components/Header.tsx
@@ -11,7 +11,7 @@ type Props = {
 export function Header({ title, description, className }: Props) {
   return (
     <div className={mergeClasses('mt-5 mb-1.5 flex flex-col gap-1', className)}>
-      <h3 className="heading-lg max-md-gutters:heading-xl font-semibold">{title}</h3>
+      <h3 className="heading-lg max-md-gutters:heading-xl">{title}</h3>
       <P className="text-secondary">{description}</P>
     </div>
   );

--- a/docs/ui/components/Home/sections/DiscoverMore.tsx
+++ b/docs/ui/components/Home/sections/DiscoverMore.tsx
@@ -77,7 +77,7 @@ export function DiscoverMore() {
         <GridCell className="from-subtle to-palette-orange3 selection:bg-palette-orange4 dark:selection:bg-palette-orange6 bg-linear-to-br from-30%">
           <SnackImage />
           <RawH3 className="text-palette-orange11! font-bold!">Try Expo in your browser</RawH3>
-          <P className="text-palette-orange11! max-w-[24ch] text-xs!">
+          <P className="text-palette-orange11! max-w-[24ch] text-sm!">
             Expo's Snack lets you try Expo with zero local setup.
           </P>
           <HomeButton
@@ -96,7 +96,7 @@ export function DiscoverMore() {
             <DiscordIcon className="text-palette-blue9 dark:text-palette-blue9 size-12!" />
           </div>
           <RawH3 className="text-palette-blue11! font-bold!">Chat with the community</RawH3>
-          <P className="text-palette-blue11! max-w-[32ch] text-xs!">
+          <P className="text-palette-blue11! max-w-[32ch] text-sm!">
             Join over 60,000 other developers
             <br />
             on the Expo Community Discord.

--- a/docs/ui/components/InlineHelp/index.tsx
+++ b/docs/ui/components/InlineHelp/index.tsx
@@ -74,7 +74,7 @@ export const InlineHelp = ({ type = 'default', size = 'md', icon, children, clas
         className={mergeClasses(
           'text-default w-full leading-normal',
           'last:mb-0',
-          size === 'sm' && 'text-xs [&_code]:text-[90%] [&_p]:text-xs'
+          size === 'sm' && 'text-sm [&_code]:text-[90%] [&_p]:text-sm'
         )}>
         {type === finalType ? children : contentChildren.filter((_, i) => i !== 0)}
       </div>

--- a/docs/ui/components/PageHeader/PageCliVersion.tsx
+++ b/docs/ui/components/PageHeader/PageCliVersion.tsx
@@ -16,7 +16,7 @@ export function PageCliVersion({ cliVersion, className }: Props) {
   return (
     <div className={mergeClasses('flex items-center gap-2', className)}>
       <div
-        className="text-secondary flex items-center justify-center gap-1.5 text-xs"
+        className="text-secondary flex items-center justify-center gap-1.5 text-sm"
         aria-hidden="true">
         <TerminalSquareDuotoneIcon className="icon-sm text-icon-secondary" />
         CLI version:

--- a/docs/ui/components/PageHeader/PagePackageVersion.tsx
+++ b/docs/ui/components/PageHeader/PagePackageVersion.tsx
@@ -48,7 +48,7 @@ export function PagePackageVersion({
       {versionRange && (
         <div
           data-md="skip"
-          className="text-secondary flex items-center justify-center gap-1.5 text-xs">
+          className="text-secondary flex items-center justify-center gap-1.5 text-sm">
           <PackageIcon className="icon-sm text-icon-secondary" />
           Bundled version:
           <Tag name={versionRange} className="select-auto" />

--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -108,7 +108,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
             </LinkBase>
           </div>
           <div>
-            <p className="text-secondary text-xs">
+            <p className="text-secondary text-sm">
               {numberOfRequirements} requirement{numberOfRequirements === 1 ? '' : 's'}
             </p>
           </div>

--- a/docs/ui/components/ProgressTracker/index.tsx
+++ b/docs/ui/components/ProgressTracker/index.tsx
@@ -100,7 +100,7 @@ export function ProgressTracker({
           )}
         />
         <div className="flex flex-col items-center justify-center gap-2">
-          <p className="text-default heading-lg flex items-center text-center font-semibold">
+          <p className="text-default heading-lg flex items-center text-center">
             <BookOpen02Icon className="text-icon-secondary max-md-gutters:hidden mr-2 size-6!" />{' '}
             {currentChapter.title}
           </p>

--- a/docs/ui/components/Search/ExpoDashboardItem.tsx
+++ b/docs/ui/components/Search/ExpoDashboardItem.tsx
@@ -27,7 +27,7 @@ export const ExpoDashboardItem = ({ item, onSelect, query }: Props) => {
         <div className="inline-flex items-center justify-between gap-3">
           <Icon className="text-icon-secondary" />
           <p
-            className="text-xs font-medium"
+            className="text-sm font-medium"
             dangerouslySetInnerHTML={{ __html: addHighlight(item.label, query) }}
           />
         </div>

--- a/docs/ui/components/Select.tsx
+++ b/docs/ui/components/Select.tsx
@@ -92,7 +92,7 @@ export function Select({
           <SelectPrimitive.Viewport>
             <SelectPrimitive.Group>
               {optionsLabel && (
-                <SelectPrimitive.Label className="text-2xs text-tertiary cursor-default px-3 pt-2 pb-1">
+                <SelectPrimitive.Label className="text-tertiary cursor-default px-3 pt-2 pb-1 text-xs">
                   {optionsLabel}
                 </SelectPrimitive.Label>
               )}
@@ -108,7 +108,7 @@ export function Select({
                   <SelectPrimitive.ItemText>
                     <div
                       className={mergeClasses(
-                        'text-default flex items-center gap-2 text-left text-xs leading-tight font-normal whitespace-pre-wrap',
+                        'text-default flex items-center gap-2 text-left text-sm leading-tight font-normal whitespace-pre-wrap',
                         size === 'lg' && 'text-lg'
                       )}>
                       {leftSlot}
@@ -148,7 +148,7 @@ export function Select({
     return (
       <div className="flex flex-col gap-1">
         {typeof caption === 'string' ? (
-          <p className="text-tertiary text-xs font-medium">{caption}</p>
+          <p className="text-tertiary text-sm font-medium">{caption}</p>
         ) : (
           caption
         )}

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -72,7 +72,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             </SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentage} />{' '}
-              <p className="text-tertiary ml-2 text-xs">{`${completedChaptersCount} of ${totalChapters}`}</p>
+              <p className="text-tertiary ml-2 text-sm">{`${completedChaptersCount} of ${totalChapters}`}</p>
             </div>
           </div>
         )}
@@ -144,7 +144,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
             </SidebarTitle>
             <div className="flex flex-row items-center pb-1">
               <CircularProgressBar progress={progressPercentageForGetStarted} />{' '}
-              <p className="text-tertiary ml-2 text-xs">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
+              <p className="text-tertiary ml-2 text-sm">{`${completedGetStartedChaptersCount} of ${totalGetStartedChapters}`}</p>
             </div>
           </div>
         )}

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -57,7 +57,7 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
       href={info.href}
       ref={ref}
       className={mergeClasses(
-        'group text-secondary -ml-2.5 flex w-full scroll-m-[60px] items-center p-1 pr-0 text-xs decoration-0',
+        'group text-secondary -ml-2.5 flex w-full scroll-m-[60px] items-center p-1 pr-0 text-sm decoration-0',
         'hocus:text-link [&_svg]:hocus:text-icon-info',
         isSelected && 'text-link [&_svg]:text-icon-info',
         info.isDeprecated && 'line-through',

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -37,7 +37,7 @@ export const SidebarSingleEntry = ({
             'hocus:bg-element',
             'focus-visible:relative focus-visible:z-10',
             allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',
-            secondary && 'text-xs',
+            secondary && 'text-sm',
             isActive &&
               'bg-palette-blue3! text-link hocus:bg-palette-blue4! hocus:text-link font-medium'
           )}
@@ -59,7 +59,7 @@ export const SidebarSingleEntry = ({
       <Tooltip.Content
         side="bottom"
         className={mergeClasses('z-50 hidden', allowCompactDisplay && 'compact-height:flex')}>
-        <span className="text-2xs text-secondary">{title}</span>
+        <span className="text-secondary text-xs">{title}</span>
       </Tooltip.Content>
     </Tooltip.Root>
   );

--- a/docs/ui/components/Snippet/FileStatus.tsx
+++ b/docs/ui/components/Snippet/FileStatus.tsx
@@ -15,7 +15,7 @@ export const FileStatus = ({ type }: FileStatusProps) => {
   return (
     <div
       className={mergeClasses(
-        'text-3xs inline-flex h-[21px] items-center gap-1 rounded-sm border px-1.5 py-1 font-semibold',
+        'inline-flex h-[21px] items-center gap-1 rounded-sm border px-1.5 py-1 text-xs font-semibold',
         getStatusTheme(type)
       )}>
       {STATUS_LABELS[type]}

--- a/docs/ui/components/Snippet/blocks/Terminal.tsx
+++ b/docs/ui/components/Snippet/blocks/Terminal.tsx
@@ -202,7 +202,7 @@ const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTa
           role="tab"
           aria-selected={isActive}
           className={mergeClasses(
-            'rounded-md px-2 py-1 text-xs font-semibold transition-colors',
+            'rounded-md px-2 py-1 text-sm font-semibold transition-colors',
             isActive
               ? 'bg-palette-gray6 text-palette-white'
               : 'text-palette-gray9 hocus:bg-palette-gray5'
@@ -220,7 +220,7 @@ const PackageTabs = ({ managers, activeManager, onSelect, className }: PackageTa
 const PackageSelect = ({ managers, activeManager, onSelect, className }: PackageTabsProps) => (
   <Select
     className={mergeClasses(
-      'h-6! min-h-[16px]! min-w-[76px] gap-1! px-2! py-0! text-xs [&_svg]:size-3!',
+      'h-6! min-h-[16px]! min-w-[76px] gap-1! px-2! py-0! text-sm [&_svg]:size-3!',
       className
     )}
     ariaLabel="Select package manager"

--- a/docs/ui/components/Step/Step.tsx
+++ b/docs/ui/components/Step/Step.tsx
@@ -14,7 +14,7 @@ export const Step = ({ children, label }: Props) => {
         theme="secondary"
         className={mergeClasses(
           'bg-element mt-1 flex h-7 min-w-[28px] items-center justify-center rounded-full',
-          label.length >= 3 && 'text-xs!'
+          label.length >= 3 && 'text-sm!'
         )}>
         {label}
       </HEADLINE>

--- a/docs/ui/components/Table/HeaderCell.tsx
+++ b/docs/ui/components/Table/HeaderCell.tsx
@@ -18,10 +18,10 @@ export const HeaderCell = ({
 }: HeaderCellProps) => (
   <th
     className={mergeClasses(
-      'border-secondary text-2xs text-secondary border-r px-4 py-3.5 font-medium',
+      'border-secondary text-secondary border-r px-4 py-3.5 text-xs font-medium',
       convertAlignToClass(align),
-      size === 'sm' && 'text-3xs py-2',
-      '[&_code]:text-3xs [&_code]:text-secondary',
+      size === 'sm' && 'py-2 text-xs',
+      '[&_code]:text-secondary [&_code]:text-xs',
       'last:border-r-0',
       className
     )}>

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -25,13 +25,13 @@ export const Table = ({
     )}>
     <table
       className={mergeClasses(
-        'text-default w-full rounded-none border-0 text-xs',
-        '[&_p]:text-xs',
-        '[&_li]:text-xs',
-        '[&_span]:text-xs',
+        'text-default w-full rounded-none border-0 text-sm',
+        '[&_p]:text-sm',
+        '[&_li]:text-sm',
+        '[&_span]:text-sm',
         '[&_code_span]:text-inherit',
-        '[&_strong]:text-xs',
-        '[&_blockquote_div]:text-xs',
+        '[&_strong]:text-sm',
+        '[&_blockquote_div]:text-sm',
         '[&_blockquote_code]:px-1 [&_blockquote_code]:py-0',
         className
       )}>

--- a/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
+++ b/docs/ui/components/TableOfContents/TableOfContentsLink.tsx
@@ -53,7 +53,7 @@ export const TableOfContentsLink = forwardRef<HTMLAnchorElement, SidebarLinkProp
             <TitleElement
               className={mergeClasses(
                 'text-secondary! hocus:text-link! w-full',
-                isCodeOrFilePath && 'text-2xs! truncate',
+                isCodeOrFilePath && 'truncate text-xs!',
                 isActive && 'text-link!',
                 isDeprecated && 'line-through opacity-80'
               )}>

--- a/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
+++ b/docs/ui/components/TableOfContents/__snapshots__/TableOfContents.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`TableOfContents correctly matches snapshot 1`] = `
           href="#code-heading-depth-1"
         >
           <code
-            class="leading-[1.6154] text-inherit text-secondary! hocus:text-link! w-full text-2xs! truncate"
+            class="leading-[1.6154] text-inherit text-secondary! hocus:text-link! w-full truncate text-xs!"
             data-text="true"
           >
             Code heading depth 1

--- a/docs/ui/components/Tabs/TabButton.tsx
+++ b/docs/ui/components/Tabs/TabButton.tsx
@@ -67,7 +67,7 @@ export function TabButton({
           <LabelElement
             theme={active ? 'default' : 'tertiary'}
             weight="medium"
-            className="max-md-gutters:text-sm max-sm-gutters:text-xs transition-colors">
+            className="max-md-gutters:text-sm max-sm-gutters:text-sm transition-colors">
             {label}
           </LabelElement>
           {rightSlot}

--- a/docs/ui/components/Tag/PlatformTag.tsx
+++ b/docs/ui/components/Tag/PlatformTag.tsx
@@ -30,7 +30,7 @@ export const PlatformTag = ({ platform, label, className, suffix, ...rest }: Pla
       )}
       {...rest}>
       <PlatformIcon platform={platformName} />
-      <span className={mergeClasses('text-3xs! leading-none! font-normal whitespace-nowrap')}>
+      <span className={mergeClasses('text-xs! leading-none! font-normal whitespace-nowrap')}>
         {displayLabel}
       </span>
       {suffix}

--- a/docs/ui/components/Tag/PlatformTags.tsx
+++ b/docs/ui/components/Tag/PlatformTags.tsx
@@ -19,9 +19,7 @@ export const PlatformTags = ({ prefix, platforms }: PlatformTagsProps) => {
   return (
     <CALLOUT tag="span" className="inline-flex items-center">
       {prefix && (
-        <span className={mergeClasses(STYLES_SECONDARY, '[table_&]:text-2xs!')}>
-          {prefix}&ensp;
-        </span>
+        <span className={mergeClasses(STYLES_SECONDARY, '[table_&]:text-xs!')}>{prefix}&ensp;</span>
       )}
       {platforms
         .sort((a, b) => a.localeCompare(b))

--- a/docs/ui/components/Tag/SDKRangeTag.tsx
+++ b/docs/ui/components/Tag/SDKRangeTag.tsx
@@ -46,8 +46,8 @@ export const SDKRangeTag = ({ min, max, exact, className, ...rest }: SDKRangeTag
           {...rest}>
           <span
             className={mergeClasses(
-              'text-3xs leading-none font-normal whitespace-nowrap',
-              '[h2_&]:text-2xs'
+              'text-xs leading-none font-normal whitespace-nowrap',
+              '[h2_&]:text-xs'
             )}>
             {label}
           </span>

--- a/docs/ui/components/Tag/StatusTag.tsx
+++ b/docs/ui/components/Tag/StatusTag.tsx
@@ -22,7 +22,7 @@ export const StatusTag = ({ status, note, className }: StatusTagProps) => {
         className
       )}>
       {status === 'experimental' && <Star06Icon className="icon-2xs text-palette-pink12" />}
-      <span className={mergeClasses('text-3xs! leading-none! font-normal whitespace-nowrap')}>
+      <span className={mergeClasses('text-xs! leading-none! font-normal whitespace-nowrap')}>
         {status ? formatName(status) + (note ? `: ${note}` : '') : note}
       </span>
     </div>

--- a/docs/ui/components/Text/index.tsx
+++ b/docs/ui/components/Text/index.tsx
@@ -203,7 +203,7 @@ export const P = createTextComponent(
 export const CODE = createTextComponent(
   TextElement.CODE,
   mergeClasses(
-    'text-[13px] leading-[130%] font-normal tracking-[-0.003rem]',
+    'text-xs leading-[130%] font-normal',
     'border-secondary bg-subtle inline-block rounded-md border px-1 py-0.5'
   )
 );
@@ -224,10 +224,7 @@ export const SPAN = createTextComponent(
   TextElement.SPAN,
   'font-normal text-[14px] leading-[1.5715] tracking-[-0.006rem]'
 );
-export const FOOTNOTE = createTextComponent(
-  TextElement.P,
-  'font-normal text-[13px] leading-[1.6154] tracking-[-0.003rem]'
-);
+export const FOOTNOTE = createTextComponent(TextElement.P, 'font-normal text-xs');
 export const CAPTION = createTextComponent(
   TextElement.P,
   'font-normal text-[12px] leading-[1.6154]'
@@ -246,7 +243,7 @@ export const KBD = createTextComponent(
   TextElement.KBD,
   mergeClasses(
     'border-secondary bg-subtle shadow-kbd relative -top-px inline-block min-h-[20px] min-w-[22px] rounded-sm border px-1',
-    'text-2xs text-secondary text-center leading-[20px] font-semibold',
+    'text-secondary text-center text-xs leading-[20px] font-semibold',
     'dark:bg-element'
   )
 );


### PR DESCRIPTION
# Why

Fix ENG-20528

# How

**Removed custom typography overrides**

- Removed the custom `fontSize` and `heading` scale from `tailwind.config.cjs`, along with the shallow-replace logic that prevented the styleguide values from applying. The styleguide v11 defaults now control all typography.

**Renamed deprecated/shifted utility classes (51 files)**

- Replaced `text-3xs` with `text-xs` in 11 files (class no longer exists in v11, both map to 12px).
- Replaced `text-2xs` with `text-xs` in 16 files (13px to 10px shift was too aggressive, 12px is the closest match).
- Replaced `text-xs` with `text-sm` in 23 files (preserves the original 14px visual size, since v11 `text-xs` is now 12px).
- Removed redundant `font-semibold` from 2 files where `heading-*` classes are used (headings now auto-apply `font-weight: 600`).
- Replaced hardcoded `text-[13px]` with `text-xs` in the `CODE` and `FOOTNOTE` components in `Text/index.tsx`.

**Added Tailwind v4 compatibility layer**

- Created `styles/tailwind-compat.css` with line-height overrides for text size utilities, border color reset (TW4 changed default to `currentcolor`), and `li` element `--tw-leading` reset.
- Imported the compat file in `styles/global.css`.

**Dark theme and theming attributes**

- Added `data-expo-theme` attribute on `<html>` in `_document.tsx`.
- Added dark-theme detection script in `<Head>` to prevent flash of light theme for dark-mode users.

# Test Plan

Run `yarn lint --max-warnings 0` and `yarn test` to confirm no regressions. 

See preview and visually spot-check these pages for correct font sizing, line-heights, and spacing (as examples):

- Any API reference page (e.g., `/versions/v55.0.0/sdk/camera/`) for tags, tables, and code blocks.
- The sidebar on any page for link text sizing.
- `/get-started/set-up-your-environment/` for terminal blocks and step components.
- The home page (`/`) for heading sizes.
- The footer on any page for footnote text.
- `/more/eas-cli/` for EAS CLI reference code blocks.
- `/get-started/introduction/` for the progress tracker heading.
