### PR TITLE
[docs] Add expo-server-sdk-go to community SDK list

### DIFF
--- a/docs/pages/push-notifications/sending-notifications.mdx
+++ b/docs/pages/push-notifications/sending-notifications.mdx
@@ -33,6 +33,7 @@ The Expo team and community have taken care of creating back-ends for you in a f
 | [expo-server-sdk-php](https://github.com/ctwillie/expo-server-sdk-php)                                   | PHP      | Community     |
 | [exponent-server-sdk-golang](https://github.com/oliveroneill/exponent-server-sdk-golang)                 | Golang   | Community     |
 | [exponent](https://github.com/9ssi7/exponent)                                                            | Golang   | Community     |
+| [expo-server-sdk-go](https://github.com/Trashwbin/expo-server-sdk-go)                                    | Golang   | Community     |
 | [exponent-server-sdk-elixir](https://github.com/pachun/exponent-server-sdk-elixir)                       | Elixir   | Community     |
 | [expo-server-sdk-dotnet](https://github.com/glyphard/expo-server-sdk-dotnet)                             | dotnet   | Community     |
 | [expo-server-sdk-java](https://github.com/hlspablo/expo-server-sdk-java)                                 | Java     | Community     |


### PR DESCRIPTION
## Why

Add [expo-server-sdk-go](https://github.com/Trashwbin/expo-server-sdk-go) to the community server SDK table for push notifications.

The existing Go SDKs (`exponent-server-sdk-golang` and `exponent`) are outdated or minimally maintained. `expo-server-sdk-go` is a modern, production-ready alternative with:

- Full Expo Push API coverage (send, broadcast, receipts)
- Concurrent batch sending with configurable parallelism
- Gzip compression (request & response)
- 429 retry with `Retry-After` header support
- Pluggable rate limiting (noop, local token bucket, Redis distributed)
- Payload validation (4KB limit)
- Complete message field support (all iOS/Android fields)
- Published on [pkg.go.dev](https://pkg.go.dev/github.com/Trashwbin/expo-server-sdk-go)
- MIT licensed with comprehensive test coverage

## How

Added one row to the SDK table in `docs/pages/push-notifications/sending-notifications.mdx`.

## Test Plan

Documentation-only change. No code changes.