### PR TITLE
[dev-launcher] add copy error button to error screens

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🎉 New features
 
+- Add a "Copy" button to the error screen that copies the error info to the clipboard.
 - [Android] Implement edge-to-edge. ([#44529](https://github.com/expo/expo/pull/44529) by [@zoontek](https://github.com/zoontek))
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
 - [Android] Add NDS service discovery.

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🎉 New features
 
-- Add a "Copy" button to the error screen that copies the error info to the clipboard.
+- Add a "Copy" button to the error screen that copies the error info to the clipboard. ([#44723](https://github.com/expo/expo/pull/44723) by [@vonovak](https://github.com/vonovak))
 - [Android] Implement edge-to-edge. ([#44529](https://github.com/expo/expo/pull/44529) by [@zoontek](https://github.com/zoontek))
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
 - [Android] Add NDS service discovery.

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/ErrorScreen.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/screens/ErrorScreen.kt
@@ -1,14 +1,25 @@
 package expo.modules.devlauncher.compose.screens
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import expo.modules.devlauncher.compose.models.ErrorAction
@@ -16,12 +27,23 @@ import expo.modules.devlauncher.compose.ui.ActionButton
 import expo.modules.devlauncher.compose.ui.StackTrace
 import expo.modules.devmenu.compose.newtheme.NewAppTheme
 import expo.modules.devmenu.compose.primitives.NewText
+import kotlinx.coroutines.delay
 
 @Composable
 fun ErrorScreen(
   stack: String,
   onAction: (ErrorAction) -> Unit = {}
 ) {
+  val context = LocalContext.current
+  var copied by remember { mutableStateOf(false) }
+
+  LaunchedEffect(copied) {
+    if (copied) {
+      delay(2000)
+      copied = false
+    }
+  }
+
   Column(
     modifier = Modifier
       .background(NewAppTheme.colors.background.subtle)
@@ -69,15 +91,35 @@ fun ErrorScreen(
         }
       )
 
-      ActionButton(
-        "Go home",
-        foreground = NewAppTheme.colors.buttons.secondary.foreground,
-        background = NewAppTheme.colors.buttons.secondary.background,
-        modifier = Modifier.padding(vertical = NewAppTheme.spacing.`2`),
-        onClick = {
-          onAction(ErrorAction.GoToHome)
+      Row(
+        horizontalArrangement = Arrangement.spacedBy(NewAppTheme.spacing.`2`)
+      ) {
+        Box(modifier = Modifier.weight(1f)) {
+          ActionButton(
+            "Go home",
+            foreground = NewAppTheme.colors.buttons.secondary.foreground,
+            background = NewAppTheme.colors.buttons.secondary.background,
+            modifier = Modifier.padding(vertical = NewAppTheme.spacing.`2`),
+            onClick = {
+              onAction(ErrorAction.GoToHome)
+            }
+          )
         }
-      )
+
+        Box(modifier = Modifier.weight(1f)) {
+          ActionButton(
+            if (copied) "Copied!" else "Copy",
+            foreground = NewAppTheme.colors.buttons.secondary.foreground,
+            background = NewAppTheme.colors.buttons.secondary.background,
+            modifier = Modifier.padding(vertical = NewAppTheme.spacing.`2`),
+            onClick = {
+              val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+              clipboard.setPrimaryClip(ClipData.newPlainText("Error", stack))
+              copied = true
+            }
+          )
+        }
+      }
     }
   }
 }

--- a/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
@@ -7,6 +7,7 @@ struct ErrorView: View {
   let error: EXDevLauncherAppError
   let onReload: () -> Void
   let onGoHome: () -> Void
+  @State private var copied = false
 
   var body: some View {
     VStack(spacing: 0) {
@@ -21,6 +22,7 @@ struct ErrorView: View {
           .foregroundColor(.secondary)
           .multilineTextAlignment(.leading)
       }
+      .frame(maxWidth: .infinity, alignment: .leading)
       .padding(.horizontal, 20)
       .padding(.top, 20)
 
@@ -55,6 +57,20 @@ struct ErrorView: View {
     .cornerRadius(8)
   }
 
+  private var errorText: String {
+    var text = error.message
+    if let stack = error.stack, !stack.isEmpty {
+      for frame in stack {
+        let method = frame.methodName ?? "Unknown method"
+        text += "\n\(method)"
+        if let file = frame.file {
+          text += "\n  at \(file):\(frame.lineNumber):\(frame.column)"
+        }
+      }
+    }
+    return text
+  }
+
   private var actions: some View {
     VStack(spacing: 6) {
       Button(action: onReload) {
@@ -67,14 +83,37 @@ struct ErrorView: View {
           .cornerRadius(8)
       }
 
-      Button(action: onGoHome) {
-        Text("Go home")
-          .font(.headline)
-          .foregroundColor(.black)
-          .frame(maxWidth: .infinity)
-          .padding()
-          .background(Color.expoSystemGray5)
-          .cornerRadius(8)
+      HStack(spacing: 6) {
+        Button(action: onGoHome) {
+          Text("Go home")
+            .font(.headline)
+            .foregroundColor(.black)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.expoSystemGray5)
+            .cornerRadius(8)
+        }
+
+        Button(action: {
+          #if !os(macOS)
+          UIPasteboard.general.string = errorText
+          #else
+          NSPasteboard.general.clearContents()
+          NSPasteboard.general.setString(errorText, forType: .string)
+          #endif
+          copied = true
+          DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            copied = false
+          }
+        }) {
+          Text(copied ? "Copied!" : "Copy")
+            .font(.headline)
+            .foregroundColor(.black)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.expoSystemGray5)
+            .cornerRadius(8)
+        }
       }
     }
     .padding(.horizontal, 20)


### PR DESCRIPTION
# Why

When the dev launcher shows an error, developers often need to share or paste the error info. Currently there's no way to do it from the UI (though the text might render in terminal where metro is running).

# How

Add a "Copy" button next to the existing "Go home" button on the error screen. Tapping it copies the error message and stack trace to the clipboard, with brief "Copied!" feedback.

# Test Plan

- tested in bare expo. on Android it's fairly easy to get the screen by running metro from an older commit and then trying to render a new component from expo-ui. on iOS I just added a temporary button to present the screen (removed now). Maybe there should be a way to test this more easily.


<details>
<summary>before and after</summary>

<img width="1080" height="2400" alt="Screenshot_1775838447" src="https://github.com/user-attachments/assets/2212fe6f-e007-4958-bb32-9d9bd3f8663b" />

<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 17e - 2026-04-13 at 13 03 07" src="https://github.com/user-attachments/assets/9c989670-0018-47dd-b599-4417086cfa1a" />



</details>

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
