### PR TITLE
[docs] Fix theme flicker on initial load when Dark mode is selected

### DIFF
--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -1,44 +1,30 @@
-import { getThemeFromCookieHeader } from '@expo/styleguide';
-import Document, {
-  Html,
-  Head,
-  Main,
-  NextScript,
-  DocumentContext,
-  DocumentProps,
-} from 'next/document';
+import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
 
-type Props = DocumentProps & {
-  serverTheme: 'dark' | 'light' | null;
-};
+export default class DocsDocument extends Document {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  static async getInitialProps(ctx: DocumentContext) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return {
+      ...initialProps,
+      styles: <>{initialProps.styles}</>,
+    };
+  }
 
-export default function DocsDocument({ serverTheme }: Props) {
-  return (
-    <Html
-      lang="en"
-      className={serverTheme === 'dark' ? 'dark-theme' : undefined}
-      data-expo-theme={serverTheme ?? undefined}
-      suppressHydrationWarning>
-      <Head>
-        {!serverTheme && (
+  render() {
+    return (
+      <Html lang="en" data-expo-theme>
+        <Head>
           <script
             dangerouslySetInnerHTML={{
-              __html: `(function(){if(window.matchMedia("(prefers-color-scheme:dark)").matches){document.documentElement.classList.add("dark-theme")}})()`,
+              __html: `(function(){try{var m=document.cookie.match(/(?:^|; )expo-theme=([^;]*)/);var t=m&&decodeURIComponent(m[1]);var isDark=t==="dark"||(t!=="light"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(isDark){document.documentElement.classList.add("dark-theme")}}catch(e){}})()`,
             }}
           />
-        )}
-      </Head>
-      <body className="text-pretty">
-        <Main />
-        <NextScript />
-      </body>
-    </Html>
-  );
+        </Head>
+        <body className="text-pretty">
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
 }
-
-DocsDocument.getInitialProps = async (ctx: DocumentContext) => {
-  const initialProps = await Document.getInitialProps(ctx);
-  const cookieHeader = ctx.req?.headers?.cookie;
-  const serverTheme = cookieHeader ? getThemeFromCookieHeader(cookieHeader) : null;
-  return { ...initialProps, serverTheme };
-};

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -1,9 +1,10 @@
+import { THEME_COOKIE_NAME } from '@expo/styleguide';
 import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
 
 const BLOCKING_THEME_SCRIPT = `
 (function() {
   function getCookieTheme() {
-    var match = document.cookie.match(/(?:^|;\\s*)expo-theme=([^;]*)/);
+    var match = document.cookie.match(/(?:^|;\\s*)${THEME_COOKIE_NAME}=([^;]*)/);
     var val = match && match[1];
     return val === 'dark' || val === 'light' ? val : null;
   }

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -1,30 +1,44 @@
-import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
+import { getThemeFromCookieHeader } from '@expo/styleguide';
+import Document, {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentContext,
+  DocumentProps,
+} from 'next/document';
 
-export default class DocsDocument extends Document {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  static async getInitialProps(ctx: DocumentContext) {
-    const initialProps = await Document.getInitialProps(ctx);
-    return {
-      ...initialProps,
-      styles: <>{initialProps.styles}</>,
-    };
-  }
+type Props = DocumentProps & {
+  serverTheme: 'dark' | 'light' | null;
+};
 
-  render() {
-    return (
-      <Html lang="en" data-expo-theme>
-        <Head>
+export default function DocsDocument({ serverTheme }: Props) {
+  return (
+    <Html
+      lang="en"
+      className={serverTheme === 'dark' ? 'dark-theme' : undefined}
+      data-expo-theme={serverTheme ?? undefined}
+      suppressHydrationWarning>
+      <Head>
+        {!serverTheme && (
           <script
             dangerouslySetInnerHTML={{
               __html: `(function(){if(window.matchMedia("(prefers-color-scheme:dark)").matches){document.documentElement.classList.add("dark-theme")}})()`,
             }}
           />
-        </Head>
-        <body className="text-pretty">
-          <Main />
-          <NextScript />
-        </body>
-      </Html>
-    );
-  }
+        )}
+      </Head>
+      <body className="text-pretty">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
 }
+
+DocsDocument.getInitialProps = async (ctx: DocumentContext) => {
+  const initialProps = await Document.getInitialProps(ctx);
+  const cookieHeader = ctx.req?.headers?.cookie;
+  const serverTheme = cookieHeader ? getThemeFromCookieHeader(cookieHeader) : null;
+  return { ...initialProps, serverTheme };
+};

--- a/docs/pages/_document.tsx
+++ b/docs/pages/_document.tsx
@@ -1,5 +1,21 @@
 import Document, { Html, Head, Main, NextScript, DocumentContext } from 'next/document';
 
+const BLOCKING_THEME_SCRIPT = `
+(function() {
+  function getCookieTheme() {
+    var match = document.cookie.match(/(?:^|;\\s*)expo-theme=([^;]*)/);
+    var val = match && match[1];
+    return val === 'dark' || val === 'light' ? val : null;
+  }
+  var theme = getCookieTheme();
+  if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    document.documentElement.classList.add('dark-theme');
+  } else {
+    document.documentElement.classList.remove('dark-theme');
+  }
+})();
+`;
+
 export default class DocsDocument extends Document {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   static async getInitialProps(ctx: DocumentContext) {
@@ -14,11 +30,7 @@ export default class DocsDocument extends Document {
     return (
       <Html lang="en" data-expo-theme>
         <Head>
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `(function(){try{var m=document.cookie.match(/(?:^|; )expo-theme=([^;]*)/);var t=m&&decodeURIComponent(m[1]);var isDark=t==="dark"||(t!=="light"&&window.matchMedia("(prefers-color-scheme:dark)").matches);if(isDark){document.documentElement.classList.add("dark-theme")}}catch(e){}})()`,
-            }}
-          />
+          <script dangerouslySetInnerHTML={{ __html: BLOCKING_THEME_SCRIPT }} />
         </Head>
         <body className="text-pretty">
           <Main />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20617

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Update the inline blocking script in `pages/_document.tsx` to read `document.cookie` for `expo-theme` before falling back to `prefers-color-scheme`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

https://github.com/user-attachments/assets/6343b614-8336-4596-bd04-3a5d1a125b65



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
