### PR TITLE
fix(expo-background-task): ios scheduler race

### DIFF
--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -291,6 +291,11 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
+  - ExpoBackgroundTask (55.0.8):
+    - ExpoModulesCore
+  - ExpoBackgroundTask/Tests (55.0.8):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
   - ExpoClipboard (55.0.8):
     - ExpoModulesCore
   - ExpoClipboard/Tests (55.0.8):
@@ -2579,6 +2584,8 @@ DEPENDENCIES:
   - expo-dev-menu/Tests (from `../../../packages/expo-dev-menu`)
   - expo-dev-menu/UITests (from `../../../packages/expo-dev-menu`)
   - Expo/Tests (from `../../../packages/expo`)
+  - ExpoBackgroundTask (from `../../../packages/expo-background-task/ios`)
+  - ExpoBackgroundTask/Tests (from `../../../packages/expo-background-task/ios`)
   - ExpoClipboard (from `../../../packages/expo-clipboard/ios`)
   - ExpoClipboard/Tests (from `../../../packages/expo-clipboard/ios`)
   - ExpoImage (from `../../../packages/expo-image/ios`)
@@ -2716,6 +2723,9 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-dev-menu"
   expo-dev-menu-interface:
     :path: "../../../packages/expo-dev-menu-interface/ios"
+  ExpoBackgroundTask:
+    inhibit_warnings: false
+    :path: "../../../packages/expo-background-task/ios"
   ExpoClipboard:
     inhibit_warnings: false
     :path: "../../../packages/expo-clipboard/ios"
@@ -2919,6 +2929,7 @@ SPEC CHECKSUMS:
   expo-dev-launcher: 52dad5ea74c968013ebb2707370e28a0cf9d8b7f
   expo-dev-menu: 3ab7b064b3d3db84334481bdb24325e0b67889c3
   expo-dev-menu-interface: 58beb5e831034c20466d8c26ba679b0aa385abd2
+  ExpoBackgroundTask: efe66eaab7afbb341b03ef11f9919552797a286a
   ExpoClipboard: 0acdce934cb6a71b507da1117399645265e51ed5
   ExpoImage: d9446e7c2d365c063df7c8acd9c88b76a7b48ee4
   ExpoMediaLibrary: 2fbddcb06042f43076cf5e495e8237ec2ab95726
@@ -2932,7 +2943,7 @@ SPEC CHECKSUMS:
   EXUpdates: a0f980531cbcf45906b2489febd4e11a5895f332
   EXUpdatesInterface: 5ab8c3e8018ef533a132b9327af5b2a1926dd299
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
-  hermes-engine: 407f52f1dca2c25263c5f76e80cc38a39e0f6ec0
+  hermes-engine: 10b65ce39e488a1f4f84f3cb25949418ea87cb3d
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -2948,7 +2959,7 @@ SPEC CHECKSUMS:
   React: 1b1536b9099195944034e65b1830f463caaa8390
   React-callinvoker: 6dff6d17d1d6cc8fdf85468a649bafed473c65f5
   React-Core: 00faa4d038298089a1d5a5b21dde8660c4f0820d
-  React-Core-prebuilt: 3fb4a39af3de556a21a2d3ed972218ef68ce6218
+  React-Core-prebuilt: a245f9ce5303eb2841466c7ffe2025345a9645d6
   React-CoreModules: a17807f849bfd86045b0b9a75ec8c19373b482f6
   React-cxxreact: c7b53ace5827be54048288bce5c55f337c41e95f
   React-debug: e1f00fcd2cef58a2897471a6d76a4ef5f5f90c74
@@ -3010,7 +3021,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 5787b37b8e2e51dfeab697ec031cc7c4080dcea2
   ReactCodegen: 77e63e24e8167e69586359b57874d7c35d7e987f
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
-  ReactNativeDependencies: 536ba8be1c7a97b32f58080f77615c68dce01cad
+  ReactNativeDependencies: 84c286f727a3bdb58abcdf5cf2b51935513301af
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec
   RNReanimated: 6e536dcd6b715b36db98376cea6f58370148c25a

