### PR TITLE
refactor(create-expo,create-expo-module): Replace `tar` with `multitars` to complete migration

### DIFF
--- a/packages/@expo/cli/src/utils/tar.ts
+++ b/packages/@expo/cli/src/utils/tar.ts
@@ -4,8 +4,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Readable } from 'node:stream';
 
-import { ensureDirectoryAsync } from './dir';
-
 const debug = require('debug')('expo:utils:tar') as typeof console.log;
 
 class ChecksumStream extends TransformStream {
@@ -40,7 +38,7 @@ export async function extractStream(
   options: ExtractOptions = {}
 ): Promise<string> {
   output = path.resolve(output);
-  await ensureDirectoryAsync(output);
+  await fs.promises.mkdir(output, { recursive: true });
 
   const { checksumAlgorithm, strip = 0, rename, filter } = options;
 

--- a/packages/create-expo-module/package.json
+++ b/packages/create-expo-module/package.json
@@ -63,7 +63,7 @@
     "getenv": "^2.0.0",
     "ora": "^5.4.1",
     "prompts": "^2.4.2",
-    "tar": "^7.5.12",
+    "multitars": "^0.2.3",
     "validate-npm-package-name": "^6.0.2"
   }
 }

--- a/packages/create-expo-module/src/utils/tar.ts
+++ b/packages/create-expo-module/src/utils/tar.ts
@@ -1,11 +1,142 @@
-import fs from 'node:fs';
-import { Stream } from 'node:stream';
-import { promisify } from 'node:util';
-import { extract as tarExtract } from 'tar';
+// NOTE(@kitten): Based on @expo/cli/src/utils/tar.ts
+// Keep in sync with that version of this module
 
