### PR TITLE
[ios][build] Fix PROJECT_ROOT in react-native-xcode.sh for pnpm isolated installs

### DIFF
--- a/packages/expo/scripts/react-native-xcode.sh
+++ b/packages/expo/scripts/react-native-xcode.sh
@@ -59,9 +59,12 @@ esac
 
 # Path to react-native folder inside node_modules
 REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-# The project should be located next to where react-native is installed
-# in node_modules.
-PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
+# Use Xcode's PROJECT_DIR (points to the ios/ directory) to derive the project
+# root. The previous approach of using REACT_NATIVE_DIR/../.. assumed a hoisted
+# node_modules layout, which breaks with package managers that use isolated
+# installs (e.g. pnpm without node-linker=hoisted), where the expo package
+# lives deep inside .pnpm/ store rather than at node_modules/expo/.
+PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/.."}
 
 cd "$PROJECT_ROOT" || exit
 


### PR DESCRIPTION
# Why

The `PROJECT_ROOT` derivation in `packages/expo/scripts/react-native-xcode.sh` breaks when using pnpm without `node-linker=hoisted` (isolated installs).

The current logic computes `PROJECT_ROOT` as `$REACT_NATIVE_DIR/../..`, which assumes the `expo` package is located at `node_modules/expo/`. In pnpm's default isolated mode, `expo` is installed deep inside `.pnpm/expo@<version>_.../node_modules/expo/`, so `../..` resolves to a path inside the `.pnpm` store instead of the project root.

This causes the Xcode "Bundle React Native code and images" build phase to fail with:

```
Unable to resolve module ./../../../.../build/apps/<app>/index from .../build/.:
```

This issue affects **all pnpm monorepo setups without `node-linker=hoisted`**, and the current workaround is setting `SKIP_BUNDLING=1` to skip the Xcode bundling phase entirely (relying on EAS Build's eager bundling).

The original script was copied from `react-native/scripts/react-native-xcode.sh` in #21397, which also uses the same `REACT_NATIVE_DIR/../..` approach — but upstream React Native's version lives at `node_modules/react-native/scripts/`, so two levels up lands at the project root in hoisted layouts. The Expo fork lives at `node_modules/expo/scripts/`, inheriting the same assumption.

# How

Use Xcode's `$PROJECT_DIR` environment variable instead of `$REACT_NATIVE_DIR/../..` to derive `PROJECT_ROOT`:

```bash
# Before
PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}

# After
PROJECT_ROOT=${PROJECT_ROOT:-"$PROJECT_DIR/.."}
```

`$PROJECT_DIR` is set by Xcode to the directory containing the `.xcodeproj` file (typically the `ios/` directory), so `$PROJECT_DIR/..` always resolves to the correct project root regardless of the package manager's `node_modules` layout.

This approach is backward-compatible:
- **hoisted installs (npm, yarn, pnpm with `node-linker=hoisted`)**: `$PROJECT_DIR/..` resolves identically to the previous `$REACT_NATIVE_DIR/../..`
- **isolated installs (pnpm default)**: `$PROJECT_DIR/..` resolves correctly, fixing the broken path
- **custom `PROJECT_ROOT`**: still respected via the `${PROJECT_ROOT:-...}` fallback syntax

# Test Plan

Tested with:
- Expo SDK 55, React Native 0.83.4
- pnpm monorepo with `pnpm-workspace.yaml` (`apps/*` + `packages/*`)
- `nodeLinker: hoisted` in `pnpm-workspace.yaml`
- EAS local build (`eas build --local --platform ios --profile preview`)
- Without `expo-dev-client` installed
- Without `SKIP_BUNDLING` set

Build succeeded with the fix applied. Without the fix, the same configuration fails at the "Bundle React Native code and images" Xcode build phase.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to this short guide
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)