### PR TITLE
fix: fix 'occured' -> 'occurred' typos in expo-camera, expo-print, expo-video

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
+
 - [Web] Fix `isAvailableAsync` returning `true` on devices without a camera. ([#43932](https://github.com/expo/expo/pull/43932) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Use runtime camera availability checks in Simulator so camera code paths can run when a runtime video device is present while preserving fallback behavior when no device is available. (by [@kmagiera](https://github.com/kmagiera)) ([#44159](https://github.com/expo/expo/pull/44159) by [@kmagiera](https://github.com/kmagiera))
 - [iOS] Fix orientation issue caused by upstream changes. ([#44171](https://github.com/expo/expo/pull/44171) by [@alanjhughes](https://github.com/alanjhughes))

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### 🐛 Bug fixes
 
-- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
-
 - [Web] Fix `isAvailableAsync` returning `true` on devices without a camera. ([#43932](https://github.com/expo/expo/pull/43932) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Use runtime camera availability checks in Simulator so camera code paths can run when a runtime video device is present while preserving fallback behavior when no device is available. (by [@kmagiera](https://github.com/kmagiera)) ([#44159](https://github.com/expo/expo/pull/44159) by [@kmagiera](https://github.com/kmagiera))
 - [iOS] Fix orientation issue caused by upstream changes. ([#44171](https://github.com/expo/expo/pull/44171) by [@alanjhughes](https://github.com/alanjhughes))
@@ -22,6 +20,7 @@
 
 ### 💡 Others
 
+- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
 - [iOS] Added explicit `import React` for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
 
 ## 55.0.9 — 2026-02-25

--- a/packages/expo-camera/ios/Common/CameraExceptions.swift
+++ b/packages/expo-camera/ios/Common/CameraExceptions.swift
@@ -50,7 +50,7 @@ internal final class CameraMetadataDecodingException: Exception {
 
 internal final class CameraInvalidPhotoData: Exception {
   override var reason: String {
-    "An error occured while generating photo data"
+    "An error occurred while generating photo data"
   }
 }
 

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -10,10 +10,9 @@
 
 ### 🐛 Bug fixes
 
-- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
-
 ### 💡 Others
 
+- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
 ## 55.0.8 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-print/CHANGELOG.md
+++ b/packages/expo-print/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintExceptions.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintExceptions.kt
@@ -18,7 +18,7 @@ internal class NullUriException :
   CodedException("Given URI is null")
 
 internal class PdfWriteException(cause: Throwable? = null) :
-  CodedException("An error occured while writing the PDF data", cause)
+  CodedException("An error occurred while writing the PDF data", cause)
 
 internal class FileNotFoundException(cause: Throwable? = null) :
   CodedException("Cannot create or open a file", cause)

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
+
 - [iOS] Fix crash when loading PHAsset url fails ([#43373](https://github.com/expo/expo/pull/43373) by [@fractalbeauty](https://github.com/fractalbeauty))
 - [iOS] Fix crashes when `VideoTrack` properties are non-finite. ([#44108](https://github.com/expo/expo/pull/44108) by [@behenate](https://github.com/behenate))
 - [Android] Fix PiP exiting immediately after auto-entering from fullscreen. ([#44157](https://github.com/expo/expo/pull/44157) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### 🐛 Bug fixes
 
-- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
-
 - [iOS] Fix crash when loading PHAsset url fails ([#43373](https://github.com/expo/expo/pull/43373) by [@fractalbeauty](https://github.com/fractalbeauty))
 - [iOS] Fix crashes when `VideoTrack` properties are non-finite. ([#44108](https://github.com/expo/expo/pull/44108) by [@behenate](https://github.com/behenate))
 - [Android] Fix PiP exiting immediately after auto-entering from fullscreen. ([#44157](https://github.com/expo/expo/pull/44157) by [@behenate](https://github.com/behenate))
@@ -22,6 +20,7 @@
 
 ### 💡 Others
 
+- Fix 'occured' -> 'occurred' typo in error messages. ([#44831](https://github.com/expo/expo/pull/44831) by [@SAY-5](https://github.com/SAY-5))
 ## 55.0.9 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-video/ios/Cache/MediaFileHandle.swift
+++ b/packages/expo-video/ios/Cache/MediaFileHandle.swift
@@ -17,7 +17,7 @@ internal class MediaFileHandle {
     do {
       return try FileManager.default.attributesOfItem(atPath: filePath)
     } catch let error as NSError {
-      log.warn("[expo-video] An error occured while reading the file attributes at \(filePath) error: \(error)")
+      log.warn("[expo-video] An error occurred while reading the file attributes at \(filePath) error: \(error)")
     }
     return nil
   }


### PR DESCRIPTION
## Why

Three error/log messages across three packages read `occured` instead of `occurred`:

| Package | File | Line |
|---------|------|------|
| expo-camera | `ios/Common/CameraExceptions.swift` | 53 |
| expo-print | `android/src/main/java/expo/modules/print/PrintExceptions.kt` | 21 |
| expo-video | `ios/Cache/MediaFileHandle.swift` | 20 |

All are user-visible in error output. Fixed to `occurred`. String-literal-only change.

## How

Direct string replacement — no code or behavior change.

## Test Plan

N/A — string-literal-only fix.