### PR TITLE
[core][Android] Move Record metadata collection to compile time

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation workletsProject
   }
 
-  implementation("io.github.lukmccall.pika:pika-api:0.1.1-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-api:0.1.2-2.1.20")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation workletsProject
   }
 
-  implementation("io.github.lukmccall.pika:pika-api:0.1.2-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-api:0.1.3-2.1.20")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/FormatterTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/FormatterTest.kt
@@ -5,10 +5,12 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.formatters.formatter
 import org.junit.Test
+import expo.modules.kotlin.types.Introspectable
 
 class FormatterTest {
   @Test
   fun uses_formatter_in_sync_function() {
+    @Introspectable
     class MyRecord(
       @Field val a: String = "a",
       @Field val b: String? = "b",
@@ -49,6 +51,7 @@ class FormatterTest {
 
   @Test
   fun uses_formatter_in_async_function() {
+    @Introspectable
     class MyRecord(
       @Field val a: String = "a",
       @Field val b: String? = "b",

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert
 import org.junit.Test
+import expo.modules.kotlin.types.Introspectable
 
 class JSIAsyncFunctionsTest {
   enum class SimpleEnumClass : Enumerable {
@@ -142,6 +143,7 @@ class JSIAsyncFunctionsTest {
 
   @Test
   fun records_should_be_obtainable_as_function_argument() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       var x: Int = 0

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -15,6 +15,7 @@ import expo.modules.kotlin.typedarray.TypedArray
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.Enumerable
 import org.junit.Test
+import expo.modules.kotlin.types.Introspectable
 
 class JSIFunctionsTest {
   enum class SimpleEnumClass : Enumerable {
@@ -202,6 +203,7 @@ class JSIFunctionsTest {
 
   @Test
   fun records_should_be_obtainable_as_function_argument() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       var x: Int = 0
@@ -571,6 +573,7 @@ class JSIFunctionsTest {
 
   @Test
   fun complex_types_should_be_convertible() {
+    @Introspectable
     data class InlineRecord(@Field var name: String = "") : Record
 
     withSingleModule({

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSISuspendableFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSISuspendableFunctionsTest.kt
@@ -14,6 +14,7 @@ import expo.modules.kotlin.types.Enumerable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert
 import org.junit.Test
+import expo.modules.kotlin.types.Introspectable
 
 class JSISuspendableFunctionsTest {
   enum class SimpleEnumClass : Enumerable {
@@ -142,6 +143,7 @@ class JSISuspendableFunctionsTest {
 
   @Test
   fun records_should_be_obtainable_as_function_argument() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       var x: Int = 0

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/RecordConversionStrategyBenchmarkTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/RecordConversionStrategyBenchmarkTest.kt
@@ -1,0 +1,174 @@
+package expo.modules.kotlin.jni
+
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.IntrospectableRecordConversionStrategy
+import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.records.ReflectionRecordConversionStrategy
+import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.TypeConverterProviderImpl
+import expo.modules.kotlin.types.descriptors.toTypeDescriptor
+import expo.modules.kotlin.types.descriptors.typeDescriptorOf
+import org.junit.Ignore
+import org.junit.Test
+import kotlin.reflect.typeOf
+import kotlin.time.Duration.Companion.nanoseconds
+import kotlin.time.measureTime
+
+@Ignore("Benchmark tests are not run by default. Run manually to compare ReflectionRecordConversionStrategy vs IntrospectableRecordConversionStrategy.")
+class RecordConversionStrategyBenchmarkTest {
+
+  class ReflectionRecord : Record {
+    @Field
+    var id: Int = 0
+
+    @Field
+    var name: String = ""
+
+    @Field
+    var value: Double = 0.0
+
+    @Field
+    var enabled: Boolean = false
+  }
+
+  @Introspectable
+  class IntrospectableRecord : Record {
+    @Field
+    var id: Int = 0
+
+    @Field
+    var name: String = ""
+
+    @Field
+    var value: Double = 0.0
+
+    @Field
+    var enabled: Boolean = false
+  }
+
+  private val sampleMap = mapOf(
+    "id" to 42,
+    "name" to "benchmark",
+    "value" to 3.14,
+    "enabled" to true
+  )
+
+  @Test
+  fun benchmarkCreation() {
+    val numberOfTries = 10
+    val numberOfCreations = 10_000
+
+    var reflectionTotal = 0.nanoseconds
+    var introspectableTotal = 0.nanoseconds
+
+    repeat(numberOfTries) {
+      val reflectionTime = measureTime {
+        repeat(numberOfCreations) {
+          val typeDescriptorForReflection = typeOf<ReflectionRecord>().toTypeDescriptor()
+          ReflectionRecordConversionStrategy<ReflectionRecord>(
+            TypeConverterProviderImpl,
+            typeDescriptorForReflection
+          )
+        }
+      }
+      reflectionTotal += reflectionTime / numberOfCreations
+
+      val introspectableTime = measureTime {
+        repeat(numberOfCreations) {
+          val typeDescriptor = typeDescriptorOf<IntrospectableRecord>()
+          IntrospectableRecordConversionStrategy<IntrospectableRecord>(
+            TypeConverterProviderImpl,
+            typeDescriptor
+          )
+        }
+      }
+      introspectableTotal += introspectableTime / numberOfCreations
+    }
+
+    println("[Creation] ReflectionRecordConversionStrategy avg: ${(reflectionTotal / numberOfTries).inWholeNanoseconds}")
+    println("[Creation] IntrospectableRecordConversionStrategy avg: ${(introspectableTotal / numberOfTries).inWholeNanoseconds}")
+  }
+
+  @Test
+  fun benchmarkConversion() {
+    val numberOfTries = 10
+    val numberOfCalls = 10_000
+
+    // Pre-create strategies (warm up lazy init)
+    val reflectionDescriptor = typeOf<ReflectionRecord>().toTypeDescriptor()
+    val reflectionStrategy = ReflectionRecordConversionStrategy<ReflectionRecord>(
+      TypeConverterProviderImpl,
+      reflectionDescriptor
+    )
+
+    val introspectableDescriptor = typeDescriptorOf<IntrospectableRecord>()
+    val introspectableStrategy = IntrospectableRecordConversionStrategy<IntrospectableRecord>(
+      TypeConverterProviderImpl,
+      introspectableDescriptor
+    )
+
+    // Warm up lazy propertyDescriptors
+    reflectionStrategy.convertFromMap(sampleMap, null, false)
+    introspectableStrategy.convertFromMap(sampleMap, null, false)
+
+    var reflectionTotal = 0.nanoseconds
+    var introspectableTotal = 0.nanoseconds
+
+    repeat(numberOfTries) {
+      val reflectionTime = measureTime {
+        repeat(numberOfCalls) {
+          reflectionStrategy.convertFromMap(sampleMap, null, false)
+        }
+      }
+      reflectionTotal += reflectionTime / numberOfCalls
+
+      val introspectableTime = measureTime {
+        repeat(numberOfCalls) {
+          introspectableStrategy.convertFromMap(sampleMap, null, false)
+        }
+      }
+      introspectableTotal += introspectableTime / numberOfCalls
+    }
+
+    println("[Conversion] ReflectionRecordConversionStrategy avg per call: ${reflectionTotal / numberOfTries}")
+    println("[Conversion] IntrospectableRecordConversionStrategy avg per call: ${introspectableTotal / numberOfTries}")
+  }
+
+  @Test
+  fun benchmarkCreationAndConversion() {
+    val numberOfTries = 10
+    val numberOfCalls = 1_000
+
+    var reflectionTotal = 0.nanoseconds
+    var introspectableTotal = 0.nanoseconds
+
+    repeat(numberOfTries) {
+      val reflectionTime = measureTime {
+        repeat(numberOfCalls) {
+          val typeDescriptor = typeOf<ReflectionRecord>().toTypeDescriptor()
+          val strategy = ReflectionRecordConversionStrategy<ReflectionRecord>(
+            TypeConverterProviderImpl,
+            typeDescriptor
+          )
+          strategy.convertFromMap(sampleMap, null, false)
+        }
+      }
+      reflectionTotal += reflectionTime / numberOfCalls
+
+      val introspectableTime = measureTime {
+        repeat(numberOfCalls) {
+          val typeDescriptor = typeDescriptorOf<IntrospectableRecord>()
+          val strategy = IntrospectableRecordConversionStrategy<IntrospectableRecord>(
+            TypeConverterProviderImpl,
+            typeDescriptor
+          )
+          strategy.convertFromMap(sampleMap, null, false)
+        }
+      }
+      introspectableTotal += introspectableTime / numberOfCalls
+    }
+
+    println("[Creation+Conversion] ReflectionRecordConversionStrategy avg: ${reflectionTotal / numberOfTries}")
+    println("[Creation+Conversion] IntrospectableRecordConversionStrategy avg: ${introspectableTotal / numberOfTries}")
+  }
+}

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/CustomTypeConvertersTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/CustomTypeConvertersTest.kt
@@ -19,7 +19,7 @@ class CustomTypeConvertersTest {
           CustomType()
         }
         .from { string: String ->
-          Truth.assertThat("string").isEqualTo("string")
+          Truth.assertThat(string).isEqualTo("string")
           CustomType()
         }
         .from { listOfNumber: List<Int> ->

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/NullableTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/NullableTypeConversionTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import org.junit.Test
+import expo.modules.kotlin.types.Introspectable
 
 class NullableTypeConversionTest {
   @Test
@@ -77,10 +78,13 @@ class NullableTypeConversionTest {
 
   @Test
   fun should_convert_null_in_deep_nested_structure() {
+    @Introspectable
     class NestedRecord : Record {
       @Field
       var a: Int? = 10
     }
+
+    @Introspectable
     class MyRecord : Record {
       @Field
       val nestedRecord: NestedRecord = NestedRecord()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -116,8 +116,10 @@ internal class MethodNotFoundException :
 internal class NullArgumentException :
   CodedException(message = "Cannot assigned null to not nullable type.")
 
-internal class FieldRequiredException(property: KProperty1<*, *>) :
-  CodedException(message = "Value for field '$property' is required, got nil")
+internal class FieldRequiredException(property: String) :
+  CodedException(message = "Value for field '$property' is required, got nil") {
+  constructor(property: KProperty1<*, *>) : this(property.toString())
+}
 
 @DoNotStrip
 class UnexpectedException(
@@ -217,6 +219,16 @@ internal class FieldCastException private constructor(
     cause: CodedException
   ) : this(
     message = "Cannot cast '${providedType.name}' for field '$fieldName' ('$fieldType').",
+    cause = cause
+  )
+
+  constructor(
+    fieldName: String,
+    fieldType: TypeDescriptor,
+    providedType: Any?,
+    cause: CodedException
+  ) : this(
+    message = "Cannot cast '$providedType' for field '$fieldName' ('$fieldType').",
     cause = cause
   )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -228,7 +228,7 @@ internal class FieldCastException private constructor(
     providedType: Any?,
     cause: CodedException
   ) : this(
-    message = "Cannot cast '$providedType' for field '$fieldName' ('$fieldType').",
+    message = "Cannot cast value for field '$fieldName' ('$fieldType') in record '$providedType'.",
     cause = cause
   )
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CommonExceptions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CommonExceptions.kt
@@ -11,7 +11,7 @@ class Exceptions {
    * An exception to throw when the view with the given tag and class cannot be found.
    */
   class ViewNotFound(
-    viewType: KClass<*>,
+    viewType: Class<*>,
     viewTag: Int
   ) : CodedException(message = "Unable to find the $viewType view with tag $viewTag")
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/functions/AnyFunction.kt
@@ -29,14 +29,14 @@ abstract class AnyFunction(
   internal val takesOwner: Boolean
     get() {
       if (canTakeOwner) {
-        val firstArgumentType = desiredArgsTypes.firstOrNull()?.typeDescriptor?.kClass
+        val firstArgumentType = desiredArgsTypes.firstOrNull()?.typeDescriptor?.jClass
           ?: return false
 
-        if (firstArgumentType == JavaScriptObject::class) {
+        if (firstArgumentType == JavaScriptObject::class.java) {
           return true
         }
 
-        val ownerClass = ownerType?.typeInfo?.kClass ?: return false
+        val ownerClass = ownerType?.typeInfo?.jClass ?: return false
 
         return firstArgumentType == ownerClass
       }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/ExpectedType.kt
@@ -185,22 +185,23 @@ class ExpectedType(
     )
 
     fun fromTypeDescriptor(typeDescriptor: TypeDescriptor): ExpectedType {
-      val kClass = typeDescriptor.kClass
-      when (kClass) {
-        Int::class -> return ExpectedType(SingleType(CppType.INT))
-        Long::class -> return ExpectedType(SingleType(CppType.LONG))
-        Double::class -> return ExpectedType(SingleType(CppType.DOUBLE))
-        Float::class -> return ExpectedType(SingleType(CppType.FLOAT))
-        Boolean::class -> return ExpectedType(SingleType(CppType.BOOLEAN))
-        String::class -> return ExpectedType(SingleType(CppType.STRING))
+      val jClass = typeDescriptor.jClass
+      @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+      when (jClass) {
+        Int::class.java, java.lang.Integer::class.java -> return ExpectedType(SingleType(CppType.INT))
+        Long::class.java, java.lang.Long::class.java -> return ExpectedType(SingleType(CppType.LONG))
+        Double::class.java, java.lang.Double::class.java -> return ExpectedType(SingleType(CppType.DOUBLE))
+        Float::class.java, java.lang.Float::class.java -> return ExpectedType(SingleType(CppType.FLOAT))
+        Boolean::class.java, java.lang.Boolean::class.java -> return ExpectedType(SingleType(CppType.BOOLEAN))
+        String::class.java -> return ExpectedType(SingleType(CppType.STRING))
       }
-      if (kClass.java.isAssignableFrom(List::class.java)) {
+      if (jClass.isAssignableFrom(List::class.java)) {
         val argType = typeDescriptor.params.firstOrNull()
         if (argType != null) {
           return forList(fromTypeDescriptor(argType))
         }
       }
-      if (kClass.java.isAssignableFrom(Map::class.java)) {
+      if (jClass.isAssignableFrom(Map::class.java)) {
         val argType = typeDescriptor.params.getOrNull(1)
         if (argType != null) {
           return forMap(fromTypeDescriptor(argType))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/JSIContext.kt
@@ -85,7 +85,7 @@ class JSIContext @DoNotStrip internal constructor(
     val classDefinition = appContext.registry
       .asSequence()
       .flatMap { it.definition.classData }
-      .firstOrNull { it.constructor.ownerType?.kClass?.java == nativeClass }
+      .firstOrNull { it.constructor.ownerType?.jClass == nativeClass }
       ?: return null
 
     val decorator = JSDecoratorsBridgingObject(runtime.deallocator)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject.kt
@@ -187,7 +187,7 @@ class JSDecoratorsBridgingObject(jniDeallocator: JNIDeallocator) : Destructible 
       }
 
       val constructor = constructor
-      val ownerClass = constructor.ownerType?.kClass?.java
+      val ownerClass = constructor.ownerType?.jClass
 
       registerClass(
         name,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleConvertersBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/modules/ModuleConvertersBuilder.kt
@@ -49,7 +49,7 @@ class ModuleConvertersBuilder {
 
       private fun findNonNullableTypeConverter(typeDescriptor: TypeDescriptor): TypeConverter<*>? {
         return converters.find { (converterType, _) ->
-          converterType.kClass == typeDescriptor.kClass && converterType.params == typeDescriptor.params
+          converterType.jClass == typeDescriptor.jClass && converterType.params == typeDescriptor.params
         }?.second
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.records
 
+import android.util.Log
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableMap
 import expo.modules.kotlin.AppContext
@@ -18,7 +19,9 @@ import expo.modules.kotlin.types.TypeConverter
 import expo.modules.kotlin.types.TypeConverterProvider
 import expo.modules.kotlin.types.TypeConverterProviderImpl
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
+import expo.modules.kotlin.types.descriptors.toRawTypeDescriptor
 import expo.modules.kotlin.types.descriptors.toTypeDescriptor
+import io.github.lukmccall.pika.PIntrospectionData
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.full.findAnnotation
@@ -26,13 +29,37 @@ import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaField
 import kotlin.reflect.typeOf
 
-class RecordTypeConverter<T : Record>(
-  private val converterProvider: TypeConverterProvider,
-  val typeDescriptor: TypeDescriptor
-) : DynamicAwareTypeConverters<T>() {
+abstract class RecordConversionStrategy<T : Record>(
+  protected val converterProvider: TypeConverterProvider,
+  protected val typeDescriptor: TypeDescriptor
+) {
   private val objectConstructorFactory = ObjectConstructorFactory()
+
+  protected fun <T : Any> getObjectConstructor(clazz: KClass<T>): ObjectConstructor<T> {
+    return objectConstructorFactory.get(clazz)
+  }
+
+  abstract fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): T
+  abstract fun convertFromMap(map: Map<String, Any?>, context: AppContext?, forceConversion: Boolean): T
+}
+
+class ReflectionRecordConversionStrategy<T : Record>(
+  converterProvider: TypeConverterProvider,
+  typeDescriptor: TypeDescriptor
+) : RecordConversionStrategy<T>(
+  converterProvider,
+  typeDescriptor
+) {
+  private data class PropertyDescriptor(
+    val typeConverter: TypeConverter<*>,
+    val fieldAnnotation: Field,
+    val isRequired: Boolean
+  )
+
   private val propertyDescriptors: Map<KProperty1<out Any, *>, PropertyDescriptor> by lazy {
-    typeDescriptor.kClass
+    typeDescriptor
+      .jClass
+      .kotlin
       .memberProperties
       .mapNotNull { property ->
         val fieldAnnotation = property.findAnnotation<Field>() ?: return@mapNotNull null
@@ -49,32 +76,8 @@ class RecordTypeConverter<T : Record>(
       .toMap()
   }
 
-  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T =
-    exceptionDecorator({ cause -> RecordCastException(typeDescriptor, cause) }) {
-      val jsMap = value.asMap() ?: throw DynamicCastException(ReadableMap::class)
-      return@exceptionDecorator convertFromReadableMap(jsMap, context, forceConversion)
-    }
-
-  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): T {
-    if (value is ReadableMap) {
-      return convertFromReadableMap(value, context, forceConversion)
-    }
-
-    if (value is Map<*, *>) {
-      @Suppress("UNCHECKED_CAST")
-      return convertFromMap(value as Map<String, Any?>, context, forceConversion)
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    return value as T
-  }
-
-  override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.READABLE_MAP)
-
-  override fun isTrivial(): Boolean = false
-
-  private fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): T {
-    val kClass = typeDescriptor.kClass
+  override fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): T {
+    val kClass = typeDescriptor.jClass.kotlin
     val instance = getObjectConstructor(kClass).construct()
 
     propertyDescriptors
@@ -105,8 +108,8 @@ class RecordTypeConverter<T : Record>(
     return instance as T
   }
 
-  internal fun convertFromMap(map: Map<String, Any?>, context: AppContext? = null, forceConversion: Boolean = false): T {
-    val kClass = typeDescriptor.kClass
+  override fun convertFromMap(map: Map<String, Any?>, context: AppContext?, forceConversion: Boolean): T {
+    val kClass = typeDescriptor.jClass.kotlin
     val instance = getObjectConstructor(kClass).construct()
 
     propertyDescriptors
@@ -147,16 +150,163 @@ class RecordTypeConverter<T : Record>(
     @Suppress("UNCHECKED_CAST")
     return instance as T
   }
+}
 
-  private fun <T : Any> getObjectConstructor(clazz: KClass<T>): ObjectConstructor<T> {
-    return objectConstructorFactory.get(clazz)
-  }
+class IntrospectableRecordConversionStrategy<T : Record>(
+  converterProvider: TypeConverterProvider,
+  typeDescriptor: TypeDescriptor
+) : RecordConversionStrategy<T>(
+  converterProvider,
+  typeDescriptor
+) {
+  val introspectableData: PIntrospectionData<*>
+    get() = requireNotNull(typeDescriptor.typeInfo.introspection) {
+      "Introspectable data is required for IntrospectableRecordConversionStrategy"
+    }
 
   private data class PropertyDescriptor(
+    val key: String,
+    val typeDescriptor: TypeDescriptor,
+    val setter: (Any, Any?) -> Unit,
     val typeConverter: TypeConverter<*>,
-    val fieldAnnotation: Field,
     val isRequired: Boolean
   )
+
+  private val propertyDescriptors by lazy {
+    introspectableData
+      .properties
+      .mapNotNull { property ->
+        val fieldAnnotation = property
+          .annotations
+          .firstOrNull { annotation -> annotation.jClass == Field::class.java }
+          ?: return@mapNotNull null
+
+        val propertyName = fieldAnnotation
+          .arguments
+          .getOrDefault("key", property.name) as String
+
+        val isRequired = property
+          .annotations
+          .any { annotation -> annotation.jClass == Required::class.java }
+
+        val propertyRawTypeDescriptor = property.type.toRawTypeDescriptor()
+        val propertyTypeDescriptor = TypeDescriptor(
+          propertyRawTypeDescriptor,
+          kTypeProvider = { error("CT type can't be obtain as KType") }
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        PropertyDescriptor(
+          key = propertyName,
+          typeDescriptor = propertyTypeDescriptor,
+          setter = property.setter as (Any, Any?) -> Unit,
+          typeConverter = converterProvider.obtainTypeConverter(propertyTypeDescriptor),
+          isRequired = isRequired
+        )
+      }
+  }
+
+  override fun convertFromReadableMap(jsMap: ReadableMap, context: AppContext?, forceConversion: Boolean): T {
+    val kClass = typeDescriptor.jClass.kotlin
+    val instance = getObjectConstructor(kClass).construct()
+
+    propertyDescriptors.forEach { property ->
+      val key = property.key
+
+      if (!jsMap.hasKey(key)) {
+        if (property.isRequired) {
+          throw FieldRequiredException(key)
+        }
+
+        return@forEach
+      }
+
+      jsMap.getDynamic(key).recycle {
+        val casted = exceptionDecorator({ cause -> FieldCastException(property.key, property.typeDescriptor, typeDescriptor, cause) }) {
+          property.typeConverter.convert(this, context, forceConversion)
+        }
+
+        property.setter(instance, casted)
+      }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return instance as T
+  }
+
+  override fun convertFromMap(map: Map<String, Any?>, context: AppContext?, forceConversion: Boolean): T {
+    val kClass = typeDescriptor.jClass.kotlin
+    val instance = getObjectConstructor(kClass).construct()
+
+    propertyDescriptors.forEach { property ->
+      val key = property.key
+      if (!map.containsKey(key)) {
+        if (property.isRequired) {
+          throw FieldRequiredException(key)
+        }
+        return@forEach
+      }
+
+      val rawValue = map[key]
+      // Normalize numeric types since JS numbers come as Double in Kotlin Maps
+      val value = if (rawValue is Number) {
+        when (property.typeDescriptor.jClass) {
+          Int::class.java -> rawValue.toInt()
+          Long::class.java -> rawValue.toLong()
+          Float::class.java -> rawValue.toFloat()
+          Double::class.java -> rawValue.toDouble()
+          else -> rawValue
+        }
+      } else {
+        rawValue
+      }
+
+      val casted = exceptionDecorator({ cause -> FieldCastException(property.key, property.typeDescriptor, value, cause) }) {
+        property.typeConverter.convert(value, context, forceConversion)
+      }
+
+      property.setter(instance, casted)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return instance as T
+  }
+}
+
+class RecordTypeConverter<T : Record>(
+  converterProvider: TypeConverterProvider,
+  val typeDescriptor: TypeDescriptor
+) : DynamicAwareTypeConverters<T>() {
+  internal val conversionStrategy: RecordConversionStrategy<T> = if (typeDescriptor.typeInfo.introspection != null) {
+    IntrospectableRecordConversionStrategy(converterProvider, typeDescriptor)
+  } else {
+    Log.w("ExpoModulesCore", "Introspectable data is missing for ${typeDescriptor.jClass}. Falling back to reflection-based conversion, which may have performance implications. To fix this, ensure that the Record class is properly annotated with expo.modules.kotlin.types.Introspectable and that the necessary metadata is available at runtime.")
+    ReflectionRecordConversionStrategy(converterProvider, typeDescriptor)
+  }
+
+  override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): T =
+    exceptionDecorator({ cause -> RecordCastException(typeDescriptor, cause) }) {
+      val jsMap = value.asMap() ?: throw DynamicCastException(ReadableMap::class)
+      return@exceptionDecorator conversionStrategy.convertFromReadableMap(jsMap, context, forceConversion)
+    }
+
+  override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): T {
+    if (value is ReadableMap) {
+      return conversionStrategy.convertFromReadableMap(value, context, forceConversion)
+    }
+
+    if (value is Map<*, *>) {
+      @Suppress("UNCHECKED_CAST")
+      return conversionStrategy.convertFromMap(value as Map<String, Any?>, context, forceConversion)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return value as T
+  }
+
+  override fun getCppRequiredTypes(): ExpectedType = ExpectedType(CppType.READABLE_MAP)
+
+  override fun isTrivial(): Boolean = false
 }
 
 /**
@@ -174,7 +324,7 @@ class RecordTypeConverter<T : Record>(
  */
 @PublishedApi
 internal fun <T : Record> recordFromMap(map: Map<String, Any?>, converter: RecordTypeConverter<T>): T {
-  return converter.convertFromMap(map)
+  return converter.conversionStrategy.convertFromMap(map, null, forceConversion = false)
 }
 
 inline fun <reified T : Record> recordFromMap(map: Map<String, Any?>): T {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -42,7 +42,8 @@ class SharedRefTypeConverter<T : SharedRef<*>>(
   private val sharedObjectTypeConverter = SharedObjectTypeConverter<T>(typeDescriptor)
 
   val sharedRefType: KType? by lazy {
-    var currentClass: KClass<*>? = typeDescriptor.kClass
+    // TODO(@lukmccall): Remove KType and KClass usage
+    var currentClass: KClass<*>? = typeDescriptor.jClass.kotlin
     var currentType: KType? = typeDescriptor.kType
     while (currentClass != null) {
       if (currentClass == SharedRef::class) {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/SavableTrait.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/SavableTrait.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.weak
 import java.io.File
 import java.util.UUID
 import kotlin.reflect.KClass
+import expo.modules.kotlin.types.Introspectable
 
 class SavableTrait<InputType> @PublishedApi internal constructor(
   val exportImpl: (AppContext) -> ObjectDefinitionData
@@ -18,6 +19,7 @@ class SavableTrait<InputType> @PublishedApi internal constructor(
   override fun export(appContext: AppContext) = exportImpl(appContext)
 
   companion object {
+    @Introspectable
     data class SavableBitmapOptions(
       val compression: Int = 100
     ) : Record

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/AnyType.kt
@@ -40,6 +40,6 @@ class AnyType(
 }
 
 inline fun <reified T> AnyType.inheritFrom(): Boolean {
-  val jClass = typeDescriptor.kClass.java
+  val jClass = typeDescriptor.jClass
   return T::class.java.isAssignableFrom(jClass)
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -65,7 +65,7 @@ class ArrayTypeConverter(
   @Suppress("UNCHECKED_CAST")
   private fun createTypedArray(size: Int): Array<Any?> {
     return java.lang.reflect.Array.newInstance(
-      (arrayType.params.first().kClass).java,
+      arrayType.params.first().jClass,
       size
     ) as Array<Any?>
   }
@@ -77,7 +77,7 @@ class ArrayTypeConverter(
 }
 
 internal fun isPrimitiveArray(typeDescriptor: TypeDescriptor): Boolean {
-  return when (typeDescriptor.kClass.java) {
+  return when (typeDescriptor.jClass) {
     BooleanArray::class.java,
     ByteArray::class.java,
     CharArray::class.java,

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Introspectable.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Introspectable.kt
@@ -1,0 +1,5 @@
+package expo.modules.kotlin.types
+
+import io.github.lukmccall.pika.Introspectable as PikaIntrospectable
+
+typealias Introspectable = PikaIntrospectable

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -116,6 +116,7 @@ interface JSTypeConverter<T> {
       get() = ReturnType.UNKNOWN // TODO(@lukmccall): Define proper ReturnType for Enums
   }
 
+  @Introspectable
   class RecordConverter : JSTypeConverter<Record> {
     override fun convertToJS(value: Any?): Any? {
       enforceType<Record?>(value)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/MapTypeConverter.kt
@@ -16,7 +16,7 @@ class MapTypeConverter(
   private val mapType: TypeDescriptor
 ) : DynamicAwareTypeConverters<Map<*, *>>() {
   init {
-    require(mapType.params.first().kClass == String::class) {
+    require(mapType.params.first().jClass == String::class.java) {
       "The map key type should be String, but received ${mapType.params.first()}."
     }
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
@@ -45,7 +45,7 @@ class TypeConverterCollection<Type : Any>(
   override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): Type {
     val possibleConverters = converters
       .map { (key, converter) -> key to converter }
-      .filter { (key, _) -> key.kClass.isInstance(value) }
+      .filter { (key, _) -> key.jClass.isInstance(value) }
 
     if (possibleConverters.isEmpty()) {
       // We don't have a converter for Dynamic, but we can try to convert it to ExpoDynamic

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -84,13 +84,13 @@ object TypeConverterProviderImpl : TypeConverterProvider {
   private val cachedConverters = createCachedConverters()
   private val cachedPrimitiveArrayConverters = createCachedPrimitiveArrayConverters()
 
-  private val cachedRecordConverters = mutableMapOf<KType, TypeConverter<*>>()
+  private val cachedRecordConverters = mutableMapOf<Class<*>, TypeConverter<*>>()
 
   private fun getCachedConverter(inputType: TypeDescriptor): TypeConverter<*>? {
-    return cachedConverters[inputType.kClass]
+    return cachedConverters[inputType.jClass]
   }
   private fun getCachedPrimitiveArrayConverter(typeDescriptor: TypeDescriptor): TypeConverter<*>? {
-    return cachedPrimitiveArrayConverters[typeDescriptor.kClass]
+    return cachedPrimitiveArrayConverters[typeDescriptor.jClass]
   }
 
   override fun obtainTypeConverter(typeDescriptor: TypeDescriptor): TypeConverter<*> {
@@ -107,8 +107,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
       return it
     }
 
-    val kClass = typeDescriptor.kClass
-    val jClass = kClass.java
+    val jClass = typeDescriptor.jClass
 
     if (jClass.isArray || Array::class.java.isAssignableFrom(jClass)) {
       return if (isPrimitiveArray(typeDescriptor)) {
@@ -136,17 +135,17 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
     if (jClass.isEnum) {
       @Suppress("UNCHECKED_CAST")
-      return EnumTypeConverter(kClass as KClass<Enum<*>>)
+      return EnumTypeConverter(jClass.kotlin as KClass<Enum<*>>)
     }
 
-    val cachedConverter = cachedRecordConverters[typeDescriptor.kType]
+    val cachedConverter = cachedRecordConverters[jClass]
     if (cachedConverter != null) {
       return cachedConverter
     }
 
     if (Record::class.java.isAssignableFrom(jClass)) {
       val converter = RecordTypeConverter<Record>(this, typeDescriptor)
-      cachedRecordConverters[typeDescriptor.kType] = converter
+      cachedRecordConverters[jClass] = converter
       return converter
     }
 
@@ -175,7 +174,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
   }
 
   private fun handelEither(typeDescriptor: TypeDescriptor): TypeConverter<*>? {
-    val jClass = typeDescriptor.kClass.java
+    val jClass = typeDescriptor.jClass
     if (Either::class.java.isAssignableFrom(jClass)) {
       if (EitherOfFour::class.java.isAssignableFrom(jClass)) {
         return EitherOfFourTypeConverter<Any, Any, Any, Any>(this, typeDescriptor)
@@ -189,7 +188,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
     return null
   }
 
-  private fun createCachedConverters(): Map<KClass<*>, TypeConverter<*>> {
+  private fun createCachedConverters(): Map<Class<*>, TypeConverter<*>> {
     val intTypeConverter = createTrivialTypeConverter(
       ExpectedType(CppType.INT)
     ) { it.asDouble().toInt() }
@@ -208,95 +207,96 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
     val serializableTypeConverter = SerializableTypeConverter()
 
+    @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     val converters = mapOf(
-      Int::class to intTypeConverter,
-      java.lang.Integer::class to intTypeConverter,
+      Int::class.java to intTypeConverter,
+      java.lang.Integer::class.java to intTypeConverter,
 
-      Long::class to longTypeConverter,
-      java.lang.Long::class to longTypeConverter,
+      Long::class.java to longTypeConverter,
+      java.lang.Long::class.java to longTypeConverter,
 
-      Double::class to doubleTypeConverter,
-      java.lang.Double::class to doubleTypeConverter,
+      Double::class.java to doubleTypeConverter,
+      java.lang.Double::class.java to doubleTypeConverter,
 
-      Float::class to floatTypeConverter,
-      java.lang.Float::class to floatTypeConverter,
+      Float::class.java to floatTypeConverter,
+      java.lang.Float::class.java to floatTypeConverter,
 
-      Boolean::class to boolTypeConverter,
-      java.lang.Boolean::class to boolTypeConverter,
+      Boolean::class.java to boolTypeConverter,
+      java.lang.Boolean::class.java to boolTypeConverter,
 
-      String::class to createTrivialTypeConverter(
+      String::class.java to createTrivialTypeConverter(
         ExpectedType(CppType.STRING)
       ) { it.asString() ?: throw DynamicCastException(String::class) },
 
-      ReadableArray::class to createTrivialTypeConverter(
+      ReadableArray::class.java to createTrivialTypeConverter(
         ExpectedType(CppType.READABLE_ARRAY)
       ) { it.asArray() ?: throw DynamicCastException(ReadableArray::class) },
-      ReadableMap::class to createTrivialTypeConverter(
+      ReadableMap::class.java to createTrivialTypeConverter(
         ExpectedType(CppType.READABLE_MAP)
       ) { it.asMap() ?: throw DynamicCastException(ReadableMap::class) },
 
-      ByteArray::class to ByteArrayTypeConverter(),
+      ByteArray::class.java to ByteArrayTypeConverter(),
 
-      JavaScriptValue::class to createTrivialTypeConverter(
+      JavaScriptValue::class.java to createTrivialTypeConverter(
         ExpectedType(CppType.JS_VALUE)
       ),
-      JavaScriptObject::class to createTrivialTypeConverter(
+      JavaScriptObject::class.java to createTrivialTypeConverter(
         ExpectedType(CppType.JS_OBJECT)
       ),
-      JavaScriptArrayBuffer::class to createTrivialTypeConverter(
+      JavaScriptArrayBuffer::class.java to createTrivialTypeConverter(
         ExpectedType(CppType.JS_ARRAY_BUFFER)
       ),
-      NativeArrayBuffer::class to createTrivialTypeConverter(
+      NativeArrayBuffer::class.java to createTrivialTypeConverter(
         ExpectedType(CppType.NATIVE_ARRAY_BUFFER)
       ),
 
-      Serializable::class to serializableTypeConverter,
-      Worklet::class to WorkletTypeConverter(serializableTypeConverter),
+      Serializable::class.java to serializableTypeConverter,
+      Worklet::class.java to WorkletTypeConverter(serializableTypeConverter),
 
-      Int8Array::class to Int8ArrayTypeConverter(),
-      Int16Array::class to Int16ArrayTypeConverter(),
-      Int32Array::class to Int32ArrayTypeConverter(),
-      Uint8Array::class to Uint8ArrayTypeConverter(),
-      Uint8ClampedArray::class to Uint8ClampedArrayTypeConverter(),
-      Uint16Array::class to Uint16ArrayTypeConverter(),
-      Uint32Array::class to Uint32ArrayTypeConverter(),
-      Float32Array::class to Float32ArrayTypeConverter(),
-      Float64Array::class to Float64ArrayTypeConverter(),
-      BigInt64Array::class to BigInt64ArrayTypeConverter(),
-      BigUint64Array::class to BigUint64ArrayTypeConverter(),
-      TypedArray::class to TypedArrayTypeConverter(),
+      Int8Array::class.java to Int8ArrayTypeConverter(),
+      Int16Array::class.java to Int16ArrayTypeConverter(),
+      Int32Array::class.java to Int32ArrayTypeConverter(),
+      Uint8Array::class.java to Uint8ArrayTypeConverter(),
+      Uint8ClampedArray::class.java to Uint8ClampedArrayTypeConverter(),
+      Uint16Array::class.java to Uint16ArrayTypeConverter(),
+      Uint32Array::class.java to Uint32ArrayTypeConverter(),
+      Float32Array::class.java to Float32ArrayTypeConverter(),
+      Float64Array::class.java to Float64ArrayTypeConverter(),
+      BigInt64Array::class.java to BigInt64ArrayTypeConverter(),
+      BigUint64Array::class.java to BigUint64ArrayTypeConverter(),
+      TypedArray::class.java to TypedArrayTypeConverter(),
 
-      URL::class to URLTypConverter(),
-      Uri::class to UriTypeConverter(),
-      URI::class to JavaURITypeConverter(),
+      URL::class.java to URLTypConverter(),
+      Uri::class.java to UriTypeConverter(),
+      URI::class.java to JavaURITypeConverter(),
 
-      File::class to FileTypeConverter(),
+      File::class.java to FileTypeConverter(),
 
-      Duration::class to DurationTypeConverter(),
+      Duration::class.java to DurationTypeConverter(),
 
-      Any::class to AnyTypeConverter(),
+      Any::class.java to AnyTypeConverter(),
 
       // Unit converter doesn't care about nullability.
       // It will always return Unit
-      Unit::class to UnitTypeConverter(),
+      Unit::class.java to UnitTypeConverter(),
 
-      ReadableArguments::class to ReadableArgumentsTypeConverter()
+      ReadableArguments::class.java to ReadableArgumentsTypeConverter()
     )
 
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
       return converters + mapOf(
-        Path::class to PathTypeConverter(),
-        Color::class to ColorTypeConverter(),
-        LocalDate::class to DateTypeConverter()
+        Path::class.java to PathTypeConverter(),
+        Color::class.java to ColorTypeConverter(),
+        LocalDate::class.java to DateTypeConverter()
       )
     }
 
     return converters
   }
 
-  private fun createCachedPrimitiveArrayConverters(): Map<KClass<*>, TypeConverter<*>> {
+  private fun createCachedPrimitiveArrayConverters(): Map<Class<*>, TypeConverter<*>> {
     return mapOf(
-      IntArray::class to createTrivialTypeConverter(
+      IntArray::class.java to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.INT)
       ) {
         val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
@@ -304,7 +304,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
           jsArray.getInt(index)
         }
       },
-      LongArray::class to createTrivialTypeConverter(
+      LongArray::class.java to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.LONG)
       ) {
         val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
@@ -312,7 +312,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
           jsArray.getDouble(index).toLong()
         }
       },
-      DoubleArray::class to createTrivialTypeConverter(
+      DoubleArray::class.java to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.DOUBLE)
       ) {
         val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
@@ -320,7 +320,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
           jsArray.getDouble(index)
         }
       },
-      FloatArray::class to createTrivialTypeConverter(
+      FloatArray::class.java to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.FLOAT)
       ) {
         val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)
@@ -328,7 +328,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
           jsArray.getDouble(index).toFloat()
         }
       },
-      BooleanArray::class to createTrivialTypeConverter(
+      BooleanArray::class.java to createTrivialTypeConverter(
         ExpectedType.forPrimitiveArray(CppType.BOOLEAN)
       ) {
         val jsArray = it.asArray() ?: throw DynamicCastException(ReadableArray::class)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/TypeDescriptor.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/TypeDescriptor.kt
@@ -1,20 +1,24 @@
 package expo.modules.kotlin.types.descriptors
 
+import io.github.lukmccall.pika.PIntrospectionData
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 
 sealed interface RawTypeDescriptor {
-  val kClass: KClass<*>
+  val jClass: Class<*>
   val isNullable: Boolean
+  val introspection: PIntrospectionData<*>?
 
   data class Simple(
-    override val kClass: KClass<*>,
-    override val isNullable: Boolean
+    override val jClass: Class<*>,
+    override val isNullable: Boolean,
+    override val introspection: PIntrospectionData<*>?
   ) : RawTypeDescriptor
 
   data class Parameterized(
-    override val kClass: KClass<*>,
+    override val jClass: Class<*>,
     override val isNullable: Boolean,
+    override val introspection: PIntrospectionData<*>?,
     val params: List<RawTypeDescriptor>
   ) : RawTypeDescriptor
 }
@@ -35,8 +39,8 @@ class TypeDescriptor(
   inline val isNullable: Boolean
     get() = typeInfo.isNullable
 
-  inline val kClass: KClass<*>
-    get() = typeInfo.kClass
+  inline val jClass: Class<*>
+    get() = typeInfo.jClass
 
   inline val params: List<TypeDescriptor>
     get() = when (typeInfo) {
@@ -55,7 +59,7 @@ class TypeDescriptor(
     } else {
       ""
     }
-    return "$kClass$paramsString${if (isNullable) "?" else ""}"
+    return "$jClass$paramsString${if (isNullable) "?" else ""}"
   }
 }
 
@@ -69,9 +73,9 @@ fun KType.toTypeDescriptor(): TypeDescriptor {
   }
 
   val rawTypeDescriptor = if (params.isEmpty()) {
-    RawTypeDescriptor.Simple(classifier, isNullable)
+    RawTypeDescriptor.Simple(classifier.java, isNullable, null)
   } else {
-    RawTypeDescriptor.Parameterized(classifier, isNullable, params.map { it.typeInfo })
+    RawTypeDescriptor.Parameterized(classifier.java, isNullable, null, params.map { it.typeInfo })
   }
 
   return TypeDescriptor(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/typeDescriptorOf.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/typeDescriptorOf.kt
@@ -2,8 +2,8 @@ package expo.modules.kotlin.types.descriptors
 
 import android.util.Log
 import io.github.lukmccall.pika.PTypeDescriptor
-import io.github.lukmccall.pika.pTypeDescriptorOf
 import kotlin.reflect.typeOf
+import io.github.lukmccall.pika.typeDescriptorOf as pikaTypeDescriptorOf
 
 @PublishedApi
 internal fun PTypeDescriptor.toRawTypeDescriptor(): RawTypeDescriptor {
@@ -11,14 +11,16 @@ internal fun PTypeDescriptor.toRawTypeDescriptor(): RawTypeDescriptor {
     is PTypeDescriptor.Concrete -> {
       if (this is PTypeDescriptor.Concrete.Parameterized) {
         RawTypeDescriptor.Parameterized(
-          pType.kClass,
+          pType.jClass,
           isNullable,
-          argumentsPTypes.map { it.toRawTypeDescriptor() }
+          introspection,
+          parameters.map { it.toRawTypeDescriptor() }
         )
       } else {
         RawTypeDescriptor.Simple(
-          pType.kClass,
-          isNullable
+          pType.jClass,
+          isNullable,
+          introspection
         )
       }
     }
@@ -28,15 +30,18 @@ internal fun PTypeDescriptor.toRawTypeDescriptor(): RawTypeDescriptor {
 }
 
 @PublishedApi
-internal inline fun <reified T> cpTypeDescriptorOf(): TypeDescriptor {
+internal inline fun <reified T> ctTypeDescriptorOf(): TypeDescriptor {
+  val typeDescriptor = pikaTypeDescriptorOf<T>().toRawTypeDescriptor()
+  val kTypeProvider = { typeOf<T>() }
+
   return TypeDescriptor(
-    typeInfo = pTypeDescriptorOf<T>().toRawTypeDescriptor(),
-    kTypeProvider = { typeOf<T>() }
+    typeDescriptor,
+    kTypeProvider
   )
 }
 
 inline fun <reified T> typeDescriptorOf(): TypeDescriptor {
-  val typeDescriptor = runCatching { cpTypeDescriptorOf<T>() }
+  val typeDescriptor = runCatching { ctTypeDescriptorOf<T>() }
     .onFailure {
       Log.e("ExpoModulesCore", "Failed to get type info for ${T::class.java.name}", it)
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/GroupViewManagerWrapper.kt
@@ -48,7 +48,7 @@ class GroupViewManagerWrapper(
   override fun getNativeProps(): MutableMap<String, String> {
     val props = super.getNativeProps()
     viewWrapperDelegate.props.forEach { (key, prop) ->
-      props[key] = prop.type.typeDescriptor.kClass.toString()
+      props[key] = prop.type.typeDescriptor.jClass.toString()
     }
     return props
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/SimpleViewManagerWrapper.kt
@@ -46,7 +46,7 @@ class SimpleViewManagerWrapper(
   override fun getNativeProps(): MutableMap<String, String> {
     val props = super.getNativeProps()
     viewWrapperDelegate.props.forEach { (key, prop) ->
-      props[key] = prop.type.typeDescriptor.kClass.toString()
+      props[key] = prop.type.typeDescriptor.jClass.toString()
     }
     return props
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/ViewTypeConverter.kt
@@ -18,7 +18,7 @@ class ViewTypeConverter<T : View>(
 
     val viewTag = value as Int
     val view = appContext.findView<T>(viewTag)
-      ?: throw Exceptions.ViewNotFound(typeDescriptor.kClass, viewTag)
+      ?: throw Exceptions.ViewNotFound(typeDescriptor.jClass, viewTag)
 
     return view
   }

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -143,7 +143,7 @@ class KotlinInteropModuleRegistryTest {
       ) to """
         Call to function 'test-1.f2' has been rejected.
         → Caused by: The 1st argument cannot be cast to type class expo.modules.kotlin.TestRecord (received class com.facebook.react.bridge.JavaOnlyMap)
-        → Caused by: Cannot cast value for field 'string' ('kotlin.String') in record 'class expo.modules.kotlin.TestRecord'.
+        → Caused by: Cannot cast value for field 'string' ('class java.lang.String') in record 'class expo.modules.kotlin.TestRecord'.
         → Caused by: java.lang.ClassCastException: class java.lang.Double cannot be cast to class java.lang.String (java.lang.Double and java.lang.String are in module java.base of loader 'bootstrap')
       """.trimIndent()
     )

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -17,9 +17,11 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.lang.ref.WeakReference
+import expo.modules.kotlin.types.Introspectable
 
 private class TestException : CodedException("Something went wrong")
 
+@Introspectable
 private class TestRecord : Record {
   @Field
   lateinit var string: String

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -62,7 +62,7 @@ class AnyFunctionTest {
 
     assertThrows<ArgumentCastException>(
       """
-      The 1st argument cannot be cast to type class kotlin.Int (received class java.lang.String)
+      The 1st argument cannot be cast to type class java.lang.Integer (received class java.lang.String)
       → Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer (java.lang.String and java.lang.Integer are in module java.base of loader 'bootstrap')
       """.trimIndent()
     ) {

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
@@ -9,10 +9,12 @@ import expo.modules.kotlin.EnumWithString
 import expo.modules.kotlin.EnumWithoutParameter
 import expo.modules.kotlin.types.convert
 import org.junit.Test
+import expo.modules.kotlin.types.Introspectable
 
 class RecordTypeConverterTest {
   @Test
   fun `should convert map to mutable record`() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       var int: Int = 0
@@ -36,6 +38,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should convert map to immutable record`() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       val int: Int = 0
@@ -59,6 +62,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should convert map to lateinit record`() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       lateinit var string: String
@@ -77,6 +81,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should convert map to mixed record`() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       val int: Int = 0
@@ -105,6 +110,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should respect required annotation`() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       @Required
@@ -119,6 +125,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should respect custom js key`() {
+    @Introspectable
     class MyRecord : Record {
       @Field(key = "point1")
       val int: Int = 0
@@ -147,6 +154,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should respect non required value`() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       val required: Int = 10
@@ -173,6 +181,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `primary constructor default values shouldn't be ignored if using the 'shorthand' class syntax`() {
+    @Introspectable
     class MyRecord(
       @Field
       val int: Int = 42,
@@ -195,6 +204,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should work with complex types`() {
+    @Introspectable
     class InnerRecord : Record {
       @Field
       lateinit var name: String
@@ -213,6 +223,7 @@ class RecordTypeConverterTest {
       }
     }
 
+    @Introspectable
     class MyRecord : Record {
       @Field
       lateinit var points: List<Double>
@@ -248,6 +259,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should work with enums`() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       lateinit var enumWithoutParameter: EnumWithoutParameter

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/formatters/FormatterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/formatters/FormatterTest.kt
@@ -5,8 +5,10 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.toJSValueExperimental
 import org.junit.Test
+import expo.modules.kotlin.types.Introspectable
 
 class FormatterTest {
+  @Introspectable
   class MyRecord(
     @Field val a: String = "a",
     @Field val b: String? = "b",
@@ -73,11 +75,13 @@ class FormatterTest {
 
   @Test
   fun `nested record`() {
+    @Introspectable
     class NestedRecord(
       @Field val a: String = "a",
       @Field val b: String = "b"
     ) : Record
 
+    @Introspectable
     class MyRecordWithNested(
       @Field val nested: NestedRecord = NestedRecord()
     ) : Record

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/JSTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/JSTypeConverterTest.kt
@@ -126,6 +126,7 @@ class JSTypeConverterTest {
   @Test
   fun `should convert Record`() {
     @Suppress("unused")
+    @Introspectable
     class MyRecord : Record {
       @Field
       val int: Int = 2
@@ -147,6 +148,7 @@ class JSTypeConverterTest {
   @Test
   fun `should convert complex structures`() {
     @Suppress("unused")
+    @Introspectable
     class MyRecord : Record {
       inner class InnerRecord : Record {
         @Field

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
@@ -9,6 +9,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.toAnyType
 import io.mockk.mockk
 import org.junit.Test
+import expo.modules.kotlin.types.Introspectable
 
 class ConcreteViewPropTest {
   @Test
@@ -30,6 +31,7 @@ class ConcreteViewPropTest {
 
   @Test
   fun `should be able to convert records`() {
+    @Introspectable
     class MyRecord : Record {
       @Field
       lateinit var id: String

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-  implementation("io.github.lukmccall.pika:pika-gradle:0.1.2-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.1.3-2.1.20")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-  implementation("io.github.lukmccall.pika:pika-gradle:0.1.1-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.1.2-2.1.20")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")


### PR DESCRIPTION
# Why

Record conversion uses Kotlin reflection at runtime. Moves metadata collection to compile time via https://github.com/lukmccall/pika introspection.

> [!NOTE]                                                                                                                                                                                                        
> To benefit from the compile-time path, every `Record` subclass must be annotated with `@Introspectable`. Records without the annotation will still work via the reflection fallback (with a warning log), but will not see the performance improvements. Annotating existing `Record` classes across the repo will be done in a **separate PR** to keep this change reviewable.                                          

# How

- Bumps `pika` to `0.1.2-2.1.20`.                       
- New `IntrospectableRecordConversionStrategy` - reads property metadata from compile-time generated `PIntrospectionData` and uses generated setters.                               
- Legacy path kept as `ReflectionRecordConversionStrategy` - used as a fallback when the record class isn't annotated with `Introspectable`. Emits a warning log pointing to the fix.
- `RecordTypeConverter` picks a strategy based on `typeDescriptor.typeInfo.introspection != null`.                                                                                                                   
- Switched lookups from `KClass` to `Class` across `TypeConverterProvider`, `ExpectedType.fromTypeDescriptor`, and related call sites. Compile-time metadata only provides `Class`, and `KClass` adds an extra      
  `.kotlin` indirection per lookup. The cached record converter map is now keyed by `Class<*>` instead of `KType`, and primitive matching handles both Kotlin and Java boxed types explicitly (e.g. `Int::class.java + java.lang.Integer::class.java`).

# Benchmarks

Introspectable vs. reflection

| Scenario | Speedup |
| --- | --- |
| Creation | **5.88×** |
| Conversion | **4.87×** |                                                                                                                                                                       

# Test Plan

- unit tests ✅ 
- bare-expo (debug and release with R8) ✅ 