### PR TITLE
[ios][dev-launcher] Restore appBridge declaration on sdk-55

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Restore the `appBridge` declaration so SDK 55 dev builds compile again.
+
 ### 💡 Others
 
 ## 55.0.27 — 2026-04-10

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Restore the `appBridge` declaration so SDK 55 dev builds compile again.
+- [iOS] Restore the `appBridge` declaration so SDK 55 dev builds compile again. ([#44688](https://github.com/expo/expo/pull/44688) by [@KinanLak](https://github.com/KinanLak))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class EXDevLauncherRecentlyOpenedAppsRegistry;
 @class EXDevLauncherController;
 @class EXDevLauncherErrorManager;
+@class RCTBridge;
 
 @protocol EXDevLauncherControllerDelegate <NSObject>
 
@@ -42,6 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXDevLauncherController : RCTDefaultReactNativeFactoryDelegate <RCTBridgeDelegate, EXUpdatesExternalInterfaceDelegate>
 
 @property (nonatomic, weak) EXAppContext * _Nullable appContext;
+@property (nonatomic, strong) RCTBridge * _Nullable appBridge;
 @property (nonatomic, strong) EXDevLauncherPendingDeepLinkRegistry *pendingDeepLinkRegistry;
 @property (nonatomic, strong) EXDevLauncherRecentlyOpenedAppsRegistry *recentlyOpenedAppsRegistry;
 @property (nonatomic, strong) id<EXUpdatesDevLauncherInterface> updatesInterface;

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.h
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface EXDevLauncherController : RCTDefaultReactNativeFactoryDelegate <RCTBridgeDelegate, EXUpdatesExternalInterfaceDelegate>
 
 @property (nonatomic, weak) EXAppContext * _Nullable appContext;
-@property (nonatomic, strong) RCTBridge * _Nullable appBridge;
+@property (nonatomic, weak) RCTBridge * _Nullable appBridge;
 @property (nonatomic, strong) EXDevLauncherPendingDeepLinkRegistry *pendingDeepLinkRegistry;
 @property (nonatomic, strong) EXDevLauncherRecentlyOpenedAppsRegistry *recentlyOpenedAppsRegistry;
 @property (nonatomic, strong) id<EXUpdatesDevLauncherInterface> updatesInterface;


### PR DESCRIPTION
# Update

Fixed in https://github.com/expo/expo/pull/44609 (5.0.27)

# Why

`expo-dev-launcher` on the SDK 55 release line removed the `appBridge` property declaration from `EXDevLauncherController.h`, but `EXDevLauncherController.m` still references `self.appBridge` in `setDevMenuAppBridge`.

That causes iOS development builds to fail with:

```text
EXDevLauncherController.m:623:37: error: property 'appBridge' not found on object of type 'EXDevLauncherController *'
  [manager updateCurrentBridge:self.appBridge];
                                    ^
```

Fix related issues :
- #44677
- #44676
- #44675

# How

This restores the missing `appBridge` declaration in `packages/expo-dev-launcher/ios/EXDevLauncherController.h`.

I kept the fix minimal and aligned it with the existing implementation on the SDK 55 branch, which still uses `self.appBridge` in `EXDevLauncherController.m`.

I also added a changelog entry for `expo-dev-launcher`.

# Test Plan

Reproduced in a real SDK 55 iOS dev build failing with:

```text
EXDevLauncherController.m:623:37: error: property 'appBridge' not found on object of type 'EXDevLauncherController *'
```

Verified the published regression by comparing `expo-dev-launcher@55.0.25` and `55.0.26`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)