### PR TITLE
fix(constants): Switch from `@expo/config` to `expo/config` public API

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Switch app config generation from `@expo/config` to `expo/config` public API ([#44721](https://github.com/expo/expo/pull/44721) by [@kitten](https://github.com/kitten))
+
 ## 55.0.7 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -42,7 +42,6 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config": "workspace:~55.0.8",
     "@expo/env": "workspace:~2.1.1"
   },
   "devDependencies": {

--- a/packages/expo-constants/scripts/build/getAppConfig.js
+++ b/packages/expo-constants/scripts/build/getAppConfig.js
@@ -3,11 +3,12 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-const config_1 = require("@expo/config");
+const config_1 = require("expo/config");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
-const possibleProjectRoot = process.argv[2];
-const destinationDir = process.argv[3];
+const cwd = process.cwd();
+const possibleProjectRoot = process.argv[2] ?? cwd;
+const destinationDir = process.argv[3] ?? cwd;
 // TODO: Verify we can remove projectRoot validation, now that we no longer
 // support React Native <= 62
 let projectRoot;

--- a/packages/expo-constants/scripts/src/getAppConfig.ts
+++ b/packages/expo-constants/scripts/src/getAppConfig.ts
@@ -1,9 +1,10 @@
-import { getConfig } from '@expo/config';
+import { getConfig } from 'expo/config';
 import fs from 'fs';
 import path from 'path';
 
-const possibleProjectRoot = process.argv[2];
-const destinationDir = process.argv[3];
+const cwd = process.cwd();
+const possibleProjectRoot = process.argv[2] ?? cwd;
+const destinationDir = process.argv[3] ?? cwd;
 
 // TODO: Verify we can remove projectRoot validation, now that we no longer
 // support React Native <= 62

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3743,9 +3743,6 @@ importers:
 
   packages/expo-constants:
     dependencies:
-      '@expo/config':
-        specifier: workspace:~55.0.8
-        version: link:../@expo/config
       '@expo/env':
         specifier: workspace:~2.1.1
         version: link:../@expo/env


### PR DESCRIPTION
# Why

We don't want `expo-constants` to apply its own version of `@expo/config`, but to instead use `expo/config` which is the public API to access the configuration. This should ensure consistency with the version of `@expo/config` used, which must be enforced for most Expo modules.

# How

- Switch `expo-constants/scripts` to `expo/config`
- Remove dependency on `@expo/config`

# Test Plan

- Tests and CI should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