-const pipeline = promisify(Stream.pipeline);
+import { streamToAsyncIterable, TarTypeFlag, untar } from 'multitars';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+// Modified:
+const debug = require('debug')('create-expo-module:tar') as typeof console.log;
+
+class ChecksumStream extends TransformStream {
+  hash: crypto.Hash;
+  constructor(algorithm: string) {
+    super({
+      transform: (chunk, controller) => {
+        this.hash.update(chunk);
+        controller.enqueue(chunk);
+      },
+    });
+    this.hash = crypto.createHash(algorithm);
+  }
+
+  digest(): Buffer;
+  digest(encoding: crypto.BinaryToTextEncoding): string;
+  digest(encoding?: crypto.BinaryToTextEncoding): string | Buffer {
+    return this.hash.digest(encoding!);
+  }
+}
+
+export interface ExtractOptions {
+  strip?: number;
+  filter?(name: string, type: TarTypeFlag): boolean | null | undefined;
+  rename?(name: string, type: TarTypeFlag): string | null | undefined;
+  checksumAlgorithm?: string;
+}
+
+export async function extractStream(
+  input: ReadableStream,
+  output: string,
+  options: ExtractOptions = {}
+): Promise<string> {
+  output = path.resolve(output);
+  await fs.promises.mkdir(output, { recursive: true });
+
+  const { checksumAlgorithm, strip = 0, rename, filter } = options;
+
+  const checksumStream = new ChecksumStream(checksumAlgorithm || 'md5');
+  const decompressionStream = new DecompressionStream('gzip');
+
+  const body = input.pipeThrough(checksumStream).pipeThrough(decompressionStream);
+
+  for await (const file of untar(body)) {
+    let name = path.normalize(file.name);
+    if (filter && !filter(name, file.typeflag)) {
+      debug(`filtered: ${path.resolve(output, name)}`);
+      continue;
+    } else if (rename) {
+      name = rename(name, file.typeflag) ?? name;
+    }
+
+    for (let idx = 0; idx < strip; idx++) {
+      const sepIdx = name.indexOf(path.sep);
+      if (sepIdx > -1) {
+        name = name.slice(sepIdx + 1);
+      } else {
+        break;
+      }
+    }
+
+    const resolved = path.resolve(output, name);
+    if (!resolved.startsWith(output)) {
+      debug(`skip: ${resolved}`);
+      continue;
+    }
+
+    const parent = path.dirname(resolved);
+    if (parent !== output) {
+      let exists = false;
+      try {
+        const stat = await fs.promises.lstat(parent);
+        if (stat.isSymbolicLink() || (!stat.isDirectory() && !stat.isFile())) {
+          debug(`skip: ${resolved}`);
+          continue;
+        } else if (stat.isDirectory()) {
+          exists = true;
+        }
+      } catch {}
+
+      if (!exists) {
+        debug(`mkdir(p): ${parent}`);
+        await fs.promises.mkdir(parent, { recursive: true });
+      }
+    }
+
+    switch (file.typeflag) {
+      case TarTypeFlag.FILE:
+        debug(`write(${file.mode.toString(8)}): ${resolved}`);
+        await fs.promises.writeFile(resolved, streamToAsyncIterable(file.stream()), {
+          mode: file.mode,
+        });
+        break;
+      case TarTypeFlag.DIRECTORY:
+        debug(`mkdir(${file.mode.toString(8)}): ${resolved}`);
+        try {
+          await fs.promises.mkdir(resolved, { mode: file.mode });
+        } catch (error: any) {
+          if (error.code !== 'EEXIST') {
+            throw error;
+          }
+        }
+        break;
+      case TarTypeFlag.SYMLINK:
+      case TarTypeFlag.LINK: {
+        const target = path.resolve(parent, file.linkname ?? '');
+        if (!target.startsWith(output) || target === parent) {
+          debug(`skip: ${resolved} -> ${target}`);
+          continue;
+        }
+
+        if (file.typeflag === TarTypeFlag.LINK) {
+          debug(`link: ${resolved} -> ${target}`);
+          await fs.promises.link(target, resolved);
+        } else {
+          const stat = await fs.promises.lstat(target).catch(() => null);
+          const type = stat?.isDirectory() ? 'dir' : 'file';
+          debug(`symlink(${type}): ${resolved} -> ${target}`);
+          await fs.promises.symlink(target, resolved, type);
+        }
+        break;
+      }
+    }
+  }
+
+  return checksumStream.digest('hex');
+}
 
 /** Extract a local tarball file to a directory */
 export async function extractLocalTarball({ filePath, dir }: { filePath: string; dir: string }) {
-  await pipeline(fs.createReadStream(filePath), tarExtract({ cwd: dir }));
+  await extractStream(Readable.toWeb(fs.createReadStream(filePath)) as ReadableStream, dir);
 }

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Replace tar dependency logic with `multitars` package ([#44764](https://github.com/expo/expo/pull/44764) by [@kitten](https://github.com/kitten))
+
 ## 3.6.6 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -58,7 +58,7 @@
     "ora": "3.4.0",
     "picomatch": "^2.3.1",
     "prompts": "^2.4.2",
-    "tar": "^7.5.12",
+    "multitars": "^0.2.3",
     "update-check": "^1.5.4"
   }
 }

--- a/packages/create-expo/src/Examples.ts
+++ b/packages/create-expo/src/Examples.ts
@@ -3,21 +3,17 @@ import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
 import prompts from 'prompts';
-import { Readable, Stream } from 'stream';
-import { extract as tarExtract } from 'tar';
-import { promisify } from 'util';
 
 import {
   getTemplateFilesToRenameAsync,
   renameTemplateAppNameAsync,
   sanitizeTemplateAsync,
 } from './Template';
-import { createEntryResolver } from './createFileTransform';
 import { env } from './utils/env';
 import { fetch } from './utils/fetch';
+import { extractNpmTarballAsync } from './utils/npm';
 
 const debug = require('debug')('expo:init:template') as typeof console.log;
