### PR TITLE
fix(autolinking): store React modulemap outside React-Core-prebuilt to survive build-time replacement

### DIFF
--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -562,9 +562,9 @@ module Expo
         xcframework_path = File.join(react_prebuilt_dir, 'React.xcframework')
         return unless File.exist?(xcframework_path)
 
-        create_nonframework_modulemap(react_prebuilt_dir)
+        create_nonframework_modulemap(installer.sandbox.root)
         patch_framework_modulemaps(xcframework_path)
-        inject_isystem_flags(installer, react_prebuilt_dir)
+        inject_isystem_flags(installer, installer.sandbox.root)
 
         Pod::UI.puts "[Expo] ".blue + "Created non-framework React modulemap for use_frameworks! compatibility"
       end
@@ -702,11 +702,11 @@ module Expo
       # ──────────────────────────────────────────────────────────────────────
 
       # Creates a non-framework modulemap so <React/X.h> resolves through -isystem + VFS.
-      def create_nonframework_modulemap(react_prebuilt_dir)
-        modulemap_path = File.join(react_prebuilt_dir, 'React-use-frameworks.modulemap')
+      def create_nonframework_modulemap(pods_root)
+        modulemap_path = File.join(pods_root, 'React-use-frameworks.modulemap')
         modulemap_content = <<~MODULEMAP
           module React {
-            umbrella header "React.xcframework/Headers/React_Core/React_Core-umbrella.h"
+            umbrella header "React-Core-prebuilt/React.xcframework/Headers/React_Core/React_Core-umbrella.h"
             export *
           }
         MODULEMAP
@@ -732,10 +732,10 @@ module Expo
 
       # Injects -fmodule-map-file and -isystem into all pod and aggregate xcconfigs.
       # Module builds don't inherit -I (HEADER_SEARCH_PATHS) but DO inherit -isystem.
-      def inject_isystem_flags(installer, react_prebuilt_dir)
-        modulemap_flag = "-fmodule-map-file=\"${PODS_ROOT}/React-Core-prebuilt/React-use-frameworks.modulemap\""
+      def inject_isystem_flags(installer, pods_root)
+        modulemap_flag = "-fmodule-map-file=\"${PODS_ROOT}/React-use-frameworks.modulemap\""
         extra_isystem = "-isystem \"${PODS_ROOT}/React-Core-prebuilt/React.xcframework/Headers\""
-        swift_modulemap = "-Xcc -fmodule-map-file=\"${PODS_ROOT}/React-Core-prebuilt/React-use-frameworks.modulemap\""
+        swift_modulemap = "-Xcc -fmodule-map-file=\"${PODS_ROOT}/React-use-frameworks.modulemap\""
         swift_extra_isystem = "-Xcc -isystem -Xcc \"${PODS_ROOT}/React-Core-prebuilt/React.xcframework/Headers\""
         skip_marker = 'React-use-frameworks.modulemap'
 


### PR DESCRIPTION
## Summary

Moves the `React-use-frameworks.modulemap` file from `Pods/React-Core-prebuilt/` to `Pods/` root to prevent it from being deleted at build time.

## Root Cause

`configure_use_frameworks` (introduced in `expo-modules-autolinking@55.0.15`) creates `React-use-frameworks.modulemap` inside `Pods/React-Core-prebuilt/` during `pod install` and injects `-fmodule-map-file` flags into all pod target xcconfigs pointing to that file.

However, React Native's `replace-rncore-version.js` runs as a **build phase** (before compile) via the `[RNDeps] Replace React Native Core for the right configuration` script phase. It deletes and re-creates the entire `Pods/React-Core-prebuilt/` directory to swap between Debug/Release configurations. This removes the modulemap, causing the build to fail:

```
module map file '.../Pods/React-Core-prebuilt/React-use-frameworks.modulemap' not found
```

This affects any project using:
- `useFrameworks: 'static'` (via `expo-build-properties`)
- Prebuilt React Native core (`RCT_USE_PREBUILT_RNCORE=1`, the default)
- `expo-modules-autolinking >= 55.0.15`

## Fix

Store the modulemap in `Pods/` root instead of inside `Pods/React-Core-prebuilt/`. The `Pods/` root is not affected by the RN build script. The umbrella header and `-fmodule-map-file` paths are updated accordingly.

## Test plan

- Verified the modulemap file is no longer inside the directory that gets replaced at build time
- Verified the `-fmodule-map-file` flags in xcconfigs point to the new location
- Verified the umbrella header path correctly resolves from the new modulemap location