### PR TITLE
[dev-launcher] do not show button for copying error on tvOS

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
@@ -94,6 +94,7 @@ struct ErrorView: View {
             .cornerRadius(8)
         }
 
+        #if !os(tvOS)
         Button(action: {
           #if !os(macOS)
           UIPasteboard.general.string = errorText
@@ -114,6 +115,7 @@ struct ErrorView: View {
             .background(Color.expoSystemGray5)
             .cornerRadius(8)
         }
+        #endif
       }
     }
     .padding(.horizontal, 20)


### PR DESCRIPTION
# Why

```
❌  (../build/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift:99:11)

​

   97 |         Button(action: {

   98 |           #if !os(macOS)

>  99 |           UIPasteboard.general.string = errorText

      |           ^ 'UIPasteboard' is unavailable in tvOS

  100 |           #else

  101 |           NSPasteboard.general.clearContents()

  102 |           NSPasteboard.general.setString(errorText, forType: .string)

​

​

❌  (../build/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift:99:32)

​


```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

remove the button on tvOS

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan



<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)