### PR TITLE
fix(expo/fetch): identify FetchResponse as a standard Response via Symbol.toStringTag

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Prevent `original*` globals from being enumerable or from being created for globals with getters, since these may be side-effectful ([#44407](https://github.com/expo/expo/pull/44407) by [@kitten](https://github.com/kitten))
 - Resolve paths relative to project root instead of server root in `expo/scripts/resolveAppEntry.js` ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
+- Identify `FetchResponse` as a standard `Response` via `Symbol.toStringTag` so `Object.prototype.toString.call(res)` returns `'[object Response]'`. ([#44795](https://github.com/expo/expo/pull/44795) by [@SAY-5](https://github.com/SAY-5))
 
 ### 💡 Others
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Decompress `gzip` / `br` / `zstd` `expo/fetch` responses on Android even when the caller sets their own `Accept-Encoding` header. ([#46398](https://github.com/expo/expo/pull/46398) by [@zoontek](https://github.com/zoontek))
 - Fix `bodyUsed` leaking across siblings when fetch Response is cloned twice ([#46397](https://github.com/expo/expo/pull/46397) by [@zoontek](https://github.com/zoontek))
 - Prevent fatal `The stream is not in a state that permits close` in `expo/fetch` when native delivers `didComplete`/`didFailWithError` after the consumer has already canceled the body stream. ([#44909](https://github.com/expo/expo/pull/44909) by [@safaiyeh](https://github.com/safaiyeh))
+- Identify `FetchResponse` as a standard `Response` via `Symbol.toStringTag` so `Object.prototype.toString.call(res)` returns `'[object Response]'`. ([#44795](https://github.com/expo/expo/pull/44795) by [@SAY-5](https://github.com/SAY-5))
 
 ### 💡 Others
 

--- a/packages/expo/src/winter/fetch/FetchResponse.ts
+++ b/packages/expo/src/winter/fetch/FetchResponse.ts
@@ -144,3 +144,13 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
     this.removeAllListeners('didFailWithError');
   };
 }
+
+// Identify FetchResponse instances as standard Fetch `Response` objects via
+// `Symbol.toStringTag`. Libraries such as `ky` use `Object.prototype.toString.call(res)`
+// to detect spec-compatible Response instances when the prototype identity
+// differs from globalThis.Response (which is the case under expo/fetch).
+// See expo/expo#44781.
+Object.defineProperty(FetchResponse.prototype, Symbol.toStringTag, {
+  value: 'Response',
+  configurable: true,
+});

--- a/packages/expo/src/winter/fetch/FetchResponse.ts
+++ b/packages/expo/src/winter/fetch/FetchResponse.ts
@@ -424,6 +424,11 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
   };
 }
 
+// Identify FetchResponse instances as standard Fetch `Response` objects via
+// `Symbol.toStringTag`. Libraries such as `ky` use `Object.prototype.toString.call(res)`
+// to detect spec-compatible Response instances when the prototype identity
+// differs from globalThis.Response (which is the case under expo/fetch).
+// See expo/expo#44781.
 Object.defineProperty(FetchResponse.prototype, Symbol.toStringTag, {
   value: 'Response',
   configurable: true,


### PR DESCRIPTION
Per #44781, `expo/fetch` returns a custom `FetchResponse` whose prototype is not `globalThis.Response`. Libraries that detect spec-compatible Response instances via `Object.prototype.toString.call(res)` (e.g. [ky](https://github.com/sindresorhus/ky/issues/857)) therefore reject expo/fetch responses as foreign objects.

Define `Symbol.toStringTag` on `FetchResponse.prototype` so `Object.prototype.toString.call(res)` returns `"[object Response]"` and these libraries accept it as a real Response without changing the underlying class identity.

Closes #44781