### PR TITLE
[ui][android] (2/3) Install module classes and add `__resolveInWorklet` in UI worklet runtime

### DIFF
--- a/apps/native-component-list/src/screens/UI/SyncSwitchScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/SyncSwitchScreen.android.tsx
@@ -9,9 +9,18 @@ import {
 } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth, padding } from '@expo/ui/jetpack-compose/modifiers';
 import { Button, View, Text } from 'react-native';
+import { scheduleOnUI } from 'react-native-worklets';
 
 export default function SyncSwitchScreen() {
   const isOn = useNativeState(false);
+
+  const toggleFromWorklet = () => {
+    scheduleOnUI(() => {
+      'worklet';
+      console.log('[UI thread] isOn:', isOn.value);
+      isOn.value = !isOn.value;
+    });
+  };
 
   return (
     <View style={{ flex: 1 }}>
@@ -21,6 +30,7 @@ export default function SyncSwitchScreen() {
           observe. Toggling from either side updates instantly.
         </Text>
         <Button title="Toggle from JS" onPress={() => (isOn.value = !isOn.value)} />
+        <Button title="Toggle from Worklet" onPress={toggleFromWorklet} />
       </View>
       <Host style={{ flex: 1 }}>
         <LazyColumn verticalArrangement={{ spacedBy: 16 }} modifiers={[padding(16, 16, 16, 16)]}>

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- [android] Add `installModuleClasses` and `__resolveInWorklet` for resolving shared object class prototypes in the worklet runtime. By [@nishan](https://github.com/intergalacticspacehighway)
 - [iOS] Add `installModuleClasses` for building shared object class prototypes in alternate JS runtimes. ([#44214](https://github.com/expo/expo/pull/44214) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Install sync functions on shared object worklet prototypes and add `SharedObject.__resolveInWorklet` for resolving shared objects in worklet runtimes. ([#44215](https://github.com/expo/expo/pull/44215) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Added `Equatable` conformance to `Either` type. ([#43954](https://github.com/expo/expo/pull/43954) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- [android] Add `installModuleClasses` and `__resolveInWorklet` for resolving shared object class prototypes in the worklet runtime. By [@nishan](https://github.com/intergalacticspacehighway) ([#44669](https://github.com/expo/expo/pull/44669) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
+- [android] Add `installModuleClasses` and `__resolveInWorklet` for resolving shared object class prototypes in the worklet runtime. ([#44669](https://github.com/expo/expo/pull/44669) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Add `installModuleClasses` for building shared object class prototypes in alternate JS runtimes. ([#44214](https://github.com/expo/expo/pull/44214) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Install sync functions on shared object worklet prototypes and add `SharedObject.__resolveInWorklet` for resolving shared objects in worklet runtimes. ([#44215](https://github.com/expo/expo/pull/44215) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Added `Equatable` conformance to `Either` type. ([#43954](https://github.com/expo/expo/pull/43954) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- [android] Add `installModuleClasses` and `__resolveInWorklet` for resolving shared object class prototypes in the worklet runtime. By [@nishan](https://github.com/intergalacticspacehighway)
+- [android] Add `installModuleClasses` and `__resolveInWorklet` for resolving shared object class prototypes in the worklet runtime. By [@nishan](https://github.com/intergalacticspacehighway) ([#44669](https://github.com/expo/expo/pull/44669) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Add `installModuleClasses` for building shared object class prototypes in alternate JS runtimes. ([#44214](https://github.com/expo/expo/pull/44214) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Install sync functions on shared object worklet prototypes and add `SharedObject.__resolveInWorklet` for resolving shared objects in worklet runtimes. ([#44215](https://github.com/expo/expo/pull/44215) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Added `Equatable` conformance to `Either` type. ([#43954](https://github.com/expo/expo/pull/43954) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -239,7 +239,7 @@ jni::local_ref<JavaScriptObject::javaobject> JSIContext::getJavascriptClass(
   return method(javaPart_, std::move(native));
 }
 
-// Installs SharedObject.__resolveInWorklet in this runtime.
+// Installs SharedObject.__resolveInWorklet in the runtime.
 void JSIContext::installModuleClasses() {
   auto &runtime = runtimeHolder->get();
   auto expoObj = runtime.global().getPropertyAsObject(runtime, "expo");

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -5,6 +5,7 @@
 #include "ExpoModulesHostObject.h"
 #include "JavaReferencesCache.h"
 #include "JSReferencesCache.h"
+#include "JSIUtils.h"
 #include "SharedObject.h"
 #include "SharedRef.h"
 #include "NativeModule.h"
@@ -30,6 +31,8 @@ void JSIContext::registerNatives() {
                    makeNativeMethod("drainJSEventLoop", JSIContext::drainJSEventLoop),
                    makeNativeMethod("setNativeStateForSharedObject",
                                     JSIContext::jniSetNativeStateForSharedObject),
+                   makeNativeMethod("installModuleClasses",
+                                    JSIContext::installModuleClasses),
                  });
 }
 
@@ -236,7 +239,88 @@ jni::local_ref<JavaScriptObject::javaobject> JSIContext::getJavascriptClass(
   return method(javaPart_, std::move(native));
 }
 
+// Installs SharedObject.__resolveInWorklet in this runtime.
+void JSIContext::installModuleClasses() {
+  auto &runtime = runtimeHolder->get();
+  auto expoObj = runtime.global().getPropertyAsObject(runtime, "expo");
+  auto sharedObjectClass = expoObj.getPropertyAsObject(runtime, "SharedObject");
+  auto *self = this;
+
+  auto resolveInWorklet = jsi::Function::createFromHostFunction(
+    runtime,
+    jsi::PropNameID::forAscii(runtime, "__resolveInWorklet"),
+    1,
+    [self](
+      jsi::Runtime &rt,
+      const jsi::Value &,
+      const jsi::Value *args,
+      size_t
+    ) -> jsi::Value {
+      if (self->wasDeallocated()) {
+        throw jsi::JSError(rt, "__resolveInWorklet: JSIContext has been deallocated");
+      }
+
+      int objectId = static_cast<int>(args[0].asNumber());
+
+      // 1. Resolve the native SharedObject's class by ID.
+      const static auto getNativeClass = expo::JSIContext::javaClassLocal()
+        ->getMethod<jni::local_ref<jclass>(int)>("getNativeSharedObjectClass");
+      auto nativeClass = getNativeClass(self->javaPart_, objectId);
+      if (!nativeClass) {
+        throw jsi::JSError(rt, "SharedObject with id '" + std::to_string(objectId) + "' not found in the registry");
+      }
+
+      // 2. Look up the JS class from classRegistry (cache).
+      auto jsClassObj = self->getJavascriptClass(jni::make_local(nativeClass));
+
+      if (!jsClassObj) {
+        // 3. Cache miss - lazily build the class prototype for this type.
+        const static auto buildClassDecorator = expo::JSIContext::javaClassLocal()
+          ->getMethod<jni::local_ref<JSDecoratorsBridgingObject::javaobject>(jni::local_ref<jclass>)>(
+            "buildClassDecorator"
+          );
+        auto decorator = buildClassDecorator(self->javaPart_, jni::make_local(nativeClass));
+        if (decorator) {
+          auto decorators = decorator->cthis()->bridge();
+          for (auto &dec: decorators) {
+            dec->install(rt);
+          }
+          // Keep decorators alive so MethodMetadata weak_ptrs remain valid.
+          for (auto &dec: decorators) {
+            self->moduleClassDecorators.push_back(std::move(dec));
+          }
+        }
+
+        jsClassObj = self->getJavascriptClass(std::move(nativeClass));
+        if (!jsClassObj) {
+          throw jsi::JSError(rt, "No class definition registered for SharedObject with id '" + std::to_string(objectId) + "'");
+        }
+      }
+
+      // 4. Create a proxy instance with the class prototype.
+      auto jsClass = jsClassObj->cthis()->get();
+      auto proto = jsClass->getProperty(rt, "prototype");
+      if (!proto.isObject()) {
+        throw jsi::JSError(rt, "Failed to create JS prototype for SharedObject with id '" + std::to_string(objectId) + "'");
+      }
+
+      auto protoObj = proto.asObject(rt);
+      auto instance = common::createObjectWithPrototype(rt, &protoObj);
+
+      // Define __expo_shared_object_id__ as an own data property.
+      jsi::Object descriptor = JavaScriptObject::preparePropertyDescriptor(rt, 0);
+      descriptor.setProperty(rt, "value", objectId);
+      common::defineProperty(rt, &instance, "__expo_shared_object_id__", std::move(descriptor));
+
+      return jsi::Value(rt, std::move(instance));
+    }
+  );
+
+  sharedObjectClass.setProperty(runtime, "__resolveInWorklet", std::move(resolveInWorklet));
+}
+
 void JSIContext::prepareForDeallocation() noexcept {
+  moduleClassDecorators.clear();
   jsRegistry.reset();
   if (runtimeHolder) {
     unbindJSIContext(runtimeHolder->get());

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -254,11 +254,9 @@ jni::local_ref<JavaScriptObject::javaobject> JSIContext::ensureClassInstalled(js
     );
   auto decorator = buildClassDecorator(javaPart_, jni::make_local(nativeClass));
   if (decorator) {
-    auto decorators = decorator->cthis()->bridge();
-    for (auto &dec: decorators) {
-      if (auto *classDec = dynamic_cast<JSClassesDecorator *>(dec.get())) {
-        classDec->installForWorklet(rt);
-      }
+    auto *classDec = decorator->cthis()->getClassDecorator();
+    if (classDec) {
+      classDec->consumeForWorklet(rt);
     }
   }
 
@@ -276,6 +274,11 @@ jsi::Value JSIContext::resolveSharedObjectInstance(jsi::Runtime &rt, int objectI
   auto protoObj = proto.asObject(rt);
   auto instance = common::createObjectWithPrototype(rt, &protoObj);
 
+  // Flags = 0 → non-configurable, non-enumerable, non-writable. Freezes the id on the proxy.
+  // Unlike the main-runtime path (SharedObject.cpp) which defines __expo_shared_object_id__
+  // as a getter on the prototype reading NativeState, here it's an own property on the instance
+  // since worklet proxies don't carry NativeState. SharedObjectIdConverter uses getProperty
+  // which finds own props first, so both paths resolve correctly.
   jsi::Object descriptor = JavaScriptObject::preparePropertyDescriptor(rt, 0);
   descriptor.setProperty(rt, "value", objectId);
   common::defineProperty(rt, &instance, "__expo_shared_object_id__", std::move(descriptor));

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -241,6 +241,48 @@ jni::local_ref<JavaScriptObject::javaobject> JSIContext::getJavascriptClass(
   return method(javaPart_, std::move(native));
 }
 
+// Returns the JS class for the given native SharedObject class, lazily building it on first access.
+jni::local_ref<JavaScriptObject::javaobject> JSIContext::ensureClassInstalled(jsi::Runtime &rt, jni::local_ref<jclass> nativeClass) {
+  auto jsClassObj = getJavascriptClass(jni::make_local(nativeClass));
+  if (jsClassObj) {
+    return jsClassObj;
+  }
+
+  const static auto buildClassDecorator = expo::JSIContext::javaClassLocal()
+    ->getMethod<jni::local_ref<JSDecoratorsBridgingObject::javaobject>(jni::local_ref<jclass>)>(
+      "buildClassDecorator"
+    );
+  auto decorator = buildClassDecorator(javaPart_, jni::make_local(nativeClass));
+  if (decorator) {
+    auto decorators = decorator->cthis()->bridge();
+    for (auto &dec: decorators) {
+      if (auto *classDec = dynamic_cast<JSClassesDecorator *>(dec.get())) {
+        classDec->installForWorklet(rt);
+      }
+    }
+  }
+
+  return getJavascriptClass(std::move(nativeClass));
+}
+
+// Creates a JS proxy object with the class prototype and the given shared object ID.
+jsi::Value JSIContext::resolveSharedObjectInstance(jsi::Runtime &rt, int objectId, jni::local_ref<JavaScriptObject::javaobject> jsClassObj) {
+  auto jsClass = jsClassObj->cthis()->get();
+  auto proto = jsClass->getProperty(rt, "prototype");
+  if (!proto.isObject()) {
+    throw jsi::JSError(rt, "Failed to get JS prototype for SharedObject with id '" + std::to_string(objectId) + "'");
+  }
+
+  auto protoObj = proto.asObject(rt);
+  auto instance = common::createObjectWithPrototype(rt, &protoObj);
+
+  jsi::Object descriptor = JavaScriptObject::preparePropertyDescriptor(rt, 0);
+  descriptor.setProperty(rt, "value", objectId);
+  common::defineProperty(rt, &instance, "__expo_shared_object_id__", std::move(descriptor));
+
+  return jsi::Value(rt, std::move(instance));
+}
+
 // Installs SharedObject.__resolveInWorklet in the runtime.
 void JSIContext::installModuleClasses() {
   auto &runtime = runtimeHolder->get();
@@ -264,7 +306,7 @@ void JSIContext::installModuleClasses() {
 
       int objectId = static_cast<int>(args[0].asNumber());
 
-      // 1. Resolve the native SharedObject's class by ID.
+      // Resolve the native SharedObject's class by ID.
       const static auto getNativeClass = expo::JSIContext::javaClassLocal()
         ->getMethod<jni::local_ref<jclass>(int)>("getNativeSharedObjectClass");
       auto nativeClass = getNativeClass(self->javaPart_, objectId);
@@ -272,47 +314,13 @@ void JSIContext::installModuleClasses() {
         throw jsi::JSError(rt, "SharedObject with id '" + std::to_string(objectId) + "' not found in the registry");
       }
 
-      // 2. Look up the JS class from classRegistry (cache).
-      auto jsClassObj = self->getJavascriptClass(jni::make_local(nativeClass));
-
+      // Ensure the class prototype is installed (lazy, cached in classRegistry).
+      auto jsClassObj = self->ensureClassInstalled(rt, std::move(nativeClass));
       if (!jsClassObj) {
-        // 3. Cache miss - lazily build the class prototype for this type.
-        const static auto buildClassDecorator = expo::JSIContext::javaClassLocal()
-          ->getMethod<jni::local_ref<JSDecoratorsBridgingObject::javaobject>(jni::local_ref<jclass>)>(
-            "buildClassDecorator"
-          );
-        auto decorator = buildClassDecorator(self->javaPart_, jni::make_local(nativeClass));
-        if (decorator) {
-          auto decorators = decorator->cthis()->bridge();
-          for (auto &dec: decorators) {
-            if (auto *classDec = dynamic_cast<JSClassesDecorator *>(dec.get())) {
-              classDec->installForWorklet(rt);
-            }
-          }
-        }
-
-        jsClassObj = self->getJavascriptClass(std::move(nativeClass));
-        if (!jsClassObj) {
-          throw jsi::JSError(rt, "No class definition registered for SharedObject with id '" + std::to_string(objectId) + "'");
-        }
+        throw jsi::JSError(rt, "No class definition registered for SharedObject with id '" + std::to_string(objectId) + "'");
       }
 
-      // 4. Create a proxy instance with the class prototype.
-      auto jsClass = jsClassObj->cthis()->get();
-      auto proto = jsClass->getProperty(rt, "prototype");
-      if (!proto.isObject()) {
-        throw jsi::JSError(rt, "Failed to create JS prototype for SharedObject with id '" + std::to_string(objectId) + "'");
-      }
-
-      auto protoObj = proto.asObject(rt);
-      auto instance = common::createObjectWithPrototype(rt, &protoObj);
-
-      // Define __expo_shared_object_id__ as an own data property.
-      jsi::Object descriptor = JavaScriptObject::preparePropertyDescriptor(rt, 0);
-      descriptor.setProperty(rt, "value", objectId);
-      common::defineProperty(rt, &instance, "__expo_shared_object_id__", std::move(descriptor));
-
-      return jsi::Value(rt, std::move(instance));
+      return self->resolveSharedObjectInstance(rt, objectId, std::move(jsClassObj));
     }
   );
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -9,6 +9,8 @@
 #include "SharedObject.h"
 #include "SharedRef.h"
 #include "NativeModule.h"
+#include "decorators/JSDecoratorsBridgingObject.h"
+#include "decorators/JSClassesDecorator.h"
 
 #include <fbjni/detail/Meta.h>
 #include <fbjni/fbjni.h>
@@ -283,11 +285,9 @@ void JSIContext::installModuleClasses() {
         if (decorator) {
           auto decorators = decorator->cthis()->bridge();
           for (auto &dec: decorators) {
-            dec->install(rt);
-          }
-          // Keep decorators alive so MethodMetadata weak_ptrs remain valid.
-          for (auto &dec: decorators) {
-            self->moduleClassDecorators.push_back(std::move(dec));
+            if (auto *classDec = dynamic_cast<JSClassesDecorator *>(dec.get())) {
+              classDec->installForWorklet(rt);
+            }
           }
         }
 
@@ -320,7 +320,6 @@ void JSIContext::installModuleClasses() {
 }
 
 void JSIContext::prepareForDeallocation() noexcept {
-  moduleClassDecorators.clear();
   jsRegistry.reset();
   if (runtimeHolder) {
     unbindJSIContext(runtimeHolder->get());

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -10,6 +10,7 @@
 #include "JSReferencesCache.h"
 #include "JNIDeallocator.h"
 #include "ThreadSafeJNIGlobalRef.h"
+#include "decorators/JSDecoratorsBridgingObject.h"
 #include "javaclasses/JSRunnable.h"
 
 #include <fbjni/fbjni.h>
@@ -129,10 +130,19 @@ public:
   std::unique_ptr<JSReferencesCache> jsRegistry;
   jni::global_ref<JNIDeallocator::javaobject> jniDeallocator;
 
+  // Used by the worklet runtime to keep class decorators alive
+  // so prototype host functions remain callable.
+  std::vector<std::unique_ptr<JSDecorator>> moduleClassDecorators;
+
   void registerClass(jni::local_ref<jclass> native,
                      jni::local_ref<JavaScriptObject::javaobject> jsClass);
 
   jni::local_ref<JavaScriptObject::javaobject> getJavascriptClass(jni::local_ref<jclass> native);
+
+  /**
+   * Installs module class prototypes and `SharedObject.__resolveInWorklet` in this runtime.
+   */
+  void installModuleClasses();
 
   void prepareForDeallocation() noexcept;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -130,8 +130,9 @@ public:
   std::unique_ptr<JSReferencesCache> jsRegistry;
   jni::global_ref<JNIDeallocator::javaobject> jniDeallocator;
 
-  // Used by the worklet runtime to keep class decorators alive
-  // so prototype host functions remain callable.
+  // Only used by the worklet runtime - keeps class decorators alive so
+  // prototype host functions remain callable (they capture weak_ptr<MethodMetadata>).
+  // On the main runtime, JavaScriptModuleObject::decorators serves the same role.
   std::vector<std::unique_ptr<JSDecorator>> moduleClassDecorators;
 
   void registerClass(jni::local_ref<jclass> native,

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -10,7 +10,6 @@
 #include "JSReferencesCache.h"
 #include "JNIDeallocator.h"
 #include "ThreadSafeJNIGlobalRef.h"
-#include "decorators/JSDecoratorsBridgingObject.h"
 #include "javaclasses/JSRunnable.h"
 
 #include <fbjni/fbjni.h>
@@ -129,11 +128,6 @@ public:
   std::shared_ptr<JavaScriptRuntime> runtimeHolder;
   std::unique_ptr<JSReferencesCache> jsRegistry;
   jni::global_ref<JNIDeallocator::javaobject> jniDeallocator;
-
-  // Only used by the worklet runtime - keeps class decorators alive so
-  // prototype host functions remain callable (they capture weak_ptr<MethodMetadata>).
-  // On the main runtime, JavaScriptModuleObject::decorators serves the same role.
-  std::vector<std::unique_ptr<JSDecorator>> moduleClassDecorators;
 
   void registerClass(jni::local_ref<jclass> native,
                      jni::local_ref<JavaScriptObject::javaobject> jsClass);

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -157,6 +157,9 @@ private:
 
   bool wasDeallocated_ = false;
 
+  jni::local_ref<JavaScriptObject::javaobject> ensureClassInstalled(jsi::Runtime &rt, jni::local_ref<jclass> nativeClass);
+  jsi::Value resolveSharedObjectInstance(jsi::Runtime &rt, int objectId, jni::local_ref<JavaScriptObject::javaobject> jsClassObj);
+
   [[nodiscard]] inline jni::local_ref<JavaScriptModuleObject::javaobject>
   callGetJavaScriptModuleObjectMethod(const std::string &moduleName) const;
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
@@ -152,11 +152,11 @@ std::shared_ptr<jsi::Function> JSClassesDecorator::installClass(
   return klassSharedPtr;
 }
 
-// Used by the worklet runtime path. Installs all classes in the runtime 
+// Used by the worklet runtime path. Installs all classes in the runtime
 // and registers them in classRegistry.
 // Transfers decorator ownership to each prototype via NativeState so
 // MethodMetadata stays alive since host functions capture weak_ptrs to it.
-void JSClassesDecorator::installForWorklet(jsi::Runtime &runtime) {
+void JSClassesDecorator::consumeForWorklet(jsi::Runtime &runtime) {
   for (auto &[name, classInfo]: classes) {
     auto klass = installClass(runtime, name, classInfo);
     jsi::Object proto = klass->getProperty(runtime, "prototype").asObject(runtime);
@@ -166,6 +166,7 @@ void JSClassesDecorator::installForWorklet(jsi::Runtime &runtime) {
     state->constructor = std::move(classInfo.constructor);
     proto.setNativeState(runtime, std::move(state));
   }
+  classes.clear();
 }
 
 // Installs all classes and sets them as properties on the passed object.

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
@@ -52,106 +52,126 @@ void JSClassesDecorator::registerClass(
   );
 }
 
+// Creates a JS class in the runtime, sets up its prototype with host functions,
+// and registers it in classRegistry.
+std::shared_ptr<jsi::Function> JSClassesDecorator::installClass(
+  jsi::Runtime &runtime,
+  const std::string &name,
+  ClassEntry &classInfo
+) {
+  auto &[prototypeDecorators, constructorDecorators, constructor, ownerClass, isSharedRef] = classInfo;
+
+  auto weakConstructor = std::weak_ptr<decltype(constructor)::element_type>(constructor);
+  expo::common::ClassConstructor jsConstructor = [weakConstructor = std::move(weakConstructor)](
+    jsi::Runtime &runtime,
+    const jsi::Value &thisValue,
+    const jsi::Value *args,
+    size_t count
+  ) -> jsi::Value {
+    // We need to check if the constructor is still alive.
+    // If not we can just ignore the call. We're destroying the module.
+    auto ctr = weakConstructor.lock();
+    if (ctr == nullptr) {
+      return jsi::Value::undefined();
+    }
+
+    auto thisObject = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
+
+    try {
+      JNIEnv *env = jni::Environment::current();
+      /**
+      * This will push a new JNI stack frame for the LocalReferences in this
+      * function call. When the stack frame for this lambda is popped,
+      * all LocalReferences are deleted.
+      */
+      jni::JniLocalScope scope(env, (int) count);
+      auto result = ctr->callJNISync(
+        env,
+        runtime,
+        thisValue,
+        args,
+        count
+      );
+      if (result == nullptr) {
+        return {runtime, thisValue};
+      }
+      jobject unpackedResult = result.get();
+      jclass resultClass = env->GetObjectClass(unpackedResult);
+      if (env->IsAssignableFrom(
+        resultClass,
+        JCacheHolder::get().jSharedObject
+      )) {
+        JSIContext *jsiContext = getJSIContext(runtime);
+        auto jsThisObject = JavaScriptObject::newInstance(
+          jsiContext,
+          jsiContext->runtimeHolder,
+          thisObject
+        );
+        jsiContext->registerSharedObject(result, jsThisObject);
+      }
+      return {runtime, thisValue};
+    } catch (jni::JniException &jniException) {
+      rethrowAsCodedError(runtime, jniException);
+    }
+  };
+
+  auto klass = createClass(
+    runtime,
+    name,
+    isSharedRef,
+    std::move(jsConstructor)
+  );
+
+  for (const auto &decorator: constructorDecorators) {
+    decorator->decorate(runtime, klass);
+  }
+
+  auto klassSharedPtr = std::make_shared<jsi::Function>(std::move(klass));
+
+  JSIContext *jsiContext = getJSIContext(runtime);
+
+  auto jsThisObject = JavaScriptObject::newInstance(
+    jsiContext,
+    jsiContext->runtimeHolder,
+    klassSharedPtr
+  );
+
+  if (ownerClass != nullptr) {
+    jsiContext->registerClass(jni::make_local(ownerClass), jsThisObject);
+  }
+
+  jsi::PropNameID prototypePropNameId = jsi::PropNameID::forAscii(runtime, "prototype", 9);
+  jsi::Object klassPrototype = klassSharedPtr
+    ->getProperty(runtime, prototypePropNameId)
+    .asObject(runtime);
+
+  for (const auto &decorator: prototypeDecorators) {
+    decorator->decorate(runtime, klassPrototype);
+  }
+
+  return klassSharedPtr;
+}
+
+// Installs all classes in the runtime and registers them in classRegistry
+void JSClassesDecorator::install(jsi::Runtime &runtime) {
+  for (auto &[name, classInfo]: classes) {
+    installClass(runtime, name, classInfo);
+  }
+}
+
+// Installs all classes and sets them as properties on the passed object.
 void JSClassesDecorator::decorate(
   jsi::Runtime &runtime,
   jsi::Object &jsObject
 ) {
   for (auto &[name, classInfo]: classes) {
-    auto &[prototypeDecorators, constructorDecorators, constructor, ownerClass, isSharedRef] = classInfo;
-
-    auto weakConstructor = std::weak_ptr<decltype(constructor)::element_type>(constructor);
-    expo::common::ClassConstructor jsConstructor = [weakConstructor = std::move(weakConstructor)](
-      jsi::Runtime &runtime,
-      const jsi::Value &thisValue,
-      const jsi::Value *args,
-      size_t count
-    ) -> jsi::Value {
-      // We need to check if the constructor is still alive.
-      // If not we can just ignore the call. We're destroying the module.
-      auto ctr = weakConstructor.lock();
-      if (ctr == nullptr) {
-        return jsi::Value::undefined();
-      }
-
-      auto thisObject = std::make_shared<jsi::Object>(thisValue.asObject(runtime));
-
-      try {
-        JNIEnv *env = jni::Environment::current();
-        /**
-        * This will push a new JNI stack frame for the LocalReferences in this
-        * function call. When the stack frame for this lambda is popped,
-        * all LocalReferences are deleted.
-        */
-        jni::JniLocalScope scope(env, (int) count);
-        auto result = ctr->callJNISync(
-          env,
-          runtime,
-          thisValue,
-          args,
-          count
-        );
-        if (result == nullptr) {
-          return {runtime, thisValue};
-        }
-        jobject unpackedResult = result.get();
-        jclass resultClass = env->GetObjectClass(unpackedResult);
-        if (env->IsAssignableFrom(
-          resultClass,
-          JCacheHolder::get().jSharedObject
-        )) {
-          JSIContext *jsiContext = getJSIContext(runtime);
-          auto jsThisObject = JavaScriptObject::newInstance(
-            jsiContext,
-            jsiContext->runtimeHolder,
-            thisObject
-          );
-          jsiContext->registerSharedObject(result, jsThisObject);
-        }
-        return {runtime, thisValue};
-      } catch (jni::JniException &jniException) {
-        rethrowAsCodedError(runtime, jniException);
-      }
-    };
-
-    auto klass = createClass(
-      runtime,
-      name,
-      isSharedRef,
-      std::move(jsConstructor)
-    );
-
-    for (const auto &decorator: constructorDecorators) {
-      decorator->decorate(runtime, klass);
-    }
-
-    auto klassSharedPtr = std::make_shared<jsi::Function>(std::move(klass));
-
-    JSIContext *jsiContext = getJSIContext(runtime);
-
-    auto jsThisObject = JavaScriptObject::newInstance(
-      jsiContext,
-      jsiContext->runtimeHolder,
-      klassSharedPtr
-    );
-
-    if (ownerClass != nullptr) {
-      jsiContext->registerClass(jni::make_local(ownerClass), jsThisObject);
-    }
+    auto klass = installClass(runtime, name, classInfo);
 
     jsObject.setProperty(
       runtime,
       jsi::String::createFromUtf8(runtime, name),
-      jsi::Value(runtime, *klassSharedPtr)
+      jsi::Value(runtime, *klass)
     );
-
-    jsi::PropNameID prototypePropNameId = jsi::PropNameID::forAscii(runtime, "prototype", 9);
-    jsi::Object klassPrototype = klassSharedPtr
-      ->getProperty(runtime, prototypePropNameId)
-      .asObject(runtime);
-
-    for (const auto &decorator: prototypeDecorators) {
-      decorator->decorate(runtime, klassPrototype);
-    }
   }
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.cpp
@@ -152,10 +152,19 @@ std::shared_ptr<jsi::Function> JSClassesDecorator::installClass(
   return klassSharedPtr;
 }
 
-// Installs all classes in the runtime and registers them in classRegistry
-void JSClassesDecorator::install(jsi::Runtime &runtime) {
+// Used by the worklet runtime path. Installs all classes in the runtime 
+// and registers them in classRegistry.
+// Transfers decorator ownership to each prototype via NativeState so
+// MethodMetadata stays alive since host functions capture weak_ptrs to it.
+void JSClassesDecorator::installForWorklet(jsi::Runtime &runtime) {
   for (auto &[name, classInfo]: classes) {
-    installClass(runtime, name, classInfo);
+    auto klass = installClass(runtime, name, classInfo);
+    jsi::Object proto = klass->getProperty(runtime, "prototype").asObject(runtime);
+    auto state = std::make_shared<ClassPrototypeState>();
+    state->prototypeDecorators = std::move(classInfo.prototypeDecorators);
+    state->constructorDecorators = std::move(classInfo.constructorDecorators);
+    state->constructor = std::move(classInfo.constructor);
+    proto.setNativeState(runtime, std::move(state));
   }
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
@@ -48,11 +48,11 @@ public:
   ) override;
 
   /**
-   * Worklet runtime path - installs classes in classRegistry and attaches
-   * decorator ownership to each prototype via NativeState.
-   * Unlike decorate(), does not set classes as properties on a parent object.
+   * Worklet runtime path - installs classes in classRegistry, transfers
+   * decorator ownership to each prototype via NativeState, and drains this
+   * decorator. Must only be called once.
    */
-  void installForWorklet(jsi::Runtime &runtime);
+  void consumeForWorklet(jsi::Runtime &runtime);
 
 private:
   struct ClassEntry {

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
@@ -17,6 +17,18 @@ namespace expo {
 
 class JSDecoratorsBridgingObject;
 
+/**
+ * NativeState attached to the class prototype in the worklet runtime.
+ * Owns the decorators (and their MethodMetadata shared_ptrs) so that the
+ * weak_ptrs captured by prototype host functions stay valid.
+ * Released automatically when the prototype is garbage-collected.
+ */
+struct ClassPrototypeState : public jsi::NativeState {
+  std::vector<std::unique_ptr<JSDecorator>> prototypeDecorators;
+  std::vector<std::unique_ptr<JSDecorator>> constructorDecorators;
+  std::shared_ptr<MethodMetadata> constructor;
+};
+
 class JSClassesDecorator : public JSDecorator {
 public:
   void registerClass(
@@ -35,7 +47,12 @@ public:
     jsi::Object &jsObject
   ) override;
 
-  void install(jsi::Runtime &runtime) override;
+  /**
+   * Worklet runtime path - installs classes in classRegistry and attaches
+   * decorator ownership to each prototype via NativeState.
+   * Unlike decorate(), does not set classes as properties on a parent object.
+   */
+  void installForWorklet(jsi::Runtime &runtime);
 
 private:
   struct ClassEntry {

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
@@ -35,6 +35,8 @@ public:
     jsi::Object &jsObject
   ) override;
 
+  void install(jsi::Runtime &runtime) override;
+
 private:
   struct ClassEntry {
     std::vector<std::unique_ptr<JSDecorator>> prototypeDecorators;
@@ -43,6 +45,12 @@ private:
     jni::global_ref<jclass> ownerClass;
     bool isSharedRef;
   };
+
+  std::shared_ptr<jsi::Function> installClass(
+    jsi::Runtime &runtime,
+    const std::string &name,
+    ClassEntry &classInfo
+  );
 
   static jsi::Function createClass(
     jsi::Runtime &runtime,

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecorator.h
@@ -23,12 +23,6 @@ public:
     jsi::Runtime &runtime,
     jsi::Object &jsObject
   ) = 0;
-
-  /**
-   * Installs class definitions in the runtime.
-   * Default is a no-op; overridden by JSClassesDecorator.
-   */
-  virtual void install(jsi::Runtime &runtime) {}
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecorator.h
@@ -23,6 +23,12 @@ public:
     jsi::Runtime &runtime,
     jsi::Object &jsObject
   ) = 0;
+
+  /**
+   * Installs class definitions in the runtime.
+   * Default is a no-op; overridden by JSClassesDecorator.
+   */
+  virtual void install(jsi::Runtime &runtime) {}
 };
 
 } // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
@@ -87,6 +87,13 @@ public:
    */
   std::vector<std::unique_ptr<JSDecorator>> bridge();
 
+  /**
+   * Returns the class decorator, or nullptr if none was registered.
+   */
+  JSClassesDecorator* getClassDecorator() const {
+    return classDecorator.get();
+  }
+
 private:
   friend HybridBase;
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -3,6 +3,7 @@ package expo.modules.kotlin.jni
 import com.facebook.jni.HybridData
 import expo.modules.core.interfaces.DoNotStrip
 import expo.modules.kotlin.exception.JavaScriptEvaluateException
+import expo.modules.kotlin.jni.decorators.JSDecoratorsBridgingObject
 import expo.modules.kotlin.runtime.Runtime
 import expo.modules.kotlin.sharedobjects.SharedObject
 import expo.modules.kotlin.sharedobjects.SharedObjectId
@@ -54,6 +55,45 @@ class JSIContext @DoNotStrip internal constructor(
   external fun drainJSEventLoop()
 
   external fun setNativeStateForSharedObject(id: Int, js: JavaScriptObject)
+
+  /**
+   * Installs `SharedObject.__resolveInWorklet` in this runtime.
+   */
+  external fun installModuleClasses()
+
+  /**
+   * Called from C++ `__resolveInWorklet`, returns the Java class of a SharedObject by its ID.
+   */
+  @Suppress("unused")
+  @DoNotStrip
+  fun getNativeSharedObjectClass(objectId: Int): Class<*>? {
+    val appContext = runtimeHolder.get()?.appContext ?: return null
+    val mainRegistry = appContext.runtime.sharedObjectRegistry
+    val nativeObject = mainRegistry.toNativeObjectOrNull(SharedObjectId(objectId))
+    return nativeObject?.javaClass
+  }
+
+  /**
+   * Exports a single SharedObject class to this runtime.
+   */
+  @Suppress("unused")
+  @DoNotStrip
+  fun buildClassDecorator(nativeClass: Class<*>): JSDecoratorsBridgingObject? {
+    val runtime = runtimeHolder.get() ?: return null
+    val appContext = runtime.appContext ?: return null
+
+    val classDefinition = appContext.registry
+      .asSequence()
+      .flatMap { it.definition.classData }
+      .firstOrNull { it.constructor.ownerType?.kClass?.java == nativeClass }
+      ?: return null
+
+    val decorator = JSDecoratorsBridgingObject(runtime.deallocator)
+    with(decorator) {
+      classDefinition.exportClass(appContext, runtime)
+    }
+    return decorator
+  }
 
   /**
    * Returns a `JavaScriptModuleObject` that is a bridge between [expo.modules.kotlin.modules.Module]

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/WorkletRuntime.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/runtime/WorkletRuntime.kt
@@ -60,6 +60,9 @@ class WorkletRuntime(
       jsiContext = WorkletRuntimeInstaller(this)
         .install(runtimePointer)
 
+      // Install `__resolveInWorklet` and shared object class definition in the worklet runtime
+      jsiContext.installModuleClasses()
+
       logger.info("✅ JSI interop was installed")
     }
   }


### PR DESCRIPTION

# Why


Implements PR 2 from the approach discussed here https://github.com/expo/expo/pull/44655/


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Registered custom serialiser in react-native-worklets that packs object id from `ObservableState` SharedObject and unpacks using `__resolveInWorklet` function. 
- Added `__resolveInWorklet` which is called from worklet runtime which creates a new `ObservableState` while referencing the original native prototype functions of `ObservableState` SharedObject

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Updated SyncSwitch example with `toggleFromWorklet` function to test ObservableState updates from UI worklet.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

SwiftUI counterpart PR - https://github.com/expo/expo/pull/44215
