### PR TITLE
[core][ui] allow derived ComposableScope

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [iOS] Remove legacy `EXNativeModulesProxy` ([#42672](https://github.com/expo/expo/pull/42672) by [@tsapeta](https://github.com/tsapeta))
 - Exclude ExpoModulesMacros.swift from SPM prebuild ([#44354](https://github.com/expo/expo/pull/44354) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Remove legacy `ExpoBridgeModule` ([#44351](https://github.com/expo/expo/pull/44351) by [@tsapeta](https://github.com/tsapeta))
+- Refactored `ComposableScope` and allow extensibility. ([#44698](https://github.com/expo/expo/pull/44698) by [@kudo](https://github.com/kudo))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -4,16 +4,12 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
-import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.RecomposeScope
 import androidx.compose.runtime.currentRecomposeScope
 import androidx.compose.runtime.key
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.size
@@ -23,34 +19,22 @@ import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.viewevent.ViewEvent
 import expo.modules.kotlin.viewevent.ViewEventDelegate
 
-data class ComposableScope(
-  val rowScope: RowScope? = null,
-  val columnScope: ColumnScope? = null,
-  val boxScope: BoxScope? = null,
-  val nestedScrollConnection: NestedScrollConnection? = null
-)
+/**
+ * A scope interface passed through the compose view hierarchy.
+ * Downstream packages (e.g. expo-ui) can implement this interface
+ * to provide strongly-typed layout and context properties.
+ */
+interface ComposableScope
 
-inline fun ComposableScope.withIf(
+private object EmptyComposableScope : ComposableScope
+
+fun ComposableScope(): ComposableScope = EmptyComposableScope
+
+inline fun <T : ComposableScope> T.withIf(
   condition: Boolean,
-  block: ComposableScope.() -> ComposableScope
-): ComposableScope {
+  block: T.() -> T
+): T {
   return if (condition) block() else this
-}
-
-fun ComposableScope.with(rowScope: RowScope?): ComposableScope {
-  return this.copy(rowScope = rowScope)
-}
-
-fun ComposableScope.with(columnScope: ColumnScope?): ComposableScope {
-  return this.copy(columnScope = columnScope)
-}
-
-fun ComposableScope.with(boxScope: BoxScope?): ComposableScope {
-  return this.copy(boxScope = boxScope)
-}
-
-fun ComposableScope.with(nestedScrollConnection: NestedScrollConnection?): ComposableScope {
-  return this.copy(nestedScrollConnection = nestedScrollConnection)
 }
 
 /**

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -82,6 +82,7 @@
 - [iOS] Introduce `SlotView` to replace structural child view types with a single generic slot. ([#43607](https://github.com/expo/expo/pull/43607) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Make RNHostView SwiftUI view ([#43570](https://github.com/expo/expo/pull/43570) by [@nishan](https://github.com/intergalacticspacehighway))
 - [jetpack-compose] Use view hash code as key for `Children`. ([#44521](https://github.com/expo/expo/pull/44521) by [@kudo](https://github.com/kudo))
+- Refactored `ComposableScope` and allow extensibility. ([#44698](https://github.com/expo/expo/pull/44698) by [@kudo](https://github.com/kudo))
 
 ## 55.0.1 — 2026-02-25
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/AnimatedVisibilityView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/AnimatedVisibilityView.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -125,6 +124,6 @@ fun FunctionalComposableScope.AnimatedVisibilityContent(props: AnimatedVisibilit
     modifier = ModifierRegistry
       .applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BadgeView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BadgeView.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.layout
 import androidx.compose.ui.unit.dp
 import androidx.core.view.size
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -36,7 +35,7 @@ fun FunctionalComposableScope.BadgeContent(props: BadgeProps) {
         modifier = Modifier.ensureBadgeContentCircular(),
         contentAlignment = Alignment.Center
       ) {
-        Children(ComposableScope())
+        Children(UIComposableScope())
       }
     }
   } else {

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BadgedBoxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BadgedBoxView.kt
@@ -3,7 +3,6 @@ package expo.modules.ui
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
 import androidx.compose.runtime.Composable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -19,6 +18,6 @@ fun FunctionalComposableScope.BadgedBoxContent(props: BadgedBoxProps) {
     badge = { badgeSlot?.renderSlot() ?: Badge() },
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope()) { !isSlotView(it) }
+    Children(UIComposableScope()) { !isSlotView(it) }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BasicAlertDialogView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BasicAlertDialogView.kt
@@ -4,7 +4,6 @@ import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.window.DialogProperties
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -29,6 +28,6 @@ fun FunctionalComposableScope.BasicAlertDialogContent(
       decorFitsSystemWindows = props.properties.decorFitsSystemWindows
     )
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -88,7 +88,7 @@ class ModalBottomSheetView(context: Context, appContext: AppContext) :
       sheetGesturesEnabled = props.sheetGesturesEnabled.value,
       dragHandle = when {
         dragHandleSlotView != null -> {
-          { with(ComposableScope()) { with(dragHandleSlotView) { Content() } } }
+          { with(UIComposableScope()) { with(dragHandleSlotView) { Content() } } }
         }
         props.showDragHandle.value -> {
           { BottomSheetDefaults.DragHandle() }
@@ -101,7 +101,7 @@ class ModalBottomSheetView(context: Context, appContext: AppContext) :
       ),
       modifier = ModifierRegistry.applyModifiers(props.modifiers.value, appContext, this@Content, globalEventDispatcher)
     ) {
-      Children(ComposableScope(), filter = { !isSlotView(it) })
+      Children(UIComposableScope(), filter = { !isSlotView(it) })
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CardView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CardView.kt
@@ -11,10 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
-import expo.modules.kotlin.views.with
 
 data class CardColors(
   @Field val containerColor: Color? = null,
@@ -65,7 +63,7 @@ fun FunctionalComposableScope.CardContent(props: CardProps) {
   }
 
   val content: @Composable ColumnScope.() -> Unit = {
-    val scope = ComposableScope().with(columnScope = this)
+    val scope = UIComposableScope(columnScope = this)
     Children(scope)
   }
 
@@ -107,7 +105,7 @@ fun FunctionalComposableScope.ElevatedCardContent(props: ElevatedCardProps) {
   }
 
   val content: @Composable ColumnScope.() -> Unit = {
-    val scope = ComposableScope().with(columnScope = this)
+    val scope = UIComposableScope(columnScope = this)
     Children(scope)
   }
 
@@ -160,7 +158,7 @@ fun FunctionalComposableScope.OutlinedCardContent(props: OutlinedCardProps) {
   }
 
   val content: @Composable ColumnScope.() -> Unit = {
-    val scope = ComposableScope().with(columnScope = this)
+    val scope = UIComposableScope(columnScope = this)
     Children(scope)
   }
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CarouselView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CarouselView.kt
@@ -16,7 +16,6 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -88,7 +87,7 @@ fun FunctionalComposableScope.HorizontalCenteredHeroCarouselContent(props: Horiz
     maxSmallItemWidth = maxSmallItemWidth,
     contentPadding = contentPadding
   ) { itemIndex ->
-    Child(ComposableScope(), itemIndex)
+    Child(UIComposableScope(), itemIndex)
   }
 }
 
@@ -127,7 +126,7 @@ fun FunctionalComposableScope.HorizontalMultiBrowseCarouselContent(props: Horizo
     maxSmallItemWidth = maxSmallItemWidth,
     contentPadding = contentPadding
   ) { itemIndex ->
-    Child(ComposableScope(), itemIndex)
+    Child(UIComposableScope(), itemIndex)
   }
 }
 
@@ -160,6 +159,6 @@ fun FunctionalComposableScope.HorizontalUncontainedCarouselContent(props: Horizo
     userScrollEnabled = props.userScrollEnabled ?: true,
     contentPadding = contentPadding
   ) { itemIndex ->
-    Child(ComposableScope(), itemIndex)
+    Child(UIComposableScope(), itemIndex)
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ChipView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ChipView.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.graphics.Color as ComposeColor
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
@@ -65,7 +64,7 @@ class ChipBorder : Record {
 private fun FunctionalComposableScope.slotContent(slotName: String): (@Composable () -> Unit)? {
   return findChildSlotView(view, slotName)?.let { slotView ->
     {
-      with(ComposableScope()) {
+      with(UIComposableScope()) {
         with(slotView) {
           Content()
         }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ComposeViews.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ComposeViews.kt
@@ -16,11 +16,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
-import expo.modules.kotlin.views.with
-import expo.modules.kotlin.views.withIf
 import expo.modules.ui.convertibles.HorizontalAlignment
 import expo.modules.ui.convertibles.HorizontalArrangement
 import expo.modules.ui.convertibles.VerticalAlignment
@@ -68,12 +65,7 @@ internal fun FunctionalComposableScope.RowContent(props: LayoutProps) {
       .applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
       .then(if (scrollBehavior != null) Modifier.nestedScroll(scrollBehavior) else Modifier)
   ) {
-    val scope = ComposableScope()
-      .with(rowScope = this@Row)
-      .withIf(scrollBehavior != null) {
-        with(nestedScrollConnection = scrollBehavior)
-      }
-    Children(scope)
+    Children(UIComposableScope(rowScope = this@Row, nestedScrollConnection = scrollBehavior))
   }
 }
 
@@ -85,9 +77,7 @@ internal fun FunctionalComposableScope.FlowRowContent(props: LayoutProps) {
     modifier = ModifierRegistry
       .applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    val scope = ComposableScope()
-      .with(rowScope = this@FlowRow)
-    Children(scope)
+    Children(UIComposableScope(rowScope = this@FlowRow))
   }
 }
 
@@ -105,12 +95,7 @@ internal fun FunctionalComposableScope.ColumnContent(props: LayoutProps) {
       .applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
       .then(if (scrollBehavior != null) Modifier.nestedScroll(scrollBehavior) else Modifier)
   ) {
-    val scope = ComposableScope()
-      .with(columnScope = this@Column)
-      .withIf(scrollBehavior != null) {
-        with(nestedScrollConnection = scrollBehavior)
-      }
-    Children(scope)
+    Children(UIComposableScope(columnScope = this@Column, nestedScrollConnection = scrollBehavior))
   }
 }
 
@@ -127,11 +112,6 @@ fun FunctionalComposableScope.BoxContent(props: LayoutProps) {
       .applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
       .then(if (scrollBehavior != null) Modifier.nestedScroll(scrollBehavior) else Modifier)
   ) {
-    val scope = ComposableScope()
-      .with(boxScope = this@Box)
-      .withIf(scrollBehavior != null) {
-        with(nestedScrollConnection = scrollBehavior)
-      }
-    Children(scope)
+    Children(UIComposableScope(boxScope = this@Box, nestedScrollConnection = scrollBehavior))
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DockedSearchBarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DockedSearchBarView.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.snapshotFlow
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -41,10 +40,10 @@ fun FunctionalComposableScope.DockedSearchBarContent(
         textFieldState = textFieldState,
         onSearch = {},
         placeholder = {
-          Children(ComposableScope(), filter = { isSlotWithName(it, "placeholder") })
+          Children(UIComposableScope(), filter = { isSlotWithName(it, "placeholder") })
         },
         leadingIcon = {
-          Children(ComposableScope(), filter = { isSlotWithName(it, "leadingIcon") })
+          Children(UIComposableScope(), filter = { isSlotWithName(it, "leadingIcon") })
         }
       )
     },

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HorizontalFloatingToolbarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HorizontalFloatingToolbarView.kt
@@ -8,7 +8,6 @@ import androidx.compose.material3.FloatingToolbarScrollBehavior
 import androidx.compose.material3.HorizontalFloatingToolbar
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -41,11 +40,11 @@ fun FunctionalComposableScope.HorizontalFloatingToolbarContent(props: Horizontal
       HorizontalFloatingToolbarVariant.VIBRANT -> FloatingToolbarDefaults.VibrantFloatingActionButton(
         onClick = fabOnClick
       ) {
-        Children(ComposableScope(), filter = { isSlotWithName(it, "floatingActionButton") })
+        Children(UIComposableScope(), filter = { isSlotWithName(it, "floatingActionButton") })
       }
 
       else -> FloatingToolbarDefaults.StandardFloatingActionButton(onClick = fabOnClick) {
-        Children(ComposableScope(), filter = { isSlotWithName(it, "floatingActionButton") })
+        Children(UIComposableScope(), filter = { isSlotWithName(it, "floatingActionButton") })
       }
     }
   }
@@ -61,7 +60,7 @@ fun FunctionalComposableScope.HorizontalFloatingToolbarContent(props: Horizontal
       scrollBehavior = scrollBehavior,
       modifier = modifier,
     ) {
-      Children(ComposableScope(), filter = { !isSlotView(it) })
+      Children(UIComposableScope(), filter = { !isSlotView(it) })
     }
   } else {
     HorizontalFloatingToolbar(
@@ -70,7 +69,7 @@ fun FunctionalComposableScope.HorizontalFloatingToolbarContent(props: Horizontal
       scrollBehavior = scrollBehavior,
       modifier = modifier,
     ) {
-      Children(ComposableScope(), filter = { !isSlotView(it) })
+      Children(UIComposableScope(), filter = { !isSlotView(it) })
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ListItemView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ListItemView.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -57,7 +56,7 @@ fun FunctionalComposableScope.ListItemContent(props: ListItemProps) {
   ListItem(
     headlineContent = {
       headlineSlotView?.let {
-        with(ComposableScope()) {
+        with(UIComposableScope()) {
           with(it) { Content() }
         }
       }
@@ -65,28 +64,28 @@ fun FunctionalComposableScope.ListItemContent(props: ListItemProps) {
     modifier = modifier,
     overlineContent = overlineSlotView?.let {
       {
-        with(ComposableScope()) {
+        with(UIComposableScope()) {
           with(it) { Content() }
         }
       }
     },
     supportingContent = supportingSlotView?.let {
       {
-        with(ComposableScope()) {
+        with(UIComposableScope()) {
           with(it) { Content() }
         }
       }
     },
     leadingContent = leadingSlotView?.let {
       {
-        with(ComposableScope()) {
+        with(UIComposableScope()) {
           with(it) { Content() }
         }
       }
     },
     trailingContent = trailingSlotView?.let {
       {
-        with(ComposableScope()) {
+        with(UIComposableScope()) {
           with(it) { Content() }
         }
       }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PullToRefreshBoxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PullToRefreshBoxView.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.records.Field
@@ -52,6 +51,6 @@ fun FunctionalComposableScope.PullToRefreshBoxContent(props: PullToRefreshBoxPro
     },
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SearchBarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SearchBarView.kt
@@ -9,7 +9,6 @@ import androidx.compose.material3.SearchBar
 import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -29,7 +28,7 @@ fun FunctionalComposableScope.SearchBarContent(props: SearchBarProps, onSearch: 
         textFieldState = textFieldState,
         onSearch = { value -> onSearch.invoke(GenericEventPayload1(value)) },
         placeholder = {
-          Children(ComposableScope(), filter = { isSlotWithName(it, "placeholder") })
+          Children(UIComposableScope(), filter = { isSlotWithName(it, "placeholder") })
         }
       )
     }
@@ -45,13 +44,13 @@ fun FunctionalComposableScope.SearchBarContent(props: SearchBarProps, onSearch: 
       state = searchBarState,
       inputField = inputField
     ) {
-      ExpandedFullScreenSearchBarView(ComposableScope(), slotView)
+      ExpandedFullScreenSearchBarView(UIComposableScope(), slotView)
     }
   }
 }
 
 @Composable
-private fun ExpandedFullScreenSearchBarView(composableScope: ComposableScope, view: SlotView) {
+private fun ExpandedFullScreenSearchBarView(composableScope: UIComposableScope, view: SlotView) {
   with(composableScope) {
     with(view) {
       Content()

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedButtonView.kt
@@ -10,7 +10,6 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRowScope
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
@@ -69,7 +68,7 @@ fun FunctionalComposableScope.SegmentedButtonContent(
   val modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   val label: @Composable () -> Unit = labelSlotView?.let {
     {
-      with(ComposableScope()) {
+      with(UIComposableScope()) {
         with(it) {
           Content()
         }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedControlView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedControlView.kt
@@ -3,10 +3,8 @@ package expo.modules.ui
 import androidx.compose.material3.MultiChoiceSegmentedButtonRow
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.runtime.Composable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
-import expo.modules.kotlin.views.with
 
 data class SingleChoiceSegmentedButtonRowProps(
   val modifiers: ModifierList = emptyList()
@@ -17,7 +15,7 @@ fun FunctionalComposableScope.SingleChoiceSegmentedButtonRowContent(props: Singl
   SingleChoiceSegmentedButtonRow(
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope().with(rowScope = this@SingleChoiceSegmentedButtonRow))
+    Children(UIComposableScope(rowScope = this@SingleChoiceSegmentedButtonRow))
   }
 }
 
@@ -30,6 +28,6 @@ fun FunctionalComposableScope.MultiChoiceSegmentedButtonRowContent(props: MultiC
   MultiChoiceSegmentedButtonRow(
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope().with(rowScope = this@MultiChoiceSegmentedButtonRow))
+    Children(UIComposableScope(rowScope = this@MultiChoiceSegmentedButtonRow))
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
@@ -14,7 +14,6 @@ import androidx.compose.runtime.setValue
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.viewevent.getValue
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -97,7 +96,7 @@ fun FunctionalComposableScope.SliderContent(props: SliderProps) {
     colors = sliderColors,
     thumb = { sliderState ->
       if (thumbSlotView != null) {
-        with(ComposableScope()) { with(thumbSlotView) { Content() } }
+        with(UIComposableScope()) { with(thumbSlotView) { Content() } }
       } else {
         SliderDefaults.Thumb(
           interactionSource = interactionSource,
@@ -108,7 +107,7 @@ fun FunctionalComposableScope.SliderContent(props: SliderProps) {
     },
     track = { sliderState ->
       if (trackSlotView != null) {
-        with(ComposableScope()) { with(trackSlotView) { Content() } }
+        with(UIComposableScope()) { with(trackSlotView) { Content() } }
       } else {
         SliderDefaults.Track(
           sliderState = sliderState,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SlotView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SlotView.kt
@@ -39,7 +39,7 @@ class SlotView(context: Context, appContext: AppContext) :
  */
 @Composable
 fun SlotView.renderSlot() {
-  with(ComposableScope()) { with(this@renderSlot) { Content() } }
+  with(UIComposableScope()) { with(this@renderSlot) { Content() } }
 }
 
 fun isSlotWithName(view: ExpoComposeView<*>, slotName: String): Boolean {

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SurfaceView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SurfaceView.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -54,7 +53,7 @@ fun FunctionalComposableScope.SurfaceContent(
     }
   }
 
-  val content: @Composable () -> Unit = { Children(ComposableScope()) }
+  val content: @Composable () -> Unit = { Children(UIComposableScope()) }
 
   when {
     // Toggleable variant

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
@@ -55,7 +54,7 @@ fun FunctionalComposableScope.SwitchContent(
     enabled = props.enabled,
     thumbContent = thumbContentSlotView?.let {
       {
-        with(ComposableScope()) {
+        with(UIComposableScope()) {
           with(it) {
             Content()
           }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ToggleButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ToggleButtonView.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.ToggleButtonDefaults
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 
@@ -57,7 +56,7 @@ fun FunctionalComposableScope.ToggleButtonContent(
       disabledContentColor = props.colors.disabledContentColor.compose
     )
   ) {
-    Children(ComposableScope(rowScope = this))
+    Children(UIComposableScope(rowScope = this))
   }
 }
 
@@ -81,7 +80,7 @@ fun FunctionalComposableScope.IconToggleButtonContent(
       disabledContentColor = props.colors.disabledContentColor.compose
     )
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }
 
@@ -105,7 +104,7 @@ fun FunctionalComposableScope.FilledIconToggleButtonContent(
       disabledContentColor = props.colors.disabledContentColor.compose
     )
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }
 
@@ -129,6 +128,6 @@ fun FunctionalComposableScope.OutlinedIconToggleButtonContent(
       disabledContentColor = props.colors.disabledContentColor.compose
     )
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TooltipView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TooltipView.kt
@@ -141,7 +141,7 @@ class TooltipBoxView(context: Context, appContext: AppContext) :
               ?: TooltipDefaults.plainTooltipContentColor,
             modifier = ModifierRegistry.applyModifiers(plainTooltipView.props.modifiers.value, appContext, this@Content, globalEventDispatcher)
           ) {
-            with(ComposableScope()) { with(plainTooltipView) { Content() } }
+            with(UIComposableScope()) { with(plainTooltipView) { Content() } }
           }
         } else if (richTooltipView != null) {
           val titleSlotView = findChildSlotView(richTooltipView, "title")
@@ -170,7 +170,7 @@ class TooltipBoxView(context: Context, appContext: AppContext) :
       state = tooltipState,
       modifier = ModifierRegistry.applyModifiers(props.modifiers.value, appContext, this@Content, globalEventDispatcher)
     ) {
-      Children(ComposableScope(), filter = { !isSlotView(it) })
+      Children(UIComposableScope(), filter = { !isSlotView(it) })
     }
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/UIComposableScope.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/UIComposableScope.kt
@@ -1,0 +1,26 @@
+package expo.modules.ui
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import expo.modules.kotlin.views.ComposableScope
+
+data class UIComposableScope(
+  val rowScope: RowScope? = null,
+  val columnScope: ColumnScope? = null,
+  val boxScope: BoxScope? = null,
+  val nestedScrollConnection: NestedScrollConnection? = null
+) : ComposableScope
+
+val ComposableScope.rowScope: RowScope?
+  get() = (this as? UIComposableScope)?.rowScope
+
+val ComposableScope.columnScope: ColumnScope?
+  get() = (this as? UIComposableScope)?.columnScope
+
+val ComposableScope.boxScope: BoxScope?
+  get() = (this as? UIComposableScope)?.boxScope
+
+val ComposableScope.nestedScrollConnection: NestedScrollConnection?
+  get() = (this as? UIComposableScope)?.nestedScrollConnection

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
@@ -11,8 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
+import expo.modules.ui.UIComposableScope
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
@@ -71,7 +71,7 @@ fun FunctionalComposableScope.ButtonContent(
     shape = shapeFromShapeRecord(props.shape) ?: ButtonDefaults.shape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope(rowScope = this))
+    Children(UIComposableScope(rowScope = this))
   }
 }
 
@@ -93,7 +93,7 @@ fun FunctionalComposableScope.FilledTonalButtonContent(
     shape = shapeFromShapeRecord(props.shape) ?: ButtonDefaults.filledTonalShape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope(rowScope = this))
+    Children(UIComposableScope(rowScope = this))
   }
 }
 
@@ -115,7 +115,7 @@ fun FunctionalComposableScope.OutlinedButtonContent(
     shape = shapeFromShapeRecord(props.shape) ?: ButtonDefaults.outlinedShape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope(rowScope = this))
+    Children(UIComposableScope(rowScope = this))
   }
 }
 
@@ -137,7 +137,7 @@ fun FunctionalComposableScope.ElevatedButtonContent(
     shape = shapeFromShapeRecord(props.shape) ?: ButtonDefaults.elevatedShape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope(rowScope = this))
+    Children(UIComposableScope(rowScope = this))
   }
 }
 
