### PR TITLE
[updates][ios] resolve Expo.plist lookup in brownfield xcframework builds

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -16,6 +16,7 @@
 - align using custom components between the platforms ([#43633](https://github.com/expo/expo/pull/43633) by [@pmleczek](https://github.com/pmleczek))
 - [state] shared state implementation improvements ([#43279](https://github.com/expo/expo/pull/43279) by [@pmleczek](https://github.com/pmleczek))
 - Use react-native prebuilds by default ([#44332](https://github.com/expo/expo/pull/44332) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Added `Expo.plist` to the brownfield framework target. ([#44645](https://github.com/expo/expo/pull/44645) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/plugin/build/ios/plugins/withXcodeProjectPlugin.js
+++ b/packages/expo-brownfield/plugin/build/ios/plugins/withXcodeProjectPlugin.js
@@ -53,6 +53,11 @@ const withXcodeProjectPlugin = (config, pluginConfig) => {
         (0, utils_1.configureBuildPhases)(xcodeProject, target, pluginConfig.targetName, projectName, templateFiles.map((file) => `${pluginConfig.targetName}/${file}`));
         // Add the required build settings
         (0, utils_1.configureBuildSettings)(xcodeProject, pluginConfig.targetName, config.ios?.buildNumber || '1', pluginConfig.bundleIdentifier, config.ios?.version || config.version);
+        // Add Expo.plist to the framework target's resources so expo-updates
+        // can read its configuration from the framework bundle at runtime.
+        // Uses addBuildPhase to create a PBXResourcesBuildPhase for the framework target
+        // since addResourceFile requires an existing Resources phase which framework targets lack.
+        xcodeProject.addBuildPhase([`${projectName}/Supporting/Expo.plist`], 'PBXResourcesBuildPhase', 'Resources', target.uuid, 'framework', '""');
         return config;
     });
 };

--- a/packages/expo-brownfield/plugin/src/ios/plugins/withXcodeProjectPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/ios/plugins/withXcodeProjectPlugin.ts
@@ -91,6 +91,19 @@ const withXcodeProjectPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
       config.ios?.version || config.version
     );
 
+    // Add Expo.plist to the framework target's resources so expo-updates
+    // can read its configuration from the framework bundle at runtime.
+    // Uses addBuildPhase to create a PBXResourcesBuildPhase for the framework target
+    // since addResourceFile requires an existing Resources phase which framework targets lack.
+    xcodeProject.addBuildPhase(
+      [`${projectName}/Supporting/Expo.plist`],
+      'PBXResourcesBuildPhase',
+      'Resources',
+      target.uuid,
+      'framework',
+      '""'
+    );
+
     return config;
   });
 };

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
 - Native interface access to state machine context. ([#44361](https://github.com/expo/expo/pull/44361) by [@douglowder](https://github.com/douglowder))
+- [ios] resolve Expo.plist lookup in brownfield xcframework builds ([#44645](https://github.com/expo/expo/pull/44645) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -145,7 +145,14 @@ public final class UpdatesConfig: NSObject {
   }
 
   private static func configDictionaryWithExpoPlist(mergingOtherDictionary: [String: Any]?) throws -> [String: Any] {
-    guard let configPlistPath = Bundle.main.path(forResource: PlistName, ofType: "plist") else {
+    // Check the main bundle first (standard app), then fall back to the framework bundle.
+    // In brownfield setups, the Expo project is packaged as an xcframework where Expo.plist
+    // is embedded in the framework bundle rather than the host app bundle.
+    var configPlistPath = Bundle.main.path(forResource: PlistName, ofType: "plist")
+    if configPlistPath == nil {
+      configPlistPath = Bundle(for: UpdatesConfig.self).path(forResource: PlistName, ofType: "plist")
+    }
+    guard let configPlistPath else {
       throw UpdatesConfigError.ExpoUpdatesConfigPlistError
     }
 


### PR DESCRIPTION
# Why

When using `expo-updates` inside a brownfield xcframework build, expo-updates is silently disabled at runtime. This happens because:

1. `Expo.plist` lookup fails because `UpdatesConfig.configDictionaryWithExpoPlist` reads the updates configuration exclusively from `Bundle.main` and in a brownfield xcframework, `Bundle.main` is the host app's bundle 

2. `Expo.plist` is not included in the framework, the brownfield config plugin creates the framework target, but never adds `Expo.plist` to its resource

# How

Added a framework bundle fallback in `configDictionaryWithExpoPlist` that tries `Bundle.main` first (, then falls back to `Bundle(for: UpdatesConfig.self)` which resolves to the framework bundle in brownfield builds. This follows the same pattern already used by `EmbeddedAppLoader` and `getRuntimeVersion`  

On the Brownfield side, added a `PBXResourcesBuildPhase` to the brownfield framework target that includes `Expo.plist` from the main target's Supporting directory. 

# Test Plan

`npx expo-brownfield -p ios`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
