### PR TITLE
fix(screen-capture): remove maxSdkVersion cap on READ_MEDIA_IMAGES

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Removed `maxSdkVersion="33"` from `READ_MEDIA_IMAGES` permission to fix Android manifest merge conflict with `expo-media-library` on Android 14+. ([#44730](https://github.com/expo/expo/pull/XXXXX) by [@oeddyo](https://github.com/oeddyo))
+- Removed `maxSdkVersion="33"` from `READ_MEDIA_IMAGES` permission to fix Android manifest merge conflict with `expo-media-library` on Android 14+. ([#44730](https://github.com/expo/expo/pull/44730) by [@oeddyo](https://github.com/oeddyo))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Removed `maxSdkVersion="33"` from `READ_MEDIA_IMAGES` permission to fix Android manifest merge conflict with `expo-media-library` on Android 14+. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@oeddyo](https://github.com/oeddyo))
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Removed `maxSdkVersion="33"` from `READ_MEDIA_IMAGES` permission to fix Android manifest merge conflict with `expo-media-library` on Android 14+. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@oeddyo](https://github.com/oeddyo))
+- Removed `maxSdkVersion="33"` from `READ_MEDIA_IMAGES` permission to fix Android manifest merge conflict with `expo-media-library` on Android 14+. ([#44730](https://github.com/expo/expo/pull/XXXXX) by [@oeddyo](https://github.com/oeddyo))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
+++ b/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33" android:maxSdkVersion="33"/>
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33"/>
   <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" android:minSdkVersion="34" />
 </manifest>


### PR DESCRIPTION
The maxSdkVersion="33" on READ_MEDIA_IMAGES causes the Android manifest merger to cap this permission at API 33 for the entire app. Any other library that declares READ_MEDIA_IMAGES without a cap (e.g. expo-media-library) loses the permission on Android 14+ (API 34+), breaking photo/video access.

expo-screen-capture only needs READ_MEDIA_IMAGES on API 33 for ContentObserver-based screenshot detection, and uses DETECT_SCREEN_CAPTURE on API 34+. Removing the cap is safe — the permission is declared but never requested at runtime on 34+.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
