### PR TITLE
fix(expo-modules-core, expo-ui): Work around Swift 6.3 compiler crash in ExpoUI

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Made `ClassDefinition.init`, `ClassAssociatedObject` protocol, and `ObjectDefinition.init` public to work around a Swift 6.3 compiler crash (`LifetimeDependenceInfoRequest`) when resolving `Class()` from a `.swiftinterface` in XCFramework builds.
+
 - [iOS] Add async/await overload for StaticAsyncFunction ([#44471](https://github.com/expo/expo/pull/44471) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fixed looking up the `EXConstants.bundle` from the main bundle to allow running with precompiled XCFrameworks. ([#44551](https://github.com/expo/expo/pull/44551) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider. ([#44550](https://github.com/expo/expo/pull/44550) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Made `ClassDefinition.init`, `ClassAssociatedObject` protocol, and `ObjectDefinition.init` public to work around a Swift 6.3 compiler crash (`LifetimeDependenceInfoRequest`) when resolving `Class()` from a `.swiftinterface` in XCFramework builds.
+- [iOS] Made `ClassDefinition.init`, `ClassAssociatedObject` protocol, and `ObjectDefinition.init` public to work around a Swift 6.3 compiler crash (`LifetimeDependenceInfoRequest`) when resolving `Class()` from a `.swiftinterface` in XCFramework builds. ([#44765](https://github.com/expo/expo/pull/44765) by [@chrfalch](https://github.com/chrfalch))
 
 - [iOS] Add async/await overload for StaticAsyncFunction ([#44471](https://github.com/expo/expo/pull/44471) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fixed looking up the `EXConstants.bundle` from the main bundle to allow running with precompiled XCFrameworks. ([#44551](https://github.com/expo/expo/pull/44551) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Classes/ClassDefinition.swift
@@ -24,7 +24,7 @@ public final class ClassDefinition: ObjectDefinition {
    */
   let isSharedRef: Bool
 
-  init<AssociatedObject: ClassAssociatedObject>(
+  public init<AssociatedObject: ClassAssociatedObject>(
     name: String,
     associatedType: AssociatedObject.Type,
     elements: [AnyClassDefinitionElement] = []
@@ -145,7 +145,7 @@ public final class ClassDefinition: ObjectDefinition {
 /**
  A protocol for types that can be used an associated type of the ``ClassDefinition``.
  */
-internal protocol ClassAssociatedObject {}
+public protocol ClassAssociatedObject {}
 
 // Basically we only need these two
 extension JavaScriptObject: ClassAssociatedObject, AnyArgument, AnyJavaScriptValue {

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -37,7 +37,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   /**
    Default initializer receiving children definitions from the result builder.
    */
-  init(definitions: [AnyDefinition]) {
+  public init(definitions: [AnyDefinition]) {
     self.functions = definitions
       .compactMap { $0 as? AnyFunctionDefinition }
       .filter { !($0 is AnyStaticFunctionDefinition) }

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -64,7 +64,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Use local `ClassDefinition` wrapper instead of ExpoModulesCore's `Class()` to work around a Swift 6.3 compiler crash when consuming ExpoModulesCore as an XCFramework. This can be reverted when ExpoUI is prebuilt as an XCFramework itself.
+- [iOS] Use local `ClassDefinition` wrapper instead of ExpoModulesCore's `Class()` to work around a Swift 6.3 compiler crash when consuming ExpoModulesCore as an XCFramework. This can be reverted when ExpoUI is prebuilt as an XCFramework itself. ([#44765](https://github.com/expo/expo/pull/44765) by [@chrfalch](https://github.com/chrfalch))
 - Fix `installOnUIRuntime` crash by ensuring `react-native-reanimated` initializes before accessing worklet runtime. ([#44582](https://github.com/expo/expo/pull/44582) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix initial prop values not being applied since `init` runs before `updateProps`. ([#43954](https://github.com/expo/expo/pull/43954) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix prop syncing race condition where stale values override user interactions. Replace `onReceive(Sequence.publisher)` with `onAppear` + `onChange` across all SwiftUI views. ([#43954](https://github.com/expo/expo/pull/43954) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Use local `ClassDefinition` wrapper instead of ExpoModulesCore's `Class()` to work around a Swift 6.3 compiler crash when consuming ExpoModulesCore as an XCFramework. This can be reverted when ExpoUI is prebuilt as an XCFramework itself.
 - Fix `installOnUIRuntime` crash by ensuring `react-native-reanimated` initializes before accessing worklet runtime. ([#44582](https://github.com/expo/expo/pull/44582) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))
 - [iOS] Fix initial prop values not being applied since `init` runs before `updateProps`. ([#43954](https://github.com/expo/expo/pull/43954) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fix prop syncing race condition where stale values override user interactions. Replace `onReceive(Sequence.publisher)` with `onAppear` + `onChange` across all SwiftUI views. ([#43954](https://github.com/expo/expo/pull/43954) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/ExpoUIModule.swift
+++ b/packages/expo-ui/ios/ExpoUIModule.swift
@@ -3,6 +3,16 @@
 import ExpoModulesCore
 import ExpoModulesWorklets
 
+// Workaround for Swift 6.3 compiler crash (LifetimeDependenceInfoRequest) when
+// resolving the `Class` free function from ExpoModulesCore's .swiftinterface.
+// This local wrapper calls ClassDefinition.init directly, avoiding the xcframework resolution.
+private func LocalClass<SharedObjectType: SharedObject>(
+  _ sharedObjectType: SharedObjectType.Type,
+  @ClassDefinitionBuilder<SharedObjectType> _ elements: () -> [AnyClassDefinitionElement]
+) -> ClassDefinition {
+  return ClassDefinition(name: String(describing: SharedObjectType.self), associatedType: SharedObjectType.self, elements: elements())
+}
+
 public final class ExpoUIModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoUI")
@@ -17,7 +27,7 @@ public final class ExpoUIModule: Module {
 
     // MARK: - Observable State
 
-    Class(WorkletCallback.self) {
+    LocalClass(WorkletCallback.self) {
       Constructor { (worklet: Worklet) -> WorkletCallback in
         let callback = WorkletCallback()
         callback.worklet = worklet
@@ -25,7 +35,7 @@ public final class ExpoUIModule: Module {
       }
     }
 
-    Class(ObservableState.self) {
+    LocalClass(ObservableState.self) {
       Constructor { (initial: [String: Any]) -> ObservableState in
         return ObservableState(value: initial["value"])
       }


### PR DESCRIPTION
# Why

When ExpoUI is built from source against ExpoModulesCore XCFramework, a crash in the Swift compiler is making the build fail. This was introduced after this fix #44750. The "offending" code in ExpoUI was added in #44216 (for reference)

Swift 6.3 (Xcode 26.4) crashes in LifetimeDependenceInfoRequest when a source-compiled module calls the Class() free function resolved from ExpoModulesCore's .swiftinterface. This only affects modules built from source against the ExpoModulesCore XCFramework — prebuilt XCFrameworks resolve Class() at their own build time and are not affected.

**Claude had this explanation:**

The consistent rule: any free function from ExpoModulesCore's .swiftinterface that involves non-escaping closures, result builders, or complex generic signatures can crash Swift 6.3's LifetimeDependenceInfoRequest. Source-compiled modules and
xcframework-to-xcframework don't trigger it because the .swiftinterface is never parsed at call sites.

<details>
<summary>Compiler error</summary>

```
SwiftCompile normal arm64 Compiling\ DisclosureGroupView.swift,\ DividerView.swift,\ EdgeOptions.swift,\ EllipseView.swift,\ EnvironmentModifier.swift,\ ExpoUIModule.swift,\ FontModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/DisclosureGroupView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/DividerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/EdgeOptions.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/EllipseView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/EnvironmentModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ExpoUIModule.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/FontModifier.swift (in target 'ExpoUI' from project 'Pods')

Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: /Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/.../repos/expo/expo/packages/expo-ui/ios/AccessoryWidgetBackgroundView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/AlignmentOptions.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ShareLink/AsyncShareableItemUtils.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ShareLink/AsyncShareDataExtension.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/BackgroundModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/BottomSheetView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Button/Button.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Button/ButtonProps.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/CapsuleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ChartView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/CircleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ClosedRangeDateRecord.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ColorPickerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ConcentricRectangleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ConfirmationDialog/ConfirmationDialog.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ConfirmationDialog/ConfirmationDialogProps.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ContainerRelativeFrameModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ContainerShapeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ContentShapeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ContentTransitionModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ContentUnavailableView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ContextMenu/ContextMenu.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ContextMenu/ContextMenuRecords.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ControlGroupView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ControlSizeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/DatePickerStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/DatePickerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/DefaultScrollAnchorForRoleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/DefaultScrollAnchorModifier.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/DisclosureGroupView.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/DividerView.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/EdgeOptions.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/EllipseView.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/EnvironmentModifier.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/ExpoUIModule.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/FontModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ForegroundStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/FormView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/GaugeStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/GaugeView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/GlassEffectContainerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/GlassEffectModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/GridView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/GroupView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/HostView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/HStackView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ImageView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/KeyboardTypeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Label.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/LabeledContentView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/LabelStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/LazyHStackView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/LazyVStackView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/LineLimitModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/LinkView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ListForEachView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ListItemModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ListStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ListView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Menu/MenuRecords.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Menu/MenuView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/NamespaceRegistry.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/NamespaceView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/State/ObservableState.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/OnSubmitModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/OverlayView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/PickerStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Picker/PickerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Popover/PopoverProps.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Popover/PopoverView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/PresentationModifiers.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ProgressView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ProgressViewStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/RectangleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/RefreshableModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ResizableModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/RNHostView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/Rotation3DEffectModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/RoundedRectangleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/SafeAreaRegionOptions.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ScrollDisabledModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ScrollTargetBehaviorModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ScrollTargetLayoutModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ScrollViewComponent.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SectionView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SecureFieldView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ShapeTypes.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ShareLink/ShareLinkView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SliderView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SlotView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SpacerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/StepperView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/SubmitLabelModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SyncToggle/SyncToggleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/TagModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/TextContentTypeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/TextFieldView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/TextInputAutocapitalizationModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/TextView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ToggleStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Toggle/ToggleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/UIBaseView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/UIBaseViewProps.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/UnevenRoundedRectangleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/View+AccessibilityModifiers.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/View+GestureModifiers.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/View+ModifierArray.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/VisibilityOptions.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/VStackView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/WidgetModifiers.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/State/WorkletCallback.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ZStackView.swift -supplementary-output-file-map /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/supplementaryOutputs-434 -target arm64-apple-ios16.4-simulator -Xllvm -aarch64-use-tbi -enable-objc-interop -sdk /Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -I /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoUI -I /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoModulesCore -I /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoModulesJSI -I /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoModulesWorklets -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoUI -F /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore -F /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/React-Core-prebuilt -F /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ReactNativeDependencies/framework/packages/react-native -F /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/hermes-engine/destroot/Library/Frameworks/universal -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/ExpoModulesCore -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/React-Core-prebuilt -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/ReactNativeDependencies -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/hermes-engine/Pre-built -no-color-diagnostics -Xcc -fno-color-diagnostics -enable-testing -g -debug-info-format=dwarf -dwarf-version=4 -import-underlying-module -module-cache-path /Users/chrfalch/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -swift-version 5 -Onone -D DEBUG -D COCOAPODS -load-plugin-executable /Users/.../repos/expo/expo/packages/expo-modules-core/node_modules/@expo/expo-modules-macros-plugin/apple/ExpoModulesMacros-tool#ExpoModulesMacros -serialize-debugging-options -const-gather-protocols-file /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/ExpoUI_const_extract_protocols.json -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -empty-abi-descriptor -validate-clang-modules-once -clang-build-session-file /Users/chrfalch/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/Session.modulevalidation -Xcc -working-directory -Xcc /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods -enable-anonymous-context-mangled-names -file-compilation-dir /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods -Xcc -fmodule-map-file=/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoModulesWorklets/ExpoModulesWorklets.modulemap -Xcc -fmodule-map-file=/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ReactCodegen/ReactCodegen.modulemap -Xcc -fmodule-map-file=/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ExpoUI/ExpoUI.modulemap -Xcc -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG -Xcc -ivfsstatcache -Xcc /Users/chrfalch/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphonesimulator26.4-23E237-ecbf06f05200385db0626cec29c5e10b.sdkstatcache -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/ExpoUI-generated-files.hmap -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/ExpoUI-own-target-headers.hmap -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/ExpoUI-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/Pods-8699adb1dd336b26511df848a716bd42-VFS-iphonesimulator/all-product-headers.yaml -Xcc -iquote -Xcc /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/ExpoUI-project-headers.hmap -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoUI/include -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Private -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Private/ExpoUI -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ExpoModulesWorklets -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/FBLazyVector -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/RCTRequired -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/RCTSwiftUIWrapper -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/RCTTypeSafety -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-Core -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-Core-prebuilt -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-CoreModules -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-Fabric -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-FabricComponents -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-FabricImage -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-ImageManager -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-Mapbuffer -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-NativeModulesApple -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTAnimation -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTBlob -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTFBReactNativeSpec -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTFabric -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTImage -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTRuntime -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTText -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RuntimeApple -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RuntimeCore -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RuntimeHermes -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-callinvoker -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-cxxreact -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-debug -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-defaultsnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-domnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-featureflags -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-featureflagsnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-graphics -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-hermes -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-idlecallbacksnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-intersectionobservernativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jserrorhandler -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsi -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsiexecutor -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsinspector -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsinspectorcdp -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsinspectornetwork -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsinspectortracing -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsitooling -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-logger -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-microtasksnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-networking -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-oscompat -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-perflogger -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-performancecdpmetrics -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-performancetimeline -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-rendererconsistency -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-renderercss -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-rendererdebug -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-runtimeexecutor -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-runtimescheduler -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-timing -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-utils -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-webperformancenativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ReactCodegen -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ReactCommon -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ReactNativeDependencies -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/Yoga -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/hermes-engine -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore/ExpoModulesCore.xcframework/ios-arm64_x86_64-simulator/ExpoModulesCore.framework/Headers -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore/ExpoModulesCore.xcframework/ios-arm64/ExpoModulesCore.framework/Headers -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore/ExpoModulesCore.xcframework/ios-arm64_x86_64-simulator/ExpoModulesCore.framework/Headers -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore/ExpoModulesCore.xcframework/ios-arm64/ExpoModulesCore.framework/Headers -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/DerivedSources-normal/arm64 -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/DerivedSources/arm64 -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/DerivedSources -Xcc -DPOD_CONFIGURATION_DEBUG=1 -Xcc -DDEBUG=1 -Xcc -DCOCOAPODS=1 -no-auto-bridging-header-chaining -module-name ExpoUI -frontend-parseable-output -disable-clang-spi -target-sdk-version 26.4 -target-sdk-name iphonesimulator26.4 -external-plugin-path /Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/lib/swift/host/plugins#/Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -external-plugin-path /Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/local/lib/swift/host/plugins#/Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -in-process-plugin-server-path /Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/libSwiftInProcPluginServer.dylib -plugin-path /Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins -plugin-path /Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/local/lib/swift/host/plugins -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/DisclosureGroupView.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/DividerView.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EdgeOptions.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EllipseView.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EnvironmentModifier.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/ExpoUIModule.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/FontModifier.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/DisclosureGroupView.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/DividerView.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EdgeOptions.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EllipseView.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EnvironmentModifier.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/ExpoUIModule.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/FontModifier.o -index-store-path /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Index.noindex/DataStore -index-system-modules
1.	Apple Swift version 6.3 (swiftlang-6.3.0.123.5 clang-2100.0.123.102)
2.	Compiling with effective version 5.10
3.	While evaluating request TypeCheckPrimaryFileRequest(source_file "/Users/.../repos/expo/expo/packages/expo-ui/ios/ExpoUIModule.swift")
4.	While evaluating request TypeCheckFunctionBodyRequest(ExpoUI.(file).ExpoUIModule.definition()@/Users/.../repos/expo/expo/packages/expo-ui/ios/ExpoUIModule.swift:7:15)
5.	While evaluating request InterfaceTypeRequest(ExpoModulesCore.(file).Class)
6.	While evaluating request LifetimeDependenceInfoRequest(ExpoModulesCore.(file).Class)
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x000000010adddcb8 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
1  swift-frontend           0x000000010addb158 llvm::sys::RunSignalHandlers() + 172
2  swift-frontend           0x000000010adde2a8 SignalHandler(int, __siginfo*, void*) + 356
3  libsystem_platform.dylib 0x000000018e02d7a4 _sigtramp + 56
4  swift-frontend           0x0000000105dfd5bc swift::LifetimeDependenceInfoRequest::OutputType swift::Evaluator::getResultUncached<swift::LifetimeDependenceInfoRequest, swift::LifetimeDependenceInfoRequest::OutputType swift::evaluateOrDefault<swift::LifetimeDependenceInfoRequest>(swift::Evaluator&, swift::LifetimeDependenceInfoRequest, swift::LifetimeDependenceInfoRequest::OutputType)::'lambda'()>(swift::LifetimeDependenceInfoRequest const&, swift::LifetimeDependenceInfoRequest::OutputType swift::evaluateOrDefault<swift::LifetimeDependenceInfoRequest>(swift::Evaluator&, swift::LifetimeDependenceInfoRequest, swift::LifetimeDependenceInfoRequest::OutputType)::'lambda'()) + 452
5  swift-frontend           0x0000000105dfd5bc swift::LifetimeDependenceInfoRequest::OutputType swift::Evaluator::getResultUncached<swift::LifetimeDependenceInfoRequest, swift::LifetimeDependenceInfoRequest::OutputType swift::evaluateOrDefault<swift::LifetimeDependenceInfoRequest>(swift::Evaluator&, swift::LifetimeDependenceInfoRequest, swift::LifetimeDependenceInfoRequest::OutputType)::'lambda'()>(swift::LifetimeDependenceInfoRequest const&, swift::LifetimeDependenceInfoRequest::OutputType swift::evaluateOrDefault<swift::LifetimeDependenceInfoRequest>(swift::Evaluator&, swift::LifetimeDependenceInfoRequest, swift::LifetimeDependenceInfoRequest::OutputType)::'lambda'()) + 452
6  swift-frontend           0x00000001062975e8 swift::AbstractFunctionDecl::getLifetimeDependencies() const + 300
7  swift-frontend           0x0000000105de7034 swift::InterfaceTypeRequest::evaluate(swift::Evaluator&, swift::ValueDecl*) const + 2144
8  swift-frontend           0x0000000106266c58 swift::ValueDecl::getInterfaceType() const + 1304
9  swift-frontend           0x00000001062666f4 swift::Decl::isInvalid() const + 184
10 swift-frontend           0x0000000105b470f0 (anonymous namespace)::ConstraintGenerator::visitOverloadedDeclRefExpr(swift::OverloadedDeclRefExpr*) + 232
11 swift-frontend           0x0000000105b425b4 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) + 1020
12 swift-frontend           0x00000001061d2144 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) + 116
13 swift-frontend           0x00000001061cf6b8 (anonymous namespace)::Traversal::visit(swift::Expr*) + 84
14 swift-frontend           0x0000000105b3d65c swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*, swift::DeclContext*) + 368
15 swift-frontend           0x0000000105b3bb20 swift::constraints::ConstraintSystem::generateConstraints(swift::constraints::SyntacticElementTarget&, swift::FreeTypeVariableBinding) + 1948
16 swift-frontend           0x0000000105b39418 (anonymous namespace)::SyntacticElementConstraintGenerator::visitDecl(swift::Decl*) + 780
17 swift-frontend           0x0000000105b30ad4 swift::constraints::ConstraintSystem::simplifySyntacticElementConstraint(swift::ASTNode, swift::constraints::ContextualTypeInfo, bool, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) + 964
18 swift-frontend           0x0000000105ba1434 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 912
19 swift-frontend           0x0000000105bbe444 swift::constraints::ConjunctionElement::attempt(swift::constraints::ConstraintSystem&) const + 1152
20 swift-frontend           0x0000000105bcc5cc swift::constraints::ConjunctionStep::attempt(swift::constraints::ConjunctionElement const&) + 408
21 swift-frontend           0x0000000105bcdf6c swift::constraints::BindingStep<swift::constraints::ConjunctionElementProducer>::take(bool) + 928
22 swift-frontend           0x0000000105bb683c swift::constraints::ConstraintSystem::solveImpl(llvm::SmallVectorImpl<swift::constraints::Solution>&) + 504
23 swift-frontend           0x0000000105bb997c swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 60
24 swift-frontend           0x0000000105ad5fd0 swift::TypeChecker::applyResultBuilderBodyTransform(swift::FuncDecl*, swift::Type) + 1728
25 swift-frontend           0x0000000105ee1cbc swift::TypeCheckFunctionBodyRequest::evaluate(swift::Evaluator&, swift::AbstractFunctionDecl*) const + 1296
26 swift-frontend           0x0000000106343c10 swift::TypeCheckFunctionBodyRequest::OutputType swift::Evaluator::getResultUncached<swift::TypeCheckFunctionBodyRequest, swift::TypeCheckFunctionBodyRequest::OutputType swift::evaluateOrDefault<swift::TypeCheckFunctionBodyRequest>(swift::Evaluator&, swift::TypeCheckFunctionBodyRequest, swift::TypeCheckFunctionBodyRequest::OutputType)::'lambda'()>(swift::TypeCheckFunctionBodyRequest const&, swift::TypeCheckFunctionBodyRequest::OutputType swift::evaluateOrDefault<swift::TypeCheckFunctionBodyRequest>(swift::Evaluator&, swift::TypeCheckFunctionBodyRequest, swift::TypeCheckFunctionBodyRequest::OutputType)::'lambda'()) + 680
27 swift-frontend           0x00000001062950cc swift::AbstractFunctionDecl::getTypecheckedBody() const + 152
28 swift-frontend           0x0000000105f33094 swift::TypeCheckPrimaryFileRequest::evaluate(swift::Evaluator&, swift::SourceFile*) const + 1276
29 swift-frontend           0x0000000105f3c32c swift::TypeCheckPrimaryFileRequest::OutputType swift::Evaluator::getResultUncached<swift::TypeCheckPrimaryFileRequest, swift::TypeCheckPrimaryFileRequest::OutputType swift::evaluateOrDefault<swift::TypeCheckPrimaryFileRequest>(swift::Evaluator&, swift::TypeCheckPrimaryFileRequest, swift::TypeCheckPrimaryFileRequest::OutputType)::'lambda'()>(swift::TypeCheckPrimaryFileRequest const&, swift::TypeCheckPrimaryFileRequest::OutputType swift::evaluateOrDefault<swift::TypeCheckPrimaryFileRequest>(swift::Evaluator&, swift::TypeCheckPrimaryFileRequest, swift::TypeCheckPrimaryFileRequest::OutputType)::'lambda'()) + 644
30 swift-frontend           0x0000000104d82c80 bool llvm::function_ref<bool (swift::SourceFile&)>::callback_fn<swift::CompilerInstance::performSema()::$_0>(long, swift::SourceFile&) + 156
31 swift-frontend           0x0000000104d7bfa0 swift::CompilerInstance::forEachFileToTypeCheck(llvm::function_ref<bool (swift::SourceFile&)>) + 176
32 swift-frontend           0x0000000104d7be30 swift::CompilerInstance::performSema() + 456
33 swift-frontend           0x0000000104963f1c performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*, llvm::ArrayRef<char const*>) + 548
34 swift-frontend           0x000000010496112c swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3308
35 swift-frontend           0x00000001048e0d38 swift::mainEntry(int, char const**) + 5224
36 dyld                     0x000000018dc67da4 start + 6992
Failed frontend command:
/Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/.../repos/expo/expo/packages/expo-ui/ios/AccessoryWidgetBackgroundView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/AlignmentOptions.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ShareLink/AsyncShareableItemUtils.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ShareLink/AsyncShareDataExtension.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/BackgroundModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/BottomSheetView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Button/Button.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Button/ButtonProps.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/CapsuleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ChartView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/CircleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ClosedRangeDateRecord.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ColorPickerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ConcentricRectangleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ConfirmationDialog/ConfirmationDialog.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ConfirmationDialog/ConfirmationDialogProps.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ContainerRelativeFrameModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ContainerShapeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ContentShapeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ContentTransitionModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ContentUnavailableView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ContextMenu/ContextMenu.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ContextMenu/ContextMenuRecords.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ControlGroupView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ControlSizeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/DatePickerStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/DatePickerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/DefaultScrollAnchorForRoleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/DefaultScrollAnchorModifier.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/DisclosureGroupView.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/DividerView.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/EdgeOptions.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/EllipseView.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/EnvironmentModifier.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/ExpoUIModule.swift -primary-file /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/FontModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ForegroundStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/FormView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/GaugeStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/GaugeView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/GlassEffectContainerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/GlassEffectModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/GridView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/GroupView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/HostView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/HStackView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ImageView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/KeyboardTypeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Label.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/LabeledContentView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/LabelStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/LazyHStackView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/LazyVStackView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/LineLimitModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/LinkView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ListForEachView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ListItemModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ListStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ListView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Menu/MenuRecords.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Menu/MenuView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/NamespaceRegistry.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/NamespaceView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/State/ObservableState.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/OnSubmitModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/OverlayView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/PickerStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Picker/PickerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Popover/PopoverProps.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Popover/PopoverView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/PresentationModifiers.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ProgressView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ProgressViewStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/RectangleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/RefreshableModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ResizableModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/RNHostView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/Rotation3DEffectModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/RoundedRectangleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/SafeAreaRegionOptions.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ScrollDisabledModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ScrollTargetBehaviorModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ScrollTargetLayoutModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ScrollViewComponent.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SectionView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SecureFieldView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ShapeTypes.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ShareLink/ShareLinkView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SliderView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SlotView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SpacerView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/StepperView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/SubmitLabelModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/SyncToggle/SyncToggleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/TagModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/TextContentTypeModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/TextFieldView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/TextInputAutocapitalizationModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/TextView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ToggleStyleModifier.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Toggle/ToggleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/UIBaseView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/UIBaseViewProps.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/UnevenRoundedRectangleView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/View+AccessibilityModifiers.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/View+GestureModifiers.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/View+ModifierArray.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/ViewModifierRegistry.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Convertibles/VisibilityOptions.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/VStackView.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/Modifiers/WidgetModifiers.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/State/WorkletCallback.swift /Users/.../repos/expo/expo/packages/expo-ui/ios/ZStackView.swift -supplementary-output-file-map /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/supplementaryOutputs-434 -target arm64-apple-ios16.4-simulator -Xllvm -aarch64-use-tbi -enable-objc-interop -sdk /Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator26.4.sdk -I /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoUI -I /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoModulesCore -I /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoModulesJSI -I /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoModulesWorklets -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoUI -F /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore -F /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/React-Core-prebuilt -F /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ReactNativeDependencies/framework/packages/react-native -F /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/hermes-engine/destroot/Library/Frameworks/universal -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/ExpoModulesCore -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/React-Core-prebuilt -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/ReactNativeDependencies -F /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/XCFrameworkIntermediates/hermes-engine/Pre-built -no-color-diagnostics -Xcc -fno-color-diagnostics -enable-testing -g -debug-info-format\=dwarf -dwarf-version\=4 -import-underlying-module -module-cache-path /Users/chrfalch/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -swift-version 5 -Onone -D DEBUG -D COCOAPODS -load-plugin-executable /Users/.../repos/expo/expo/packages/expo-modules-core/node_modules/@expo/expo-modules-macros-plugin/apple/ExpoModulesMacros-tool\#ExpoModulesMacros -serialize-debugging-options -const-gather-protocols-file /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/ExpoUI_const_extract_protocols.json -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -empty-abi-descriptor -validate-clang-modules-once -clang-build-session-file /Users/chrfalch/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/Session.modulevalidation -Xcc -working-directory -Xcc /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods -enable-anonymous-context-mangled-names -file-compilation-dir /Users/.../repos/expo/expo/apps/bare-expo/ios/Pods -Xcc -fmodule-map-file\=/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoModulesWorklets/ExpoModulesWorklets.modulemap -Xcc -fmodule-map-file\=/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ReactCodegen/ReactCodegen.modulemap -Xcc -fmodule-map-file\=/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ExpoUI/ExpoUI.modulemap -Xcc -D_LIBCPP_HARDENING_MODE\=_LIBCPP_HARDENING_MODE_DEBUG -Xcc -ivfsstatcache -Xcc /Users/chrfalch/Library/Developer/Xcode/DerivedData/SDKStatCaches.noindex/iphonesimulator26.4-23E237-ecbf06f05200385db0626cec29c5e10b.sdkstatcache -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/ExpoUI-generated-files.hmap -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/ExpoUI-own-target-headers.hmap -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/ExpoUI-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/Pods-8699adb1dd336b26511df848a716bd42-VFS-iphonesimulator/all-product-headers.yaml -Xcc -iquote -Xcc /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/ExpoUI-project-headers.hmap -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Products/Debug-iphonesimulator/ExpoUI/include -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Private -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Private/ExpoUI -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ExpoModulesWorklets -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/FBLazyVector -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/RCTRequired -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/RCTSwiftUIWrapper -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/RCTTypeSafety -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-Core -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-Core-prebuilt -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-CoreModules -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-Fabric -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-FabricComponents -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-FabricImage -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-ImageManager -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-Mapbuffer -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-NativeModulesApple -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTAnimation -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTBlob -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTFBReactNativeSpec -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTFabric -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTImage -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTRuntime -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RCTText -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RuntimeApple -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RuntimeCore -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-RuntimeHermes -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-callinvoker -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-cxxreact -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-debug -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-defaultsnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-domnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-featureflags -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-featureflagsnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-graphics -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-hermes -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-idlecallbacksnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-intersectionobservernativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jserrorhandler -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsi -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsiexecutor -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsinspector -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsinspectorcdp -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsinspectornetwork -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsinspectortracing -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-jsitooling -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-logger -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-microtasksnativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-networking -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-oscompat -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-perflogger -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-performancecdpmetrics -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-performancetimeline -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-rendererconsistency -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-renderercss -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-rendererdebug -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-runtimeexecutor -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-runtimescheduler -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-timing -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-utils -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/React-webperformancenativemodule -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ReactCodegen -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ReactCommon -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/ReactNativeDependencies -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/Yoga -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/Headers/Public/hermes-engine -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore/ExpoModulesCore.xcframework/ios-arm64_x86_64-simulator/ExpoModulesCore.framework/Headers -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore/ExpoModulesCore.xcframework/ios-arm64/ExpoModulesCore.framework/Headers -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore/ExpoModulesCore.xcframework/ios-arm64_x86_64-simulator/ExpoModulesCore.framework/Headers -Xcc -I/Users/.../repos/expo/expo/apps/bare-expo/ios/Pods/ExpoModulesCore/ExpoModulesCore.xcframework/ios-arm64/ExpoModulesCore.framework/Headers -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/DerivedSources-normal/arm64 -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/DerivedSources/arm64 -Xcc -I/Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/DerivedSources -Xcc -DPOD_CONFIGURATION_DEBUG\=1 -Xcc -DDEBUG\=1 -Xcc -DCOCOAPODS\=1 -no-auto-bridging-header-chaining -module-name ExpoUI -frontend-parseable-output -disable-clang-spi -target-sdk-version 26.4 -target-sdk-name iphonesimulator26.4 -external-plugin-path /Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/lib/swift/host/plugins\#/Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -external-plugin-path /Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/local/lib/swift/host/plugins\#/Applications/Xcode-26.4.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -in-process-plugin-server-path /Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/libSwiftInProcPluginServer.dylib -plugin-path /Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins -plugin-path /Applications/Xcode-26.4.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/local/lib/swift/host/plugins -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/DisclosureGroupView.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/DividerView.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EdgeOptions.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EllipseView.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EnvironmentModifier.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/ExpoUIModule.o -o /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Build/Intermediates.noindex/Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/FontModifier.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/DisclosureGroupView.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/DividerView.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EdgeOptions.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EllipseView.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/EnvironmentModifier.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/ExpoUIModule.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/ExpoUI.build/Objects-normal/arm64/FontModifier.o -index-store-path /Users/chrfalch/Library/Developer/Xcode/DerivedData/BareExpo-eydqheesaycnxkakpyadslgtsqmb/Index.noindex/DataStore -index-system-modules
```
</details>

Claude explains:

> This is a Swift 6.3 (Xcode 26.4) compiler bug, not a problem in your code. Specifically:                                                                                                      
>                                                                                                                                                                                              
> Frames 4 and 5 in the stack dump are identical (0x0000000105dfd5bc + 452), which means LifetimeDependenceInfoRequest is recursing into itself. The compiler is stuck trying to infer lifetime 
dependencies for ExpoModulesCore.Class (at packages/expo-modules-core/ios/Api/Factories/ClassFactories.swift). That's a known class of Swift 6.3 crashes triggered by overloaded generic      
functions — Class has three overloads, and Constructor uses variadic generics (repeat each A), which is a common trigger for this bug.                                                        
                                                                                                                                                                                                
> The crash appears in ExpoUI because ExpoUIModule.definition() calls Class(...) and that's where overload resolution happens — but any module that references Class from ExpoModulesCore under 
Xcode 26.4 is vulnerable.

# How

Made ClassDefinition.init, ClassAssociatedObject, and ObjectDefinition.init public so that ExpoUI can define a local ClassDefinition wrapper that bypasses the XCFramework's Class() function entirely.

# Test Plan

Tested both with/without precompiled XCFrameworks.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
