### PR TITLE
[autolinking] move modulemap to Target Support Files

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Stop dependency resolution at depth limit and increase max depth limit to 9 ([#43636](https://github.com/expo/expo/pull/43636) by [@kitten](https://github.com/kitten))
 - Sort on unresolved path and load `version` for duplicate dependencies ([#43636](https://github.com/expo/expo/pull/43636) by [@kitten](https://github.com/kitten))
 - [Android] Fixed build failures caused by the "=" character in pnpm virtual store paths. ([#44109](https://github.com/expo/expo/pull/44109) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fixes an issue where the modulemap is destroyed when switching between Debug and Release configurations. ([#44665](https://github.com/expo/expo/pull/44665) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -554,6 +554,13 @@ module Expo
       # 1. Creates a non-framework modulemap so <React/X.h> resolves through -isystem + VFS
       # 2. Patches framework modulemaps to remove `framework module React` (keep React_RCTAppDelegate)
       # 3. Injects -isystem and -fmodule-map-file into all pod and aggregate xcconfigs
+      #
+      # The modulemap is placed in Target Support Files/ rather than in the pod
+      # directory itself, because React Native's replace-rncore-version.js script
+      # phase deletes and re-extracts the entire React-Core-prebuilt/ directory at
+      # build time when switching Debug↔Release configurations. The -fmodule-map-file
+      # flag takes precedence over the xcframework's own framework modulemaps, so
+      # patch_framework_modulemaps does not need to survive the re-extraction.
       def configure_use_frameworks(installer)
         return unless prebuilt_react_active?
         return if linkage(installer).nil?
@@ -562,9 +569,12 @@ module Expo
         xcframework_path = File.join(react_prebuilt_dir, 'React.xcframework')
         return unless File.exist?(xcframework_path)
 
-        create_nonframework_modulemap(react_prebuilt_dir)
+        target_support_dir = File.join(installer.sandbox.root, 'Target Support Files', 'React-Core-prebuilt')
+        FileUtils.mkdir_p(target_support_dir)
+
+        create_nonframework_modulemap(target_support_dir, installer.sandbox.root)
         patch_framework_modulemaps(xcframework_path)
-        inject_isystem_flags(installer, react_prebuilt_dir)
+        inject_isystem_flags(installer, target_support_dir)
 
         Pod::UI.puts "[Expo] ".blue + "Created non-framework React modulemap for use_frameworks! compatibility"
       end
@@ -702,11 +712,12 @@ module Expo
       # ──────────────────────────────────────────────────────────────────────
 
       # Creates a non-framework modulemap so <React/X.h> resolves through -isystem + VFS.
-      def create_nonframework_modulemap(react_prebuilt_dir)
-        modulemap_path = File.join(react_prebuilt_dir, 'React-use-frameworks.modulemap')
+      def create_nonframework_modulemap(target_support_dir, pods_root)
+        modulemap_path = File.join(target_support_dir, 'React-use-frameworks.modulemap')
+        umbrella_header = File.join(pods_root, 'React-Core-prebuilt', 'React.xcframework', 'Headers', 'React_Core', 'React_Core-umbrella.h')
         modulemap_content = <<~MODULEMAP
           module React {
-            umbrella header "React.xcframework/Headers/React_Core/React_Core-umbrella.h"
+            umbrella header "#{umbrella_header}"
             export *
           }
         MODULEMAP
@@ -732,10 +743,10 @@ module Expo
 
       # Injects -fmodule-map-file and -isystem into all pod and aggregate xcconfigs.
       # Module builds don't inherit -I (HEADER_SEARCH_PATHS) but DO inherit -isystem.
-      def inject_isystem_flags(installer, react_prebuilt_dir)
-        modulemap_flag = "-fmodule-map-file=\"${PODS_ROOT}/React-Core-prebuilt/React-use-frameworks.modulemap\""
+      def inject_isystem_flags(installer, target_support_dir)
+        modulemap_flag = "-fmodule-map-file=\"${PODS_ROOT}/Target\\ Support\\ Files/React-Core-prebuilt/React-use-frameworks.modulemap\""
         extra_isystem = "-isystem \"${PODS_ROOT}/React-Core-prebuilt/React.xcframework/Headers\""
-        swift_modulemap = "-Xcc -fmodule-map-file=\"${PODS_ROOT}/React-Core-prebuilt/React-use-frameworks.modulemap\""
+        swift_modulemap = "-Xcc -fmodule-map-file=\"${PODS_ROOT}/Target\\ Support\\ Files/React-Core-prebuilt/React-use-frameworks.modulemap\""
         swift_extra_isystem = "-Xcc -isystem -Xcc \"${PODS_ROOT}/React-Core-prebuilt/React.xcframework/Headers\""
         skip_marker = 'React-use-frameworks.modulemap'
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -558,9 +558,7 @@ module Expo
       # The modulemap is placed in Target Support Files/ rather than in the pod
       # directory itself, because React Native's replace-rncore-version.js script
       # phase deletes and re-extracts the entire React-Core-prebuilt/ directory at
-      # build time when switching Debug↔Release configurations. The -fmodule-map-file
-      # flag takes precedence over the xcframework's own framework modulemaps, so
-      # patch_framework_modulemaps does not need to survive the re-extraction.
+      # build time when switching Debug↔Release configurations.
       def configure_use_frameworks(installer)
         return unless prebuilt_react_active?
         return if linkage(installer).nil?


### PR DESCRIPTION
# Why
Closes #44515
Closes #44644

# How
`configure_use_frameworks()` creates `React-use-frameworks.modulemap` during pod install and injects `-fmodule-map-file` references to it in all pods. Previously, this file was written to `Pods/React-Core-prebuilt`. React Native's `replace-rncore-version.js` script runs at build time to swap Debug and Release prebuilt binaries. It deletes the entire `React-Core-prebuilt` directory and re-extracts from a tarball, destroying the modulemap.

This affects any project using `use_frameworks!`

The fix is to move the modulemap to `Pods/Target Support Files/React-Core-prebuilt`, which is not touched by the replacement script. Update the `-fmodule-map-file` to reference the new location. Use an absolute path for the umbrella header inside the modulemap since it is no longer located with the xcframework.

# Test Plan
Tested various configuration combinations with a clean pod install followed by a build.
Precompiled: yes, static Frameworks: yes ✅
Precompiled: yes, static Frameworks: no ✅
Precompiled: no, static Frameworks: yes ✅
Precompiled: no, static Frameworks: no ✅

