### PR TITLE
[core][Android] Exposed `OkHttpClient` through `AppContext`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [Android] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#43481](https://github.com/expo/expo/pull/43481) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `nativeModule` look up function and `bundleURL` to AppContext. ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions. ([#44122](https://github.com/expo/expo/pull/44122) by [@tsapeta](https://github.com/tsapeta))
+- [Android] Exposed a shared OkHttpClient instance through AppContext with new coroutine-friendly extensions.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [Android] Use the `RuntimeScheduler` to schedule tasks on the JS thread. ([#43481](https://github.com/expo/expo/pull/43481) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Add `nativeModule` look up function and `bundleURL` to AppContext. ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions. ([#44122](https://github.com/expo/expo/pull/44122) by [@tsapeta](https://github.com/tsapeta))
-- [Android] Exposed a shared OkHttpClient instance through AppContext with new coroutine-friendly extensions.
+- [Android] Exposed a shared OkHttpClient instance through AppContext with new coroutine-friendly extensions. ([#44854](https://github.com/expo/expo/pull/44854) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/AppContext.kt
@@ -9,6 +9,7 @@ import android.view.View
 import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatActivity
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.modules.network.OkHttpClientProvider
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.common.UIManagerType
@@ -42,6 +43,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.cancel
+import okhttp3.OkHttpClient
 import java.io.File
 import java.lang.ref.WeakReference
 
@@ -143,7 +145,8 @@ class AppContext(
       val inlineModulesList = Class.forName("inline.modules.ExpoInlineModulesList").getConstructor()
         .newInstance() as ModulesProvider
       registry.register(inlineModulesList)
-    } catch (_: ClassNotFoundException) {}
+    } catch (_: ClassNotFoundException) {
+    }
   }
 
   /**
@@ -229,6 +232,17 @@ class AppContext(
    */
   val hasActiveReactInstance: Boolean
     get() = runtime.reactContext?.hasActiveReactInstance() == true
+
+  /**
+   * @returns an OkHttpClient instance that can be used to perform network requests
+   * with the same configuration as React Native's networking module. See [com.facebook.react.modules.network.OkHttpClientProvider].
+   * This client will share the same cookie jar and has no timeouts by default.
+   */
+  val okHttpClient: OkHttpClient
+    get() = OkHttpClientProvider.getOkHttpClient()
+
+  fun createOkHttpClientBuilder(): OkHttpClient.Builder =
+    OkHttpClientProvider.createClientBuilder()
 
   /**
    * Provides access to the event emitter

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/okhttp/OkHttpCoroutinesExtensions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/okhttp/OkHttpCoroutinesExtensions.kt
@@ -23,13 +23,13 @@ suspend fun Call.await(): Response =
 
         override fun onResponse(
           call: Call,
-          response: Response,
+          response: Response
         ) {
           continuation.resume(response) { _, value, _ ->
             value.closeQuietly()
           }
         }
-      },
+      }
     )
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/okhttp/OkHttpCoroutinesExtensions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/okhttp/OkHttpCoroutinesExtensions.kt
@@ -1,0 +1,37 @@
+package expo.modules.kotlin.okhttp
+
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.internal.closeQuietly
+import java.io.IOException
+import kotlin.coroutines.resumeWithException
+
+suspend fun Call.await(): Response =
+  suspendCancellableCoroutine { continuation ->
+    continuation.invokeOnCancellation {
+      this.cancel()
+    }
+    this.enqueue(
+      object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+          continuation.resumeWithException(e)
+        }
+
+        override fun onResponse(
+          call: Call,
+          response: Response,
+        ) {
+          continuation.resume(response) { _, value, _ ->
+            value.closeQuietly()
+          }
+        }
+      },
+    )
+  }
+
+suspend fun Request.await(okHttpClient: OkHttpClient): Response =
+  okHttpClient.newCall(this).await()


### PR DESCRIPTION
# Why

Exposed a shared OkHttpClient instance through AppContext with new coroutine-friendly extensions.

# How

The extensions implementation is based on the https://github.com/square/okhttp/blob/5e5ff63f611715b32db397d9cdaf0be230907729/okhttp-coroutines/src/main/kotlin/okhttp3/coroutines/ExecuteAsync.kt#L30

# Test Plan

- I've used this client in other packages, which are right now using the client from RN directly ✅ 