### PR TITLE
[observ][Android] Downgrade `okhttp3` to `4.9.2`

### DIFF
--- a/packages/expo-observe/android/build.gradle
+++ b/packages/expo-observe/android/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     implementation project(':expo-updates-interface')
     implementation "com.facebook.react:react-android"
     implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0"
-    implementation "com.squareup.okhttp3:okhttp:5.3.0"
+    implementation "com.squareup.okhttp3:okhttp:4.9.2"
     // This is a workaround for IDE warning - https://youtrack.jetbrains.com/issue/KTIJ-31549
     implementation "androidx.annotation:annotation-experimental:1.5.1"
 
@@ -76,7 +76,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.11.1'
     testImplementation 'androidx.test:core:1.5.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:5.3.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.2'
     testImplementation 'io.mockk:mockk:1.13.8'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
 }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -73,7 +73,7 @@ class EventDispatcher(
         }
 
         val response = call.execute()
-        Log.d(TAG, "Server responded with: ${response.body.string()}")
+        Log.d(TAG, "Server responded with: ${response.body?.string()}")
 
         continuation.resume(response.code in 200..299)
       } catch (e: Exception) {


### PR DESCRIPTION
# Why

Downgrades `okhttp3` to `4.9.2` - this version is used by React Native. Using 5.x will lead to:
```
FATAL EXCEPTION: OkHttp Dispatcher
  Process: dev.expo.payments, PID: 6215
  java.lang.NoClassDefFoundError: Failed resolution of: Lokhttp3/internal/Util;
  	at okhttp3.JavaNetCookieJar.decodeHeaderAsJavaNetCookies(JavaNetCookieJar.kt:81)
  	at okhttp3.JavaNetCookieJar.loadForRequest(JavaNetCookieJar.kt:59)
  	at com.facebook.react.modules.network.ReactCookieJarContainer.loadForRequest(ReactCookieJarContainer.kt:37)
  	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:75)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:74)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpAppInterceptor.intercept(ExpoNetworkInspectOkHttpInterceptors.kt:60)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at okhttp3.brotli.BrotliInterceptor.intercept(BrotliInterceptor.kt:44)
  	at expo.modules.networkaddons.ExpoOkHttpInterceptor.intercept(ExpoOkHttpInterceptor.kt:12)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpAppInterceptor.intercept(ExpoNetworkInspectOkHttpInterceptors.kt:60)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at okhttp3.brotli.BrotliInterceptor.intercept(BrotliInterceptor.kt:44)
  	at expo.modules.networkaddons.ExpoOkHttpInterceptor.intercept(ExpoOkHttpInterceptor.kt:12)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at expo.modules.fetch.OkHttpFileUrlInterceptor.intercept(OkHttpFileUrlInterceptor.kt:42)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at expo.modules.kotlin.devtools.ExpoNetworkInspectOkHttpAppInterceptor.intercept(ExpoNetworkInspectOkHttpInterceptors.kt:60)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at okhttp3.brotli.BrotliInterceptor.intercept(BrotliInterceptor.kt:40)
  	at expo.modules.networkaddons.ExpoOkHttpInterceptor.intercept(ExpoOkHttpInterceptor.kt:12)
  	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:126)
  	at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:226)
  	at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:574)
  	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1156)
  	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:651)
  	at java.lang.Thread.run(Thread.java:1119)
  Caused by: java.lang.ClassNotFoundException: Didn't find class "okhttp3.internal.Util" on path: DexPathList[[zip file "/data/app/~~7QdPofka6PWhaIXkgTgOcA==/dev.expo.payments-Nfi6ck5h_OWXyihqdXIegA==/base.apk"],nativeLibraryDirectories=[/data/app/~~7QdPofka6PWhaIXkgTgOcA==/dev.expo.payments-Nfi6ck5h_OWXyihqdXIegA==/lib/arm64, /data/app/~~7QdPofka6PWhaIXkgTgOcA==/dev.expo.payments-Nfi6ck5h_OWXyihqdXIegA==/base.apk!/lib/arm64-v8a, /system/lib64, /system_ext/lib64]]
  	at dalvik.system.BaseDexClassLoader.findClass(BaseDexClassLoader.java:259)
  	at java.lang.ClassLoader.loadClass(ClassLoader.java:637)
  	at java.lang.ClassLoader.loadClass(ClassLoader.java:573)
```

# Test Plan

- run fetch tests in bare-expo ✅ 