### PR TITLE
Add codemention entry for expo-background-task

### DIFF
--- a/.github/codemention.yml
+++ b/.github/codemention.yml
@@ -72,6 +72,8 @@ rules:
     mentions: ['alanjhughes', 'behenate']
   - patterns: ['packages/expo-background-fetch/**']
     mentions: ['Kudo', 'chrfalch']
+  - patterns: ['packages/expo-background-task/**']
+    mentions: ['chrfalch', 'bycedric']
   - patterns: ['packages/expo-battery/**']
     mentions: ['behenate']
   - patterns: ['packages/expo-blur/**']


### PR DESCRIPTION
# Why

`packages/expo-background-task/**` had no entry in `.github/codemention.yml`, so community PRs that touch it are never routed to a maintainer and can sit without review. Concrete example: #44646 fixes a live iOS regression (the `ModuleRegistryProvider.singletonModules()` lookup broken by #41911, see #44540) and has had zero activity in five days because CodeMention never pinged anyone.

# How

Adds a single `codemention` rule for `packages/expo-background-task/**`, pinging `chrfalch` and `bycedric` - the same two maintainers already listed for `packages/expo-task-manager/**`. That mirrors current ownership: `expo-background-task` shares `EXTaskService` with `expo-task-manager`, and the recent `expo-background-task` bug fixes (#44666, #44667, #44663) were all authored or merged by @chrfalch.

# Test Plan

Pure configuration change to `.github/codemention.yml`; nothing to build or test. On the next PR that touches `packages/expo-background-task/**`, the CodeMention bot should post a "Subscribed to pull request" comment mentioning @chrfalch and @bycedric.

# Checklist

- [ ] I added a \`changelog.md\` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for \`npx expo prebuild\` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

_(Checklist items are N/A for a \`codemention.yml\`-only change.)_