### PR TITLE
[docs] Fix YAML indentation in workflows get-started guide

### DIFF
--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -103,15 +103,15 @@ on:
     branches: ['main']
   # @end #
 
-  jobs:
-    build_android:
-      type: build
-      params:
-        platform: android
-    build_ios:
-      type: build
-      params:
-        platform: ios
+jobs:
+  build_android:
+    type: build
+    params:
+      platform: android
+  build_ios:
+    type: build
+    params:
+      platform: ios
 ```
 
 ### Trigger workflows from App Store Connect events


### PR DESCRIPTION
# Why

The example YAML snippet in the "Automate workflows with GitHub events" section had `jobs` indented under `on`, making it an invalid workflow.

<img width="564" height="67" alt="Screenshot 2026-04-09 at 12 17 48 PM" src="https://github.com/user-attachments/assets/33c908c2-1b60-4155-b92b-ee0fa1b65b7b" />

# How
Remove indentation from `jobs` and its children so it's a top-level key alongside `name` and `on`.

# Test Plan
Verified the YAML in the code block is now valid by confirming `name`, `on`, and `jobs` are all at the root indentation level.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
