### PR TITLE
[cli] prevent export command from hanging on refd timers

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `expo export` hanging forever when libraries evaluated during static rendering leak ref'd timers.
+- Fix `expo export` hanging forever when libraries evaluated during static rendering leak ref'd timers. ([#44837](https://github.com/expo/expo/pull/44837) by [@vonovak](https://github.com/vonovak))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix `expo export` hanging forever when libraries evaluated during static rendering leak ref'd timers.
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/utils/__tests__/exit-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/exit-test.ts
@@ -45,6 +45,26 @@ describe(ensureProcessExitsAfterDelay, () => {
 
     // Immediately let it pass
     expect(exitSpy).not.toHaveBeenCalled();
+    exitSpy.mockRestore();
+  });
+
+  it("force-exits when a ref'd Timeout leaks", async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
+
+    // Simulate a library leaking a ref'd timer. Without the fix,
+    // ensureProcessExitsAfterDelay returns early because only Timeouts remain and
+    // never schedules an exit — hanging the process forever.
+    const leaked = setTimeout(() => {}, 60000);
+
+    ensureProcessExitsAfterDelay();
+
+    // Wait long enough for the 200ms force-exit grace period to fire (wider margin for slow CI)
+    await timers.setTimeout(800);
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    clearTimeout(leaked);
+    exitSpy.mockRestore();
   });
 
   it('detects and logs unexpected active child processes and force exits', async () => {
@@ -68,7 +88,7 @@ describe(ensureProcessExitsAfterDelay, () => {
       'Detected 1 process preventing Expo from exiting, forcefully exiting now.'
     );
 
-    exitSpy.mockReset();
+    exitSpy.mockRestore();
     pending.kill();
   });
 });

--- a/packages/@expo/cli/src/utils/exit.ts
+++ b/packages/@expo/cli/src/utils/exit.ts
@@ -107,25 +107,40 @@ export function ensureProcessExitsAfterDelay(waitUntilExitMs = 10000, startedAtM
     return true;
   });
 
+  if (!unexpectedActiveResources.length) {
+    debug('no active resources detected, process can safely exit');
+    return;
+  }
+
   // Check if only Timeouts remain (no blocking resources like ProcessWrap/PipeWrap)
   const hasBlockingResources = unexpectedActiveResources.some(
     (resource) => resource !== 'Timeout' && resource !== 'CloseReq'
   );
 
-  const canExitProcess = !unexpectedActiveResources.length || !hasBlockingResources;
-  if (canExitProcess) {
-    if (unexpectedActiveResources.length && !hasBlockingResources) {
-      debug('only non-blocking resources remain (Timeout/CloseReq), process can safely exit');
-    } else {
-      debug('no active resources detected, process can safely exit');
-    }
+  if (!hasBlockingResources) {
+    // NOTE: process.getActiveResourcesInfo() returns both ref'd and unref'd Timeouts,
+    // so we can't assume remaining Timeouts will let the process exit naturally.
+    // During export, user modules are evaluated in this Node process for static
+    // rendering. Libraries with module-level side effects can leak ref'd timers
+    // (setInterval/setTimeout without .unref()) that keep the event loop alive
+    // indefinitely after export completes.
+    //
+    // Schedule an unref'd force-exit: if the process can exit naturally (timers are
+    // actually unref'd), natural exit wins and this never fires. If the timers are
+    // ref'd and blocking, we force-exit after a brief delay instead of hanging.
+    debug('only non-blocking resources remain (Timeout/CloseReq), scheduling force-exit');
+    const forceExitId = setTimeout(() => {
+      debug('force-exiting after Timeout/CloseReq grace period');
+      process.exit(0);
+    }, 200) as unknown as NodeJS.Timeout;
+    forceExitId.unref();
     return;
-  } else {
-    debug(
-      `process is trying to exit, but is stuck on unexpected active resources:`,
-      unexpectedActiveResources
-    );
   }
+
+  debug(
+    `process is trying to exit, but is stuck on unexpected active resources:`,
+    unexpectedActiveResources
+  );
 
   // Check if the process needs to be force-closed
   const elapsedTime = Date.now() - startedAtMs;


### PR DESCRIPTION
# Why

`npx expo export` hangs indefinitely when libraries evaluated during static rendering leak ref'd timers. Observed this on web.

`ensureProcessExitsAfterDelay` (#41692) returns early when only `Timeout`/`CloseReq` handles remain, assuming they're unref'd. But `process.getActiveResourcesInfo()` returns both ref'd and unref'd Timeouts — no way to distinguish. If any are ref'd, the process hangs forever.

# How

When only `Timeout`/`CloseReq` remain, schedule an unref'd `setTimeout(() => process.exit(0), 200)` instead of returning. If the timers are unref'd, natural exit wins. If they're ref'd, force-exit fires after 200ms.

# Test Plan

- Added regression test that leaks a ref'd timer and asserts force-exit fires. Verified it fails on unpatched code.
- Existing tests pass.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)