### PR TITLE
[file-system][ios] Fix `totalDiskSpace` returning free space instead of total capacity

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - [Android] Fix copy/move support for SAF and content provider URIs. ([#42887](https://github.com/expo/expo/pull/42887) by [@barthap](https://github.com/barthap))
 - Fix out-of-memory errors when calculating file `md5` hash. ([#44064](https://github.com/expo/expo/pull/44064) by [@barthap](https://github.com/barthap))
+- [iOS] Fix `totalDiskSpace` returning free disk space instead of total disk capacity. ([#44849](https://github.com/expo/expo/pull/44849) by [@shanebdavis](https://github.com/shanebdavis))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/ios/FileSystemModule.swift
+++ b/packages/expo-file-system/ios/FileSystemModule.swift
@@ -23,7 +23,7 @@ public final class FileSystemModule: Module {
       let attributes = try? FileManager.default.attributesOfFileSystem(forPath: path) else {
       return nil
     }
-    return attributes[.systemFreeSize] as? Int64
+    return attributes[.systemSize] as? Int64
   }
 
   var availableDiskSpace: Int64? {


### PR DESCRIPTION
`totalDiskSpace` was using `.systemFreeSize` instead of `.systemSize`, making it return the same value as
`availableDiskSpace`.

# Why

`Paths.totalDiskSpace` on iOS returns the same value as `Paths.availableDiskSpace` because both properties read
`attributes[.systemFreeSize]`. This means any app relying on `totalDiskSpace` to calculate usage (e.g. `total - available`)
gets zero.

# How

Changed `totalDiskSpace` to use `.systemSize` instead of `.systemFreeSize` in `FileSystemModule.swift`. The Android
implementation already uses the correct `File.totalSpace` API and was unaffected.

# Test Plan

- Read `Paths.totalDiskSpace` and `Paths.availableDiskSpace` on an iOS device/simulator
- Before fix: both values are identical
- After fix: `totalDiskSpace` returns the full disk capacity (significantly larger than `availableDiskSpace`)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short
guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- N/A This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- N/A Conforms with the [Documentation Writing Style
Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)