### PR TITLE
fix(cli): Move location of length incrementer in event stream implementation

### DIFF
--- a/packages/@expo/cli/src/events/stream.ts
+++ b/packages/@expo/cli/src/events/stream.ts
@@ -302,12 +302,12 @@ export class LogStream extends EventEmitter implements NodeJS.WritableStream {
       return false;
     }
 
-    this.#len += data.length;
-
     // Fast path: For complete lines with no pending partial we can skip the work below
     if (this.#partialLine === 0 && data.charCodeAt(data.length - 1) === 10 /*'\n'*/) {
       return this._writeln(data);
     }
+
+    this.#len += data.length;
 
     let startIdx = 0;
     let endIdx = -1;


### PR DESCRIPTION
# Why

Spotted by @hassankhan during another round of reviews.
This won't be picked, backported, or receive a changelog since we don't rely on this codepath right now.

# How

- Move faulty `length` incrementer

# Test Plan

- n/a

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
