### PR TITLE
[android][media-library] Read video dimensions from MediaStore cursor directly

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Read video dimensions from MediaStore cursor instead of opening each file with `MediaMetadataRetriever`, fixing extremely slow `getAssetsAsync` on devices with many videos. ([#44714](https://github.com/expo/expo/pull/44714) by [@oeddyo](https://github.com/oeddyo))
+
 ### 💡 Others
 
 ### ⚠️ Notices

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -227,7 +227,7 @@ fun getAssetDimensionsFromCursor(
     val width = cursor.getInt(widthIndex)
     val height = cursor.getInt(heightIndex)
     if (width > 0 && height > 0) {
-      val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+      val orientationIndex = cursor.getColumnIndex(MediaStore.MediaColumns.ORIENTATION)
       val orientation = cursor.getInt(orientationIndex)
 
       return maybeRotateAssetSize(width, height, orientation)

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -220,6 +220,16 @@ fun getAssetDimensionsFromCursor(
 ): Pair<Int, Int> {
   val uri = cursor.getString(localUriColumnIndex)
   if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+    // Fast path: read dimensions from MediaStore cursor (no file I/O).
+    // MediaStore populates these when the media scanner indexes the file.
+    val cursorWidth = cursor.getInt(cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH))
+    val cursorHeight = cursor.getInt(cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT))
+    if (cursorWidth > 0 && cursorHeight > 0) {
+      val orientation = cursor.getInt(cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION))
+      return maybeRotateAssetSize(cursorWidth, cursorHeight, orientation)
+    }
+
+    // Slow fallback for files not yet indexed by the media scanner.
     val videoUri = Uri.parse("file://$uri")
     try {
       contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -222,10 +222,14 @@ fun getAssetDimensionsFromCursor(
   if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
     // Fast path: read dimensions from MediaStore cursor (no file I/O).
     // MediaStore populates these when the media scanner indexes the file.
-    val cursorWidth = cursor.getInt(cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH))
-    val cursorHeight = cursor.getInt(cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT))
+    val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
+    val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
+    val width = cursor.getInt(widthIndex)
+    val height = cursor.getInt(heightIndex)
     if (cursorWidth > 0 && cursorHeight > 0) {
-      val orientation = cursor.getInt(cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION))
+      val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+      val orientation = cursor.getInt(orientationIndex)
+
       return maybeRotateAssetSize(cursorWidth, cursorHeight, orientation)
     }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -226,11 +226,11 @@ fun getAssetDimensionsFromCursor(
     val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
     val width = cursor.getInt(widthIndex)
     val height = cursor.getInt(heightIndex)
-    if (cursorWidth > 0 && cursorHeight > 0) {
+    if (width > 0 && height > 0) {
       val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
       val orientation = cursor.getInt(orientationIndex)
 
-      return maybeRotateAssetSize(cursorWidth, cursorHeight, orientation)
+      return maybeRotateAssetSize(width, height, orientation)
     }
 
     // Slow fallback for files not yet indexed by the media scanner.


### PR DESCRIPTION
## Summary

On Android, `getAssetDimensionsFromCursor()` uses `MediaMetadataRetriever` for every video asset, which opens each file from disk (~140ms per video). This makes `getAssetsAsync()` extremely slow on devices with many videos.

MediaStore already has `WIDTH` and `HEIGHT` columns populated by the media scanner. This PR reads dimensions from the cursor first and only falls back to `MediaMetadataRetriever` when the cursor returns 0 (rare — only for files not yet indexed by the media scanner).

## Benchmarks

Physical Android device with 10,611 assets (448 videos):

| Batch size | Before | After | Speedup |
|---|---|---|---|
| 500 assets | ~2,200ms | ~180ms | ~12x |
| 5,000 assets | ~5,500ms | 883ms | ~6x |
| 10,611 assets (all) | 11,768ms | 1,609ms | **7.3x** |

## Why this is safe

1. **Same data source.** MediaStore populates `WIDTH`/`HEIGHT` using `MediaMetadataRetriever` internally when the media scanner indexes a file — values are identical.
2. **Verified empirically.** Compared cursor dimensions vs `MediaMetadataRetriever` dimensions for all 448 videos on a physical device — zero mismatches.
3. **Graceful fallback.** The `> 0` guard ensures we still use `MediaMetadataRetriever` for any edge case where MediaStore hasn't indexed the file yet.
4. **No change to image path.** Only the video code path is affected.

## Test plan

- [x] Compared cursor and `MediaMetadataRetriever` output for 448 videos — 0 mismatches
- [x] Test on device with freshly transferred videos (to verify fallback path)


## Related issue

Fixes #44713

## Minimal reproducible example

https://github.com/oeddyo/slow-expo-media-query-repro
