### PR TITLE
[sqlite] Handle empty statements as no-ops

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Add explicit secure context error for `web/wa-sqlite/AccessHandlePoolVFS.js` ([#40605](https://github.com/expo/expo/pull/40605) by [@BDav24](https://github.com/BDav24))
+- Fix crashes on comment-only or empty SQL statements. ([#44623](https://github.com/expo/expo/pull/44623) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fixed a fatal JNI crash on Android when using `useLibSQL: true`, caused by the libSQL session bindings still declaring `byte[]` signatures after [#42638](https://github.com/expo/expo/pull/42638) switched Kotlin and the default native bindings to `ByteBuffer`. ([#46651](https://github.com/expo/expo/pull/46651) by [@zoontek](https://github.com/zoontek))
 - [tvOS] Fix path for DB creation. ([#46715](https://github.com/expo/expo/pull/46715) by [@douglowder](https://github.com/douglowder))
+- Fix crashes on comment-only or empty SQL statements. ([#44623](https://github.com/expo/expo/pull/44623) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/android/src/main/cpp/NativeStatementBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeStatementBinding.cpp
@@ -32,6 +32,7 @@ void NativeStatementBinding::registerNatives() {
                        NativeStatementBinding::sqlite3_finalize),
       makeNativeMethod("sqlite3_reset", NativeStatementBinding::sqlite3_reset),
       makeNativeMethod("sqlite3_step", NativeStatementBinding::sqlite3_step),
+      makeNativeMethod("isNoop", NativeStatementBinding::isNoop),
       makeNativeMethod("bindStatementParam",
                        NativeStatementBinding::bindStatementParam),
       makeNativeMethod("getColumnNames",
@@ -65,6 +66,8 @@ int NativeStatementBinding::sqlite3_finalize() {
 int NativeStatementBinding::sqlite3_reset() { return ::exsqlite3_reset(stmt); }
 
 int NativeStatementBinding::sqlite3_step() { return ::exsqlite3_step(stmt); }
+
+bool NativeStatementBinding::isNoop() { return stmt == nullptr; }
 
 int NativeStatementBinding::bindStatementParam(
     int index, jni::alias_ref<jni::JObject> param) {

--- a/packages/expo-sqlite/android/src/main/cpp/NativeStatementBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/NativeStatementBinding.h
@@ -28,6 +28,7 @@ public:
   int sqlite3_finalize();
   int sqlite3_reset();
   int sqlite3_step();
+  bool isNoop();
 
   // helpers
   int bindStatementParam(int index, jni::alias_ref<jni::JObject> param);

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeStatementBinding.cpp
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeStatementBinding.cpp
@@ -36,6 +36,7 @@ void NativeStatementBinding::registerNatives() {
                        NativeStatementBinding::sqlite3_finalize),
       makeNativeMethod("sqlite3_reset", NativeStatementBinding::sqlite3_reset),
       makeNativeMethod("sqlite3_step", NativeStatementBinding::sqlite3_step),
+      makeNativeMethod("isNoop", NativeStatementBinding::isNoop),
       makeNativeMethod("bindStatementParam",
                        NativeStatementBinding::bindStatementParam),
       makeNativeMethod("getColumnNames",
@@ -106,6 +107,8 @@ int NativeStatementBinding::sqlite3_step() {
   }
   return currentRow != nullptr ? SQLITE_ROW : SQLITE_DONE;
 }
+
+bool NativeStatementBinding::isNoop() { return stmt == nullptr; }
 
 int NativeStatementBinding::bindStatementParam(
     int index, jni::alias_ref<jni::JObject> param) {

--- a/packages/expo-sqlite/android/src/main/cpp/libsql/NativeStatementBinding.h
+++ b/packages/expo-sqlite/android/src/main/cpp/libsql/NativeStatementBinding.h
@@ -28,6 +28,7 @@ public:
   int sqlite3_finalize();
   int sqlite3_reset();
   int sqlite3_step();
+  bool isNoop();
 
   // helpers
   int bindStatementParam(int index, jni::alias_ref<jni::JObject> param);

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatementBinding.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/NativeStatementBinding.kt
@@ -32,6 +32,7 @@ internal class NativeStatementBinding : Closeable {
   external fun sqlite3_finalize(): Int
   external fun sqlite3_reset(): Int
   external fun sqlite3_step(): Int
+  external fun isNoop(): Boolean
 
   external fun bindStatementParam(index: Int, param: Any?): Int
   external fun getColumnNames(): SQLiteColumnNames

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteModule.kt
@@ -249,10 +249,16 @@ class SQLiteModule : Module() {
 
       AsyncFunction("getColumnNamesAsync") { statement: NativeStatement ->
         maybeThrowForFinalizedStatement(statement)
+        if (isNoopStatement(statement)) {
+          return@AsyncFunction arrayListOf()
+        }
         return@AsyncFunction statement.ref.getColumnNames()
       }.runOnQueue(moduleCoroutineScope)
       Function("getColumnNamesSync") { statement: NativeStatement ->
         maybeThrowForFinalizedStatement(statement)
+        if (isNoopStatement(statement)) {
+          return@Function arrayListOf()
+        }
         return@Function statement.ref.getColumnNames()
       }
 
@@ -388,6 +394,9 @@ class SQLiteModule : Module() {
   private fun run(statement: NativeStatement, database: NativeDatabase, bindParams: Map<String, Any?>, bindBlobParams: Map<String, ArrayBuffer>, shouldPassAsArray: Boolean): Map<String, Any> {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
+    if (isNoopStatement(statement)) {
+      return makeNoopRunResult()
+    }
 
     // The statement with parameter bindings is stateful,
     // we have to guard with a critical section for thread safety.
@@ -437,6 +446,9 @@ class SQLiteModule : Module() {
   private fun step(statement: NativeStatement, database: NativeDatabase): SQLiteColumnValues? {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
+    if (isNoopStatement(statement)) {
+      return null
+    }
     val ret = statement.ref.sqlite3_step()
     if (ret == NativeDatabaseBinding.SQLITE_ROW) {
       return statement.getTransformedColumnValues()
@@ -451,6 +463,9 @@ class SQLiteModule : Module() {
   private fun getAll(statement: NativeStatement, database: NativeDatabase): List<SQLiteColumnValues> {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
+    if (isNoopStatement(statement)) {
+      return emptyList()
+    }
     val columnValuesList = mutableListOf<SQLiteColumnValues>()
     while (true) {
       val ret = statement.ref.sqlite3_step()
@@ -469,6 +484,9 @@ class SQLiteModule : Module() {
   private fun reset(statement: NativeStatement, database: NativeDatabase) {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
+    if (isNoopStatement(statement)) {
+      return
+    }
     if (statement.ref.sqlite3_reset() != NativeDatabaseBinding.SQLITE_OK) {
       throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
     }
@@ -478,10 +496,22 @@ class SQLiteModule : Module() {
   private fun finalize(statement: NativeStatement, database: NativeDatabase) {
     maybeThrowForClosedDatabase(database)
     maybeThrowForFinalizedStatement(statement)
-    if (statement.ref.sqlite3_finalize() != NativeDatabaseBinding.SQLITE_OK) {
+    if (!isNoopStatement(statement) && statement.ref.sqlite3_finalize() != NativeDatabaseBinding.SQLITE_OK) {
       throw SQLiteErrorException(database.ref.convertSqlLiteErrorToString())
     }
     statement.isFinalized = true
+  }
+
+  private fun isNoopStatement(statement: NativeStatement): Boolean {
+    return !statement.isFinalized && statement.ref.isNoop()
+  }
+
+  private fun makeNoopRunResult(): Map<String, Any> {
+    return mapOf(
+      "lastInsertRowId" to 0,
+      "changes" to 0,
+      "firstRowValues" to arrayListOf<Any>()
+    )
   }
 
   private fun addUpdateHook(database: NativeDatabase) {

--- a/packages/expo-sqlite/ios/SQLiteModule.swift
+++ b/packages/expo-sqlite/ios/SQLiteModule.swift
@@ -389,6 +389,10 @@ public final class SQLiteModule: Module {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
 
+    if isNoopStatement(statement) {
+      return makeNoopRunResult()
+    }
+
     // The statement with parameter bindings is stateful,
     // we have to guard with a critical section for thread safety.
     statement.lock.wait()
@@ -428,6 +432,9 @@ public final class SQLiteModule: Module {
   private func step(statement: NativeStatement, database: NativeDatabase) throws -> SQLiteColumnValues? {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return nil
+    }
     let ret = exsqlite3_step(statement.pointer)
     if ret == SQLITE_ROW {
       return try getColumnValues(statement: statement)
@@ -441,6 +448,9 @@ public final class SQLiteModule: Module {
   private func getAll(statement: NativeStatement, database: NativeDatabase) throws -> [SQLiteColumnValues] {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return []
+    }
     var columnValuesList: [SQLiteColumnValues] = []
     while true {
       let ret = exsqlite3_step(statement.pointer)
@@ -459,6 +469,9 @@ public final class SQLiteModule: Module {
   private func reset(statement: NativeStatement, database: NativeDatabase) throws {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return
+    }
     if exsqlite3_reset(statement.pointer) != SQLITE_OK {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
@@ -467,7 +480,7 @@ public final class SQLiteModule: Module {
   private func finalize(statement: NativeStatement, database: NativeDatabase) throws {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
-    if exsqlite3_finalize(statement.pointer) != SQLITE_OK {
+    if !isNoopStatement(statement) && exsqlite3_finalize(statement.pointer) != SQLITE_OK {
       throw SQLiteErrorException(convertSqlLiteErrorToString(database))
     }
     statement.isFinalized = true
@@ -580,6 +593,9 @@ public final class SQLiteModule: Module {
 
   private func getColumnNames(statement: NativeStatement) throws -> SQLiteColumnNames {
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return []
+    }
     let columnCount = Int(exsqlite3_column_count(statement.pointer))
     var columnNames: SQLiteColumnNames = Array(repeating: "", count: columnCount)
     for i in 0..<columnCount {
@@ -660,6 +676,18 @@ public final class SQLiteModule: Module {
     if statement.isFinalized {
       throw AccessClosedResourceException()
     }
+  }
+
+  private func isNoopStatement(_ statement: NativeStatement) -> Bool {
+    return statement.pointer == nil && !statement.isFinalized
+  }
+
+  private func makeNoopRunResult() -> [String: Any] {
+    return [
+      "lastInsertRowId": 0,
+      "changes": 0,
+      "firstRowValues": []
+    ]
   }
 
   @inline(__always)

--- a/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
@@ -374,7 +374,9 @@ public final class SQLiteModule: Module {
     if libsql_prepare(database.extraPointer, sourceString, &statement.pointer, &errMsg) != 0 {
       throw SQLiteErrorException(convertLibSqlErrorToString(errMsg))
     }
-    maybeAddCachedStatement(database: database, statement: statement)
+    if !isNoopStatement(statement) {
+      maybeAddCachedStatement(database: database, statement: statement)
+    }
   }
 
   // swiftlint:disable line_length
@@ -382,6 +384,10 @@ public final class SQLiteModule: Module {
   private func run(statement: NativeStatement, database: NativeDatabase, bindParams: [String: Any], bindBlobParams: [String: Data], shouldPassAsArray: Bool) throws -> [String: Any] {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+
+    if isNoopStatement(statement) {
+      return makeNoopRunResult()
+    }
 
     // The statement with parameter bindings is stateful,
     // we have to guard with a critical section for thread safety.
@@ -435,6 +441,9 @@ public final class SQLiteModule: Module {
   private func step(statement: NativeStatement, database: NativeDatabase) throws -> SQLiteColumnValues? {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return nil
+    }
     let rows = try maybeBindStatementRows(statement)
     var row: OpaquePointer?
     var errMsg: UnsafePointer<CChar>?
@@ -453,6 +462,9 @@ public final class SQLiteModule: Module {
   private func getAll(statement: NativeStatement, database: NativeDatabase) throws -> [SQLiteColumnValues] {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return []
+    }
     var columnValuesList: [SQLiteColumnValues] = []
     var errMsg: UnsafePointer<CChar>?
     let rows = try maybeBindStatementRows(statement)
@@ -477,6 +489,9 @@ public final class SQLiteModule: Module {
   private func reset(statement: NativeStatement, database: NativeDatabase) throws {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return
+    }
     if let rows = statement.extraPointer {
       libsql_free_rows(rows)
       statement.extraPointer = nil
@@ -494,7 +509,9 @@ public final class SQLiteModule: Module {
     if let rows = statement.extraPointer {
       libsql_free_rows(rows)
     }
-    libsql_free_stmt(statement.pointer)
+    if !isNoopStatement(statement) {
+      libsql_free_stmt(statement.pointer)
+    }
     statement.isFinalized = true
   }
 
@@ -554,6 +571,9 @@ public final class SQLiteModule: Module {
 
   private func getColumnNames(statement: NativeStatement) throws -> SQLiteColumnNames {
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return []
+    }
     let rows = try maybeBindStatementRows(statement)
     let columnCount = Int(libsql_column_count(rows))
     var columnNames: SQLiteColumnNames = Array(repeating: "", count: columnCount)
@@ -683,6 +703,18 @@ public final class SQLiteModule: Module {
     if statement.isFinalized {
       throw AccessClosedResourceException()
     }
+  }
+
+  private func isNoopStatement(_ statement: NativeStatement) -> Bool {
+    return statement.pointer == nil && !statement.isFinalized
+  }
+
+  private func makeNoopRunResult() -> [String: Any] {
+    return [
+      "lastInsertRowId": 0,
+      "changes": 0,
+      "firstRowValues": []
+    ]
   }
 
   @inline(__always)

--- a/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
+++ b/packages/expo-sqlite/ios/SQLiteModuleLibSQL.swift
@@ -378,7 +378,9 @@ public final class SQLiteModule: Module {
     if libsql_prepare(database.extraPointer, sourceString, &statement.pointer, &errMsg) != 0 {
       throw SQLiteErrorException(convertLibSqlErrorToString(errMsg))
     }
-    maybeAddCachedStatement(database: database, statement: statement)
+    if !isNoopStatement(statement) {
+      maybeAddCachedStatement(database: database, statement: statement)
+    }
   }
 
   // swiftlint:disable line_length
@@ -386,6 +388,10 @@ public final class SQLiteModule: Module {
   private func run(statement: NativeStatement, database: NativeDatabase, bindParams: [String: Any], bindBlobParams: [String: Data], shouldPassAsArray: Bool) throws -> [String: Any] {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+
+    if isNoopStatement(statement) {
+      return makeNoopRunResult()
+    }
 
     // The statement with parameter bindings is stateful,
     // we have to guard with a critical section for thread safety.
@@ -439,6 +445,9 @@ public final class SQLiteModule: Module {
   private func step(statement: NativeStatement, database: NativeDatabase) throws -> SQLiteColumnValues? {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return nil
+    }
     let rows = try maybeBindStatementRows(statement)
     var row: OpaquePointer?
     var errMsg: UnsafePointer<CChar>?
@@ -457,6 +466,9 @@ public final class SQLiteModule: Module {
   private func getAll(statement: NativeStatement, database: NativeDatabase) throws -> [SQLiteColumnValues] {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return []
+    }
     var columnValuesList: [SQLiteColumnValues] = []
     var errMsg: UnsafePointer<CChar>?
     let rows = try maybeBindStatementRows(statement)
@@ -481,6 +493,9 @@ public final class SQLiteModule: Module {
   private func reset(statement: NativeStatement, database: NativeDatabase) throws {
     try maybeThrowForClosedDatabase(database)
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return
+    }
     if let rows = statement.extraPointer {
       libsql_free_rows(rows)
       statement.extraPointer = nil
@@ -498,7 +513,9 @@ public final class SQLiteModule: Module {
     if let rows = statement.extraPointer {
       libsql_free_rows(rows)
     }
-    libsql_free_stmt(statement.pointer)
+    if !isNoopStatement(statement) {
+      libsql_free_stmt(statement.pointer)
+    }
     statement.isFinalized = true
   }
 
@@ -558,6 +575,9 @@ public final class SQLiteModule: Module {
 
   private func getColumnNames(statement: NativeStatement) throws -> SQLiteColumnNames {
     try maybeThrowForFinalizedStatement(statement)
+    if isNoopStatement(statement) {
+      return []
+    }
     let rows = try maybeBindStatementRows(statement)
     let columnCount = Int(libsql_column_count(rows))
     var columnNames: SQLiteColumnNames = Array(repeating: "", count: columnCount)
@@ -687,6 +707,18 @@ public final class SQLiteModule: Module {
     if statement.isFinalized {
       throw AccessClosedResourceException()
     }
+  }
+
+  private func isNoopStatement(_ statement: NativeStatement) -> Bool {
+    return statement.pointer == nil && !statement.isFinalized
+  }
+
+  private func makeNoopRunResult() -> [String: Any] {
+    return [
+      "lastInsertRowId": 0,
+      "changes": 0,
+      "firstRowValues": []
+    ]
   }
 
   @inline(__always)

--- a/packages/expo-sqlite/src/__mocks__/ExpoSQLite.ts
+++ b/packages/expo-sqlite/src/__mocks__/ExpoSQLite.ts
@@ -64,6 +64,10 @@ class NativeDatabase {
   prepareAsync = jest
     .fn()
     .mockImplementation(async (nativeStatement: NativeStatement, source: string) => {
+      if (isNoopStatementSql(source)) {
+        nativeStatement.sqlite3Stmt = null;
+        return;
+      }
       nativeStatement.sqlite3Stmt = this.sqlite3Db.prepare(source);
     });
 
@@ -79,6 +83,10 @@ class NativeDatabase {
     return this.sqlite3Db.serialize({ attached: databaseName });
   });
   prepareSync = jest.fn().mockImplementation((nativeStatement: NativeStatement, source: string) => {
+    if (isNoopStatementSql(source)) {
+      nativeStatement.sqlite3Stmt = null;
+      return;
+    }
     nativeStatement.sqlite3Stmt = this.sqlite3Db.prepare(source);
   });
 
@@ -108,6 +116,9 @@ class NativeStatement {
         )
     );
   public stepAsync = jest.fn().mockImplementation((database: NativeDatabase): Promise<any> => {
+    if (this.sqlite3Stmt == null) {
+      return Promise.resolve(null);
+    }
     assert(this.sqlite3Stmt);
     if (this.iterator == null) {
       this.iterator = this.sqlite3Stmt.iterate();
@@ -123,6 +134,9 @@ class NativeStatement {
     .fn()
     .mockImplementation((database: NativeDatabase) => Promise.resolve(this._allValues()));
   public getColumnNamesAsync = jest.fn().mockImplementation(async (database: NativeDatabase) => {
+    if (this.sqlite3Stmt == null) {
+      return [];
+    }
     assert(this.sqlite3Stmt);
     return this.sqlite3Stmt.columns().map((column) => column.name);
   });
@@ -149,6 +163,9 @@ class NativeStatement {
         this._run(normalizeSQLite3Args(bindParams, bindBlobParams, shouldPassAsArray))
     );
   public stepSync = jest.fn().mockImplementation((database: NativeDatabase): any => {
+    if (this.sqlite3Stmt == null) {
+      return null;
+    }
     assert(this.sqlite3Stmt);
     if (this.iterator == null) {
       this.iterator = this.sqlite3Stmt.iterate();
@@ -163,6 +180,9 @@ class NativeStatement {
   });
   public getAllSync = jest.fn().mockImplementation((database: NativeDatabase) => this._allValues());
   public getColumnNamesSync = jest.fn().mockImplementation((database: NativeDatabase) => {
+    if (this.sqlite3Stmt == null) {
+      return [];
+    }
     assert(this.sqlite3Stmt);
     return this.sqlite3Stmt.columns().map((column) => column.name);
   });
@@ -176,6 +196,13 @@ class NativeStatement {
   //#endregion
 
   private _run = (...params: any[]): SQLiteRunResult & { firstRowValues: SQLiteColumnValues } => {
+    if (this.sqlite3Stmt == null) {
+      return {
+        lastInsertRowId: 0,
+        changes: 0,
+        firstRowValues: [],
+      };
+    }
     assert(this.sqlite3Stmt);
     this.sqlite3Stmt.bind(...params);
     const result = this.sqlite3Stmt.run();
@@ -196,6 +223,9 @@ class NativeStatement {
   };
 
   private _allValues = (): SQLiteColumnNames[] => {
+    if (this.sqlite3Stmt == null) {
+      return [];
+    }
     assert(this.sqlite3Stmt);
     const sqlite3Stmt = this.sqlite3Stmt as any;
     // Since the first row is retrieved by `_run()`, we need to skip the first row here.
@@ -206,6 +236,10 @@ class NativeStatement {
   };
 
   private _reset = () => {
+    if (this.sqlite3Stmt == null) {
+      this.iterator = null;
+      return;
+    }
     assert(this.sqlite3Stmt);
     this.iterator?.return?.();
     this.iterator = this.sqlite3Stmt.iterate();
@@ -218,6 +252,15 @@ class NativeStatement {
 }
 
 //#endregion
+
+function isNoopStatementSql(source: string): boolean {
+  const normalizedSource = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/--[^\n\r]*/g, '')
+    .replace(/;/g, '')
+    .trim();
+  return normalizedSource.length === 0;
+}
 
 function normalizeSQLite3Args(
   bindParams: SQLiteBindPrimitiveParams,

--- a/packages/expo-sqlite/src/__mocks__/ExpoSQLite.ts
+++ b/packages/expo-sqlite/src/__mocks__/ExpoSQLite.ts
@@ -112,6 +112,13 @@ class NativeStatement {
   private boundParams: SQLiteBindParams = [];
 
   prepare(nodeDb: DatabaseSync, source: string) {
+    if (isNoopStatementSql(source)) {
+      this.nodeStmt = null;
+      this.iterator = null;
+      this.boundParams = [];
+      return;
+    }
+
     const stmt = nodeDb.prepare(source);
     // The native module strips the `:@$` prefixes from named parameters.
     stmt.setAllowBareNamedParameters(true);
@@ -188,6 +195,16 @@ class NativeStatement {
   private _run = (
     params: SQLiteBindParams
   ): SQLiteRunResult & { firstRowValues: SQLiteColumnValues } => {
+    if (this.nodeStmt == null) {
+      this.boundParams = [];
+      this.iterator = null;
+      return {
+        lastInsertRowId: 0,
+        changes: 0,
+        firstRowValues: [],
+      };
+    }
+
     assert(this.nodeStmt);
     this.boundParams = params;
     this.iterator = null;
@@ -234,11 +251,17 @@ class NativeStatement {
   };
 
   private _columnNames = (): SQLiteColumnNames => {
-    assert(this.nodeStmt);
+    if (this.nodeStmt == null) {
+      return [];
+    }
     return this.nodeStmt.columns().map((column) => column.name);
   };
 
   private _reset = () => {
+    if (this.nodeStmt == null) {
+      this.iterator = null;
+      return;
+    }
     assert(this.nodeStmt);
     this.iterator?.return?.();
     this.iterator = this.nodeStmt.iterate(...asBindArgs(this.boundParams));
@@ -251,6 +274,15 @@ class NativeStatement {
 }
 
 //#endregion
+
+function isNoopStatementSql(source: string): boolean {
+  const normalizedSource = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/--[^\n\r]*/g, '')
+    .replace(/;/g, '')
+    .trim();
+  return normalizedSource.length === 0;
+}
 
 function asBindArgs(params: SQLiteBindParams): SQLInputValue[] {
   // Booleans are already normalized to 1/0 upstream, so values fit node:sqlite's input types.

--- a/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
@@ -66,6 +66,13 @@ describe('Database', () => {
     expect(result.changes).toBe(1);
   });
 
+  it('runAsync should no-op for whitespace-only statements', async () => {
+    db = await openDatabaseAsync(':memory:');
+    const result = await db.runAsync('\n');
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
+  });
+
   it('getFirstAsync should return a row', async () => {
     db = await openDatabaseAsync(':memory:');
     await db.execAsync(
@@ -278,6 +285,13 @@ describe('Database - Synchronous calls', () => {
     const result = db.getFirstSync<TestEntity>('SELECT * FROM test');
     expect(result?.value).toBe('test');
     expect(result?.intValue).toBe(123);
+  });
+
+  it('runSync should no-op for whitespace-only statements', () => {
+    db = openDatabaseSync(':memory:');
+    const result = db.runSync('\n');
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
   });
 
   it('getEachSync should return iterable', () => {

--- a/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteDatabase-test.ios.ts
@@ -67,6 +67,13 @@ describe('Database', () => {
     expect(result.changes).toBe(1);
   });
 
+  it('runAsync should no-op for whitespace-only statements', async () => {
+    db = await openDatabaseAsync(':memory:');
+    const result = await db.runAsync('\n');
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
+  });
+
   it('getFirstAsync should return a row', async () => {
     db = await openDatabaseAsync(':memory:');
     await db.execAsync(
@@ -279,6 +286,13 @@ describe('Database - Synchronous calls', () => {
     const result = db.getFirstSync<TestEntity>('SELECT * FROM test');
     expect(result?.value).toBe('test');
     expect(result?.intValue).toBe(123);
+  });
+
+  it('runSync should no-op for whitespace-only statements', () => {
+    db = openDatabaseSync(':memory:');
+    const result = db.runSync('\n');
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
   });
 
   it('getEachSync should return iterable', () => {

--- a/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
@@ -129,6 +129,28 @@ describe(SQLiteStatement, () => {
     await statement.finalizeAsync();
   });
 
+  it('prepareAsync should allow whitespace-only statements as no-ops', async () => {
+    const statement = await db.prepareAsync('\n');
+    const result = await statement.executeAsync<TestEntity>();
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
+    expect(await result.getFirstAsync()).toBeNull();
+    await result.resetAsync();
+    expect(await result.getAllAsync()).toEqual([]);
+    expect(await statement.getColumnNamesAsync()).toEqual([]);
+    await expect(result.resetAsync()).resolves.toBeUndefined();
+    await expect(statement.finalizeAsync()).resolves.toBeUndefined();
+  });
+
+  it('prepareAsync should allow comment-only statements as no-ops', async () => {
+    const statement = await db.prepareAsync('-- comment only');
+    const result = await statement.executeAsync<TestEntity>();
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
+    expect(await result.getFirstAsync()).toBeNull();
+    await statement.finalizeAsync();
+  });
+
   it('getColumnNamesAsync should return column names', async () => {
     const statement = await db.prepareAsync('SELECT * FROM test');
     const columnNames = await statement.getColumnNamesAsync();
@@ -156,5 +178,18 @@ describe(SQLiteStatement, () => {
     row = (await result.next()).value;
     expect(row?.intValue).toBe(123);
     await statement.finalizeAsync();
+  });
+
+  it('prepareSync should allow whitespace-only statements as no-ops', () => {
+    const statement = db.prepareSync('\n');
+    const result = statement.executeSync<TestEntity>();
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
+    expect(result.getFirstSync()).toBeNull();
+    result.resetSync();
+    expect(result.getAllSync()).toEqual([]);
+    expect(statement.getColumnNamesSync()).toEqual([]);
+    expect(() => result.resetSync()).not.toThrow();
+    expect(() => statement.finalizeSync()).not.toThrow();
   });
 });

--- a/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
+++ b/packages/expo-sqlite/src/__tests__/SQLiteStatement-test.ios.ts
@@ -128,6 +128,28 @@ describe(SQLiteStatement, () => {
     await statement.finalizeAsync();
   });
 
+  it('prepareAsync should allow whitespace-only statements as no-ops', async () => {
+    const statement = await db.prepareAsync('\n');
+    const result = await statement.executeAsync<TestEntity>();
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
+    expect(await result.getFirstAsync()).toBeNull();
+    await result.resetAsync();
+    expect(await result.getAllAsync()).toEqual([]);
+    expect(await statement.getColumnNamesAsync()).toEqual([]);
+    await expect(result.resetAsync()).resolves.toBeUndefined();
+    await expect(statement.finalizeAsync()).resolves.toBeUndefined();
+  });
+
+  it('prepareAsync should allow comment-only statements as no-ops', async () => {
+    const statement = await db.prepareAsync('-- comment only');
+    const result = await statement.executeAsync<TestEntity>();
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
+    expect(await result.getFirstAsync()).toBeNull();
+    await statement.finalizeAsync();
+  });
+
   it('getColumnNamesAsync should return column names', async () => {
     const statement = await db.prepareAsync('SELECT * FROM test');
     const columnNames = await statement.getColumnNamesAsync();
@@ -155,5 +177,18 @@ describe(SQLiteStatement, () => {
     row = (await result.next()).value;
     expect(row?.intValue).toBe(123);
     await statement.finalizeAsync();
+  });
+
+  it('prepareSync should allow whitespace-only statements as no-ops', () => {
+    const statement = db.prepareSync('\n');
+    const result = statement.executeSync<TestEntity>();
+    expect(result.lastInsertRowId).toBe(0);
+    expect(result.changes).toBe(0);
+    expect(result.getFirstSync()).toBeNull();
+    result.resetSync();
+    expect(result.getAllSync()).toEqual([]);
+    expect(statement.getColumnNamesSync()).toEqual([]);
+    expect(() => result.resetSync()).not.toThrow();
+    expect(() => statement.finalizeSync()).not.toThrow();
   });
 });


### PR DESCRIPTION
# Why

`expo-sqlite` could crash when `run()` / `runSync()` received an empty SQL statement such as `"\n"`.

The root cause is that SQLite treats empty, whitespace-only, and comment-only SQL as a special case: `sqlite3_prepare_v2()` may return `SQLITE_OK` while also returning a null statement pointer because the input produced no executable statement. This behavior is documented by SQLite and also called out in the SQLite forum: [forum thread](https://sqlite.org/forum/forumpost/70bb8576c6c084c2).

While investigating, I reproduced this difference locally with both the system SQLite and Expo’s vendored SQLite:

- my system SQLite `3.43.2`: preparing `"\n"` returned success with `stmt == NULL`, but follow-up calls were null-tolerant and did not crash
- Expo vendored SQLite `3.50.3`: preparing `"\n"` also returned success with `stmt == NULL`, but later statement APIs like `clear_bindings(NULL)` could crash

`expo-sqlite` assumed that a successful prepare always produced a valid statement pointer, so it continued into the normal execution path and called statement APIs on a null pointer. This PR fixes that mismatch by treating empty/comment-only statements as valid no-ops, which is closer to SQLite’s documented behavior and avoids introducing stricter semantics than upstream.

# How

Updated the native statement flow to treat `pointer == nil/null && !isFinalized` as a no-op statement.

On both iOS and Android, for sqlite and libsql:

- `prepare*()` now succeeds when SQLite returns success with a null statement pointer
- `run*()` short-circuits and returns a synthetic no-op result:
  - `lastInsertRowId: 0`
  - `changes: 0`
  - `firstRowValues: []`
- `step*()` returns `null`
- `getAll*()` returns `[]`
- `getColumnNames*()` returns `[]`
- `reset*()` becomes a no-op
- `finalize*()` becomes a no-op aside from marking the statement finalized

The public JS API is unchanged.

I also updated the Jest mock to model the same behavior for empty, whitespace-only, and comment-only SQL statements.

# Test Plan

- Test Suite
- My personal project - no longer crashing on executing `sqlFileString.split(';')` statements
- Added TS tests (although they rely on mocks)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
