### PR TITLE
[modules-core][iOS] Fix finding EXConstants.bundle inside framework bundle for brownfield

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -33,6 +33,7 @@
 - [iOS] Fixed runtime setup crashing in the old bridge module. ([#44121](https://github.com/expo/expo/pull/44121) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Resolve `react-native-worklets` from existing podspec, falling back to peer resolution ([#44232](https://github.com/expo/expo/pull/44232) by [@kitten](https://github.com/kitten))
 - [iOS] Fixed adding SwiftUI views to tabs BottomAccessory. ([#44247](https://github.com/expo/expo/pull/44247) by [@t0maboro](https://github.com/t0maboro))
+- [iOS] Fix finding EXConstants.bundle inside framework bundle for brownfield ([#44810](https://github.com/expo/expo/pull/44810) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
+++ b/packages/expo-modules-core/ios/Utilities/ConstantsProvider.swift
@@ -87,9 +87,27 @@ private func getDeviceName() -> String {
   #endif
 }
 
+private func findEXConstantsBundle() -> Bundle? {
+  let bundleName = "EXConstants.bundle"
+
+  // Check the main app bundle first (standard CocoaPods setup)
+  if let bundleUrl = Bundle.main.resourceURL?.appendingPathComponent(bundleName),
+     let bundle = Bundle(url: bundleUrl) {
+    return bundle
+  }
+
+  // Fall back to the bundle containing this code, which handles the case where
+  // EXConstants.bundle is embedded inside a dynamic framework (e.g. expo-brownfield xcframework)
+  if let bundleUrl = Bundle(for: ConstantsProvider.self).resourceURL?.appendingPathComponent(bundleName),
+     let bundle = Bundle(url: bundleUrl) {
+    return bundle
+  }
+
+  return nil
+}
+
 private func getManifest() -> [String: Any]? {
-  guard let bundleUrl = Bundle.main.resourceURL?.appendingPathComponent("EXConstants.bundle"),
-        let bundle = Bundle(url: bundleUrl),
+  guard let bundle = findEXConstantsBundle(),
         let url = bundle.url(forResource: "app", withExtension: "config") else {
     log.error("Unable to find the embedded app config")
     return nil


### PR DESCRIPTION
# Why

After https://github.com/expo/expo/issues/44551,  apps that use `expo-linking`  with `expo-brownfield` as an xcframework,(or anything else that reads from `Constants.expoConfig`) will crash at runtime with:

```
Unhandled JS Exception: Error: expo-linking needs access to the expo-constants manifest (app.json or app.config.js) to determine what URI scheme to use. Setup the manifest and rebuild
at resolveScheme
at createURL
at getInitialURL 
```

# How

Added a `findEXConstantsBundle()` helper in `ConstantsProvider.swift` that:

1. First checks `Bundle.main` (standard CocoaPods path — unchanged behavior).
2. Falls back to `Bundle(for: ConstantsProvider.self)`, which resolves to the dynamic framework bundle when the code is packaged inside an xcframework (brownfield case).  

# Test Plan

Build the expo-app brownfield framework

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
