### PR TITLE
fix(expo-background-task): preserve worker cancellation on Android

### DIFF
--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Preserve WorkManager cancellation semantics when a background task worker is cancelled.
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Preserve WorkManager cancellation semantics when a background task worker is cancelled.
+- [Android] Preserve WorkManager cancellation semantics when a background task worker is cancelled. ([#44667](https://github.com/expo/expo/pull/44667) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskWork.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskWork.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.Data
 import androidx.work.WorkerParameters
+import kotlinx.coroutines.CancellationException
 
 class BackgroundTaskWork(context: Context, params: WorkerParameters) : CoroutineWorker(context, params) {
   companion object {
@@ -24,6 +25,9 @@ class BackgroundTaskWork(context: Context, params: WorkerParameters) : Coroutine
       // Run tasks async using the task service. This call will return when the task has finished
       // ie. When JS task executor has notified the task manager that it is done.
       BackgroundTaskScheduler.runTasks(applicationContext, appScopeKey)
+    } catch (e: CancellationException) {
+      Log.i(TAG, "doWork: Worker was cancelled")
+      throw e
     } catch (e: Exception) {
       // Wrap exception in Data:
       val outputData = Data.Builder()


### PR DESCRIPTION
# Why

`BackgroundTaskWork.doWork()` catches `Exception` and converts it into `Result.failure()`. On the JVM, `CancellationException` is a subclass of `Exception`, so WorkManager coroutine cancellation can be swallowed by this generic catch block.

When a running background task worker is cancelled, for example through `unregisterTask()` calling `stopWorker()`, the coroutine scope may throw `CancellationException` while waiting for task completion. Returning `Result.failure()` from that path incorrectly reports a cancelled worker as a failed worker.

# How

Catch `CancellationException` before the generic `Exception` handler, log that the worker was cancelled, and rethrow it.

This preserves structured concurrency semantics and lets WorkManager handle the worker as stopped/cancelled instead of failed.

# Test-plan

- Verified the Android source compiles locally.
- Confirmed the change only affects cancellation handling in `BackgroundTaskWork.doWork()`.
- Confirmed generic task execution exceptions are still converted to `Result.failure()` with error output data.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
