### PR TITLE
fix(dev-launcher): fix JSI crash when embedded bundle and dev-launcher race on startup

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix JSI crash (`EXC_BAD_ACCESS` in `jsi::Pointer::~Pointer`) when an embedded `main.jsbundle` and dev-launcher race on startup. ([#44799](https://github.com/expo/expo/pull/44799) by [@fabriziocucci](https://github.com/fabriziocucci))
 - [iOS] Fixed deep links not reaching the app because `EXDevLauncherController.isAppRunning` always returned `false`. ([#44609](https://github.com/expo/expo/pull/44609) by [@vonovak](https://github.com/vonovak))
 - [Android] Fix `DevLauncherErrorActivity` dark theme. ([#44529](https://github.com/expo/expo/pull/44529) by [@zoontek](https://github.com/zoontek))
 - [iOS] Fix issue when using `fullScreenModal` with `expo-router`. ([#43520](https://github.com/expo/expo/pull/43520) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -215,6 +215,15 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
     });
   };
 
+  // When a local bundle is available, skip trying to reload the last-opened app.
+  // The autoload logic in DevLauncherViewController.viewDidLoad will load it instead.
+  // Without this guard, loadApp's error handler would call navigateToLauncher and
+  // invalidate the bridge that loadLocalBundle created, causing a JSI crash.
+  if ([[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"] != nil) {
+    [self navigateToLauncher];
+    return;
+  }
+
 #if TARGET_OS_SIMULATOR
   BOOL hasGrantedNetworkPermission = YES;
 #else


### PR DESCRIPTION
## Summary

Fix a JSI crash (`EXC_BAD_ACCESS` in `jsi::Pointer::~Pointer`) that occurs when an embedded `main.jsbundle` and expo-dev-launcher race on startup.

> **Note:** This is a corner case that only affects advanced configurations where an app ships a pre-bundled `main.jsbundle` alongside expo-dev-launcher (e.g., for offline-first development workflows or custom dev clients with fallback bundles). The standard expo-dev-launcher usage — connecting to a dev server — is not affected.

> **Backport request:** We'd like this cherry-picked to `sdk-55` as well, since we rely on embedded bundle support there.

## Problem

When an app ships a `main.jsbundle` alongside expo-dev-launcher, the following race condition can occur during `start`:

1. `start` defines `navigateToLauncher` error handler
2. `start` calls `loadApp` to try reloading the last-opened app
3. Meanwhile, `DevLauncherViewController.viewDidLoad` detects `main.jsbundle` and calls `loadLocalBundle`, which creates a new bridge
4. `loadApp` fails (e.g., no dev server), its error handler calls `navigateToLauncher`
5. `navigateToLauncher` invalidates the bridge that `loadLocalBundle` just created
6. **Crash**: `EXC_BAD_ACCESS` in `jsi::Pointer::~Pointer` — the JSI runtime was destroyed while still in use

## Fix

Add an early-return guard in `start`: if `main.jsbundle` exists in the app bundle, skip the `loadApp` attempt and go straight to `navigateToLauncher`. The autoload logic in `DevLauncherViewController.viewDidLoad` will handle loading the local bundle without interference.

```objc
if ([[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"] != nil) {
    [self navigateToLauncher];
    return;
}
```

## Changes

1 file changed, **9 insertions** (4 comment lines + 3 code lines + 2 blank lines).

- `EXDevLauncherController.m`: Add guard before the simulator/permission check block

## Test Plan

- [x] App with embedded `main.jsbundle` + expo-dev-launcher: no crash on cold start, local bundle loads correctly
- [x] App without embedded bundle: behavior unchanged (guard condition is false, normal flow continues)