### PR TITLE
fix(expo-background-task): avoid replacing scheduled Android workers

### DIFF
--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Prevent background task registration from replacing an already scheduled or running worker.
+- [Android] Prevent background task registration from replacing an already scheduled or running worker. ([#44663](https://github.com/expo/expo/pull/44663) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Prevent background task registration from replacing an already scheduled or running worker.
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
@@ -79,6 +79,20 @@ object BackgroundTaskScheduler {
       return false
     }
 
+    val existingWorkInfo = getWorkerInfo(context)
+
+    // During startup/headless restore, task consumers register again while the
+    // unique worker is already scheduled or executing. Replacing it here resets
+    // the pending run or cancels the active run, which can create a
+    // cancel/reschedule loop.
+    if (
+      cancelExisting &&
+      (existingWorkInfo?.state == WorkInfo.State.ENQUEUED || existingWorkInfo?.state == WorkInfo.State.RUNNING)
+    ) {
+      Log.d(TAG, "Worker is already scheduled, skipping cancel-and-replace scheduling.")
+      return true
+    }
+
     // Stop the current worker (if any)
     if (cancelExisting) {
       stopWorker(context)


### PR DESCRIPTION
# Why

Android task registration can run again during app startup or headless restore while the unique WorkManager worker is already enqueued or running.

Previously, registration always cancelled and replaced the existing worker. If this happened during headless task execution, it could cancel the active run and create a cancel/reschedule loop. If it happened during normal startup, it could reset an already scheduled pending run.

Fixes #44581

# How

Check the existing unique worker state before cancel-and-replace scheduling.

If the worker is already ENQUEUED or RUNNING, skip replacing it and treat the schedule request as successful. This keeps the existing pending or active worker intact while preserving the existing behavior for absent, completed, failed, or cancelled work.

# Test-plan

- Reproduced the Android background task flow in the issue repro app.
- Verified app startup registration no longer replaces an already enqueued worker.
- Verified headless restore logs `Worker is already scheduled, skipping cancel-and-replace scheduling.`
- Verified the background task can complete successfully and enqueue the next worker.
- Confirmed changes are limited to expo-background-task scheduler logic plus changelog.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
