### PR TITLE
[precompiled] Fix expo-camera barcode scanning with precompiled modules

### DIFF
--- a/packages/expo-camera/ios/ExpoCamera.podspec
+++ b/packages/expo-camera/ios/ExpoCamera.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
 podfile_properties = JSON.parse(File.read("#{Pod::Config.instance.installation_root}/Podfile.properties.json")) rescue {}
 
-barcode_scanner_enabled = podfile_properties.fetch('expo-camera.barcode-scanner-enabled', 'true') != 'false'
+barcode_scanner_enabled = podfile_properties.fetch('expo.camera.barcode-scanner-enabled', 'true') != 'false'
 
 Pod::Spec.new do |s|
   s.name           = 'ExpoCamera'

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -7,7 +7,13 @@ import { getPrecompileDir } from '../Directories';
 import logger from '../Logger';
 import type { SPMPackageSource } from './ExternalPackage';
 import { BuildFlavor } from './Prebuilder.types';
-import { getBuildFolderPrefixForPlatform, getBuildPlatformsForProduct, SPMBuild } from './SPMBuild';
+import {
+  enrichFrameworkWithHeaders,
+  findFirstExisting,
+  getBuildFolderPrefixForPlatform,
+  getBuildPlatformsForProduct,
+  SPMBuild,
+} from './SPMBuild';
 import { BuiltFramework } from './SPMBuild.types';
 import { BuildPlatform, SPMConfig, SPMProduct } from './SPMConfig.types';
 import { SPMGenerator } from './SPMGenerator';
@@ -497,35 +503,15 @@ const copySPMDependencyXCFrameworksAsync = async (
       continue;
     }
 
-    // Look for the pre-built xcframework in SourcePackages/artifacts/<packageName>/<productName>/
-    const artifactsDir = path.join(
-      buildPath,
-      'SourcePackages',
-      'artifacts',
-      packageName,
-      productName
-    );
-
     const xcframeworkName = `${productName}.xcframework`;
-    const sourceXCFrameworkPath = path.join(artifactsDir, xcframeworkName);
-
-    if (!(await fs.pathExists(sourceXCFrameworkPath))) {
-      logger.warn(
-        `⚠️  SPM dependency xcframework not found at ${path.relative(pkg.path, sourceXCFrameworkPath)}`
-      );
-      continue;
-    }
-
     const destXCFrameworkPath = path.join(outputDir, xcframeworkName);
-
-    // Use xcodebuild -create-xcframework to re-compose with only the slices matching
-    // the product's platforms. The source xcframework may contain macOS/tvOS/visionOS
-    // slices with Versions/Current/ symlink structures that cause fs.copy to fail.
-    // By extracting only the iOS frameworks from the build output, we avoid both the
-    // symlink issues and shipping unnecessary platform slices.
     const productBuildPlatforms = getBuildPlatformsForProduct(product);
 
