### PR TITLE
[ios][camera] Fix inconsistent barcode type string returned by ZXing fallback scanner

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -15,6 +15,8 @@
 - [Web] Fix `isAvailableAsync` returning `true` on devices without a camera. ([#43932](https://github.com/expo/expo/pull/43932) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Use runtime camera availability checks in Simulator so camera code paths can run when a runtime video device is present while preserving fallback behavior when no device is available. (by [@kmagiera](https://github.com/kmagiera)) ([#44159](https://github.com/expo/expo/pull/44159) by [@kmagiera](https://github.com/kmagiera))
 - [iOS] Fix orientation issue caused by upstream changes. ([#44171](https://github.com/expo/expo/pull/44171) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix inconsistent barcode `type` value returned by ZXing fallback scanner (code39, pdf417, codabar) — it now returns the same format as the AVFoundation scanner (e.g. `"code39"` instead of `"org.iso.Code39"`). ([#44726](https://github.com/expo/expo/pull/44726) by [@jensdev](https://github.com/jensdev))
+
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 #if canImport(ZXingObjC)
-  import ZXingObjC
+import ZXingObjC
 #endif
 import VisionKit
 import Vision
@@ -104,12 +104,12 @@ class BarcodeScannerUtils {
   }
 
   #if canImport(ZXingObjC)
-    static func zxResultToDictionary(_ barcodeScannerResult: ZXResult) -> [String: Any] {
-      var result = [String: Any]()
-      result["type"] = BarcodeScannerUtils.zxingFormatToBarcodeType(barcodeScannerResult.barcodeFormat)?.rawValue ?? "unknown"
+  static func zxResultToDictionary(_ barcodeScannerResult: ZXResult) -> [String: Any] {
+    var result = [String: Any]()
+    result["type"] = BarcodeScannerUtils.zxingFormatToBarcodeType(barcodeScannerResult.barcodeFormat)?.rawValue ?? "unknown"
 
-      var data = ""
-      for i in 0..<barcodeScannerResult.text.count {
+    var data = ""
+    for i in 0..<barcodeScannerResult.text.count {
       let character = barcodeScannerResult.text[barcodeScannerResult.text.index(barcodeScannerResult.text.startIndex, offsetBy: i)]
         if character != "\0" {
           data.append(character)
@@ -117,8 +117,8 @@ class BarcodeScannerUtils {
       }
       result["data"] = data
 
-      return result
-    }
+    return result
+  }
 
     static func zxingFormatToBarcodeType(_ format: ZXBarcodeFormat) -> BarcodeType? {
       switch format {

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -108,15 +108,9 @@ class BarcodeScannerUtils {
     var result = [String: Any]()
     result["type"] = BarcodeScannerUtils.zxingFormatToBarcodeType(barcodeScannerResult.barcodeFormat)?.rawValue ?? "unknown"
 
-    var data = ""
-    for i in 0..<barcodeScannerResult.text.count {
-      let character = barcodeScannerResult.text[barcodeScannerResult.text.index(barcodeScannerResult.text.startIndex, offsetBy: i)]
-        if character != "\0" {
-          data.append(character)
-        }
-      }
-      result["data"] = data
-
+    let data = barcodeScannerResult.text.filter { $0 != "\0" }
+    result["data"] = data
+    
     return result
   }
 

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -1,6 +1,6 @@
 import AVFoundation
 #if canImport(ZXingObjC)
-import ZXingObjC
+  import ZXingObjC
 #endif
 import VisionKit
 import Vision
@@ -104,36 +104,36 @@ class BarcodeScannerUtils {
   }
 
   #if canImport(ZXingObjC)
-  static func zxResultToDictionary(_ barcodeScannerResult: ZXResult) -> [String: Any] {
-    var result = [String: Any]()
-    result["type"] = BarcodeScannerUtils.zxingFormatToString(barcodeScannerResult.barcodeFormat)
+    static func zxResultToDictionary(_ barcodeScannerResult: ZXResult) -> [String: Any] {
+      var result = [String: Any]()
+      result["type"] = BarcodeScannerUtils.zxingFormatToBarcodeType(barcodeScannerResult.barcodeFormat)?.rawValue ?? "unknown"
 
-    var data = ""
-    for i in 0..<barcodeScannerResult.text.count {
+      var data = ""
+      for i in 0..<barcodeScannerResult.text.count {
       let character = barcodeScannerResult.text[barcodeScannerResult.text.index(barcodeScannerResult.text.startIndex, offsetBy: i)]
-      if character != "\0" {
-        data.append(character)
+        if character != "\0" {
+          data.append(character)
+        }
+      }
+      result["data"] = data
+
+      return result
+    }
+
+    static func zxingFormatToBarcodeType(_ format: ZXBarcodeFormat) -> BarcodeType? {
+      switch format {
+      case kBarcodeFormatPDF417:
+        return .pdf417
+      case kBarcodeFormatCode39:
+        return .code39
+      case kBarcodeFormatCodabar:
+        if #available(iOS 15.4, *) {
+          return .codabar
+        }
+        return nil
+      default:
+        return nil
       }
     }
-    result["data"] = data
-
-    return result
-  }
-
-  static func zxingFormatToString(_ format: ZXBarcodeFormat) -> String {
-    switch format {
-    case kBarcodeFormatPDF417:
-      return AVMetadataObject.ObjectType.pdf417.rawValue
-    case kBarcodeFormatCode39:
-      return AVMetadataObject.ObjectType.code39.rawValue
-    case kBarcodeFormatCodabar:
-      if #available(iOS 15.4, *) {
-        return AVMetadataObject.ObjectType.codabar.rawValue
-      }
-      return "unknown"
-    default:
-      return "unknown"
-    }
-  }
   #endif
 }

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -110,7 +110,7 @@ class BarcodeScannerUtils {
 
     let data = barcodeScannerResult.text.filter { $0 != "\0" }
     result["data"] = data
-    
+
     return result
   }
 

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -120,20 +120,20 @@ class BarcodeScannerUtils {
     return result
   }
 
-    static func zxingFormatToBarcodeType(_ format: ZXBarcodeFormat) -> BarcodeType? {
-      switch format {
-      case kBarcodeFormatPDF417:
-        return .pdf417
-      case kBarcodeFormatCode39:
-        return .code39
-      case kBarcodeFormatCodabar:
-        if #available(iOS 15.4, *) {
-          return .codabar
-        }
-        return nil
-      default:
-        return nil
+  static func zxingFormatToBarcodeType(_ format: ZXBarcodeFormat) -> BarcodeType? {
+    switch format {
+    case kBarcodeFormatPDF417:
+      return .pdf417
+    case kBarcodeFormatCode39:
+      return .code39
+    case kBarcodeFormatCodabar:
+      if #available(iOS 15.4, *) {
+        return .codabar
       }
+      return nil
+    default:
+      return nil
     }
+  }
   #endif
 }


### PR DESCRIPTION
## Summary

When scanning `code39`, `pdf417`, or `codabar` barcodes on iOS, the `type` field in the `onBarcodeScanned` event was returning the raw `AVMetadataObject.ObjectType` string (e.g. `"org.iso.Code39"`) instead of the `BarcodeType` enum value (e.g. `"code39"`).

This only affected the ZXing fallback scanner path, which handles barcode types not natively supported by AVFoundation. The AVFoundation path was already using `BarcodeType.toBarcodeType(...).rawValue` and returning the correct format.

### Root cause

`BarcodeScannerUtils.zxingFormatToString` was returning `AVMetadataObject.ObjectType.rawValue` directly, while the AVFoundation path was going through `BarcodeType.toBarcodeType()` first.

### Fix

Replaced `zxingFormatToString(_ format:) -> String` with `zxingFormatToBarcodeType(_ format:) -> BarcodeType?`, aligning the ZXing path with the AVFoundation path. As a side effect, the redundant `#available(iOS 15.4, *)` guard for `codabar` inside the format mapper was removed — the codabar ZXing reader is only registered on iOS 15.4+ in BarcodeScanner.swift`, so the case can never be reached on earlier versions.

## Test Plan

- [ ] Scan a **Code39** barcode using `<CameraView onBarcodeScanned={...} />` on a
      physical iOS device and verify `event.data` is the expected string and
      `event.type === "code39"` (previously returned `"org.iso.Code39"`)
- [ ] Scan a **PDF417** barcode and verify `event.type === "pdf417"`
      (previously returned `"org.iso.PDF417"`)
- [ ] Scan a **Codabar** barcode on iOS 15.4+ and verify `event.type === "codabar"`
- [ ] Verify other barcode types (QR, EAN-13, Code128, etc.) still work correctly —
      those go through the AVFoundation path and are unaffected by this change
