### PR TITLE
[expo-screen-capture][Android] Remove maxSdkVersion on READ_MEDIA_IMAGES to fix manifest merger conflicts

### DIFF
--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Removed `maxSdkVersion` on `READ_MEDIA_IMAGES` permission to prevent Android manifest merger from capping it app-wide, which broke other libraries (like `expo-media-library`) on Android 14+. ([44769](https://github.com/expo/expo/issues/44769) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-screen-capture/CHANGELOG.md
+++ b/packages/expo-screen-capture/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- Removed `maxSdkVersion` on `READ_MEDIA_IMAGES` permission to prevent Android manifest merger from capping it app-wide, which broke other libraries (like `expo-media-library`) on Android 14+. ([44769](https://github.com/expo/expo/issues/44769) by [@zoontek](https://github.com/zoontek))
+- Removed `maxSdkVersion` on `READ_MEDIA_IMAGES` permission to prevent Android manifest merger from capping it app-wide, which broke other libraries (like `expo-media-library`) on Android 14+. ([#44769](https://github.com/expo/expo/pull/44769) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others
 

--- a/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
+++ b/packages/expo-screen-capture/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33" android:maxSdkVersion="33"/>
+  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33" />
   <uses-permission android:name="android.permission.DETECT_SCREEN_CAPTURE" android:minSdkVersion="34" />
 </manifest>


### PR DESCRIPTION
# Why

Closes #44729

# How

Remove `maxSdkVersion="33"` from the `READ_MEDIA_IMAGES` permission in `expo-screen-capture`'s `AndroidManifest.xml`. The cap is unnecessary, `expo-screen-capture` already never requests this permission at runtime on API 34+ and causes the Android manifest merger to strip `READ_MEDIA_IMAGES` app-wide, breaking libraries like `expo-media-library`.

# Test Plan

1. `npx expo prebuild --platform android`
2. `cd android && ./gradlew :app:processDebugManifest`
3. Verify merged manifest no longer has `maxSdkVersion="33"` on `READ_MEDIA_IMAGES`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
