### PR TITLE
[expo-cli][android] Handle insufficient storage error during APK install

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Fix `react-native-web` install check being unconditional ([#44450](https://github.com/expo/expo/pull/44450) by [@kitten](https://github.com/kitten))
 - Fix mangled async chunk filenames for catch-all routes ([#43547](https://github.com/expo/expo/pull/43547) by [@hassankhan](https://github.com/hassankhan))
 - Consistently resolve `mainModuleName`s using `convertEntryPointToRelative` and fix relative path semantics of `--entry-file` argumnts, which was previously expected to be relative to the server root rather than the project root. This fixes build issues when using export commands for projects in monorepos on Windows ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
+- Handle `INSTALL_FAILED_INSUFFICIENT_STORAGE` error in `installAsync` ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@jairejustin](https://github.com/jairejustin))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -33,7 +33,7 @@
 - Fix `react-native-web` install check being unconditional ([#44450](https://github.com/expo/expo/pull/44450) by [@kitten](https://github.com/kitten))
 - Fix mangled async chunk filenames for catch-all routes ([#43547](https://github.com/expo/expo/pull/43547) by [@hassankhan](https://github.com/hassankhan))
 - Consistently resolve `mainModuleName`s using `convertEntryPointToRelative` and fix relative path semantics of `--entry-file` argumnts, which was previously expected to be relative to the server root rather than the project root. This fixes build issues when using export commands for projects in monorepos on Windows ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
-- Handle `INSTALL_FAILED_INSUFFICIENT_STORAGE` error in `installAsync` ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@jairejustin](https://github.com/jairejustin))
+- Handle `INSTALL_FAILED_INSUFFICIENT_STORAGE` error in `installAsync` ([#44702](https://github.com/expo/expo/pull/44702) by [@jairejustin](https://github.com/jairejustin))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -12,6 +12,7 @@ import {
   launchActivityAsync,
   sanitizeAdbDeviceName,
   openUrlAsync,
+  installAsync
 } from '../adb';
 
 jest.mock('../ADBServer', () => ({
@@ -384,5 +385,34 @@ describe(sanitizeAdbDeviceName, () => {
 
   it(`returns the avd device name from multi line with CR`, () => {
     expect(sanitizeAdbDeviceName(`Pixel_6_API_31\rOK`)).toBe('Pixel_6_API_31');
+  });
+});
+
+describe(installAsync, () => {
+  it(`installs an apk to the specified device`, async () => {
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce('Success');
+
+    await installAsync(device, { filePath: '/path/to/build.apk' });
+
+    expect(getServer().runAsync).toHaveBeenCalledWith([
+      '-s',
+      '123',
+      'install',
+      '-r',
+      '-d',
+      '--user',
+      expect.any(String),
+      '/path/to/build.apk',
+    ]);
+  });
+
+  it(`throws a CommandError when storage is insufficient`, async () => {
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce(
+      'Performing Streamed Install\nFailure [INSTALL_FAILED_INSUFFICIENT_STORAGE]'
+    );
+
+    await expect(
+      installAsync(device, { filePath: '/path/to/build.apk' })
+    ).rejects.toThrow(CommandError);
   });
 });

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -193,10 +193,18 @@ export async function getPackageInfoAsync(
 
 /** Install an app on a connected device. */
 export async function installAsync(device: DeviceContext, { filePath }: { filePath: string }) {
-  // TODO: Handle the `INSTALL_FAILED_INSUFFICIENT_STORAGE` error.
-  return await getServer().runAsync(
+  const result = await getServer().runAsync(
     adbArgs(device.pid, 'install', '-r', '-d', '--user', env.EXPO_ADB_USER, filePath)
   );
+
+  if (result.includes('INSTALL_FAILED_INSUFFICIENT_STORAGE')) {
+    throw new CommandError(
+      'INSUFFICIENT_STORAGE',
+      `Failed to install the app on the device (${device.pid}) because there is not enough storage space. Please free up some space and try again.`
+    );
+  }
+
+  return result;
 }
 
 /** Format ADB args with process ID. */


### PR DESCRIPTION
# Why
- There is an existing `TODO: Handle the INSTALL_FAILED_INSUFFICIENT_STORAGE error` comment in the `installAsync` function with no implementation.
- The `installAsync` function has no unit test coverage.

# How
- In `installAsync`, added a check on the resolved output of `getServer().runAsync`. Looking at how `openAsync` is implemented in the same file, ADB prints failures in stdout rather than throwing exceptions. So instead of a try-catch, the resolved string is inspected and a `CommandError` with a descriptive message is thrown when insufficient storage is detected.
- Added unit tests in `adb-test.ts` covering:
  - Successful installation - asserts the appropriate ADB arguments are passed.
  - Insufficient storage - mocks the ADB resolved output string and asserts a `CommandError` is thrown.

# Test Plan
- Run `pnpm test adb` inside the `packages/@expo/cli` directory.
- Verify that the new `installAsync` test suite passes, asserting both the command arguments and the storage error handling.

# Checklist
- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)