### PR TITLE
fix(asset): Use OkHttpClientProvider for Android asset downloads

### DIFF
--- a/packages/expo-asset/android/build.gradle
+++ b/packages/expo-asset/android/build.gradle
@@ -15,6 +15,8 @@ android {
 }
 
 dependencies {
+  implementation 'com.squareup.okhttp3:okhttp:4.9.2'
+  implementation 'com.facebook.react:react-android'
   testImplementation 'io.mockk:mockk:1.13.11'
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
+++ b/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
@@ -11,6 +11,8 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.services.FilePermissionService
 import kotlinx.coroutines.withContext
+import com.facebook.react.modules.network.OkHttpClientProvider
+import okhttp3.Request
 import java.io.File
 import java.net.URI
 import java.security.MessageDigest
@@ -43,7 +45,14 @@ class AssetModule : Module() {
         val inputStream = when {
           uri.toString().contains(":").not() -> openAssetResourceStream(context, uri.toString())
           uri.toString().startsWith(ANDROID_EMBEDDED_URL_BASE_RESOURCE) -> openAndroidResStream(context, uri.toString())
-          else -> uri.toURL().openStream()
+          else -> {
+            val request = Request.Builder().url(uri.toURL()).build()
+            val response = OkHttpClientProvider.getOkHttpClient().newCall(request).execute()
+            if (!response.isSuccessful || response.body == null) {
+              throw Exception("HTTP ${response.code} for $uri")
+            }
+            response.body!!.byteStream()
+          }
         }
         inputStream.use { input ->
           localUrl.outputStream().use { output ->

--- a/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
+++ b/packages/expo-asset/android/src/main/java/expo/modules/asset/AssetModule.kt
@@ -48,10 +48,12 @@ class AssetModule : Module() {
           else -> {
             val request = Request.Builder().url(uri.toURL()).build()
             val response = OkHttpClientProvider.getOkHttpClient().newCall(request).execute()
-            if (!response.isSuccessful || response.body == null) {
+            val body = response.body
+            if (!response.isSuccessful || body == null) {
+              response.close()
               throw Exception("HTTP ${response.code} for $uri")
             }
-            response.body!!.byteStream()
+            body.byteStream()
           }
         }
         inputStream.use { input ->


### PR DESCRIPTION
# Why

Replace `uri.toURL().openStream()` with `OkHttpClientProvider.getOkHttpClient()` for downloading assets on Android. 

This ensures asset downloads go through React Native's shared OkHttpClient, which allows apps to attach custom interceptors (e.g. for authentication headers or proxy configuration).

Calling `.openStream()` results in requests from expo-assets escaping all the centralized logic.

# Test Plan

Tested in my local deployment of expo

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