--- a/apps/native-tests/package.json
+++ b/apps/native-tests/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "expo": "workspace:*",
+    "expo-background-task": "workspace:*",
     "expo-clipboard": "workspace:*",
     "expo-dev-client": "workspace:*",
     "expo-router": "workspace:*",

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Prevent background task registration from replacing an already scheduled or running worker. ([#44663](https://github.com/expo/expo/pull/44663) by [@chrfalch](https://github.com/chrfalch))
+- [iOS] Fixed a race when rescheduling background tasks concurrently.
 
 ### 💡 Others
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - [Android] Prevent background task registration from replacing an already scheduled or running worker. ([#44663](https://github.com/expo/expo/pull/44663) by [@chrfalch](https://github.com/chrfalch))
-- [iOS] Fixed a race when rescheduling background tasks concurrently.
+- [iOS] Fixed a race when rescheduling background tasks concurrently. ([#44666](https://github.com/expo/expo/pull/44666) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
@@ -1,8 +1,8 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 import BackgroundTasks
-import Dispatch
+import Foundation
 
-protocol BackgroundTaskScheduling {
+protocol BackgroundTaskScheduling: Sendable {
   func cancel(taskRequestWithIdentifier identifier: String)
   func submit(_ request: BGProcessingTaskRequest) throws
   func pendingTaskRequests() async -> [BGTaskRequest]
@@ -23,17 +23,6 @@ private struct SystemBackgroundTaskScheduler: BackgroundTaskScheduling {
 }
 
 public class BackgroundTaskScheduler {
-  /**
-   * Keep track of number of registered task consumers
-   */
-  static var numberOfRegisteredTasksOfThisType: Int = 0
-
-  /**
-   * Interval for task scheduler. The iOS BGTaskScheduler does not guarantee that the number of minutes will be
-   * exact, but it indicates when we'd like the task to start. This will be set to at least 12 hours
-   */
-  private static var intervalSeconds: TimeInterval = 12 * 60 * 60
-
   /**
    A one-time async gate that becomes ready after BGTaskScheduler registration finishes.
    Multiple awaiters will be resumed when ready; subsequent awaiters return immediately.
@@ -69,8 +58,85 @@ public class BackgroundTaskScheduler {
    */
   private static let registrationGate = RegistrationGate()
 
-  private static let schedulerQueue = DispatchQueue(label: "expo.modules.backgroundtask.scheduler")
-  private static var scheduler: BackgroundTaskScheduling = SystemBackgroundTaskScheduler()
+  private actor SchedulerState {
+    private var scheduler: BackgroundTaskScheduling = SystemBackgroundTaskScheduler()
+    private var numberOfRegisteredTasksOfThisType: Int = 0
+    private var intervalSeconds: TimeInterval = 12 * 60 * 60
+
+    func didRegisterTask(minutes: Int?) -> Bool {
+      if let minutes = minutes {
+        intervalSeconds = Double(minutes) * 60
+      }
+      numberOfRegisteredTasksOfThisType += 1
+
+      return numberOfRegisteredTasksOfThisType == 1
+    }
+
+    func didUnregisterTask() -> Bool {
+      numberOfRegisteredTasksOfThisType = max(0, numberOfRegisteredTasksOfThisType - 1)
+      return numberOfRegisteredTasksOfThisType == 0
+    }
+
+    func hasRegisteredTasks() -> Bool {
+      return numberOfRegisteredTasksOfThisType > 0
+    }
+
+    func scheduleWorker() throws {
+      if numberOfRegisteredTasksOfThisType == 0 {
+        print("Background Task: skipping scheduling. No registered tasks")
+        return
+      }
+
+      stopWorkerOnce()
+
+      let request = BGProcessingTaskRequest(identifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
+      request.requiresNetworkConnectivity = true
+      request.requiresExternalPower = false
+      request.earliestBeginDate = Date().addingTimeInterval(intervalSeconds)
+
+      do {
+        try scheduler.submit(request)
+      } catch let error as BGTaskScheduler.Error {
+        switch error.code {
+        case .unavailable:
+          throw CouldNotRegisterWorkerTask("Background task scheduling is unavailable.")
+        case .tooManyPendingTaskRequests:
+          throw CouldNotRegisterWorkerTask("Too many pending task requests.")
+        case .notPermitted:
+          throw CouldNotRegisterWorkerTask("Task request not permitted.")
+        @unknown default:
+          print("An unknown BGTaskScheduler error occurred.")
+        }
+      } catch {
+        throw CouldNotRegisterWorkerTask("Unknown error occurred.")
+      }
+    }
+
+    func stopWorker() {
+      stopWorkerOnce()
+    }
+
+    func isWorkerRunning() async -> Bool {
+      let requests = await scheduler.pendingTaskRequests()
+      return requests.contains(where: { $0.identifier == BackgroundTaskConstants.BackgroundWorkerIdentifier })
+    }
+
+    func setSchedulerForTesting(_ scheduler: BackgroundTaskScheduling) {
+      self.scheduler = scheduler
+    }
+
+    func resetForTesting(registeredTaskCount: Int = 0) {
+      scheduler = SystemBackgroundTaskScheduler()
+      numberOfRegisteredTasksOfThisType = registeredTaskCount
+      intervalSeconds = 12 * 60 * 60
+    }
+
+    private func stopWorkerOnce() {
+      scheduler.cancel(taskRequestWithIdentifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
+    }
+  }
+
+  private static let schedulerState = SchedulerState()
 
   /**
    Call from the BackgroundTaskAppDelegate after the call to BGTaskScheduler.shared.register has finished
@@ -87,17 +153,8 @@ public class BackgroundTaskScheduler {
    * Call when a task is registered to keep track of how many background task consumers we have
    */
   public static func didRegisterTask(minutes: Int?) {
-    let shouldSchedule = schedulerQueue.sync {
-      if let minutes = minutes {
-        intervalSeconds = Double(minutes) * 60
-      }
-      numberOfRegisteredTasksOfThisType += 1
-
-      return numberOfRegisteredTasksOfThisType == 1
-    }
-
-    if shouldSchedule {
-      Task {
+    Task {
+      if await schedulerState.didRegisterTask(minutes: minutes) {
         try await tryScheduleWorker()
       }
     }
@@ -107,13 +164,8 @@ public class BackgroundTaskScheduler {
    * Call when a task is unregistered to keep track of how many background task consumers we have
    */
   public static func didUnregisterTask() {
-    let shouldStop = schedulerQueue.sync {
-      numberOfRegisteredTasksOfThisType = max(0, numberOfRegisteredTasksOfThisType - 1)
-      return numberOfRegisteredTasksOfThisType == 0
-    }
-
-    if shouldStop {
-      Task {
+    Task {
+      if await schedulerState.didUnregisterTask() {
         await stopWorker()
       }
     }
@@ -123,7 +175,7 @@ public class BackgroundTaskScheduler {
    * Tries to schedule the worker task to run
    */
   public static func tryScheduleWorker() async throws {
-    if schedulerQueue.sync(execute: { numberOfRegisteredTasksOfThisType == 0 }) {
+    if await !schedulerState.hasRegisteredTasks() {
       print("Background Task: skipping scheduling. No registered tasks")
       return
     }
@@ -131,82 +183,29 @@ public class BackgroundTaskScheduler {
     // Wait until BGTaskScheduler registration has completed.
     await registrationGate.awaitReady()
 
-    try schedulerQueue.sync {
-      if numberOfRegisteredTasksOfThisType == 0 {
-        print("Background Task: skipping scheduling. No registered tasks")
-        return
-      }
-
-      // Stop existing tasks
-      stopWorkerOnce()
-
-      // Create request
-      let request = BGProcessingTaskRequest(identifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
-
-      // We'll require network but accept running on battery power.
-      request.requiresNetworkConnectivity = true
-      request.requiresExternalPower = false
-
-      // Set up mimimum start date
-      request.earliestBeginDate = Date().addingTimeInterval(intervalSeconds)
-
-      do {
-        try scheduler.submit(request)
-      } catch let error as BGTaskScheduler.Error {
-        switch error.code {
-        case .unavailable:
-          throw CouldNotRegisterWorkerTask("Background task scheduling is unavailable.")
-        case .tooManyPendingTaskRequests:
-          throw CouldNotRegisterWorkerTask("Too many pending task requests.")
-        case .notPermitted:
-          throw CouldNotRegisterWorkerTask("Task request not permitted.")
-        @unknown default:
-          print("An unknown BGTaskScheduler error occurred.")
-          // Handle any future cases added by Apple
-        }
-      } catch {
-        // All other errors
-        throw CouldNotRegisterWorkerTask("Unknown error occurred.")
-      }
-    }
+    try await schedulerState.scheduleWorker()
   }
 
   /**
    Cancels the worker task
    */
   public static func stopWorker() async {
-    schedulerQueue.sync {
-      stopWorkerOnce()
-    }
-  }
-
-  private static func stopWorkerOnce() {
-    scheduler.cancel(taskRequestWithIdentifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
+    await schedulerState.stopWorker()
   }
 
   /**
    Returns true if the worker task is pending
    */
   public static func isWorkerRunning() async -> Bool {
-    let scheduler: BackgroundTaskScheduling = schedulerQueue.sync {
-      return self.scheduler
-    }
-    let requests = await scheduler.pendingTaskRequests()
-    return requests.contains(where: { $0.identifier == BackgroundTaskConstants.BackgroundWorkerIdentifier })
+    return await schedulerState.isWorkerRunning()
   }
 
-  static func setSchedulerForTesting(_ scheduler: BackgroundTaskScheduling) {
-    schedulerQueue.sync {
-      self.scheduler = scheduler
-    }
+  static func setSchedulerForTesting(_ scheduler: BackgroundTaskScheduling) async {
+    await schedulerState.setSchedulerForTesting(scheduler)
   }
 
-  static func resetForTesting(registeredTaskCount: Int = 0) {
-    schedulerQueue.sync {
-      scheduler = SystemBackgroundTaskScheduler()
-      numberOfRegisteredTasksOfThisType = registeredTaskCount
-      intervalSeconds = 12 * 60 * 60
-    }
+  static func resetForTesting(registeredTaskCount: Int = 0) async {
+    await schedulerState.resetForTesting(registeredTaskCount: registeredTaskCount)
   }
 
   /**

--- a/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
+++ b/packages/expo-background-task/ios/BackgroundTaskScheduler.swift
@@ -1,5 +1,26 @@
 // Copyright 2024-present 650 Industries. All rights reserved.
 import BackgroundTasks
+import Dispatch
+
+protocol BackgroundTaskScheduling {
+  func cancel(taskRequestWithIdentifier identifier: String)
+  func submit(_ request: BGProcessingTaskRequest) throws
+  func pendingTaskRequests() async -> [BGTaskRequest]
+}
+
+private struct SystemBackgroundTaskScheduler: BackgroundTaskScheduling {
+  func cancel(taskRequestWithIdentifier identifier: String) {
+    BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: identifier)
+  }
+
+  func submit(_ request: BGProcessingTaskRequest) throws {
+    try BGTaskScheduler.shared.submit(request)
+  }
+
+  func pendingTaskRequests() async -> [BGTaskRequest] {
+    return await BGTaskScheduler.shared.pendingTaskRequests()
+  }
+}
 
 public class BackgroundTaskScheduler {
   /**
@@ -48,6 +69,9 @@ public class BackgroundTaskScheduler {
    */
   private static let registrationGate = RegistrationGate()
 
+  private static let schedulerQueue = DispatchQueue(label: "expo.modules.backgroundtask.scheduler")
+  private static var scheduler: BackgroundTaskScheduling = SystemBackgroundTaskScheduler()
+
   /**
    Call from the BackgroundTaskAppDelegate after the call to BGTaskScheduler.shared.register has finished
    so that we can hold back any tryScheduleWorker calls, especially the call to BGTaskScheduler.shared.submit
@@ -63,12 +87,16 @@ public class BackgroundTaskScheduler {
    * Call when a task is registered to keep track of how many background task consumers we have
    */
   public static func didRegisterTask(minutes: Int?) {
-    if let minutes = minutes {
-      intervalSeconds = Double(minutes) * 60
-    }
-    numberOfRegisteredTasksOfThisType += 1
+    let shouldSchedule = schedulerQueue.sync {
+      if let minutes = minutes {
+        intervalSeconds = Double(minutes) * 60
+      }
+      numberOfRegisteredTasksOfThisType += 1
 
-    if numberOfRegisteredTasksOfThisType == 1 {
+      return numberOfRegisteredTasksOfThisType == 1
+    }
+
+    if shouldSchedule {
       Task {
         try await tryScheduleWorker()
       }
@@ -79,8 +107,12 @@ public class BackgroundTaskScheduler {
    * Call when a task is unregistered to keep track of how many background task consumers we have
    */
   public static func didUnregisterTask() {
-    numberOfRegisteredTasksOfThisType -= 1
-    if numberOfRegisteredTasksOfThisType == 0 {
+    let shouldStop = schedulerQueue.sync {
+      numberOfRegisteredTasksOfThisType = max(0, numberOfRegisteredTasksOfThisType - 1)
+      return numberOfRegisteredTasksOfThisType == 0
+    }
+
+    if shouldStop {
       Task {
         await stopWorker()
       }
@@ -91,7 +123,7 @@ public class BackgroundTaskScheduler {
    * Tries to schedule the worker task to run
    */
   public static func tryScheduleWorker() async throws {
-    if numberOfRegisteredTasksOfThisType == 0 {
+    if schedulerQueue.sync(execute: { numberOfRegisteredTasksOfThisType == 0 }) {
       print("Background Task: skipping scheduling. No registered tasks")
       return
     }
@@ -99,36 +131,43 @@ public class BackgroundTaskScheduler {
     // Wait until BGTaskScheduler registration has completed.
     await registrationGate.awaitReady()
 
-    // Stop existing tasks
-    await stopWorker()
-
-    // Create request
-    let request = BGProcessingTaskRequest(identifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
-
-    // We'll require network but accept running on battery power.
-    request.requiresNetworkConnectivity = true
-    request.requiresExternalPower = false
-
-    // Set up mimimum start date
-    request.earliestBeginDate = Date().addingTimeInterval(intervalSeconds)
-
-    do {
-      try BGTaskScheduler.shared.submit(request)
-    } catch let error as BGTaskScheduler.Error {
-      switch error.code {
-      case .unavailable:
-        throw CouldNotRegisterWorkerTask("Background task scheduling is unavailable.")
-      case .tooManyPendingTaskRequests:
-        throw CouldNotRegisterWorkerTask("Too many pending task requests.")
-      case .notPermitted:
-        throw CouldNotRegisterWorkerTask("Task request not permitted.")
-      @unknown default:
-        print("An unknown BGTaskScheduler error occurred.")
-        // Handle any future cases added by Apple
+    try schedulerQueue.sync {
+      if numberOfRegisteredTasksOfThisType == 0 {
+        print("Background Task: skipping scheduling. No registered tasks")
+        return
       }
-    } catch {
-      // All other errors
-      throw CouldNotRegisterWorkerTask("Unknown error occurred.")
+
+      // Stop existing tasks
+      stopWorkerOnce()
+
+      // Create request
+      let request = BGProcessingTaskRequest(identifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
+
+      // We'll require network but accept running on battery power.
+      request.requiresNetworkConnectivity = true
+      request.requiresExternalPower = false
+
+      // Set up mimimum start date
+      request.earliestBeginDate = Date().addingTimeInterval(intervalSeconds)
+
+      do {
+        try scheduler.submit(request)
+      } catch let error as BGTaskScheduler.Error {
+        switch error.code {
+        case .unavailable:
+          throw CouldNotRegisterWorkerTask("Background task scheduling is unavailable.")
+        case .tooManyPendingTaskRequests:
+          throw CouldNotRegisterWorkerTask("Too many pending task requests.")
+        case .notPermitted:
+          throw CouldNotRegisterWorkerTask("Task request not permitted.")
+        @unknown default:
+          print("An unknown BGTaskScheduler error occurred.")
+          // Handle any future cases added by Apple
+        }
+      } catch {
+        // All other errors
+        throw CouldNotRegisterWorkerTask("Unknown error occurred.")
+      }
     }
   }
 
@@ -136,15 +175,38 @@ public class BackgroundTaskScheduler {
    Cancels the worker task
    */
   public static func stopWorker() async {
-    BGTaskScheduler.shared.cancel(taskRequestWithIdentifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
+    schedulerQueue.sync {
+      stopWorkerOnce()
+    }
+  }
+
+  private static func stopWorkerOnce() {
+    scheduler.cancel(taskRequestWithIdentifier: BackgroundTaskConstants.BackgroundWorkerIdentifier)
   }
 
   /**
    Returns true if the worker task is pending
    */
   public static func isWorkerRunning() async -> Bool {
-    let requests = await BGTaskScheduler.shared.pendingTaskRequests()
+    let scheduler: BackgroundTaskScheduling = schedulerQueue.sync {
+      return self.scheduler
+    }
+    let requests = await scheduler.pendingTaskRequests()
     return requests.contains(where: { $0.identifier == BackgroundTaskConstants.BackgroundWorkerIdentifier })
+  }
+
+  static func setSchedulerForTesting(_ scheduler: BackgroundTaskScheduling) {
+    schedulerQueue.sync {
+      self.scheduler = scheduler
+    }
+  }
+
+  static func resetForTesting(registeredTaskCount: Int = 0) {
+    schedulerQueue.sync {
+      scheduler = SystemBackgroundTaskScheduler()
+      numberOfRegisteredTasksOfThisType = registeredTaskCount
+      intervalSeconds = 12 * 60 * 60
+    }
   }
 
   /**

--- a/packages/expo-background-task/ios/ExpoBackgroundTask.podspec
+++ b/packages/expo-background-task/ios/ExpoBackgroundTask.podspec
@@ -20,8 +20,16 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   s.source_files = "**/*.{h,m,swift}"
+  s.exclude_files = 'Tests/'
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
+
+  s.test_spec 'Tests' do |test_spec|
+    # ExpoModulesCore requires React-hermes or React-jsc in tests, add ExpoModulesTestCore for the underlying dependencies
+    test_spec.dependency 'ExpoModulesTestCore'
+
+    test_spec.source_files = 'Tests/**/*.{m,swift}'
+  end
 end

--- a/packages/expo-background-task/ios/Tests/BackgroundTaskSchedulerTests.swift
+++ b/packages/expo-background-task/ios/Tests/BackgroundTaskSchedulerTests.swift
@@ -4,17 +4,16 @@ import XCTest
 @testable import ExpoBackgroundTask
 
 final class BackgroundTaskSchedulerTests: XCTestCase {
-  override func tearDown() {
-    BackgroundTaskScheduler.resetForTesting()
-    super.tearDown()
+  override func tearDown() async throws {
+    await BackgroundTaskScheduler.resetForTesting()
+    try await super.tearDown()
   }
 
   func testConcurrentScheduleWorkerCallsDoNotOverlapCancel() async throws {
     let scheduler = OverlapDetectingScheduler()
 
-    BackgroundTaskScheduler.setSchedulerForTesting(scheduler)
-    BackgroundTaskScheduler.resetForTesting(registeredTaskCount: 1)
-    BackgroundTaskScheduler.setSchedulerForTesting(scheduler)
+    await BackgroundTaskScheduler.resetForTesting(registeredTaskCount: 1)
+    await BackgroundTaskScheduler.setSchedulerForTesting(scheduler)
     BackgroundTaskScheduler.bgTaskSchedulerDidFinishRegister()
 
     async let first: Void = BackgroundTaskScheduler.tryScheduleWorker()
@@ -28,7 +27,7 @@ final class BackgroundTaskSchedulerTests: XCTestCase {
   }
 }
 
-private final class OverlapDetectingScheduler: BackgroundTaskScheduling {
+private final class OverlapDetectingScheduler: BackgroundTaskScheduling, @unchecked Sendable {
   private let lock = NSLock()
   private var activeCancelCalls = 0
 

--- a/packages/expo-background-task/ios/Tests/BackgroundTaskSchedulerTests.swift
+++ b/packages/expo-background-task/ios/Tests/BackgroundTaskSchedulerTests.swift
@@ -1,0 +1,60 @@
+import BackgroundTasks
+import XCTest
+
+@testable import ExpoBackgroundTask
+
+final class BackgroundTaskSchedulerTests: XCTestCase {
+  override func tearDown() {
+    BackgroundTaskScheduler.resetForTesting()
+    super.tearDown()
+  }
+
+  func testConcurrentScheduleWorkerCallsDoNotOverlapCancel() async throws {
+    let scheduler = OverlapDetectingScheduler()
+
+    BackgroundTaskScheduler.setSchedulerForTesting(scheduler)
+    BackgroundTaskScheduler.resetForTesting(registeredTaskCount: 1)
+    BackgroundTaskScheduler.setSchedulerForTesting(scheduler)
+    BackgroundTaskScheduler.bgTaskSchedulerDidFinishRegister()
+
+    async let first: Void = BackgroundTaskScheduler.tryScheduleWorker()
+    async let second: Void = BackgroundTaskScheduler.tryScheduleWorker()
+
+    try await first
+    try await second
+
+    XCTAssertEqual(scheduler.maxConcurrentCancelCalls, 1)
+    XCTAssertEqual(scheduler.submitCallCount, 2)
+  }
+}
+
+private final class OverlapDetectingScheduler: BackgroundTaskScheduling {
+  private let lock = NSLock()
+  private var activeCancelCalls = 0
+
+  private(set) var maxConcurrentCancelCalls = 0
+  private(set) var submitCallCount = 0
+
+  func cancel(taskRequestWithIdentifier identifier: String) {
+    lock.lock()
+    activeCancelCalls += 1
+    maxConcurrentCancelCalls = max(maxConcurrentCancelCalls, activeCancelCalls)
+    lock.unlock()
+
+    Thread.sleep(forTimeInterval: 0.05)
+
+    lock.lock()
+    activeCancelCalls -= 1
+    lock.unlock()
+  }
+
+  func submit(_ request: BGProcessingTaskRequest) throws {
+    lock.lock()
+    submitCallCount += 1
+    lock.unlock()
+  }
+
+  func pendingTaskRequests() async -> [BGTaskRequest] {
+    return []
+  }
+}

--- a/packages/expo-background-task/spm.config.json
+++ b/packages/expo-background-task/spm.config.json
@@ -19,6 +19,9 @@
           "name": "ExpoBackgroundTask",
           "path": "ios",
           "pattern": "*.swift",
+          "exclude": [
+            "Tests/**"
+          ],
           "dependencies": [
             "Hermes",
             "React",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1182,6 +1182,9 @@ importers:
       expo:
         specifier: workspace:*
         version: link:../../packages/expo
+      expo-background-task:
+        specifier: workspace:*
+        version: link:../../packages/expo-background-task
       expo-clipboard:
         specifier: workspace:*
         version: link:../../packages/expo-clipboard


### PR DESCRIPTION
# Why
Concurrent background task rescheduling can call into BGTaskScheduler cancellation at the same time from multiple threads. The stack trace in #44583 shows overlapping calls through BackgroundTaskScheduler.tryScheduleWorker(), which can crash inside BGTaskScheduler.cancelTaskRequestWithIdentifier.

Fixes #44583

# How
Serialize ExpoBackgroundTask scheduler state and the cancel-submit sequence on a private queue. Add a small BackgroundTaskScheduling seam so the scheduler behavior can be tested without calling the system BGTaskScheduler directly. Wire ExpoBackgroundTask into native-tests and add a focused XCTest that starts two concurrent tryScheduleWorker() calls, then verifies cancellation does not overlap. Exclude the new Tests directory from the production CocoaPods and SPM source targets.

# Test-plan

Added test to apps/Native-tests project, verified that XCTest goes red without the fix, and green with it.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
