### PR TITLE
[android][audio] Fix lock screen controls on android 12

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unpublished
 
-
 ### 🛠 Breaking changes
 
 - Bumped minimum iOS/tvOS version to 16.4, macOS to 13.4. ([#43296](https://github.com/expo/expo/pull/43296) by [@tsapeta](https://github.com/tsapeta))
@@ -19,6 +18,7 @@
 - [iOS] Fix crash during seek. ([#43564](https://github.com/expo/expo/pull/43564) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Improve looping support. ([#43600](https://github.com/expo/expo/pull/43600) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Prevent stale lock screen artwork updates from crashing or overwriting newer metadata. ([#44498](https://github.com/expo/expo/pull/44498) by [@kotadd](https://github.com/kotadd))
+- [Android] Fix lock screen controls on android 12 and earlier.
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [iOS] Fix crash during seek. ([#43564](https://github.com/expo/expo/pull/43564) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Improve looping support. ([#43600](https://github.com/expo/expo/pull/43600) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Prevent stale lock screen artwork updates from crashing or overwriting newer metadata. ([#44498](https://github.com/expo/expo/pull/44498) by [@kotadd](https://github.com/kotadd))
-- [Android] Fix lock screen controls on android 12 and earlier.
+- [Android] Fix lock screen controls on android 12 and earlier. ([#44754](https://github.com/expo/expo/pull/44754) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -92,7 +92,7 @@ class AudioControlsService : MediaSessionService() {
 
   override fun onCreate() {
     super.onCreate()
-    audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+    audioManager = getSystemService(AUDIO_SERVICE) as AudioManager
     createNotificationChannelIfNeeded()
   }
 
@@ -101,7 +101,7 @@ class AudioControlsService : MediaSessionService() {
   }
 
   private fun createNotificationChannelIfNeeded() {
-    val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       if (notificationManager.getNotificationChannel(CHANNEL_ID) == null) {
         notificationManager.createNotificationChannel(
@@ -125,6 +125,16 @@ class AudioControlsService : MediaSessionService() {
     )
   }
 
+  private fun buildActionPendingIntent(action: String): PendingIntent {
+    val intent = Intent(this, AudioControlsService::class.java).setAction(action)
+    return PendingIntent.getService(
+      this,
+      action.hashCode(),
+      intent,
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+    )
+  }
+
   private fun buildNotification(): Notification? {
     val session = mediaSession ?: return null
 
@@ -139,53 +149,109 @@ class AudioControlsService : MediaSessionService() {
       .setAutoCancel(false)
       .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
 
-    // Using only session custom layout: do NOT call setShowActionsInCompactView.
-    // The compact layout will follow the order of the custom layout provided to the session.
-    builder.setStyle(MediaStyleNotificationHelper.MediaStyle(session))
+    val style = MediaStyleNotificationHelper.MediaStyle(session)
 
+    // Older Android system UI expects explicit notification actions for transport controls.
+    if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+      val compactViewIndices = mutableListOf<Int>()
+      var currentIndex = 0
+
+      if (currentOptions?.showSeekBackward == true) {
+        builder.addAction(
+          NotificationCompat.Action(
+            androidx.media3.session.R.drawable.media3_icon_skip_back,
+            "Seek Backward",
+            buildActionPendingIntent(ACTION_SEEK_BACKWARD)
+          )
+        )
+        compactViewIndices.add(currentIndex)
+        currentIndex++
+      }
+
+      builder.addAction(
+        NotificationCompat.Action(
+          if (session.player.isPlaying) {
+            androidx.media3.session.R.drawable.media3_icon_pause
+          } else {
+            androidx.media3.session.R.drawable.media3_icon_play
+          },
+          if (session.player.isPlaying) "Pause" else "Play",
+          buildActionPendingIntent(if (session.player.isPlaying) ACTION_PAUSE else ACTION_PLAY)
+        )
+      )
+      compactViewIndices.add(currentIndex)
+      currentIndex++
+
+      if (currentOptions?.showSeekForward == true) {
+        builder.addAction(
+          NotificationCompat.Action(
+            androidx.media3.session.R.drawable.media3_icon_skip_forward,
+            "Seek Forward",
+            buildActionPendingIntent(ACTION_SEEK_FORWARD)
+          )
+        )
+        compactViewIndices.add(currentIndex)
+      }
+
+      style.setShowActionsInCompactView(*compactViewIndices.toIntArray())
+    }
+
+    builder.setStyle(style)
     return builder.build()
   }
 
   private fun updateSessionCustomLayout(isPlaying: Boolean) {
     val session = mediaSession ?: return
-    val customLayout = mutableListOf<CommandButton>()
+    val mediaButtons = mutableListOf<CommandButton>()
 
     // Add seek backward button if enabled
     if (currentOptions?.showSeekBackward == true) {
-      customLayout.add(
-        CommandButton.Builder(CommandButton.ICON_SKIP_BACK)
+      mediaButtons.add(
+        CommandButton.Builder(CommandButton.ICON_SKIP_BACK_10)
           .setDisplayName("Seek Backward")
           .setEnabled(true)
           .setSessionCommand(SessionCommand(ACTION_SEEK_BACKWARD, Bundle.EMPTY))
+          .setSlots(CommandButton.SLOT_BACK)
           .build()
       )
     }
 
     // Add play/pause button (always present)
-    customLayout.add(
+    mediaButtons.add(
       CommandButton.Builder(if (isPlaying) CommandButton.ICON_PAUSE else CommandButton.ICON_PLAY)
         .setDisplayName(if (isPlaying) "Pause" else "Play")
         .setEnabled(true)
         .setPlayerCommand(Player.COMMAND_PLAY_PAUSE)
+        .setSlots(CommandButton.SLOT_CENTRAL)
         .build()
     )
 
     // Add seek forward button if enabled
     if (currentOptions?.showSeekForward == true) {
-      customLayout.add(
-        CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD)
+      mediaButtons.add(
+        CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD_10)
           .setDisplayName("Seek Forward")
           .setEnabled(true)
           .setSessionCommand(SessionCommand(ACTION_SEEK_FORWARD, Bundle.EMPTY))
+          .setSlots(CommandButton.SLOT_FORWARD)
           .build()
       )
     }
 
-    session.setCustomLayout(customLayout)
+    session.setCustomLayout(mediaButtons)
+    session.setMediaButtonPreferences(mediaButtons)
   }
 
   private fun postOrStartForegroundNotification(startInForeground: Boolean) {
-    val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    appContext?.let {
+      it.mainQueue.launch {
+        postOrStartForegroundNotificationNow(startInForeground)
+      }
+    } ?: postOrStartForegroundNotificationNow(startInForeground)
+  }
+
+  private fun postOrStartForegroundNotificationNow(startInForeground: Boolean) {
+    val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
     val notification = buildNotification() ?: return
 
     if (startInForeground) {
@@ -317,10 +383,6 @@ class AudioControlsService : MediaSessionService() {
   override fun onBind(intent: Intent?): IBinder {
     super.onBind(intent)
     return binder
-  }
-
-  fun registerPlayer(player: AudioPlayer) {
-    setActivePlayerInternal(player, null, null)
   }
 
   fun setPlayerMetadata(player: AudioPlayer, metadata: Metadata?) {


### PR DESCRIPTION
# Why
Closes #44736

# How
Pre android 13, lockscreen controls are more tied to the legacy notification system and require explicit actions to be set for seek forward, seek backward etc.

# Test Plan
Bare expo. 

<img width="450" height="975" alt="Screenshot_1776151090" src="https://github.com/user-attachments/assets/105be80c-af30-4005-8e1e-1b653ec9e08b" />
