### PR TITLE
fix(expo-file-system): add ./next subpath to package exports

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 ### 🐛 Bug fixes
 
+- Added `./next` subpath to package `exports` field to resolve Metro bundler warning. ([#44793](https://github.com/expo/expo/pull/44793) by [@chang-in](https://github.com/chang-in))
+
 - [Android] Fix copy/move support for SAF and content provider URIs. ([#42887](https://github.com/expo/expo/pull/42887) by [@barthap](https://github.com/barthap))
 - Fix out-of-memory errors when calculating file `md5` hash. ([#44064](https://github.com/expo/expo/pull/44064) by [@barthap](https://github.com/barthap))
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug fixes
 
+- Added `./next` subpath to package `exports` field to resolve Metro bundler warning. ([#44793](https://github.com/expo/expo/pull/44793) by [@chang-in](https://github.com/chang-in))
 - Fixed `FileHandle` security-scoped access, and non-SAF `content://` URI support. ([#47176](https://github.com/expo/expo/pull/47176) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -16,6 +16,10 @@
     "./legacy": {
       "types": "./build/legacy/index.d.ts",
       "default": "./src/legacy/index.ts"
+    },
+    "./next": {
+      "types": "./build/next/index.d.ts",
+      "default": "./next.ts"
     }
   },
   "sideEffects": false,

--- a/packages/expo-file-system/package.json
+++ b/packages/expo-file-system/package.json
@@ -42,6 +42,14 @@
       },
       "expo-source": "./src/legacy/index.ts",
       "default": "./build/legacy/index.js"
+    },
+    "./next": {
+      "types": {
+        "expo-source": "./src/index.ts",
+        "default": "./build/index.d.ts"
+      },
+      "expo-source": "./src/index.ts",
+      "default": "./build/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

The `expo-file-system/next` subpath exists as a file (`next.ts`) but is not listed in the `exports` field of `package.json`. This causes a Metro bundler warning:

```
WARN  Attempted to import the module "expo-file-system/next" which is not listed in the "exports" of "expo-file-system" under the requested subpath "./next". Falling back to file-based resolution.
```

This PR adds `./next` to the `exports` field to resolve the warning and provide proper module resolution.

## Test Plan

- Import `{ File, Directory, Paths }` from `expo-file-system/next`
- Verify no Metro warning is emitted
- Verify the import resolves correctly

## Context

In SDK 54, `expo-file-system/next` was the recommended way to use the new File/Directory API. In SDK 55, these APIs are also available from the main `expo-file-system` entry point, but the `./next` subpath still exists for backward compatibility. Adding it to `exports` ensures developers upgrading from SDK 54 don't encounter warnings.