### PR TITLE
chore(expo 55): upgraded react-native-get-random-values to 2.0.0

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -99,7 +99,7 @@
   "react-native": "0.85.0",
   "react-native-web": "~0.21.0",
   "react-native-gesture-handler": "~2.30.0",
-  "react-native-get-random-values": "~1.11.0",
+  "react-native-get-random-values": "~2.0.0",
   "react-native-keyboard-controller": "1.20.7",
   "react-native-maps": "1.27.2",
   "react-native-pager-view": "8.0.0",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Since we are on new arch only react-native-get-random-values supports new arch with version [2.0.0](https://github.com/LinusU/react-native-get-random-values/releases/tag/v2.0.0).

also closing https://github.com/LinusU/react-native-get-random-values/issues/68

# How

<!--
How did you build this feature or fix this bug and why?
-->
looked for react-native-get-random-values in expo repo and only found in bundledNativeModules.json so I updated it

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
run bunx expo install --check
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
