### PR TITLE
[gha] Upload precompiled XCFramework archives on SDK branches

### DIFF
--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       packages:
-        description: 'Space-separated external package names to prebuild (leave empty for all)'
+        description: 'Space-separated external package names (leave empty for all external packages)'
         required: false
         default: ''
       concurrency:
@@ -22,8 +22,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.event.inputs.publish == 'true' && format('{0}-publish-{1}', github.workflow, github.event.inputs.sdk-version) || format('{0}-run-{1}', github.workflow, github.run_id) }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   prebuild:
@@ -102,7 +102,6 @@ jobs:
           include-hidden-files: true
 
       - name: Package XCFrameworks (${{ matrix.flavor }})
-        if: ${{ !cancelled() }}
         run: |
           FLAVOR_LOWER=$(echo "${{ matrix.flavor }}" | tr '[:upper:]' '[:lower:]')
           ARCHIVE_PATH="$RUNNER_TEMP/xcframeworks-${{ matrix.flavor }}.zip"
@@ -136,6 +135,9 @@ jobs:
       - name: Upload XCFramework zip to GCS
         if: ${{ success() && github.event.inputs.publish == 'true' }}
         run: |
+          # Create the canonical artifact only if it does not already exist.
+          # This keeps concurrent publish attempts from overwriting each other.
           gcloud storage cp \
+            --if-generation-match=0 \
             "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \
             "gs://eas-build-precompiled-modules/precompiled-modules/${{ github.event.inputs.sdk-version }}/xcframeworks-${{ matrix.flavor }}.zip"

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -139,9 +139,6 @@ jobs:
       - name: Upload XCFramework zip to GCS
         if: ${{ !cancelled() && github.event.inputs.publish == 'true' && steps.package_xcframeworks.outputs.archive_path != '' }}
         run: |
-          # Create the canonical artifact only if it does not already exist.
-          # This keeps concurrent publish attempts from overwriting each other.
           gcloud storage cp \
-            --if-generation-match=0 \
             "${{ steps.package_xcframeworks.outputs.archive_path }}" \
             "gs://eas-build-precompiled-modules/precompiled-modules/${{ github.event.inputs.sdk-version }}/xcframeworks-${{ matrix.flavor }}.zip"

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -62,7 +62,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Resolve SDK version
-        run: echo "SDK_VERSION=$(node -p \"require('./packages/expo/package.json').version\")" >> $GITHUB_ENV
+        run: |
+          SDK_VERSION="$(node -p "require('./packages/expo/package.json').version")"
+
+          if [[ -z "$SDK_VERSION" ]]; then
+            echo "Failed to resolve SDK version"
+            exit 1
+          fi
+
+          echo "SDK_VERSION=$SDK_VERSION" >> "$GITHUB_ENV"
 
       - name: Decide whether to publish XCFramework archive
         env:
@@ -113,15 +121,7 @@ jobs:
           FILE_LIST="$RUNNER_TEMP/xcframeworks-${{ matrix.flavor }}.txt"
 
           cd packages/precompile/.build
