### PR TITLE
fix(prebuilds): remove expo-ui from prebuilds

### DIFF
--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -27,7 +27,7 @@ const IOS_PREBUILD_PACKAGES = [
   'expo-modules-core',
   'expo-print',
   'expo-sensors',
-  'expo-ui',
+  //'expo-ui', // Until we have support for worklets (3rd party frameworks) in prebuilds, we can't include this package because it has a dependency on react-native-worklets
   'expo-video',
 ];
 


### PR DESCRIPTION
# Why

Expo-UI needs react-native-worklets which are not yet prebuilt (3rd party framework).

# How

Until we have this in place, we have to remove it from being precompiled.

# Test Plan

✅ Run prebuild of all current projects (IOS_PREBUILD_PACKAGES) and verify that they build
 
Publish canaries from main
