### PR TITLE
Bump react-native-worklets to 0.7.4

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3046,7 +3046,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNWorklets (0.7.2):
+  - RNWorklets (0.7.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3068,9 +3068,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/worklets (= 0.7.2)
+    - RNWorklets/worklets (= 0.7.4)
     - Yoga
-  - RNWorklets/worklets (0.7.2):
+  - RNWorklets/worklets (0.7.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3092,9 +3092,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNWorklets/worklets/apple (= 0.7.2)
+    - RNWorklets/worklets/apple (= 0.7.4)
     - Yoga
-  - RNWorklets/worklets/apple (0.7.2):
+  - RNWorklets/worklets/apple (0.7.4):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3812,193 +3812,193 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  BenchmarkingModule: 69aa39c6f6d42bf6fc47caeacb070d24de22d54f
-  EASClient: 414b26bae592cf8db64aa60461aff9d84ebbd944
-  EXApplication: c2dcab659064299662da96cc6032c4334b79777f
-  EXConstants: 6965c4c970052e7a04dff7bb6b3c50ae292a5833
+  BenchmarkingModule: 272c02f4a7e9e0d9e9f25d018661094608e2d91f
+  EASClient: 8077eb9af46cc7ad3ad216cec12d2bf5763cca13
+  EXApplication: ab5a9ca485adce8be81309a5172d1565e9d7467f
+  EXConstants: bfe4ae4e5d882e2e0b130e049665d0af4f4cc1b8
   EXJSONUtils: 04bc3807d351331a5fe154ce1da596ec15d99169
-  EXManifests: 2cf22467ed628c61467ad7b6ee56b4ea81ddf510
-  Expo: 988e63a4c41c1206c4d75b9ecbb2e5c731013ac9
-  expo-dev-client: 0fe1c8853cdf673ff979a6b73407347c058e3588
-  expo-dev-launcher: 9a5051ab930c50ce646b8daf6bd4cc64d8ef6e6b
-  expo-dev-menu: 0ad7cb1887e400733d3b03daac2e7a3e7ba7268e
+  EXManifests: a4e214e6a66372e662ef38adf2afca773bbd0c18
+  Expo: a43f44ff1e3a1c73fcabba766e13a38dea22236a
+  expo-dev-client: aadaa25520524f33ff54e9a94b285343f2be7a38
+  expo-dev-launcher: 1ddd052d53ba302d68739e4e37893f802f823785
+  expo-dev-menu: 35ddd9bf91d63179e40c0166d0dc0b0dca770b37
   expo-dev-menu-interface: 833795f4c98a674d36cbc12b11b21756c38e01e8
-  ExpoAgeRange: ec26d88646d544de24e189261aec537e5613f44a
-  ExpoAppIntegrity: 9fd00a7e48bd94dd4dc838f933b8fdd628ee6dab
-  ExpoAppleAuthentication: 9e3a40e8f9d95d23d980956f6dbf0b6c0302940b
-  ExpoAsset: 639cd3ba5c2f751362ea86602e532be7f8b09146
-  ExpoAudio: 885bdbc085e0374bcc983ea473b1ed42d5ce5a25
-  ExpoBackgroundFetch: b7a1e6658f6da3137f68a13d4b6bad6ff3b632a5
-  ExpoBackgroundTask: b8f57191843bc66b3df39e91db21f14004d123d4
-  ExpoBattery: d943385262ab8a22c034784cbeb92dcea1ccac98
-  ExpoBlob: 882fa24430fdfdc8e7dc90cf0b90e1e4c7d0e6c5
-  ExpoBlur: 08afa305ca20b1adb0b580fd3b09a38b64ce8804
-  ExpoBrightness: 80dc3bd175cb30c56075ec5d9dac18984bc9b688
-  ExpoBrownfield: 116c11976b2ddf9cdebcf96728fbd1e98c850e61
-  ExpoCalendar: 8c535db6cc831ae56358501712566df056b40ad9
-  ExpoCamera: 707b4b20b5522e2e41c744182bdc6321dce03c86
-  ExpoCellular: 109862658315190acad24b669408133ec2fe496f
-  ExpoClipboard: 56f5dac55e9e19bb6f084ada68bfc634a36e9533
-  ExpoContacts: 7756695714758162fd8c15bad4a0b7b1a11fd826
-  ExpoCrypto: a064d6db094c48d5b11ed1b0e97f2bf1af83757b
-  ExpoDevice: abca0e3c05fbf884669bfa27ad2b67464bba3dcc
-  ExpoDocumentPicker: c218333e865c586f255b26eec640635f03e12485
-  ExpoDomWebView: 4937eda7ff9112ddcb8701b52ae4e8e9c2e181b5
-  ExpoFileSystem: e7075f07fdadcd6e55f2de1af6065faa097d41b4
-  ExpoFont: e4fe17baebfe22a21576d6efd8f27b0dad06d653
-  ExpoGL: 8b6f93558aa1591bb40609f765b0eff1117a7c24
-  ExpoGlassEffect: 174b96e3503cdc0c507fc53699029299891bf5a7
-  ExpoHaptics: 18a4632ae8de62130208c76ba2bb0a0a144e99b3
-  ExpoImage: 008430e5aa8f7b66ccf12808aafa52de3e08b821
-  ExpoImageManipulator: 41c2bfd6483c78533b4836774c4e168118aa5c14
-  ExpoImagePicker: a2166588c8ee535bac8d39fb61705fa2c30a7535
-  ExpoInsights: 3cdab47e97c78948478e693eb1c9feea371fd0c8
-  ExpoKeepAwake: 5e391c2c712b7af91e044be8ab44b7f542d81f3c
-  ExpoLinearGradient: f7a3da6577688c5fb627e9ee6b47ed620c169da3
-  ExpoLinking: 36e1e619adec0a946395142444210d848c80cb54
-  ExpoLivePhoto: 99d40280350c6efd9b8743f008607433a09a6277
-  ExpoLocalAuthentication: 22f5fbc0935bdc7057ec7144fcfad0792ed8a3f2
-  ExpoLocalization: e9dbdecfb6a2a36d14c6c628e5c3f9fb9b6f305d
-  ExpoLocation: e3367a4274fff89fdd5ea70e166484fa9fd6d333
-  ExpoLogBox: ba1ad09d3e7632ce488e1eeab684ee6fd75f2777
-  ExpoMailComposer: e89b0b8ac6a0b557b1d7078585c9cc0c3f7eca35
-  ExpoMaps: ebe02e7c4fd8c19933678e1d7bf9ab77703a9a97
-  ExpoMediaLibrary: 166307c412aa12d7e801696d52ea45fdd1cb36dc
-  ExpoMeshGradient: 9f25b0df295222281a5398f71fba44ee9910450f
-  ExpoModulesCore: adc32664653ab2d9b7bd8dd52dd9ec3a16b24e82
-  ExpoModulesJSI: 353160c13f3d9d1ff3751453d18f456c13d5f289
-  ExpoModulesTestCore: 15b132dcc38f95c14ba445efc336c806d48884a2
-  ExpoNetwork: 2b9fa25a6cbb1cce2e31863c88cc8c5ab883898b
-  ExpoNotifications: f3300053f7b01c89038ac1d3a3429edbb32d9eb6
-  ExpoPrint: 4de2eaf713b1f23ad6a306dd1034158d6d84d43a
-  ExpoRouter: 978657094cf0a42d17bb891706282c8a4031d70f
-  ExpoScreenCapture: 3cde76108a8c6ca1ec75d0da772b4adf0f6ae89f
-  ExpoScreenOrientation: 0ae57967b00b3e90cbea24560683bf0f2e1c03fe
-  ExpoSecureStore: 03372541cb9b7f67601fa2ed0a8c2abbc9037e04
-  ExpoSensors: a6a6b0cba1488e548119e201613268bc247821d4
-  ExpoSharing: 7bc7b17aaaab37a933a012a14aa776562999feaa
-  ExpoSMS: 97950b69618e3757174960e8d50d949d82939f0b
-  ExpoSpeech: 1cd5d4582a81ddc8259f77391a5174f19ebf8bff
-  ExpoSplashScreen: 2369a893d4c2ffa6fd05a66c7bcc248e40b62457
-  ExpoSQLite: 9989421186383e2229b8736ff58cea4ee8e21d8b
-  ExpoStoreReview: dd070408095f59c82a019de10a5a414f751741b2
-  ExpoSymbols: 9dfd60e35b2fafb284adefaefe1c6d757e331708
-  ExpoSystemUI: f4a4f3dd9f62f0d4e6799c57f600288fd861ce95
-  ExpoTaskManager: c9b0af884aa9e1e512b4926cded2e6c2097e12d3
-  ExpoTrackingTransparency: 287445639184c0f885ccff78f6e2b6d8414d58c4
-  ExpoUI: b5d265006b73002c70856d87e922ded4ee64d99d
-  ExpoVideo: fe990ba488ca5e4b2e9b7b63c4039134de9e6205
-  ExpoVideoThumbnails: e33e336b7db87b701d62ce309d99ce8bc003cc2a
-  ExpoWebBrowser: 0f4255b795de0eca7e0337de591c3d1c20efbdf0
+  ExpoAgeRange: 66d3128006e8696bbea49b45f7972fa92c1b5695
+  ExpoAppIntegrity: 67d82f2d15751d44430104ecf0ca24589586fb6a
+  ExpoAppleAuthentication: 08b3d0e502f46731abdf4c59203769fb685f66c8
+  ExpoAsset: dc4f25f84886120f82b23233bba563ea7afa88f5
+  ExpoAudio: effd4eb58abee67050f79e8764fe1078daea39c8
+  ExpoBackgroundFetch: fa10491c77b4210d13bd0de889453750e9dadb81
+  ExpoBackgroundTask: 611cfb3fdd1a3389f99dcb290ec76178d2912d9f
+  ExpoBattery: 2b5ba5940ec9e0b723fb83346109175473a9e1c4
+  ExpoBlob: 279acf437681366f2869a655107c02d1d956d229
+  ExpoBlur: 7a86e84e7728108fa6908d7103fa527705a3dbbf
+  ExpoBrightness: c45644152fa9087c9d6cc75418a1f9621802181e
+  ExpoBrownfield: 43537c46e11b77dcfa9008a428f5cbc7fe8c05a6
+  ExpoCalendar: b6256830f2effeee5e8ba5e327fd6e3d0eb78683
+  ExpoCamera: 5f6ae5fd7365ceb741168a71eeaa5b65e556c672
+  ExpoCellular: 932205e4470962b8b1048c6c0f297bcdf6ba6920
+  ExpoClipboard: 5d1b0cd2686406f21e616f2d9b3431259dee2e6a
+  ExpoContacts: f893ee6893bfcbb8bcd0be12a0c8472a8ea7b9c3
+  ExpoCrypto: 9fd0b78215cffa1aa20de026d452242401aa37dc
+  ExpoDevice: 3a4a361d685333e4139da5d56bb2740c86132beb
+  ExpoDocumentPicker: be59b82799ae30811e3f37a7521d6622baa63a19
+  ExpoDomWebView: 2b2fbd9a07de8790569257cbf9dfdaa31cf95c70
+  ExpoFileSystem: 310d367cccbd30b9bda13c5865fe3d8d581dcf2a
+  ExpoFont: cdd7a1d574a376fa003c713eff49e0a4df8672c7
+  ExpoGL: 7dadcb781777ef5c90144eef2efaf8425635a2b2
+  ExpoGlassEffect: 72bcb9dc634262c59897ff7c53c16e2ff03990d0
+  ExpoHaptics: 679f09dc37d5981e619bc197732007a3334e80b8
+  ExpoImage: ef931bba1fd3e907c2262216d17eb21095c9ac2b
+  ExpoImageManipulator: ae0a562f2d405de275e011915c811564106baa70
+  ExpoImagePicker: ce50d0bf7d27d1a822b08a84bea9bfc0b3924557
+  ExpoInsights: 8750dec51041529d4f966fbef6234e4b4cf8f2d7
+  ExpoKeepAwake: a1baf9810a2dee1905aa9bdd336852598f7220e9
+  ExpoLinearGradient: c654e92d726a6d64c588a0988bb22bea331d5e79
+  ExpoLinking: b3edfb991a148fecf22512bf2ca3bcfa1edc4610
+  ExpoLivePhoto: c5c031368683c69f25dc8a169e0eb69ef6a252b8
+  ExpoLocalAuthentication: bdf67eef520f5eb22b105d139b9cb48aa994b071
+  ExpoLocalization: c5cd7fa65c797d3a2f1adbd1fd4c601c524fd677
+  ExpoLocation: ba5fff1510a7f123abf620fc2242db2fc87eba0f
+  ExpoLogBox: a3de999775d423ac9cb85d24bd47628e5392761f
+  ExpoMailComposer: bb63854e80400563d4a1537f1c9fadf7c8e70ab1
+  ExpoMaps: e52b8c7536e923daecb02277919ed382ebaa7da3
+  ExpoMediaLibrary: d6b22096da42dea0b5a68fd3eef96761bbf592c4
+  ExpoMeshGradient: 846122d3c20a25e21a13f58462c98f59b45d6a63
+  ExpoModulesCore: df468e597146b519b08dbfa59b206e2c5ad932bd
+  ExpoModulesJSI: 4f9a951679fdfbfca1e4feb5c1e10df045333a5a
+  ExpoModulesTestCore: bdd36eccdc0a62ec803abf21a894cf82b1a22722
+  ExpoNetwork: aec041c4e9cb5a30cb4da32b2e315bcca6a7c2e4
+  ExpoNotifications: 52440855fb1c86e9bd2033e849489c1b915eeefc
+  ExpoPrint: 3b79c16d6778b4a89fb4eb9cc346925690cb0c74
+  ExpoRouter: 42de21e959ea28e44c0edee85d8c785fc71548e7
+  ExpoScreenCapture: bcbb78db8311c51553ce6178c43e52bef0654c2a
+  ExpoScreenOrientation: 651e404bda8f9b6a3c8669fc6709c0b7c64e6e16
+  ExpoSecureStore: 38954f6bcef1287aa04c06fba3b86e8af3291ccd
+  ExpoSensors: 8a6cb82a28ed592cc6923021b39aa4078dea3a53
+  ExpoSharing: 5acc9d78894386d31b862b12ed1cebe7dce74e68
+  ExpoSMS: cd74cf9d83be085384481c47bfe7240baba70cb6
+  ExpoSpeech: 7f5d4a94aea1fbc509cf4ab2649bc2e3f05ea15e
+  ExpoSplashScreen: 6ae5b8547defd9e561b6cdf9439bb2db235f85d8
+  ExpoSQLite: f63db535d24c59722971241ea9ade2a878dfabea
+  ExpoStoreReview: dab6e25f0641784bd6207f729f893423afbb6574
+  ExpoSymbols: 8b63e859ba013df1f2fc666f535fddb3d5270569
+  ExpoSystemUI: 709410d6e473378d568e5df28fe409cade0ba530
+  ExpoTaskManager: cd4cb9405637f52e26c8a54c1cfe7b974bc9ac2d
+  ExpoTrackingTransparency: 6973cece26b4a38fc3a600fadd4d7efb83fd660b
+  ExpoUI: 5e98fba91241cd4bdd976729be965ab71d7f761d
+  ExpoVideo: 434d1e32486309359b8eff4880d636fd8c0c0ba1
+  ExpoVideoThumbnails: 4e7d245fc770bcf831dd954ec68977aaf480d98f
+  ExpoWebBrowser: f88a3ba50a025b673236a46d2654a49b985953d6
   EXStructuredHeaders: 93ad4f31a2eec124428675e28aca11de243ee1e4
-  EXUpdates: dc63fe3b75c62f6235ccecdbd73f3d976010c9e6
-  EXUpdatesInterface: fb4c97f3412d5040616fdb588a4718219533c7e4
+  EXUpdates: e0d925614958306429cd255722655ec61216887c
+  EXUpdatesInterface: 39d05400a9226c438565dbaaa8447b5f0672ba45
   FBLazyVector: a76e8b43a91eb8989ce0c9500aa5350b38af1a95
-  hermes-engine: e8575e624b55b129d38704ac588af5105ca680ec
+  hermes-engine: fdb1abef6ce01a7bdbdfbc2fa1f6a762f42fea55
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: 97a11537edc72d0763edab0c83e8cc8a0b9d8484
+  lottie-react-native: cbe3d931a7c24f7891a8e8032c2bb9b2373c4b9c
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
   RCTDeprecation: 0555d2c36cb30caa59dd7dbb28f037138a26c7aa
   RCTRequired: c0be0ef3af02a658a2906218d3cd9d88e43b4911
   RCTSwiftUI: e20c56b190b3f0e9c31e0564c4cc2c0ac5eb88e7
-  RCTSwiftUIWrapper: 1571834f292f2c9ed90a90f70d93cecb165d8ca5
+  RCTSwiftUIWrapper: a6e6b705b24b0246306fab7a338a4d3661820c6b
   RCTTypeSafety: 058ffd471583a052e16ee629da2171b9984454b4
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: 184a8e3cdd90ae29c15c6cc79ce108ea35f03781
   React-callinvoker: 3c48fe5b43d37f4ae803fbcad6728b64a4f7378f
-  React-Core: b785b0f29445fb1fbafc26f5646cc6b826b66cc1
-  React-Core-prebuilt: b8332fabad5fd0c58ed72c45e0284c6bcb17b47c
-  React-CoreModules: f2766882acd2f18f0ff1436941b66d4af77a3839
-  React-cxxreact: 4d7c00662c362be3495e95f98e5c21fcb17f212e
+  React-Core: 79bd7e39eb61e97c9d5a1b9f01608863331daff5
+  React-Core-prebuilt: 9d0d16779b6968fff7161a9984bfa6a716651856
+  React-CoreModules: 032eae739d412d851a9a2d66f716a7e0004d15d9
+  React-cxxreact: f88f2cbba3a58592164413eca7c59293357f35a5
   React-debug: 84935fa9a3f094b4f39dffa95c9ae23699f5427c
-  React-defaultsnativemodule: 6078af4ba1c4920d7da2038a9ee238d2be6464a7
-  React-domnativemodule: 6b897cb43038ece92e714eeee09149c566eebe92
-  React-Fabric: 7f1411765b0fef14f03ce4e890ee67c3274f31d5
-  React-FabricComponents: fc39a446da73c58030e3740d27514f3ab97ffd8c
-  React-FabricImage: 166452c3c08f2898d1a409440c1db99af46b844f
-  React-featureflags: c075d2c08967fd891723d531e91574f691a7e115
-  React-featureflagsnativemodule: aa45652d5fc1266a135b5f0ea5752bfd20ae2a28
-  React-graphics: 2359dd2ce2dc56595635d6688e7ba7d59c4a91a5
-  React-hermes: 1e638c8161ba98b61e7773a399f4334acebced66
-  React-idlecallbacksnativemodule: a4ba5c0418cb20961d0e777a87af3c6750c5becd
-  React-ImageManager: 8c32d616c2dd4a53c078f715e759dff581c5567a
-  React-intersectionobservernativemodule: a3dbd7299602fd2e64a363b1dbf326a65d06da6f
-  React-jserrorhandler: 68595d5014171ed836c78280c874f99d823913fb
-  React-jsi: 0c7f7792b1af72c0efcd70224bfcf193cf64fe89
-  React-jsiexecutor: 57f09a9ade93a73bedd6d0d1ab7251c0f9cb123a
-  React-jsinspector: 4537db7b52e6540a3f97f72ef3e263a65bff3751
-  React-jsinspectorcdp: c64d6fed881557b89de207ac1dee5d53ca426084
-  React-jsinspectornetwork: 3a6a5daa4b5b025876867f87a5d4a18352eac7ab
-  React-jsinspectortracing: 9ba50d1288f7e964ef54f390f3db36690e1e22e1
-  React-jsitooling: 2850e02142570c24c3eeab2dd52b19a3b8a45f96
-  React-jsitracing: 7fb099e64710494fca59c7051a4b86f430340b70
-  React-logger: ec42c99bc9d0ed91bdb51c4dbb54e3b986a0c816
-  React-Mapbuffer: 835c6897655cea65df9980d0afb7685fb4070b59
-  React-microtasksnativemodule: 45a09039f1523596936539898afb76e9e1b1ea09
-  react-native-keyboard-controller: 171c71f104a40568afcde57f5426b67b5252e71d
-  react-native-netinfo: 789d8e48d938a77af984e9d6b7a08242d59f8e15
-  react-native-pager-view: e37989fc447aa4b5de6d0d2ffb0229e817329246
-  react-native-safe-area-context: 53f796cb6c814661bbe99fbdfd0585d07b996cdd
-  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  react-native-skia: 9f66ac6335a2fe03db06733fafb746435c097ca0
-  react-native-slider: a4bbed2fba298dbcd09225b5f4a1e9baf2d04268
-  react-native-view-shot: 26174e54ec6b4b7c5d70b86964b747919759adc1
-  react-native-webview: a0107c12442bf2ac454d509f615daef00f34df47
-  React-NativeModulesApple: f40b43fbd1d42af9707eca02e7dea2726fc1fb85
-  React-networking: e85385eec489a76313b742862678adcaf2c23767
+  React-defaultsnativemodule: c999955b1c1a6efc50a5bd18dff1a70467d2f81e
+  React-domnativemodule: ddaa0f8dafcbe5755f9ba8039698f58a334edbd9
+  React-Fabric: 0df6c4558a7d7c49479f6d09c8b6646eb5a2d92c
+  React-FabricComponents: 08b6ad031f0043a2c789fc8ed0ea88301637b242
+  React-FabricImage: 3856f60a204ad1c601f795286ada5ba7f4b446dd
+  React-featureflags: bfe4f2abe5a6593a403cab54eb30ee7669526004
+  React-featureflagsnativemodule: 5234c57c76f7f0abdeecbea38a14051be92c6c20
+  React-graphics: 553ac230ccb4a7da930918c4644d053edda07343
+  React-hermes: c29648197f68b78563b6792436fbb25d94cccf35
+  React-idlecallbacksnativemodule: c39b591a1a0b6076dc18ef732da3ee855ee26d1d
+  React-ImageManager: f700e9cc1f4558f3ac371652f00a470c0355f30d
+  React-intersectionobservernativemodule: 48f5e5a9e9b60b9673f979d93a57094bc5b64215
+  React-jserrorhandler: c1f9d73a277cb95a5b6f1029f63e94e49eeb2b1d
+  React-jsi: 907a71b33482f40a68429f8890d196b79cdc69bc
+  React-jsiexecutor: 508fdb37c4cc5d198d4c62fac24a6f8432b68d44
+  React-jsinspector: 60a6aeca430fee14e321ee5f50810c5a01b031bd
+  React-jsinspectorcdp: 91b811da3bbd38d073d5c16ee63337b31de6cd83
+  React-jsinspectornetwork: 4dfa86b5b09b8da80e6a723f193ad1db8f2a5eb0
+  React-jsinspectortracing: 491b9b18f1060ba7b09b0117104f9aaaa8b65d81
+  React-jsitooling: d56a48e2c5a5cd36d3868a8c8f6f2a344c99bf9c
+  React-jsitracing: efa0e557793fabedbe27929653cc746dfbeda2f1
+  React-logger: 0d59d8c6c73d7082253f1eb04186c85fa1e0f4cc
+  React-Mapbuffer: 88e8cdb3f2dac9ad26241198d7659c0840fdf407
+  React-microtasksnativemodule: 97471e5249e41a671481695b1bfef43e74bd3aa0
+  react-native-keyboard-controller: c872321fc580f8d815e9e2ad5558b24c26c18b4f
+  react-native-netinfo: f852c868bf5175e46165c7e4db48a204a95c3800
+  react-native-pager-view: c8817c1d9f4643417e68f0b846c51214b2252eea
+  react-native-safe-area-context: 37e680fc4cace3c0030ee46e8987d24f5d3bdab2
+  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
+  react-native-skia: b1ba694c208db8a184ea55fe086a76b4ef0b2493
+  react-native-slider: 8b9a218d1a3e526146a170cb6133be9cda23e70e
+  react-native-view-shot: fb3c0774edb448f42705491802a455beac1502a2
+  react-native-webview: 3e303e80cadb5f17118c8c1502aa398e9287e415
+  React-NativeModulesApple: 2a64c0a7a1f0e70e3af900ecf028ce720a8d8c50
+  React-networking: 446e098d8e7653fd5fe8cddf1882fe739356affb
   React-oscompat: f40c7fd31b5cdedc093a2488ec90bf27a0fd5b65
-  React-perflogger: 07b6d590471789bbb8fed15b942d9b3ae7ab9eba
-  React-performancecdpmetrics: 107672bfd61fe98b2707a53ace12d63b28cae514
-  React-performancetimeline: 6e6300f265c989800e7132b6a2d08a6664e61d54
+  React-perflogger: 6efa1c85aa94017aa29818041110b92b5185ba63
+  React-performancecdpmetrics: b5d607a37c392258acbd5865f96eb8efbe251628
+  React-performancetimeline: c8be22f0277d12f76b1ab4693f9225cdfbfcf91f
   React-RCTActionSheet: 91c30dd7c5d56862d369270973e196b3d82501af
-  React-RCTAnimation: b863dff839a98f80047945bb07c235f8b1e17b08
-  React-RCTAppDelegate: 2a06765bcca266bcac958cb10aed008af71248cf
-  React-RCTBlob: efb69b75ddf0f8eb9f32db0eec55290ea85ad09d
-  React-RCTFabric: 43907ac2bba843335fab5e049980e6912e61ed78
-  React-RCTFBReactNativeSpec: e6318d14508023ea71274981dd00ead2d02d34ae
-  React-RCTImage: dbcffa989d446ea0694833c8a306b33db664d222
-  React-RCTLinking: 78e8467aae25a0e7c89eed361c0c7b847aba5f36
-  React-RCTNetwork: 20cdcd4ed40fbe2005b17fa6f6b6399b7cfee887
-  React-RCTRuntime: 255537892919e05e5a4e103d56410d0324e2b64a
-  React-RCTSettings: 00e8f8bf9551318a5c5d571b4d7d2d1c6a049c6e
-  React-RCTText: 32279027034aa4d3f408bb1c7dbd519bf970d087
-  React-RCTVibration: e1e7c0d358bfae9c867fbd84c59a7fcb22557be9
+  React-RCTAnimation: 867ab7033270a09ba1e5c18862589c19e9ec9f64
+  React-RCTAppDelegate: 5e2fa88dc8dd423ee5664c9037c6c2ce64c10055
+  React-RCTBlob: 82fd99eac3d46374e275fd388a450068f960e413
+  React-RCTFabric: 4e18e850aa6d430a50f1fcb9521c5fc6c021acd2
+  React-RCTFBReactNativeSpec: eab9e24099faff96d5cc234aa3269da7d184756c
+  React-RCTImage: ef681c36ab516bc87b3011c6681302ad321fa5eb
+  React-RCTLinking: 9b99605f978bc891012f9b9cb142f67a4e139cfd
+  React-RCTNetwork: b623d9babf72e36196bc3d4997d78610aa971f03
+  React-RCTRuntime: fb9cf67f367a956ed7ae31b7fe7f0fb0f0ddb839
+  React-RCTSettings: 0984d972ed20c1cdac56f31d598503a3ac8ab4e4
+  React-RCTText: 26c95fb5cfe2f2a4fc4acfdf423e37c5ede43b0b
+  React-RCTVibration: a50482ca31c6ff9ae2de27faa5588a030fd7b1f9
   React-rendererconsistency: ba1ea8aeb695c9467b589d9e614348007b9ca474
-  React-renderercss: c14d6c95495d79368d191c5ba3f93beff8a1e110
-  React-rendererdebug: f4f03805fd4828579eb5416a576de8b64275c721
-  React-RuntimeApple: 03b0d953995661c025e4721ebd7d21a34c88efab
-  React-RuntimeCore: e50e5a89bdf097aa9c1f492490b151bf765ed4a6
-  React-runtimeexecutor: 4822b5715fdff0f5efc9fbab88dc74c6848ce003
-  React-RuntimeHermes: a07e6f1292d64e818d1aaf307286c35ee336228b
-  React-runtimescheduler: c2a33a0fd9cdcd014077920f6d589989a4188d5a
-  React-timing: 2b46d0fa12cd9da6f073d51ffc21bf2db4d01682
-  React-utils: 53f3f2a6c3c1e48a522377881ebe6f9b6a659b16
-  React-webperformancenativemodule: aedf72d99505892bcaf2f3372c6eac1593efcb0f
-  ReactAppDependencyProvider: 105856c6da6fe71c545dec3c2466ae04f25f9a73
-  ReactCodegen: f44c78aee9678ed7f61664fad362f9abebc033d7
-  ReactCommon: fc29f4a8617db8fda63347485427fbf441d7d89e
-  ReactNativeDependencies: e18eea1c8f20580f98dc75361810ac95d9b1bc21
-  RNCAsyncStorage: e85a99325df9eb0191a6ee2b2a842644c7eb29f4
-  RNCMaskedView: 3c9d7586e2b9bbab573591dcb823918bc4668005
-  RNCPicker: e0149590451d5eae242cf686014a6f6d808f93c7
-  RNDateTimePicker: 5e0666de98f1edfac67ee7dde6be8a5415e487a0
-  RNGestureHandler: 8e4a9372425d4caa9e3da5072a8dda7a54ed1097
-  RNReanimated: 61462806110686a6f5d7c45c6f910cf73cd57dd9
-  RNScreens: fb11b7412bcbdc0ffafcaf9174938d998d4e2bc4
-  RNSVG: b5bd4454de003a99d3130a3c6a1b1c949c89d37d
-  RNWorklets: 87faff8e75d34d1240c75189e490e92901dd3544
+  React-renderercss: 009206313f0e6a6c49c681ab92b32cf390be2499
+  React-rendererdebug: b7f62f537b95a4d652901bcbbb1d042e5a1c7543
+  React-RuntimeApple: 33f82480b0af873f20911c93f56fcecf038b31c7
+  React-RuntimeCore: d60e3c387fbeed36b5fa50f855a9d03aa45231de
+  React-runtimeexecutor: 0f1a74b1b5594d0be4595db5ab69508faa753d57
+  React-RuntimeHermes: 71dea706b6732fc36caaea51cdfdec26f19a159d
+  React-runtimescheduler: d8bb7c68afb488cbd88b94a21a0530da8fd7308a
+  React-timing: 97588437fd7c4d76c79f4200a10c24b99161c31b
+  React-utils: 42ea0fb39aab55d68c6b1459b0b6cf064a985708
+  React-webperformancenativemodule: ad5d832fdbdfad4ada32e571175bd781dfc4ab72
+  ReactAppDependencyProvider: fcd4b54f13d868d196f37f077da0ebb0c106ff6f
+  ReactCodegen: f52ffb3b23048fdd8eca7e3115e054fe00709bed
+  ReactCommon: 5edb92f823f8fc7d11ce211fc54edb42b9220aa8
+  ReactNativeDependencies: 0220e249b802e6f44ad5db9b1b54ab0e396f92ca
+  RNCAsyncStorage: 3a4f5e2777dae1688b781a487923a08569e27fe4
+  RNCMaskedView: d2578d41c59b936db122b2798ba37e4722d21035
+  RNCPicker: c8a3584b74133464ee926224463fcc54dfdaebca
+  RNDateTimePicker: 9c0a849bbe1c256f0854fea255734b715f5ea876
+  RNGestureHandler: 5494787ce29288a8941fa825663f2b1fa0a5aaf1
+  RNReanimated: 55f3c45edaee604ad1f1447cb13e928cb6e21660
+  RNScreens: 14243fa0d9842ffa7f8bb2d00b6c3cfd3ca817e8
+  RNSVG: 0bd149b873018bc6e0e3321e2f6435bdba294460
+  RNWorklets: 7a182b959563d4307562463f0618464bba735947
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  TestExpoUi: 3c8a53d43492d7db3f4c94cf4a48cba7a82da424
+  TestExpoUi: b0251bd5cda9a28079a7d8b09137016b77ac00a6
   UMAppLoader: 6f70977c93a7033f0dc7cf2f0de9b49ce006f7bd
-  WorkletsTester: f76956000cdf163c71f8eb20fe09f1bfa21acbaf
+  WorkletsTester: 3239bd193d419e4033072b4af3680526f277c55a
   Yoga: 3cc41fbd3ea44430dff441e223820ac6da36bc9a
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 

--- a/apps/bare-expo/macos/Podfile.lock
+++ b/apps/bare-expo/macos/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EASClient (55.0.2):
+  - EASClient (55.0.5):
     - ExpoModulesCore
-  - EXConstants (55.0.7):
+  - EXConstants (55.0.14):
     - ExpoModulesCore
-  - EXManifests (55.0.9):
+  - EXManifests (55.0.15):
     - ExpoModulesCore
-  - Expo (55.0.2):
+  - Expo (55.0.15):
     - boost
     - DoubleConversion
     - ExpoModulesCore
@@ -38,17 +38,17 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-client (55.0.9):
+  - expo-dev-client (55.0.27):
     - EXManifests
     - expo-dev-launcher
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (55.0.10):
+  - expo-dev-launcher (55.0.28):
     - boost
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 55.0.10)
+    - expo-dev-launcher/Main (= 55.0.28)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -81,7 +81,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Main (55.0.10):
+  - expo-dev-launcher/Main (55.0.28):
     - boost
     - DoubleConversion
     - EXManifests
@@ -118,7 +118,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Unsafe (55.0.10):
+  - expo-dev-launcher/Unsafe (55.0.28):
     - boost
     - DoubleConversion
     - EXManifests
@@ -154,10 +154,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu (55.0.9):
+  - expo-dev-menu (55.0.23):
     - boost
     - DoubleConversion
-    - expo-dev-menu/Main (= 55.0.9)
+    - expo-dev-menu/Main (= 55.0.23)
     - fast_float
     - fmt
     - glog
@@ -183,8 +183,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu-interface (55.0.1)
-  - expo-dev-menu/Main (55.0.9):
+  - expo-dev-menu-interface (55.0.2)
+  - expo-dev-menu/Main (55.0.23):
     - boost
     - DoubleConversion
     - EXManifests
@@ -216,25 +216,25 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoAsset (55.0.7):
+  - ExpoAsset (55.0.15):
     - ExpoModulesCore
-  - ExpoCrypto (55.0.8):
+  - ExpoCrypto (55.0.14):
     - ExpoModulesCore
-  - ExpoFileSystem (55.0.9):
+  - ExpoFileSystem (55.0.16):
     - ExpoModulesCore
-  - ExpoFont (55.0.4):
+  - ExpoFont (55.0.6):
     - ExpoModulesCore
-  - ExpoKeepAwake (55.0.4):
+  - ExpoKeepAwake (55.0.6):
     - ExpoModulesCore
-  - ExpoLinking (55.0.7):
+  - ExpoLinking (55.0.13):
     - ExpoModulesCore
-  - ExpoLocalAuthentication (55.0.8):
+  - ExpoLocalAuthentication (55.0.13):
     - ExpoModulesCore
-  - ExpoLogBox (55.0.7):
+  - ExpoLogBox (55.0.10):
     - React-Core
-  - ExpoMeshGradient (55.0.8):
+  - ExpoMeshGradient (55.0.13):
     - ExpoModulesCore
-  - ExpoModulesCore (55.0.12):
+  - ExpoModulesCore (55.0.22):
     - boost
     - DoubleConversion
     - ExpoModulesJSI
@@ -265,17 +265,17 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - ExpoModulesJSI (55.0.12):
+  - ExpoModulesJSI (55.0.22):
     - hermes-engine
     - React-Core
     - React-runtimescheduler
     - ReactCommon
-  - ExpoSQLite (55.0.10):
+  - ExpoSQLite (55.0.15):
     - ExpoModulesCore
-  - ExpoWebBrowser (55.0.9):
+  - ExpoWebBrowser (55.0.14):
     - ExpoModulesCore
-  - EXStructuredHeaders (55.0.0)
-  - EXUpdates (55.0.11):
+  - EXStructuredHeaders (55.0.2)
+  - EXUpdates (55.0.20):
     - boost
     - DoubleConversion
     - EASClient
@@ -309,10 +309,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - EXUpdatesInterface (55.1.3):
+  - EXUpdatesInterface (55.1.5):
     - ExpoModulesCore
   - fast_float (8.0.0)
-  - FBLazyVector (0.81.3)
+  - FBLazyVector (0.81.6)
   - fmt (11.0.2)
   - glog (0.3.5)
   - hermes-engine (0.81.6):
@@ -367,28 +367,28 @@ PODS:
     - fast_float (= 8.0.0)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.81.3)
