### PR TITLE
ci(@expo/cli): fix flaky Playwright E2E test for RSC

### DIFF
--- a/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
@@ -4,7 +4,7 @@ import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoStart } from '../../utils/expo';
 import { sanitizeRSCPayloadString } from '../../utils/rsc';
-import { pageCollectErrors } from '../page';
+import { pageCollectErrors, replayRequestText } from '../page';
 
 test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
@@ -87,20 +87,11 @@ test.describe(inputDir, () => {
       );
     });
 
-    const serverActionResponsePromise = page.waitForResponse((response) => {
-      const pathname = new URL(response.url()).pathname;
-      return (
-        pathname.startsWith('/_flight/web/ACTION_') && pathname.endsWith('_$$INLINE_ACTION.txt')
-      );
-    });
-
     // Call the server action
     await page.locator('[data-testid="call-jsx-server-action"]').click();
 
-    await serverActionRequest;
-    const response = await serverActionResponsePromise;
-
-    const rscPayload = await response.text();
+    const request = await serverActionRequest;
+    const rscPayload = await replayRequestText(request);
 
     expect(sanitizeRSCPayloadString(rscPayload))
       .toBe(`1:I["node_modules/react-native-web/dist/exports/Text/index.js",["/node_modules/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F02-server-actions%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"],"",1]

--- a/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
@@ -100,7 +100,7 @@ test.describe(inputDir, () => {
     await serverActionRequest;
     const response = await serverActionResponsePromise;
 
-    const rscPayload = new TextDecoder().decode(await response.body());
+    const rscPayload = await response.text();
 
     expect(sanitizeRSCPayloadString(rscPayload))
       .toBe(`1:I["node_modules/react-native-web/dist/exports/Text/index.js",["/node_modules/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F02-server-actions%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"],"",1]

--- a/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
@@ -14,6 +14,7 @@ const testName = '02-server-actions';
 const inputDir = 'dist-' + testName;
 
 test.describe(inputDir, () => {
+  test.describe.configure({ mode: 'serial' });
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {

--- a/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
@@ -14,7 +14,6 @@ const testName = '02-server-actions';
 const inputDir = 'dist-' + testName;
 
 test.describe(inputDir, () => {
-  test.describe.configure({ mode: 'serial' });
   const expoStart = createExpoStart({
     cwd: projectRoot,
     env: {

--- a/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/02-server-actions.test.ts
@@ -100,7 +100,7 @@ test.describe(inputDir, () => {
     await serverActionRequest;
     const response = await serverActionResponsePromise;
 
-    const rscPayload = await response.text();
+    const rscPayload = new TextDecoder().decode(await response.body());
 
     expect(sanitizeRSCPayloadString(rscPayload))
       .toBe(`1:I["node_modules/react-native-web/dist/exports/Text/index.js",["/node_modules/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F02-server-actions%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"],"",1]

--- a/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
+++ b/packages/@expo/cli/e2e/playwright/dev/03-server-actions-only.test.ts
@@ -4,7 +4,7 @@ import { clearEnv, restoreEnv } from '../../__tests__/export/export-side-effects
 import { getRouterE2ERoot } from '../../__tests__/utils';
 import { createExpoStart } from '../../utils/expo';
 import { sanitizeRSCPayloadString } from '../../utils/rsc';
-import { pageCollectErrors } from '../page';
+import { pageCollectErrors, replayRequestText } from '../page';
 
 test.beforeAll(() => clearEnv());
 test.afterAll(() => restoreEnv());
@@ -67,22 +67,16 @@ test.describe(inputDir, () => {
       );
     });
 
-    const serverActionResponsePromise = page.waitForResponse((response) => {
-      return new URL(response.url()).pathname.startsWith('/_flight/web/ACTION_');
-    });
-
     // Navigate to the app
     console.time('Open page');
     await page.goto(expoStart.url.href);
     console.timeEnd('Open page');
 
-    await serverActionRequest;
-    const response = await serverActionResponsePromise;
-
     // Wait for the app to load
     await page.waitForSelector('[data-testid="index-text"]');
 
-    const rscPayload = await response.text();
+    const request = await serverActionRequest;
+    const rscPayload = await replayRequestText(request);
 
     expect(sanitizeRSCPayloadString(rscPayload)).toMatch(
       '2:I["node_modules/react-native-web/dist/exports/Text/index.js",["/node_modules/react-native-web/dist/exports/Text/index.js.bundle?platform=web&dev=true&hot=false&transform.asyncRoutes=true&transform.routerRoot=__e2e__%2F03-server-actions-only%2Fapp&modulesOnly=true&runModule=false&resolver.clientboundary=true&xRSC=1"]'

--- a/packages/@expo/cli/e2e/playwright/page.ts
+++ b/packages/@expo/cli/e2e/playwright/page.ts
@@ -1,4 +1,4 @@
-import type { ConsoleMessage, Page } from '@playwright/test';
+import type { ConsoleMessage, Page, Request } from '@playwright/test';
 
 /** Collect all console and thrown errors of the page */
 export function pageCollectErrors(page: Page) {
@@ -21,4 +21,19 @@ export function pageCollectErrors(page: Page) {
   });
 
   return collected;
+}
+
+export async function replayRequestText(request: Request) {
+  const headers = { ...request.headers() };
+  delete headers.connection;
+  delete headers['content-length'];
+  delete headers.host;
+
+  const response = await fetch(request.url(), {
+    method: request.method(),
+    headers,
+    body: request.postData() ?? undefined,
+  });
+
+  return await response.text();
 }


### PR DESCRIPTION
# Why

The Playwright E2E RSC tests were intermittently failing. These tests used `page.waitForResponse()` to capture the server action response and then called `response.text()` to read the RSC payload. This seems to be unreliable because Playwright's response interception races with the browser consuming the response body.

# How

Introduced a `replayRequestText()` helper in `packages/@expo/cli/e2e/playwright/page.ts` that takes a captured Playwright `Request` object and re-issues it using Node's `fetch()` with the same method, headers (minus the `connection`, `content-length`, `host` headers), and body.

# Test Plan

- CI (ran it 10+ times to confirm no failure re-occurs)

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