-    // Collect the matching frameworks from the SPM build output
+    // Collect built frameworks from Build/Products/ — this covers source-built SPM
+    // dependencies (e.g., ZXingObjC fetched from a git URL and compiled by Xcode).
+    // SPM places dependency frameworks in PackageFrameworks/ subdirectory; check there
+    // first, then the top-level build products dir.
+    const checkoutDir = path.join(buildPath, 'SourcePackages', 'checkouts', packageName);
     const depFrameworks: { frameworkPath: string; debugSymbolsPath?: string }[] = [];
     for (const buildPlatform of productBuildPlatforms) {
       const buildFolderPrefix = getBuildFolderPrefixForPlatform(buildPlatform);
@@ -535,29 +521,60 @@ const copySPMDependencyXCFrameworksAsync = async (
         'Products',
         `${buildType}-${buildFolderPrefix}`
       );
-      const frameworkPath = path.join(buildProductsDir, `${productName}.framework`);
-      const dsymPath = path.join(buildProductsDir, `${productName}.framework.dSYM`);
+      const candidatePaths = [
+        path.join(buildProductsDir, 'PackageFrameworks', `${productName}.framework`),
+        path.join(buildProductsDir, `${productName}.framework`),
+      ];
+      const frameworkPath = await findFirstExisting(candidatePaths);
+      const dsymPath = await findFirstExisting(candidatePaths.map((p) => `${p}.dSYM`));
 
-      if (await fs.pathExists(frameworkPath)) {
+      if (frameworkPath) {
+        // SPM's PackageFrameworks/ output may lack Headers/ and Modules/ — they live
+        // in build intermediates. Enrich the framework so the xcframework is usable
+        // as a build dependency with module imports.
+        if (await fs.pathExists(checkoutDir)) {
+          await enrichFrameworkWithHeaders(
+            frameworkPath,
+            productName,
+            checkoutDir,
+            buildPath,
+            buildFolderPrefix,
+            buildType
+          );
+        }
         depFrameworks.push({
           frameworkPath,
-          debugSymbolsPath: (await fs.pathExists(dsymPath)) ? dsymPath : undefined,
+          debugSymbolsPath: dsymPath ?? undefined,
         });
       }
     }
 
     if (depFrameworks.length === 0) {
-      // Fallback: the dependency may be a binary target (not built locally).
-      // In that case, the framework only exists inside the xcframework slices in
-      // SourcePackages/artifacts. Use rsync to copy while preserving symlinks.
-      logger.info(
-        `📦 Copying SPM dependency ${chalk.cyan(xcframeworkName)} → ${path.relative(pkg.path, destXCFrameworkPath)}`
+      // No locally-built frameworks found. Check SourcePackages/artifacts/ for binary
+      // targets (pre-built xcframeworks distributed via SPM, not compiled locally).
+      const artifactsDir = path.join(
+        buildPath,
+        'SourcePackages',
+        'artifacts',
+        packageName,
+        productName
       );
-      await fs.remove(destXCFrameworkPath);
-      execSync(`rsync -a --delete "${sourceXCFrameworkPath}/" "${destXCFrameworkPath}/"`, {
-        stdio: 'pipe',
-      });
-      logger.info(`✅ Copied ${xcframeworkName} alongside ${product.name}.xcframework`);
+      const sourceXCFrameworkPath = path.join(artifactsDir, xcframeworkName);
+
+      if (await fs.pathExists(sourceXCFrameworkPath)) {
+        logger.info(
+          `📦 Copying SPM dependency ${chalk.cyan(xcframeworkName)} → ${path.relative(pkg.path, destXCFrameworkPath)}`
+        );
+        await fs.remove(destXCFrameworkPath);
+        execSync(`rsync -a --delete "${sourceXCFrameworkPath}/" "${destXCFrameworkPath}/"`, {
+          stdio: 'pipe',
+        });
+        logger.info(`✅ Copied ${xcframeworkName} alongside ${product.name}.xcframework`);
+      } else {
+        logger.warn(
+          `⚠️  SPM dependency ${chalk.cyan(productName)} not found in Build/Products/ or SourcePackages/artifacts/`
+        );
+      }
       continue;
     }
 

--- a/tools/src/prebuilds/SPMBuild.ts
+++ b/tools/src/prebuilds/SPMBuild.ts
@@ -581,7 +581,7 @@ async function patchCheckoutWithSharedDeps(
  * are in the build intermediates. We need them for the xcframework to be usable as
  * a build dependency with `import Module`.
  */
-async function enrichFrameworkWithHeaders(
+export async function enrichFrameworkWithHeaders(
   frameworkPath: string,
   productName: string,
   checkoutDir: string,
@@ -649,6 +649,10 @@ async function enrichFrameworkWithHeaders(
       `${productName}.build`,
       `${productName}.modulemap`
     ),
+    // Fallback: SPM-generated module map in the checkout's public headers directory.
+    // For ObjC packages built via SPM, the module map may only exist here when
+    // Xcode doesn't copy it to Build/Intermediates.noindex/.
+    ...(headersDir ? [path.join(headersDir, 'module.modulemap')] : []),
   ];
   const modulemapPath = await findFirstExisting(modulemapPaths);
   if (modulemapPath) {
@@ -666,11 +670,18 @@ async function enrichFrameworkWithHeaders(
     modulemapContent = modulemapContent.replace(/^module /m, 'framework module ');
 
     if (modulemapContent.includes('umbrella header')) {
-      // Single umbrella header — rewrite to just the filename
-      modulemapContent = modulemapContent.replace(
-        /umbrella header "[^"]*\/([^"\/]+)"/,
-        'umbrella header "$1"'
-      );
+      // Extract the umbrella header path to decide how to rewrite it.
+      const umbrellaPathMatch = modulemapContent.match(/umbrella header "([^"]+)"/);
+      if (umbrellaPathMatch && path.isAbsolute(umbrellaPathMatch[1])) {
+        // Absolute path (from xcodebuild-generated modulemaps) — strip to just the filename.
+        // Relative paths are preserved — they resolve correctly relative to the framework's Headers/ dir.
+        const filename = path.basename(umbrellaPathMatch[1]);
+        modulemapContent = modulemapContent.replace(
+          /umbrella header "[^"]+"/,
+          `umbrella header "${filename}"`
+        );
+      }
+
       // Copy the umbrella header if not already in Headers/
       const umbrellaMatch = modulemapContent.match(/umbrella header "([^"]+)"/);
       if (umbrellaMatch) {


### PR DESCRIPTION
# Why
Closes #44491
Fixes expo-camera barcode scanning being disabled when the module is precompiled.

# How

When `ZXingObjC` is pre-built as a shared SPM dependency, the resulting xcframework had no `Modules/module.modulemap`. This caused `#if canImport(ZXingObjC)` to fail, so the barcode scanning stub was compiled instead.

The modulemap was missing because `enrichFrameworkWithHeaders` only searched Xcode DerivedData paths for it. `ZXingObjC`'s modulemap lives in the SPM checkout's public headers directory instead. Added it as a fallback, and fixed the modulemap path rewrite to preserve relative umbrella header paths.

Also fixes a key mismatch where `barcodeScannerEnabled: false` in the config plugin had no effect on iOS, the key was incorrect in the podspec.

# Test Plan
- `et prebuild expo-camera`, `ZXingObjC` symbols present in binary
- `et prebuild`, all  packages build, all shared SPMdeps have valid module maps.

