### PR TITLE
fix(expo-modules-autolinking): register companion pods with :path

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -183,7 +183,7 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
-- [iOS] Added modular headers for companion pods
+- [iOS] Added modular headers for companion pods ([#44805](https://github.com/expo/expo/pull/44805) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Added support for pre-install step when USE_FRAMEWORKS is set in Podfile ([#39479](https://github.com/expo/expo/pull/39479) by [@chrfalch](https://github.com/chrfalch))
 - Remove dependency on `find-up` ([#39470](https://github.com/expo/expo/pull/39470) by [@kitten](https://github.com/kitten))
 - [iOS] Force codegen for `FBReactNativeSpec` when generated files are missing in React Native source ([#39512](https://github.com/expo/expo/pull/39512) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -183,6 +183,7 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
+- [iOS] Added modular headers for companion pods
 - [iOS] Added support for pre-install step when USE_FRAMEWORKS is set in Podfile ([#39479](https://github.com/expo/expo/pull/39479) by [@chrfalch](https://github.com/chrfalch))
 - Remove dependency on `find-up` ([#39470](https://github.com/expo/expo/pull/39470) by [@kitten](https://github.com/kitten))
 - [iOS] Force codegen for `FBReactNativeSpec` when generated files are missing in React Native source ([#39512](https://github.com/expo/expo/pull/39512) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -384,13 +384,29 @@ module Expo
 
           podspec_rel = Pathname.new(podspec_file).relative_path_from(project_directory).to_s
 
-          if enabled? && has_prebuilt_xcframework?(pod_name)
-            Pod::UI.message "— #{pod_name.green} (prebuilt companion, gated by #{property})"
-          else
-            Pod::UI.message "— #{pod_name.green} (companion, gated by #{property})"
+          # Enable modular headers for the companion pod's transitive Objective-C dependencies so
+          # the Swift pod can `import` them. Mirrors the logic in autolinking_manager.rb's
+          # `use_modular_headers_for_dependencies`.
+          begin
+            spec = Pod::Specification.from_file(podspec_file)
+            spec.all_dependencies.each do |dep|
+              root_spec_name = dep.name.partition('/').first
+              unless target_definition.build_pod_as_module?(root_spec_name)
+                target_definition.set_use_modular_headers_for_pod(root_spec_name, true)
+              end
+            end
+          rescue => e
+            Pod::UI.warn "[Expo] Companion pod #{pod_name}: failed to enable modular headers for dependencies: #{e.message}"
           end
 
-          podfile.pod(pod_name, :podspec => podspec_rel)
+          if enabled? && has_prebuilt_xcframework?(pod_name)
+            Pod::UI.message "— #{pod_name.green} (prebuilt companion, gated by #{property})"
+            podfile.pod(pod_name, :podspec => podspec_rel)
+          else
+            Pod::UI.message "— #{pod_name.green} (companion, gated by #{property})"
+            podspec_dir_rel = Pathname.new(info[:podspec_dir]).relative_path_from(project_directory).to_s
+            podfile.pod(pod_name, :path => podspec_dir_rel)
+          end
         end
       end
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -342,6 +342,7 @@ module Expo
       #   1. The podspec exists (source build) or prebuilt xcframework exists (precompiled)
       #   2. The gating Podfile.properties.json value is not the disabled value
       #   3. It's not already registered in the Podfile
+      #   4. All of its local dependencies (pods in the lookup map) are already registered
       #
       # Works for both precompiled and source builds. For precompiled builds, the
       # podspec is patched to use the xcframework. For source builds, CocoaPods
@@ -384,19 +385,37 @@ module Expo
 
           podspec_rel = Pathname.new(podspec_file).relative_path_from(project_directory).to_s
 
+          # Parse the companion podspec to inspect its dependencies.
+          begin
+            spec = Pod::Specification.from_file(podspec_file)
+          rescue => e
+            Pod::UI.warn "[Expo] Companion pod #{pod_name}: failed to parse podspec: #{e.message}"
+            next
+          end
+
+          # Skip companion pods whose local dependencies (sibling pods from the same
+          # monorepo / node_modules) aren't registered in the Podfile. For example,
+          # ExpoCameraBarcodeScanning depends on ExpoCamera — if expo-camera isn't
+          # installed in the project, ExpoCamera won't be in the Podfile and CocoaPods
+          # would fail with "Unable to find a specification for ExpoCamera".
+          registered_pod_names = target_definition.dependencies.map(&:name)
+          missing_local_dep = spec.all_dependencies.find do |dep|
+            root_spec_name = dep.name.partition('/').first
+            pod_lookup_map.key?(root_spec_name) && !registered_pod_names.include?(root_spec_name)
+          end
+          if missing_local_dep
+            Pod::UI.message "[Expo] Skipping companion pod #{pod_name}: dependency #{missing_local_dep.name} is not installed"
+            next
+          end
+
           # Enable modular headers for the companion pod's transitive Objective-C dependencies so
           # the Swift pod can `import` them. Mirrors the logic in autolinking_manager.rb's
           # `use_modular_headers_for_dependencies`.
-          begin
-            spec = Pod::Specification.from_file(podspec_file)
-            spec.all_dependencies.each do |dep|
-              root_spec_name = dep.name.partition('/').first
-              unless target_definition.build_pod_as_module?(root_spec_name)
-                target_definition.set_use_modular_headers_for_pod(root_spec_name, true)
-              end
+          spec.all_dependencies.each do |dep|
+            root_spec_name = dep.name.partition('/').first
+            unless target_definition.build_pod_as_module?(root_spec_name)
+              target_definition.set_use_modular_headers_for_pod(root_spec_name, true)
             end
-          rescue => e
-            Pod::UI.warn "[Expo] Companion pod #{pod_name}: failed to enable modular headers for dependencies: #{e.message}"
           end
 
           if enabled? && has_prebuilt_xcframework?(pod_name)


### PR DESCRIPTION
# Why

The PR #44766 introduced a companion pod for the old barcode scanner on iOS. This was missing modular headers.

Also if the ExpoCamera was not included in the consuming project we got an error:

```
Command `pod install` failed.
└─ Cause: Unable to find a specification for `ExpoCamera` depended upon by `ExpoCameraBarcodeScanning`
```

# How

Fixed it by registering companion pods with :path for source builds and enable modular headers for their dependencies and not adding companion pods if parent pod is not included.

# Test-plan

Tested in BareExpo with / without the `expo.camera.barcode-scanner-enabled` setting.


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
