### PR TITLE
[dev-launcher] Align UI labels across iOS and Android

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### 💡 Others
 
-- Align dev launcher labels across iOS and Android.
+- Align dev launcher labels across iOS and Android. ([#44720](https://github.com/expo/expo/pull/44720) by [@vonovak](https://github.com/vonovak))
 - Removed `DevLauncherExpoActivityConfigurator`. System bars configuration is now handled by the `expo-status-bar` and `expo-navigation-bar` modules. ([#44469](https://github.com/expo/expo/pull/44469) by [@zoontek](https://github.com/zoontek))
 - Enforce transparent status bar and navigation bar on Android, remove unused `backgroundColor` / `translucent` options handling. ([#43518](https://github.com/expo/expo/pull/43518) by [@zoontek](https://github.com/zoontek))
 - [Android] Bump Apollo Kotlin from 4.3.1 to 4.4.2. ([#44386](https://github.com/expo/expo/pull/44386) by [@radko93](https://github.com/radko93))

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### 💡 Others
 
+- Align dev launcher labels across iOS and Android.
 - Removed `DevLauncherExpoActivityConfigurator`. System bars configuration is now handled by the `expo-status-bar` and `expo-navigation-bar` modules. ([#44469](https://github.com/expo/expo/pull/44469) by [@zoontek](https://github.com/zoontek))
 - Enforce transparent status bar and navigation bar on Android, remove unused `backgroundColor` / `translucent` options handling. ([#43518](https://github.com/expo/expo/pull/43518) by [@zoontek](https://github.com/zoontek))
 - [Android] Bump Apollo Kotlin from 4.3.1 to 4.4.2. ([#44386](https://github.com/expo/expo/pull/44386) by [@radko93](https://github.com/radko93))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/routes/Profile.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/routes/Profile.kt
@@ -121,7 +121,7 @@ private fun LoggedOut(authLauncher: ManagedActivityResultLauncher<AuthRequestTyp
     }
 
     NewText(
-      "Login or create an account to view local\ndevelopment servers and more",
+      "Log in or create an account to view local\ndevelopment servers and more",
       style = NewAppTheme.font.sm.merge(
         lineHeight = 19.sp,
         textAlign = TextAlign.Center

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/BranchesScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/BranchesScreen.kt
@@ -79,7 +79,7 @@ private fun BranchBadge(
 }
 
 @Composable
-private fun NeedToSingInComponent(
+private fun NeedToSignInComponent(
   onProfileClick: () -> Unit = {}
 ) {
   Box(
@@ -93,7 +93,7 @@ private fun NeedToSingInComponent(
     ) {
       Icon(
         painter = painterResource(R.drawable.log_in),
-        contentDescription = "Sign In Icon",
+        contentDescription = "Log in icon",
         tint = NewAppTheme.colors.icon.info
       )
 
@@ -103,7 +103,7 @@ private fun NeedToSingInComponent(
         modifier = Modifier.fillMaxWidth()
       ) {
         NewText(
-          "Sign in to view updates",
+          "Log in to view updates",
           style = NewAppTheme.font.lg.merge(
             fontWeight = FontWeight.SemiBold,
             lineHeight = 20.sp,
@@ -112,7 +112,7 @@ private fun NeedToSingInComponent(
         )
 
         NewText(
-          "Sign in to your Expo account to see available\nEAS updates for this project.",
+          "Log in to your Expo account to see available\nupdates for this project.",
           style = NewAppTheme.font.sm.merge(
             lineHeight = 19.6.sp,
             textAlign = TextAlign.Center
@@ -122,7 +122,7 @@ private fun NeedToSingInComponent(
       }
 
       ActionButton(
-        "Sign In",
+        "Log in",
         foreground = Color.White,
         background = Color.Black,
         fill = false,
@@ -154,7 +154,7 @@ fun BranchesScreen(
     }
 
     if (needToSignIn) {
-      NeedToSingInComponent(onProfileClick)
+      NeedToSignInComponent(onProfileClick)
       return@Column
     }
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/ErrorScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/ErrorScreen.kt
@@ -43,7 +43,7 @@ fun ErrorScreen(
         )
       )
 
-      NewText("This development build encountered the following error.")
+      NewText("This development build encountered the following error:")
     }
 
     StackTrace(
@@ -70,7 +70,7 @@ fun ErrorScreen(
       )
 
       ActionButton(
-        "Go To Home",
+        "Go home",
         foreground = NewAppTheme.colors.buttons.secondary.foreground,
         background = NewAppTheme.colors.buttons.secondary.background,
         modifier = Modifier.padding(vertical = NewAppTheme.spacing.`2`),

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/SettingsScreen.kt
@@ -176,7 +176,7 @@ private fun MenuGesturesSection(state: SettingsState, onAction: (SettingsAction)
           },
           content = {
             NewText(
-              text = "3 fingers long press"
+              text = "Three-finger long-press"
             )
           },
           rightComponent = {

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AccountSelector.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/AccountSelector.kt
@@ -72,7 +72,7 @@ fun AccountSelector(
     }
 
     ActionButton(
-      "Log Out",
+      "Log out",
       foreground = Color.White,
       background = Color.Black,
       modifier = Modifier.padding(NewAppTheme.spacing.`3`),

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/SignUp.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/SignUp.kt
@@ -18,7 +18,7 @@ fun SignUp(
     verticalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)
   ) {
     ActionButton(
-      "Login",
+      "Log in",
       foreground = Color.White,
       background = Color.Black,
       modifier = Modifier.padding(NewAppTheme.spacing.`3`),
@@ -26,7 +26,7 @@ fun SignUp(
     )
 
     ActionButton(
-      "Sign Up",
+      "Sign up",
       foreground = NewAppTheme.colors.text.secondary,
       background = NewAppTheme.colors.background.element,
       modifier = Modifier.padding(NewAppTheme.spacing.`3`),

--- a/packages/expo-dev-launcher/ios/SwiftUI/AccountSheet.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/AccountSheet.swift
@@ -80,7 +80,7 @@ struct AccountSheet: View {
         viewModel.signOut()
       }
       label: {
-        Text("Logout")
+        Text("Log out")
           .font(.headline)
           .fontWeight(.bold)
           .foregroundColor(.white)
@@ -126,7 +126,7 @@ struct AccountSheet: View {
             .transition(.scale.combined(with: .opacity))
         }
 
-        Text("Log In")
+        Text("Log in")
           .font(.headline)
           .fontWeight(.semibold)
       }
@@ -147,7 +147,7 @@ struct AccountSheet: View {
       }
     }
     label: {
-      Text("Sign Up")
+      Text("Sign up")
         .font(.headline)
         .fontWeight(.semibold)
         .foregroundColor(.black.opacity(0.7))

--- a/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
@@ -68,7 +68,7 @@ struct ErrorView: View {
       }
 
       Button(action: onGoHome) {
-        Text("Go to home")
+        Text("Go home")
           .font(.headline)
           .foregroundColor(.black)
           .frame(maxWidth: .infinity)

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -119,7 +119,7 @@ struct SettingsTabView: View {
             .resizable()
             .frame(width: 24, height: 24)
             .opacity(0.6)
-          Toggle("Shake Device", isOn: $viewModel.shakeDevice)
+          Toggle("Shake device", isOn: $viewModel.shakeDevice)
         }
         .padding()
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotSignedInView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotSignedInView.swift
@@ -13,12 +13,12 @@ struct NotSignedInView: View {
         .foregroundColor(.blue)
 
       VStack(spacing: 8) {
-        Text("Sign in to view updates")
+        Text("Log in to view updates")
           .font(.title3)
           .fontWeight(.semibold)
           .multilineTextAlignment(.center)
 
-        Text("Sign in to your Expo account to see available EAS Updates for this project.")
+        Text("Log in to your Expo account to see available EAS updates for this project.")
           .font(.system(size: 14))
           .multilineTextAlignment(.center)
           .foregroundStyle(.secondary)
@@ -27,7 +27,7 @@ struct NotSignedInView: View {
       Button {
         navigation.showUserProfile()
       } label: {
-        Text("Sign in")
+        Text("Log in")
           .padding(.horizontal, 16)
           .padding(.vertical, 8)
           .background(Color.black)


### PR DESCRIPTION
# Why

fix label casing (use Sentence case) and nouns / verbs

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

use the same "Log in" wording as https://expo.dev

# Test Plan

- bare expo

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)