### PR TITLE
fix(expo): evaluate DOM bridge check lazily to survive WebView renderer restarts

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fixed DOM component native bridge becoming permanently broken after WebView renderer process restart. ([#40413](https://github.com/expo/expo/issues/40413) by [@erenkulaksiz](https://github.com/erenkulaksiz))
+- [Android] Fixed DOM component native bridge becoming permanently broken after WebView renderer process restart. ([#40413](https://github.com/expo/expo/issues/40413) by [@erenkulaksiz](https://github.com/erenkulaksiz)) ([#44846](https://github.com/expo/expo/pull/44846) by [@erenkulaksiz](https://github.com/erenkulaksiz))
 - Add `Symbol.toStringTag` to `expo/fetch` `Response` so it identifies as a standard `Response` object ([#44806](https://github.com/expo/expo/pull/44806) by [@zoontek](https://github.com/zoontek))
 - Prevent `original*` globals from being enumerable or from being created for globals with getters, since these may be side-effectful ([#44407](https://github.com/expo/expo/pull/44407) by [@kitten](https://github.com/kitten))
 - Resolve paths relative to project root instead of server root in `expo/scripts/resolveAppEntry.js` ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed DOM component native bridge becoming permanently broken after WebView renderer process restart. ([#40413](https://github.com/expo/expo/issues/40413) by [@erenkulaksiz](https://github.com/erenkulaksiz))
 - Add `Symbol.toStringTag` to `expo/fetch` `Response` so it identifies as a standard `Response` object ([#44806](https://github.com/expo/expo/pull/44806) by [@zoontek](https://github.com/zoontek))
 - Prevent `original*` globals from being enumerable or from being created for globals with getters, since these may be side-effectful ([#44407](https://github.com/expo/expo/pull/44407) by [@kitten](https://github.com/kitten))
 - Resolve paths relative to project root instead of server root in `expo/scripts/resolveAppEntry.js` ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))

--- a/packages/expo/src/dom/marshal.tsx
+++ b/packages/expo/src/dom/marshal.tsx
@@ -1,15 +1,18 @@
 import { BridgeMessage, JSONValue } from './dom.types';
 import { DOM_EVENT, NATIVE_ACTION, NATIVE_ACTION_RESULT } from './injection';
 
-const IS_DOM =
-  typeof window !== 'undefined' &&
-  // @ts-expect-error: Added via expo/dom
-  typeof window.$$EXPO_INITIAL_PROPS !== 'undefined' &&
-  // @ts-expect-error: Added via react-native-webview
-  typeof window.ReactNativeWebView !== 'undefined';
+function isDom(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    // @ts-expect-error: Added via expo/dom
+    typeof window.$$EXPO_INITIAL_PROPS !== 'undefined' &&
+    // @ts-expect-error: Added via react-native-webview
+    typeof window.ReactNativeWebView !== 'undefined'
+  );
+}
 
 const emit = <TData extends JSONValue>(message: BridgeMessage<TData>) => {
-  if (!IS_DOM) {
+  if (!isDom()) {
     return;
   }
   (window as any).ReactNativeWebView.postMessage(JSON.stringify(message));
@@ -18,7 +21,7 @@ const emit = <TData extends JSONValue>(message: BridgeMessage<TData>) => {
 export const addEventListener = <TData extends JSONValue>(
   onSubscribe: (message: BridgeMessage<TData>) => void
 ): (() => void) => {
-  if (!IS_DOM) {
+  if (!isDom()) {
     return () => {};
   }
   const listener = ({ detail }: any) => {
@@ -33,7 +36,7 @@ export const addEventListener = <TData extends JSONValue>(
 };
 
 function invokeNativeAction(actionId: string, args: any[]): Promise<any> {
-  if (!IS_DOM) {
+  if (!isDom()) {
     throw new Error('Cannot invoke native actions outside of a webview');
   }
   return new Promise((res, rej) => {


### PR DESCRIPTION
# Why

Fixes #40413

On Android, when an ad (e.g. AdMob interstitial) is displayed, it creates its own WebView that shares the renderer process with the app's DOM component WebView. When the ad closes, Android can recycle the shared renderer process, causing the DOM component's WebView to reload. On reload, the bundle re-evaluates but `window.$$EXPO_INITIAL_PROPS` / `window.ReactNativeWebView` may not be injected yet — so `IS_DOM` locks to false permanently, and every subsequent native bridge call throws "Cannot invoke native actions outside of a webview".

# How

Changed `IS_DOM` in [`marshal.tsx`](https://github.com/expo/expo/blob/main/packages/expo/src/dom/marshal.tsx#L4) from a module-level constant (evaluated once at import time) to a function `isDom()` that checks the globals on each call. This way the bridge correctly detects the WebView environment even after a renderer restart, once the globals are re-injected.

**Note:** There are two other `IS_DOM` exports in [`dom.ts`](https://github.com/expo/expo/blob/main/packages/expo/src/dom/dom.ts#L8) and [`dom.web.ts`](https://github.com/expo/expo/blob/main/packages/expo/src/dom/dom.web.ts#L4) — these are public API exports for app code to check "am I in a DOM component?" and are not involved in the bridge call path. This PR only changes the private `IS_DOM` in [`marshal.tsx`](https://github.com/expo/expo/blob/main/packages/expo/src/dom/marshal.tsx#L4) which gates `emit()`, `addEventListener()`, and `invokeNativeAction()`.

# Test Plan

**Reproduction with ads:**
  1. Use a `"use dom"` component that calls native function props (e.g. `onSave`, `onClose`)
  2. Show an interstitial or rewarded ad while the DOM component is mounted
  3. Dismiss the ad
  4. Interact with the DOM component — native bridge calls should work without throwing

**Reproduction with two DOM components:**
  1. Render two instances of the same `"use dom"` component on the same screen
  2. Interact with the second instance — it should be able to call native function props without throwing

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
