### PR TITLE
internal(cli): Improve debug logging throughput

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -51,6 +51,7 @@
 - Update to `fetch-nodeshim@^0.4.10` ([#44588](https://github.com/expo/expo/pull/44588) by [@kitten](https://github.com/kitten))
 - Update to `dnssd-advertise@^1.1.4` ([#44589](https://github.com/expo/expo/pull/44589) by [@kitten](https://github.com/kitten))
 - Update to `multitars@^1.0.0` ([#44774](https://github.com/expo/expo/pull/44774) by [@kitten](https://github.com/kitten))
+- [Internal] Improve performance of internal debug logging ([#44706](https://github.com/expo/expo/pull/44706) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/CLAUDE.md
+++ b/packages/@expo/cli/CLAUDE.md
@@ -85,6 +85,7 @@ CLI tool for all Expo projects. The public interface should be lean, all command
 Read additional resource files:
 
 - ./docs/testing.md - Anything related to testing
+- ./docs/events.md - Anything related to event logging
 
 ## Windows
 
@@ -149,32 +150,7 @@ debug('hello');
 ```
 
 **New debugging system:**
-Newer modules use the `events` helper from `src/events/index.ts` to define structured events in JSON format.
-
-```ts
-export const event = events('metro', (t) => [
-  t.event<'example:start', {
-    value: string;
-  }>(),
-]);
-
-event('metro:example:start', { value: 'hello' });
-```
-
-The `events` function accepts a category name and a function that is used to define the event types, but never called.
-When setting `LOG_EVENTS=1` JSONL events will be logged to the standard output, or with `LOG_EVENTS=events.log` events will log to an events.log file.
-This is a faster events system than `debug`, captures structured JSON events, and is scalable, and can be used in any module to add richer debug output.
-
-When creatin a nwe events category, add the `event` function it returns to the `Events` type in `src/events/types.ts` to collect all the events' types in one place:
-
-```
-// Add a new import:
-import type { event as myNewEvent } from '...';
-
-export type Events = collectEventLoggers<[
-  typeof myNewEvent, // Add the imported new event function here
-]>;
-```
+Newer modules use the `events` helper from `src/events` as documented in `./docs/events.md` to define structured events in JSON format.
 
 ## Production
 

--- a/packages/@expo/cli/docs/events.md
+++ b/packages/@expo/cli/docs/events.md
@@ -1,0 +1,88 @@
+# `src/events/` — Structured JSONL Event Logger
+
+Structured JSONL logging for Expo CLI, activated via the `LOG_EVENTS` environment variable. Streams events to a file or file descriptor for automated tooling, debugging, and session documentation.
+
+## Activation
+
+```bash
+LOG_EVENTS=events.jsonl npx expo start    # Write to file
+LOG_EVENTS=1 npx expo start               # Write to stdout (redirects console to stderr)
+LOG_EVENTS=2 npx expo start               # Write to stderr (redirects console to stdout)
+```
+
+## Defining events
+
+Create a typed event logger with `events(category, typeDefinition)`:
+
+```ts
+import { events } from '../events';
+
+export const event = events('my_module', (t) => [
+  t.event<'something_started', {
+    platform: string;
+  }>(),
+  t.event<'something_finished', {
+    platform: string;
+    duration: number;
+  }>(),
+]);
+```
+
+The type definition callback is never called at runtime — it exists purely for TypeScript inference. Event names and payloads are fully type-checked.
+
+Payload fields must not use `_e` or `_t` — these are reserved for the event name and timestamp.
+
+## Emitting events
+
+```ts
+event('something_started', { platform: 'ios' });
+
+// event names and payloads are type-checked:
+event('something_started', { wrong: true }); // TS error
+event('nonexistent', {});                     // TS error
+```
+
+When the logger is inactive (`LOG_EVENTS` not set), `event()` is a no-op.
+
+## Relative paths
+
+Each logger has a `.path()` helper that resolves absolute paths relative to the log target directory:
+
+```ts
+event('file_changed', { file: event.path('/Users/me/project/src/App.tsx') });
+// logs: { "_e": "my_module:file_changed", "_t": 1713000000000, "file": "src/App.tsx" }
+```
+
+## Registering event types
+
+After creating a new event logger, add it to `src/events/types.ts` to collect all event types:
+
+```ts
+import type { event as myModuleEvent } from '../path/to/module';
+
+export type Events = collectEventLoggers<[
+  // ... existing entries
+  typeof myModuleEvent,
+]>;
+```
+
+## Output format
+
+Each event is a single JSON line:
+
+```jsonl
+{"_e":"my_module:something_started","_t":1713000000000,"platform":"ios"}
+{"_e":"my_module:something_finished","_t":1713000000500,"platform":"ios","duration":500}
+```
+
+- `_e` — fully qualified event name (`category:event_name`)
+- `_t` — wall-clock timestamp (`Date.now()`) for cross-process correlation
+
+## Files
+
+| File | Role |
+|---|---|
+| `index.ts` | Public API: `events()` factory, `installEventLogger()`, `isEventLoggerActive()`, `shouldReduceLogs()` |
+| `stream.ts` | `LogStream` write stream and `writeEvent()` serializer |
+| `builder.ts` | TypeScript type definitions for the `events()` factory |
+| `types.ts` | Central registry of all event logger types |

--- a/packages/@expo/cli/src/events/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/events/__tests__/index-test.ts
@@ -46,11 +46,14 @@ describe('installEventLogger', () => {
     const stderr = createMockStream(2);
     const LogStream = jest.fn().mockImplementation(() => ({
       writable: true,
-      _write: jest.fn(),
+      _writeln: jest.fn(),
     }));
 
     jest.isolateModules(() => {
-      jest.doMock('../stream', () => ({ LogStream }));
+      jest.doMock('../stream', () => ({
+        LogStream,
+        writeEvent: jest.requireActual('../stream').writeEvent,
+      }));
       jest.doMock('node:tty', () => ({
         WriteStream: jest.fn(() => {
           throw new Error('TTY initialization should not run');
@@ -73,11 +76,14 @@ describe('installEventLogger', () => {
     const stdout = createMockStream(1);
     const LogStream = jest.fn().mockImplementation(() => ({
       writable: true,
-      _write: jest.fn(),
+      _writeln: jest.fn(),
     }));
 
     jest.isolateModules(() => {
-      jest.doMock('../stream', () => ({ LogStream }));
+      jest.doMock('../stream', () => ({
+        LogStream,
+        writeEvent: jest.requireActual('../stream').writeEvent,
+      }));
       jest.doMock('node:tty', () => ({
         WriteStream: jest.fn(() => {
           throw new Error('TTY initialization should not run');

--- a/packages/@expo/cli/src/events/__tests__/stream-test.ts
+++ b/packages/@expo/cli/src/events/__tests__/stream-test.ts
@@ -432,8 +432,8 @@ describe('events', () => {
 
     stream.write('line\n');
 
-    const _drain = new Promise((resolve) => stream.on('drain', resolve));
-    await _drain;
+    const _flush = new Promise((resolve) => stream.flush(resolve));
+    await _flush;
 
     stream.end();
     await _close;

--- a/packages/@expo/cli/src/events/index.ts
+++ b/packages/@expo/cli/src/events/index.ts
@@ -2,7 +2,7 @@ import { Console } from 'node:console';
 import path from 'node:path';
 
 import type { EventBuilder, EventLoggerBuilder, EventShape } from './builder';
-import { LogStream } from './stream';
+import { LogStream, writeEvent } from './stream';
 import { env } from '../utils/env';
 
 interface InitMetadata {
@@ -106,10 +106,7 @@ export const events: EventLoggerBuilder = ((
 ) => {
   function log(event: string, data: any) {
     if (logStream) {
-      const _e = `${category}:${String(event)}`;
-      const _t = Date.now();
-      const payload = JSON.stringify({ _e, _t, ...data });
-      logStream._write(payload + '\n');
+      writeEvent(logStream, category, event, data);
     }
   }
   log.category = category;

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -75,6 +75,18 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         // Fast path: complete write (exact for ASCII, the common case for JSONL)
         this.#len -= this.#output.length;
         this.#output = '';
+
+        if (this.#lines.length - this.#head > this.#partialLine) {
+          this.#writeLine();
+        } else if (this.#ending) {
+          this.#writing = false;
+          this.#close();
+        } else {
+          this.#writing = false;
+          if (this.#flushPending) {
+            this.emit('drain');
+          }
+        }
       } else {
         // Multi-byte complete write (written > length) or partial write (written < length)
         const outputLength = Buffer.byteLength(this.#output);
@@ -86,18 +98,17 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
           this.#len -= this.#output.length;
           this.#output = '';
         }
-      }
 
-      if (this.#output || this.#lines.length - this.#head > this.#partialLine) {
-        this.#writeLine();
-      } else if (this.#ending) {
-        this.#writing = false;
-        this.#close();
-      } else {
-        this.#writing = false;
-        // NOTE: This breaks the WritableStream contract slightly, but helps performance here
-        if (this.#flushPending) {
-          this.emit('drain');
+        if (this.#output || this.#lines.length - this.#head > this.#partialLine) {
+          this.#writeLine();
+        } else if (this.#ending) {
+          this.#writing = false;
+          this.#close();
+        } else {
+          this.#writing = false;
+          if (this.#flushPending) {
+            this.emit('drain');
+          }
         }
       }
     }

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -6,6 +6,16 @@ import path from 'node:path';
 const BUSY_WRITE_TIMEOUT = 100;
 const HIGH_WATER_MARK = 16_387; /*16KB*/
 
+export function writeEvent(dest: LogStream, category: string, kind: string, payload: any) {
+  const timestamp = Date.now();
+  const rest = JSON.stringify(payload).slice(1);
+  const line =
+    rest.length > 1
+      ? `{"_e":"${category}:${kind}","_t":${timestamp},${rest}\n`
+      : `{"_e":"${category}:${kind}","_t":${timestamp}}\n`;
+  dest._write(line);
+}
+
 export class LogStream extends EventEmitter implements NodeJS.WritableStream {
   #fd = -1;
   #file: string | null = null;

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -29,6 +29,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
   #output = '';
   #len = 0;
   #lines: string[] = [];
+  #head = 0;
   #partialLine = 0;
 
   constructor(dest: string | number) {
@@ -79,7 +80,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         this.#output = '';
       }
 
-      if (this.#output || this.#lines.length > this.#partialLine) {
+      if (this.#output || this.#lines.length - this.#head > this.#partialLine) {
         this.#writeLine();
       } else if (this.#ending) {
         this.#writing = false;
@@ -109,7 +110,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         if (this.#destroyed) {
           // do nothing when we're already closing the file
         } else if (
-          (!this.writing && this.#lines.length > this.#partialLine) ||
+          (!this.writing && this.#lines.length - this.#head > this.#partialLine) ||
           this.#flushPending
         ) {
           this.#writeLine();
@@ -132,6 +133,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
     this.#destroyed = true;
     this.#partialLine = 0;
     this.#lines.length = 0;
+    this.#head = 0;
 
     const onClose = (error?: NodeJS.ErrnoException | null) => {
       if (error) {
@@ -154,7 +156,13 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
 
   #writeLine() {
     this.#writing = true;
-    this.#output ||= this.#lines.length > this.#partialLine ? this.#lines.shift() || '' : '';
+    if (!this.#output && this.#lines.length - this.#head > this.#partialLine) {
+      this.#output = this.#lines[this.#head++] || '';
+      if (this.#head === this.#lines.length) {
+        this.#lines.length = 0;
+        this.#head = 0;
+      }
+    }
     fs.write(this.#fd, this.#output, (err, written) => this.#release(err, written));
   }
 
@@ -164,7 +172,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
       if (this.#opening) {
         this.once('ready', () => this._end());
       } else if (!this.#writing && this.#fd >= 0) {
-        if (this.#lines.length > this.#partialLine) {
+        if (this.#lines.length - this.#head > this.#partialLine) {
           this.#writeLine();
         } else {
           this.#close();
@@ -232,7 +240,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
       this.once('error', onError);
 
       if (!this.#writing) {
-        if (this.#lines.length > this.#partialLine || this.#output) {
+        if (this.#lines.length - this.#head > this.#partialLine || this.#output) {
           // There are complete lines or remaining output to write
           this.#writeLine();
         } else {
@@ -253,7 +261,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
     // Fast path (1): For complete lines with no pending partial we can skip the work below
     if (this.#partialLine === 0 && data.charCodeAt(data.length - 1) === 10 /*'\n'*/) {
       // Fast path (2): When no write is pending, directly write the line
-      if (!this.#writing && this.#lines.length === 0 && !this.#output) {
+      if (!this.#writing && this.#lines.length === this.#head && !this.#output) {
         this.#writing = true;
         this.#output = data;
         fs.write(this.#fd, data, (err, written) => this.#release(err, written));
@@ -289,7 +297,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
       this.#partialLine = 1;
     }
 
-    if (!this.#writing && this.#lines.length > this.#partialLine) {
+    if (!this.#writing && this.#lines.length - this.#head > this.#partialLine) {
       this.#writeLine();
     }
 

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -31,6 +31,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
   #lines: string[] = [];
   #head = 0;
   #partialLine = 0;
+  #onRelease = (err: NodeJS.ErrnoException | null, written: number) => this.#release(err, written);
 
   constructor(dest: string | number) {
     super();
@@ -181,7 +182,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         }
       }
     }
-    fs.write(this.#fd, this.#output, (err, written) => this.#release(err, written));
+    fs.write(this.#fd, this.#output, this.#onRelease);
   }
 
   _end() {
@@ -282,7 +283,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
       if (!this.#writing && this.#lines.length === this.#head && !this.#output) {
         this.#writing = true;
         this.#output = data;
-        fs.write(this.#fd, data, (err, written) => this.#release(err, written));
+        fs.write(this.#fd, data, this.#onRelease);
       } else {
         this.#lines.push(data);
         if (!this.#writing) {

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -70,14 +70,21 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
     } else {
       this.emit('write', written);
 
-      const outputLength = Buffer.byteLength(this.#output);
-      if (outputLength > written) {
-        const output = Buffer.from(this.#output).subarray(written).toString();
-        this.#len -= this.#output.length - output.length;
-        this.#output = output;
-      } else {
+      if (written === this.#output.length) {
+        // Fast path: complete write (exact for ASCII, the common case for JSONL)
         this.#len -= this.#output.length;
         this.#output = '';
+      } else {
+        // Multi-byte complete write (written > length) or partial write (written < length)
+        const outputLength = Buffer.byteLength(this.#output);
+        if (outputLength > written) {
+          const output = Buffer.from(this.#output).toString('utf8', written);
+          this.#len -= this.#output.length - output.length;
+          this.#output = output;
+        } else {
+          this.#len -= this.#output.length;
+          this.#output = '';
+        }
       }
 
       if (this.#output || this.#lines.length - this.#head > this.#partialLine) {

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -13,7 +13,7 @@ export function writeEvent(dest: LogStream, category: string, kind: string, payl
     rest.length > 1
       ? `{"_e":"${category}:${kind}","_t":${timestamp},${rest}\n`
       : `{"_e":"${category}:${kind}","_t":${timestamp}}\n`;
-  dest._write(line);
+  dest._writeln(line);
 }
 
 export class LogStream extends EventEmitter implements NodeJS.WritableStream {
@@ -279,6 +279,21 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         }
       }
     }
+  }
+
+  _writeln(data: string): boolean {
+    this.#len += data.length;
+    if (!this.#writing && this.#lines.length === this.#head && !this.#output) {
+      this.#writing = true;
+      this.#output = data;
+      fs.write(this.#fd, data, this.#onRelease);
+    } else {
+      this.#lines.push(data);
+      if (!this.#writing) {
+        this.#writeLine();
+      }
+    }
+    return this.#len < HIGH_WATER_MARK;
   }
 
   _write(data: string): boolean {

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -284,6 +284,7 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
   _writeln(data: string): boolean {
     this.#len += data.length;
     if (!this.#writing && this.#lines.length === this.#head && !this.#output) {
+      // Fast path: When no write is pending, directly write the line
       this.#writing = true;
       this.#output = data;
       fs.write(this.#fd, data, this.#onRelease);
@@ -303,20 +304,9 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
 
     this.#len += data.length;
 
-    // Fast path (1): For complete lines with no pending partial we can skip the work below
+    // Fast path: For complete lines with no pending partial we can skip the work below
     if (this.#partialLine === 0 && data.charCodeAt(data.length - 1) === 10 /*'\n'*/) {
-      // Fast path (2): When no write is pending, directly write the line
-      if (!this.#writing && this.#lines.length === this.#head && !this.#output) {
-        this.#writing = true;
-        this.#output = data;
-        fs.write(this.#fd, data, this.#onRelease);
-      } else {
-        this.#lines.push(data);
-        if (!this.#writing) {
-          this.#writeLine();
-        }
-      }
-      return this.#len < HIGH_WATER_MARK;
+      return this._writeln(data);
     }
 
     let startIdx = 0;

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -156,11 +156,19 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
 
   #writeLine() {
     this.#writing = true;
-    if (!this.#output && this.#lines.length - this.#head > this.#partialLine) {
-      this.#output = this.#lines[this.#head++] || '';
-      if (this.#head === this.#lines.length) {
-        this.#lines.length = 0;
-        this.#head = 0;
+    if (!this.#output) {
+      const end = this.#lines.length - this.#partialLine;
+      if (end > this.#head) {
+        this.#output = this.#lines[this.#head++] || '';
+        // Batch multiple lines into one write call below HWM, to avoid
+        // excessive syscalls after when lines accumulated during a previous write
+        while (this.#head < end && this.#output.length < HIGH_WATER_MARK) {
+          this.#output += this.#lines[this.#head++];
+        }
+        if (this.#head === this.#lines.length) {
+          this.#lines.length = 0;
+          this.#head = 0;
+        }
       }
     }
     fs.write(this.#fd, this.#output, (err, written) => this.#release(err, written));

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -250,6 +250,22 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
 
     this.#len += data.length;
 
+    // Fast path (1): For complete lines with no pending partial we can skip the work below
+    if (this.#partialLine === 0 && data.charCodeAt(data.length - 1) === 10 /*'\n'*/) {
+      // Fast path (2): When no write is pending, directly write the line
+      if (!this.#writing && this.#lines.length === 0 && !this.#output) {
+        this.#writing = true;
+        this.#output = data;
+        fs.write(this.#fd, data, (err, written) => this.#release(err, written));
+      } else {
+        this.#lines.push(data);
+        if (!this.#writing) {
+          this.#writeLine();
+        }
+      }
+      return this.#len < HIGH_WATER_MARK;
+    }
+
     let startIdx = 0;
     let endIdx = -1;
     while ((endIdx = data.indexOf('\n', startIdx)) > -1) {

--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -94,7 +94,10 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
         this.#close();
       } else {
         this.#writing = false;
-        this.emit('drain');
+        // NOTE: This breaks the WritableStream contract slightly, but helps performance here
+        if (this.#flushPending) {
+          this.emit('drain');
+        }
       }
     }
   }


### PR DESCRIPTION
# Why

The internal debug logging is meant to be low-overhead, but I've skipped some optimizations in the past, since it wasn't active by default. The intent with #44146 is to change this.

In most JSONL fast path cases we can increase throughput by ~100x (sounds weird, but is true) for bursty event outputs, which helps if we're looking at add roughly that amount of events. With the changes on this branch we get to the performance that was originally intended, i.e. lower than console calls.

# How

- Avoid event payload copying overhead and intermediate string allocation
- Add fast-path for JSONL complete lines to avoid partial line checks
- Replace dequeue `.shift()` call with index tracking on the lines queue
- Batch lines passed to `fs.write` under high-water mark to reduce syscalls
- Add fast path to `#release` since most batches will be written in one syscall
  - Simplify result checks in `#release` for fast-path
- Avoid redundant `emit('drain')` breaking `WritableStream` contract slightly
- Prebing `#release` callback to `#onRelease`
- Add direct `_writeln` method for higher chance of V8 inlining

# Test Plan

- Existing tests pass
- One change was made due to the `emit('drain')` branch

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