-const pipeline = promisify(Stream.pipeline);
 
 /**
  * The partial GitHub content type, used to filter out examples.
@@ -131,17 +127,12 @@ export async function downloadAndExtractExampleAsync(root: string, name: string)
     throw new Error('Failed to fetch the examples code from https://github.com/expo/examples');
   }
 
-  await pipeline(
-    Readable.fromWeb(response.body),
-    tarExtract(
-      {
-        cwd: root,
-        onentry: createEntryResolver(projectName),
-        strip: 2,
-      },
-      [`examples-master/${name}`]
-    )
-  );
+  const prefix = `examples-master/${name}/`;
+  await extractNpmTarballAsync(response.body, root, {
+    expName: projectName,
+    strip: 2,
+    filter: (entryName) => entryName.startsWith(prefix),
+  });
 
   const files = await getTemplateFilesToRenameAsync({ cwd: root });
   await renameTemplateAppNameAsync({

--- a/packages/create-expo/src/Template.ts
+++ b/packages/create-expo/src/Template.ts
@@ -16,7 +16,6 @@ import {
   applyBetaTag,
   applyKnownNpmPackageNameRules,
   downloadAndExtractNpmModuleAsync,
-  ExtractProps,
   getResolvedTemplateName,
 } from './utils/npm';
 
@@ -128,15 +127,13 @@ export async function extractAndPrepareTemplateAppAsync(
   const { type, uri } = resolvePackageModuleId(npmPackage || 'expo-template-default');
 
   if (type === 'repository') {
-    await downloadAndExtractGitHubRepositoryAsync(uri, {
-      cwd: projectRoot,
-      name: projectName,
+    await downloadAndExtractGitHubRepositoryAsync(uri, projectRoot, {
+      expName: projectName,
     });
   } else {
     const resolvedUri = type === 'file' ? uri : getResolvedTemplateName(applyBetaTag(uri));
-    await downloadAndExtractNpmModuleAsync(resolvedUri, {
-      cwd: projectRoot,
-      name: projectName,
+    await downloadAndExtractNpmModuleAsync(resolvedUri, projectRoot, {
+      expName: projectName,
       disableCache: type === 'file',
     });
   }
@@ -175,7 +172,7 @@ function escapeXMLCharacters(original: string): string {
  * specified.
  *
  * By convention, the app name of all templates is "HelloWorld". During
- * extraction, filepaths are transformed via `createEntryResolver()` in
+ * extraction, filepaths are transformed via `createEntryRenamer()` in
  * `createFileTransform.ts`, but the contents of files are left untouched.
  * Technically, the contents used to be transformed during extraction as well,
  * but due to poor configurability, we've moved to a post-extraction approach.
@@ -240,7 +237,10 @@ export async function getTemplateFilesToRenameAsync({
    * @see defaultRenameConfig
    */
   renameConfig: userConfig,
