### PR TITLE
[dev-launcher][macOS] Fix LocalNetworkPermissionView max height

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [iOS] Fix orientation change regression. ([#43847](https://github.com/expo/expo/pull/43847) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix hard-coded usage of http with exps URLs ([#43982](https://github.com/expo/expo/pull/43982) by [@muvaf](https://github.com/muvaf))
 - [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
+- [macOS] Fix LocalNetworkPermissionView max height ([#44745](https://github.com/expo/expo/pull/44745) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/LocalNetworkPermissionView.swift
@@ -21,7 +21,7 @@ struct LocalNetworkPermissionView: View {
       Color
         .expoSystemBackground
         .ignoresSafeArea(.all)
-      
+
       VStack(spacing: 24) {
         Image("radar-icon", bundle: getDevLauncherBundle())
           .resizable()
@@ -49,6 +49,9 @@ struct LocalNetworkPermissionView: View {
         }
       }
       .padding()
+      #if os(macOS)
+      .frame(maxHeight: 600)
+      #endif
     }
     .alert("Permission Not Granted", isPresented: $showTryAgainFailedAlert) {
       Button("Open Settings") {


### PR DESCRIPTION
# Why

Running BareExpo on macOS results in a giant window that the user can't resize

<img  height="800" alt="image" src="https://github.com/user-attachments/assets/76f52baa-2e28-4396-b4bf-79b1fde2cfa1" />
<img   height="500" alt="image" src="https://github.com/user-attachments/assets/f3f80715-9968-4d90-9df8-365253e91764" />

# How

Add max height to LocalNetworkPermissionView on macOS

# Test Plan

Run BareExpo on macOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