@@ -159,6 +159,6 @@ fun FunctionalComposableScope.TextButtonContent(
     shape = shapeFromShapeRecord(props.shape) ?: ButtonDefaults.textShape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope(rowScope = this))
+    Children(UIComposableScope(rowScope = this))
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/FloatingActionButton.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/FloatingActionButton.kt
@@ -8,8 +8,8 @@ import androidx.compose.material3.LargeFloatingActionButton
 import androidx.compose.material3.SmallFloatingActionButton
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.types.Enumerable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
+import expo.modules.ui.UIComposableScope
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
@@ -41,7 +41,7 @@ fun FunctionalComposableScope.FloatingActionButtonContent(
   val iconSlotView = findChildSlotView(view, "icon")
   val iconContent: (@Composable () -> Unit) = iconSlotView?.let {
     {
-      with(ComposableScope()) {
+      with(UIComposableScope()) {
         with(it) {
           Content()
         }
@@ -66,7 +66,7 @@ fun FunctionalComposableScope.FloatingActionButtonContent(
       val textSlotView = findChildSlotView(view, "text")
       val textContent: (@Composable () -> Unit) = textSlotView?.let {
         {
-          with(ComposableScope()) {
+          with(UIComposableScope()) {
             with(it) {
               Content()
             }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/IconButton.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/IconButton.kt
@@ -6,8 +6,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.runtime.Composable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.ui.UIComposableScope
 import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.compose
 import expo.modules.ui.shapeFromShapeRecord
@@ -30,7 +30,7 @@ fun FunctionalComposableScope.IconButtonContent(
     shape = shape ?: IconButtonDefaults.standardShape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }
 
@@ -52,7 +52,7 @@ fun FunctionalComposableScope.FilledIconButtonContent(
     shape = shape ?: IconButtonDefaults.filledShape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }
 
@@ -74,7 +74,7 @@ fun FunctionalComposableScope.FilledTonalIconButtonContent(
     shape = shape ?: IconButtonDefaults.filledShape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }
 
@@ -96,6 +96,6 @@ fun FunctionalComposableScope.OutlinedIconButtonContent(
     shape = shape ?: IconButtonDefaults.outlinedShape,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)
   ) {
-    Children(ComposableScope())
+    Children(UIComposableScope())
   }
 }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenu.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenu.kt
@@ -4,8 +4,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.MenuDefaults
 import androidx.compose.runtime.Composable
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.ui.UIComposableScope
 import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.composeOrNull
 import expo.modules.ui.findChildSlotView
@@ -20,7 +20,7 @@ fun FunctionalComposableScope.DropdownMenuContent(
 
   Box(modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher)) {
     // Trigger - non-items children
-    Children(ComposableScope(), filter = { !isSlotView(it) })
+    Children(UIComposableScope(), filter = { !isSlotView(it) })
 
     DropdownMenu(
       containerColor = props.color?.composeOrNull ?: MenuDefaults.containerColor,
@@ -28,7 +28,7 @@ fun FunctionalComposableScope.DropdownMenuContent(
       onDismissRequest = onDismissRequest
     ) {
       itemsSlotView?.let {
-        with(ComposableScope()) {
+        with(UIComposableScope()) {
           with(it) {
             Content()
           }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuItem.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuItem.kt
@@ -7,8 +7,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
+import expo.modules.ui.UIComposableScope
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
@@ -46,7 +46,7 @@ fun FunctionalComposableScope.DropdownMenuItemContent(
   val defaultColors = MenuDefaults.itemColors()
 
   DropdownMenuItem(
-    text = { textSlotView?.let { with(ComposableScope()) { with(it) { Content() } } } ?: Unit },
+    text = { textSlotView?.let { with(UIComposableScope()) { with(it) { Content() } } } ?: Unit },
     enabled = props.enabled,
     modifier = ModifierRegistry.applyModifiers(props.modifiers, appContext, composableScope, globalEventDispatcher),
     colors = MenuDefaults.itemColors(
@@ -58,10 +58,10 @@ fun FunctionalComposableScope.DropdownMenuItemContent(
       disabledTrailingIconColor = colors.disabledTrailingIconColor.composeOrNull ?: defaultColors.disabledTrailingIconColor
     ),
     leadingIcon = leadingSlotView?.let {
-      { with(ComposableScope()) { with(it) { Content() } } }
+      { with(UIComposableScope()) { with(it) { Content() } } }
     },
     trailingIcon = trailingSlotView?.let {
-      { with(ComposableScope()) { with(it) { Content() } } }
+      { with(UIComposableScope()) { with(it) { Content() } } }
     },
     onClick = {
       onItemPressed(ItemPressedEvent())


### PR DESCRIPTION
# Why

for #44201 to support new composable scope

# How

- [core] turn `ComposableScope` as interface and allow derived class to extend the properties
- [ui] move `rowScope` / `columnScope` / `boxScope` / `nestedScrollConnection` into the new UIComposableScope

# Test Plan

NCL jetpack compose

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
