### PR TITLE
[brownfield-tester] Add artifacts folder to .gitignore

### DIFF
--- a/apps/brownfield-tester/expo-app/.gitignore
+++ b/apps/brownfield-tester/expo-app/.gitignore
@@ -84,3 +84,4 @@ local.properties
 # Generated native projects
 android/
 ios/
+artifacts/


### PR DESCRIPTION
# Why

Artifacts folder should be ignored inside the brownfield-tester expo-app

# How

 Add artifacts folder to `expo-app`'s .gitignore

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
