### PR TITLE
fix(dev-launcher): use OkHttpClientProvider instead of bare OkHttpClient

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Use `OkHttpClientProvider` instead of bare `OkHttpClient` so custom interceptors are applied. ([#44798](https://github.com/expo/expo/pull/44798) by [@fabriziocucci](https://github.com/fabriziocucci))
+
 ### 💡 Others
 
 - Align dev launcher labels across iOS and Android. ([#44720](https://github.com/expo/expo/pull/44720) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-dev-launcher/android/src/debug/java/com/facebook/react/devsupport/DevLauncherDevServerHelper.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/com/facebook/react/devsupport/DevLauncherDevServerHelper.kt
@@ -12,8 +12,10 @@ import okhttp3.Callback
 import okhttp3.Request
 import okhttp3.Response
 import java.io.IOException
+import java.util.concurrent.TimeUnit
 
 private const val PACKAGER_OK_STATUS = "packager-status:running"
+private const val HTTP_CONNECT_TIMEOUT_MS = 5000L
 private const val PACKAGER_STATUS_ENDPOINT = "status"
 
 class DevLauncherDevServerHelper(
@@ -23,7 +25,11 @@ class DevLauncherDevServerHelper(
   packagerConnection: PackagerConnectionSettings
 ) : DevServerHelper(devSettings, context, packagerConnection) {
 
-  private val httpClient = OkHttpClientProvider.getOkHttpClient()
+  private val httpClient = OkHttpClientProvider.getOkHttpClient().newBuilder()
+    .connectTimeout(HTTP_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+    .readTimeout(0, TimeUnit.MILLISECONDS)
+    .writeTimeout(0, TimeUnit.MILLISECONDS)
+    .build()
 
   override fun getDevServerBundleURL(jsModulePath: String): String {
     return controller?.manifest?.getBundleURL() ?: super.getDevServerBundleURL(jsModulePath)

--- a/packages/expo-dev-launcher/android/src/debug/java/com/facebook/react/devsupport/DevLauncherDevServerHelper.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/com/facebook/react/devsupport/DevLauncherDevServerHelper.kt
@@ -2,20 +2,18 @@ package com.facebook.react.devsupport
 
 import android.content.Context
 import androidx.core.net.toUri
+import com.facebook.react.modules.network.OkHttpClientProvider
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
 import com.facebook.react.packagerconnection.PackagerConnectionSettings
 import expo.modules.devlauncher.launcher.DevLauncherControllerInterface
 import okhttp3.Call
 import okhttp3.Callback
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import java.io.IOException
-import java.util.concurrent.TimeUnit
 
 private const val PACKAGER_OK_STATUS = "packager-status:running"
-private const val HTTP_CONNECT_TIMEOUT_MS = 5000L
 private const val PACKAGER_STATUS_ENDPOINT = "status"
 
 class DevLauncherDevServerHelper(
@@ -25,13 +23,7 @@ class DevLauncherDevServerHelper(
   packagerConnection: PackagerConnectionSettings
 ) : DevServerHelper(devSettings, context, packagerConnection) {
 
-  private val httpClient: OkHttpClient by lazy {
-    OkHttpClient.Builder()
-      .connectTimeout(HTTP_CONNECT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
-      .readTimeout(0, TimeUnit.MILLISECONDS)
-      .writeTimeout(0, TimeUnit.MILLISECONDS)
-      .build()
-  }
+  private val httpClient = OkHttpClientProvider.getOkHttpClient()
 
   override fun getDevServerBundleURL(jsModulePath: String): String {
     return controller?.manifest?.getBundleURL() ?: super.getDevServerBundleURL(jsModulePath)

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -16,6 +16,7 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.modules.network.OkHttpClientProvider
 import expo.modules.devlauncher.helpers.DevLauncherInstallationIDHelper
 import expo.modules.devlauncher.helpers.DevLauncherMetadataHelper
 import expo.modules.devlauncher.helpers.DevLauncherUrl
@@ -46,7 +47,6 @@ import expo.modules.updatesinterface.UpdatesDevLauncherInterface
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import okhttp3.OkHttpClient
 
 private const val NEW_ACTIVITY_FLAGS = Intent.FLAG_ACTIVITY_NEW_TASK or
   Intent.FLAG_ACTIVITY_CLEAR_TASK or
@@ -64,7 +64,7 @@ class DevLauncherController private constructor(
   val nullableContext: Context?
     get() = contextHolder.get()
 
-  val httpClient by lazy { OkHttpClient() }
+  val httpClient by lazy { OkHttpClientProvider.getOkHttpClient() }
   val lifecycle by lazy { DevLauncherLifecycle() }
   private val pendingIntentRegistry by lazy { DevLauncherIntentRegistry() }
   private val installationIDHelper by lazy { DevLauncherInstallationIDHelper() }

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/HttpClientService.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/HttpClientService.kt
@@ -32,7 +32,20 @@ data class DevelopmentSession(
 class HttpClientService() {
   private var currentSession: String? = null
 
-  val httpClient = OkHttpClientProvider.getOkHttpClient()
+  val httpClient = OkHttpClientProvider.getOkHttpClient().newBuilder()
+    .addInterceptor { chain ->
+      val originalRequest = chain.request()
+      val session = currentSession
+      if (session == null || !originalRequest.url.toString().startsWith(restEndpoint)) {
+        return@addInterceptor chain.proceed(originalRequest)
+      }
+
+      val newRequest = originalRequest.newBuilder()
+        .header("expo-session", session)
+        .build()
+      chain.proceed(newRequest)
+    }
+    .build()
 
   internal fun setSession(sessionSecret: String?) {
     currentSession = sessionSecret

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/HttpClientService.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/services/HttpClientService.kt
@@ -1,8 +1,8 @@
 package expo.modules.devlauncher.services
 
 import androidx.core.net.toUri
+import com.facebook.react.modules.network.OkHttpClientProvider
 import expo.modules.devlauncher.helpers.await
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import org.json.JSONObject
 
@@ -32,20 +32,7 @@ data class DevelopmentSession(
 class HttpClientService() {
   private var currentSession: String? = null
 
-  val httpClient = OkHttpClient.Builder()
-    .addInterceptor { chain ->
-      val originalRequest = chain.request()
-      val session = currentSession
-      if (session == null || !originalRequest.url.toString().startsWith(restEndpoint)) {
-        return@addInterceptor chain.proceed(originalRequest)
-      }
-
-      val newRequest = originalRequest.newBuilder()
-        .header("expo-session", session)
-        .build()
-      chain.proceed(newRequest)
-    }
-    .build()
+  val httpClient = OkHttpClientProvider.getOkHttpClient()
 
   internal fun setSession(sessionSecret: String?) {
     currentSession = sessionSecret


### PR DESCRIPTION
## Summary

Replace direct `OkHttpClient()` and `OkHttpClient.Builder().build()` usages with `OkHttpClientProvider.getOkHttpClient()` in expo-dev-launcher Android code.

## Motivation

Using the standard React Native `OkHttpClientProvider` allows apps to register custom interceptors (for logging, authentication, certificate pinning, etc.) that will be applied to all HTTP requests made by expo-dev-launcher.

Currently, bare `OkHttpClient` instances bypass any interceptors that apps register via `OkHttpClientProvider`, which is the standard React Native mechanism for customizing the HTTP client.

This is consistent with the same change already merged for:
- **expo-dev-menu** — [PR #44418](https://github.com/expo/expo/pull/44418)
- **@expo/log-box** — [PR #44416](https://github.com/expo/expo/pull/44416)
- **expo-image** — [PR #44431](https://github.com/expo/expo/pull/44431)

## Changes

3 files changed. All use `OkHttpClientProvider.getOkHttpClient()` as the base client while preserving existing behavior via `.newBuilder()` where needed.

| File | Before | After |
|------|--------|-------|
| `DevLauncherController.kt` | `OkHttpClient()` | `OkHttpClientProvider.getOkHttpClient()` |
| `DevLauncherDevServerHelper.kt` | `OkHttpClient.Builder()` with custom timeouts | `OkHttpClientProvider.getOkHttpClient().newBuilder()` + same timeouts preserved |
| `HttpClientService.kt` | `OkHttpClient.Builder()` with session interceptor | `OkHttpClientProvider.getOkHttpClient().newBuilder()` + session interceptor preserved |

### Behavioral notes

- **`DevLauncherDevServerHelper.kt`**: Custom timeouts (5s connect, infinite read/write) are preserved via `.newBuilder()`. These are needed for dev server communication which may involve long-polling.
- **`HttpClientService.kt`**: The `expo-session` header interceptor for `exp.host` API requests is preserved via `.newBuilder()`. Development session discovery continues to work as before.
- **`DevLauncherController.kt`**: No custom configuration was present — direct replacement.

## Test Plan

- [x] Verified `OkHttpClientProvider.getOkHttpClient()` falls back to a default `OkHttpClient` when no custom provider is registered (no behavioral change for apps that don't customize the HTTP client)
- [x] Verified `expo-session` header interceptor is preserved for development session API calls
- [x] Verified custom timeouts are preserved for dev server helper
- [x] Consistent with the pattern in expo-dev-menu, @expo/log-box, and expo-image