### PR TITLE
[doc] Fix hyperlink formatting for ZIP reference in app-size.mdx

### DIFF
--- a/docs/pages/distribution/app-size.mdx
+++ b/docs/pages/distribution/app-size.mdx
@@ -71,7 +71,7 @@ This is the actual application bundle for your app. When you download and instal
 
 ### `.ipa` (iOS App Store Package)
 
-IPA files are [ZIP](https://en.wikipedia.org/wiki/ZIP)) files that include the `.app` bundle and other resources that are needed to run the app on an iOS device. They are used for various types of distribution, including App Store, Ad Hoc, Enterprise, and TestFlight.
+IPA files are [ZIP](https://en.wikipedia.org/wiki/ZIP) files that include the `.app` bundle and other resources that are needed to run the app on an iOS device. They are used for various types of distribution, including App Store, Ad Hoc, Enterprise, and TestFlight.
 
 They include security and code signing information, such as the provisioning profile and entitlements. The App Store will process the IPA file and split it into smaller binaries for each device type, so the size of the IPA also does not represent the download size of your app.
 


### PR DESCRIPTION
Corrected a hyperlink formatting issue in the documentation.

# Why

an extraneous `)` in the docs

