### PR TITLE
[video][audio][Android] Bump media3 version to 1.9.0

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### 💡 Others
 
 - [iOS] Added explicit `import React` for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
+- [Android] Bump media3 version to 1.9.0.
 
 ## 55.0.8 — 2026-02-25
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -23,7 +23,7 @@
 ### 💡 Others
 
 - [iOS] Added explicit `import React` for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
-- [Android] Bump media3 version to 1.9.0.
+- [Android] Bump media3 version to 1.9.0. ([#44823](https://github.com/expo/expo/pull/44823) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.8 — 2026-02-25
 

--- a/packages/expo-audio/android/build.gradle
+++ b/packages/expo-audio/android/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   implementation 'androidx.appcompat:appcompat:1.7.1'
   implementation 'androidx.core:core-ktx:1.15.0'
 
-  def androidxMedia3Version = "1.8.0"
+  def androidxMedia3Version = "1.9.0"
   implementation "androidx.media3:media3-session:$androidxMedia3Version"
   implementation "androidx.media3:media3-ui:$androidxMedia3Version"
   implementation "androidx.media3:media3-exoplayer:$androidxMedia3Version"

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### 💡 Others
 
+- [Android] Bump media3 version to 1.9.0.
+
 ## 55.0.9 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 💡 Others
 
-- [Android] Bump media3 version to 1.9.0.
+- [Android] Bump media3 version to 1.9.0. ([#44823](https://github.com/expo/expo/pull/44823) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   implementation 'com.facebook.react:react-android'
 
   // Remember to keep this in sync with the version in `expo-audio`
-  def androidxMedia3Version = "1.8.0"
+  def androidxMedia3Version = "1.9.0"
   implementation "androidx.media3:media3-session:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer:${androidxMedia3Version}"
   implementation "androidx.media3:media3-exoplayer-dash:${androidxMedia3Version}"

--- a/packages/expo-video/android/src/main/java/expo/modules/video/player/DefaultLoadControl.java
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/player/DefaultLoadControl.java
@@ -389,7 +389,7 @@ public class DefaultLoadControl implements LoadControl {
   }
 
   @Override
-  public Allocator getAllocator() {
+  public Allocator getAllocator(PlayerId playerId) {
     return allocator;
   }
 
@@ -449,7 +449,7 @@ public class DefaultLoadControl implements LoadControl {
 
   @Override
   public boolean shouldContinuePreloading(
-    Timeline timeline, MediaPeriodId mediaPeriodId, long bufferedDurationUs) {
+    PlayerId playerId, Timeline timeline, MediaPeriodId mediaPeriodId, long bufferedDurationUs) {
     for (PlayerLoadingState playerLoadingState : loadingStates.values()) {
       if (playerLoadingState.isLoading) {
         return false;


### PR DESCRIPTION
# Why

Bumps `androidx.media3` from 1.8.0 to 1.9.0 in `expo-video` and `expo-audio`, and updates the forked `DefaultLoadControl` in `expo-video` to match the new `LoadControl` interface.

# How

This bump was forced by a recent change in `expo-camera`. If you check the dependencies to see which version of `exoplayer` is being used, you'll notice we are currently using `1.9`, even though the audio and video packages require `1.8`. It turns out that `androidx.camera` also has a dependency on `exoplayer`, forcing us to use the newer version.

```
androidx.media3:media3-container:1.9.0                                                                                                                                                                           
   +--- androidx.camera:camera-video:1.6.0                                                                                                                                                                         
   +--- androidx.media3:media3-exoplayer:1.9.0                                                                                                                                                                     
        +--- project :expo-video (requested androidx.media3:media3-exoplayer:1.8.0)     
```

# Test Plan

- bare-expo ✅ 