-  - RCTRequired (0.81.3)
-  - RCTTypeSafety (0.81.3):
-    - FBLazyVector (= 0.81.3)
-    - RCTRequired (= 0.81.3)
-    - React-Core (= 0.81.3)
+  - RCTDeprecation (0.81.6)
+  - RCTRequired (0.81.6)
+  - RCTTypeSafety (0.81.6):
+    - FBLazyVector (= 0.81.6)
+    - RCTRequired (= 0.81.6)
+    - React-Core (= 0.81.6)
   - ReachabilitySwift (5.2.4)
-  - React (0.81.3):
-    - React-Core (= 0.81.3)
-    - React-Core/DevSupport (= 0.81.3)
-    - React-Core/RCTWebSocket (= 0.81.3)
-    - React-RCTActionSheet (= 0.81.3)
-    - React-RCTAnimation (= 0.81.3)
-    - React-RCTBlob (= 0.81.3)
-    - React-RCTImage (= 0.81.3)
-    - React-RCTLinking (= 0.81.3)
-    - React-RCTNetwork (= 0.81.3)
-    - React-RCTSettings (= 0.81.3)
-    - React-RCTText (= 0.81.3)
-    - React-RCTVibration (= 0.81.3)
-  - React-callinvoker (0.81.3)
-  - React-Core (0.81.3):
+  - React (0.81.6):
+    - React-Core (= 0.81.6)
+    - React-Core/DevSupport (= 0.81.6)
+    - React-Core/RCTWebSocket (= 0.81.6)
+    - React-RCTActionSheet (= 0.81.6)
+    - React-RCTAnimation (= 0.81.6)
+    - React-RCTBlob (= 0.81.6)
+    - React-RCTImage (= 0.81.6)
+    - React-RCTLinking (= 0.81.6)
+    - React-RCTNetwork (= 0.81.6)
+    - React-RCTSettings (= 0.81.6)
+    - React-RCTText (= 0.81.6)
+    - React-RCTVibration (= 0.81.6)
+  - React-callinvoker (0.81.6)
+  - React-Core (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -398,7 +398,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.3)
+    - React-Core/Default (= 0.81.6)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -413,82 +413,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/CoreModulesHeaders (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/Default (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/DevSupport (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTDeprecation
-    - React-Core/Default (= 0.81.3)
-    - React-Core/RCTWebSocket (= 0.81.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-jsinspectorcdp
-    - React-jsitooling
-    - React-perflogger
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.81.3):
+  - React-Core/CoreModulesHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -513,7 +438,57 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.81.3):
+  - React-Core/Default (0.81.6):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/DevSupport (0.81.6):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.6)
+    - React-Core/RCTWebSocket (= 0.81.6)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -538,7 +513,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTBlobHeaders (0.81.3):
+  - React-Core/RCTAnimationHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -563,7 +538,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTImageHeaders (0.81.3):
+  - React-Core/RCTBlobHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -588,7 +563,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.81.3):
+  - React-Core/RCTImageHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -613,7 +588,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.81.3):
+  - React-Core/RCTLinkingHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -638,7 +613,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.81.3):
+  - React-Core/RCTNetworkHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -663,7 +638,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTTextHeaders (0.81.3):
+  - React-Core/RCTSettingsHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -688,7 +663,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.81.3):
+  - React-Core/RCTTextHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -713,7 +688,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-Core/RCTWebSocket (0.81.3):
+  - React-Core/RCTVibrationHeaders (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -723,7 +698,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - RCTDeprecation
-    - React-Core/Default (= 0.81.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -738,7 +713,32 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-CoreModules (0.81.3):
+  - React-Core/RCTWebSocket (0.81.6):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTDeprecation
+    - React-Core/Default (= 0.81.6)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-jsinspectorcdp
+    - React-jsitooling
+    - React-perflogger
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket
+    - Yoga
+  - React-CoreModules (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -746,20 +746,20 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTTypeSafety (= 0.81.3)
-    - React-Core/CoreModulesHeaders (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - RCTTypeSafety (= 0.81.6)
+    - React-Core/CoreModulesHeaders (= 0.81.6)
+    - React-jsi (= 0.81.6)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.81.3)
+    - React-RCTImage (= 0.81.6)
     - React-runtimeexecutor
     - ReactCommon
     - SocketRocket
-  - React-cxxreact (0.81.3):
+  - React-cxxreact (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -768,19 +768,19 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.3)
-    - React-debug (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-callinvoker (= 0.81.6)
+    - React-debug (= 0.81.6)
+    - React-jsi (= 0.81.6)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
+    - React-logger (= 0.81.6)
+    - React-perflogger (= 0.81.6)
     - React-runtimeexecutor
-    - React-timing (= 0.81.3)
+    - React-timing (= 0.81.6)
     - SocketRocket
-  - React-debug (0.81.3)
-  - React-defaultsnativemodule (0.81.3):
+  - React-debug (0.81.6)
+  - React-defaultsnativemodule (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -797,7 +797,7 @@ PODS:
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
     - SocketRocket
-  - React-domnativemodule (0.81.3):
+  - React-domnativemodule (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -817,7 +817,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric (0.81.3):
+  - React-Fabric (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -831,23 +831,23 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.81.3)
-    - React-Fabric/attributedstring (= 0.81.3)
-    - React-Fabric/bridging (= 0.81.3)
-    - React-Fabric/componentregistry (= 0.81.3)
-    - React-Fabric/componentregistrynative (= 0.81.3)
-    - React-Fabric/components (= 0.81.3)
-    - React-Fabric/consistency (= 0.81.3)
-    - React-Fabric/core (= 0.81.3)
-    - React-Fabric/dom (= 0.81.3)
-    - React-Fabric/imagemanager (= 0.81.3)
-    - React-Fabric/leakchecker (= 0.81.3)
-    - React-Fabric/mounting (= 0.81.3)
-    - React-Fabric/observers (= 0.81.3)
-    - React-Fabric/scheduler (= 0.81.3)
-    - React-Fabric/telemetry (= 0.81.3)
-    - React-Fabric/templateprocessor (= 0.81.3)
-    - React-Fabric/uimanager (= 0.81.3)
+    - React-Fabric/animations (= 0.81.6)
+    - React-Fabric/attributedstring (= 0.81.6)
+    - React-Fabric/bridging (= 0.81.6)
+    - React-Fabric/componentregistry (= 0.81.6)
+    - React-Fabric/componentregistrynative (= 0.81.6)
+    - React-Fabric/components (= 0.81.6)
+    - React-Fabric/consistency (= 0.81.6)
+    - React-Fabric/core (= 0.81.6)
+    - React-Fabric/dom (= 0.81.6)
+    - React-Fabric/imagemanager (= 0.81.6)
+    - React-Fabric/leakchecker (= 0.81.6)
+    - React-Fabric/mounting (= 0.81.6)
+    - React-Fabric/observers (= 0.81.6)
+    - React-Fabric/scheduler (= 0.81.6)
+    - React-Fabric/telemetry (= 0.81.6)
+    - React-Fabric/templateprocessor (= 0.81.6)
+    - React-Fabric/uimanager (= 0.81.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -859,32 +859,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/animations (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/attributedstring (0.81.3):
+  - React-Fabric/animations (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -909,7 +884,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/bridging (0.81.3):
+  - React-Fabric/attributedstring (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -934,7 +909,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistry (0.81.3):
+  - React-Fabric/bridging (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -959,7 +934,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/componentregistrynative (0.81.3):
+  - React-Fabric/componentregistry (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -984,36 +959,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.3)
-    - React-Fabric/components/root (= 0.81.3)
-    - React-Fabric/components/scrollview (= 0.81.3)
-    - React-Fabric/components/view (= 0.81.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimeexecutor
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-  - React-Fabric/components/legacyviewmanagerinterop (0.81.3):
+  - React-Fabric/componentregistrynative (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1038,7 +984,36 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/root (0.81.3):
+  - React-Fabric/components (0.81.6):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.81.6)
+    - React-Fabric/components/root (= 0.81.6)
+    - React-Fabric/components/scrollview (= 0.81.6)
+    - React-Fabric/components/view (= 0.81.6)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/legacyviewmanagerinterop (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1063,7 +1038,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/scrollview (0.81.3):
+  - React-Fabric/components/root (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1088,7 +1063,32 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/components/view (0.81.3):
+  - React-Fabric/components/scrollview (0.81.6):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimeexecutor
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+  - React-Fabric/components/view (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1115,7 +1115,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-Fabric/consistency (0.81.3):
+  - React-Fabric/consistency (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1140,7 +1140,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/core (0.81.3):
+  - React-Fabric/core (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1165,7 +1165,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/dom (0.81.3):
+  - React-Fabric/dom (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1190,7 +1190,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/imagemanager (0.81.3):
+  - React-Fabric/imagemanager (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1215,7 +1215,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/leakchecker (0.81.3):
+  - React-Fabric/leakchecker (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1240,7 +1240,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/mounting (0.81.3):
+  - React-Fabric/mounting (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1265,7 +1265,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers (0.81.3):
+  - React-Fabric/observers (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1279,7 +1279,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.81.3)
+    - React-Fabric/observers/events (= 0.81.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1291,7 +1291,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/observers/events (0.81.3):
+  - React-Fabric/observers/events (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1316,7 +1316,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/scheduler (0.81.3):
+  - React-Fabric/scheduler (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1343,7 +1343,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/telemetry (0.81.3):
+  - React-Fabric/telemetry (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1368,7 +1368,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/templateprocessor (0.81.3):
+  - React-Fabric/templateprocessor (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1393,7 +1393,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager (0.81.3):
+  - React-Fabric/uimanager (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1407,7 +1407,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.81.3)
+    - React-Fabric/uimanager/consistency (= 0.81.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1420,7 +1420,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-Fabric/uimanager/consistency (0.81.3):
+  - React-Fabric/uimanager/consistency (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1446,7 +1446,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-FabricComponents (0.81.3):
+  - React-FabricComponents (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1461,8 +1461,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.81.3)
-    - React-FabricComponents/textlayoutmanager (= 0.81.3)
+    - React-FabricComponents/components (= 0.81.6)
+    - React-FabricComponents/textlayoutmanager (= 0.81.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1475,7 +1475,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components (0.81.3):
+  - React-FabricComponents/components (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1490,17 +1490,17 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.81.3)
-    - React-FabricComponents/components/iostextinput (= 0.81.3)
-    - React-FabricComponents/components/modal (= 0.81.3)
-    - React-FabricComponents/components/rncore (= 0.81.3)
-    - React-FabricComponents/components/safeareaview (= 0.81.3)
-    - React-FabricComponents/components/scrollview (= 0.81.3)
-    - React-FabricComponents/components/switch (= 0.81.3)
-    - React-FabricComponents/components/text (= 0.81.3)
-    - React-FabricComponents/components/textinput (= 0.81.3)
-    - React-FabricComponents/components/unimplementedview (= 0.81.3)
-    - React-FabricComponents/components/virtualview (= 0.81.3)
+    - React-FabricComponents/components/inputaccessory (= 0.81.6)
+    - React-FabricComponents/components/iostextinput (= 0.81.6)
+    - React-FabricComponents/components/modal (= 0.81.6)
+    - React-FabricComponents/components/rncore (= 0.81.6)
+    - React-FabricComponents/components/safeareaview (= 0.81.6)
+    - React-FabricComponents/components/scrollview (= 0.81.6)
+    - React-FabricComponents/components/switch (= 0.81.6)
+    - React-FabricComponents/components/text (= 0.81.6)
+    - React-FabricComponents/components/textinput (= 0.81.6)
+    - React-FabricComponents/components/unimplementedview (= 0.81.6)
+    - React-FabricComponents/components/virtualview (= 0.81.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -1513,34 +1513,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.81.3):
-    - boost
-    - DoubleConversion
-    - fast_float
-    - fmt
-    - glog
-    - hermes-engine
-    - RCT-Folly
-    - RCT-Folly/Fabric
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-RCTFBReactNativeSpec
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - SocketRocket
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.81.3):
+  - React-FabricComponents/components/inputaccessory (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1567,7 +1540,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/modal (0.81.3):
+  - React-FabricComponents/components/iostextinput (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1594,7 +1567,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/rncore (0.81.3):
+  - React-FabricComponents/components/modal (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1621,7 +1594,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.81.3):
+  - React-FabricComponents/components/rncore (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1648,7 +1621,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/scrollview (0.81.3):
+  - React-FabricComponents/components/safeareaview (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1675,7 +1648,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/switch (0.81.3):
+  - React-FabricComponents/components/scrollview (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1702,7 +1675,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/text (0.81.3):
+  - React-FabricComponents/components/switch (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1729,7 +1702,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/textinput (0.81.3):
+  - React-FabricComponents/components/text (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1756,7 +1729,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.81.3):
+  - React-FabricComponents/components/textinput (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1783,7 +1756,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/components/virtualview (0.81.3):
+  - React-FabricComponents/components/unimplementedview (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1810,7 +1783,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.81.3):
+  - React-FabricComponents/components/virtualview (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1837,7 +1810,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-FabricImage (0.81.3):
+  - React-FabricComponents/textlayoutmanager (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1846,21 +1819,48 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - RCTRequired (= 0.81.3)
-    - RCTTypeSafety (= 0.81.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-RCTFBReactNativeSpec
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - React-FabricImage (0.81.6):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired (= 0.81.6)
+    - RCTTypeSafety (= 0.81.6)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.81.3)
+    - React-jsiexecutor (= 0.81.6)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-featureflags (0.81.3):
+  - React-featureflags (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1869,7 +1869,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-featureflagsnativemodule (0.81.3):
+  - React-featureflagsnativemodule (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1884,7 +1884,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-graphics (0.81.3):
+  - React-graphics (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1898,7 +1898,7 @@ PODS:
     - React-jsiexecutor
     - React-utils
     - SocketRocket
-  - React-hermes (0.81.3):
+  - React-hermes (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1907,16 +1907,16 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.3)
+    - React-cxxreact (= 0.81.6)
     - React-jsi
-    - React-jsiexecutor (= 0.81.3)
+    - React-jsiexecutor (= 0.81.6)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.6)
     - React-runtimeexecutor
     - SocketRocket
-  - React-idlecallbacksnativemodule (0.81.3):
+  - React-idlecallbacksnativemodule (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1932,7 +1932,7 @@ PODS:
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-ImageManager (0.81.3):
+  - React-ImageManager (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1947,7 +1947,7 @@ PODS:
     - React-rendererdebug
     - React-utils
     - SocketRocket
-  - React-jserrorhandler (0.81.3):
+  - React-jserrorhandler (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1962,7 +1962,7 @@ PODS:
     - React-jsi
     - ReactCommon/turbomodule/bridging
     - SocketRocket
-  - React-jsi (0.81.3):
+  - React-jsi (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1972,7 +1972,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsiexecutor (0.81.3):
+  - React-jsiexecutor (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -1981,15 +1981,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-cxxreact (= 0.81.6)
+    - React-jsi (= 0.81.6)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.6)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspector (0.81.3):
+  - React-jsinspector (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2004,10 +2004,10 @@ PODS:
     - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-oscompat
-    - React-perflogger (= 0.81.3)
+    - React-perflogger (= 0.81.6)
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsinspectorcdp (0.81.3):
+  - React-jsinspectorcdp (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2016,7 +2016,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-jsinspectornetwork (0.81.3):
+  - React-jsinspectornetwork (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2029,7 +2029,7 @@ PODS:
     - React-performancetimeline
     - React-timing
     - SocketRocket
-  - React-jsinspectortracing (0.81.3):
+  - React-jsinspectortracing (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2040,7 +2040,7 @@ PODS:
     - React-oscompat
     - React-timing
     - SocketRocket
-  - React-jsitooling (0.81.3):
+  - React-jsitooling (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2048,16 +2048,16 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
+    - React-cxxreact (= 0.81.6)
+    - React-jsi (= 0.81.6)
     - React-jsinspector
     - React-jsinspectorcdp
     - React-jsinspectortracing
     - React-runtimeexecutor
     - SocketRocket
-  - React-jsitracing (0.81.3):
+  - React-jsitracing (0.81.6):
     - React-jsi
-  - React-logger (0.81.3):
+  - React-logger (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2066,7 +2066,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-Mapbuffer (0.81.3):
+  - React-Mapbuffer (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2076,7 +2076,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-microtasksnativemodule (0.81.3):
+  - React-microtasksnativemodule (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2233,7 +2233,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - React-NativeModulesApple (0.81.3):
+  - React-NativeModulesApple (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2253,8 +2253,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - React-oscompat (0.81.3)
-  - React-perflogger (0.81.3):
+  - React-oscompat (0.81.6)
+  - React-perflogger (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2263,7 +2263,7 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
-  - React-performancetimeline (0.81.3):
+  - React-performancetimeline (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2276,9 +2276,9 @@ PODS:
     - React-perflogger
     - React-timing
     - SocketRocket
-  - React-RCTActionSheet (0.81.3):
-    - React-Core/RCTActionSheetHeaders (= 0.81.3)
-  - React-RCTAnimation (0.81.3):
+  - React-RCTActionSheet (0.81.6):
+    - React-Core/RCTActionSheetHeaders (= 0.81.6)
+  - React-RCTAnimation (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2294,7 +2294,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTAppDelegate (0.81.3):
+  - React-RCTAppDelegate (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2328,7 +2328,7 @@ PODS:
     - React-utils
     - ReactCommon
     - SocketRocket
-  - React-RCTBlob (0.81.3):
+  - React-RCTBlob (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2347,7 +2347,7 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTFabric (0.81.3):
+  - React-RCTFabric (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2382,7 +2382,7 @@ PODS:
     - React-utils
     - SocketRocket
     - Yoga
-  - React-RCTFBReactNativeSpec (0.81.3):
+  - React-RCTFBReactNativeSpec (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2396,10 +2396,10 @@ PODS:
     - React-Core
     - React-jsi
     - React-NativeModulesApple
-    - React-RCTFBReactNativeSpec/components (= 0.81.3)
+    - React-RCTFBReactNativeSpec/components (= 0.81.6)
     - ReactCommon
     - SocketRocket
-  - React-RCTFBReactNativeSpec/components (0.81.3):
+  - React-RCTFBReactNativeSpec/components (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2422,7 +2422,7 @@ PODS:
     - ReactCommon
     - SocketRocket
     - Yoga
-  - React-RCTImage (0.81.3):
+  - React-RCTImage (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2438,14 +2438,14 @@ PODS:
     - React-RCTNetwork
     - ReactCommon
     - SocketRocket
-  - React-RCTLinking (0.81.3):
-    - React-Core/RCTLinkingHeaders (= 0.81.3)
-    - React-jsi (= 0.81.3)
+  - React-RCTLinking (0.81.6):
+    - React-Core/RCTLinkingHeaders (= 0.81.6)
+    - React-jsi (= 0.81.6)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.81.3)
-  - React-RCTNetwork (0.81.3):
+    - ReactCommon/turbomodule/core (= 0.81.6)
+  - React-RCTNetwork (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2463,7 +2463,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTRuntime (0.81.3):
+  - React-RCTRuntime (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2483,7 +2483,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - SocketRocket
-  - React-RCTSettings (0.81.3):
+  - React-RCTSettings (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2498,10 +2498,10 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-RCTText (0.81.3):
-    - React-Core/RCTTextHeaders (= 0.81.3)
+  - React-RCTText (0.81.6):
+    - React-Core/RCTTextHeaders (= 0.81.6)
     - Yoga
-  - React-RCTVibration (0.81.3):
+  - React-RCTVibration (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2515,11 +2515,11 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon
     - SocketRocket
-  - React-rendererconsistency (0.81.3)
-  - React-renderercss (0.81.3):
+  - React-rendererconsistency (0.81.6)
+  - React-renderercss (0.81.6):
     - React-debug
     - React-utils
-  - React-rendererdebug (0.81.3):
+  - React-rendererdebug (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2529,7 +2529,7 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - SocketRocket
-  - React-RuntimeApple (0.81.3):
+  - React-RuntimeApple (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2558,7 +2558,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-RuntimeCore (0.81.3):
+  - React-RuntimeCore (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2580,7 +2580,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - SocketRocket
-  - React-runtimeexecutor (0.81.3):
+  - React-runtimeexecutor (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2590,10 +2590,10 @@ PODS:
     - RCT-Folly/Fabric
     - React-debug
     - React-featureflags
-    - React-jsi (= 0.81.3)
+    - React-jsi (= 0.81.6)
     - React-utils
     - SocketRocket
-  - React-RuntimeHermes (0.81.3):
+  - React-RuntimeHermes (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2614,7 +2614,7 @@ PODS:
     - React-runtimeexecutor
     - React-utils
     - SocketRocket
-  - React-runtimescheduler (0.81.3):
+  - React-runtimescheduler (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2636,9 +2636,9 @@ PODS:
     - React-timing
     - React-utils
     - SocketRocket
-  - React-timing (0.81.3):
+  - React-timing (0.81.6):
     - React-debug
-  - React-utils (0.81.3):
+  - React-utils (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2648,11 +2648,11 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - React-debug
-    - React-jsi (= 0.81.3)
+    - React-jsi (= 0.81.6)
     - SocketRocket
-  - ReactAppDependencyProvider (0.81.3):
+  - ReactAppDependencyProvider (0.81.6):
     - ReactCodegen
-  - ReactCodegen (0.81.3):
+  - ReactCodegen (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2678,7 +2678,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-  - ReactCommon (0.81.3):
+  - ReactCommon (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2686,9 +2686,9 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
-    - ReactCommon/turbomodule (= 0.81.3)
+    - ReactCommon/turbomodule (= 0.81.6)
     - SocketRocket
-  - ReactCommon/turbomodule (0.81.3):
+  - ReactCommon/turbomodule (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2697,15 +2697,15 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.3)
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
-    - ReactCommon/turbomodule/bridging (= 0.81.3)
-    - ReactCommon/turbomodule/core (= 0.81.3)
+    - React-callinvoker (= 0.81.6)
+    - React-cxxreact (= 0.81.6)
+    - React-jsi (= 0.81.6)
+    - React-logger (= 0.81.6)
+    - React-perflogger (= 0.81.6)
+    - ReactCommon/turbomodule/bridging (= 0.81.6)
+    - ReactCommon/turbomodule/core (= 0.81.6)
     - SocketRocket
-  - ReactCommon/turbomodule/bridging (0.81.3):
+  - ReactCommon/turbomodule/bridging (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2714,13 +2714,13 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.3)
-    - React-cxxreact (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
+    - React-callinvoker (= 0.81.6)
+    - React-cxxreact (= 0.81.6)
+    - React-jsi (= 0.81.6)
+    - React-logger (= 0.81.6)
+    - React-perflogger (= 0.81.6)
     - SocketRocket
-  - ReactCommon/turbomodule/core (0.81.3):
+  - ReactCommon/turbomodule/core (0.81.6):
     - boost
     - DoubleConversion
     - fast_float
@@ -2729,14 +2729,14 @@ PODS:
     - hermes-engine
     - RCT-Folly
     - RCT-Folly/Fabric
-    - React-callinvoker (= 0.81.3)
-    - React-cxxreact (= 0.81.3)
-    - React-debug (= 0.81.3)
-    - React-featureflags (= 0.81.3)
-    - React-jsi (= 0.81.3)
-    - React-logger (= 0.81.3)
-    - React-perflogger (= 0.81.3)
-    - React-utils (= 0.81.3)
+    - React-callinvoker (= 0.81.6)
+    - React-cxxreact (= 0.81.6)
+    - React-debug (= 0.81.6)
+    - React-featureflags (= 0.81.6)
+    - React-jsi (= 0.81.6)
+    - React-logger (= 0.81.6)
+    - React-perflogger (= 0.81.6)
+    - React-utils (= 0.81.6)
     - SocketRocket
   - RNCAsyncStorage (2.2.0):
     - boost
@@ -2886,7 +2886,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNWorklets (0.7.2):
+  - RNWorklets (0.7.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2913,10 +2913,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.7.2)
+    - RNWorklets/worklets (= 0.7.4)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets (0.7.2):
+  - RNWorklets/worklets (0.7.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -2943,10 +2943,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.7.2)
+    - RNWorklets/worklets/apple (= 0.7.4)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets/apple (0.7.2):
+  - RNWorklets/worklets/apple (0.7.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3326,110 +3326,110 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: cea1d4f90a3a59537f3deb03ff5656489d7133dd
   DoubleConversion: d31b1eb37f6d6f456530c4fd9124b857d6889cab
-  EASClient: a4b8ae18e8de52019ec94d14795faac4800905f0
-  EXConstants: a16ad8db13865e97aaecf64bb92e8ad8e8ce1ae8
-  EXManifests: 22ec6b0abf4e9b54ea22624aa955cf68d6c90590
-  Expo: 32293c3c6a3ed43a7df7f735452b34b6492ac4b8
-  expo-dev-client: de1af4570c4d213e52b700f701914521270ad93d
-  expo-dev-launcher: e81f3a1edd9292b18fbceb5547f41686019647de
-  expo-dev-menu: 5088d5e44ace01845dcb5f15d58f8a62defb4d2d
-  expo-dev-menu-interface: bf6f816d29b45bec038080790963c635e8d588c2
-  ExpoAsset: 7c5ca25ca94db0d34d8d3148b9cb18a1a66a2277
-  ExpoCrypto: ac96b323c2badd6326887eb68647dd07f1ec2bd0
-  ExpoFileSystem: 7bc4dd246598030591c391c735d5493741c41eee
-  ExpoFont: 4d2a6dedce012c4793532cb38d561d3da95eaafd
-  ExpoKeepAwake: 55711a70fe88a41e793bbe28543c93cb47ff265d
-  ExpoLinking: 31827b9e0d27d058026a87a0e852f238c5834804
-  ExpoLocalAuthentication: ccc92a75fd11b83b1e321074a803ba7dd90bead1
-  ExpoLogBox: 35febda08748ff213ea133f51acf976ba8c44b2c
-  ExpoMeshGradient: 3cf846fe392cee87c16d3208d03326712fe1c906
-  ExpoModulesCore: a502756f9a8415d90d142b503b7d3d426438736f
-  ExpoModulesJSI: 1733437df661254d42bc5b1f030e6ba30b758b63
-  ExpoSQLite: c01882b3ce0d20ad2351213dbd081a6e0e1f8837
-  ExpoWebBrowser: 19c5d250e0c101027677970a5f2fc635d9df2e73
-  EXStructuredHeaders: aa49a5557fa24aa61dda4ac665f3987bf3e9e35d
-  EXUpdates: d88d60c37e35277d651837bd5dc9320d80a90e14
-  EXUpdatesInterface: 26412751a0f7a7130614655929e316f684552aab
+  EASClient: 8077eb9af46cc7ad3ad216cec12d2bf5763cca13
+  EXConstants: bfe4ae4e5d882e2e0b130e049665d0af4f4cc1b8
+  EXManifests: a4e214e6a66372e662ef38adf2afca773bbd0c18
+  Expo: c54186f56dcc342ab86f4e79531344a0d703e4e0
+  expo-dev-client: aadaa25520524f33ff54e9a94b285343f2be7a38
+  expo-dev-launcher: 218855f2c1cb4c1d8a3ba2a5fdf1b5de9deda3ba
+  expo-dev-menu: 1bfd7b76e0b16700f8e3ccc9988d5ddeb9214d2f
+  expo-dev-menu-interface: 833795f4c98a674d36cbc12b11b21756c38e01e8
+  ExpoAsset: dc4f25f84886120f82b23233bba563ea7afa88f5
+  ExpoCrypto: 9fd0b78215cffa1aa20de026d452242401aa37dc
+  ExpoFileSystem: 310d367cccbd30b9bda13c5865fe3d8d581dcf2a
+  ExpoFont: cdd7a1d574a376fa003c713eff49e0a4df8672c7
+  ExpoKeepAwake: a1baf9810a2dee1905aa9bdd336852598f7220e9
+  ExpoLinking: b3edfb991a148fecf22512bf2ca3bcfa1edc4610
+  ExpoLocalAuthentication: bdf67eef520f5eb22b105d139b9cb48aa994b071
+  ExpoLogBox: a3de999775d423ac9cb85d24bd47628e5392761f
+  ExpoMeshGradient: 846122d3c20a25e21a13f58462c98f59b45d6a63
+  ExpoModulesCore: 09ff7f203930e7c425a38aa243e91f884a2516a2
+  ExpoModulesJSI: 4f9a951679fdfbfca1e4feb5c1e10df045333a5a
+  ExpoSQLite: f63db535d24c59722971241ea9ade2a878dfabea
+  ExpoWebBrowser: f88a3ba50a025b673236a46d2654a49b985953d6
+  EXStructuredHeaders: 93ad4f31a2eec124428675e28aca11de243ee1e4
+  EXUpdates: 0dcf94c01ed94a8740a7e883f4b8f912cafef285
+  EXUpdatesInterface: 39d05400a9226c438565dbaaa8447b5f0672ba45
   fast_float: 20817c22759af6ac8d4d67e6e059b8b499953656
-  FBLazyVector: ac5833da37759ba00e917acade2f6ee83c64849b
+  FBLazyVector: 63d2ab5b273d131609255f4a5441460f8b56cc5a
   fmt: 24e7591456deb60b4a77518f83d9a916ac84223f
   glog: 0b31c25149b9d350b2666c7d459229861a00ec07
   hermes-engine: 7219f6e751ad6ec7f3d7ec121830ee34dae40749
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: d849be4292d467c0e13fd4ca5042bb352b7d1a61
-  RCT-Folly: 0a7558aedae101878b4a1273756c05613dbdfb61
-  RCTDeprecation: 78aa7764dbddbc2c87060d26a3ab19fb65dad4ce
-  RCTRequired: 418deca3d896d69dd28208b5756e4e620dab426d
-  RCTTypeSafety: 69bd5ed86837aa6c405d6fdaf0872da0e5931e54
+  lottie-react-native: 86fa7488b1476563f41071244aa73d5b738faf19
+  RCT-Folly: c803cf33238782d5fd21a5e02d44f64068e0e130
+  RCTDeprecation: d4ef510f229cea15314176aee5e3ba10064a8496
+  RCTRequired: 846f04c1108e1693b0bbb8d257e72e5b817cc8b6
+  RCTTypeSafety: 9612c7b259253c4ccd6a6b156c7dcb53d5f8e77c
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
-  React: 70e9096fc23f1f8ee768e95bd95c930f4ca11eea
-  React-callinvoker: f69dc6fa70787abae5816ea817b4eccd758eebba
-  React-Core: b6b65763ee58d02519c58d9ca6558162efc78161
-  React-CoreModules: b393e90402e20dde703d6a45c4ff1489acec571d
-  React-cxxreact: 0e2fee6a2e8baa33fd0571a4a58671606acec893
-  React-debug: 7f60989bdc5b7eea5f17ecdcbefb88f57216c892
-  React-defaultsnativemodule: 63f582341120e877269453542228720f7117821b
-  React-domnativemodule: 4a0207059b276f46d97e9a96e7562f494ef36c4f
-  React-Fabric: f33fc9516cc1e68f31331d01d024b2baf862ac8d
-  React-FabricComponents: 0f80782c5367017021f377c96268fb2096b44b7f
-  React-FabricImage: e32ca782d06332943de88e2cb86e87603e72f50d
-  React-featureflags: efa6225dbc8b22264544d2fbc1cb20ddb3afe0c2
-  React-featureflagsnativemodule: 54721f923fa0f332f230dbd14d13473980d1f9d9
-  React-graphics: 7968ca6f7e8a111be160e8108dfb11fc5ce98bb1
-  React-hermes: 16489d51a1dedf72663649272ca316d9d6792c5b
-  React-idlecallbacksnativemodule: 20b1fb44a4384e19ffc806a46f57fc47aa679d4d
-  React-ImageManager: 4bcccc5302a78d5e82374b665cf444ecfa4e43fa
-  React-jserrorhandler: 413cbbdbb6ff6eb5eabc27df5b516d9cf7666574
-  React-jsi: 6e6fa09154224037093b1a2dddf26819f58a2c54
-  React-jsiexecutor: 9924ed19861e3e824ed1f5901e9fd366459777c4
-  React-jsinspector: 961b0c593cdea3f6b8f43d6f39a4e5c032f18ac6
-  React-jsinspectorcdp: 7adc5777a01ffafee595bd50f0cd41c2ca7c390f
-  React-jsinspectornetwork: 3a9a18c1ed46ab9dee372e07a4e74c2e8cc73e4e
-  React-jsinspectortracing: 8fe9e9a2bdb10cbfae929a648cfc1e36ebe659b2
-  React-jsitooling: f68e0f1bfb1c09c7e853a6c5a7ed9fd9dbfe3717
-  React-jsitracing: 14b48de455dc94916b42120b3e1a24ddfc793cb7
-  React-logger: 05e45617e07a6d3ec98367d6c68ffcd690197174
-  React-Mapbuffer: 542b27423f39e66b2afb2cf95ea04e5946618868
-  React-microtasksnativemodule: 4326b8b0aba7ca44ce7f92ada728fc3ac3215a80
-  react-native-netinfo: 5e036f49ab00a53569bcc0cbc2954b608b6532c3
-  react-native-safe-area-context: 54d812805f3c4e08a4580ad086cbde1d8780c2e4
-  react-native-webview: 8b9097e270a99ee8798449f191a7ea27c790fa1c
-  React-NativeModulesApple: 8db9300ac6e2fa3f442d88725375ef463782a8a5
-  React-oscompat: aed7511b40db9142cb90957c06a8eaa4f4fb8f35
-  React-perflogger: 3086100c15bfdf5b04422573d991fc36c0e5ef80
-  React-performancetimeline: 67246835bb032e2a20bf66d3a889a7691a1cc80f
-  React-RCTActionSheet: 588ca9b68b9e7af4a918dfbb1ad2df73a8597c30
-  React-RCTAnimation: dbe4b8651fd1d876d67e2bf5575f3eabd397d9f6
-  React-RCTAppDelegate: a9b05fa0d9a9c35fe54c05bf319ce30ac055463d
-  React-RCTBlob: 513e325f293e23a41713bae3c7bf456f1ef92f07
-  React-RCTFabric: a9fc62d10b0dfbc9efbefdbfd5f2f21fa59ebdf1
-  React-RCTFBReactNativeSpec: 67c9f42ab8f09f7c4ff44ddcc6c2281e31e9dcd8
-  React-RCTImage: 5e7bc1ecedb3b01efd77a84a97c94d223f8c7540
-  React-RCTLinking: c25a7bc71475bf9531f0f0567c8b17a38c53ef3f
-  React-RCTNetwork: bbc81097558f6ae674940f50cc2e63397643a8da
-  React-RCTRuntime: 4b758e1306504373079737de29484069ef481ab3
-  React-RCTSettings: a87b70611d381003351b571b7365ca28c66d249e
-  React-RCTText: d5e9836cef2714c0577d3474529178b7488970fd
-  React-RCTVibration: ededc3390d835709d9400ed46dcf55764b292e3c
-  React-rendererconsistency: dadd29700cf4c64650791276aaa1d713adca5a5d
-  React-renderercss: 476f17552ab220c0fd108c61c802d33aa4318643
-  React-rendererdebug: ad85df5c72eb29e1ff6949ca9dbecace4e1ee88d
-  React-RuntimeApple: 8bbc747b31f821921d31c9cff63cf39727d9b663
-  React-RuntimeCore: 31e692cdf4604a2bd75d32403e051df22694e743
-  React-runtimeexecutor: e33393724b54876e7263c3aa8bd5275e0c8a48ef
-  React-RuntimeHermes: e6894347fffe47a69b75e107860e6b81cbb0685f
-  React-runtimescheduler: af9520acb355f2a15a3e4b87a2791adffa26b350
-  React-timing: b1d071d301d69805aba4d9c7b70041014adcd091
-  React-utils: f67cebb439053dd82368c38880fa722208634bd3
-  ReactAppDependencyProvider: 5fad3905658e584239aa16c0582083d3f4343227
-  ReactCodegen: b553c40b6d72dfb3b7736b2b857c2b5c95026b43
-  ReactCommon: 11314ceed7043fec3d8d9f1dbf352eb2b3431eb3
-  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
-  RNGestureHandler: 77eecab5fd636666ca73a55bb61e2f1a685b7e84
-  RNReanimated: 31da8d5f1605f5367e2392748ba9f4ba6eaf1178
-  RNWorklets: 8e934a6b6d5a2710b9250e63a18a2d2f8b875a18
+  React: 537c743384b64e0d2400a96f3b8ce6397e56713b
+  React-callinvoker: b40304cebafc2dd831f37f6fca518e2d13a77bb9
+  React-Core: fd4c79ff0a37b262299a40c8a526a9a2a5339c4d
+  React-CoreModules: 3610e5b26eabe828401e995f181197f21545fd29
+  React-cxxreact: 35c43c6982c1a643ae2d7f7bc916d26df5e7ad96
+  React-debug: d65525cdc3b201065b1c1635fd52fcd400522370
+  React-defaultsnativemodule: ceb8a5ba0f213bb6e52c7dba475f34433c828b73
+  React-domnativemodule: 3b977a0cf2d08d024e2f9ea3f63046047efa30e4
+  React-Fabric: e41937c427c611cd958f580bd0df1667a33eb7ee
+  React-FabricComponents: f7806f1e4ddcb135849ee6991b9bed447ff835dc
+  React-FabricImage: 4e5dc54712ecf58e109c9342a7f3a371a7d8c67a
+  React-featureflags: 5f21612e741a6959542d8fe706c4e408e28df5eb
+  React-featureflagsnativemodule: fab17f69a0c0db906358afc527afcfd50bc6faca
+  React-graphics: 0c19cd6ee84ac52db6f31f148878e5e421b84f80
+  React-hermes: 9458e47f87aecc2c040ff8a2b097a1ce028ea58f
+  React-idlecallbacksnativemodule: a7f43d182f6c289ba454be87cd4cf544dece53be
+  React-ImageManager: 662b96b50dde121bb5ef7429df660322b9996949
+  React-jserrorhandler: ffe37d921cda5c1c093feed29ec6cc88e14e336b
+  React-jsi: f994abc66885e0a28f9c0a5637efb8d7152fa69c
+  React-jsiexecutor: d63d044e0fabd016c97cba3894601ed1be11363b
+  React-jsinspector: eb14bf0c9a2815091cf9e878779decef0a39cfac
+  React-jsinspectorcdp: f60dbc75fbb95d5b7af33b5b48bec755549412e1
+  React-jsinspectornetwork: a9d16d4710af7bf09e2245858cad2e1e16c905dc
+  React-jsinspectortracing: e0716a75c32815fc0baf0a7a9175168f115f0247
+  React-jsitooling: d6b89bd5b49af512af212266b67fce8fbccc9cb9
+  React-jsitracing: f1fdc2bec92f494824684b598469741231d7b3eb
+  React-logger: 65336f6a10b0ac89df16ff23b5351403fa763eae
+  React-Mapbuffer: fa14f5595331aa721489b678a042d6bc809896bb
+  React-microtasksnativemodule: 78677a5cc3e5f722223142fc0919fdc092e6fc84
+  react-native-netinfo: 57447b5a45c98808f8eae292cf641f3d91d13830
+  react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
+  react-native-webview: 654f794a7686b47491cf43aa67f7f428bea00eed
+  React-NativeModulesApple: e321afaa9d0782040d9e32c9e5b9b1921f4bf22b
+  React-oscompat: 236551c635e28b39815d9ea1f93bb60a2c786b77
+  React-perflogger: 2074fb7603a5a8bc8ff9f88fdef15d01c7189429
+  React-performancetimeline: 38663303309a27503ed9e80b2a065bff90c3b9cd
+  React-RCTActionSheet: 23ff92d411e044d7569f7ac4a490f8f4bea3dd48
+  React-RCTAnimation: c384ddc7404ef706e86c50ef3c2e403978885c71
+  React-RCTAppDelegate: 0386d130bcf96158150cf53effd037b15d249f92
+  React-RCTBlob: 8c90d6dc5874ef4c828f100a41ab5bd9b3972418
+  React-RCTFabric: f111a4fca43a069375e19d5494cac08582c41417
+  React-RCTFBReactNativeSpec: d42453b1d19f395b6e1176edc603553e4708e031
+  React-RCTImage: 6712961d66ae8a395ebe4e081d3d86d7def37a4e
+  React-RCTLinking: 8bbe1dc8e24c40f4101a79bc465d54abb0f487cc
+  React-RCTNetwork: 3ace479252ae66af133cc9150e5799231760f223
+  React-RCTRuntime: 5554e6403284ef5963d9d0e9fddd2bf981912e93
+  React-RCTSettings: 14746edf4fe9fd3939475eba4f867939a1f293d3
+  React-RCTText: 53bc126997b49379c4e45a0bda62ca01169976fe
+  React-RCTVibration: 0243430276ce76bff6d7bbc408a187d98903a9b6
+  React-rendererconsistency: 84eb81e8759ae7ff392e0ae517c5bfb9c391d889
+  React-renderercss: ccbdd4bbe6453f7b858bf77c3942e9ae22332709
+  React-rendererdebug: 2df8c2ac5d31993bc149307e6f80be3af45a9ac2
+  React-RuntimeApple: b0358c5e06cd0c559e2a0b6771b2eb2bad44ad5b
+  React-RuntimeCore: dc9d2b513add8ba6efb74b973c26ecf7629e74e2
+  React-runtimeexecutor: 604d8d382737c6620abf74d445fe8da4285989b2
+  React-RuntimeHermes: a214e2ade1423e6a78d3002e3a9b394b1ecc4587
+  React-runtimescheduler: abb26a3c1abf64a4131f3b2b6c36e0a56f38aff1
+  React-timing: 291554e007ea18d583f1aeaf46189e0445967a3b
+  React-utils: e361a5cce0727b348623f5d49c7630f07d0d437f
+  ReactAppDependencyProvider: 0777e8eba3203a526414e7b2510e010022535833
+  ReactCodegen: 687b7f41c3fd61aafefbef8d2c7b909082d35794
+  ReactCommon: 00493dc3f5afa413244a800c9371255a7fe1ed20
+  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
+  RNGestureHandler: cd4be101cfa17ea6bbd438710caa02e286a84381
+  RNReanimated: 132940c4c15ca2757f4f7d1fd7c9c3c01dbc4689
+  RNWorklets: d9fe4a51421f69ce78bb415a7e0710c15fe61150
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: a12947ee35fb381e3be96cbf365b554402b0dfd6
+  Yoga: 4ef4653dfc35ebc95b49047afcf7a690e32efc0a
 
 PODFILE CHECKSUM: 8a504db1001201acbfe0854c65ce07ebcc292524
 

--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -79,7 +79,7 @@
     "react-native-screens": "4.23.0",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.16.0",
-    "react-native-worklets": "0.7.2",
+    "react-native-worklets": "0.7.4",
     "test-suite": "*"
   },
   "devDependencies": {

--- a/apps/brownfield-tester/expo-app/package.json
+++ b/apps/brownfield-tester/expo-app/package.json
@@ -32,7 +32,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.5",
     "react-native-gesture-handler": "~2.30.0",
-    "react-native-worklets": "0.7.2",
+    "react-native-worklets": "0.7.4",
     "react-native-reanimated": "~4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -3855,7 +3855,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - RNWorklets (0.7.2):
+  - RNWorklets (0.7.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3882,10 +3882,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets (= 0.7.2)
+    - RNWorklets/worklets (= 0.7.4)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets (0.7.2):
+  - RNWorklets/worklets (0.7.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -3912,10 +3912,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNWorklets/worklets/apple (= 0.7.2)
+    - RNWorklets/worklets/apple (= 0.7.4)
     - SocketRocket
     - Yoga
-  - RNWorklets/worklets/apple (0.7.2):
+  - RNWorklets/worklets/apple (0.7.4):
     - boost
     - DoubleConversion
     - fast_float
@@ -4681,78 +4681,78 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 414b26bae592cf8db64aa60461aff9d84ebbd944
-  EXApplication: c2dcab659064299662da96cc6032c4334b79777f
-  EXConstants: 6965c4c970052e7a04dff7bb6b3c50ae292a5833
+  EASClient: 8077eb9af46cc7ad3ad216cec12d2bf5763cca13
+  EXApplication: ab5a9ca485adce8be81309a5172d1565e9d7467f
+  EXConstants: bfe4ae4e5d882e2e0b130e049665d0af4f4cc1b8
   EXJSONUtils: 04bc3807d351331a5fe154ce1da596ec15d99169
-  EXManifests: 2cf22467ed628c61467ad7b6ee56b4ea81ddf510
-  Expo: 464bea2ef55686c50ff7d9edf506a24ede0fdaaf
-  expo-dev-menu: c80256a61c8a0c6ecafa7536367019d49b0c4a57
+  EXManifests: a4e214e6a66372e662ef38adf2afca773bbd0c18
+  Expo: c54186f56dcc342ab86f4e79531344a0d703e4e0
+  expo-dev-menu: 1bfd7b76e0b16700f8e3ccc9988d5ddeb9214d2f
   expo-dev-menu-interface: 833795f4c98a674d36cbc12b11b21756c38e01e8
-  ExpoAgeRange: ec26d88646d544de24e189261aec537e5613f44a
-  ExpoAppleAuthentication: 9e3a40e8f9d95d23d980956f6dbf0b6c0302940b
-  ExpoAsset: 639cd3ba5c2f751362ea86602e532be7f8b09146
-  ExpoAudio: 885bdbc085e0374bcc983ea473b1ed42d5ce5a25
-  ExpoBackgroundFetch: b7a1e6658f6da3137f68a13d4b6bad6ff3b632a5
-  ExpoBackgroundTask: b8f57191843bc66b3df39e91db21f14004d123d4
-  ExpoBattery: d943385262ab8a22c034784cbeb92dcea1ccac98
-  ExpoBlob: 882fa24430fdfdc8e7dc90cf0b90e1e4c7d0e6c5
-  ExpoBlur: 08afa305ca20b1adb0b580fd3b09a38b64ce8804
-  ExpoBrightness: 80dc3bd175cb30c56075ec5d9dac18984bc9b688
-  ExpoCalendar: 8c535db6cc831ae56358501712566df056b40ad9
-  ExpoCamera: 707b4b20b5522e2e41c744182bdc6321dce03c86
-  ExpoCellular: 109862658315190acad24b669408133ec2fe496f
-  ExpoClipboard: 56f5dac55e9e19bb6f084ada68bfc634a36e9533
-  ExpoContacts: 7756695714758162fd8c15bad4a0b7b1a11fd826
-  ExpoCrypto: a064d6db094c48d5b11ed1b0e97f2bf1af83757b
-  ExpoDevice: abca0e3c05fbf884669bfa27ad2b67464bba3dcc
-  ExpoDocumentPicker: c218333e865c586f255b26eec640635f03e12485
-  ExpoDomWebView: 4937eda7ff9112ddcb8701b52ae4e8e9c2e181b5
-  ExpoFileSystem: e7075f07fdadcd6e55f2de1af6065faa097d41b4
-  ExpoFont: e4fe17baebfe22a21576d6efd8f27b0dad06d653
-  ExpoGL: 8b6f93558aa1591bb40609f765b0eff1117a7c24
-  ExpoGlassEffect: 174b96e3503cdc0c507fc53699029299891bf5a7
-  ExpoHaptics: 18a4632ae8de62130208c76ba2bb0a0a144e99b3
-  ExpoImage: 008430e5aa8f7b66ccf12808aafa52de3e08b821
-  ExpoImageManipulator: 41c2bfd6483c78533b4836774c4e168118aa5c14
-  ExpoImagePicker: a2166588c8ee535bac8d39fb61705fa2c30a7535
-  ExpoKeepAwake: 5e391c2c712b7af91e044be8ab44b7f542d81f3c
-  ExpoLinearGradient: f7a3da6577688c5fb627e9ee6b47ed620c169da3
-  ExpoLinking: 36e1e619adec0a946395142444210d848c80cb54
-  ExpoLivePhoto: 99d40280350c6efd9b8743f008607433a09a6277
-  ExpoLocalAuthentication: 22f5fbc0935bdc7057ec7144fcfad0792ed8a3f2
-  ExpoLocalization: e9dbdecfb6a2a36d14c6c628e5c3f9fb9b6f305d
-  ExpoLocation: e3367a4274fff89fdd5ea70e166484fa9fd6d333
-  ExpoLogBox: ba1ad09d3e7632ce488e1eeab684ee6fd75f2777
-  ExpoMailComposer: e89b0b8ac6a0b557b1d7078585c9cc0c3f7eca35
-  ExpoMediaLibrary: 166307c412aa12d7e801696d52ea45fdd1cb36dc
-  ExpoMeshGradient: 9f25b0df295222281a5398f71fba44ee9910450f
-  ExpoModulesCore: afd92c5425438324aadfbe74285bab12186512b0
-  ExpoModulesJSI: 353160c13f3d9d1ff3751453d18f456c13d5f289
-  ExpoModulesTestCore: 15b132dcc38f95c14ba445efc336c806d48884a2
-  ExpoNetwork: 2b9fa25a6cbb1cce2e31863c88cc8c5ab883898b
-  ExpoNotifications: f3300053f7b01c89038ac1d3a3429edbb32d9eb6
-  ExpoPrint: 4de2eaf713b1f23ad6a306dd1034158d6d84d43a
-  ExpoRouter: 978657094cf0a42d17bb891706282c8a4031d70f
-  ExpoScreenCapture: 3cde76108a8c6ca1ec75d0da772b4adf0f6ae89f
-  ExpoScreenOrientation: 71450ffcb365db5b9b48defea53b52f18d4d650b
-  ExpoSecureStore: 03372541cb9b7f67601fa2ed0a8c2abbc9037e04
-  ExpoSensors: a6a6b0cba1488e548119e201613268bc247821d4
-  ExpoSharing: 7bc7b17aaaab37a933a012a14aa776562999feaa
-  ExpoSMS: 97950b69618e3757174960e8d50d949d82939f0b
-  ExpoSpeech: 1cd5d4582a81ddc8259f77391a5174f19ebf8bff
-  ExpoSQLite: 9989421186383e2229b8736ff58cea4ee8e21d8b
-  ExpoStoreReview: dd070408095f59c82a019de10a5a414f751741b2
-  ExpoSymbols: 9dfd60e35b2fafb284adefaefe1c6d757e331708
-  ExpoSystemUI: f4a4f3dd9f62f0d4e6799c57f600288fd861ce95
-  ExpoTaskManager: c9b0af884aa9e1e512b4926cded2e6c2097e12d3
-  ExpoTrackingTransparency: 287445639184c0f885ccff78f6e2b6d8414d58c4
-  ExpoVideo: fe990ba488ca5e4b2e9b7b63c4039134de9e6205
-  ExpoVideoThumbnails: e33e336b7db87b701d62ce309d99ce8bc003cc2a
-  ExpoWebBrowser: 0f4255b795de0eca7e0337de591c3d1c20efbdf0
+  ExpoAgeRange: 66d3128006e8696bbea49b45f7972fa92c1b5695
+  ExpoAppleAuthentication: 08b3d0e502f46731abdf4c59203769fb685f66c8
+  ExpoAsset: dc4f25f84886120f82b23233bba563ea7afa88f5
+  ExpoAudio: effd4eb58abee67050f79e8764fe1078daea39c8
+  ExpoBackgroundFetch: fa10491c77b4210d13bd0de889453750e9dadb81
+  ExpoBackgroundTask: 611cfb3fdd1a3389f99dcb290ec76178d2912d9f
+  ExpoBattery: 2b5ba5940ec9e0b723fb83346109175473a9e1c4
+  ExpoBlob: 279acf437681366f2869a655107c02d1d956d229
+  ExpoBlur: 7a86e84e7728108fa6908d7103fa527705a3dbbf
+  ExpoBrightness: c45644152fa9087c9d6cc75418a1f9621802181e
+  ExpoCalendar: b6256830f2effeee5e8ba5e327fd6e3d0eb78683
+  ExpoCamera: 5f6ae5fd7365ceb741168a71eeaa5b65e556c672
+  ExpoCellular: 932205e4470962b8b1048c6c0f297bcdf6ba6920
+  ExpoClipboard: 5d1b0cd2686406f21e616f2d9b3431259dee2e6a
+  ExpoContacts: f893ee6893bfcbb8bcd0be12a0c8472a8ea7b9c3
+  ExpoCrypto: 9fd0b78215cffa1aa20de026d452242401aa37dc
+  ExpoDevice: 3a4a361d685333e4139da5d56bb2740c86132beb
+  ExpoDocumentPicker: be59b82799ae30811e3f37a7521d6622baa63a19
+  ExpoDomWebView: 2b2fbd9a07de8790569257cbf9dfdaa31cf95c70
+  ExpoFileSystem: 310d367cccbd30b9bda13c5865fe3d8d581dcf2a
+  ExpoFont: cdd7a1d574a376fa003c713eff49e0a4df8672c7
+  ExpoGL: 7dadcb781777ef5c90144eef2efaf8425635a2b2
+  ExpoGlassEffect: 72bcb9dc634262c59897ff7c53c16e2ff03990d0
+  ExpoHaptics: 679f09dc37d5981e619bc197732007a3334e80b8
+  ExpoImage: ef931bba1fd3e907c2262216d17eb21095c9ac2b
+  ExpoImageManipulator: ae0a562f2d405de275e011915c811564106baa70
+  ExpoImagePicker: ce50d0bf7d27d1a822b08a84bea9bfc0b3924557
+  ExpoKeepAwake: a1baf9810a2dee1905aa9bdd336852598f7220e9
+  ExpoLinearGradient: c654e92d726a6d64c588a0988bb22bea331d5e79
+  ExpoLinking: b3edfb991a148fecf22512bf2ca3bcfa1edc4610
+  ExpoLivePhoto: c5c031368683c69f25dc8a169e0eb69ef6a252b8
+  ExpoLocalAuthentication: bdf67eef520f5eb22b105d139b9cb48aa994b071
+  ExpoLocalization: c5cd7fa65c797d3a2f1adbd1fd4c601c524fd677
+  ExpoLocation: ba5fff1510a7f123abf620fc2242db2fc87eba0f
+  ExpoLogBox: a3de999775d423ac9cb85d24bd47628e5392761f
+  ExpoMailComposer: bb63854e80400563d4a1537f1c9fadf7c8e70ab1
+  ExpoMediaLibrary: d6b22096da42dea0b5a68fd3eef96761bbf592c4
+  ExpoMeshGradient: 846122d3c20a25e21a13f58462c98f59b45d6a63
+  ExpoModulesCore: 21a8d025e7bf34b0c2194238658f8e5e321c07a7
+  ExpoModulesJSI: 4f9a951679fdfbfca1e4feb5c1e10df045333a5a
+  ExpoModulesTestCore: bdd36eccdc0a62ec803abf21a894cf82b1a22722
+  ExpoNetwork: aec041c4e9cb5a30cb4da32b2e315bcca6a7c2e4
+  ExpoNotifications: 52440855fb1c86e9bd2033e849489c1b915eeefc
+  ExpoPrint: 3b79c16d6778b4a89fb4eb9cc346925690cb0c74
+  ExpoRouter: 42de21e959ea28e44c0edee85d8c785fc71548e7
+  ExpoScreenCapture: bcbb78db8311c51553ce6178c43e52bef0654c2a
+  ExpoScreenOrientation: 07fb2a646a29e669a893151eb857517b734211e0
+  ExpoSecureStore: 38954f6bcef1287aa04c06fba3b86e8af3291ccd
+  ExpoSensors: 8a6cb82a28ed592cc6923021b39aa4078dea3a53
+  ExpoSharing: 5acc9d78894386d31b862b12ed1cebe7dce74e68
+  ExpoSMS: cd74cf9d83be085384481c47bfe7240baba70cb6
+  ExpoSpeech: 7f5d4a94aea1fbc509cf4ab2649bc2e3f05ea15e
+  ExpoSQLite: f63db535d24c59722971241ea9ade2a878dfabea
+  ExpoStoreReview: dab6e25f0641784bd6207f729f893423afbb6574
+  ExpoSymbols: 8b63e859ba013df1f2fc666f535fddb3d5270569
+  ExpoSystemUI: 709410d6e473378d568e5df28fe409cade0ba530
+  ExpoTaskManager: cd4cb9405637f52e26c8a54c1cfe7b974bc9ac2d
+  ExpoTrackingTransparency: 6973cece26b4a38fc3a600fadd4d7efb83fd660b
+  ExpoVideo: 434d1e32486309359b8eff4880d636fd8c0c0ba1
+  ExpoVideoThumbnails: 4e7d245fc770bcf831dd954ec68977aaf480d98f
+  ExpoWebBrowser: f88a3ba50a025b673236a46d2654a49b985953d6
   EXStructuredHeaders: 93ad4f31a2eec124428675e28aca11de243ee1e4
-  EXUpdates: e6cb770618528950d3f03644ba922f832e7a18ce
-  EXUpdatesInterface: fb4c97f3412d5040616fdb588a4718219533c7e4
+  EXUpdates: 3b81c6fb821dd67d581363601b677d36435c6e4e
+  EXUpdatesInterface: 39d05400a9226c438565dbaaa8447b5f0672ba45
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 7f47b3463fec4f3acdd9a7e24741908b9c5b493b
   FirebaseAnalytics: acfa848bf81e1a4dbf60ef1f0eddd7328fe6673e
@@ -4768,114 +4768,114 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 26a3abef001b6533cf678d3eb38fd3f614b7872d
-  hermes-engine: 49e6d6ae6255733a1c9c2163e6c69dd36aae6193
+  hermes-engine: 42785a4a1bbb28ca14ba5069e35e0ec7f908e9f4
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   lottie-ios: a881093fab623c467d3bce374367755c272bdd59
-  lottie-react-native: d849be4292d467c0e13fd4ca5042bb352b7d1a61
+  lottie-react-native: 86fa7488b1476563f41071244aa73d5b738faf19
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   Nimble: 97d90931cca412a23224ff29e258809f75c258f7
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 121436bcc4611f6bde5c09bf35f0a7a82cef1969
+  RCT-Folly: b29feb752b08042c62badaef7d453f3bb5e6ae23
   RCTDeprecation: 66da7829306a6741edb3f866687c13a4938ca5f4
   RCTRequired: c6853c7a563306968f833210c476741e09fc5f61
   RCTSwiftUI: e20c56b190b3f0e9c31e0564c4cc2c0ac5eb88e7
-  RCTSwiftUIWrapper: 1571834f292f2c9ed90a90f70d93cecb165d8ca5
+  RCTSwiftUIWrapper: a6e6b705b24b0246306fab7a338a4d3661820c6b
   RCTTypeSafety: 3da7bf235358e50371118adbe559fdd3525f25fa
   ReachabilitySwift: 32793e867593cfc1177f5d16491e3a197d2fccda
   React: 184a8e3cdd90ae29c15c6cc79ce108ea35f03781
   React-callinvoker: 205204d89b2582e34395da353514b27f7aeef441
-  React-Core: 469de800ccc77e5d8de84ca067fa5d8d9dfaed43
-  React-CoreModules: e58a273e7ba6fad7968b5bbc4d1d25b7791ce47d
-  React-cxxreact: af78935ad798110c3c417f13b87bc1d0ee70edbe
+  React-Core: b477d3a7a19d1f9be435dcd85df30be4ecfa48da
+  React-CoreModules: d8476186f811cf7ac687db30a35f769a9c8b1763
+  React-cxxreact: 08e72f66cb8387cb4e4a0703334389e73aea04dc
   React-debug: 5787f273069bfcebb8bb3bcd888ab752d4991f80
-  React-defaultsnativemodule: 04a7f443d765d380631ff82282583719e686fce9
-  React-domnativemodule: 2c4fdc905baacbb20f8a0a715454fdef98c8c00d
-  React-Fabric: 3b631954408ec94572751b337c74850a0ec0578e
-  React-FabricComponents: f80a195046902def86ce4802f631dcc73a1eb6f2
-  React-FabricImage: 815bdbc53b51294f8282f4fc41f67cde2e1ddffa
-  React-featureflags: 420fb73e7606793e9d9097de4709e95351348af3
-  React-featureflagsnativemodule: 8ebc4916f3d311a08e90e3cc479fe976207c5d67
-  React-graphics: b9ede2af310085c462aa9c98a7171149f686aa5d
-  React-hermes: ba61dad04832de29e0464cb30246665114bd550c
-  React-idlecallbacksnativemodule: dca8675f43810b2e0b0ea529ddaebe373edbabaf
-  React-ImageManager: 5fb07131d7677bea8d44164ab2924f3f3f25eb21
-  React-intersectionobservernativemodule: 94f904076b26abb89d3b1c0ee8706a8900228132
-  React-jserrorhandler: ea818bbe52958db1dbbf912cfb25d4c5b65309db
-  React-jsi: 139d1f2508cf99c94cb2f8ef8a1a6a48a9bda889
-  React-jsiexecutor: e33d86f7d475672f36386f65817730dbcbf59951
-  React-jsinspector: 495b0b7c22b8c9325927ac27993981ce21a1575d
-  React-jsinspectorcdp: 50c263788b30d0643662171aafa32795ee583b67
-  React-jsinspectornetwork: c0bc0fb95d8552a3289f397e67e98424ef7453de
-  React-jsinspectortracing: 118c55f2c9baad1562653add17ef82aea62c1703
-  React-jsitooling: cbce9648319d71cc22b70a1f81825495475587de
-  React-jsitracing: f32131039333eae2605ef6e013ba83e0daaeb6fd
-  React-logger: 42d166b8087c17202c0c5d052a49176e0e0359d8
-  React-Mapbuffer: 9733d6346c2e06a3156dd5d6775068028e888b81
-  React-microtasksnativemodule: 375752f191e0f6a831cfab34d23c9bc3ee5c0c1f
-  react-native-keyboard-controller: c00d45d824a23740eeb3d5bcff30e427a26e311d
-  react-native-maps: 00f50855f1a061186f2923be0709b3f09708ddf7
-  react-native-netinfo: 5e036f49ab00a53569bcc0cbc2954b608b6532c3
-  react-native-pager-view: 4cc305d9d25eda66adf44029a84a591d8b98c072
-  react-native-safe-area-context: 54d812805f3c4e08a4580ad086cbde1d8780c2e4
-  react-native-segmented-control: 44d14c6899ee12de3384517f4fa1cf4a66ae105c
-  react-native-skia: 25d09b13dc75872083c31c9ad1136931480d6e85
-  react-native-slider: 5da4af460d0dd1346f927e829dfecbb81bd46f91
-  react-native-view-shot: aac285cd08144be29c19ab659930172836f0067f
-  react-native-webview: 8b9097e270a99ee8798449f191a7ea27c790fa1c
-  React-NativeModulesApple: 2f114735ec6367d0499e1bdf45026575600777bc
-  React-networking: fefe9156c8669636ca8ed50892e596addc609c93
+  React-defaultsnativemodule: d7d0332fd8a63a5537939471d4a64769085b1a87
+  React-domnativemodule: 3a711467567579eb68dbffd27432d48a7db98ae2
+  React-Fabric: 37d39777a479439ad2e15d59dba5a154d22ee178
+  React-FabricComponents: 1231dbde60c42df7691c7a438762b266f464b305
+  React-FabricImage: b11ec173130dd592565978d74781cd94e19c1c36
+  React-featureflags: b8380442882b11099d25718d331c132fe30cb7d6
+  React-featureflagsnativemodule: 9adec377f4d5e8a38f22b6e3c0e2dfbd61ce3d0a
+  React-graphics: c0d3e124897d5ec9732b562953d36d5d9f0199d3
+  React-hermes: 88bb918a4f87ddd8b7601ae061e59423e519f2f6
+  React-idlecallbacksnativemodule: 2d80d55d2686b1dc9c4f58adab0e1f1b16327a50
+  React-ImageManager: 82b18470d2db80b957ff8515d39d696a58ff9c62
+  React-intersectionobservernativemodule: 88f46f14748054c0091067b7b25176c58dceffb4
+  React-jserrorhandler: 80f40fe4ae87f668c703ff7167eadccc079a6903
+  React-jsi: 16e218c2c58b7651d99958a3dd21928735b3e1c3
+  React-jsiexecutor: 71bcb8a3a698cc1021298c42ca08ae0f17f83128
+  React-jsinspector: 23d255a4e2ff037c44b1e23ac3d13e20aabc4ab9
+  React-jsinspectorcdp: ee0152be63f35f734a4de50f8ada081faa9747a4
+  React-jsinspectornetwork: 63a5fd9f0a512fc53668210d9a5bdb3f8cf4ff5b
+  React-jsinspectortracing: 029efd35ee9fdb3eed64413f245279939a63558c
+  React-jsitooling: cf169271c5e8fb2fce65c01d4676bfc16c0cea90
+  React-jsitracing: e9b52afbcfcb51f8b175da5fb687dc05d23f074a
+  React-logger: 661e84a3f43439fc2e81478b7d055c3edc44697b
+  React-Mapbuffer: 05f0d11c9c28b80913abdd580840d5a3b1e75328
+  React-microtasksnativemodule: d433adcf1a5e2f7e6d1fcef57b42efd76aa0aded
+  react-native-keyboard-controller: dbf568b5d029cdc5b26667a7c2323b160c25dc00
+  react-native-maps: b5af575a371e57847c6d8490e726c08036f7c80f
+  react-native-netinfo: 57447b5a45c98808f8eae292cf641f3d91d13830
+  react-native-pager-view: d7d2aa47f54343bf55fdcee3973503dd27c2bd37
+  react-native-safe-area-context: c00143b4823773bba23f2f19f85663ae89ceb460
+  react-native-segmented-control: bf6e0032726727498e18dd437ae88afcdbc18e99
+  react-native-skia: 03e8994164f792bc9fa464ed475e7f8edce36d0e
+  react-native-slider: 34064ca1a6864d7b263e44dd76a2d794e8d26744
+  react-native-view-shot: 6c008e58f4720de58370848201c5d4a082c6d4ca
+  react-native-webview: 654f794a7686b47491cf43aa67f7f428bea00eed
+  React-NativeModulesApple: 9070626e7bc2b0b1efd106ce5ff9d4c207ef0ad6
+  React-networking: e26aade54c2eeff9f1e60336e26202965895dc2a
   React-oscompat: 7427e1c3527c66edd789d63d0603c68b52b50a12
-  React-perflogger: c53df415514fd0f05f16c8dcfbe2802c67b0bb6c
-  React-performancecdpmetrics: a407687b68fe13c7fbd321e0cf00693547c1c025
-  React-performancetimeline: c2ab93f12347f7965f498fc04b1cfa975d6ba20f
+  React-perflogger: 8f182d3b237c76c64fdca7d20429143e4865e39d
+  React-performancecdpmetrics: 5aab744cf3d41baf6a1df1791f96cdf137ad9c98
+  React-performancetimeline: 13570ab1183d1141b872c071e7b6b04be54e3659
   React-RCTActionSheet: 6cbaea8ad7a0b7331e9c112a41a396fb4536a93e
-  React-RCTAnimation: b874c3b1fb1c6f62434571a3d49ecdb226457598
-  React-RCTAppDelegate: fd5cda0cd1024508f5c76b219a2db625bbe89bd7
-  React-RCTBlob: 528cc7c6917265971ddadf6cd5002c6e28b6b45a
-  React-RCTFabric: c23727bb9fb9e6f77aeb12773a016fae4e3d54e8
-  React-RCTFBReactNativeSpec: e95633a28f9b1e99add3af3bab6d0df5efbe694c
-  React-RCTImage: 07dd6f28bcae9621c164c900f4c21330aff6f3e8
-  React-RCTLinking: 022df4a3a414ff2554087914f43730890a8b2e3a
-  React-RCTNetwork: 7763db9796a6973326d894d355c2a426c64ddba4
-  React-RCTRuntime: c35e4aea21d20c7119a767da6d93c58348f5e2d5
-  React-RCTSettings: 98d54a443fd00745fbdc10681b9b1b23663ddd61
-  React-RCTText: 3c6271d81e6e72dfb5494823833a3d59aff865f6
-  React-RCTVibration: 829fd2f8f951353fc52eb5d25f9fede7293703fc
+  React-RCTAnimation: 87122e18bb2f593b7705a9b13447ce82a4e61724
+  React-RCTAppDelegate: fa06af2b1fdf4e87cb55d3d20ecd2575f6fab290
+  React-RCTBlob: 4488c9a35030388ce5d209de8dd234db140f1344
+  React-RCTFabric: db2ee86c9de6e00d01445dcb1d720a4247cf451d
+  React-RCTFBReactNativeSpec: 38d3f42e710e0785ad1818bfb00b233f03c81c1a
+  React-RCTImage: 8a40a03d4775c4c86943589223ce74b12a840ba4
+  React-RCTLinking: d53790a01217d0d4f6236baf57ce7db0acb2741d
+  React-RCTNetwork: 0b267e7c762fe01369494e488b8b04a19e76ccf4
+  React-RCTRuntime: 714a55812e47646621b7d044e073b4dc1ed37884
+  React-RCTSettings: eac6e5cd794796786ad3cba47264b904ee87a480
+  React-RCTText: 9c6f47b8e56ba0b804c006d1236f9587b8575933
+  React-RCTVibration: 406e4de3b7398fc20715f4d135bc56a4f17e4fd8
   React-rendererconsistency: cc3bf7dacf69c1a4e3d0ede01cf92b43f50dc3e4
-  React-renderercss: 577ee0a56b8ea8f367b018017a2da54574c4df6e
-  React-rendererdebug: 9c68e7e6eadf78a7c8d9ad977f72a67e4de3f9d0
-  React-RuntimeApple: 6c88c90ae7f463daee987cacc5e77404d059f8cb
-  React-RuntimeCore: da068ae17054e6fcd2cadb0c44723793c2bf3cfc
-  React-runtimeexecutor: 1275baecfdd7fd2f09576d23bce0bdf450296674
-  React-RuntimeHermes: 58f3601b93b9c11c0a546521483523f5c463d9cd
-  React-runtimescheduler: dbb366238c0b5aeeb89cf6777a8361b0a498d47a
-  React-timing: c301b40b9fc49ebc71d9ef96aa721f9860849f6e
-  React-utils: 6df3ee003c6b13eca3668473048fd840baf822a1
-  React-webperformancenativemodule: 09fb6b2b98b2bb7444207efd92ad1f7ff516cf37
-  ReactAppDependencyProvider: 105856c6da6fe71c545dec3c2466ae04f25f9a73
-  ReactCodegen: 5e38a3fd2ca2e2bd9bd5fabb10746ca162e3639b
-  ReactCommon: 506ceb24983c6b80e0075968be21aac74a367739
-  RNCAsyncStorage: 302f2fac014fd450046c120567ca364632da682b
-  RNCMaskedView: 63268de1986a098b5f4d1fb5b1bc1e97fade0aee
-  RNCPicker: 3fc4d505041318ee8f59662d8d66892ce3c3295c
-  RNDateTimePicker: e9e210197c267461f70f3f47bec705401ff72077
-  RNGestureHandler: 77eecab5fd636666ca73a55bb61e2f1a685b7e84
-  RNReanimated: 31da8d5f1605f5367e2392748ba9f4ba6eaf1178
-  RNScreens: ec8bdc9f024d5828e5adf4f5e8870d5260cff616
-  RNSVG: 8744ec9d5c0ca0f51cdd7a577c30ce01cd3d76b0
-  RNWorklets: 8e934a6b6d5a2710b9250e63a18a2d2f8b875a18
+  React-renderercss: 2544e6683020815d09cfbf603600a0409e1f9331
+  React-rendererdebug: 70b42a0ecef8ffd9831f6ee6df8f60397aa9f61b
+  React-RuntimeApple: fd5c455c7ac22a32f131b339df13e390b882ce81
+  React-RuntimeCore: ee4e4c4971ec9689fd40bc637626bd27a9b0dda0
+  React-runtimeexecutor: 3becd4a1616cc866675399d34ae7c6a15403299a
+  React-RuntimeHermes: a0c83d12d3c5fe341c492fd4035b684f5c16b64f
+  React-runtimescheduler: 0d9e9fe61d0ad5b49677f5fae8524c2823a976df
+  React-timing: 212c29f2a5e49d912d645d55b583779abab13e47
+  React-utils: fe274c1eefca5e3d830aa477793fcbba9b779544
+  React-webperformancenativemodule: 447ed3e2379b7a4bad03162ef6cf6c918ea770ab
+  ReactAppDependencyProvider: fcd4b54f13d868d196f37f077da0ebb0c106ff6f
+  ReactCodegen: 718698af6374bad6a2350b2d0c7d2bc1317c4b08
+  ReactCommon: fad0a491b8dd74829780b8eff7a505035efe263b
+  RNCAsyncStorage: 29f0230e1a25f36c20b05f65e2eb8958d6526e82
+  RNCMaskedView: 5ef8c95cbab95334a32763b72896a7b7d07e6299
+  RNCPicker: bf95ec4b2483e2ab256047130bc536b437cd916c
+  RNDateTimePicker: 97a86d7c8b51f2d51f694a9dddfe5996dfd9a407
+  RNGestureHandler: cd4be101cfa17ea6bbd438710caa02e286a84381
+  RNReanimated: 132940c4c15ca2757f4f7d1fd7c9c3c01dbc4689
+  RNScreens: afaf526a9c804c3b4503f950cf3e67ed81e29ada
+  RNSVG: 595abfa0f9ac26d56afcaaedf4e37a00f54cab71
+  RNWorklets: d9fe4a51421f69ce78bb415a7e0710c15fe61150
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Stripe: 94302932d03430b90a54c04e69d3e0fd5d577088
-  stripe-react-native: 09299eb37b3a36b14aed8b88b5403db85e77680d
+  stripe-react-native: e5a279578c1a1b2ba638a867613b909ea49a4047
   StripeApplePay: 601bfe7cfeb189a746d8b16cd5268ef61eb2b6ca
   StripeCore: b8ed1f6970bfff4c121fbfe23574a696c43606a9
   StripeFinancialConnections: e2493d0e75f4654c08ffcf9d8ad9a16ac4feb079

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -81,7 +81,7 @@
     "react-native-screens": "4.23.0",
     "react-native-view-shot": "4.0.3",
     "react-native-webview": "13.16.0",
-    "react-native-worklets": "0.7.2",
+    "react-native-worklets": "0.7.4",
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",

--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -149,7 +149,7 @@
     "react-native-maps": "1.27.2",
     "react-native-pager-view": "8.0.0",
     "react-native-paper": "^5.12.5",
-    "react-native-worklets": "0.7.2",
+    "react-native-worklets": "0.7.4",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "5.6.2",
     "react-native-svg": "15.15.3",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -103,7 +103,7 @@
   "react-native-keyboard-controller": "1.20.7",
   "react-native-maps": "1.27.2",
   "react-native-pager-view": "8.0.0",
-  "react-native-worklets": "0.7.2",
+  "react-native-worklets": "0.7.4",
   "react-native-reanimated": "4.2.1",
   "react-native-screens": "~4.23.0",
   "react-native-safe-area-context": "~5.6.2",

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -32,7 +32,7 @@
     "react-dom": "19.2.0",
     "react-native": "0.83.5",
     "react-native-gesture-handler": "~2.30.0",
-    "react-native-worklets": "0.7.2",
+    "react-native-worklets": "0.7.4",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",

--- a/templates/expo-template-tabs/package.json
+++ b/templates/expo-template-tabs/package.json
@@ -24,7 +24,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.5",
-    "react-native-worklets": "0.7.2",
+    "react-native-worklets": "0.7.4",
     "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-screens": "~4.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13439,10 +13439,10 @@ react-native-webview@13.16.0:
     escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
-react-native-worklets@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/react-native-worklets/-/react-native-worklets-0.7.2.tgz#acfbfe4f8c7f3b2889e7f394e4fbd7e78e167134"
-  integrity sha512-DuLu1kMV/Uyl9pQHp3hehAlThoLw7Yk2FwRTpzASOmI+cd4845FWn3m2bk9MnjUw8FBRIyhwLqYm2AJaXDXsog==
+react-native-worklets@0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/react-native-worklets/-/react-native-worklets-0.7.4.tgz#6cc1eed31417ced2b007d82bfbd506ac27797de5"
+  integrity sha512-NYOdM1MwBb3n+AtMqy1tFy3Mn8DliQtd8sbzAVRf9Gc+uvQ0zRfxN7dS8ZzoyX7t6cyQL5THuGhlnX+iFlQTag==
   dependencies:
     "@babel/plugin-transform-arrow-functions" "7.27.1"
     "@babel/plugin-transform-class-properties" "7.27.1"


### PR DESCRIPTION
# Why

⚠️ This PR targets the `sdk-55` branch

Currently, there's two versions of `react-native-worklets` when using npm with the base templates: https://github.com/expo/expo/issues/44789

# How

- Bump `react-native-worklets` to `0.7.4`

# Test Plan

- CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
