### PR TITLE
fix(expo-image): flatten style prop on web for third-party style system compatibility

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Web] Fixed images being invisible when styled via third-party style systems (e.g. `react-native-unistyles` v3) by flattening the `style` prop and importing `View` from `react-native` instead of `react-native-web`. ([#44844](https://github.com/expo/expo/pull/44844) by [@naimkhrof](https://github.com/naimkhrof))
 - [iOS] Fixed `contentPosition` misalignment by using the unrounded cover/contain layout size for offset math. ([#44497](https://github.com/expo/expo/pull/44497) by [@alicenoknow](https://github.com/alicenoknow))
 - [Android] Apply `ApplicationVersionSignature` to local resource URIs (`res:/` scheme) to prevent stale cached images after app updates. by [@linkeryoon](https://github.com/linkeryoon) ([#44355](https://github.com/expo/expo/pull/44355) by [@Yoon-Hae-Min](https://github.com/Yoon-Hae-Min))
 - Added `tintColor` option to `ImageLoadOptions`. This resolves [#42007](https://github.com/expo/expo/issues/42007). ([#42821](https://github.com/expo/expo/pull/42821)) by [@HubertBer](https://github.com/HubertBer).

--- a/packages/expo-image/src/ExpoImage.web.tsx
+++ b/packages/expo-image/src/ExpoImage.web.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
-import { StyleSheet as RNStyleSheet, View } from 'react-native';
+// TODO(@kitten): We shouldn't be importing all of react-native-web or rely on it for a web module in this way optimally
+import { View } from 'react-native-web';
 
 import type { ImageNativeProps, ImageSource, ImageLoadEventData, ImageRef } from './Image.types';
 import AnimationManager, { AnimationManagerNode } from './web/AnimationManager';
 import ImageWrapper from './web/ImageWrapper';
 import loadStyle from './web/imageStyles';
 import useSourceSelection from './web/useSourceSelection';
+import { resolveStyle } from './utils/resolveStyle';
 
 loadStyle();
 
@@ -81,11 +83,6 @@ export default function ExpoImage({
   draggable,
   ...props
 }: ImageNativeProps) {
-  // Flatten the style to ensure compatibility with third-party style systems
-  // (e.g. react-native-unistyles) that may return opaque style references
-  // instead of plain objects on web.
-  const flatStyle = RNStyleSheet.flatten(style);
-
   const imagePlaceholderContentFit = placeholderContentFit || 'scale-down';
   const imageHashStyle = {
     objectFit: placeholderContentFit || contentFit,
@@ -172,7 +169,7 @@ export default function ExpoImage({
       ref={containerViewRef}
       // @ts-expect-error: TODO(@kitten): This is related to react-native-web presumably
       dataSet={{ expoimage: true }}
-      style={[{ overflow: 'hidden' }, flatStyle]}
+      style={[{ overflow: 'hidden' }, resolveStyle(style)]}
       {...props}>
       <AnimationManager transition={transition} recyclingKey={recyclingKey} initial={initialNode}>
         {currentNode}

--- a/packages/expo-image/src/ExpoImage.web.tsx
+++ b/packages/expo-image/src/ExpoImage.web.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// TODO(@kitten): We shouldn't be importing all of react-native-web or rely on it for a web module in this way optimally
-import { View } from 'react-native-web';
+import { StyleSheet as RNStyleSheet, View } from 'react-native';
 
 import type { ImageNativeProps, ImageSource, ImageLoadEventData, ImageRef } from './Image.types';
 import AnimationManager, { AnimationManagerNode } from './web/AnimationManager';
@@ -82,6 +81,11 @@ export default function ExpoImage({
   draggable,
   ...props
 }: ImageNativeProps) {
+  // Flatten the style to ensure compatibility with third-party style systems
+  // (e.g. react-native-unistyles) that may return opaque style references
+  // instead of plain objects on web.
+  const flatStyle = RNStyleSheet.flatten(style);
+
   const imagePlaceholderContentFit = placeholderContentFit || 'scale-down';
   const imageHashStyle = {
     objectFit: placeholderContentFit || contentFit,
@@ -168,7 +172,7 @@ export default function ExpoImage({
       ref={containerViewRef}
       // @ts-expect-error: TODO(@kitten): This is related to react-native-web presumably
       dataSet={{ expoimage: true }}
-      style={[{ overflow: 'hidden' }, style]}
+      style={[{ overflow: 'hidden' }, flatStyle]}
       {...props}>
       <AnimationManager transition={transition} recyclingKey={recyclingKey} initial={initialNode}>
         {currentNode}

--- a/packages/expo-image/src/Image.tsx
+++ b/packages/expo-image/src/Image.tsx
@@ -17,6 +17,7 @@ import {
 } from './Image.types';
 import ImageModule from './ImageModule';
 import { resolveContentFit, resolveContentPosition, resolveTransition } from './utils';
+import { resolveStyle } from './utils/resolveStyle';
 import { resolveSource, resolveSources } from './utils/resolveSources';
 
 /**
@@ -271,7 +272,7 @@ export class Image extends React.PureComponent<ImageProps> {
       color: colorStyle,
       fontSize: fontSizeStyle,
       ...restStyle
-    } = (StyleSheet.flatten(style) as ImageStyle & TextStyle) || {};
+    } = (StyleSheet.flatten(resolveStyle(style)) as ImageStyle & TextStyle) || {};
     const resizeMode = resizeModeProp ?? resizeModeStyle;
 
     if ((defaultSource || loadingIndicatorSource) && !loggedDefaultSourceDeprecationWarning) {

--- a/packages/expo-image/src/utils/resolveStyle.ts
+++ b/packages/expo-image/src/utils/resolveStyle.ts
@@ -1,0 +1,3 @@
+export function resolveStyle(style: any): any {
+  return style;
+}

--- a/packages/expo-image/src/utils/resolveStyle.web.ts
+++ b/packages/expo-image/src/utils/resolveStyle.web.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolves style objects that may contain non-enumerable properties
+ * (e.g. from react-native-unistyles v3) into plain objects with
+ * enumerable properties compatible with react-native-web's style pipeline.
+ *
+ * Some third-party style systems use Object.defineProperties with
+ * enumerable: false, which causes Object.assign, spread, and for...in
+ * (used internally by react-native-web) to silently drop all properties.
+ */
+export function resolveStyle(style: any): any {
+  if (!style || typeof style !== 'object') {
+    return style;
+  }
+  if (Array.isArray(style)) {
+    return style.map(resolveStyle);
+  }
+
+  const ownProps = Object.getOwnPropertyNames(style);
+  const enumKeys = Object.keys(style);
+
+  // Fast path: all properties already enumerable, nothing to resolve
+  if (ownProps.length === enumKeys.length) {
+    return style;
+  }
+
+  // Re-create object with enumerable properties, filtering out
+  // internal marker keys from third-party style systems
+  const resolved: Record<string, any> = {};
+  for (const key of ownProps) {
+    if (!key.startsWith('unistyles_')) {
+      resolved[key] = style[key];
+    }
+  }
+  return resolved;
+}


### PR DESCRIPTION
## Summary

Fixes #44843

Images rendered with `expo-image` are **completely invisible on web** when styled via `react-native-unistyles` v3's `StyleSheet.create()`. This affects any third-party style system that returns style objects with non-enumerable properties.

## Root cause

`react-native-unistyles` v3 uses `Object.defineProperties(..., { enumerable: false })` to hide inline style properties on web (it uses CSS classes instead). This means:

```js
const style = unistyles.StyleSheet.create({ image: { width: '100%', height: 300 } }).image;

Object.keys(style)           // → []  (empty!)
Object.assign({}, style)     // → {}  (empty!)
StyleSheet.flatten(style)    // → {}  (uses Object.assign internally)
style.width                  // → '100%'  (direct access works)
Object.getOwnPropertyNames(style) // → ['width', 'height']  (values exist!)
```

There are **two points** where non-enumerable properties are silently lost:

1. **`Image.tsx:274`** — `StyleSheet.flatten(style)` uses `Object.assign` internally → returns `{}`
2. **`ExpoImage.web.tsx:171`** — react-native-web's `View` processes styles with `for...in` → skips non-enumerable props

## Changes

### New: `resolveStyle` utility (platform-split)

- **`src/utils/resolveStyle.ts`** (native) — Identity function, zero overhead
- **`src/utils/resolveStyle.web.ts`** (web) — Uses `Object.getOwnPropertyNames()` to re-enumerate hidden properties

```ts
// resolveStyle.web.ts
export function resolveStyle(style: any): any {
  if (!style || typeof style !== 'object') return style;
  if (Array.isArray(style)) return style.map(resolveStyle);

  const ownProps = Object.getOwnPropertyNames(style);
  const enumKeys = Object.keys(style);

  // Fast path: all properties already enumerable
  if (ownProps.length === enumKeys.length) return style;

  // Re-create with enumerable properties
  const resolved: Record<string, any> = {};
  for (const key of ownProps) {
    if (!key.startsWith('unistyles_')) {
      resolved[key] = style[key];
    }
  }
  return resolved;
}
```

### Modified files

- **`src/Image.tsx`** — Apply `resolveStyle(style)` before `StyleSheet.flatten()` (line 274)
- **`src/ExpoImage.web.tsx`** — Apply `resolveStyle(style)` before passing to the container `View` (line 171)

## Design decisions

- **Platform-split pattern** (`.ts` / `.web.ts`): Follows existing expo-image convention. Zero cost on native.
- **Fast path**: When all properties are enumerable (`ownProps.length === enumKeys.length`), returns immediately — zero allocation for 99% of users.
- **Defense in depth**: Fix applied at both loss points (Image.tsx + ExpoImage.web.tsx).
- **Generic**: Works for any style system using non-enumerable properties, not just unistyles.

## Test plan

- [ ] Images display correctly on web with `react-native-unistyles` v3 styles
- [ ] Images display correctly on web with standard `StyleSheet.create` styles
- [ ] Images display correctly on web with inline styles
- [ ] Images display correctly on web with style arrays `[style1, style2]`
- [ ] No regression on native (iOS/Android)
- [ ] Transitions/animations still work on web

## Related

- jpudysz/react-native-unistyles#1165