### PR TITLE
[updates][ios] Support multiple root view creations in brownfield

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
 - Native interface access to state machine context. ([#44361](https://github.com/expo/expo/pull/44361) by [@douglowder](https://github.com/douglowder))
 - [ios] resolve Expo.plist lookup in brownfield xcframework builds ([#44645](https://github.com/expo/expo/pull/44645) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [ios] Support multiple root view creations in brownfield ([#44771](https://github.com/expo/expo/pull/44771) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-updates/ios/EXUpdates/AppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppController.swift
@@ -149,6 +149,7 @@ public protocol InternalAppControllerInterface: AppControllerInterface {
   var reloadScreenManager: Reloadable? { get }
 
   var eventManager: UpdatesEventManager { get }
+  var isStarted: Bool { get }
   func onEventListenerStartObserving()
 
   func getConstantsForModule() -> UpdatesModuleConstants

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -55,6 +55,7 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   public var embeddedUpdateId: UUID?
 
   public var isEnabled: Bool
+  public var isStarted = false
 
   public let eventManager: UpdatesEventManager = NoOpUpdatesEventManager()
   public var reloadScreenManager: Reloadable? = ReloadScreenManager()

--- a/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DevLauncherAppController.swift
@@ -55,7 +55,7 @@ public final class DevLauncherAppController: NSObject, InternalAppControllerInte
   public var embeddedUpdateId: UUID?
 
   public var isEnabled: Bool
-  public var isStarted = false
+  public let isStarted = false
 
   public let eventManager: UpdatesEventManager = NoOpUpdatesEventManager()
   public var reloadScreenManager: Reloadable? = ReloadScreenManager()

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -29,7 +29,7 @@ public class DisabledAppController: InternalAppControllerInterface, UpdatesInter
   public var reloadScreenManager: Reloadable?
 
   public let isActiveController = false
-  public var isStarted: Bool = false
+  public private(set) var isStarted: Bool = false
   private var startupStartTime: DispatchTime?
   private var startupEndTime: DispatchTime?
 

--- a/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/DisabledAppController.swift
@@ -29,7 +29,7 @@ public class DisabledAppController: InternalAppControllerInterface, UpdatesInter
   public var reloadScreenManager: Reloadable?
 
   public let isActiveController = false
-  private var isStarted: Bool = false
+  public var isStarted: Bool = false
   private var startupStartTime: DispatchTime?
   private var startupEndTime: DispatchTime?
 

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -39,7 +39,7 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesInterf
   private let updatesDirectoryInternal: URL
   private let controllerQueue = DispatchQueue(label: "expo.controller.ControllerQueue")
   public let isActiveController = true
-  public var isStarted = false
+  public private(set) var isStarted = false
   private var startupStartTime: DispatchTime?
   private var startupEndTime: DispatchTime?
 

--- a/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
+++ b/packages/expo-updates/ios/EXUpdates/EnabledAppController.swift
@@ -39,7 +39,7 @@ public class EnabledAppController: InternalAppControllerInterface, UpdatesInterf
   private let updatesDirectoryInternal: URL
   private let controllerQueue = DispatchQueue(label: "expo.controller.ControllerQueue")
   public let isActiveController = true
-  private var isStarted = false
+  public var isStarted = false
   private var startupStartTime: DispatchTime?
   private var startupEndTime: DispatchTime?
 

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -16,28 +16,6 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
   private var rootViewModuleName: String?
   private var rootViewInitialProperties: [AnyHashable: Any]?
 
-  public required override init() {
-    super.init()
-
-    // Initialize and start the controller as soon as the handler is constructed,
-    // which happens during ExpoAppDelegate setup — well before the first React
-    // root view is requested. Doing it here (instead of in createReactRootView)
-    // means createReactRootView can be safely invoked multiple times, which is
-    // required for brownfield setups where the host app may mount and unmount
-    // RN views many times during its lifetime.
-    if UpdatesUtils.isUsingCustomInitialization() {
-      return
-    }
-
-    AppController.initializeWithoutStarting()
-    let controller = AppController.sharedInstance
-    guard controller.isActiveController else {
-      return
-    }
-    controller.delegate = self
-    controller.start()
-  }
-
   public override func createReactRootView(
     reactDelegate: ExpoReactDelegate,
     moduleName: String,
@@ -48,27 +26,19 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
       return nil
     }
 
+    AppController.initializeWithoutStarting()
     let controller = AppController.sharedInstance
     if !controller.isActiveController {
       return nil
     }
 
-    // If startup has already completed, create the view directly with the launch
-    // asset URL the controller resolved. This is the path hit on every brownfield
-    // re-mount, and on standard apps when the React view is created after startup.
-    if let launchAssetUrl = controller.launchAssetUrl() {
-      return reactDelegate.reactNativeFactory.recreateRootView(
-        withBundleURL: launchAssetUrl,
-        moduleName: moduleName,
-        initialProps: initialProperties,
-        launchOptions: launchOptions
-      )
-    }
-
-    // Startup is still in-flight. Return a deferred placeholder; the delegate
-    // callback will swap in the real view once startup finishes.
     self.reactDelegate = reactDelegate
     self.launchOptions = launchOptions
+    if !controller.isStarted {
+      controller.delegate = self
+      controller.start()
+    }
+
     self.rootViewModuleName = moduleName
     self.rootViewInitialProperties = initialProperties
     self.deferredRootView = EXDeferredRCTRootView()
@@ -104,11 +74,8 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     if UpdatesUtils.isUsingCustomInitialization() {
       return
     }
-    // No deferred view waiting — startup completed before any React view was
-    // requested. The view will be created on demand via createReactRootView,
-    // which will use the now-resolved launchAssetUrl directly.
     guard let reactDelegate = self.reactDelegate else {
-      return
+      fatalError("`reactDelegate` should not be nil")
     }
 
     let rootView = reactDelegate.reactNativeFactory.recreateRootView(

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -32,6 +32,18 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
       return nil
     }
 
+    // If startup already completed, create the real view directly to handle
+    // brownfield re-mounts and simultaneous multi-view scenarios, given that
+    // didStartWithSuccess fires only once per controller lifetime.
+    if controller.isStarted, let launchAssetUrl = controller.launchAssetUrl() {
+      return reactDelegate.reactNativeFactory.recreateRootView(
+        withBundleURL: launchAssetUrl,
+        moduleName: moduleName,
+        initialProps: initialProperties,
+        launchOptions: launchOptions
+      )
+    }
+
     self.reactDelegate = reactDelegate
     self.launchOptions = launchOptions
     if !controller.isStarted {

--- a/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
+++ b/packages/expo-updates/ios/EXUpdates/ReactDelegateHandler/ExpoUpdatesReactDelegateHandler.swift
@@ -16,6 +16,28 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
   private var rootViewModuleName: String?
   private var rootViewInitialProperties: [AnyHashable: Any]?
 
+  public required override init() {
+    super.init()
+
+    // Initialize and start the controller as soon as the handler is constructed,
+    // which happens during ExpoAppDelegate setup — well before the first React
+    // root view is requested. Doing it here (instead of in createReactRootView)
+    // means createReactRootView can be safely invoked multiple times, which is
+    // required for brownfield setups where the host app may mount and unmount
+    // RN views many times during its lifetime.
+    if UpdatesUtils.isUsingCustomInitialization() {
+      return
+    }
+
+    AppController.initializeWithoutStarting()
+    let controller = AppController.sharedInstance
+    guard controller.isActiveController else {
+      return
+    }
+    controller.delegate = self
+    controller.start()
+  }
+
   public override func createReactRootView(
     reactDelegate: ExpoReactDelegate,
     moduleName: String,
@@ -26,17 +48,27 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
       return nil
     }
 
-    AppController.initializeWithoutStarting()
     let controller = AppController.sharedInstance
     if !controller.isActiveController {
       return nil
     }
 
+    // If startup has already completed, create the view directly with the launch
+    // asset URL the controller resolved. This is the path hit on every brownfield
+    // re-mount, and on standard apps when the React view is created after startup.
+    if let launchAssetUrl = controller.launchAssetUrl() {
+      return reactDelegate.reactNativeFactory.recreateRootView(
+        withBundleURL: launchAssetUrl,
+        moduleName: moduleName,
+        initialProps: initialProperties,
+        launchOptions: launchOptions
+      )
+    }
+
+    // Startup is still in-flight. Return a deferred placeholder; the delegate
+    // callback will swap in the real view once startup finishes.
     self.reactDelegate = reactDelegate
     self.launchOptions = launchOptions
-    controller.delegate = self
-    controller.start()
-
     self.rootViewModuleName = moduleName
     self.rootViewInitialProperties = initialProperties
     self.deferredRootView = EXDeferredRCTRootView()
@@ -72,8 +104,11 @@ public final class ExpoUpdatesReactDelegateHandler: ExpoReactDelegateHandler, Ap
     if UpdatesUtils.isUsingCustomInitialization() {
       return
     }
+    // No deferred view waiting — startup completed before any React view was
+    // requested. The view will be created on demand via createReactRootView,
+    // which will use the now-resolved launchAssetUrl directly.
     guard let reactDelegate = self.reactDelegate else {
-      fatalError("`reactDelegate` should not be nil")
+      return
     }
 
     let rootView = reactDelegate.reactNativeFactory.recreateRootView(


### PR DESCRIPTION
# Why

In brownfield setups, the host app controls the view lifecycle and may mount/unmount React Native views multiple times (e.g. user navigates to an RN screen, pops back, then pushes again). Each mount triggers `createReactRootView` on `ExpoUpdatesReactDelegateHandler`, which unconditionally called `AppController.initializeWithoutStarting()` and `controller.start()`. Since `EnabledAppController.start()` has a `precondition(!isStarted)`, the second invocation crashes the app.

# How

Moved controller initialization out of `createReactRootView` and into the handler's `init()`. The handler is instantiated once during `ExpoAppDelegate` setup, before any view is requested. This ensures the startup procedure runs exactly once.

`createReactRootView` is now a pure view-creation function with two paths:
- Startup already completed (`launchAssetUrl() != nil`): creates the view directly via `recreateRootView` with the resolved bundle URL  
- Startup still in-flight (`launchAssetUrl()` is nil): falls back to the existing deferred-view placeholder, which gets swapped by the `appController(didStartWithSuccess:)` callback once startup finishes  
 

# Test Plan

- Using minimal tester run `npx expo-brownfield -p ios`
- In brownfield-tester, navigate back and forth to the rn app 


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
