### PR TITLE
[docs] Improve Expo Router sidebar position and sidebar titles

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -694,10 +694,20 @@ const versionsReference = VERSIONS.reduce(
       makeSection('Configuration files', pagesFromDir(`versions/${version}/config`), {
         expanded: true,
       }),
+      ...(fs.existsSync(path.resolve(PAGES_DIR, `versions/${version}/sdk/router`))
+        ? [
+            makeSection('Expo Router', pagesFromDir(`versions/${version}/sdk/router`), {
+              expanded: true,
+              hideIcon: true,
+            }),
+          ]
+        : []),
       makeSection(
         'Expo SDK',
         shiftEntryToFront(
-          pagesFromDir(`versions/${version}/sdk`).filter(entry => !entry.inExpoGo),
+          pagesFromDir(`versions/${version}/sdk`).filter(
+            entry => !entry.inExpoGo && entry.name !== 'Router'
+          ),
           entry => entry.name === 'Expo'
         ),
         { expanded: true }

--- a/docs/pages/versions/unversioned/sdk/router/color.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/color.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Color
+sidebar_title: Color
 description: An Expo Router API for accessing platform-specific native colors.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/unversioned/sdk/router/link.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/link.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Link
+sidebar_title: Link
 description: An Expo Router API that provides Link, Redirect, preview, and zoom transition components.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/unversioned/sdk/router/native-tabs.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/native-tabs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Native tabs
+sidebar_title: Native tabs
 description: An Expo Router submodule that provides native tabs layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/unversioned/sdk/router/split-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/split-view.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Split View
+sidebar_title: Split View
 description: An Expo Router submodule that provides native split view layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/unversioned/sdk/router/stack.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/stack.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Stack
+sidebar_title: Stack
 description: An Expo Router API that provides Stack navigator, toolbar, and screen components.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/unversioned/sdk/router/ui.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/ui.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router UI
+sidebar_title: UI
 description: An Expo Router submodule that provides headless tab components to create custom tab layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/v55.0.0/sdk/router/color.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/router/color.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Color
+sidebar_title: Color
 description: An Expo Router API for accessing platform-specific native colors.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/v55.0.0/sdk/router/link.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/router/link.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Link
+sidebar_title: Link
 description: An Expo Router API that provides Link, Redirect, preview, and zoom transition components.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/v55.0.0/sdk/router/native-tabs.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/router/native-tabs.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Native tabs
+sidebar_title: Native tabs
 description: An Expo Router submodule that provides native tabs layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/v55.0.0/sdk/router/split-view.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/router/split-view.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Split View
+sidebar_title: Split View
 description: An Expo Router submodule that provides native split view layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/v55.0.0/sdk/router/stack.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/router/stack.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router Stack
+sidebar_title: Stack
 description: An Expo Router API that provides Stack navigator, toolbar, and screen components.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/pages/versions/v55.0.0/sdk/router/ui.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/router/ui.mdx
@@ -1,5 +1,6 @@
 ---
 title: Router UI
+sidebar_title: UI
 description: An Expo Router submodule that provides headless tab components to create custom tab layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-router'
 packageName: 'expo-router'

--- a/docs/types/common.ts
+++ b/docs/types/common.ts
@@ -43,6 +43,7 @@ export type NavigationRoute = {
   as?: string;
   hidden?: boolean;
   expanded?: boolean;
+  hideIcon?: boolean;
   sidebarTitle?: string;
   weight?: number;
   isNew?: boolean;

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -40,7 +40,7 @@ export const SidebarGroup = ({ route, parentRoute }: SidebarNodeProps) => {
   const router = useRouter();
 
   const title = route.sidebarTitle ?? route.name;
-  const Icon = getIconElement(title);
+  const Icon = route.hideIcon ? undefined : getIconElement(title);
 
   if (route.children?.[0]?.section === 'EAS tutorial') {
     const allChaptersCompleted = chapters.every(chapter => chapter.completed);


### PR DESCRIPTION
# Why

Fixes ENG-20567

# How

**Sidebar restructure**

- In `constants/navigation.js`, add a new `Expo Router` section under Reference, positioned between `Configuration files` and `Expo SDK`, populated from `pagesFromDir('versions/${version}/sdk/router')`.
- Wrap the new section in `fs.existsSync` so older versions without the `sdk/router` folder (v54, v53) are not affected.
- Filter the Router group out of the `Expo SDK` section with `entry.name !== 'Router'` so the same pages do not appear twice.

**Sidebar titles**

- Add `sidebar_title` frontmatter to the 6 nested Router reference pages in both `pages/versions/v55.0.0/sdk/router/` and `pages/versions/unversioned/sdk/router/`: `Link`, `UI`, `Native tabs`, `Split View`, `Stack`, `Color`. The MDX `title` (page H1) is left as `Router X` so the page heading still reads naturally on direct landings from search and outputs "Expo Router X".
- The router index already uses `sidebar_title: Overview`, so it appears as "Overview" at the top of the new section.

**Sidebar icon opt-out**

- The `getIconElement()` switch in `SidebarGroup.tsx` mapped `Expo Router` to `RouterLogo` for the existing Guides section of the same name, which caused the new Reference section to inherit an icon other Reference sections do not have.
- Add an opt-out `hideIcon` prop on `NavigationRoute` (`types/common.ts`), pass `hideIcon: true` on the new Reference section in `navigation.js`, and respect it in `SidebarGroup.tsx`. The Guides "Expo Router" section keeps its icon.

# Test Plan

See preview.

Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
