### PR TITLE
fix(dev-launcher, dev-menu): remove SwiftUI #Preview blocks that cause build failures

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -116,8 +116,4 @@ struct NetworkPermissionsBanner: View {
     .cornerRadius(18)
   }
 }
-
-#Preview {
-  HomeTabView()
-}
 // swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -271,8 +271,3 @@ struct SettingsTabView: View {
   }
   #endif
 }
-
-#Preview {
-  SettingsTabView()
-    .environmentObject(DevLauncherViewModel())
-}

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotSignedInView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotSignedInView.swift
@@ -39,7 +39,3 @@ struct NotSignedInView: View {
     .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
-
-#Preview {
-  NotSignedInView()
-}

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotUsingUpdatesView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotUsingUpdatesView.swift
@@ -32,7 +32,3 @@ struct NotUsingUpdatesView: View {
     }
   }
 }
-
-#Preview {
-  NotUsingUpdatesView()
-}

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -190,8 +190,4 @@ struct UpdatesListView: View {
     }
   }
 }
-
-#Preview {
-  UpdatesListView()
-}
 // swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
@@ -25,7 +25,3 @@ struct UpdatesTabView: View {
     #endif
   }
 }
-
-#Preview {
-  UpdatesTabView()
-}

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Remove `#Preview` SwiftUI blocks that cause build failures when consuming the package as a dependency. ([#44775](https://github.com/expo/expo/pull/44775) by [@fabriziocucci](https://github.com/fabriziocucci))
+
 ### 💡 Others
 
 ## 55.0.23 — 2026-04-11

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuButtons.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuButtons.swift
@@ -75,7 +75,3 @@ struct DevMenuToggleButton: View {
     .opacity(disabled ? 0.6 : 1.0)
   }
 }
-
-#Preview {
-  DevMenuActionButton(title: "Action", icon: "person.fast") {}
-}

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -91,8 +91,4 @@ struct DevMenuDeveloperTools: View {
   }
 }
 
-#Preview {
-  DevMenuDeveloperTools()
-}
-
 // swiftlint:enable closure_body_length

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift
@@ -16,7 +16,3 @@ struct DevMenuRNDevMenu: View {
     .cornerRadius(18)
   }
 }
-
-#Preview {
-  DevMenuRNDevMenu {}
-}

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
@@ -45,7 +45,3 @@ struct DevMenuRootView: View {
 #endif
   }
 }
-
-#Preview {
-  DevMenuRootView()
-}


### PR DESCRIPTION
## Summary

Remove all `#Preview { ... }` SwiftUI macro blocks from `expo-dev-launcher` and `expo-dev-menu` iOS Swift files.

## Motivation

These preview providers cause **build failures** when the packages are consumed as dependencies in a host app. The `#Preview` macro expands to code that references types from the package's own build context, which are not available when the package is built as a dependency. This is a [well-known SwiftUI packaging issue](https://developer.apple.com/forums/thread/762038).

The `#Preview` macro is only useful during development of the packages themselves (for Xcode canvas previews) and has **zero runtime effect**.

## Changes

Pure deletions — **41 lines removed, 0 lines added**.

**expo-dev-launcher** (6 files):
- `HomeTabView.swift`
- `SettingsTabView.swift`
- `NotSignedInView.swift`
- `NotUsingUpdatesView.swift`
- `UpdatesListView.swift`
- `UpdatesTabView.swift`

**expo-dev-menu** (4 files):
- `DevMenuButtons.swift`
- `DevMenuDeveloperTools.swift`
- `DevMenuRNDevMenu.swift`
- `DevMenuRootView.swift`

## Test Plan

- [x] Verified no runtime behavior change (preview blocks are compile-time only)
- [x] Builds successfully as a dependency in a host app that previously failed