### PR TITLE
[docs] Fix onPress to onClick in Jetpack Compose examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -29,7 +29,7 @@ export default function BasicDropdownMenuExample() {
     <Host matchContents>
       <DropdownMenu expanded={isExpanded} onDismissRequest={() => setIsExpanded(false)}>
         <DropdownMenu.Trigger>
-          <Button variant="bordered" onPress={() => setIsExpanded(true)}>
+          <Button variant="bordered" onClick={() => setIsExpanded(true)}>
             Show Menu
           </Button>
         </DropdownMenu.Trigger>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/host.mdx
@@ -27,7 +27,7 @@ import { Host, Button } from '@expo/ui/jetpack-compose';
 export default function MatchContents() {
   return (
     <Host matchContents>
-      <Button onPress={() => console.log('Pressed')}>Sized to content</Button>
+      <Button onClick={() => console.log('Pressed')}>Sized to content</Button>
     </Host>
   );
 }
@@ -43,7 +43,7 @@ import { Host, Button } from '@expo/ui/jetpack-compose';
 export default function HostWithStyle() {
   return (
     <Host style={{ padding: 16, backgroundColor: '#f0f0f0', borderRadius: 8 }}>
-      <Button onPress={() => console.log('Pressed')}>Styled host</Button>
+      <Button onClick={() => console.log('Pressed')}>Styled host</Button>
     </Host>
   );
 }

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
@@ -29,7 +29,7 @@ import { Host, Button } from '@expo/ui/jetpack-compose';
 export function SaveButton() {
   return (
     <Host matchContents>
-      <Button onPress={() => alert('Saved!')}>Save changes</Button>
+      <Button onClick={() => alert('Saved!')}>Save changes</Button>
     </Host>
   );
 }

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -29,7 +29,7 @@ export default function BasicDropdownMenuExample() {
     <Host matchContents>
       <DropdownMenu expanded={isExpanded} onDismissRequest={() => setIsExpanded(false)}>
         <DropdownMenu.Trigger>
-          <Button variant="bordered" onPress={() => setIsExpanded(true)}>
+          <Button variant="bordered" onClick={() => setIsExpanded(true)}>
             Show Menu
           </Button>
         </DropdownMenu.Trigger>

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
@@ -28,10 +28,10 @@ export default function ToolbarWithFABExample() {
   return (
     <Host matchContents>
       <HorizontalFloatingToolbar>
-        <IconButton onPress={() => console.log('Edit pressed')}>
+        <IconButton onClick={() => console.log('Edit pressed')}>
           <Icon source={require('./assets/edit.xml')} contentDescription="Edit" />
         </IconButton>
-        <IconButton onPress={() => console.log('Share pressed')}>
+        <IconButton onClick={() => console.log('Share pressed')}>
           <Icon source={require('./assets/share.xml')} contentDescription="Share" />
         </IconButton>
         <HorizontalFloatingToolbar.FloatingActionButton onPress={() => console.log('Add pressed')}>

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/host.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/host.mdx
@@ -27,7 +27,7 @@ import { Host, Button } from '@expo/ui/jetpack-compose';
 export default function MatchContents() {
   return (
     <Host matchContents>
-      <Button onPress={() => console.log('Pressed')}>Sized to content</Button>
+      <Button onClick={() => console.log('Pressed')}>Sized to content</Button>
     </Host>
   );
 }
@@ -43,7 +43,7 @@ import { Host, Button } from '@expo/ui/jetpack-compose';
 export default function HostWithStyle() {
   return (
     <Host style={{ padding: 16, backgroundColor: '#f0f0f0', borderRadius: 8 }}>
-      <Button onPress={() => console.log('Pressed')}>Styled host</Button>
+      <Button onClick={() => console.log('Pressed')}>Styled host</Button>
     </Host>
   );
 }

--- a/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/index.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/jetpack-compose/index.mdx
@@ -29,7 +29,7 @@ import { Host, Button } from '@expo/ui/jetpack-compose';
 export function SaveButton() {
   return (
     <Host matchContents>
-      <Button onPress={() => alert('Saved!')}>Save changes</Button>
+      <Button onClick={() => alert('Saved!')}>Save changes</Button>
     </Host>
   );
 }


### PR DESCRIPTION
# Why

Several Jetpack Compose component docs use `onPress` in code examples for `Button` and `IconButton`, but the actual API uses `onClick` (https://docs.expo.dev/versions/latest/sdk/ui/jetpack-compose/button/#onclick & https://docs.expo.dev/versions/latest/sdk/ui/jetpack-compose/iconbutton/#onclick).

Follow-up https://github.com/expo/expo/pull/44572

# How

- Changed `onPress` to `onClick` on `Button` and `IconButton` components in 7 Jetpack Compose doc pages across `v55.0.0` and `unversioned` versions.
- Files changed: `horizontalfloatingtoolbar.mdx`, `host.mdx`, `index.mdx`, `dropdownmenu.mdx`.

# Test Plan

Verify the code examples render correctly on these pages:
- `/versions/v55.0.0/sdk/ui/jetpack-compose/host/`
- `/versions/v55.0.0/sdk/ui/jetpack-compose/horizontalfloatingtoolbar/`
- `/versions/v55.0.0/sdk/ui/jetpack-compose/dropdownmenu/`
- `/versions/unversioned/sdk/ui/jetpack-compose/host/`
- `/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu/`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
