### PR TITLE
[media-library][Android] Read video dimensions from MediaStore cursor (sdk-55 backport)

### DIFF
--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Read video dimensions from MediaStore cursor instead of opening each file with `MediaMetadataRetriever`, fixing extremely slow `getAssetsAsync` on devices with many videos. ([#44714](https://github.com/expo/expo/pull/44714) by [@oeddyo](https://github.com/oeddyo))
+
 ### 💡 Others
 
 ## 55.0.14 — 2026-04-09

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -220,6 +220,16 @@ fun getAssetDimensionsFromCursor(
 ): Pair<Int, Int> {
   val uri = cursor.getString(localUriColumnIndex)
   if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
+    // Fast path: read dimensions from MediaStore cursor (no file I/O).
+    // MediaStore populates these when the media scanner indexes the file.
+    val cursorWidth = cursor.getInt(cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH))
+    val cursorHeight = cursor.getInt(cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT))
+    if (cursorWidth > 0 && cursorHeight > 0) {
+      val orientation = cursor.getInt(cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION))
+      return maybeRotateAssetSize(cursorWidth, cursorHeight, orientation)
+    }
+
+    // Slow fallback for files not yet indexed by the media scanner.
     val videoUri = Uri.parse("file://$uri")
     try {
       contentResolver.openAssetFileDescriptor(videoUri, "r").use { photoDescriptor ->

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -222,10 +222,14 @@ fun getAssetDimensionsFromCursor(
   if (mediaType == MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO) {
     // Fast path: read dimensions from MediaStore cursor (no file I/O).
     // MediaStore populates these when the media scanner indexes the file.
-    val cursorWidth = cursor.getInt(cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH))
-    val cursorHeight = cursor.getInt(cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT))
+    val widthIndex = cursor.getColumnIndex(MediaStore.MediaColumns.WIDTH)
+    val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
+    val width = cursor.getInt(widthIndex)
+    val height = cursor.getInt(heightIndex)
     if (cursorWidth > 0 && cursorHeight > 0) {
-      val orientation = cursor.getInt(cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION))
+      val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
+      val orientation = cursor.getInt(orientationIndex)
+
       return maybeRotateAssetSize(cursorWidth, cursorHeight, orientation)
     }
 

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/assets/AssetUtils.kt
@@ -226,11 +226,11 @@ fun getAssetDimensionsFromCursor(
     val heightIndex = cursor.getColumnIndex(MediaStore.MediaColumns.HEIGHT)
     val width = cursor.getInt(widthIndex)
     val height = cursor.getInt(heightIndex)
-    if (cursorWidth > 0 && cursorHeight > 0) {
+    if (width > 0 && height > 0) {
       val orientationIndex = cursor.getColumnIndex(MediaStore.Images.Media.ORIENTATION)
       val orientation = cursor.getInt(orientationIndex)
 
-      return maybeRotateAssetSize(cursorWidth, cursorHeight, orientation)
+      return maybeRotateAssetSize(width, height, orientation)
     }
 
     // Slow fallback for files not yet indexed by the media scanner.


### PR DESCRIPTION
# Why

Backport of #44714 to `sdk-55`.

On Android, `getAssetsAsync` opens every video file from disk using `MediaMetadataRetriever` to read dimensions (~140ms per video). This makes the call extremely slow on devices with many videos — for 10,611 assets the query took ~12s.

This fix reads video dimensions directly from the MediaStore cursor (`WIDTH`/`HEIGHT` columns), which are already populated by the system's media scanner. It falls back to the existing `MediaMetadataRetriever` path for files not yet indexed.

# Performance

Benchmarked on a Pixel 7 with 10,611 total assets:

- **7.3x faster** overall for `getAssetsAsync`
- Batch operations show **6x–12x** speedup depending on asset count

# How

Cherry-picked the 4 commits from `main` (`b90d25161f`, `a6656395ea`, `00d39d9e13`, `bfe64df500`) — applied cleanly with no conflicts.

The change is isolated to `AssetUtils.kt`:
- Adds a fast path that reads `WIDTH`/`HEIGHT` from the cursor before falling back to `MediaMetadataRetriever`
- Respects orientation for rotated videos
- No API changes

# Test Plan

- [x] Cherry-pick applied cleanly onto `sdk-55`
- [x] Original PR was reviewed and merged to `main` by @AJanik

# Checklist

- [x] Documentation is up to date to reflect these changes (CHANGELOG updated)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build