### PR TITLE
[create-expo-module] Update field defaults

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -39,6 +39,8 @@ describe('CLI flags', () => {
     expect(result.stdout).toMatch(/--author-name/);
     expect(result.stdout).toMatch(/--barrel/);
     expect(result.stdout).toMatch(/--platform/);
+    expect(result.stdout).toMatch(/--license/);
+    expect(result.stdout).toMatch(/--module-version/);
   });
 
   it('shows version with --version flag', async () => {
@@ -484,5 +486,73 @@ describe('CI mode detection', () => {
       { cwd: ciProjectRoot, env: { CI: '0' } }
     );
     expect(result.stdout).toMatch(/Successfully created/);
+  });
+});
+
+describe('non-interactive defaults warning', () => {
+  it('warns about defaulted fields when none are explicitly provided', async () => {
+    const projectName = 'defaults-warning-module';
+
+    const result = await executePassing([
+      projectName,
+      '--no-example',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    // Warning should appear on stderr
+    expect(result.stderr).toMatch(/The following fields were not explicitly provided/);
+    // All non-explicitly-provided fields are listed — hardcoded defaults and auto-derived values
+    expect(result.stderr).toMatch(/\bname\b/);
+    expect(result.stderr).toMatch(/\bpackage\b/);
+    expect(result.stderr).toMatch(/\bdescription\b/);
+    expect(result.stderr).toMatch(/\blicense\b/);
+    expect(result.stderr).toMatch(/\bversion\b/);
+    expect(result.stderr).toMatch(/\bauthorName\b/);
+    expect(result.stderr).toMatch(/\bauthorEmail\b/);
+    expect(result.stderr).toMatch(/\bauthorUrl\b/);
+    expect(result.stderr).toMatch(/\brepo\b/);
+  });
+
+  it('omits fields from the warning when they are explicitly provided', async () => {
+    const projectName = 'partial-defaults-warning';
+
+    const result = await executePassing([
+      projectName,
+      '--no-example',
+      '--name', 'PartialDefaults',
+      '--description', 'Provided description',
+      '--package', 'com.test.partial',
+      '--author-name', 'Test Author',
+      '--author-email', 'test@example.com',
+      '--author-url', 'https://github.com/test',
+      '--repo', 'https://github.com/test/partial',
+      '--license', 'Apache-2.0',
+      '--module-version', '1.0.0',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    // All fields were explicitly provided — no warning
+    expect(result.stderr).not.toMatch(/The following fields were not explicitly provided/);
+  });
+
+  it('respects --license and --module-version in the generated package.json', async () => {
+    const projectName = 'custom-license-version';
+
+    await executePassing([
+      projectName,
+      '--no-example',
+      '--name', 'CustomLicenseVersion',
+      '--package', 'com.test.custom',
+      '--license', 'Apache-2.0',
+      '--module-version', '2.0.0',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const packageJson = readJson(projectName, 'package.json');
+    expect(packageJson.license).toBe('Apache-2.0');
+    expect(packageJson.version).toBe('2.0.0');
   });
 });

--- a/packages/create-expo-module/src/__tests__/defaults-test.ts
+++ b/packages/create-expo-module/src/__tests__/defaults-test.ts
@@ -1,0 +1,51 @@
+import { buildDefaultsWarning } from '../utils/defaults';
+
+describe('buildDefaultsWarning', () => {
+  it('returns null when no defaults were used', () => {
+    expect(buildDefaultsWarning([])).toBeNull();
+  });
+
+  it('contains the header line', () => {
+    const result = buildDefaultsWarning([{ field: 'license', value: 'MIT' }]);
+    expect(result).toMatch(/Warning: The following fields were not explicitly provided/);
+  });
+
+  it('contains the field name and its value', () => {
+    const result = buildDefaultsWarning([{ field: 'license', value: 'MIT' }]);
+    expect(result).toContain('license');
+    expect(result).toContain('MIT');
+  });
+
+  it('shows (empty) for empty string values', () => {
+    const result = buildDefaultsWarning([{ field: 'authorName', value: '' }]);
+    expect(result).toContain('(empty)');
+    expect(result).not.toContain('""');
+  });
+
+  it('aligns values so they all start at the same column', () => {
+    const result = buildDefaultsWarning([
+      { field: 'name', value: 'MyModule' },
+      { field: 'authorName', value: 'Jane' },
+    ])!;
+    const lines = result.split('\n').slice(1, -1); // skip header and footer
+    const col0 = lines[0].indexOf('MyModule');
+    const col1 = lines[1].indexOf('Jane');
+    expect(col0).toBe(col1);
+  });
+
+  it('contains the footer line', () => {
+    const result = buildDefaultsWarning([{ field: 'license', value: 'MIT' }]);
+    expect(result).toContain('provide all values explicitly via CLI flags');
+  });
+
+  it('lists every entry when multiple defaults are provided', () => {
+    const result = buildDefaultsWarning([
+      { field: 'license', value: 'MIT' },
+      { field: 'version', value: '0.1.0' },
+    ])!;
+    expect(result).toContain('license');
+    expect(result).toContain('version');
+    expect(result).toContain('MIT');
+    expect(result).toContain('0.1.0');
+  });
+});

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -36,6 +36,7 @@ import {
 } from './snippets';
 import { eventCreateExpoModule, getTelemetryClient, logEventAsync } from './telemetry';
 import type { CommandOptions, Feature, LocalSubstitutionData, SubstitutionData } from './types';
+import { buildDefaultsWarning } from './utils/defaults';
 import { env } from './utils/env';
 import { findGitHubEmail, findMyName } from './utils/git';
 import { findGitHubUserFromEmail, guessRepoUrl } from './utils/github';
@@ -822,12 +823,14 @@ async function askForSubstitutionDataAsync(
     promptedValues.authorUrl ??
     (authorEmail ? ((await findGitHubUserFromEmail(authorEmail)) ?? '') : '');
   const repo = options.repo ?? promptedValues.repo ?? (await guessRepoUrl(authorUrl, slug)) ?? '';
+  const license = options.license ?? promptedValues.license ?? 'MIT';
+  const version = options.moduleVersion ?? promptedValues.version ?? '0.1.0';
 
   return {
     project: {
       slug,
       name,
-      version: '0.1.0',
+      version,
       description,
       package: projectPackage,
       moduleName: handleSuffix(name, 'Module'),
@@ -837,7 +840,7 @@ async function askForSubstitutionDataAsync(
       features,
     },
     author: `${authorName} <${authorEmail}> (${authorUrl})`,
-    license: 'MIT',
+    license,
     repo,
     type: 'standalone',
   };
@@ -862,6 +865,10 @@ function getCliValueForPrompt(promptName: string, options: CommandOptions): stri
       return options.authorUrl;
     case 'repo':
       return options.repo;
+    case 'license':
+      return options.license;
+    case 'version':
+      return options.moduleVersion;
     default:
       return undefined;
   }
@@ -877,13 +884,21 @@ async function getSubstitutionDataFromOptions(
   platforms: Platform[],
   features: Feature[]
 ): Promise<SubstitutionData | LocalSubstitutionData> {
+  const defaults: { field: string; value: string }[] = [];
+
   const rawName = options.name ?? slugToModuleName(slug);
   const name = resolveModuleName(rawName);
+  if (options.name === undefined) defaults.push({ field: 'name', value: name });
+
   const projectPackage = options.package ?? slugToAndroidPackage(slug);
+  if (options.package === undefined) defaults.push({ field: 'package', value: projectPackage });
 
   debug(`Non-interactive mode: name="${name}", package="${projectPackage}"`);
 
   if (isLocal) {
+    const warning = buildDefaultsWarning(defaults);
+    if (warning) process.stderr.write(chalk.yellow(warning) + '\n');
+
     return {
       project: {
         slug,
@@ -899,23 +914,39 @@ async function getSubstitutionDataFromOptions(
     };
   }
 
-  // For standalone modules, resolve author info
   const description = options.description ?? 'My new module';
   const authorName = options.authorName ?? (await findMyName()) ?? '';
   const authorEmail = options.authorEmail ?? (await findGitHubEmail()) ?? '';
   const authorUrl =
     options.authorUrl ?? (authorEmail ? ((await findGitHubUserFromEmail(authorEmail)) ?? '') : '');
   const repo = options.repo ?? (await guessRepoUrl(authorUrl, slug)) ?? '';
+  const license = options.license ?? 'MIT';
+  const version = options.moduleVersion ?? '0.1.0';
+
+  if (options.description === undefined)
+    defaults.push({ field: 'description', value: description });
+  if (options.authorName === undefined) defaults.push({ field: 'authorName', value: authorName });
+  if (options.authorEmail === undefined)
+    defaults.push({ field: 'authorEmail', value: authorEmail });
+  if (options.authorUrl === undefined) defaults.push({ field: 'authorUrl', value: authorUrl });
+  if (options.repo === undefined) defaults.push({ field: 'repo', value: repo });
+  if (options.license === undefined) defaults.push({ field: 'license', value: license });
+  if (options.moduleVersion === undefined) defaults.push({ field: 'version', value: version });
 
   debug(
-    `Non-interactive mode: description="${description}", authorName="${authorName}", authorEmail="${authorEmail}", authorUrl="${authorUrl}", repo="${repo}"`
+    `Non-interactive mode: description="${description}", authorName="${authorName}", authorEmail="${authorEmail}", authorUrl="${authorUrl}", repo="${repo}", license="${license}", version="${version}"`
   );
+
+  const warning = buildDefaultsWarning(defaults);
+  if (warning) {
+    process.stderr.write(chalk.yellow(warning) + '\n');
+  }
 
   return {
     project: {
       slug,
       name,
-      version: '0.1.0',
+      version,
       description,
       package: projectPackage,
       moduleName: handleSuffix(name, 'Module'),
@@ -925,7 +956,7 @@ async function getSubstitutionDataFromOptions(
       features,
     },
     author: `${authorName} <${authorEmail}> (${authorUrl})`,
-    license: 'MIT',
+    license,
     repo,
     type: 'standalone',
   };
@@ -1086,6 +1117,8 @@ program
   .option('--author-email <email>', 'Author email for package.json.')
   .option('--author-url <url>', "URL to the author's profile (e.g., GitHub profile).")
   .option('--repo <url>', 'URL of the repository.')
+  .option('--license <license>', 'License identifier for package.json (e.g., MIT).')
+  .option('--module-version <version>', 'Initial version for package.json (e.g., 0.1.0).')
   .option(
     '-p, --platform <platforms...>',
     `Target platforms for the module. Available values: ${ALL_PLATFORMS.join(', ')}.`

--- a/packages/create-expo-module/src/prompts.ts
+++ b/packages/create-expo-module/src/prompts.ts
@@ -124,6 +124,20 @@ export async function getSubstitutionDataPrompts(slug: string): Promise<PromptOb
       initial: async (_, answers: Answers<string>) => await guessRepoUrl(answers.authorUrl, slug),
       validate: (input) => /^https?:\/\//.test(input) || 'Must be a valid URL',
     },
+    {
+      type: 'text',
+      name: 'license',
+      message: 'What license does the module use?',
+      initial: 'MIT',
+      validate: (input) => !!input || 'The license cannot be empty',
+    },
+    {
+      type: 'text',
+      name: 'version',
+      message: 'What is the initial version of the module?',
+      initial: '0.1.0',
+      validate: (input) => !!input || 'The version cannot be empty',
+    },
   ];
 }
 

--- a/packages/create-expo-module/src/types.ts
+++ b/packages/create-expo-module/src/types.ts
@@ -23,6 +23,8 @@ export type CommandOptions = {
   authorEmail?: string;
   authorUrl?: string;
   repo?: string;
+  license?: string;
+  moduleVersion?: string;
   platform?: Platform[];
   features?: Feature[];
   fullExample?: boolean;

--- a/packages/create-expo-module/src/utils/defaults.ts
+++ b/packages/create-expo-module/src/utils/defaults.ts
@@ -1,0 +1,24 @@
+export type DefaultEntry = { field: string; value: string };
+
+/**
+ * Builds a warning message listing all fields that were not explicitly provided —
+ * whether they fell back to a hardcoded default or were auto-derived from the environment.
+ * Returns null if every field was explicitly provided.
+ */
+export function buildDefaultsWarning(defaults: DefaultEntry[]): string | null {
+  if (defaults.length === 0) return null;
+
+  const maxLen = Math.max(...defaults.map((d) => d.field.length));
+
+  const lines = defaults.map(({ field, value }) => {
+    const displayValue = value === '' ? '(empty)' : value;
+    const dots = '.'.repeat(maxLen - field.length + 4);
+    return `  ${field} ${dots} ${displayValue}`;
+  });
+
+  return [
+    'Warning: The following fields were not explicitly provided — using defaults or values derived from your environment:',
+    ...lines,
+    'To skip this warning, provide all values explicitly via CLI flags.',
+  ].join('\n');
+}


### PR DESCRIPTION
# Why

The command will fail if some of the options are not provided in CI mode. We can relatively safely pass defaults, especially that it is easy to change the values later if needed.


# How

- Add --license and --module-version CLI flags        
- In non-interactive mode, warn on about any fields that weren't explicitly provided                                                                                                                                    
- Add buildDefaultsWarning utility + unit and E2E tests   
<img width="1089" height="221" alt="image" src="https://github.com/user-attachments/assets/192df433-21e4-426f-8528-44f8ba9a93e1" />

# Test Plan

Tested with the e2e tests and by creatning a few test modules