-}: Pick<ExtractProps, 'cwd'> & { renameConfig?: string[] }) {
+}: {
+  cwd: string;
+  renameConfig?: string[];
+}) {
   let config = userConfig ?? defaultRenameConfig;
 
   // Strip comments, trim whitespace, and remove empty lines.
@@ -264,7 +264,9 @@ export async function renameTemplateAppNameAsync({
   cwd,
   name,
   files,
-}: Pick<ExtractProps, 'cwd' | 'name'> & {
+}: {
+  cwd: string;
+  name: string;
   /**
    * An array of files to transform. Usually provided by calling
    * getTemplateFilesToRenameAsync().

--- a/packages/create-expo/src/__tests__/createFileTransformer.test.ts
+++ b/packages/create-expo/src/__tests__/createFileTransformer.test.ts
@@ -1,37 +1,27 @@
-import { createGlobFilter, modifyFileDuringPipe } from '../createFileTransform';
+import { TarTypeFlag } from 'multitars';
 
-describe(modifyFileDuringPipe, () => {
+import { createEntryRenamer, createGlobFilter } from '../createFileTransform';
+
+describe(createEntryRenamer, () => {
+  const rename = createEntryRenamer('');
+
   it(`renames _vscode to .vscode`, () => {
-    expect(
-      modifyFileDuringPipe({
-        path: 'package/_vscode/',
-        type: 'File',
-      }).path
-    ).toEqual('package/.vscode/');
+    expect(rename('package/_vscode/', TarTypeFlag.FILE)).toEqual('package/.vscode/');
   });
   it(`renames files within _vscode to .vscode`, () => {
-    expect(
-      modifyFileDuringPipe({
-        path: 'package/_vscode/settings.json',
-        type: 'File',
-      }).path
-    ).toEqual('package/.vscode/settings.json');
+    expect(rename('package/_vscode/settings.json', TarTypeFlag.FILE)).toEqual(
+      'package/.vscode/settings.json'
+    );
   });
   it(`does not rename extraneous _ segments`, () => {
-    expect(
-      modifyFileDuringPipe({
-        path: '_package/_vscode/settings.json',
-        type: 'File',
-      }).path
-    ).toEqual('_package/.vscode/settings.json');
+    expect(rename('_package/_vscode/settings.json', TarTypeFlag.FILE)).toEqual(
+      '_package/.vscode/settings.json'
+    );
   });
   it(`does not rename multiple instances of _vscode`, () => {
-    expect(
-      modifyFileDuringPipe({
-        path: '_package/_vscode/foo/_vscode/settings.json',
-        type: 'File',
-      }).path
-    ).toEqual('_package/.vscode/foo/_vscode/settings.json');
+    expect(rename('_package/_vscode/foo/_vscode/settings.json', TarTypeFlag.FILE)).toEqual(
+      '_package/.vscode/foo/_vscode/settings.json'
+    );
   });
 });
 

--- a/packages/create-expo/src/createFileTransform.ts
+++ b/packages/create-expo/src/createFileTransform.ts
@@ -1,6 +1,6 @@
+import { TarTypeFlag } from 'multitars';
 import path from 'path';
 import picomatch from 'picomatch';
-import type { ReadEntry } from 'tar';
 
 const debug = require('debug')('expo:init:fileTransform') as typeof console.log;
 
@@ -17,50 +17,39 @@ const SUPPORTED_DIRECTORIES_PATTERN = new RegExp(
   `(^|/|\\\\)_(${SUPPORTED_DIRECTORIES.join('|')})(/|\\\\|$)`
 );
 
-function applyNameDuringPipe(entry: Pick<ReadEntry, 'path'>, name: string) {
-  if (name) {
-    // Rewrite paths for bare workflow
-    entry.path = entry.path
-      .replace(
-        /HelloWorld/g,
-        entry.path.includes('android') ? sanitizedName(name.toLowerCase()) : sanitizedName(name)
-      )
-      .replace(/helloworld/g, sanitizedName(name).toLowerCase());
-  }
-  return entry;
-}
-
-const ENTRY_FILE_PATTERN = /^file$/i;
-const ENTRY_FILE_OR_DIRECTORY_PATTERN = /^(file|directory)$/i;
-
-export function modifyFileDuringPipe(entry: Pick<ReadEntry, 'path' | 'type'>) {
-  if (!entry.type) return entry;
-
-  if (ENTRY_FILE_PATTERN.test(entry.type) && path.basename(entry.path) === 'gitignore') {
-    // Rename `gitignore` because npm ignores files named `.gitignore` when publishing.
-    // See: https://github.com/npm/npm/issues/1862
-    entry.path = entry.path.replace(/gitignore$/, '.gitignore');
-  }
-
-  if (ENTRY_FILE_OR_DIRECTORY_PATTERN.test(entry.type)) {
+function renameDirectories(input: string, typeflag: TarTypeFlag): string {
+  if (typeflag === TarTypeFlag.FILE || typeflag === TarTypeFlag.DIRECTORY) {
     // Detect if the file contains one of the supported directories
     // and rename it to the correct format.
     // For example, if the file is `_vscode`, we want to rename it to `.vscode`.
-
-    // Match one instance of the supported directory name, starting with an underscore, and containing slashes on both sides.
-    entry.path = entry.path.replace(
-      SUPPORTED_DIRECTORIES_PATTERN,
-      (match, p1, p2, p3) => `${p1}.${p2}${p3}`
-    );
+    input = input.replace(SUPPORTED_DIRECTORIES_PATTERN, (match, p1, p2, p3) => `${p1}.${p2}${p3}`);
   }
-
-  return entry;
+  return input;
 }
 
-export function createEntryResolver(name: string) {
-  return (entry: ReadEntry) => {
-    applyNameDuringPipe(entry, name);
-    modifyFileDuringPipe(entry);
+function renameConfigs(input: string, typeflag: TarTypeFlag): string {
+  if (typeflag === TarTypeFlag.FILE && path.basename(input) === 'gitignore') {
+    // Rename `gitignore` because npm ignores files named `.gitignore` when publishing.
+    // See: https://github.com/npm/npm/issues/1862
+    input = input.replace(/gitignore$/, '.gitignore');
+  }
+  return input;
+}
+
+export function createEntryRenamer(name: string) {
+  return (input: string, typeflag: TarTypeFlag): string => {
+    if (name) {
+      // Rewrite paths for bare workflow
+      input = input
+        .replace(
+          /HelloWorld/g,
+          input.includes('android') ? sanitizedName(name.toLowerCase()) : sanitizedName(name)
+        )
+        .replace(/helloworld/g, sanitizedName(name).toLowerCase());
+    }
+    input = renameConfigs(input, typeflag);
+    input = renameDirectories(input, typeflag);
+    return input;
   };
 }
 

--- a/packages/create-expo/src/utils/github.ts
+++ b/packages/create-expo/src/utils/github.ts
@@ -1,5 +1,4 @@
 import type { Endpoints } from '@octokit/types';
-import { Readable } from 'stream';
 
 import { fetch } from './fetch';
 import { extractNpmTarballAsync, type ExtractProps } from './npm';
@@ -60,8 +59,9 @@ async function isValidGitHubRepoAsync(repo: GitHubRepoInfo): Promise<boolean> {
 async function extractRemoteGitHubTarballAsync(
   url: string,
   repo: GitHubRepoInfo,
+  output: string,
   props: ExtractProps
-): Promise<void> {
+): Promise<string> {
   const response = await fetch(url);
 
   if (!response.ok) throw new Error(`Unexpected response: ${response.statusText} (${url})`);
@@ -72,7 +72,7 @@ async function extractRemoteGitHubTarballAsync(
   // Remove the (sub)directory paths, and the root folder added by GitHub
   const strip = directory.length + 1;
   // Only extract the relevant (sub)directories, ignoring irrelevant files
-  // The filder auto-ignores dotfiles, unless explicitly included
+  // The filter auto-ignores dotfiles, unless explicitly included
   const filter = createGlobFilter(
     !directory.length
       ? ['*/**', '*/ios/.xcode.env']
@@ -83,13 +83,18 @@ async function extractRemoteGitHubTarballAsync(
     }
   );
 
-  await extractNpmTarballAsync(Readable.fromWeb(response.body), { ...props, filter, strip });
+  return await extractNpmTarballAsync(response.body, output, {
+    ...props,
+    filter,
+    strip,
+  });
 }
 
 export async function downloadAndExtractGitHubRepositoryAsync(
   repoUrl: URL,
+  output: string,
   props: ExtractProps
-): Promise<void> {
+): Promise<string> {
   debug('Looking for GitHub repository');
 
   const info = await getGitHubRepoAsync(repoUrl);
@@ -106,5 +111,5 @@ export async function downloadAndExtractGitHubRepositoryAsync(
   debug('Resolved GitHub repository', info);
   debug('Downloading GitHub repository from:', url);
 
-  await extractRemoteGitHubTarballAsync(url, info, props);
+  return await extractRemoteGitHubTarballAsync(url, info, output, props);
 }

--- a/packages/create-expo/src/utils/npm.ts
+++ b/packages/create-expo/src/utils/npm.ts
@@ -2,28 +2,22 @@ import spawnAsync from '@expo/spawn-async';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { Stream } from 'stream';
-import { extract as tarExtract, TarOptionsWithAliases } from 'tar';
-import { promisify } from 'util';
+import { Readable } from 'stream';
 
 import { env } from './env';
-import { createEntryResolver } from '../createFileTransform';
+import { extractStream } from './tar';
+import { createEntryRenamer } from '../createFileTransform';
 import { ALIASES } from '../legacyTemplates';
 import { Log } from '../log';
 
 const debug = require('debug')('expo:init:npm') as typeof console.log;
 
-export type ExtractProps = {
-  name: string;
-  cwd: string;
+export interface ExtractProps {
+  expName: string;
+  filter?(path: string): boolean | undefined | null;
   strip?: number;
-  fileList?: string[];
   disableCache?: boolean;
-  filter?: TarOptionsWithAliases['filter'];
-};
-
-// @ts-ignore
-const pipeline = promisify(Stream.pipeline);
+}
 
 function getTemporaryCacheFilePath(subdir: string = 'template-cache') {
   // This is cleared when the device restarts
@@ -107,36 +101,30 @@ export function applyKnownNpmPackageNameRules(name: string): string | null {
   );
 }
 
-export async function extractLocalNpmTarballAsync(
-  tarFilePath: string,
+/**
+ * Extracts a tarball stream to a directory.
+ */
+export async function extractNpmTarballAsync(
+  stream: ReadableStream,
+  output: string,
   props: ExtractProps
-): Promise<void> {
-  const readStream = fs.createReadStream(tarFilePath);
-  await extractNpmTarballAsync(readStream, props);
+): Promise<string> {
+  return await extractStream(stream, output, {
+    filter: props.filter,
+    rename: createEntryRenamer(props.expName),
+    strip: props.strip ?? 1,
+  });
 }
 
-export async function extractNpmTarballAsync(
-  stream: NodeJS.ReadableStream | null,
+export async function extractLocalNpmTarballAsync(
+  tarFilePath: string,
+  output: string,
   props: ExtractProps
-): Promise<void> {
-  if (!stream) {
-    throw new Error('Missing stream');
-  }
-  const { cwd, strip, name, fileList = [], filter } = props;
-
-  await fs.promises.mkdir(cwd, { recursive: true });
-
-  await pipeline(
-    stream,
-    tarExtract(
-      {
-        cwd,
-        filter,
-        onentry: createEntryResolver(name),
-        strip: strip ?? 1,
-      },
-      fileList
-    )
+): Promise<string> {
+  return await extractNpmTarballAsync(
+    Readable.toWeb(fs.createReadStream(tarFilePath)) as ReadableStream,
+    output,
+    props
   );
 }
 
@@ -259,8 +247,9 @@ async function fileExistsAsync(path: string): Promise<boolean> {
 
 export async function downloadAndExtractNpmModuleAsync(
   npmName: string,
+  output: string,
   props: ExtractProps
-): Promise<void> {
+): Promise<string> {
   const cachePath = getTemporaryCacheFilePath();
 
   debug(`Looking for NPM tarball (id: ${npmName}, cache: ${cachePath})`);
@@ -285,9 +274,8 @@ export async function downloadAndExtractNpmModuleAsync(
   }
 
   try {
-    await extractLocalNpmTarballAsync(cacheFilename, {
-      cwd: props.cwd,
-      name: props.name,
+    return await extractLocalNpmTarballAsync(cacheFilename, output, {
+      expName: props.expName,
     });
   } catch (error: any) {
     Log.error('Error extracting template package: ' + npmName);

--- a/packages/create-expo/src/utils/tar.ts
+++ b/packages/create-expo/src/utils/tar.ts
@@ -1,0 +1,150 @@
+// NOTE(@kitten): Based on @expo/cli/src/utils/tar.ts
+// Keep in sync with that version of this module
+
+import { streamToAsyncIterable, TarTypeFlag, untar } from 'multitars';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+// Modified:
+const debug = require('debug')('create-expo:tar') as typeof console.log;
+
+class ChecksumStream extends TransformStream {
+  hash: crypto.Hash;
+  constructor(algorithm: string) {
+    super({
+      transform: (chunk, controller) => {
+        this.hash.update(chunk);
+        controller.enqueue(chunk);
+      },
+    });
+    this.hash = crypto.createHash(algorithm);
+  }
+
+  digest(): Buffer;
+  digest(encoding: crypto.BinaryToTextEncoding): string;
+  digest(encoding?: crypto.BinaryToTextEncoding): string | Buffer {
+    return this.hash.digest(encoding!);
+  }
+}
+
+export interface ExtractOptions {
+  strip?: number;
+  filter?(name: string, type: TarTypeFlag): boolean | null | undefined;
+  rename?(name: string, type: TarTypeFlag): string | null | undefined;
+  checksumAlgorithm?: string;
+}
+
+export async function extractStream(
+  input: ReadableStream,
+  output: string,
+  options: ExtractOptions = {}
+): Promise<string> {
+  output = path.resolve(output);
+  await fs.promises.mkdir(output, { recursive: true });
+
+  const { checksumAlgorithm, strip = 0, rename, filter } = options;
+
+  const checksumStream = new ChecksumStream(checksumAlgorithm || 'md5');
+  const decompressionStream = new DecompressionStream('gzip');
+
+  const body = input.pipeThrough(checksumStream).pipeThrough(decompressionStream);
+
+  for await (const file of untar(body)) {
+    let name = path.normalize(file.name);
+    if (filter && !filter(name, file.typeflag)) {
+      debug(`filtered: ${path.resolve(output, name)}`);
+      continue;
+    } else if (rename) {
+      name = rename(name, file.typeflag) ?? name;
+    }
+
+    for (let idx = 0; idx < strip; idx++) {
+      const sepIdx = name.indexOf(path.sep);
+      if (sepIdx > -1) {
+        name = name.slice(sepIdx + 1);
+      } else {
+        break;
+      }
+    }
+
+    const resolved = path.resolve(output, name);
+    if (!resolved.startsWith(output)) {
+      debug(`skip: ${resolved}`);
+      continue;
+    }
+
+    const parent = path.dirname(resolved);
+    if (parent !== output) {
+      let exists = false;
+      try {
+        const stat = await fs.promises.lstat(parent);
+        if (stat.isSymbolicLink() || (!stat.isDirectory() && !stat.isFile())) {
+          debug(`skip: ${resolved}`);
+          continue;
+        } else if (stat.isDirectory()) {
+          exists = true;
+        }
+      } catch {}
+
+      if (!exists) {
+        debug(`mkdir(p): ${parent}`);
+        await fs.promises.mkdir(parent, { recursive: true });
+      }
+    }
+
+    switch (file.typeflag) {
+      case TarTypeFlag.FILE:
+        debug(`write(${file.mode.toString(8)}): ${resolved}`);
+        await fs.promises.writeFile(resolved, streamToAsyncIterable(file.stream()), {
+          mode: file.mode,
+        });
+        break;
+      case TarTypeFlag.DIRECTORY:
+        debug(`mkdir(${file.mode.toString(8)}): ${resolved}`);
+        try {
+          await fs.promises.mkdir(resolved, { mode: file.mode });
+        } catch (error: any) {
+          if (error.code !== 'EEXIST') {
+            throw error;
+          }
+        }
+        break;
+      case TarTypeFlag.SYMLINK:
+      case TarTypeFlag.LINK: {
+        const target = path.resolve(parent, file.linkname ?? '');
+        if (!target.startsWith(output) || target === parent) {
+          debug(`skip: ${resolved} -> ${target}`);
+          continue;
+        }
+
+        if (file.typeflag === TarTypeFlag.LINK) {
+          debug(`link: ${resolved} -> ${target}`);
+          await fs.promises.link(target, resolved);
+        } else {
+          const stat = await fs.promises.lstat(target).catch(() => null);
+          const type = stat?.isDirectory() ? 'dir' : 'file';
+          debug(`symlink(${type}): ${resolved} -> ${target}`);
+          await fs.promises.symlink(target, resolved, type);
+        }
+        break;
+      }
+    }
+  }
+
+  return checksumStream.digest('hex');
+}
+
+/** Extract a tar using built-in tools if available and falling back on Node.js. */
+export async function extractAsync(
+  input: string,
+  output: string,
+  options?: ExtractOptions
+): Promise<void> {
+  await extractStream(
+    Readable.toWeb(fs.createReadStream(input)) as ReadableStream,
+    output,
+    options
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2944,6 +2944,9 @@ importers:
       glob:
         specifier: ^13.0.0
         version: 13.0.6
+      multitars:
+        specifier: ^0.2.3
+        version: 0.2.4
       nock:
         specifier: ^14.0.10
         version: 14.0.11
@@ -2956,9 +2959,6 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
-      tar:
-        specifier: ^7.5.12
-        version: 7.5.12
       update-check:
         specifier: ^1.5.4
         version: 1.5.4
@@ -3022,15 +3022,15 @@ importers:
       getenv:
         specifier: ^2.0.0
         version: 2.0.0
+      multitars:
+        specifier: ^0.2.3
+        version: 0.2.4
       ora:
         specifier: ^5.4.1
         version: 5.4.1
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
-      tar:
-        specifier: ^7.5.12
-        version: 7.5.12
       validate-npm-package-name:
         specifier: ^6.0.2
         version: 6.0.2


### PR DESCRIPTION
# Why

This mirrors #42472 to `create-expo` and `create-expo-module`, which completes the migration from the `tar` package to `multitars`, dropping the former dependency. The goal is to change no observable behavior while doing so.

# How

- cli: Remove one-off `dir.ts` utility to make the module copyable again
- create-expo-module: Sync `tar.ts` utility with `@expo/cli`
- create-expo: Add `tar.ts` utility from `@expo/cli` then update usages of tar extraction

Effectively, the `tar.ts` utility is now "shared"

# Test Plan

- No E2E test for `create-expo` or `create-expo-module` should fail

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
