### PR TITLE
fix(dev-launcher): Guard #Preview macros with availability check XCode 26

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/HomeTabView.swift
@@ -117,7 +117,10 @@ struct NetworkPermissionsBanner: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   HomeTabView()
 }
+#endif
 // swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -272,7 +272,10 @@ struct SettingsTabView: View {
   #endif
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   SettingsTabView()
     .environmentObject(DevLauncherViewModel())
 }
+#endif

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotSignedInView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotSignedInView.swift
@@ -40,6 +40,9 @@ struct NotSignedInView: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   NotSignedInView()
 }
+#endif

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotUsingUpdatesView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/NotUsingUpdatesView.swift
@@ -33,6 +33,9 @@ struct NotUsingUpdatesView: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   NotUsingUpdatesView()
 }
+#endif

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesListView.swift
@@ -191,7 +191,10 @@ struct UpdatesListView: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   UpdatesListView()
 }
+#endif
 // swiftlint:enable closure_body_length

--- a/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/UpdatesTab/UpdatesTabView.swift
@@ -26,6 +26,9 @@ struct UpdatesTabView: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   UpdatesTabView()
 }
+#endif


### PR DESCRIPTION
# Why

The `#Preview` macro requires iOS 17.0+ but the podspec declares a deployment target of iOS 16.4. Xcode 26 enforces this strictly, causing build failures. Wrap all `#Preview` blocks with `#if compiler(>=5.9)` and `@available(iOS 17.0, *)` guards.

The alternative is also to remove the `#Preview` macro altogether as consumers won't benefit from this. Only Expo developer will.

You folks tell me what is the preferred approach here 👍 

# Test Plan

Tested in my local expo deployment (with `#Preview` fully removed).

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
