### PR TITLE
[ui] use HorizontalAlignment converter

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -89,6 +89,7 @@
 - [iOS] Make RNHostView SwiftUI view ([#43570](https://github.com/expo/expo/pull/43570) by [@nishan](https://github.com/intergalacticspacehighway))
 - [jetpack-compose] Use view hash code as key for `Children`. ([#44521](https://github.com/expo/expo/pull/44521) by [@kudo](https://github.com/kudo))
 - Refactored `ComposableScope` and allow extensibility. ([#44698](https://github.com/expo/expo/pull/44698) by [@kudo](https://github.com/kudo))
+- [jetpack-compose] Reuse `HorizontalAlignment` converter in `LazyColumn`. ([#44755](https://github.com/expo/expo/pull/44755) by [@kudo](https://github.com/kudo))
 
 ## 55.0.1 — 2026-02-25
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyColumnView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyColumnView.kt
@@ -20,6 +20,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
+import expo.modules.ui.convertibles.HorizontalAlignment
 import expo.modules.ui.convertibles.VerticalArrangement
 import expo.modules.ui.convertibles.toComposeArrangement
 
@@ -32,7 +33,7 @@ data class ContentPadding(
 
 data class LazyColumnProps(
   val verticalArrangement: MutableState<VerticalArrangement?> = mutableStateOf(null),
-  val horizontalAlignment: MutableState<String?> = mutableStateOf(null),
+  val horizontalAlignment: MutableState<HorizontalAlignment?> = mutableStateOf(null),
   val contentPadding: MutableState<ContentPadding?> = mutableStateOf(null),
   val modifiers: MutableState<ModifierList> = mutableStateOf(emptyList())
 ) : ComposeProps
@@ -59,12 +60,7 @@ class LazyColumnView(context: Context, appContext: AppContext) :
     recomposeScope = currentRecomposeScope
     val verticalArrangement = props.verticalArrangement.value?.toComposeArrangement() ?: Arrangement.Top
 
-    val horizontalAlignment = when (props.horizontalAlignment.value) {
-      "start" -> Alignment.Start
-      "end" -> Alignment.End
-      "center" -> Alignment.CenterHorizontally
-      else -> Alignment.Start
-    }
+    val horizontalAlignment = props.horizontalAlignment.value?.toComposeAlignment() ?: Alignment.Start
 
     val padding = props.contentPadding.value
 


### PR DESCRIPTION
# Why

aligned change from https://github.com/expo/expo/pull/44615#discussion_r3077296302

# How

reuse the HorizontalAlignment converter

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
