### PR TITLE
[docs] Fix expo-av redirect to point to v54 instead of expo-audio

### DIFF
--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -617,7 +617,7 @@ const RENAMED_PAGES: Record<string, string> = {
 
   // Based on Algolia 404 report 2026-04-01
   '/versions/latest/sdk/secure-store/': '/versions/latest/sdk/securestore/',
-  '/versions/latest/sdk/av/': '/versions/latest/sdk/audio/',
+  '/versions/latest/sdk/av/': '/versions/v54.0.0/sdk/av/',
   '/versions/latest/sdk/ui/jetpack-compose/floatingactionbutton/':
     '/versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton/',
 };

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -359,7 +359,7 @@
 
 # Based on Algolia 404 report 2026-04-01
 /versions/latest/sdk/secure-store /versions/latest/sdk/securestore 301
-/versions/latest/sdk/av /versions/latest/sdk/audio 301
+/versions/latest/sdk/av /versions/v54.0.0/sdk/av 301
 /versions/latest/sdk/ui/jetpack-compose/floatingactionbutton /versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton 301
 
 # TextInput renamed to TextField


### PR DESCRIPTION
# Why

`https://docs.expo.dev/versions/latest/sdk/av/` redirects to `/versions/latest/sdk/audio/`, which is incorrect. `expo-av` and `expo-audio` are different packages. Since `expo-av` was removed in SDK 55, the redirect should point to v54.0.0 (the last version where the page exists) instead of to a different package.

Shared by @kitten .

# How

- Update the redirect in `common/client-redirects.ts` to point `/versions/latest/sdk/av/` to `/versions/v54.0.0/sdk/av/` instead of `/versions/latest/sdk/audio/`.
- Update the same redirect in `public/_redirects` to match.

# Test Plan

Visit `https://docs.expo.dev/versions/latest/sdk/av/` and confirm it redirects to `https://docs.expo.dev/versions/v54.0.0/sdk/av/` instead of the audio page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
