### PR TITLE
[ci] Exclude `expo-module-gradle-plugin` from iOS build detection

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -57,7 +57,8 @@ jobs:
         with:
           android-paths: >-
             "packages/**/android/**",
-            "apps/bare-expo/**/android/**"
+            "apps/bare-expo/**/android/**",
+            "packages/expo-modules-core/expo-module-gradle-plugin/**"
 
           ios-paths: >-
             "packages/**/ios/**",
@@ -71,6 +72,7 @@ jobs:
             "packages/**",
             "!packages/@expo/cli/**",
             "!packages/{create-expo,create-expo-nightly,create-expo-module}/**",
+            "!packages/expo-modules-core/expo-module-gradle-plugin/**",
             pnpm-lock.yaml,
             "!packages/**/{ios,android}/**",
             "!apps/bare-expo/**/{ios,android}/**"
@@ -81,6 +83,7 @@ jobs:
         with:
           android-paths: >-
             "packages/expo-modules-core/**/android/**",
+            "packages/expo-modules-core/expo-module-gradle-plugin/**",
             "packages/expo-modules-autolinking/**/android/**",
             "packages/expo/**/android/**",
             "packages/expo-constants/**/android/**",
@@ -117,6 +120,7 @@ jobs:
             "apps/bare-expo/**",
             "apps/test-suite/**",
             "packages/expo-modules-core/**",
+            "!packages/expo-modules-core/expo-module-gradle-plugin/**",
             "packages/expo-modules-autolinking/**",
             "packages/expo/**",
             "packages/expo-constants/**",


### PR DESCRIPTION
# Why

Changes in `expo-modules-gradle-plugin` shouldn't trigger iOS build https://github.com/expo/expo/pull/44654

# How

Excluded `expo-module-gradle-plugin` from `common-paths` and added it to `android-paths` in both build and e2e detection steps in test-suite.yml.

# Test Plan
Make a change to `expo-module-gradle-plugin` and verify that `ios-build` job is skipped and `android-build` job runs.