### PR TITLE
[core] throw from invalid color array

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -48,6 +48,7 @@
 - [iOS] Remove legacy `ExpoBridgeModule` ([#44351](https://github.com/expo/expo/pull/44351) by [@tsapeta](https://github.com/tsapeta))
 - Refactored `ComposableScope` and allow extensibility. ([#44698](https://github.com/expo/expo/pull/44698) by [@kudo](https://github.com/kudo))
 - [iOS] Added broader colors support to convertibles. ([#44630](https://github.com/expo/expo/pull/44630) by [@kudo](https://github.com/kudo))
+- Throwing error when converting invalid color array. ([#44734](https://github.com/expo/expo/pull/44734) by [@kudo](https://github.com/kudo))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ColorTypeConverter.kt
@@ -6,6 +6,7 @@ import androidx.annotation.RequiresApi
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
 import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.UnexpectedException
 import expo.modules.kotlin.jni.CppType
@@ -384,6 +385,9 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
   }
 
   private fun colorFromDoubleArray(value: DoubleArray): Color {
+    if (value.size < 3) {
+      throw InvalidColorComponentsException(value.size)
+    }
     val alpha = value.getOrNull(3) ?: 1.0
     return Color.valueOf(value[0].toFloat(), value[1].toFloat(), value[2].toFloat(), alpha.toFloat())
   }
@@ -427,3 +431,7 @@ class ColorTypeConverter : DynamicAwareTypeConverters<Color>() {
 
   override fun isTrivial() = false
 }
+
+internal class InvalidColorComponentsException(count: Int) : CodedException(
+  message = "Color components array must contain at least 3 values (red, green, blue), but got $count"
+)

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/ColorTypeConverterTest.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import com.facebook.react.bridge.DynamicFromObject
 import com.facebook.react.bridge.JavaOnlyArray
 import com.google.common.truth.Truth
+import expo.modules.assertThrows
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -247,5 +248,23 @@ internal class ColorTypeConverterTest {
     Truth.assertThat(color.green()).isEqualTo(0f)
     Truth.assertThat(color.blue()).isEqualTo(0f)
     Truth.assertThat(color.alpha()).isEqualTo(0.5f)
+  }
+
+  @Test
+  fun `should throw when color components array has fewer than 3 values`() {
+    val shortArrays = listOf(
+      JavaOnlyArray(),
+      JavaOnlyArray().apply { pushDouble(1.0) },
+      JavaOnlyArray().apply {
+        pushDouble(1.0)
+        pushDouble(0.5)
+      }
+    )
+
+    for (array in shortArrays) {
+      assertThrows<InvalidColorComponentsException> {
+        convert<Color>(DynamicFromObject(array))
+      }
+    }
   }
 }

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -11,12 +11,12 @@ extension UIColor: Convertible {
     // swiftlint:disable force_cast
     if let value = value as? String {
       if let namedColorComponents = namedColors[value] {
-        return uiColorWithComponents(namedColorComponents) as! Self
+        return try uiColorWithComponents(namedColorComponents) as! Self
       }
       return try colorFromString(value) as! Self
     }
     if let components = value as? [Double] {
-      return uiColorWithComponents(components) as! Self
+      return try uiColorWithComponents(components) as! Self
     }
     if let value = value as? Int {
       return try colorFromArgb(UInt64(value)) as! Self
@@ -153,7 +153,10 @@ private func uiColorFromSemanticName(name: String) -> UIColor? {
   return UIColor.perform(selector).takeUnretainedValue() as? UIColor
 }
 
-private func uiColorWithComponents(_ components: [Double]) -> UIColor {
+private func uiColorWithComponents(_ components: [Double]) throws -> UIColor {
+  guard components.count >= 3 else {
+    throw InvalidColorComponentsException(components.count)
+  }
   let alpha = components.count > 3 ? components[3] : 1.0
   return UIColor(red: components[0], green: components[1], blue: components[2], alpha: alpha)
 }
@@ -600,5 +603,11 @@ internal class InvalidHWBColorException: GenericException<String>, @unchecked Se
 internal class HexColorOverflowException: GenericException<UInt64>, @unchecked Sendable {
   override var reason: String {
     "Provided hex color '\(param)' would result in an overflow"
+  }
+}
+
+internal class InvalidColorComponentsException: GenericException<Int>, @unchecked Sendable {
+  override var reason: String {
+    "Color components array must contain at least 3 values (red, green, blue), but got \(param)"
   }
 }

--- a/packages/expo-modules-core/ios/Tests/ColorConvertiblesTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ColorConvertiblesTests.swift
@@ -292,4 +292,20 @@ struct ColorConvertiblesTests {
       try CGColor.convert(from: "hwb(invalid)", appContext: appContext)
     }
   }
+
+  @Test
+  func `throws when color components array has fewer than 3 values`() {
+    let shortArrays: [[Double]] = [[], [1.0], [1.0, 0.5]]
+
+    for components in shortArrays {
+      #expect {
+        try CGColor.convert(from: components, appContext: appContext)
+      } throws: { error in
+        guard let componentsError = error as? InvalidColorComponentsException else {
+          return false
+        }
+        return componentsError.description == InvalidColorComponentsException(components.count).description
+      }
+    }
+  }
 }


### PR DESCRIPTION
# Why

following up https://github.com/expo/expo/pull/44630#discussion_r3072427577

# How

throw errors from invalid color array

# Test Plan

add unit tests

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
