### PR TITLE
[brownfield][iOS] Add define_modules build setting

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [state] shared state implementation improvements ([#43279](https://github.com/expo/expo/pull/43279) by [@pmleczek](https://github.com/pmleczek))
 - Use react-native prebuilds by default ([#44332](https://github.com/expo/expo/pull/44332) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added `Expo.plist` to the brownfield framework target. ([#44645](https://github.com/expo/expo/pull/44645) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Add `DEFINE_MODULES=TRUE` build setting ([#44672](https://github.com/expo/expo/pull/44672) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/plugin/build/ios/utils/project.js
+++ b/packages/expo-brownfield/plugin/build/ios/utils/project.js
@@ -92,6 +92,7 @@ const getCommonBuildSettings = (targetName, currentProjectVersion, bundleIdentif
         SWIFT_OPTIMIZATION_LEVEL: `"-Onone"`,
         CODE_SIGN_ENTITLEMENTS: `"${targetName}/${targetName}.entitlements"`,
         // DEVELOPMENT_TEAM: `""`,
+        DEFINES_MODULE: '"YES"',
         BUILD_LIBRARY_FOR_DISTRIBUTION: '"YES"',
         USER_SCRIPT_SANDBOXING: '"NO"',
         SKIP_INSTALL: '"NO"',

--- a/packages/expo-brownfield/plugin/src/ios/utils/project.ts
+++ b/packages/expo-brownfield/plugin/src/ios/utils/project.ts
@@ -165,6 +165,7 @@ const getCommonBuildSettings = (
     SWIFT_OPTIMIZATION_LEVEL: `"-Onone"`,
     CODE_SIGN_ENTITLEMENTS: `"${targetName}/${targetName}.entitlements"`,
     // DEVELOPMENT_TEAM: `""`,
+    DEFINES_MODULE: '"YES"',
     BUILD_LIBRARY_FOR_DISTRIBUTION: '"YES"',
     USER_SCRIPT_SANDBOXING: '"NO"',
     SKIP_INSTALL: '"NO"',


### PR DESCRIPTION
# Why

Currently, the brownfield xcframework cannot be consumed by Objective-C. Without `DEFINES_MODULE = YES`, Xcode does not generate a Clang `module.modulemap` for the framework and the xcframework only ships with `.swiftmodule` interfaces.  

This causes: 
- `@import MyAppBrownfield;` to fail in ObjC files 
- `#import <MyAppBrownfield/MyAppBrownfield-Swift.h>` (the generated ObjC compatibility header) is not available

The brownfield `ExpoBrownfield.podspec` already sets `DEFINES_MODULE = YES` for the pod target, but this setting was missing from the framework target created by the config plugin.

# How

Added `DEFINES_MODULE: '"YES"'` to the framework target's common build settings in `project.ts`. With this flag, Xcode auto-generates a `module.modulemap` for each architecture slice during the build, which `xcodebuild -create-xcframework` then includes in both the simulator and device slices of the xcframework.

# Test Plan

- Run `npx expo prebuild` and build the brownfield xcframework
- Inspect the output: each slice should contain `Modules/module.modulemap` alongside the existing `Modules/<TargetName>.swiftmodule/`
- Import the xcframework from an ObjC file with `@import MyAppBrownfield;` n

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
