### PR TITLE
Add `Symbol.toStringTag` to `expo/fetch` `Response` so it identifies as a standard `Response` object

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- Add `Symbol.toStringTag` to `expo/fetch` `Response` so it identifies as a standard `Response` object ([#44806](https://github.com/expo/expo/issues/44806) by [@zoontek](https://github.com/zoontek))
+- Add `Symbol.toStringTag` to `expo/fetch` `Response` so it identifies as a standard `Response` object ([#44806](https://github.com/expo/expo/pull/44806) by [@zoontek](https://github.com/zoontek))
 - Prevent `original*` globals from being enumerable or from being created for globals with getters, since these may be side-effectful ([#44407](https://github.com/expo/expo/pull/44407) by [@kitten](https://github.com/kitten))
 - Resolve paths relative to project root instead of server root in `expo/scripts/resolveAppEntry.js` ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- Add `Symbol.toStringTag` to `expo/fetch` `Response` so it identifies as a standard `Response` object ([#44806](https://github.com/expo/expo/issues/44806) by [@zoontek](https://github.com/zoontek))
 - Prevent `original*` globals from being enumerable or from being created for globals with getters, since these may be side-effectful ([#44407](https://github.com/expo/expo/pull/44407) by [@kitten](https://github.com/kitten))
 - Resolve paths relative to project root instead of server root in `expo/scripts/resolveAppEntry.js` ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
 

--- a/packages/expo/src/winter/fetch/FetchResponse.ts
+++ b/packages/expo/src/winter/fetch/FetchResponse.ts
@@ -144,3 +144,8 @@ export class FetchResponse extends ConcreteNativeResponse implements Response {
     this.removeAllListeners('didFailWithError');
   };
 }
+
+Object.defineProperty(FetchResponse.prototype, Symbol.toStringTag, {
+  value: 'Response',
+  configurable: true,
+});

--- a/packages/expo/src/winter/fetch/__tests__/FetchResponse-test.ts
+++ b/packages/expo/src/winter/fetch/__tests__/FetchResponse-test.ts
@@ -1,0 +1,22 @@
+/// <reference types="node" />
+
+/** @jest-environment node */
+
+import { FetchResponse } from '../FetchResponse';
+
+jest.mock('../ExpoFetchModule', () => {
+  class StubNativeResponse {}
+  class StubNativeRequest {}
+  return {
+    ExpoFetchModule: {
+      NativeRequest: StubNativeRequest,
+      NativeResponse: StubNativeResponse,
+    },
+  };
+});
+
+describe('FetchResponse', () => {
+  it('identifies as a standard Response via Symbol.toStringTag', () => {
+    expect(Object.prototype.toString.call(FetchResponse.prototype)).toBe('[object Response]');
+  });
+});


### PR DESCRIPTION
# Why

Fixes [#44781](https://github.com/expo/expo/issues/44781).

Libraries that detect standard Fetch types via `Object.prototype.toString.call(x)` (the spec-recommended duck-typing path via the `@@toStringTag` protocol) currently don't recognize `expo/fetch`'s `Response` implementation as a standard `Response`. This breaks interop with libraries like [`ky`](https://github.com/sindresorhus/ky/issues/857).

# How

Added `Symbol.toStringTag = 'Response'` to `FetchResponse.prototype` via `Object.defineProperty` with `configurable: true`, matching the ECMAScript spec convention for built-in `@@toStringTag` properties (same descriptor used by `Response.prototype`, `Request.prototype`, `Map.prototype`, etc.).

No change is needed on the Request side: `expo/fetch` doesn't expose its own `FetchRequest` class.

# Test Plan

Added `FetchResponse-test.ts` which verifies:

- `Object.prototype.toString.call(FetchResponse.prototype) === '[object Response]'` (checked on the prototype directly, no native module needed).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)