### PR TITLE
[android][camera] Bump CameraX

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -338,6 +338,9 @@ PODS:
     - ExpoModulesCore
   - ExpoBackgroundTask (55.0.8):
     - ExpoModulesCore
+  - ExpoBackgroundTask/Tests (55.0.8):
+    - ExpoModulesCore
+    - ExpoModulesTestCore
   - ExpoBattery (55.0.8):
     - ExpoModulesCore
   - ExpoBlob (55.0.8):
@@ -596,6 +599,7 @@ PODS:
     - ExpoModulesCore
   - ExpoUI (55.0.1):
     - ExpoModulesCore
+    - ExpoModulesWorklets
     - React-RCTFabric
   - ExpoVideo (55.0.9):
     - ExpoModulesCore
@@ -3167,6 +3171,7 @@ DEPENDENCIES:
   - ExpoAudio (from `../../../packages/expo-audio/ios`)
   - ExpoBackgroundFetch (from `../../../packages/expo-background-fetch/ios`)
   - ExpoBackgroundTask (from `../../../packages/expo-background-task/ios`)
+  - ExpoBackgroundTask/Tests (from `../../../packages/expo-background-task/ios`)
   - ExpoBattery (from `../../../packages/expo-battery/ios`)
   - ExpoBlob (from `../../../packages/expo-blob/ios`)
   - ExpoBlur (from `../../../packages/expo-blur/ios`)
@@ -3816,7 +3821,7 @@ SPEC CHECKSUMS:
   ExpoAsset: 595cc0587b67afaaedddca79d4c1cf506400cb27
   ExpoAudio: 40c883c60ed3bb17ecb3744a00732fb47029535b
   ExpoBackgroundFetch: ee315c8d1a54a3f358fc0cedb68e808e95935c57
-  ExpoBackgroundTask: da109d7e8e8bafe08fafb76c22fca8d6a10b8c86
+  ExpoBackgroundTask: efe66eaab7afbb341b03ef11f9919552797a286a
   ExpoBattery: 978934da47fa3414103aea2b61aeaa459658e06d
   ExpoBlob: 8aadbb43ad4e2cdabc9a10fd26344d7911bb9805
   ExpoBlur: d3a8f3dbdfadac5f4f7ebe201deb245678257b72
@@ -3875,7 +3880,7 @@ SPEC CHECKSUMS:
   ExpoSystemUI: 45304f7673a470749a0fc099b09ba0a23d1a89c2
   ExpoTaskManager: f980f9df7beb21d409decf4bc610f5676318da18
   ExpoTrackingTransparency: a980b930c8e2affc688dd93940dc5b88f55c875b
-  ExpoUI: 470515a8095675c5f4efc12ab685d8758e1ee945
+  ExpoUI: e6e61b9aa1424349659c6cb1165adee716a89b69
   ExpoVideo: eca730ba53ec45c2a188aa9dbfe11f7f809d66a1
   ExpoVideoThumbnails: 2340f0b7f599c9ce6ba49a885f783de919cf4dd3
   ExpoWebBrowser: b65b3921741b51c5513e2a369f59c37076987d9b
@@ -3883,7 +3888,7 @@ SPEC CHECKSUMS:
   EXUpdates: a0f980531cbcf45906b2489febd4e11a5895f332
   EXUpdatesInterface: 5ab8c3e8018ef533a132b9327af5b2a1926dd299
   FBLazyVector: c00c20551d40126351a6783c47ce75f5b374851b
-  hermes-engine: 407f52f1dca2c25263c5f76e80cc38a39e0f6ec0
+  hermes-engine: 725fd85144e1348879039099a6be950c471a4f2c
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3901,7 +3906,7 @@ SPEC CHECKSUMS:
   React: 1b1536b9099195944034e65b1830f463caaa8390
   React-callinvoker: 6dff6d17d1d6cc8fdf85468a649bafed473c65f5
   React-Core: 00faa4d038298089a1d5a5b21dde8660c4f0820d
-  React-Core-prebuilt: 705f99b0bd56f86a0236e6fcdc1050e9d688561a
+  React-Core-prebuilt: 90227d29159eefbb7ba8c84cc1f095a68bb2c582
   React-CoreModules: a17807f849bfd86045b0b9a75ec8c19373b482f6
   React-cxxreact: c7b53ace5827be54048288bce5c55f337c41e95f
   React-debug: e1f00fcd2cef58a2897471a6d76a4ef5f5f90c74
@@ -3971,7 +3976,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 5787b37b8e2e51dfeab697ec031cc7c4080dcea2
   ReactCodegen: c6d3cb3ac0f52891ba8d0fb1ddadaca8f4491df2
   ReactCommon: fe2a3af8975e63efa60f95fca8c34dc85deee360
-  ReactNativeDependencies: 0c3e1ac9f777b276b1b6bf0d630829e3c72d54ad
+  ReactNativeDependencies: 511cad08f3f5c96333ac3cfb56ec12027ba6fa1f
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNCPicker: d74667bdfc08ed389a2a277d95b8faf2349290a9

--- a/packages/expo-camera/android/build.gradle
+++ b/packages/expo-camera/android/build.gradle
@@ -17,8 +17,15 @@ android {
   }
 }
 
+// CameraX 1.6.0 requires listenablefuture:1.0 at compile time, but the React Native
+// Gradle plugin pulls in full Guava which forces listenablefuture to 9999.0-empty
+// (an intentionally empty jar). Override this to restore the real ListenableFuture class.
+configurations.configureEach {
+  resolutionStrategy.force "com.google.guava:listenablefuture:1.0"
+}
+
 dependencies {
-  def camerax_version = "1.5.3"
+  def camerax_version = "1.6.0"
 
   api "androidx.exifinterface:exifinterface:1.4.2"
   api "androidx.appcompat:appcompat:1.7.1"
@@ -30,7 +37,7 @@ dependencies {
 
   implementation "androidx.camera:camera-view:${camerax_version}"
   implementation "androidx.camera:camera-extensions:${camerax_version}"
-  implementation "androidx.core:core-ktx:1.17.0"
+  implementation "androidx.core:core-ktx:1.18.0"
 
   def barcodeDependencyConfiguration = isBarcodeScannerEnabled ? "implementation" : "compileOnly"
   add(barcodeDependencyConfiguration, "com.google.android.gms:play-services-code-scanner:16.1.0")


### PR DESCRIPTION
# Why
`1.6.0` is supposed to bring some free performance improvements. 

# How
I ran into one issue. CameraX changed `listenablefuture` from a runtime to a compile dependency. This means the `ListenableFuture` class must be resolvable at compile time.

The RN gradle plugin depends on full Guava, which imposes a constraint forcing `listenablefuture` to `9999.0-empty-to-avoid-conflict-with-guava`. Gradle resolves 9999.0 instead of 1.0 removing the `ListenableFuture` class from the classpath. This breaks cameraX 1.6.0.

Fix is a `resolutionStrategy` to override the constraint and use `listenablefuture:1.0`.

# Test Plan
Bare expo. Working as normal
