### PR TITLE
fix(manifest): Drop unused `@expo/config` dependency

### DIFF
--- a/packages/expo-manifests/CHANGELOG.md
+++ b/packages/expo-manifests/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Replaced deprecated `androidStatusBar` and `androidNavigationBar` manifest accessors with `extra["expo-status-bar"]` and `extra["expo-navigation-bar"]`. ([#44469](https://github.com/expo/expo/pull/44469) by [@zoontek](https://github.com/zoontek))
+- Remove unused `@expo/config` dependency ([#44722](https://github.com/expo/expo/pull/44722) by [@kitten](https://github.com/kitten))
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/expo-manifests/package.json
+++ b/packages/expo-manifests/package.json
@@ -33,7 +33,6 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/config": "workspace:~55.0.8",
     "expo-json-utils": "workspace:~55.0.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4420,9 +4420,6 @@ importers:
 
   packages/expo-manifests:
     dependencies:
-      '@expo/config':
-        specifier: workspace:~55.0.8
-        version: link:../@expo/config
       expo:
         specifier: workspace:*
         version: link:../expo


### PR DESCRIPTION
# Why

This seems to have been unused. If it was used I'd have replaced it with `expo/config`, but I can't find a code reference to it.

# How

- Drop `@expo/config`

# Test Plan

- CI should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
