### PR TITLE
[expo-speech] Prevent NullPointerException by falling back to locale.language / locale.country

### DIFF
--- a/packages/expo-speech/CHANGELOG.md
+++ b/packages/expo-speech/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `NullPointerException` in `LanguageUtils.getISOCode` when the TTS engine returns a voice with a non-standard locale. ([#44807](https://github.com/expo/expo/pull/44807) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
@@ -17,18 +17,21 @@ object LanguageUtils {
     }
   }
 
-  // NOTE: These helpers are null-unsafe and should be called ONLY with codes
-  // returned by Locale.getISO3Country() and Locale.getISO3Language() respectively
-  private fun transformCountryISO(code: String) = countryISOCodes[code]!!.country
-  private fun transformLanguageISO(code: String) = languageISOCodes[code]!!.language
-
   fun getISOCode(locale: Locale): String {
-    var language = transformLanguageISO(locale.isO3Language)
-    val country = locale.isO3Country
-    if (country != "") {
-      val countryCode = transformCountryISO(country)
-      language += "-$countryCode"
-    }
-    return language
+    val language =
+      runCatching {
+          val isO3Language = locale.isO3Language
+          languageISOCodes[isO3Language]?.language
+        }
+        .getOrNull() ?: locale.language
+
+    val country =
+      runCatching {
+          val isO3Country = locale.isO3Country
+          isO3Country.takeIf { it.isNotEmpty() }?.let { countryISOCodes[it]?.country }
+        }
+        .getOrNull() ?: locale.country
+
+    return if (country.isNotEmpty()) "$language-$country" else language
   }
 }

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
@@ -17,21 +17,23 @@ object LanguageUtils {
     }
   }
 
+  private fun getLanguageISO(locale: Locale) =
+    try {
+      languageISOCodes[locale.isO3Language]?.language
+    } catch (_: MissingResourceException) {
+      null
+    } ?: locale.language
+
+  private fun getCountryISO(locale: Locale) =
+    try {
+      locale.isO3Country.takeIf { it.isNotEmpty() }?.let { countryISOCodes[it]?.country }
+    } catch (_: MissingResourceException) {
+      null
+    } ?: locale.country
+
   fun getISOCode(locale: Locale): String {
-    val language =
-      try {
-        languageISOCodes[locale.isO3Language]?.language
-      } catch (_: MissingResourceException) {
-        null
-      } ?: locale.language
-
-    val country =
-      try {
-        locale.isO3Country.takeIf { it != "" }?.let { countryISOCodes[it]?.country }
-      } catch (_: MissingResourceException) {
-        null
-      } ?: locale.country
-
+    val language = getLanguageISO(locale)
+    val country = getCountryISO(locale)
     return if (country.isNotEmpty()) "$language-$country" else language
   }
 }

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
@@ -19,16 +19,11 @@ object LanguageUtils {
 
   fun getISOCode(locale: Locale): String {
     val language =
-      runCatching {
-          val isO3Language = locale.isO3Language
-          languageISOCodes[isO3Language]?.language
-        }
-        .getOrNull() ?: locale.language
+      runCatching { languageISOCodes[locale.isO3Language]?.language }.getOrNull() ?: locale.language
 
     val country =
       runCatching {
-          val isO3Country = locale.isO3Country
-          isO3Country.takeIf { it.isNotEmpty() }?.let { countryISOCodes[it]?.country }
+          locale.isO3Country.takeIf { it.isNotEmpty() }?.let { countryISOCodes[it]?.country }
         }
         .getOrNull() ?: locale.country
 

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/LanguageUtils.kt
@@ -19,13 +19,18 @@ object LanguageUtils {
 
   fun getISOCode(locale: Locale): String {
     val language =
-      runCatching { languageISOCodes[locale.isO3Language]?.language }.getOrNull() ?: locale.language
+      try {
+        languageISOCodes[locale.isO3Language]?.language
+      } catch (_: MissingResourceException) {
+        null
+      } ?: locale.language
 
     val country =
-      runCatching {
-          locale.isO3Country.takeIf { it.isNotEmpty() }?.let { countryISOCodes[it]?.country }
-        }
-        .getOrNull() ?: locale.country
+      try {
+        locale.isO3Country.takeIf { it != "" }?.let { countryISOCodes[it]?.country }
+      } catch (_: MissingResourceException) {
+        null
+      } ?: locale.country
 
     return if (country.isNotEmpty()) "$language-$country" else language
   }


### PR DESCRIPTION
# Why

Fixes [#44686](https://github.com/expo/expo/issues/44686).

On Android, `Speech.getAvailableVoicesAsync()` crashed with a fatal `NullPointerException` when the TTS engine returned a voice whose locale wasn't in Java's standard ISO lists (reported on custom Android builds):

```
java.lang.NullPointerException: null
    at expo.modules.speech.LanguageUtils.transformCountryISO(LanguageUtils.kt:22)
    at expo.modules.speech.LanguageUtils.getISOCode(LanguageUtils.kt:29)
    at expo.modules.speech.SpeechModule.getVoices(SpeechModule.kt:95)
```

# How

In `LanguageUtils.kt`:

- Replaced the `!!` unwraps with nullable lookups, falling back to `locale.language` / `locale.country` on a miss. Those already return ISO2 in the normal case, so the output stays BCP 47–shaped (unlike the issue's suggested `?: code` fallback, which yields malformed tags like `eng-USA`).
- Wrapped the `isO3Language` / `isO3Country` accessors with `runCatching` to also guard against the `MissingResourceException` they're documented to throw on arbitrary locales.

# Test Plan

- Existing voices on a standard Android device still resolve to the same BCP 47 tags (`en-US`, `fr-FR`, etc.).

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
