### PR TITLE
[expo-observe] Fix crash in ObservabilityBackgroundWorker on pre-Android 12 devices

### DIFF
--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
@@ -1,10 +1,15 @@
 package expo.modules.observe
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.ExistingWorkPolicy
+import androidx.work.ForegroundInfo
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
@@ -51,6 +56,21 @@ class ObservabilityBackgroundWorker(
     )
   }
 
+  override suspend fun getForegroundInfo(): ForegroundInfo {
+    val channelId = "expo-observe-background"
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      val channel = NotificationChannel(channelId, "Metrics dispatch", NotificationManager.IMPORTANCE_LOW)
+      val manager = applicationContext.getSystemService(NotificationManager::class.java)
+      manager.createNotificationChannel(channel)
+    }
+    val notification = NotificationCompat.Builder(applicationContext, channelId)
+      .setSmallIcon(android.R.drawable.ic_popup_sync)
+      .setContentTitle("Sending metrics")
+      .setPriority(NotificationCompat.PRIORITY_LOW)
+      .build()
+    return ForegroundInfo(NOTIFICATION_ID, notification)
+  }
+
   override suspend fun doWork(): Result {
     return try {
       if (observabilityManager == null) {
@@ -73,6 +93,7 @@ class ObservabilityBackgroundWorker(
 
   companion object {
     private const val WORK_NAME = "eas-observe-dispatch"
+    private val NOTIFICATION_ID = WORK_NAME.hashCode()
 
     fun scheduleBackgroundDispatch(
       context: Context,

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
@@ -68,7 +68,7 @@ class ObservabilityBackgroundWorker(
       .setContentTitle("Sending metrics")
       .setPriority(NotificationCompat.PRIORITY_LOW)
       .build()
-    return ForegroundInfo(NOTIFICATION_ID, notification)
+    return ForegroundInfo(WORK_NAME.hashCode(), notification)
   }
 
   override suspend fun doWork(): Result {
@@ -93,7 +93,6 @@ class ObservabilityBackgroundWorker(
 
   companion object {
     private const val WORK_NAME = "eas-observe-dispatch"
-    private val NOTIFICATION_ID = WORK_NAME.hashCode()
 
     fun scheduleBackgroundDispatch(
       context: Context,


### PR DESCRIPTION
# Why

`ObservabilityBackgroundWorker` extends `CoroutineWorker` but doesn't override `getForegroundInfo()`. On pre-Android 12 devices, the OS can promote a background worker to a foreground service for backwards compatibility. When this happens, it calls `getForegroundInfo()` to obtain a notification, but the default `CoroutineWorker` implementation throws `IllegalStateException("Not implemented")`, crashing the app.

This is a [documented pitfall](https://developer.android.com/develop/background-work/background-tasks/persistent/getting-started/define-work) in the WorkManager API.

Example crash:

```
DiagnosticCoroutineContextException: 
java.lang.IllegalStateException: Not implemented
    at androidx.work.CoroutineWorker.getForegroundInfo$suspendImpl(CoroutineWorker.kt:100)
    at androidx.work.CoroutineWorker.getForegroundInfo(:0)
    at androidx.work.CoroutineWorker$getForegroundInfoAsync$1.invokeSuspend(CoroutineWorker.kt:134)
    at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
    at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
    at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:586)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:829)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:717)
    at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:704)
```

# How

The fix overrides `getForegroundInfo()` with a minimal low-priority notification. The notification uses a built-in Android drawable (`ic_popup_sync`) to avoid bundling a custom asset. Since this worker is short-lived, the notification should rarely (if ever) be visible.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Hard to test in the wild, but could be manually triggered in development by adding a `setForeground(getForegroundInfo())` call at the top of `doWork()` which will forces the worker to run as a foreground service.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
