### PR TITLE
[updates][ios] Fix loading assets in brownfield 

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Use react-native prebuilds by default ([#44332](https://github.com/expo/expo/pull/44332) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Added `Expo.plist` to the brownfield framework target. ([#44645](https://github.com/expo/expo/pull/44645) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Add `DEFINE_MODULES=TRUE` build setting ([#44672](https://github.com/expo/expo/pull/44672) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [ios] Fix loading assets in brownfield. ([#44724](https://github.com/expo/expo/pull/44724) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### 🐛 Bug fixes
 
 - Pass absolute path to CLI helpers when creating build manifest, since the underlying functions now handle entry file inputs properly, instead of applying `mainModuleName` semantics to them ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
+- [ios] Fix loading assets in brownfield ([#44724](https://github.com/expo/expo/pull/44724) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherNoDatabase.swift
@@ -21,7 +21,7 @@ public final class AppLauncherNoDatabase: NSObject, AppLauncher {
 
   public func launchUpdate() {
     precondition(assetFilesMap == nil, "assetFilesMap should be null for embedded updates")
-    launchAssetUrl = Bundle.main.url(
+    launchAssetUrl = updatesBundle.url(
       forResource: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFilename,
       withExtension: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFileType
     )

--- a/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLauncher/AppLauncherWithDatabase.swift
@@ -179,7 +179,7 @@ public class AppLauncherWithDatabase: NSObject, AppLauncher {
 
     if launchedUpdate.status == UpdateStatus.StatusEmbedded {
       precondition(assetFilesMap == nil, "assetFilesMap should be null for embedded updates")
-      launchAssetUrl = Bundle.main.url(
+      launchAssetUrl = updatesBundle.url(
         forResource: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFilename,
         withExtension: EmbeddedAppLoader.EXUpdatesBareEmbeddedBundleFileType
       )

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -83,14 +83,27 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
       launchOptions: self.launchOptions
     )
 
-    let window = getWindow()
-    let rootViewController = reactDelegate.createRootViewController()
 #if os(iOS) || os(tvOS)
     rootView.backgroundColor = self.deferredRootView?.backgroundColor ?? UIColor.white
-    rootViewController.view = rootView
-    window.rootViewController = rootViewController
-    window.makeKeyAndVisible()
+
+    // In brownfield setups, the deferred root view is embedded within the host app's
+    // view hierarchy (e.g. inside a NavigationController). Replacing the window's root
+    // view controller would break the host app's navigation. Instead, find the view
+    // controller that owns the deferred view and replace its view in-place.
+    if let deferredRootView = self.deferredRootView,
+      let owningViewController = findViewController(for: deferredRootView),
+      owningViewController != getWindow().rootViewController {
+      owningViewController.view = rootView
+    } else {
+      let window = getWindow()
+      let rootViewController = reactDelegate.createRootViewController()
+      rootViewController.view = rootView
+      window.rootViewController = rootViewController
+      window.makeKeyAndVisible()
+    }
 #else
+    let window = getWindow()
+    let rootViewController = reactDelegate.createRootViewController()
     rootViewController.view = rootView
     rootView.frame = window.frame
     window.contentViewController = rootViewController
@@ -134,6 +147,22 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     return view
   }
 #endif
+
+  /**
+   Finds the nearest view controller that owns the given view by walking
+   up the responder chain. Returns the first UIViewController whose view
+   matches the target view.
+   */
+  private func findViewController(for view: UIView) -> UIViewController? {
+    var responder: UIResponder? = view.next
+    while let current = responder {
+      if let viewController = current as? UIViewController, viewController.view == view {
+        return viewController
+      }
+      responder = current.next
+    }
+    return nil
+  }
 
   private func getWindow() -> UIWindow {
     #if os(macOS)

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -146,7 +146,6 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
 
     return view
   }
-#endif
 
   /**
    Finds the nearest view controller that owns the given view by walking
@@ -163,6 +162,7 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     }
     return nil
   }
+#endif
 
   private func getWindow() -> UIWindow {
     #if os(macOS)

--- a/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesConfig.swift
@@ -145,14 +145,7 @@ public final class UpdatesConfig: NSObject {
   }
 
   private static func configDictionaryWithExpoPlist(mergingOtherDictionary: [String: Any]?) throws -> [String: Any] {
-    // Check the main bundle first (standard app), then fall back to the framework bundle.
-    // In brownfield setups, the Expo project is packaged as an xcframework where Expo.plist
-    // is embedded in the framework bundle rather than the host app bundle.
-    var configPlistPath = Bundle.main.path(forResource: PlistName, ofType: "plist")
-    if configPlistPath == nil {
-      configPlistPath = Bundle(for: UpdatesConfig.self).path(forResource: PlistName, ofType: "plist")
-    }
-    guard let configPlistPath else {
+    guard let configPlistPath = updatesBundle.path(forResource: PlistName, ofType: "plist") else {
       throw UpdatesConfigError.ExpoUpdatesConfigPlistError
     }
 

--- a/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
+++ b/packages/expo-updates/ios/EXUpdates/UpdatesUtils.swift
@@ -16,6 +16,22 @@ internal extension Array where Element: Equatable {
   }
 }
 
+/**
+ * In brownfield setups the Expo project is packaged as an xcframework, so
+ * resources like Expo.plist, main.jsbundle, and image assets live in the
+ * framework bundle instead of the host app's main bundle.
+ *
+ * `updatesBundle` resolves to whichever bundle actually contains the
+ * expo-updates resources at runtime: `Bundle.main` for standard apps,
+ * or the framework bundle for brownfield xcframeworks.
+ */
+internal let updatesBundle: Bundle = {
+  if Bundle.main.path(forResource: "Expo", ofType: "plist") != nil {
+    return Bundle.main
+  }
+  return Bundle(for: UpdatesUtils.self)
+}()
+
 @objc(EXUpdatesUtils)
 @objcMembers
 public final class UpdatesUtils: NSObject {
@@ -110,16 +126,16 @@ public final class UpdatesUtils: NSObject {
 
   internal static func url(forBundledAsset asset: UpdateAsset) -> URL? {
     guard let mainBundleDir = asset.mainBundleDir else {
-      return Bundle.main.url(forResource: asset.mainBundleFilename, withExtension: asset.type)
+      return updatesBundle.url(forResource: asset.mainBundleFilename, withExtension: asset.type)
     }
-    return Bundle.main.url(forResource: asset.mainBundleFilename, withExtension: asset.type, subdirectory: mainBundleDir)
+    return updatesBundle.url(forResource: asset.mainBundleFilename, withExtension: asset.type, subdirectory: mainBundleDir)
   }
 
   internal static func path(forBundledAsset asset: UpdateAsset) -> String? {
     guard let mainBundleDir = asset.mainBundleDir else {
-      return Bundle.main.path(forResource: asset.mainBundleFilename, ofType: asset.type)
+      return updatesBundle.path(forResource: asset.mainBundleFilename, ofType: asset.type)
     }
-    return Bundle.main.path(forResource: asset.mainBundleFilename, ofType: asset.type, inDirectory: mainBundleDir)
+    return updatesBundle.path(forResource: asset.mainBundleFilename, ofType: asset.type, inDirectory: mainBundleDir)
   }
 
   /**


### PR DESCRIPTION
# Why

When generating a release xcframework with `expo-brownfield` and `expo-updates` is installed, expo-updates would fail to load assets and render a blank screen. 

# How

Introduced an `updatesBundle` helper function that resolves the correct bundle location at startup. Also updated the logic for replacing the deferred root view in custom setups 


# Test Plan

- Generated a release xcframework with `expo-brownfield` for an app using `expo-updates` and consumed it from a host app
- Verified `Expo.plist`, `main.jsbundle`, and `assets/` are all bundled inside `myappbrownfield.framework` after the build
- Verified at runtime: `EnabledAppController` is created (not `DisabledAppController`), the JS bundle loads, the embedded update is stored with all assets, and the app renders correctly 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