-          shopt -s globstar nullglob
-          files=(**/"${FLAVOR_LOWER}"/xcframeworks/*.tar.gz)
-
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "No XCFramework tarballs found for flavor ${{ matrix.flavor }}"
-            exit 1
-          fi
-
-          printf '%s\n' "${files[@]}" | sort > "$FILE_LIST"
+          find . -type f -path "./*/output/${FLAVOR_LOWER}/xcframeworks/*.tar.gz" | sort > "$FILE_LIST"
 
           if [ ! -s "$FILE_LIST" ]; then
             echo "No XCFramework tarballs found for flavor ${{ matrix.flavor }}"
@@ -133,20 +133,20 @@ jobs:
           echo "THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH=$ARCHIVE_PATH" >> $GITHUB_ENV
 
       - name: Authenticate to Google Cloud
-        if: ${{ !cancelled() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        if: ${{ success() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
         uses: google-github-actions/auth@v3
         with:
           project_id: exponentjs
           workload_identity_provider: projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo
 
       - name: Setup gcloud
-        if: ${{ !cancelled() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        if: ${{ success() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: exponentjs
 
       - name: Upload XCFramework zip to GCS
-        if: ${{ !cancelled() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        if: ${{ success() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
         run: |
           gcloud storage cp \
             "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -121,7 +121,7 @@ jobs:
           FILE_LIST="$RUNNER_TEMP/xcframeworks-${{ matrix.flavor }}.txt"
 
           cd packages/precompile/.build
-          find . -type f -path "./*/output/${FLAVOR_LOWER}/xcframeworks/*.tar.gz" | sort > "$FILE_LIST"
+          find . -type f -name "*.tar.gz" | grep "/${FLAVOR_LOWER}/xcframeworks/" | sort > "$FILE_LIST"
 
           if [ ! -s "$FILE_LIST" ]; then
             echo "No XCFramework tarballs found for flavor ${{ matrix.flavor }}"

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -28,6 +28,8 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      SDK_VERSION: ${{ github.event.inputs.sdk-version }}
     strategy:
       matrix:
         flavor: [Debug, Release]
@@ -56,19 +58,6 @@ jobs:
 
       - name: Install node modules
         run: pnpm install --frozen-lockfile
-
-      - name: Resolve SDK version
-        env:
-          INPUT_SDK_VERSION: ${{ github.event.inputs.sdk-version }}
-        run: |
-          SDK_VERSION="${INPUT_SDK_VERSION//[[:space:]]/}"
-
-          if [[ -z "$SDK_VERSION" ]]; then
-            echo "sdk-version input cannot be empty"
-            exit 1
-          fi
-
-          echo "SDK_VERSION=$SDK_VERSION" >> "$GITHUB_ENV"
 
       - name: Decide whether to publish XCFramework archive
         env:

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -20,6 +20,9 @@ jobs:
   prebuild:
     runs-on: macos-15
     timeout-minutes: 120
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       matrix:
         flavor: [Debug, Release]
@@ -49,6 +52,23 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
 
+      - name: Resolve SDK version
+        run: echo "SDK_VERSION=$(node -p \"require('./packages/expo/package.json').version\")" >> $GITHUB_ENV
+
+      - name: Decide whether to publish XCFramework archive
+        env:
+          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
+        run: |
+          INPUT_PACKAGES_TRIMMED="${INPUT_PACKAGES//[[:space:]]/}"
+
+          if [[ "$GITHUB_REF" == refs/heads/sdk-* ]] && [[ -z "$INPUT_PACKAGES_TRIMMED" ]]; then
+            echo "PUBLISH_XCFRAMEWORK_ARCHIVE=1" >> $GITHUB_ENV
+            echo "Publishing XCFramework archive to GCS from release branch $GITHUB_REF"
+          else
+            echo "PUBLISH_XCFRAMEWORK_ARCHIVE=0" >> $GITHUB_ENV
+            echo "Skipping XCFramework archive publish for ref $GITHUB_REF (packages input: '${INPUT_PACKAGES}')"
+          fi
+
       - name: Prebuild External XCFrameworks (${{ matrix.flavor }})
         env:
           INPUT_PACKAGES: ${{ github.event.inputs.packages }}
@@ -66,6 +86,53 @@ jobs:
 
           echo "Running: et prebuild $ARGS"
           et prebuild $ARGS
+
+      - name: Package XCFrameworks (${{ matrix.flavor }})
+        if: ${{ !cancelled() }}
+        run: |
+          FLAVOR_LOWER=$(echo "${{ matrix.flavor }}" | tr '[:upper:]' '[:lower:]')
+          ARCHIVE_PATH="$RUNNER_TEMP/xcframeworks-${{ matrix.flavor }}.zip"
+          FILE_LIST="$RUNNER_TEMP/xcframeworks-${{ matrix.flavor }}.txt"
+
+          cd packages/precompile/.build
+          shopt -s globstar nullglob
+          files=(**/"${FLAVOR_LOWER}"/xcframeworks/*.tar.gz)
+
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No XCFramework tarballs found for flavor ${{ matrix.flavor }}"
+            exit 1
+          fi
+
+          printf '%s\n' "${files[@]}" | sort > "$FILE_LIST"
+
+          if [ ! -s "$FILE_LIST" ]; then
+            echo "No XCFramework tarballs found for flavor ${{ matrix.flavor }}"
+            exit 1
+          fi
+
+          rm -f "$ARCHIVE_PATH"
+          zip -q "$ARCHIVE_PATH" -@ < "$FILE_LIST"
+          echo "THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH=$ARCHIVE_PATH" >> $GITHUB_ENV
+
+      - name: Authenticate to Google Cloud
+        if: ${{ !cancelled() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: exponentjs
+          workload_identity_provider: projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo
+
+      - name: Setup gcloud
+        if: ${{ !cancelled() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: exponentjs
+
+      - name: Upload XCFramework zip to GCS
+        if: ${{ !cancelled() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        run: |
+          gcloud storage cp \
+            "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \
+            "gs://turtle-v2/precompiled-modules/$SDK_VERSION/xcframeworks-${{ matrix.flavor }}.zip"
 
       - name: Upload XCFrameworks
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -28,8 +28,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    env:
-      SDK_VERSION: ${{ github.event.inputs.sdk-version }}
     strategy:
       matrix:
         flavor: [Debug, Release]
@@ -72,6 +70,16 @@ jobs:
           echo "Running: et prebuild $ARGS"
           et prebuild $ARGS
 
+      - name: Upload XCFrameworks
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: xcframeworks-${{ matrix.flavor }}
+          path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
+          if-no-files-found: error
+          retention-days: 14
+          include-hidden-files: true
+
       - name: Package XCFrameworks (${{ matrix.flavor }})
         if: ${{ !cancelled() }}
         run: |
@@ -91,16 +99,6 @@ jobs:
           zip -q "$ARCHIVE_PATH" -@ < "$FILE_LIST"
           echo "THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH=$ARCHIVE_PATH" >> $GITHUB_ENV
 
-      - name: Upload XCFrameworks
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: xcframeworks-${{ matrix.flavor }}
-          path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
-          if-no-files-found: error
-          retention-days: 14
-          include-hidden-files: true
-
       - name: Authenticate to Google Cloud
         if: ${{ success() && github.event.inputs.publish == 'true' }}
         uses: google-github-actions/auth@v3
@@ -119,4 +117,4 @@ jobs:
         run: |
           gcloud storage cp \
             "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \
-            "gs://eas-build-precompiled-modules/precompiled-modules/$SDK_VERSION/xcframeworks-${{ matrix.flavor }}.zip"
+            "gs://eas-build-precompiled-modules/precompiled-modules/${{ github.event.inputs.sdk-version }}/xcframeworks-${{ matrix.flavor }}.zip"

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -91,6 +91,16 @@ jobs:
           zip -q "$ARCHIVE_PATH" -@ < "$FILE_LIST"
           echo "THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH=$ARCHIVE_PATH" >> $GITHUB_ENV
 
+      - name: Upload XCFrameworks
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: xcframeworks-${{ matrix.flavor }}
+          path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
+          if-no-files-found: error
+          retention-days: 14
+          include-hidden-files: true
+
       - name: Authenticate to Google Cloud
         if: ${{ success() && github.event.inputs.publish == 'true' }}
         uses: google-github-actions/auth@v3
@@ -110,13 +120,3 @@ jobs:
           gcloud storage cp \
             "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \
             "gs://eas-build-precompiled-modules/precompiled-modules/$SDK_VERSION/xcframeworks-${{ matrix.flavor }}.zip"
-
-      - name: Upload XCFrameworks
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: xcframeworks-${{ matrix.flavor }}
-          path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
-          if-no-files-found: error
-          retention-days: 14
-          include-hidden-files: true

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -18,8 +18,8 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.event.inputs.publish == 'true' && format('{0}-publish-{1}', github.workflow, github.event.inputs.sdk-version) || format('{0}-run-{1}', github.workflow, github.run_id) }}
+  cancel-in-progress: false
 
 jobs:
   prebuild:

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -3,10 +3,6 @@ name: Prebuild External iOS XCFrameworks
 on:
   workflow_dispatch:
     inputs:
-      packages:
-        description: 'Space-separated external package names (leave empty for all external packages)'
-        required: false
-        default: ''
       concurrency:
         description: 'Max parallel packages (default: auto)'
         required: false
@@ -16,10 +12,10 @@ on:
         required: false
         type: boolean
         default: false
-      publish-prefix:
-        description: 'GCS prefix under the bucket (release default: precompiled-modules)'
-        required: false
-        default: 'precompiled-modules'
+      sdk-version:
+        description: 'SDK version used in the GCS object path'
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -62,11 +58,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Resolve SDK version
+        env:
+          INPUT_SDK_VERSION: ${{ github.event.inputs.sdk-version }}
         run: |
-          SDK_VERSION="$(node -p "require('./packages/expo/package.json').version")"
+          SDK_VERSION="${INPUT_SDK_VERSION//[[:space:]]/}"
 
           if [[ -z "$SDK_VERSION" ]]; then
-            echo "Failed to resolve SDK version"
+            echo "sdk-version input cannot be empty"
             exit 1
           fi
 
@@ -74,37 +72,21 @@ jobs:
 
       - name: Decide whether to publish XCFramework archive
         env:
-          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
           INPUT_PUBLISH: ${{ github.event.inputs.publish }}
-          INPUT_PUBLISH_PREFIX: ${{ github.event.inputs.publish-prefix }}
         run: |
-          INPUT_PACKAGES_TRIMMED="${INPUT_PACKAGES//[[:space:]]/}"
-          INPUT_PUBLISH_PREFIX_TRIMMED="${INPUT_PUBLISH_PREFIX//[[:space:]]/}"
-
-          if [[ -z "$INPUT_PUBLISH_PREFIX_TRIMMED" ]]; then
-            echo "publish-prefix input cannot be empty"
-            exit 1
-          fi
-
-          if ([[ "$GITHUB_REF" == refs/heads/sdk-* ]] && [[ -z "$INPUT_PACKAGES_TRIMMED" ]]) || [[ "$INPUT_PUBLISH" == "true" ]]; then
+          if [[ "$GITHUB_REF" == refs/heads/sdk-* ]] || [[ "$INPUT_PUBLISH" == "true" ]]; then
             echo "PUBLISH_XCFRAMEWORK_ARCHIVE=1" >> $GITHUB_ENV
-            echo "XCFRAMEWORK_ARCHIVE_PUBLISH_PREFIX=$INPUT_PUBLISH_PREFIX_TRIMMED" >> $GITHUB_ENV
-            echo "Publishing XCFramework archive to GCS from ref $GITHUB_REF with prefix $INPUT_PUBLISH_PREFIX_TRIMMED"
+            echo "Publishing XCFramework archive to GCS from ref $GITHUB_REF"
           else
             echo "PUBLISH_XCFRAMEWORK_ARCHIVE=0" >> $GITHUB_ENV
-            echo "Skipping XCFramework archive publish for ref $GITHUB_REF (packages input: '${INPUT_PACKAGES}')"
+            echo "Skipping XCFramework archive publish for ref $GITHUB_REF"
           fi
 
       - name: Prebuild External XCFrameworks (${{ matrix.flavor }})
         env:
-          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
           INPUT_CONCURRENCY: ${{ github.event.inputs.concurrency }}
         run: |
           ARGS="-f ${{ matrix.flavor }} -v --external-only"
-
-          if [ -n "$INPUT_PACKAGES" ]; then
-            ARGS="$ARGS $INPUT_PACKAGES"
-          fi
 
           if [ -n "$INPUT_CONCURRENCY" ]; then
             ARGS="$ARGS -j $INPUT_CONCURRENCY"
@@ -150,7 +132,7 @@ jobs:
         run: |
           gcloud storage cp \
             "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \
-            "gs://eas-build-precompiled-modules/$XCFRAMEWORK_ARCHIVE_PUBLISH_PREFIX/$SDK_VERSION/xcframeworks-${{ matrix.flavor }}.zip"
+            "gs://eas-build-precompiled-modules/precompiled-modules/$SDK_VERSION/xcframeworks-${{ matrix.flavor }}.zip"
 
       - name: Upload XCFrameworks
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -3,6 +3,10 @@ name: Prebuild External iOS XCFrameworks
 on:
   workflow_dispatch:
     inputs:
+      packages:
+        description: 'Space-separated external package names to prebuild (leave empty for all)'
+        required: false
+        default: ''
       concurrency:
         description: 'Max parallel packages (default: auto)'
         required: false
@@ -57,11 +61,28 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
 
+      - name: Validate inputs
+        env:
+          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
+          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
+        run: |
+          INPUT_PACKAGES_TRIMMED="${INPUT_PACKAGES//[[:space:]]/}"
+
+          if [[ "$INPUT_PUBLISH" == "true" ]] && [[ -n "$INPUT_PACKAGES_TRIMMED" ]]; then
+            echo "packages input must be empty when publish=true"
+            exit 1
+          fi
+
       - name: Prebuild External XCFrameworks (${{ matrix.flavor }})
         env:
+          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
           INPUT_CONCURRENCY: ${{ github.event.inputs.concurrency }}
         run: |
           ARGS="-f ${{ matrix.flavor }} -v --external-only"
+
+          if [ -n "$INPUT_PACKAGES" ]; then
+            ARGS="$ARGS $INPUT_PACKAGES"
+          fi
 
           if [ -n "$INPUT_CONCURRENCY" ]; then
             ARGS="$ARGS -j $INPUT_CONCURRENCY"

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -41,6 +41,16 @@ jobs:
         with:
           submodules: true
 
+      - name: Validate inputs
+        env:
+          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
+          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
+        run: |
+          if [[ "$INPUT_PUBLISH" == "true" ]] && [[ -n "$INPUT_PACKAGES" ]]; then
+            echo "packages input must be empty when publish=true"
+            exit 1
+          fi
+
       - name: Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app
 
@@ -60,18 +70,6 @@ jobs:
 
       - name: Install node modules
         run: pnpm install --frozen-lockfile
-
-      - name: Validate inputs
-        env:
-          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
-          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
-        run: |
-          INPUT_PACKAGES_TRIMMED="${INPUT_PACKAGES//[[:space:]]/}"
-
-          if [[ "$INPUT_PUBLISH" == "true" ]] && [[ -n "$INPUT_PACKAGES_TRIMMED" ]]; then
-            echo "packages input must be empty when publish=true"
-            exit 1
-          fi
 
       - name: Prebuild External XCFrameworks (${{ matrix.flavor }})
         env:

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -8,7 +8,7 @@ on:
         required: false
         default: ''
       publish:
-        description: 'Publish XCFramework archive to GCS even on non-sdk branches'
+        description: 'Publish XCFramework archive to GCS'
         required: false
         type: boolean
         default: false
@@ -59,18 +59,6 @@ jobs:
       - name: Install node modules
         run: pnpm install --frozen-lockfile
 
-      - name: Decide whether to publish XCFramework archive
-        env:
-          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
-        run: |
-          if [[ "$GITHUB_REF" == refs/heads/sdk-* ]] || [[ "$INPUT_PUBLISH" == "true" ]]; then
-            echo "PUBLISH_XCFRAMEWORK_ARCHIVE=1" >> $GITHUB_ENV
-            echo "Publishing XCFramework archive to GCS from ref $GITHUB_REF"
-          else
-            echo "PUBLISH_XCFRAMEWORK_ARCHIVE=0" >> $GITHUB_ENV
-            echo "Skipping XCFramework archive publish for ref $GITHUB_REF"
-          fi
-
       - name: Prebuild External XCFrameworks (${{ matrix.flavor }})
         env:
           INPUT_CONCURRENCY: ${{ github.event.inputs.concurrency }}
@@ -104,20 +92,20 @@ jobs:
           echo "THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH=$ARCHIVE_PATH" >> $GITHUB_ENV
 
       - name: Authenticate to Google Cloud
-        if: ${{ success() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        if: ${{ success() && github.event.inputs.publish == 'true' }}
         uses: google-github-actions/auth@v3
         with:
           project_id: exponentjs
           workload_identity_provider: projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo
 
       - name: Setup gcloud
-        if: ${{ success() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        if: ${{ success() && github.event.inputs.publish == 'true' }}
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: exponentjs
 
       - name: Upload XCFramework zip to GCS
-        if: ${{ success() && env.PUBLISH_XCFRAMEWORK_ARCHIVE == '1' }}
+        if: ${{ success() && github.event.inputs.publish == 'true' }}
         run: |
           gcloud storage cp \
             "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -33,6 +33,7 @@ jobs:
       contents: read
       id-token: write
     strategy:
+      fail-fast: false
       matrix:
         flavor: [Debug, Release]
     steps:
@@ -72,6 +73,8 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Prebuild External XCFrameworks (${{ matrix.flavor }})
+        id: prebuild_xcframeworks
+        continue-on-error: true
         env:
           INPUT_PACKAGES: ${{ github.event.inputs.packages }}
           INPUT_CONCURRENCY: ${{ github.event.inputs.concurrency }}
@@ -95,11 +98,13 @@ jobs:
         with:
           name: xcframeworks-${{ matrix.flavor }}
           path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 14
           include-hidden-files: true
 
       - name: Package XCFrameworks (${{ matrix.flavor }})
+        id: package_xcframeworks
+        if: ${{ !cancelled() }}
         run: |
           FLAVOR_LOWER=$(echo "${{ matrix.flavor }}" | tr '[:upper:]' '[:lower:]')
           ARCHIVE_PATH="$RUNNER_TEMP/xcframeworks-${{ matrix.flavor }}.zip"
@@ -109,33 +114,34 @@ jobs:
           find . -type f -name "*.tar.gz" | grep "/${FLAVOR_LOWER}/xcframeworks/" | sort > "$FILE_LIST"
 
           if [ ! -s "$FILE_LIST" ]; then
-            echo "No XCFramework tarballs found for flavor ${{ matrix.flavor }}"
-            exit 1
+            echo "::warning::No XCFramework tarballs found for flavor ${{ matrix.flavor }}; skipping zip packaging."
+            echo "archive_path=" >> $GITHUB_OUTPUT
+            exit 0
           fi
 
           rm -f "$ARCHIVE_PATH"
           zip -q "$ARCHIVE_PATH" -@ < "$FILE_LIST"
-          echo "THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH=$ARCHIVE_PATH" >> $GITHUB_ENV
+          echo "archive_path=$ARCHIVE_PATH" >> $GITHUB_OUTPUT
 
       - name: Authenticate to Google Cloud
-        if: ${{ success() && github.event.inputs.publish == 'true' }}
+        if: ${{ !cancelled() && github.event.inputs.publish == 'true' && steps.package_xcframeworks.outputs.archive_path != '' }}
         uses: google-github-actions/auth@v3
         with:
           project_id: exponentjs
           workload_identity_provider: projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo
 
       - name: Setup gcloud
-        if: ${{ success() && github.event.inputs.publish == 'true' }}
+        if: ${{ !cancelled() && github.event.inputs.publish == 'true' && steps.package_xcframeworks.outputs.archive_path != '' }}
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: exponentjs
 
       - name: Upload XCFramework zip to GCS
-        if: ${{ success() && github.event.inputs.publish == 'true' }}
+        if: ${{ !cancelled() && github.event.inputs.publish == 'true' && steps.package_xcframeworks.outputs.archive_path != '' }}
         run: |
           # Create the canonical artifact only if it does not already exist.
           # This keeps concurrent publish attempts from overwriting each other.
           gcloud storage cp \
             --if-generation-match=0 \
-            "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \
+            "${{ steps.package_xcframeworks.outputs.archive_path }}" \
             "gs://eas-build-precompiled-modules/precompiled-modules/${{ github.event.inputs.sdk-version }}/xcframeworks-${{ matrix.flavor }}.zip"

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -11,6 +11,15 @@ on:
         description: 'Max parallel packages (default: auto)'
         required: false
         default: ''
+      publish:
+        description: 'Publish XCFramework archive to GCS even on non-sdk branches'
+        required: false
+        type: boolean
+        default: false
+      publish-prefix:
+        description: 'GCS prefix under the bucket (release default: precompiled-modules)'
+        required: false
+        default: 'precompiled-modules'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -58,12 +67,21 @@ jobs:
       - name: Decide whether to publish XCFramework archive
         env:
           INPUT_PACKAGES: ${{ github.event.inputs.packages }}
+          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
+          INPUT_PUBLISH_PREFIX: ${{ github.event.inputs.publish-prefix }}
         run: |
           INPUT_PACKAGES_TRIMMED="${INPUT_PACKAGES//[[:space:]]/}"
+          INPUT_PUBLISH_PREFIX_TRIMMED="${INPUT_PUBLISH_PREFIX//[[:space:]]/}"
 
-          if [[ "$GITHUB_REF" == refs/heads/sdk-* ]] && [[ -z "$INPUT_PACKAGES_TRIMMED" ]]; then
+          if [[ -z "$INPUT_PUBLISH_PREFIX_TRIMMED" ]]; then
+            echo "publish-prefix input cannot be empty"
+            exit 1
+          fi
+
+          if ([[ "$GITHUB_REF" == refs/heads/sdk-* ]] && [[ -z "$INPUT_PACKAGES_TRIMMED" ]]) || [[ "$INPUT_PUBLISH" == "true" ]]; then
             echo "PUBLISH_XCFRAMEWORK_ARCHIVE=1" >> $GITHUB_ENV
-            echo "Publishing XCFramework archive to GCS from release branch $GITHUB_REF"
+            echo "XCFRAMEWORK_ARCHIVE_PUBLISH_PREFIX=$INPUT_PUBLISH_PREFIX_TRIMMED" >> $GITHUB_ENV
+            echo "Publishing XCFramework archive to GCS from ref $GITHUB_REF with prefix $INPUT_PUBLISH_PREFIX_TRIMMED"
           else
             echo "PUBLISH_XCFRAMEWORK_ARCHIVE=0" >> $GITHUB_ENV
             echo "Skipping XCFramework archive publish for ref $GITHUB_REF (packages input: '${INPUT_PACKAGES}')"
@@ -132,7 +150,7 @@ jobs:
         run: |
           gcloud storage cp \
             "$THIRD_PARTY_PRECOMPILED_MODULES_ARCHIVE_PATH" \
-            "gs://turtle-v2/precompiled-modules/$SDK_VERSION/xcframeworks-${{ matrix.flavor }}.zip"
+            "gs://eas-build-precompiled-modules/$XCFRAMEWORK_ARCHIVE_PUBLISH_PREFIX/$SDK_VERSION/xcframeworks-${{ matrix.flavor }}.zip"
 
       - name: Upload XCFrameworks
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
Compared to `main`, this updates `.github/workflows/ios-prebuild-external-xcframeworks.yml` so manual runs can optionally publish per-flavor zip archives of the generated external XCFramework tarballs to GCS.

## What Changed
- add `workflow_dispatch` inputs for `publish` and required `sdk-version`
- keep `packages` and `concurrency` as manual prebuild controls
- validate that `publish=true` is only allowed for full builds, not package-scoped runs (not sure what is the expected flow here if we wanted to allow both `publish` and `packages`. Would we merge ZIP from some previous publish with the newly published partial packages? How would we learn what was the previous publish?)
- add the OIDC permissions needed to authenticate GitHub Actions to Google Cloud
- keep uploading raw XCFramework tarballs to GitHub artifacts before zip packaging
- package available tarballs into `xcframeworks-{Debug|Release}.zip`
- upload those zips to `gs://eas-build-precompiled-modules/precompiled-modules/$SDK_VERSION/...`, allowing reruns to overwrite the same object path
- disable matrix fail-fast and allow partial outputs to continue through artifact upload and GCS upload when packaging produced a zip

## Validation
- Successful smoke run: [24712070220](https://github.com/expo/expo/actions/runs/24712070220)
- GitHub artifact downloads:
  - [xcframeworks-Debug](https://github.com/expo/expo/actions/runs/24712070220/artifacts/6550439823)
  - [xcframeworks-Release](https://github.com/expo/expo/actions/runs/24712070220/artifacts/6550611596)
- GCS uploads:
  - `gs://eas-build-precompiled-modules/precompiled-modules/55.0.2-alpha.0-gcs-smoke.20260421.2/xcframeworks-Debug.zip`
  - `gs://eas-build-precompiled-modules/precompiled-modules/55.0.2-alpha.0-gcs-smoke.20260421.2/xcframeworks-Release.zip`
- `mise exec -- yarn prettier --check .github/workflows/ios-prebuild-external-xcframeworks.yml`
