### PR TITLE
fix(expo-modules-core): fixed re-export of ExpoModulesMacros from ExpoModulesCore

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Updated `ExpoModulesMacros` to be correctly re-exported when using XCFrameworks.
+
 - [iOS] Add async/await overload for StaticAsyncFunction ([#44471](https://github.com/expo/expo/pull/44471) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fixed looking up the `EXConstants.bundle` from the main bundle to allow running with precompiled XCFrameworks. ([#44551](https://github.com/expo/expo/pull/44551) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider. ([#44550](https://github.com/expo/expo/pull/44550) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Updated `ExpoModulesMacros` to be correctly re-exported when using XCFrameworks.
+- [iOS] Updated `ExpoModulesMacros` to be correctly re-exported when using XCFrameworks. ([#44772](https://github.com/expo/expo/pull/44772) by [@chrfalch](https://github.com/chrfalch))
 
 - [iOS] Add async/await overload for StaticAsyncFunction ([#44471](https://github.com/expo/expo/pull/44471) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fixed looking up the `EXConstants.bundle` from the main bundle to allow running with precompiled XCFrameworks. ([#44551](https://github.com/expo/expo/pull/44551) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
@@ -2,5 +2,13 @@
  * Re-export the `@OptimizedFunction` or other macros from the standalone macros plugin package
  * (`@expo/expo-modules-macros-plugin`). This allows module authors to use the macro
  * by importing ExpoModulesCore alone, without adding a direct dependency on the plugin package.
+ * Note: The plugin is not be available at compile time for prebuilts, so we need to 
+ * conditionally import it and provide a fallback implementation of the macro.
  */
-@_exported import ExpoModulesMacros
+ #if canImport(ExpoModulesMacros)
+ @_exported import ExpoModulesMacros
+ #else
+ @attached(peer, names: arbitrary)
+ public macro OptimizedFunction() =
+   #externalMacro(module: "ExpoModulesMacros", type: "OptimizedFunctionAttachedMacro")
+ #endif

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -122,8 +122,7 @@
             "Tests/**",
             "BridgeModule/**",
             "Views/**",
-            "Worklets/**",
-            "Core/ExpoModulesMacros.swift"
+            "Worklets/**"
           ],
           "dependencies": [
             "Hermes",


### PR DESCRIPTION
# Why

When building everything from source this works well - but the fix (#44354) for doing the same when using it from prebuilt XCFrameworks was wrong.

The issue is that when building E-M-C as an XCFramework we don't have the `ExpoModulesMacros` library installed as an XCFramework so we can't depend on it.

# How 

This commit fixes this by re-introducing the ExpoModulesMacros.swift file in E-M-C in its prebuilt config (it was excluded in #44354).

In addition it has a conditional import that also works for precompiled - where the Macro doesn't need to be loaded to be referenced and declared:

```swift
 #if canImport(ExpoModulesMacros)
 @_exported import ExpoModulesMacros
 #else
 @attached(peer, names: arbitrary)
 public macro OptimizedFunction() =
   #externalMacro(module: "ExpoModulesMacros", type: "OptimizedFunctionAttachedMacro")
 #endif
```

Tested with/without precompiled XCFrameworks in BareExpo.

The file BenchmarkingExpoModule.swift tests this throught the APIs/Benchmarks in BareExpo.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
