### PR TITLE
fix(dev-menu): Guard #Preview macros with availability check for XCode 26

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuButtons.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuButtons.swift
@@ -76,6 +76,9 @@ struct DevMenuToggleButton: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   DevMenuActionButton(title: "Action", icon: "person.fast") {}
 }
+#endif

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuDeveloperTools.swift
@@ -91,8 +91,11 @@ struct DevMenuDeveloperTools: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   DevMenuDeveloperTools()
 }
+#endif
 
 // swiftlint:enable closure_body_length

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRNDevMenu.swift
@@ -17,6 +17,9 @@ struct DevMenuRNDevMenu: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   DevMenuRNDevMenu {}
 }
+#endif

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
@@ -46,6 +46,9 @@ struct DevMenuRootView: View {
   }
 }
 
+#if compiler(>=5.9)
+@available(iOS 17.0, *)
 #Preview {
   DevMenuRootView()
 }
+#endif


### PR DESCRIPTION
# Why

The `#Preview` macro requires iOS 17.0+ but the podspec declares a deployment target of iOS 16.4. Xcode 26 enforces this strictly, causing build failures. Wrap all `#Preview` blocks with `#if compiler(>=5.9)` and `@available(iOS 17.0, *)` guards.

The alternative is also to remove the `#Preview` macro altogether as consumers won't benefit from this. Only Expo developer will.

You folks tell me what is the preferred approach here 👍 

# Test Plan

Tested in my local expo deployment (with `#Preview` fully removed).

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
