### PR TITLE
[nightlies] Fix resolutions

### DIFF
--- a/packages/create-expo-nightly/src/ExpoRepo.ts
+++ b/packages/create-expo-nightly/src/ExpoRepo.ts
@@ -43,13 +43,10 @@ export async function setupExpoRepoAsync(
     }
   );
 
-  try {
-    await runAsync('pnpm', ['install'], { cwd: expoRepoPath });
-  } catch (e) {
-    if (e instanceof Error) {
-      console.warn(`Failed to install dependencies in ${expoRepoPath}`, e.toString());
-    }
-  }
+  // --no-frozen-lockfile is required because setupDependenciesAsync adds
+  // react-native nightly overrides to package.json, which won't match the
+  // existing lockfile. In CI (where CI=true), pnpm defaults to frozen lockfile.
+  await runAsync('pnpm', ['install', '--no-frozen-lockfile'], { cwd: expoRepoPath });
   console.timeEnd('Installed dependencies in expo repository');
 
   return expoRepoPath;

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -90,9 +90,13 @@ async function setupProjectPackageJsonAsync(
   for (const name of REACT_NATIVE_TRANSITIVE_DEPENDENCIES) {
     resolutions[name] = `${nightlyVersion}`;
   }
+  const workspaceGlobs = [
+    `${workspacePrefix}/packages/*`,
+    `${workspacePrefix}/packages/@expo/*`,
+  ];
+
   await mergeJsonFilesAsync(packageJsonPath, {
-    // Add workspaces
-    workspaces: [`${workspacePrefix}/packages/*`, `${workspacePrefix}/packages/@expo/*`],
+    workspaces: workspaceGlobs,
 
     // Exclude templates from autolinking
     expo: {
@@ -104,6 +108,14 @@ async function setupProjectPackageJsonAsync(
     // Pin the versions of transitive dependencies
     resolutions,
   });
+
+  // pnpm requires its own workspace config to recognize workspace packages.
+  // preferWorkspacePackages ensures local packages are used even when the
+  // canary template has dependency ranges from a different SDK version.
+  await fs.promises.writeFile(
+    path.join(projectRoot, 'pnpm-workspace.yaml'),
+    ['packages:', ...workspaceGlobs.map((g) => `  - '${g}'`), 'preferWorkspacePackages: true', ''].join('\n')
+  );
 }
 
 /**

--- a/packages/create-expo-nightly/src/Project.ts
+++ b/packages/create-expo-nightly/src/Project.ts
@@ -90,13 +90,15 @@ async function setupProjectPackageJsonAsync(
   for (const name of REACT_NATIVE_TRANSITIVE_DEPENDENCIES) {
     resolutions[name] = `${nightlyVersion}`;
   }
+  // pnpm workspace globs must be relative to the workspace root.
+  const relativePrefix = path.relative(projectRoot, expoRepoPath);
   const workspaceGlobs = [
-    `${workspacePrefix}/packages/*`,
-    `${workspacePrefix}/packages/@expo/*`,
+    `${relativePrefix}/packages/*`,
+    `${relativePrefix}/packages/@expo/*`,
   ];
 
   await mergeJsonFilesAsync(packageJsonPath, {
-    workspaces: workspaceGlobs,
+    workspaces: [`${workspacePrefix}/packages/*`, `${workspacePrefix}/packages/@expo/*`],
 
     // Exclude templates from autolinking
     expo: {
@@ -109,12 +111,10 @@ async function setupProjectPackageJsonAsync(
     resolutions,
   });
 
-  // pnpm requires its own workspace config to recognize workspace packages.
-  // preferWorkspacePackages ensures local packages are used even when the
-  // canary template has dependency ranges from a different SDK version.
+  // pnpm requires pnpm-workspace.yaml to recognize workspace packages.
   await fs.promises.writeFile(
     path.join(projectRoot, 'pnpm-workspace.yaml'),
-    ['packages:', ...workspaceGlobs.map((g) => `  - '${g}'`), 'preferWorkspacePackages: true', ''].join('\n')
+    ['packages:', ...workspaceGlobs.map((g) => `  - '${g}'`), ''].join('\n')
   );
 }
 


### PR DESCRIPTION
# Why
Attempt to fix nightlies package resolution failure

# How
In CI, pnpm defaults to frozen lockfile. When this is used the nightly resolutions fail with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. This caused the test project to pull the canaries instead of using local workspace packages.

# Test Plan
CI

