### PR TITLE
[JSI] Fix xcframework build script when PODS_ROOT changes

### DIFF
--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -90,10 +90,14 @@ compute_hash() {
   )
   # Force C locale so sort order is consistent regardless of the environment.
   # Xcode build phases run without locale variables, which changes sort ordering.
-  echo "$all_files" | LC_ALL=C sort | while IFS= read -r file; do
-    echo "$file"
-    cat "$file"
-  done | shasum -a 256 | cut -d' ' -f1
+  (
+    # Include PODS_ROOT so switching between worktrees invalidates the cache.
+    echo "PODS_ROOT=${PODS_ROOT:-}"
+    echo "$all_files" | LC_ALL=C sort | while IFS= read -r file; do
+      echo "$file"
+      cat "$file"
+    done
+  ) | shasum -a 256 | cut -d' ' -f1
 }
 
 # Resolves the xcodebuild destination for a given platform name.
@@ -230,16 +234,19 @@ symlink_dependencies() {
   # in sync when PODS_ROOT changes.
   local hermes_destroot="${sources}/hermes-engine/destroot"
   if [[ -d "${PODS_ROOT}/hermes-engine/destroot" ]]; then
+    [[ -d "$hermes_destroot" && ! -L "$hermes_destroot" ]] && rm -rf "$hermes_destroot"
     ln -sfn "${PODS_ROOT}/hermes-engine/destroot" "$hermes_destroot"
   fi
 
   local react_xcframework="${sources}/React/React.xcframework"
   if [[ -d "${PODS_ROOT}/React-Core-prebuilt/React.xcframework" ]]; then
+    [[ -d "$react_xcframework" && ! -L "$react_xcframework" ]] && rm -rf "$react_xcframework"
     ln -sfn "${PODS_ROOT}/React-Core-prebuilt/React.xcframework" "$react_xcframework"
   fi
 
   local rndeps_xcframework="${sources}/ReactNativeDependencies/ReactNativeDependencies.xcframework"
   if [[ -d "${PODS_ROOT}/ReactNativeDependencies/framework/packages/react-native/ReactNativeDependencies.xcframework" ]]; then
+    [[ -d "$rndeps_xcframework" && ! -L "$rndeps_xcframework" ]] && rm -rf "$rndeps_xcframework"
     ln -sfn "${PODS_ROOT}/ReactNativeDependencies/framework/packages/react-native/ReactNativeDependencies.xcframework" "$rndeps_xcframework"
   fi
 
@@ -250,11 +257,18 @@ symlink_dependencies() {
   local vfs_output="${sources}/React/React-VFS.yaml"
   local vfs_source="${PODS_ROOT}/React-Core-prebuilt/React-VFS.yaml"
   if [[ -f "$vfs_source" ]] && [[ ! -f "$vfs_output" || "$vfs_source" -nt "$vfs_output" ]]; then
+    log "Regenerating React VFS overlay"
     sed "s|${PODS_ROOT}/React-Core-prebuilt|${sources}/React|g" "$vfs_source" > "$vfs_output"
   fi
 }
 
 # --- Main ---
+
+if [[ -n "${PODS_ROOT:-}" ]]; then
+  # Resolve to an absolute path so symlinks and the build hash are stable
+  # regardless of whether PODS_ROOT was passed as relative or absolute.
+  PODS_ROOT="$(cd "$PODS_ROOT" && pwd)"
+fi
 
 if [[ "$CLEAN" == true ]]; then
   rm -rf "$XCFRAMEWORK_PATH" "$SLICES_DIR"


### PR DESCRIPTION
When I tried to call `./scripts/build-xcframework.sh` manually with a relative `PODS_ROOT` env, the script was doing wrong things. Also, for some reasons `ln -sfn` didn't work for me when I ran it for the first time.

## Summary

- Fix `ln -sfn` failing silently when dependency symlink targets (React, hermes-engine, ReactNativeDependencies) exist as real directories instead of symlinks, which broke xcframework code signatures with "sealed resource is missing or invalid"
- Resolve `PODS_ROOT` to an absolute path early so symlinks get correct targets when a relative path is passed and the build hash stays stable across invocation styles
- Include `PODS_ROOT` in the build cache hash so switching between worktrees (or any change to the Pods location) automatically invalidates the cache and regenerates the VFS overlay

## Test plan

- `PODS_ROOT=/absolute/path/to/Pods ./scripts/build-xcframework.sh` succeeds
- `PODS_ROOT=../../../apps/bare-expo/ios/Pods ./scripts/build-xcframework.sh` succeeds with relative path
- Re-running with same `PODS_ROOT` hits the hash cache ("xcframework is up to date")
- Re-running with a different `PODS_ROOT` triggers a full rebuild
- `./scripts/build-xcframework.sh --clean` followed by a build succeeds
