### PR TITLE
[docs] Fix StickerSmash tutorial crashing on Expo Go Android

### DIFF
--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -54,7 +54,7 @@ Using `Platform` module from React Native, we can implement platform-specific be
 ```tsx app/(tabs)/index.tsx
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { ImageSourcePropType, View, StyleSheet, /* @tutinfo */Platform/* @end */ } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { captureRef } from 'react-native-view-shot';
@@ -75,15 +75,8 @@ export default function Index() {
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   const [pickedEmoji, setPickedEmoji] = useState<ImageSourcePropType | undefined>(undefined);
-  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
 
   const imageRef = useRef<View>(null);
-
-  useEffect(() => {
-    if (!permissionResponse?.granted) {
-      requestPermission();
-    }
-  }, []);
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -54,7 +54,7 @@ Using `Platform` module from React Native, we can implement platform-specific be
 ```tsx app/(tabs)/index.tsx
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ImageSourcePropType, View, StyleSheet, /* @tutinfo */Platform/* @end */ } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { captureRef } from 'react-native-view-shot';
@@ -75,8 +75,14 @@ export default function Index() {
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   const [isModalVisible, setIsModalVisible] = useState<boolean>(false);
   const [pickedEmoji, setPickedEmoji] = useState<ImageSourcePropType | undefined>(undefined);
-
+  const [permissionResponse, requestPermission] = ImagePicker.useMediaLibraryPermissions();
   const imageRef = useRef<View>(null);
+
+  useEffect(() => {
+    if (!permissionResponse?.granted) {
+      requestPermission();
+    }
+  }, []);
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -35,36 +35,18 @@ To install `react-native-view-shot` and `expo-media-library`, run the following 
 
 <Step label="2">
 
-## Prompt for permissions
+## Import expo-media-library
 
-An app that requires sensitive information, such as accessing a device's media library, has to prompt permission to allow or deny access. Using `usePermissions()` hook from `expo-media-library`, we can use the permission `permissionResponse` and `requestPermission()` method to ask for access.
+When an app loads for the first time, saving images to the device's media library is a sensitive operation. Both Android and iOS have their own rules on how to handle those permissions. The `expo-media-library` handles the details for us on each platform.
 
-When the app loads for the first time and the permission status is neither granted nor denied, the value of the `permissionResponse` is `null`. When asked for permission, a user can either grant the permission or deny it. We can add a condition to check if it is not granted. If it is not granted, trigger the `requestPermission()` method. After getting the access, the value of the `permissionResponse` changes to `granted`.
-
-Add the following code snippet inside the **app/(tabs)/index.tsx**:
+Since we are using Expo Go, we don't need to explicitly ask for permissions to save images using the media library. We can start by importing the `expo-media-library` to **app/(tabs)/index.tsx**:
 
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx
-import { /* @tutinfo */useEffect/* @end */, useState } from 'react';
 /* @tutinfo Import <CODE>expo-media-library</CODE>. */import * as MediaLibrary from 'expo-media-library';/* @end */
-
-// ...rest of the code remains same
-
-export default function Index() {
-  /* @tutinfo Add this statement to import the permissions response and <CODE>requestPermission()</CODE> method from the hook. */const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();/* @end */
-  // ...rest of the code remains same
-
-  /* @tutinfo Add an if statement to check the permission status. The requestPermission() method will trigger a dialog box for the user to grant or deny the permission. */
-  useEffect(() => {
-    if (!permissionResponse?.granted) {
-      requestPermission();
-    }
-  }, []);
-  /* @end */
-
-  // ...rest of the code remains same
-}
 ```
+
+> **info** **Tip:** If you later build an app that needs to _read_ the media library (for example, listing existing photos with `getAssetsAsync()`), you'll need to request permission explicitly with `MediaLibrary.usePermissions()`. Note that in Expo Go on Android, reading the media library is blocked by the platform. To implement this functionality, you need create a [development build](/develop/development-builds/create-a-build/).
 
 </Step>
 
@@ -80,7 +62,7 @@ We'll use `react-native-view-shot` to allow the user to take a screenshot within
 
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
-import { useEffect, useState, /* @tutinfo Import <CODE>useRef</CODE> hook from <CODE>react</CODE>. */useRef/* @end */ } from 'react';
+import { useState, /* @tutinfo Import <CODE>useRef</CODE> hook from <CODE>react</CODE>. */useRef/* @end */ } from 'react';
 /* @tutinfo Import <CODE>captureRef</CODE> from <CODE>react-native-view-shot</CODE>. */import { captureRef } from 'react-native-view-shot';/* @end */
 
 export default function Index() {
@@ -120,7 +102,7 @@ Inside **app/(tabs)/index.tsx**, update the `onSaveImageAsync()` function with t
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { ImageSourcePropType, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { captureRef } from 'react-native-view-shot';
@@ -145,14 +127,7 @@ export default function Index() {
   const [pickedEmoji, setPickedEmoji] = useState<
     ImageSourcePropType | undefined
   >(undefined);
-  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions();
   const imageRef = useRef<View>(null);
-
-  useEffect(() => {
-    if (!permissionResponse?.granted) {
-      requestPermission();
-    }
-  }, []);
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
@@ -265,14 +240,11 @@ Now, choose a photo and add a sticker in the app. Then tap the "Save" button. We
   name="GET_STARTED"
   summary={
     <>
-
-        We've successfully used <CODE>react-native-view-shot</CODE> and <CODE>expo-media-library</CODE> to capture a
-        screenshot and save it on the device's library.
+      We've successfully used <CODE>react-native-view-shot</CODE> and{' '}
+      <CODE>expo-media-library</CODE> to capture a screenshot and save it on the device's library.
     </>
-
-}
-nextChapterDescription="In the next chapter, let's learn how to handle the differences between mobile and web
-platforms to implement the same functionality on web."
-nextChapterTitle="Handle platform differences"
-nextChapterLink="/tutorial/platform-differences"
+  }
+  nextChapterDescription="In the next chapter, let's learn how to handle the differences between mobile and web platforms to implement the same functionality on web."
+  nextChapterTitle="Handle platform differences"
+  nextChapterLink="/tutorial/platform-differences"
 />

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -35,18 +35,36 @@ To install `react-native-view-shot` and `expo-media-library`, run the following 
 
 <Step label="2">
 
-## Import expo-media-library
+## Prompt for permissions
 
-When an app loads for the first time, saving images to the device's media library is a sensitive operation. Both Android and iOS have their own rules on how to handle those permissions. The `expo-media-library` handles the details for us on each platform.
+An app that requires sensitive information, such as accessing a device's media library, has to prompt permission to allow or deny access. Using `useMediaLibraryPermissions()` hook from `expo-image-picker`, we can use the permission `permissionResponse` and `requestPermission()` method to ask for access. This hook requests both read and write permissions, which covers picking images from the library and saving screenshots to it.
 
-Since we are using Expo Go, we don't need to explicitly ask for permissions to save images using the media library. We can start by importing the `expo-media-library` to **app/(tabs)/index.tsx**:
+When the app loads for the first time and the permission status is neither granted nor denied, the value of the `permissionResponse` is `null`. When asked for permission, a user can either grant the permission or deny it. We can add a condition to check if it is not granted. If it is not granted, trigger the `requestPermission()` method. After getting the access, the value of the `permissionResponse` changes to `granted`.
+
+Add the following code snippet inside the **src/app/(tabs)/index.tsx**:
 
 {/* prettier-ignore */}
-```tsx app/(tabs)/index.tsx
-/* @tutinfo Import <CODE>expo-media-library</CODE>. */import * as MediaLibrary from 'expo-media-library';/* @end */
-```
+```tsx src/app/(tabs)/index.tsx
+import { /* @tutinfo */useEffect/* @end */, useState } from 'react';
+import * as ImagePicker from 'expo-image-picker';
 
-> **info** **Tip:** If you later build an app that needs to _read_ the media library (for example, listing existing photos with `getAssetsAsync()`), you'll need to request permission explicitly with `MediaLibrary.usePermissions()`. Note that in Expo Go on Android, reading the media library is blocked by the platform. To implement this functionality, you need create a [development build](/develop/development-builds/create-a-build/).
+// ...rest of the code remains same
+
+export default function Index() {
+  /* @tutinfo Add this statement to import the permissions response and <CODE>requestPermission()</CODE> method from the hook. */const [permissionResponse, requestPermission] = ImagePicker.useMediaLibraryPermissions();/* @end */
+  // ...rest of the code remains same
+
+  /* @tutinfo Add an if statement to check the permission status. The requestPermission() method will trigger a dialog box for the user to grant or deny the permission. */
+  useEffect(() => {
+    if (!permissionResponse?.granted) {
+      requestPermission();
+    }
+  }, []);
+  /* @end */
+
+  // ...rest of the code remains same
+}
+```
 
 </Step>
 
@@ -102,7 +120,7 @@ Inside **app/(tabs)/index.tsx**, update the `onSaveImageAsync()` function with t
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
 import * as ImagePicker from 'expo-image-picker';
 import * as MediaLibrary from 'expo-media-library';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ImageSourcePropType, StyleSheet, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { captureRef } from 'react-native-view-shot';
@@ -127,7 +145,14 @@ export default function Index() {
   const [pickedEmoji, setPickedEmoji] = useState<
     ImageSourcePropType | undefined
   >(undefined);
+  const [permissionResponse, requestPermission] = ImagePicker.useMediaLibraryPermissions();
   const imageRef = useRef<View>(null);
+
+  useEffect(() => {
+    if (!permissionResponse?.granted) {
+      requestPermission();
+    }
+  }, []);
 
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({


### PR DESCRIPTION
# Why

Fix ENG-20537


# How

- Replace `MediaLibrary.usePermissions()` by `ImagePicker.useMediaLibraryPermissions()`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2508" height="1552" alt="CleanShot 2026-04-09 at 21 11 10@2x" src="https://github.com/user-attachments/assets/ae5b2923-62e3-4358-8d04-9667521451cd" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
