### PR TITLE
feat(doctor): Check for invalid resolutions/overrides that break Expo

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Add version to the `--verbose` output ([#44592](https://github.com/expo/expo/pull/44592) by [@kitten](https://github.com/kitten))
+- Add check that warns about invalid `overrides`/`resolutions` for critical package versions ([#44770](https://github.com/expo/expo/pull/44770) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
+++ b/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
@@ -1,0 +1,145 @@
+import fs from 'fs';
+import path from 'path';
+import resolveFrom from 'resolve-from';
+import semver from 'semver';
+
+import { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+import { joinWithCommasAnd } from '../utils/strings';
+
+/**
+ * Dependency traversal chains for critical transitive dependencies that should
+ * not have their versions overridden via resolutions/overrides. Each chain is
+ * an array of package names representing a path through the dependency graph.
+ * The last entry is the package whose installed version is checked against the
+ * range declared by its parent (second-to-last entry). Each package is resolved
+ * from the previous package's directory using Node resolution, so this works
+ * correctly with isolated node_modules layouts (e.g. pnpm). If any package
+ * along the chain cannot be resolved, the check is skipped (e.g. expo-router
+ * is optional).
+ */
+const dependencyChains: [...string[], string, string][] = [
+  ['expo', '@expo/cli'],
+
+  ['expo-router', '@expo/metro-runtime'],
+
+  ['expo', '@expo/metro', 'metro'],
+  ['expo', '@expo/metro', 'metro-babel-transformer'],
+  ['expo', '@expo/metro', 'metro-cache'],
+  ['expo', '@expo/metro', 'metro-cache-key'],
+  ['expo', '@expo/metro', 'metro-config'],
+  ['expo', '@expo/metro', 'metro-core'],
+  ['expo', '@expo/metro', 'metro-file-map'],
+  ['expo', '@expo/metro', 'metro-minify-terser'],
+  ['expo', '@expo/metro', 'metro-resolver'],
+  ['expo', '@expo/metro', 'metro-runtime'],
+  ['expo', '@expo/metro', 'metro-source-map'],
+  ['expo', '@expo/metro', 'metro-symbolicate'],
+  ['expo', '@expo/metro', 'metro-transform-plugins'],
+  ['expo', '@expo/metro', 'metro-transform-worker'],
+];
+
+interface ResolvedPackage {
+  dir: string;
+  pkg: { version: string; dependencies?: Record<string, string> };
+}
+
+/**
+ * Resolve a package's package.json from a base directory using Node resolution.
+ * Returns the parsed package.json and the package directory, or null if not found.
+ */
+function resolvePackage(baseDir: string, packageName: string): ResolvedPackage | null {
+  const packageJsonPath = resolveFrom.silent(baseDir, `${packageName}/package.json`);
+  if (!packageJsonPath) {
+    return null;
+  }
+  try {
+    return {
+      dir: path.dirname(packageJsonPath),
+      pkg: JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function getOverridesEntries(pkg: Record<string, any>): Record<string, string> {
+  // npm uses "overrides", yarn uses "resolutions", pnpm uses "pnpm.overrides" or "resolutions"
+  return {
+    ...pkg.resolutions,
+    ...pkg.overrides,
+    ...pkg.pnpm?.overrides,
+  };
+}
+
+export class DependencyVersionOverrideCheck implements DoctorCheck {
+  description = 'Check for overridden dependency versions that may cause issues';
+
+  sdkVersionRange = '>=53.0.0';
+
+  async runAsync({ pkg, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+    const overriddenPackages: string[] = [];
+
+    const allOverrides = getOverridesEntries(pkg);
+
+    for (const chain of dependencyChains) {
+      const dependencyName = chain[chain.length - 1]!;
+      const parentName = chain[chain.length - 2]!;
+
+      // Walk the chain, resolving each package from the previous package's directory
+      let resolveDir = projectRoot;
+      let parentResolved: ResolvedPackage | undefined;
+      let chainValid = true;
+      for (let idx = 0; idx < chain.length - 1; idx++) {
+        const parentPackageName = chain[idx]!;
+        const childPackageName = chain[idx + 1]!;
+        const resolved = resolvePackage(resolveDir, parentPackageName);
+        if (!resolved || !resolved?.pkg.dependencies?.[childPackageName]) {
+          chainValid = false;
+          break;
+        }
+        resolveDir = resolved.dir;
+        parentResolved = resolved;
+      }
+
+      const childPackageName = chain[chain.length - 1]!;
+      const expectedRange = parentResolved?.pkg.dependencies?.[childPackageName];
+      if (!chainValid || !parentResolved || !expectedRange) {
+        continue;
+      }
+
+      const installedResolved = resolvePackage(parentResolved.dir, childPackageName);
+      const actualVersion = installedResolved?.pkg.version;
+      if (!actualVersion || !semver.valid(actualVersion)) {
+        continue;
+      }
+
+      if (!semver.satisfies(actualVersion, expectedRange)) {
+        issues.push(
+          `"${parentName}" should install "${dependencyName}@${expectedRange}", but ${actualVersion} is installed.`
+        );
+        if (allOverrides[dependencyName]) {
+          overriddenPackages.push(dependencyName);
+        }
+      }
+    }
+
+    const advice: string[] = [];
+    if (issues.length) {
+      advice.push(
+        'An incompatible version of a critical dependency is installed, which is unsupported and may cause unexpected behavior.'
+      );
+      if (overriddenPackages.length) {
+        advice.push(
+          `Remove the resolution/override for ${joinWithCommasAnd(overriddenPackages)} from your package.json and reinstall your dependencies.`
+        );
+      }
+    }
+
+    return {
+      isSuccessful: issues.length === 0,
+      issues,
+      advice,
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
+++ b/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
@@ -82,36 +82,33 @@ export class DependencyVersionOverrideCheck implements DoctorCheck {
 
     const allOverrides = getOverridesEntries(pkg);
 
-    for (const chain of dependencyChains) {
+    const checkChain = (chain: [...string[], string, string]) => {
       const dependencyName = chain[chain.length - 1]!;
       const parentName = chain[chain.length - 2]!;
 
       // Walk the chain, resolving each package from the previous package's directory
       let resolveDir = projectRoot;
       let parentResolved: ResolvedPackage | undefined;
-      let chainValid = true;
       for (let idx = 0; idx < chain.length - 1; idx++) {
         const parentPackageName = chain[idx]!;
         const childPackageName = chain[idx + 1]!;
         const resolved = resolvePackage(resolveDir, parentPackageName);
-        if (!resolved || !resolved?.pkg.dependencies?.[childPackageName]) {
-          chainValid = false;
-          break;
+        if (!resolved?.pkg.dependencies?.[childPackageName]) {
+          return;
         }
         resolveDir = resolved.dir;
         parentResolved = resolved;
       }
 
-      const childPackageName = chain[chain.length - 1]!;
-      const expectedRange = parentResolved?.pkg.dependencies?.[childPackageName];
-      if (!chainValid || !parentResolved || !expectedRange) {
-        continue;
+      const expectedRange = parentResolved?.pkg.dependencies?.[dependencyName];
+      if (!parentResolved || !expectedRange) {
+        return;
       }
 
-      const installedResolved = resolvePackage(parentResolved.dir, childPackageName);
+      const installedResolved = resolvePackage(parentResolved.dir, dependencyName);
       const actualVersion = installedResolved?.pkg.version;
       if (!actualVersion || !semver.valid(actualVersion)) {
-        continue;
+        return;
       }
 
       if (!semver.satisfies(actualVersion, expectedRange)) {
@@ -122,6 +119,10 @@ export class DependencyVersionOverrideCheck implements DoctorCheck {
           overriddenPackages.push(dependencyName);
         }
       }
+    };
+
+    for (const chain of dependencyChains) {
+      checkChain(chain);
     }
 
     const advice: string[] = [];

--- a/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
+++ b/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
@@ -83,7 +83,7 @@ function getOverridesEntries(pkg: Record<string, any>): Record<string, string> {
 export class DependencyVersionOverrideCheck implements DoctorCheck {
   description = 'Check for overridden dependency versions that may cause issues';
 
-  sdkVersionRange = '>=53.0.0';
+  sdkVersionRange = '>=55.0.0';
 
   async runAsync({ pkg, projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
     const issues: string[] = [];

--- a/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
+++ b/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
@@ -81,7 +81,7 @@ function getOverridesEntries(pkg: Record<string, any>): Record<string, string> {
 }
 
 export class DependencyVersionOverrideCheck implements DoctorCheck {
-  description = 'Check for overridden dependency versions that may cause issues';
+  description = 'Check for overridden dependencies';
 
   sdkVersionRange = '>=55.0.0';
 
@@ -136,13 +136,18 @@ export class DependencyVersionOverrideCheck implements DoctorCheck {
 
     const advice: string[] = [];
     if (issues.length) {
-      advice.push(
-        'An incompatible version of a critical dependency is installed, which is unsupported and may cause unexpected behavior.'
+      issues.unshift(
+        (issues.length > 1
+          ? 'Incompatible versions of critical dependencies are installed, '
+          : 'An incompatible version of a critical dependency is installed, ') +
+          'which is unsupported and may cause unexpected behavior.'
       );
       if (overriddenPackages.length) {
         advice.push(
           `Remove the resolution/override for ${joinWithCommasAnd(overriddenPackages)} from your package.json and reinstall your dependencies.`
         );
+      } else {
+        advice.push(`Reinstall your dependencies and check that they're not in a corrupted state.`);
       }
     }
 

--- a/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
+++ b/packages/expo-doctor/src/checks/DependencyVersionOverrideCheck.ts
@@ -8,20 +8,29 @@ import { joinWithCommasAnd } from '../utils/strings';
 
 /**
  * Dependency traversal chains for critical transitive dependencies that should
- * not have their versions overridden via resolutions/overrides. Each chain is
- * an array of package names representing a path through the dependency graph.
- * The last entry is the package whose installed version is checked against the
- * range declared by its parent (second-to-last entry). Each package is resolved
- * from the previous package's directory using Node resolution, so this works
- * correctly with isolated node_modules layouts (e.g. pnpm). If any package
- * along the chain cannot be resolved, the check is skipped (e.g. expo-router
- * is optional).
+ * not have their versions overridden via resolutions/overrides.
+ *
+ * When users upgrade, they tend to run into issues if they've added resolutions
+ * or overrides that break our expectations of which versions of packages are installed.
+ * There's a few internal dependencies that should never not pass version checks.
+ *
+ * To check these, we walk the dependency paths defined here and check the last
+ * package's version against the penultimate package's range.
+ *
+ * NOTE: Only add packages here that cannot be overridden in most cases, and are known
+ * to cause build failures if they are overridden! Typically, that doesn't include
+ * Expo Modules.
  */
 const dependencyChains: [...string[], string, string][] = [
+  // these are critical versions tied to an SDK release that mustn't be changed
   ['expo', '@expo/cli'],
+  ['expo', '@expo/config'],
+  ['expo', '@expo/metro-config'],
 
+  // @expo/metro-runtime is a peer, and often resolved to mute peer warnings, instead of being upgraded
   ['expo-router', '@expo/metro-runtime'],
 
+  // metro packages are commonly resolved, and this will cause issues
   ['expo', '@expo/metro', 'metro'],
   ['expo', '@expo/metro', 'metro-babel-transformer'],
   ['expo', '@expo/metro', 'metro-cache'],

--- a/packages/expo-doctor/src/checks/__tests__/DependencyVersionOverrideCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/DependencyVersionOverrideCheck.test.ts
@@ -110,9 +110,9 @@ describe('runAsync', () => {
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeFalsy();
-    expect(result.issues).toHaveLength(1);
-    expect(result.issues[0]).toContain('@expo/cli');
-    expect(result.issues[0]).toContain('0.18.0');
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[1]).toContain('@expo/cli');
+    expect(result.issues[1]).toContain('0.18.0');
   });
 
   it('adds advice to remove resolutions when dependency is in resolutions', async () => {
@@ -233,10 +233,10 @@ describe('runAsync', () => {
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeFalsy();
-    expect(result.issues).toHaveLength(2);
-    expect(result.issues[0]).toContain('@expo/metro');
-    expect(result.issues[0]).toContain('metro');
-    expect(result.issues[1]).toContain('metro-resolver');
+    expect(result.issues).toHaveLength(3);
+    expect(result.issues[1]).toContain('@expo/metro');
+    expect(result.issues[1]).toContain('metro');
+    expect(result.issues[2]).toContain('metro-resolver');
   });
 
   it('skips chain when an optional package cannot be resolved (e.g. expo-router not installed)', async () => {
@@ -304,9 +304,9 @@ describe('runAsync', () => {
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeFalsy();
-    expect(result.issues).toHaveLength(1);
-    expect(result.issues[0]).toContain('expo-router');
-    expect(result.issues[0]).toContain('@expo/metro-runtime');
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[1]).toContain('expo-router');
+    expect(result.issues[1]).toContain('@expo/metro-runtime');
   });
 
   it('resolves packages from isolated node_modules (pnpm-style)', async () => {
@@ -351,8 +351,8 @@ describe('runAsync', () => {
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeFalsy();
-    expect(result.issues).toHaveLength(1);
-    expect(result.issues[0]).toContain('metro');
-    expect(result.issues[0]).toContain('0.76.0');
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[1]).toContain('metro');
+    expect(result.issues[1]).toContain('0.76.0');
   });
 });

--- a/packages/expo-doctor/src/checks/__tests__/DependencyVersionOverrideCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/DependencyVersionOverrideCheck.test.ts
@@ -1,0 +1,358 @@
+import { vol } from 'memfs';
+
+import { DependencyVersionOverrideCheck } from '../DependencyVersionOverrideCheck';
+
+jest.mock('fs');
+
+const mockResolveFromSilent = jest.fn();
+jest.mock('resolve-from', () => ({
+  __esModule: true,
+  default: { silent: (...args: any[]) => mockResolveFromSilent(...args) },
+}));
+
+const projectRoot = '/tmp/project';
+
+// required by runAsync
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+    sdkVersion: '53.0.0',
+  },
+  projectRoot,
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+/**
+ * Sets up memfs and mocks resolveFrom.silent to simulate Node resolution.
+ *
+ * @param packages - flat map of package name to package.json content.
+ *   By default all packages are placed at <projectRoot>/node_modules/<name>.
+ * @param resolutionGraph - maps "baseDir > packageName" to the directory that
+ *   contains the package. When provided, only explicitly listed resolutions work.
+ *   When omitted, all packages resolve from any base directory (flat hoisted layout).
+ */
+function setupNodeModules(
+  packages: Record<string, { version: string; dependencies?: Record<string, string> }>,
+  resolutionGraph?: Record<string, string>
+) {
+  const files: Record<string, string> = {};
+  const packageDirs: Record<string, string> = {};
+
+  for (const [name, content] of Object.entries(packages)) {
+    const dir = `${projectRoot}/node_modules/${name}`;
+    files[`${dir}/package.json`] = JSON.stringify(content);
+    packageDirs[name] = dir;
+  }
+
+  vol.fromJSON(files);
+
+  mockResolveFromSilent.mockImplementation((baseDir: string, moduleId: string) => {
+    const match = moduleId.match(/^(.+)\/package\.json$/);
+    if (!match) {
+      return undefined;
+    }
+    const packageName = match[1];
+
+    if (resolutionGraph) {
+      const key = `${baseDir} > ${packageName}`;
+      const resolvedDir = resolutionGraph[key];
+      if (resolvedDir) {
+        const filePath = `${resolvedDir}/package.json`;
+        if (vol.existsSync(filePath)) {
+          return filePath;
+        }
+      }
+      return undefined;
+    }
+
+    // Default: resolve all packages from anywhere (flat hoisted layout)
+    const dir = packageDirs[packageName];
+    if (dir && vol.existsSync(`${dir}/package.json`)) {
+      return `${dir}/package.json`;
+    }
+    return undefined;
+  });
+}
+
+describe('runAsync', () => {
+  afterEach(() => {
+    vol.reset();
+    jest.restoreAllMocks();
+  });
+
+  it('returns result with isSuccessful = true when dependency versions satisfy expected ranges', async () => {
+    setupNodeModules({
+      expo: { version: '53.0.0', dependencies: { '@expo/cli': '^0.20.0' } },
+      '@expo/cli': { version: '0.20.5' },
+    });
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('returns result with isSuccessful = false when an installed version does not satisfy the expected range', async () => {
+    setupNodeModules({
+      expo: { version: '53.0.0', dependencies: { '@expo/cli': '^0.20.0' } },
+      '@expo/cli': { version: '0.18.0' },
+    });
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toContain('@expo/cli');
+    expect(result.issues[0]).toContain('0.18.0');
+  });
+
+  it('adds advice to remove resolutions when dependency is in resolutions', async () => {
+    setupNodeModules({
+      expo: { version: '53.0.0', dependencies: { '@expo/cli': '^0.20.0' } },
+      '@expo/cli': { version: '0.18.0' },
+    });
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0', resolutions: { '@expo/cli': '0.18.0' } },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.advice.some((a) => a.includes('Remove the resolution/override'))).toBeTruthy();
+    expect(result.advice.some((a) => a.includes('@expo/cli'))).toBeTruthy();
+  });
+
+  it('adds advice to remove overrides when dependency is in npm overrides', async () => {
+    setupNodeModules({
+      expo: { version: '53.0.0', dependencies: { '@expo/cli': '^0.20.0' } },
+      '@expo/cli': { version: '0.18.0' },
+    });
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0', overrides: { '@expo/cli': '0.18.0' } },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.advice.some((a) => a.includes('Remove the resolution/override'))).toBeTruthy();
+  });
+
+  it('adds advice to remove overrides when dependency is in pnpm overrides', async () => {
+    setupNodeModules({
+      expo: { version: '53.0.0', dependencies: { '@expo/cli': '^0.20.0' } },
+      '@expo/cli': { version: '0.18.0' },
+    });
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'test',
+        version: '1.0.0',
+        pnpm: { overrides: { '@expo/cli': '0.18.0' } },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.advice.some((a) => a.includes('Remove the resolution/override'))).toBeTruthy();
+  });
+
+  it('skips check when root package in chain cannot be resolved', async () => {
+    setupNodeModules(
+      {
+        '@expo/cli': { version: '0.18.0' },
+      },
+      {
+        // expo is not resolvable from project root
+        [`${projectRoot} > @expo/cli`]: `${projectRoot}/node_modules/@expo/cli`,
+      }
+    );
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('skips check when the target dependency cannot be resolved from parent', async () => {
+    const expoDir = `${projectRoot}/node_modules/expo`;
+
+    setupNodeModules(
+      {
+        expo: { version: '53.0.0', dependencies: { '@expo/cli': '^0.20.0' } },
+      },
+      {
+        [`${projectRoot} > expo`]: expoDir,
+        // @expo/cli is not resolvable from expo's dir
+      }
+    );
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('traverses multi-step chains resolving each package from its parent', async () => {
+    const expoDir = `${projectRoot}/node_modules/expo`;
+    const metroWrapperDir = `${projectRoot}/node_modules/@expo/metro`;
+
+    setupNodeModules(
+      {
+        expo: { version: '53.0.0', dependencies: { '@expo/metro': '^1.0.0' } },
+        '@expo/metro': {
+          version: '1.0.0',
+          dependencies: { metro: '^0.81.0', 'metro-resolver': '^0.81.0' },
+        },
+        metro: { version: '0.76.0' },
+        'metro-resolver': { version: '0.76.0' },
+      },
+      {
+        [`${projectRoot} > expo`]: expoDir,
+        [`${expoDir} > @expo/metro`]: metroWrapperDir,
+        [`${metroWrapperDir} > metro`]: `${projectRoot}/node_modules/metro`,
+        [`${metroWrapperDir} > metro-resolver`]: `${projectRoot}/node_modules/metro-resolver`,
+      }
+    );
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues).toHaveLength(2);
+    expect(result.issues[0]).toContain('@expo/metro');
+    expect(result.issues[0]).toContain('metro');
+    expect(result.issues[1]).toContain('metro-resolver');
+  });
+
+  it('skips chain when an optional package cannot be resolved (e.g. expo-router not installed)', async () => {
+    setupNodeModules(
+      {
+        '@expo/metro-runtime': { version: '1.0.0' },
+      },
+      {
+        // expo-router cannot be resolved from project root (not installed)
+        [`${projectRoot} > @expo/metro-runtime`]: `${projectRoot}/node_modules/@expo/metro-runtime`,
+      }
+    );
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('skips chain when intermediate package does not declare next package as dependency', async () => {
+    const expoDir = `${projectRoot}/node_modules/expo`;
+
+    setupNodeModules(
+      {
+        expo: { version: '53.0.0', dependencies: {} },
+        '@expo/metro': { version: '1.0.0', dependencies: { metro: '^0.81.0' } },
+        metro: { version: '0.76.0' },
+      },
+      {
+        [`${projectRoot} > expo`]: expoDir,
+        [`${expoDir} > @expo/metro`]: `${projectRoot}/node_modules/@expo/metro`,
+      }
+    );
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('checks the expo-router chain when expo-router is installed', async () => {
+    const routerDir = `${projectRoot}/node_modules/expo-router`;
+
+    setupNodeModules(
+      {
+        'expo-router': {
+          version: '5.0.0',
+          dependencies: { '@expo/metro-runtime': '^5.0.0' },
+        },
+        '@expo/metro-runtime': { version: '4.0.0' },
+      },
+      {
+        [`${projectRoot} > expo-router`]: routerDir,
+        [`${routerDir} > @expo/metro-runtime`]: `${projectRoot}/node_modules/@expo/metro-runtime`,
+      }
+    );
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toContain('expo-router');
+    expect(result.issues[0]).toContain('@expo/metro-runtime');
+  });
+
+  it('resolves packages from isolated node_modules (pnpm-style)', async () => {
+    const expoDir = `${projectRoot}/node_modules/.pnpm/expo@53.0.0/node_modules/expo`;
+    const metroWrapperDir = `${projectRoot}/node_modules/.pnpm/@expo+metro@1.0.0/node_modules/@expo/metro`;
+    const metroDir = `${projectRoot}/node_modules/.pnpm/metro@0.76.0/node_modules/metro`;
+
+    const files: Record<string, string> = {};
+    files[`${expoDir}/package.json`] = JSON.stringify({
+      version: '53.0.0',
+      dependencies: { '@expo/metro': '^1.0.0' },
+    });
+    files[`${metroWrapperDir}/package.json`] = JSON.stringify({
+      version: '1.0.0',
+      dependencies: { metro: '^0.81.0' },
+    });
+    files[`${metroDir}/package.json`] = JSON.stringify({ version: '0.76.0' });
+
+    vol.fromJSON(files);
+
+    mockResolveFromSilent.mockImplementation((baseDir: string, moduleId: string) => {
+      const match = moduleId.match(/^(.+)\/package\.json$/);
+      if (!match) {
+        return undefined;
+      }
+      const packageName = match[1];
+
+      const graph: Record<string, string | undefined> = {
+        [`${projectRoot} > expo`]: expoDir,
+        [`${expoDir} > @expo/metro`]: metroWrapperDir,
+        [`${metroWrapperDir} > metro`]: metroDir,
+        // metro is NOT resolvable from the project root
+      };
+
+      const resolved = graph[`${baseDir} > ${packageName}`];
+      return resolved ? `${resolved}/package.json` : undefined;
+    });
+
+    const check = new DependencyVersionOverrideCheck();
+    const result = await check.runAsync({
+      pkg: { name: 'test', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toContain('metro');
+    expect(result.issues[0]).toContain('0.76.0');
+  });
+});

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -9,6 +9,7 @@ import { env } from './env';
 import { Log } from './log';
 import { AppConfigFieldsNotSyncedToNativeProjectsCheck } from '../checks/AppConfigFieldsNotSyncedToNativeProjectsCheck';
 import { AutolinkingDependencyDuplicatesCheck } from '../checks/AutolinkingDependencyDuplicatesCheck';
+import { DependencyVersionOverrideCheck } from '../checks/DependencyVersionOverrideCheck';
 import { DirectPackageInstallCheck } from '../checks/DirectPackageInstallCheck';
 import { ExpoConfigCommonIssueCheck } from '../checks/ExpoConfigCommonIssueCheck';
 import { ExpoConfigSchemaCheck } from '../checks/ExpoConfigSchemaCheck';
@@ -55,6 +56,7 @@ export function resolveChecksInScope(exp: ExpoConfig, pkg: PackageJSONConfig): D
     // Version Checks
     new SupportPackageVersionCheck(),
     new NativeToolingVersionCheck(),
+    new DependencyVersionOverrideCheck(),
 
     // Compatibility Checks
     new StoreCompatibilityCheck(),


### PR DESCRIPTION
# Why

We commonly warn people to remove resolutions/overrides when upgrading Expo. However, this is still something that's easily missed, but just as easily checked by `expo-doctor`. Corrupted installations can also catch people out, and while those are less likely and common, they're still confusing.

`expo-doctor` can trivially resolve & walk a list of "critical" dependencies that are highly likely to break Expo if they're broken or altered and provide suggestions on how to fix them.

> [!NOTE]
> The motivation here is that #44767 will introduce a Metro upgrade in SDK 55 that's internally "breaking", i.e. it requires changes in `@expo/cli`. Breaking changes like these have caught people with manual overrides/resolutions out in the past, and while this isn't a new problem, if expo-doctor warned about this, we wouldn't have to worry about this as much anymore

# How

- Add a check that walks a dependency chain, and if this chain resolves, checks if the version of the last package in this chain matches the range of the penultimate package

# Test Plan

- Unit test added
- manually tested with a `resolutions` entry on a fresh yarn-installed project

<img width="898" height="96" alt="image" src="https://github.com/user-attachments/assets/117f182d-2b22-4efb-9173-b3a6765a7fad" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
