### PR TITLE
fix(babel-preset-expo): use splash background color from `expo-splash-screen`'s config plugin

### DIFF
--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.d.ts
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.d.ts
@@ -1,6 +1,11 @@
 import type { ConfigAPI, PluginObj, PluginPass } from '@babel/core';
+import type { ExpoConfig } from 'expo/config';
 interface InlineManifestState extends PluginPass {
     projectRoot: string;
 }
 export declare function expoInlineManifestPlugin(api: ConfigAPI & typeof import('@babel/core')): PluginObj<InlineManifestState>;
+/**
+ * Get the props for a config-plugin
+ */
+export declare function getConfigPluginProps<Props>(config: ExpoConfig, pluginName: string): Props | null;
 export {};

--- a/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
+++ b/packages/babel-preset-expo/build/expo-inline-manifest-plugin.js
@@ -1,6 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.expoInlineManifestPlugin = expoInlineManifestPlugin;
+exports.getConfigPluginProps = getConfigPluginProps;
 const common_1 = require("./common");
 const debug = require('debug')('expo:babel:inline-manifest');
 // Convert expo value to PWA value
@@ -40,7 +41,7 @@ function getExpoConstantsManifest(projectRoot) {
 function applyWebDefaults({ config, appName, webName }) {
     const appJSON = config.exp;
     // For RN CLI support
-    const { web: webManifest = {}, splash = {}, ios = {}, android = {} } = appJSON;
+    const { web: webManifest = {}, ios = {}, android = {} } = appJSON;
     const languageISOCode = webManifest.lang;
     const primaryColor = appJSON.primaryColor;
     const description = appJSON.description;
@@ -59,7 +60,8 @@ function applyWebDefaults({ config, appName, webName }) {
      * The background_color should be the same color as the load page,
      * to provide a smooth transition from the splash screen to your app.
      */
-    const backgroundColor = webManifest.backgroundColor || splash.backgroundColor; // No default background color
+    const splash = getConfigPluginProps(appJSON, 'expo-splash-screen');
+    const backgroundColor = webManifest.backgroundColor || splash?.backgroundColor; // No default background color
     return {
         ...appJSON,
         name: appName,
@@ -188,4 +190,19 @@ function expoInlineManifestPlugin(api) {
             },
         },
     };
+}
+/**
+ * Get the props for a config-plugin
+ */
+function getConfigPluginProps(config, pluginName) {
+    const plugin = (config.plugins ?? []).find((plugin) => {
+        if (Array.isArray(plugin)) {
+            return plugin[0] === pluginName;
+        }
+        return plugin === pluginName;
+    });
+    if (Array.isArray(plugin)) {
+        return (plugin[1] ?? null);
+    }
+    return null;
 }

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -89,6 +89,7 @@
     "@types/node": "^22.14.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "expo-module-scripts": "workspace:*",
+    "expo-splash-screen": "workspace:*",
     "jest": "^29.2.1",
     "react-refresh": "^0.14.2",
     "resolve-from": "^5.0.0"

--- a/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
+++ b/packages/babel-preset-expo/src/expo-inline-manifest-plugin.ts
@@ -1,5 +1,6 @@
 import type { ConfigAPI, PluginObj, PluginPass } from '@babel/core';
 import type { ExpoConfig, ProjectConfig } from 'expo/config';
+import type { Props as SplashProps } from 'expo-splash-screen/plugin';
 
 import { getIsReactServer, getPlatform, getPossibleProjectRoot } from './common';
 
@@ -43,7 +44,7 @@ function getExpoConstantsManifest(projectRoot: string) {
 function applyWebDefaults({ config, appName, webName }: ConfigMemo) {
   const appJSON: ExpoConfig = config.exp;
   // For RN CLI support
-  const { web: webManifest = {}, splash = {}, ios = {}, android = {} } = appJSON;
+  const { web: webManifest = {}, ios = {}, android = {} } = appJSON;
   const languageISOCode = webManifest.lang;
   const primaryColor = appJSON.primaryColor;
   const description = appJSON.description;
@@ -62,7 +63,8 @@ function applyWebDefaults({ config, appName, webName }: ConfigMemo) {
    * The background_color should be the same color as the load page,
    * to provide a smooth transition from the splash screen to your app.
    */
-  const backgroundColor = webManifest.backgroundColor || splash.backgroundColor; // No default background color
+  const splash = getConfigPluginProps<SplashProps>(appJSON, 'expo-splash-screen');
+  const backgroundColor = webManifest.backgroundColor || splash?.backgroundColor; // No default background color
   return {
     ...appJSON,
     name: appName,
@@ -211,4 +213,20 @@ export function expoInlineManifestPlugin(
       },
     },
   };
+}
+
+/**
+ * Get the props for a config-plugin
+ */
+export function getConfigPluginProps<Props>(config: ExpoConfig, pluginName: string): Props | null {
+  const plugin = (config.plugins ?? []).find((plugin) => {
+    if (Array.isArray(plugin)) {
+      return plugin[0] === pluginName;
+    }
+    return plugin === pluginName;
+  });
+  if (Array.isArray(plugin)) {
+    return (plugin[1] ?? null) as Props;
+  }
+  return null;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2878,6 +2878,9 @@ importers:
       expo-module-scripts:
         specifier: workspace:*
         version: link:../expo-module-scripts
+      expo-splash-screen:
+        specifier: workspace:*
+        version: link:../expo-splash-screen
       jest:
         specifier: ^29.2.1
         version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@5.9.3))


### PR DESCRIPTION
# Why

Followup to https://github.com/expo/expo/pull/44542. See also https://github.com/expo/expo/pull/44598.

The changes in https://github.com/expo/expo/pull/44542 removed the top-level `splash` property from the `app.json`, this prevented `babel-preset-expo` from building because it relied on said property.

# How

Modified `expo-inline-manifest-plugin.ts` to read the background color from `expo-splash-screen`'s config plugin options instead.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
