### PR TITLE
[docs] Sync EAS CLI reference to v18.6.0

### DIFF
--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.5.0
+cliVersion: 18.6.0
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-04-04T06:57:27.992Z",
-    "cliVersion": "18.5.0"
+    "fetchedAt": "2026-04-14T07:27:57.281Z",
+    "cliVersion": "18.6.0"
   },
   "totalCommands": 102,
   "commands": [


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Bump EAS CLI version to 18.6.0 in reference.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Run `yarn run eas-cli-sync`.