### PR TITLE
[install-expo-modules] Skip pod install on platforms other than MacOS

### DIFF
--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Added `--skip-pod-install` option. ([#](https://github.com/expo/expo/pull/) by [@radoslawrolka](https://github.com/radoslawrolka))
 - Added react-native 0.83 support. ([#43855](https://github.com/expo/expo/pull/43855) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes

--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Added `--skip-pod-install` option. ([#](https://github.com/expo/expo/pull/) by [@radoslawrolka](https://github.com/radoslawrolka))
+- Added `--skip-pod-install` option. ([#44633](https://github.com/expo/expo/pull/44633) by [@radoslawrolka](https://github.com/radoslawrolka))
 - Added react-native 0.83 support. ([#43855](https://github.com/expo/expo/pull/43855) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes

--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Added `--skip-pod-install` option. ([#44633](https://github.com/expo/expo/pull/44633) by [@radoslawrolka](https://github.com/radoslawrolka))
+- Skip pods install on non-darwin platforms. ([#44633](https://github.com/expo/expo/pull/44633) by [@radoslawrolka](https://github.com/radoslawrolka))
 - Added react-native 0.83 support. ([#43855](https://github.com/expo/expo/pull/43855) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -37,6 +37,7 @@ const program = new Command(packageJSON.name)
   .description('Install expo-modules into your project')
   .option('-s, --sdk-version <version>', 'Install specified expo-modules sdk version')
   .option('--non-interactive', 'Disable interactive prompts')
+  .option('--skip-pod-install', 'Skip the step installing iOS pods')
   .parse(process.argv);
 
 function getSdkVersionInfo(projectRoot: string): VersionInfo {
@@ -194,8 +195,10 @@ async function runAsync() {
     await installBabelPresetExpoNonInteractiveAsync(projectRoot);
   }
 
-  console.log('\u203A Installing ios pods...');
-  await installPodsAsync(projectRoot);
+  if (!program.opts().skipPodInstall) {
+    console.log('\u203A Installing ios pods...');
+    await installPodsAsync(projectRoot);
+  }
 
   console.log(chalk.bold('\u203A Installation completed!'));
 }

--- a/packages/install-expo-modules/src/index.ts
+++ b/packages/install-expo-modules/src/index.ts
@@ -37,7 +37,6 @@ const program = new Command(packageJSON.name)
   .description('Install expo-modules into your project')
   .option('-s, --sdk-version <version>', 'Install specified expo-modules sdk version')
   .option('--non-interactive', 'Disable interactive prompts')
-  .option('--skip-pod-install', 'Skip the step installing iOS pods')
   .parse(process.argv);
 
 function getSdkVersionInfo(projectRoot: string): VersionInfo {
@@ -195,7 +194,7 @@ async function runAsync() {
     await installBabelPresetExpoNonInteractiveAsync(projectRoot);
   }
 
-  if (!program.opts().skipPodInstall) {
+  if (process.platform === 'darwin') {
     console.log('\u203A Installing ios pods...');
     await installPodsAsync(projectRoot);
   }


### PR DESCRIPTION
# Why

Since CocoaPods is only supported on macOS, attempting to run pod installation on other operating systems (such as Linux or Windows) results in unnecessary errors or failed setups. By skipping this step in non-macOS environments, we ensure smoother installation and better cross-platform compatibility.

# How

Add flag via commander

# Test Plan

```
$ npx install-expo-modules@latest --skip-pod-install
```
Pods should not be installed, so the process can safely proceed on non-macOS systems.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
