### PR TITLE
[expo][Android] Annotate `Records` with `@OptimizedRecord`

### DIFF
--- a/packages/@expo/dom-webview/android/src/main/java/expo/modules/webview/DomWebViewEvents.kt
+++ b/packages/@expo/dom-webview/android/src/main/java/expo/modules/webview/DomWebViewEvents.kt
@@ -4,7 +4,9 @@ package expo.modules.webview
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal data class OnMessageEvent(
   @Field val title: String,
   @Field val url: String,

--- a/packages/@expo/dom-webview/android/src/main/java/expo/modules/webview/DomWebViewRecords.kt
+++ b/packages/@expo/dom-webview/android/src/main/java/expo/modules/webview/DomWebViewRecords.kt
@@ -4,11 +4,14 @@ package expo.modules.webview
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal data class DomWebViewSource(
   @Field val uri: String?
 ) : Record
 
+@OptimizedRecord
 internal data class ScrollToParam(
   @Field val x: Double = 0.0,
   @Field val y: Double = 0.0,

--- a/packages/expo-age-range/android/src/main/java/expo/modules/agerange/AgeRangeRecords.kt
+++ b/packages/expo-age-range/android/src/main/java/expo/modules/agerange/AgeRangeRecords.kt
@@ -9,7 +9,9 @@ import com.google.android.play.agesignals.model.AgeSignalsVerificationStatus.VER
 import com.google.android.play.agesignals.model.AgeSignalsVerificationStatus.UNKNOWN
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class AgeRangeResult(
   @Field
   val lowerBound: Int?,

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
@@ -6,7 +6,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
 import java.net.URL
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class AudioSource(
   @Field val uri: String?,
   @Field val headers: Map<String, String>?,
@@ -19,6 +21,7 @@ enum class LoopMode(val value: String) : Enumerable {
   ALL("all")
 }
 
+@OptimizedRecord
 class AudioMode(
   @Field val shouldPlayInBackground: Boolean = false,
   @Field val shouldRouteThroughEarpiece: Boolean?,
@@ -28,6 +31,7 @@ class AudioMode(
 ) : Record
 
 // Data class because we want `equals`
+@OptimizedRecord
 data class RecordingOptions(
   @Field val extension: String,
   @Field val sampleRate: Double?,
@@ -40,6 +44,7 @@ data class RecordingOptions(
   @Field val audioSource: RecordingSource?
 ) : Record
 
+@OptimizedRecord
 class Metadata(
   @Field val title: String?,
   @Field val artist: String?,
@@ -95,6 +100,7 @@ enum class AndroidAudioEncoder(val value: String) : Enumerable {
   }
 }
 
+@OptimizedRecord
 class AudioLockScreenOptions(
   @Field val showSeekForward: Boolean,
   @Field val showSeekBackward: Boolean,
@@ -107,6 +113,7 @@ enum class InterruptionMode(val value: String) : Enumerable {
   MIX_WITH_OTHERS("mixWithOthers")
 }
 
+@OptimizedRecord
 class RecordOptions(
   @Field val atTime: Double?,
   @Field val forDuration: Double?

--- a/packages/expo-blob/android/src/main/java/expo/modules/blob/Blob.kt
+++ b/packages/expo-blob/android/src/main/java/expo/modules/blob/Blob.kt
@@ -9,6 +9,7 @@ import expo.modules.kotlin.types.Enumerable
 import java.io.ByteArrayOutputStream
 import kotlin.math.max
 import kotlin.math.min
+import expo.modules.kotlin.types.OptimizedRecord
 
 internal const val DEFAULT_TYPE = ""
 
@@ -176,6 +177,7 @@ internal enum class EndingType(val str: String) : Enumerable {
   NATIVE("native")
 }
 
+@OptimizedRecord
 internal class BlobOptionsBag : Record {
   @Field
   val type: String = DEFAULT_TYPE

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/dialogs/CreatedEventOptions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/dialogs/CreatedEventOptions.kt
@@ -5,7 +5,9 @@ import expo.modules.calendar.domain.event.records.input.RecurrenceRuleInput
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class CreatedEventOptions : Record, Serializable {
   @Field
   val title: String? = null

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/dialogs/ViewEventIntentResult.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/dialogs/ViewEventIntentResult.kt
@@ -2,7 +2,9 @@ package expo.modules.calendar.dialogs
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 open class ViewEventIntentResult(
   @Field val action: String = "done"
 ) : Record

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/dialogs/ViewedEventOptions.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/dialogs/ViewedEventOptions.kt
@@ -3,7 +3,9 @@ package expo.modules.calendar.dialogs
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class ViewedEventOptions(
   @Field
   val id: String = "",

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/attendee/records/Attendee.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/attendee/records/Attendee.kt
@@ -9,7 +9,9 @@ import expo.modules.calendar.exceptions.FieldMissingException
 import expo.modules.core.utilities.ifNull
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class Attendee : Record {
   // Key "id" should be called "attendeeId",
   // but for now to keep API reverse compatibility it wasn't changed

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/records/CalendarEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/records/CalendarEntity.kt
@@ -6,10 +6,12 @@ import expo.modules.calendar.domain.event.enums.AlarmMethod
 import expo.modules.calendar.domain.event.enums.Availability
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
 /**
  * Calendar info that is returned to JS
  */
+@OptimizedRecord
 data class CalendarEntity(
   @Field val id: String?,
   @Field val title: String?,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/records/CalendarSource.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/records/CalendarSource.kt
@@ -4,6 +4,7 @@ import android.provider.CalendarContract
 import expo.modules.calendar.exceptions.FieldMissingException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
 /**
  * This is used for both input and return type
@@ -13,6 +14,7 @@ import expo.modules.kotlin.records.Record
  * - When returning to JS, none field is required
  *   - `isLocalAccount` is inferred based on `type`
  */
+@OptimizedRecord
 class CalendarSource : Record {
   constructor(name: String?, type: String?) {
     this.name = name

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/records/input/CalendarUpdateInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/records/input/CalendarUpdateInput.kt
@@ -5,7 +5,9 @@ import android.provider.CalendarContract
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.Required
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class CalendarUpdateInput(
   @Field @Required val id: String,
   @Field val name: String?,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/records/input/NewCalendarInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/calendar/records/input/NewCalendarInput.kt
@@ -11,7 +11,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.Required
 import java.util.TimeZone
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class NewCalendarInput(
   @Field @Required val name: String,
   @Field @Required val title: String,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/Alarm.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/Alarm.kt
@@ -3,7 +3,9 @@ package expo.modules.calendar.domain.event.records
 import expo.modules.calendar.domain.event.enums.AlarmMethod
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class Alarm(
   @Field val relativeOffset: Int?,
   @Field val method: AlarmMethod?

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/EventEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/EventEntity.kt
@@ -4,7 +4,9 @@ import expo.modules.calendar.domain.event.enums.Availability
 import expo.modules.calendar.domain.event.enums.EventAccessLevel
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class EventEntity(
   @Field val id: String,
   @Field val calendarId: String?,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/RecurrenceRuleEntity.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/RecurrenceRuleEntity.kt
@@ -5,7 +5,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.util.Date
 import java.util.Locale
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class RecurrenceRuleEntity(
   @Field val frequency: String,
   @Field val interval: Int?,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RecurrenceRuleInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RecurrenceRuleInput.kt
@@ -6,7 +6,9 @@ import expo.modules.calendar.extensions.getTimeInMillis
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.util.Calendar
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class RecurrenceRuleInput(
   @Field val frequency: String = "",
   @Field val interval: Int? = null,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RemoveEventInput.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/records/input/RemoveEventInput.kt
@@ -4,7 +4,9 @@ import expo.modules.calendar.extensions.DateTimeInput
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.Required
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class RemoveEventInput(
   @Field @Required val id: String,
   @Field val instanceStartDate: DateTimeInput?

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/AttendeeRecord.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/AttendeeRecord.kt
@@ -3,7 +3,9 @@ package expo.modules.calendar.next.records
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class AttendeeRecord(
   @Field
   var id: String? = null,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/AttendeeUpdateRecord.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/AttendeeUpdateRecord.kt
@@ -3,7 +3,9 @@ package expo.modules.calendar.next.records
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.ValueOrUndefined
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class AttendeeUpdateRecord(
   @Field val email: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),
   @Field val name: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/CalendarRecord.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/CalendarRecord.kt
@@ -4,7 +4,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.Required
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class CalendarInputRecord(
   @Required @Field var title: String,
   @Field val name: String?,
@@ -36,6 +38,7 @@ enum class CalendarAccessLevel(val value: String) : Enumerable {
   NONE("none")
 }
 
+@OptimizedRecord
 data class Source(
   @Field
   val id: String? = null,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/CalendarUpdateRecord.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/CalendarUpdateRecord.kt
@@ -3,7 +3,9 @@ package expo.modules.calendar.next.records
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.ValueOrUndefined
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class CalendarUpdateRecord(
   @Field val name: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),
   @Field val title: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/EventRecord.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/EventRecord.kt
@@ -7,7 +7,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
 import java.util.Locale
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class EventInputRecord(
   @Field val startDate: String,
   @Field val endDate: String,
@@ -30,6 +32,7 @@ data class EventInputRecord(
   @Field val instanceId: String? = null
 ) : Record
 
+@OptimizedRecord
 data class AlarmRecord(
   @Field
   val relativeOffset: Int?,
@@ -37,6 +40,7 @@ data class AlarmRecord(
   val method: AlarmMethod?
 ) : Record
 
+@OptimizedRecord
 data class RecurrenceRuleRecord(
   @Field
   val endDate: String? = null,
@@ -85,6 +89,7 @@ data class RecurrenceRuleRecord(
   }
 }
 
+@OptimizedRecord
 data class RecurringEventOptions(
   @Field
   val instanceStartDate: String? = null,

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/EventUpdateRecord.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/next/records/EventUpdateRecord.kt
@@ -3,7 +3,9 @@ package expo.modules.calendar.next.records
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.ValueOrUndefined
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class EventUpdateRecord(
   @Field val title: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),
   @Field val startDate: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/Options.kt
@@ -3,7 +3,9 @@ package expo.modules.camera
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class PictureOptions(
   @Field val quality: Double = 1.0,
   @Field val base64: Boolean = false,
@@ -19,12 +21,14 @@ data class PictureOptions(
   @Field val pictureRef: Boolean = false
 ) : Record
 
+@OptimizedRecord
 data class SavePictureOptions(
   @Field val quality: Double = 1.0,
   @Field val base64: Boolean = false,
   @Field val metadata: Map<String, Any>? = emptyMap()
 ) : Record
 
+@OptimizedRecord
 data class RecordingOptions(
   @Field val maxDuration: Int = 0,
   @Field val maxFileSize: Int = 0

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/common/CommonEvents.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/common/CommonEvents.kt
@@ -3,7 +3,9 @@ package expo.modules.camera.common
 import android.os.Bundle
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class BarcodeScannedEvent(
   @Field val target: Int,
   @Field val data: String,
@@ -14,10 +16,12 @@ class BarcodeScannedEvent(
   @Field val extra: Bundle?
 ) : Record
 
+@OptimizedRecord
 class CameraMountErrorEvent(
   @Field val message: String
 ) : Record
 
+@OptimizedRecord
 class PictureSavedEvent(
   @Field val id: Int,
   @Field val data: Bundle

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/records/CameraRecords.kt
@@ -8,6 +8,7 @@ import com.google.mlkit.vision.barcode.common.Barcode
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class CameraType(val value: String) : Enumerable {
   FRONT("front"),
@@ -80,6 +81,7 @@ enum class VideoStabilizationMode(val value: String) : Enumerable {
   fun isEnabled() = this != OFF
 }
 
+@OptimizedRecord
 data class BarcodeSettings(
   @Field val barcodeTypes: List<BarcodeType>
 ) : Record

--- a/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardOptions.kt
+++ b/packages/expo-clipboard/android/src/main/java/expo/modules/clipboard/ClipboardOptions.kt
@@ -4,7 +4,9 @@ import android.graphics.Bitmap
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal class GetImageOptions : Record {
   @Field(key = "format")
   var imageFormat: ImageFormat = ImageFormat.JPG
@@ -13,11 +15,13 @@ internal class GetImageOptions : Record {
   var jpegQuality: Double = 1.0
 }
 
+@OptimizedRecord
 internal class GetStringOptions : Record {
   @Field
   var preferredFormat: StringFormat = StringFormat.PLAIN
 }
 
+@OptimizedRecord
 internal class SetStringOptions : Record {
   @Field
   var inputFormat: StringFormat = StringFormat.PLAIN

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/ContactsModule.kt
@@ -32,6 +32,7 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import kotlinx.coroutines.launch
 import java.util.UUID
+import expo.modules.kotlin.types.OptimizedRecord
 
 const val onContactsChangeEventName = "onContactsChange"
 
@@ -100,6 +101,7 @@ private val DEFAULT_PROJECTION = listOf(
   ContactsContract.Data.STARRED
 )
 
+@OptimizedRecord
 class ContactQuery : Record {
   @Field
   val pageSize = 0

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/ContactQueryOptions.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/ContactQueryOptions.kt
@@ -4,7 +4,9 @@ import android.provider.ContactsContract
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class ContactQueryOptions : Record {
   @Field val limit: Int? = null
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/Existing.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/Existing.kt
@@ -1,11 +1,18 @@
 package expo.modules.contacts.next.records
 
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 interface RecordWithId : Record {
   val id: String
 }
 
+@OptimizedRecord
 interface ExistingRecord : RecordWithId
+
+@OptimizedRecord
 interface PatchRecord : RecordWithId
+
+@OptimizedRecord
 interface NewRecord : Record

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/contact/CreateContactRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/contact/CreateContactRecord.kt
@@ -9,7 +9,9 @@ import expo.modules.contacts.next.records.fields.RelationRecord
 import expo.modules.contacts.next.records.fields.UrlAddressRecord
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class CreateContactRecord(
   @Field val givenName: String? = null,
   @Field val middleName: String? = null,

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/contact/GetContactDetailsRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/contact/GetContactDetailsRecord.kt
@@ -9,7 +9,9 @@ import expo.modules.contacts.next.records.fields.RelationRecord
 import expo.modules.contacts.next.records.fields.UrlAddressRecord
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class GetContactDetailsRecord(
   @Field val id: String,
   @Field val fullName: String? = null,

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/contact/PatchContactRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/contact/PatchContactRecord.kt
@@ -11,7 +11,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.ValueOrUndefined
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class PatchContactRecord(
   @Field val isFavourite: ValueOrUndefined<Boolean> = ValueOrUndefined.Undefined(),
   @Field val givenName: ValueOrUndefined<String?> = ValueOrUndefined.Undefined(),

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/AddressRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/AddressRecord.kt
@@ -5,9 +5,11 @@ import expo.modules.contacts.next.records.NewRecord
 import expo.modules.contacts.next.records.PatchRecord
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Required
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.types.ValueOrUndefined
 
 sealed interface AddressRecord {
+  @OptimizedRecord
   data class Existing(
     @Required @Field override val id: String,
     @Field val label: String? = null,
@@ -18,6 +20,7 @@ sealed interface AddressRecord {
     @Field val country: String? = null
   ) : ExistingRecord
 
+  @OptimizedRecord
   data class New(
     @Field val label: String? = null,
     @Field val street: String? = null,
@@ -27,7 +30,8 @@ sealed interface AddressRecord {
     @Field val country: String? = null
   ) : NewRecord
 
-  class Patch() : PatchRecord {
+  @OptimizedRecord
+  class Patch : PatchRecord {
     @Required @Field
     override lateinit var id: String
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/DateRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/DateRecord.kt
@@ -7,20 +7,24 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.Required
 import expo.modules.kotlin.types.ValueOrUndefined
+import expo.modules.kotlin.types.OptimizedRecord
 
 sealed interface DateRecord {
+  @OptimizedRecord
   data class Existing(
     @Required @Field override val id: String,
     @Field val label: String? = null,
     @Field val date: ContactDateRecord? = null
   ) : ExistingRecord
 
+  @OptimizedRecord
   data class New(
     @Field val label: String? = null,
     @Field val date: ContactDateRecord? = null
   ) : NewRecord
 
-  class Patch() : PatchRecord {
+  @OptimizedRecord
+  class Patch : PatchRecord {
     @Required @Field
     override lateinit var id: String
 
@@ -29,6 +33,7 @@ sealed interface DateRecord {
     @Field val date: ValueOrUndefined<ContactDateRecord?> = ValueOrUndefined.Undefined()
   }
 
+  @OptimizedRecord
   data class ContactDateRecord(
     @Field val year: Int? = null,
     @Required @Field val month: Int,

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/EmailRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/EmailRecord.kt
@@ -5,21 +5,25 @@ import expo.modules.contacts.next.records.NewRecord
 import expo.modules.contacts.next.records.PatchRecord
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Required
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.types.ValueOrUndefined
 
 sealed interface EmailRecord {
+  @OptimizedRecord
   data class Existing(
     @Required @Field override val id: String,
     @Field val label: String? = null,
     @Field val address: String? = null
   ) : ExistingRecord
 
+  @OptimizedRecord
   data class New(
     @Field val label: String? = null,
     @Field val address: String? = null
   ) : NewRecord
 
-  class Patch() : PatchRecord {
+  @OptimizedRecord
+  class Patch : PatchRecord {
     @Required @Field
     override lateinit var id: String
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/ExtraNameRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/ExtraNameRecord.kt
@@ -5,21 +5,25 @@ import expo.modules.contacts.next.records.NewRecord
 import expo.modules.contacts.next.records.PatchRecord
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Required
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.types.ValueOrUndefined
 
 sealed interface ExtraNameRecord {
+  @OptimizedRecord
   data class Existing(
     @Required @Field override val id: String,
     @Field val label: String? = null,
     @Field val name: String? = null
   ) : ExistingRecord
 
+  @OptimizedRecord
   data class New(
     @Field val label: String? = null,
     @Field val name: String? = null
   ) : NewRecord
 
-  class Patch() : PatchRecord {
+  @OptimizedRecord
+  class Patch : PatchRecord {
     @Required @Field
     override lateinit var id: String
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/PhoneRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/PhoneRecord.kt
@@ -5,21 +5,25 @@ import expo.modules.contacts.next.records.NewRecord
 import expo.modules.contacts.next.records.PatchRecord
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Required
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.types.ValueOrUndefined
 
 sealed interface PhoneRecord {
+  @OptimizedRecord
   data class Existing(
     @Required @Field override val id: String,
     @Field val label: String? = null,
     @Field val number: String? = null
   ) : ExistingRecord
 
+  @OptimizedRecord
   data class New(
     @Field val label: String? = null,
     @Field val number: String? = null
   ) : NewRecord
 
-  class Patch() : PatchRecord {
+  @OptimizedRecord
+  class Patch : PatchRecord {
     @Required @Field
     override lateinit var id: String
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/RelationRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/RelationRecord.kt
@@ -5,21 +5,25 @@ import expo.modules.contacts.next.records.NewRecord
 import expo.modules.contacts.next.records.PatchRecord
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Required
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.types.ValueOrUndefined
 
 sealed interface RelationRecord {
+  @OptimizedRecord
   data class Existing(
     @Required @Field override val id: String,
     @Field val name: String? = null,
     @Field val label: String? = null
   ) : ExistingRecord
 
+  @OptimizedRecord
   data class New(
     @Field val label: String? = null,
     @Field val name: String? = null
   ) : NewRecord
 
-  class Patch() : PatchRecord {
+  @OptimizedRecord
+  class Patch : PatchRecord {
     @Required @Field
     override lateinit var id: String
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/UrlAddressRecord.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/records/fields/UrlAddressRecord.kt
@@ -5,21 +5,25 @@ import expo.modules.contacts.next.records.NewRecord
 import expo.modules.contacts.next.records.PatchRecord
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Required
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.types.ValueOrUndefined
 
 sealed interface UrlAddressRecord {
+  @OptimizedRecord
   data class Existing(
     @Required @Field override val id: String,
     @Field val label: String? = null,
     @Field val url: String? = null
   ) : ExistingRecord
 
+  @OptimizedRecord
   data class New(
     @Field val label: String? = null,
     @Field val url: String? = null
   ) : NewRecord
 
-  class Patch() : PatchRecord {
+  @OptimizedRecord
+  class Patch : PatchRecord {
     @Required @Field
     override lateinit var id: String
 

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestOptions.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/DigestOptions.kt
@@ -3,7 +3,9 @@ package expo.modules.crypto
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class DigestOptions : Record {
   @Field
   var encoding: Encoding = Encoding.HEX

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/CiphertextOptions.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/CiphertextOptions.kt
@@ -3,7 +3,9 @@ package expo.modules.crypto.aes.records
 import expo.modules.crypto.aes.enums.DataFormat
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class CiphertextOptions(
   @Field val includeTag: Boolean = false,
   @Field val outputFormat: DataFormat = DataFormat.BYTES

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/DecryptOptions.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/DecryptOptions.kt
@@ -4,7 +4,9 @@ import expo.modules.crypto.aes.BinaryInput
 import expo.modules.crypto.aes.enums.DataFormat
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class DecryptOptions : Record {
   @Field
   val output: DataFormat = DataFormat.BYTES

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/EncryptOptions.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/EncryptOptions.kt
@@ -9,7 +9,9 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.EitherOfThree
 import java.security.SecureRandom
 import javax.crypto.spec.GCMParameterSpec
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class EncryptOptions : Record {
   @Field
   val nonce: EitherOfThree<String, ByteArray, Int>? = null

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/SealedDataConfig.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/aes/records/SealedDataConfig.kt
@@ -4,7 +4,9 @@ import expo.modules.crypto.aes.AesConfig.DEFAULT_IV_SIZE
 import expo.modules.crypto.aes.AesConfig.DEFAULT_TAG_SIZE
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class SealedDataConfig(
   @Field val ivLength: Int = DEFAULT_IV_SIZE,
   @Field val tagLength: Int = DEFAULT_TAG_SIZE

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/modules/DevMenuModule.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/modules/DevMenuModule.kt
@@ -11,7 +11,9 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.weak
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class DevMenuCallback(
   @Field
   val name: String,

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerOptions.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerOptions.kt
@@ -2,7 +2,9 @@ package expo.modules.documentpicker
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class DocumentPickerOptions(
   @Field
   val copyToCacheDirectory: Boolean,

--- a/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerResults.kt
+++ b/packages/expo-document-picker/android/src/main/java/expo/modules/documentpicker/DocumentPickerResults.kt
@@ -3,7 +3,9 @@ package expo.modules.documentpicker
 import android.net.Uri
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class DocumentPickerResult(
   @Field
   val canceled: Boolean = false,
@@ -12,6 +14,7 @@ data class DocumentPickerResult(
   val assets: List<DocumentInfo>? = null
 ) : Record
 
+@OptimizedRecord
 data class DocumentInfo(
   @Field
   val uri: Uri,

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
@@ -12,7 +12,9 @@ import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import kotlin.math.min
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 enum class FileMode(val descriptor: String) : Record {
   /** Read-only */
   READ("r"),

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemNextRecords.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemNextRecords.kt
@@ -3,12 +3,15 @@ package expo.modules.filesystem
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class InfoOptions(
   @Field
   val md5: Boolean?
 ) : Record
 
+@OptimizedRecord
 data class CreateOptions(
   @Field
   val intermediates: Boolean = false,
@@ -23,6 +26,7 @@ enum class EncodingType(val value: String) : Enumerable {
   BASE64("base64")
 }
 
+@OptimizedRecord
 data class WriteOptions(
   @Field
   val encoding: EncodingType = EncodingType.UTF8,
@@ -30,6 +34,7 @@ data class WriteOptions(
   val append: Boolean = false
 ) : Record
 
+@OptimizedRecord
 data class DownloadOptions(
   @Field
   val headers: Map<String, String> = emptyMap(),
@@ -37,11 +42,13 @@ data class DownloadOptions(
   val idempotent: Boolean = false
 ) : Record
 
+@OptimizedRecord
 data class RelocationOptions(
   @Field
   val overwrite: Boolean = false
 ) : Record
 
+@OptimizedRecord
 data class FileInfo(
   @Field var exists: Boolean,
   @Field var uri: String?,
@@ -51,11 +58,13 @@ data class FileInfo(
   @Field var creationTime: Long? = null
 ) : Record
 
+@OptimizedRecord
 data class PathInfo(
   @Field var exists: Boolean,
   @Field var isDirectory: Boolean?
 ) : Record
 
+@OptimizedRecord
 data class DirectoryInfo(
   @Field var exists: Boolean,
   @Field var uri: String?,

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/PickFileOptions.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/PickFileOptions.kt
@@ -3,7 +3,9 @@ package expo.modules.filesystem
 import android.net.Uri
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class PickFileOptions(
   @Field
   val initialUri: Uri?,

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/legacy/FileSystemRecords.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/legacy/FileSystemRecords.kt
@@ -3,17 +3,21 @@ package expo.modules.filesystem.legacy
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class InfoOptionsLegacy(
   @Field
   val md5: Boolean?
 ) : Record
 
+@OptimizedRecord
 data class DeletingOptions(
   @Field
   val idempotent: Boolean = false
 ) : Record
 
+@OptimizedRecord
 data class ReadingOptions(
   @Field
   val encoding: EncodingType = EncodingType.UTF8,
@@ -38,11 +42,13 @@ enum class FileSystemUploadType(val value: Int) : Enumerable {
   MULTIPART(1)
 }
 
+@OptimizedRecord
 data class MakeDirectoryOptions(
   @Field
   val intermediates: Boolean = false
 ) : Record
 
+@OptimizedRecord
 data class RelocatingOptions(
   @Field
   val from: String,
@@ -50,6 +56,7 @@ data class RelocatingOptions(
   val to: String
 ) : Record
 
+@OptimizedRecord
 data class DownloadOptionsLegacy(
   @Field
   val md5: Boolean = false,
@@ -61,6 +68,7 @@ data class DownloadOptionsLegacy(
   val sessionType: SessionType = SessionType.BACKGROUND
 ) : Record
 
+@OptimizedRecord
 data class WritingOptions(
   @Field
   val encoding: EncodingType = EncodingType.UTF8,
@@ -68,6 +76,7 @@ data class WritingOptions(
   val append: Boolean = false
 ) : Record
 
+@OptimizedRecord
 data class FileSystemUploadOptions(
   @Field
   val headers: Map<String, String>?,

--- a/packages/expo-font/android/src/main/java/expo/modules/font/FontUtilsRecords.kt
+++ b/packages/expo-font/android/src/main/java/expo/modules/font/FontUtilsRecords.kt
@@ -3,7 +3,9 @@ package expo.modules.font
 import android.graphics.Color
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class RenderToImageOptions(
   @Field
   val fontFamily: String = "",

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLView.kt
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLView.kt
@@ -9,7 +9,9 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class OnSurfaceCreateRecord(
   @Field val exglCtxId: Int
 ) : Record

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorArguments.kt
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorArguments.kt
@@ -4,10 +4,12 @@ import android.graphics.Bitmap
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 /**
  * Options provided for resize action.
  */
+@OptimizedRecord
 class ResizeOptions : Record {
   @Field
   val width: Int? = null
@@ -19,6 +21,7 @@ class ResizeOptions : Record {
 /**
  * Cropping rect for crop action.
  */
+@OptimizedRecord
 class CropRect : Record {
   @Field
   val originX: Double = 0.0
@@ -36,6 +39,7 @@ class CropRect : Record {
 /**
  * Options to use when saving the resulted image.
  */
+@OptimizedRecord
 class ManipulateOptions : Record {
   @Field
   val base64: Boolean = false

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerOptions.kt
@@ -10,9 +10,11 @@ import expo.modules.imagepicker.contracts.ImageLibraryContractOptions
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 internal const val UNLIMITED_SELECTION: Int = 0
 
+@OptimizedRecord
 internal class ImagePickerOptions : Record, Serializable {
   @Field
   var allowsEditing: Boolean = false

--- a/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
+++ b/packages/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerResponse.kt
@@ -4,7 +4,9 @@ import android.os.Bundle
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal class ImagePickerAsset(
   @Field val assetId: String? = null,
   @Field val type: MediaType? = MediaType.IMAGE,
@@ -20,6 +22,7 @@ internal class ImagePickerAsset(
   @Field val rotation: Int? = null
 ) : Record
 
+@OptimizedRecord
 internal class ImagePickerResponse(
   @Field val canceled: Boolean = false,
   @Field val assets: List<ImagePickerAsset>? = null

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/ContentPosition.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/ContentPosition.kt
@@ -6,6 +6,7 @@ import expo.modules.image.calcXTranslation
 import expo.modules.image.calcYTranslation
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
 /**
  * Represents a position value that might be either `Double` or `String`.
@@ -21,6 +22,7 @@ private typealias CalcAxisOffset = (
   isReverse: Boolean
 ) -> Float
 
+@OptimizedRecord
 class ContentPosition : Record {
   @Field
   val top: ContentPositionValue? = null

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/ImageLoadOptions.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/ImageLoadOptions.kt
@@ -4,7 +4,9 @@ import android.graphics.Color
 import com.bumptech.glide.request.target.Target.SIZE_ORIGINAL
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ImageLoadOptions(
   @Field
   val maxWidth: Int = SIZE_ORIGINAL,

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/ImageTransition.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/ImageTransition.kt
@@ -2,7 +2,9 @@ package expo.modules.image.records
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ImageTransition(
   @Field val duration: Int = 0
 ) : Record

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/SourceMap.kt
@@ -21,6 +21,7 @@ import expo.modules.image.customize
 import expo.modules.image.okhttp.GlideUrlWithCustomCacheKey
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
 sealed interface Source {
   val width: Int
@@ -58,6 +59,7 @@ class DecodedSource(
   }
 }
 
+@OptimizedRecord
 data class SourceMap(
   @Field val uri: String? = null,
   @Field override val width: Int = 0,

--- a/packages/expo-image/android/src/main/java/expo/modules/image/records/events.kt
+++ b/packages/expo-image/android/src/main/java/expo/modules/image/records/events.kt
@@ -2,7 +2,9 @@ package expo.modules.image.records
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ImageSource(
   @Field val url: String,
   @Field val width: Int,
@@ -11,16 +13,19 @@ data class ImageSource(
   @Field val isAnimated: Boolean
 ) : Record
 
+@OptimizedRecord
 data class ImageLoadEvent(
   @Field val cacheType: String,
   @Field val source: ImageSource
 ) : Record
 
+@OptimizedRecord
 data class ImageProgressEvent(
   @Field val loaded: Int,
   @Field val total: Int
 ) : Record
 
+@OptimizedRecord
 data class ImageErrorEvent(
   @Field val error: String
 ) : Record

--- a/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherParams.kt
+++ b/packages/expo-intent-launcher/android/src/main/java/expo/modules/intentlauncher/IntentLauncherParams.kt
@@ -2,7 +2,9 @@ package expo.modules.intentlauncher
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class IntentLauncherParams(
   @Field
   val type: String?,

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationRecords.kt
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationRecords.kt
@@ -4,6 +4,7 @@ import androidx.biometric.BiometricManager
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 internal enum class BiometricsSecurityLevel(val value: String) : Enumerable {
   WEAK("weak"),
@@ -17,6 +18,7 @@ internal enum class BiometricsSecurityLevel(val value: String) : Enumerable {
   }
 }
 
+@OptimizedRecord
 internal class AuthOptions : Record {
   @Field
   val promptMessage: String = ""

--- a/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/LocationModule.kt
@@ -131,7 +131,11 @@ class LocationModule : Module(), LifecycleEventListener, SensorEventListener, Ac
     AsyncFunction("requestForegroundPermissionsAsync") Coroutine { ->
       val permissionsManager = appContext.permissions ?: throw NoPermissionsModuleException()
 
-      LocationHelpers.askForPermissionsWithPermissionsManager(permissionsManager, Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
+      LocationHelpers.askForPermissionsWithPermissionsManager(
+        permissionsManager,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+        Manifest.permission.ACCESS_COARSE_LOCATION
+      )
       // We aren't using the values returned above, because we need to check if the user has provided fine location permissions
       return@Coroutine getForegroundPermissionsAsync()
     }

--- a/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationArguments.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationArguments.kt
@@ -6,6 +6,7 @@ import expo.modules.location.LocationModule.Companion.ACCURACY_BALANCED
 import java.io.Serializable
 
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class GeofencingRegionState : Enumerable {
   UNKNOWN,
@@ -13,11 +14,13 @@ enum class GeofencingRegionState : Enumerable {
   OUTSIDE
 }
 
+@OptimizedRecord
 internal class LocationLastKnownOptions(
   @Field var maxAge: Double? = null,
   @Field var requiredAccuracy: Double? = null
 ) : Record, Serializable
 
+@OptimizedRecord
 internal open class LocationOptions(
   @Field var accuracy: Int = ACCURACY_BALANCED,
   @Field var distanceInterval: Int? = null,
@@ -32,6 +35,7 @@ internal open class LocationOptions(
   )
 }
 
+@OptimizedRecord
 internal class ReverseGeocodeLocation(
   @Field var latitude: Double,
   @Field var longitude: Double,
@@ -60,6 +64,7 @@ internal class LocationTaskOptions(
   }
 }
 
+@OptimizedRecord
 internal class LocationTaskServiceOptions(
   @Field var notificationTitle: String? = null,
   @Field var notificationBody: String? = null,
@@ -75,6 +80,7 @@ internal class LocationTaskServiceOptions(
   )
 }
 
+@OptimizedRecord
 internal class GeofencingOptions(
   @Field var regions: List<Region>
 ) : Record, Serializable {
@@ -83,6 +89,7 @@ internal class GeofencingOptions(
   )
 }
 
+@OptimizedRecord
 internal class Region(
   @Field var identifier: String? = null,
   @Field var latitude: Double = .0,

--- a/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt
+++ b/packages/expo-location/android/src/main/java/expo/modules/location/records/LocationResults.kt
@@ -12,7 +12,9 @@ import expo.modules.kotlin.records.Record
 import expo.modules.location.ConversionException
 import expo.modules.location.LocationModule
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal class PermissionRequestResponse(
   @Field var canAskAgain: Boolean?,
   @Field var expires: String?,
@@ -31,6 +33,7 @@ internal class PermissionRequestResponse(
   )
 }
 
+@OptimizedRecord
 internal class PermissionDetailsLocationAndroid(
   @Field var accuracy: String
 ) : Record, Serializable {
@@ -39,6 +42,7 @@ internal class PermissionDetailsLocationAndroid(
   )
 }
 
+@OptimizedRecord
 internal class LocationProviderStatus(
   @Field var backgroundModeEnabled: Boolean? = null,
   @Field var gpsAvailable: Boolean? = false,
@@ -61,6 +65,7 @@ internal class Heading(
   }
 }
 
+@OptimizedRecord
 internal class HeadingEventResponse(
   @Field var watchId: Int? = null,
   @Field var heading: Heading? = null
@@ -73,6 +78,7 @@ internal class HeadingEventResponse(
   }
 }
 
+@OptimizedRecord
 internal class LocationResponse(
   @Field var coords: LocationObjectCoords? = null,
   @Field var timestamp: Double? = null,
@@ -103,6 +109,7 @@ internal class LocationResponse(
   }
 }
 
+@OptimizedRecord
 internal class LocationObjectCoords(
   @Field var latitude: Double? = null,
   @Field var longitude: Double? = null,
@@ -146,6 +153,7 @@ internal class LocationObjectCoords(
   }
 }
 
+@OptimizedRecord
 internal class GeocodeResponse(
   @Field var latitude: Double,
   @Field var longitude: Double,
@@ -171,6 +179,7 @@ internal class GeocodeResponse(
   }
 }
 
+@OptimizedRecord
 internal class ReverseGeocodeResponse(
   @Field var city: String?,
   @Field var district: String?,

--- a/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/Records.kt
+++ b/packages/expo-mail-composer/android/src/main/java/expo/modules/mailcomposer/Records.kt
@@ -2,10 +2,12 @@ package expo.modules.mailcomposer
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
 /**
  * Represents a mail client with a label and package name.
  */
+@OptimizedRecord
 data class MailClient(
   @Field
   val label: String,
@@ -13,6 +15,7 @@ data class MailClient(
   val packageName: String
 ) : Record
 
+@OptimizedRecord
 data class MailComposerOptions(
   @Field
   val recipients: List<String>?,

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/Records.kt
@@ -16,7 +16,9 @@ import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.Enumerable
 import java.util.UUID
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class SetCameraPositionConfig(
   @Field
   val coordinates: Coordinates?,
@@ -28,6 +30,7 @@ data class SetCameraPositionConfig(
   val duration: Int?
 ) : Record
 
+@OptimizedRecord
 data class Coordinates(
   @Field
   val latitude: Double = 0.0,
@@ -44,6 +47,7 @@ data class Coordinates(
   }
 }
 
+@OptimizedRecord
 data class AnchorRecord(
   @Field
   val x: Float = 0.5f,
@@ -54,6 +58,7 @@ data class AnchorRecord(
   fun toOffset() = Offset(x = x, y = y)
 }
 
+@OptimizedRecord
 data class MarkerRecord(
   @Field
   val id: String = UUID.randomUUID().toString(),
@@ -83,6 +88,7 @@ data class MarkerRecord(
   val zIndex: Float = 0.0f
 ) : Record
 
+@OptimizedRecord
 data class PolylineRecord(
   @Field
   val id: String = UUID.randomUUID().toString(),
@@ -100,6 +106,7 @@ data class PolylineRecord(
   val width: Float = 10f
 ) : Record
 
+@OptimizedRecord
 data class PolygonRecord(
   @Field
   val id: String = UUID.randomUUID().toString(),
@@ -117,6 +124,7 @@ data class PolygonRecord(
   val color: Int = 0xFF0000FF.toInt()
 ) : Record
 
+@OptimizedRecord
 data class CameraPositionRecord(
   @Field
   val coordinates: Coordinates = Coordinates(),
@@ -125,6 +133,7 @@ data class CameraPositionRecord(
   val zoom: Float = 10f
 ) : Record
 
+@OptimizedRecord
 data class CircleRecord(
   @Field
   val id: String = UUID.randomUUID().toString(),
@@ -148,6 +157,7 @@ data class CircleRecord(
   val clickCoordinates: Coordinates? = null
 ) : Record
 
+@OptimizedRecord
 data class UserLocationRecord(
   @Field
   val coordinates: Coordinates? = null,
@@ -156,6 +166,7 @@ data class UserLocationRecord(
   val followUserLocation: Boolean = false
 ) : Record
 
+@OptimizedRecord
 data class MapUiSettingsRecord(
   @Field
   val compassEnabled: Boolean = true,
@@ -210,11 +221,13 @@ enum class MapTypeEnum : Enumerable {
   }
 }
 
+@OptimizedRecord
 data class MapStyleOptionsRecord(
   @Field
   val json: String
 ) : Record
 
+@OptimizedRecord
 data class MapPropertiesRecord(
   @Field
   val isBuildingEnabled: Boolean = false,
@@ -250,6 +263,7 @@ data class MapPropertiesRecord(
   }
 }
 
+@OptimizedRecord
 data class POIRecord(
   @Field
   val name: String,
@@ -272,6 +286,7 @@ enum class MapColorSchemeEnum : Enumerable {
   }
 }
 
+@OptimizedRecord
 data class CameraMoveEvent(
   @Field
   val coordinates: Coordinates,
@@ -286,11 +301,13 @@ data class CameraMoveEvent(
   val bearing: Float
 ) : Record
 
+@OptimizedRecord
 data class MapClickEvent(
   @Field
   val coordinates: Coordinates
 ) : Record
 
+@OptimizedRecord
 data class CameraPositionStreetViewRecord(
   @Field
   val coordinates: Coordinates = Coordinates(),
@@ -305,6 +322,7 @@ data class CameraPositionStreetViewRecord(
   val bearing: Float = 0f
 ) : Record
 
+@OptimizedRecord
 data class MapContentPaddingRecord(
   @Field
   val start: Float = 0f,
@@ -319,11 +337,13 @@ data class MapContentPaddingRecord(
   val bottom: Float = 0f
 ) : Record
 
+@OptimizedRecord
 data class MapOptionsRecord(
   @Field
   val mapId: String? = null
 ) : Record
 
+@OptimizedRecord
 data class SelectOptionsRecord(
   @Field
   val zoom: Float? = null,

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/AssetsOptions.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/AssetsOptions.kt
@@ -2,7 +2,9 @@ package expo.modules.medialibrary
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class AssetsOptions(
   @Field val first: Double,
   @Field val after: String?,

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/AssetInfo.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/AssetInfo.kt
@@ -4,7 +4,9 @@ import android.net.Uri
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.medialibrary.next.objects.wrappers.MediaType
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class AssetInfo(
   @Field val id: Uri,
   @Field val creationTime: Long?,

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/Location.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/Location.kt
@@ -2,7 +2,9 @@ package expo.modules.medialibrary.next.records
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class Location(
   @Field val latitude: Double?,
   @Field val longitude: Double?

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/Shape.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/Shape.kt
@@ -2,7 +2,9 @@ package expo.modules.medialibrary.next.records
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class Shape(
   @Field val width: Int,
   @Field val height: Int

--- a/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/SortDescriptor.kt
+++ b/packages/expo-media-library/android/src/main/java/expo/modules/medialibrary/next/records/SortDescriptor.kt
@@ -2,7 +2,9 @@ package expo.modules.medialibrary.next.records
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class SortDescriptor(
   @Field val key: AssetField,
   @Field val ascending: Boolean? = true

--- a/packages/expo-mesh-gradient/android/src/main/java/expo/modules/meshgradient/MeshGradientView.kt
+++ b/packages/expo-mesh-gradient/android/src/main/java/expo/modules/meshgradient/MeshGradientView.kt
@@ -27,7 +27,9 @@ import androidx.compose.ui.graphics.drawscope.scale
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class Resolution(
   @Field
   val x: Int = 8,

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation workletsProject
   }
 
-  implementation("io.github.lukmccall.pika:pika-api:0.1.3-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-api:0.1.4-2.1.20")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/FormatterTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/FormatterTest.kt
@@ -5,12 +5,12 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.formatters.formatter
 import org.junit.Test
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class FormatterTest {
   @Test
   fun uses_formatter_in_sync_function() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord(
       @Field val a: String = "a",
       @Field val b: String? = "b",
@@ -51,7 +51,7 @@ class FormatterTest {
 
   @Test
   fun uses_formatter_in_async_function() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord(
       @Field val a: String = "a",
       @Field val b: String? = "b",

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIAsyncFunctionsTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import org.junit.Assert
 import org.junit.Test
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class JSIAsyncFunctionsTest {
   enum class SimpleEnumClass : Enumerable {
@@ -143,7 +143,7 @@ class JSIAsyncFunctionsTest {
 
   @Test
   fun records_should_be_obtainable_as_function_argument() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       var x: Int = 0

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSIFunctionsTest.kt
@@ -15,7 +15,7 @@ import expo.modules.kotlin.typedarray.TypedArray
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.Enumerable
 import org.junit.Test
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class JSIFunctionsTest {
   enum class SimpleEnumClass : Enumerable {
@@ -203,7 +203,7 @@ class JSIFunctionsTest {
 
   @Test
   fun records_should_be_obtainable_as_function_argument() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       var x: Int = 0
@@ -573,7 +573,7 @@ class JSIFunctionsTest {
 
   @Test
   fun complex_types_should_be_convertible() {
-    @Introspectable
+    @OptimizedRecord
     data class InlineRecord(@Field var name: String = "") : Record
 
     withSingleModule({

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSISuspendableFunctionsTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/JSISuspendableFunctionsTest.kt
@@ -14,7 +14,7 @@ import expo.modules.kotlin.types.Enumerable
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Assert
 import org.junit.Test
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class JSISuspendableFunctionsTest {
   enum class SimpleEnumClass : Enumerable {
@@ -143,7 +143,7 @@ class JSISuspendableFunctionsTest {
 
   @Test
   fun records_should_be_obtainable_as_function_argument() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       var x: Int = 0

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/RecordConversionStrategyBenchmarkTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/RecordConversionStrategyBenchmarkTest.kt
@@ -4,7 +4,7 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.IntrospectableRecordConversionStrategy
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.ReflectionRecordConversionStrategy
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.types.TypeConverterProviderImpl
 import expo.modules.kotlin.types.descriptors.toTypeDescriptor
 import expo.modules.kotlin.types.descriptors.typeDescriptorOf
@@ -31,7 +31,7 @@ class RecordConversionStrategyBenchmarkTest {
     var enabled: Boolean = false
   }
 
-  @Introspectable
+  @OptimizedRecord
   class IntrospectableRecord : Record {
     @Field
     var id: Int = 0

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/NullableTypeConversionTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/types/NullableTypeConversionTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import org.junit.Test
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class NullableTypeConversionTest {
   @Test
@@ -78,13 +78,13 @@ class NullableTypeConversionTest {
 
   @Test
   fun should_convert_null_in_deep_nested_structure() {
-    @Introspectable
+    @OptimizedRecord
     class NestedRecord : Record {
       @Field
       var a: Int? = 10
     }
 
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       val nestedRecord: NestedRecord = NestedRecord()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/SavableTrait.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/traits/SavableTrait.kt
@@ -11,7 +11,7 @@ import expo.modules.kotlin.weak
 import java.io.File
 import java.util.UUID
 import kotlin.reflect.KClass
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class SavableTrait<InputType> @PublishedApi internal constructor(
   val exportImpl: (AppContext) -> ObjectDefinitionData
@@ -19,7 +19,7 @@ class SavableTrait<InputType> @PublishedApi internal constructor(
   override fun export(appContext: AppContext) = exportImpl(appContext)
 
   companion object {
-    @Introspectable
+    @OptimizedRecord
     data class SavableBitmapOptions(
       val compression: Int = 100
     ) : Record

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Introspectable.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Introspectable.kt
@@ -2,4 +2,4 @@ package expo.modules.kotlin.types
 
 import io.github.lukmccall.pika.Introspectable as PikaIntrospectable
 
-typealias Introspectable = PikaIntrospectable
+typealias OptimizedRecord = PikaIntrospectable

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Introspectable.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/Introspectable.kt
@@ -1,5 +1,0 @@
-package expo.modules.kotlin.types
-
-import io.github.lukmccall.pika.Introspectable as PikaIntrospectable
-
-typealias OptimizedRecord = PikaIntrospectable

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -116,7 +116,7 @@ interface JSTypeConverter<T> {
       get() = ReturnType.UNKNOWN // TODO(@lukmccall): Define proper ReturnType for Enums
   }
 
-  @Introspectable
+  @OptimizedRecord
   class RecordConverter : JSTypeConverter<Record> {
     override fun convertToJS(value: Any?): Any? {
       enforceType<Record?>(value)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/OptimizedRecord.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/OptimizedRecord.kt
@@ -1,0 +1,6 @@
+package expo.modules.kotlin.types
+
+// Keep in sync with `expo-modules-gradle-plugin`.
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class OptimizedRecord

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/KotlinInteropModuleRegistryTest.kt
@@ -17,11 +17,11 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.lang.ref.WeakReference
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 private class TestException : CodedException("Something went wrong")
 
-@Introspectable
+@OptimizedRecord
 private class TestRecord : Record {
   @Field
   lateinit var string: String

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/RecordTypeConverterTest.kt
@@ -9,12 +9,12 @@ import expo.modules.kotlin.EnumWithString
 import expo.modules.kotlin.EnumWithoutParameter
 import expo.modules.kotlin.types.convert
 import org.junit.Test
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class RecordTypeConverterTest {
   @Test
   fun `should convert map to mutable record`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       var int: Int = 0
@@ -38,7 +38,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should convert map to immutable record`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       val int: Int = 0
@@ -62,7 +62,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should convert map to lateinit record`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       lateinit var string: String
@@ -81,7 +81,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should convert map to mixed record`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       val int: Int = 0
@@ -110,7 +110,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should respect required annotation`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       @Required
@@ -125,7 +125,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should respect custom js key`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field(key = "point1")
       val int: Int = 0
@@ -154,7 +154,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should respect non required value`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       val required: Int = 10
@@ -181,7 +181,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `primary constructor default values shouldn't be ignored if using the 'shorthand' class syntax`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord(
       @Field
       val int: Int = 42,
@@ -204,7 +204,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should work with complex types`() {
-    @Introspectable
+    @OptimizedRecord
     class InnerRecord : Record {
       @Field
       lateinit var name: String
@@ -223,7 +223,7 @@ class RecordTypeConverterTest {
       }
     }
 
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       lateinit var points: List<Double>
@@ -259,7 +259,7 @@ class RecordTypeConverterTest {
 
   @Test
   fun `should work with enums`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       lateinit var enumWithoutParameter: EnumWithoutParameter

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/formatters/FormatterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/records/formatters/FormatterTest.kt
@@ -5,10 +5,10 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.toJSValueExperimental
 import org.junit.Test
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class FormatterTest {
-  @Introspectable
+  @OptimizedRecord
   class MyRecord(
     @Field val a: String = "a",
     @Field val b: String? = "b",
@@ -75,13 +75,13 @@ class FormatterTest {
 
   @Test
   fun `nested record`() {
-    @Introspectable
+    @OptimizedRecord
     class NestedRecord(
       @Field val a: String = "a",
       @Field val b: String = "b"
     ) : Record
 
-    @Introspectable
+    @OptimizedRecord
     class MyRecordWithNested(
       @Field val nested: NestedRecord = NestedRecord()
     ) : Record

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/JSTypeConverterTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/types/JSTypeConverterTest.kt
@@ -126,7 +126,7 @@ class JSTypeConverterTest {
   @Test
   fun `should convert Record`() {
     @Suppress("unused")
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       val int: Int = 2
@@ -148,7 +148,7 @@ class JSTypeConverterTest {
   @Test
   fun `should convert complex structures`() {
     @Suppress("unused")
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       inner class InnerRecord : Record {
         @Field

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/ConcreteViewPropTest.kt
@@ -9,7 +9,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.toAnyType
 import io.mockk.mockk
 import org.junit.Test
-import expo.modules.kotlin.types.Introspectable
+import expo.modules.kotlin.types.OptimizedRecord
 
 class ConcreteViewPropTest {
   @Test
@@ -31,7 +31,7 @@ class ConcreteViewPropTest {
 
   @Test
   fun `should be able to convert records`() {
-    @Introspectable
+    @OptimizedRecord
     class MyRecord : Record {
       @Field
       lateinit var id: String

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-  implementation("io.github.lukmccall.pika:pika-gradle:0.1.3-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.1.4-2.1.20")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -13,6 +13,7 @@ import expo.modules.plugin.android.createExpoPublishTask
 import expo.modules.plugin.android.createExpoPublishToMavenLocalTask
 import expo.modules.plugin.android.createReleasePublication
 import expo.modules.plugin.gradle.ExpoModuleExtension
+import io.github.lukmccall.pika.PikaGradleExtension
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.internal.extensions.core.extra
@@ -34,6 +35,9 @@ internal fun Project.applyPikaPlugin() {
   if (!plugins.hasPlugin("io.github.lukmccall.pika")) {
     plugins.apply("io.github.lukmccall.pika")
   }
+
+  val pika = extensions.getByType(PikaGradleExtension::class.java)
+  pika.introspectableAnnotation("expo.modules.kotlin.types.OptimizedRecord")
 }
 
 internal fun Project.applyKotlin(kotlinVersion: String, kspVersion: String) {

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/categories/ExpoNotificationCategoriesModule.kt
@@ -20,7 +20,9 @@ import expo.modules.notifications.service.NotificationsService
 import expo.modules.notifications.service.NotificationsService.Companion.deleteCategory
 import expo.modules.notifications.service.NotificationsService.Companion.getCategories
 import expo.modules.notifications.service.NotificationsService.Companion.setCategory
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class NotificationActionRecord : Record {
   @Field
   @Required
@@ -36,12 +38,14 @@ class NotificationActionRecord : Record {
   @Field
   val options = Options()
 
+  @OptimizedRecord
   class TextInput : Record {
     @Field
     @Required
     val placeholder: String = ""
   }
 
+  @OptimizedRecord
   class Options : Record {
     @Field
     val opensAppToForeground = true

--- a/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationBehaviorRecord.kt
+++ b/packages/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationBehaviorRecord.kt
@@ -5,8 +5,10 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.notifications.notifications.enums.NotificationPriority
 import kotlinx.parcelize.Parcelize
+import expo.modules.kotlin.types.OptimizedRecord
 
 @Parcelize
+@OptimizedRecord
 data class NotificationBehaviorRecord(
   @Field val shouldShowAlert: Boolean = false,
   @Field val shouldShowBanner: Boolean = false,

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintOptions.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintOptions.kt
@@ -3,7 +3,9 @@ package expo.modules.print
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal class PrintOptions(
   @Field var html: String? = null,
   @Field var uri: String? = null,

--- a/packages/expo-print/android/src/main/java/expo/modules/print/PrintResponse.kt
+++ b/packages/expo-print/android/src/main/java/expo/modules/print/PrintResponse.kt
@@ -3,7 +3,9 @@ package expo.modules.print
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal class FilePrintResult(
   @Field var uri: String = "",
   @Field var numberOfPages: Int = 0,

--- a/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreOptions.kt
+++ b/packages/expo-secure-store/android/src/main/java/expo/modules/securestore/SecureStoreOptions.kt
@@ -3,7 +3,9 @@ package expo.modules.securestore
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class SecureStoreOptions(
   // Prompt can't be an empty string
   @Field var authenticationPrompt: String = " ",

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingOptions.kt
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingOptions.kt
@@ -2,7 +2,9 @@ package expo.modules.sharing
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class SharingOptions(
   @Field val mimeType: String?,
   @Field val UTI: String?,

--- a/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingRecords.kt
+++ b/packages/expo-sharing/android/src/main/java/expo/modules/sharing/SharingRecords.kt
@@ -3,6 +3,7 @@ package expo.modules.sharing
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class ShareType(val value: String) : Enumerable {
   Text("text"),
@@ -47,12 +48,14 @@ enum class ContentType(val value: String) : Enumerable {
   }
 }
 
+@OptimizedRecord
 internal data class SharePayload(
   @Field var value: String = "",
   @Field var shareType: ShareType = ShareType.Text,
   @Field var mimeType: String = "text/plain"
 ) : Record
 
+@OptimizedRecord
 data class ResolvedSharePayload(
   @Field var value: String = "",
   @Field var shareType: ShareType = ShareType.Text,

--- a/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSOptions.kt
+++ b/packages/expo-sms/android/src/main/java/expo/modules/sms/SMSOptions.kt
@@ -2,11 +2,14 @@ package expo.modules.sms
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class SMSOptions(
   @Field val attachments: List<SMSAttachment> = emptyList()
 ) : Record
 
+@OptimizedRecord
 data class SMSAttachment(
   @Field val uri: String,
   @Field val mimeType: String,

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechOptions.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/SpeechOptions.kt
@@ -2,7 +2,9 @@ package expo.modules.speech
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class SpeechOptions(
   @Field val language: String?,
   @Field val pitch: Float?,

--- a/packages/expo-speech/android/src/main/java/expo/modules/speech/VoiceRecord.kt
+++ b/packages/expo-speech/android/src/main/java/expo/modules/speech/VoiceRecord.kt
@@ -3,12 +3,14 @@ package expo.modules.speech
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class VoiceQuality(val value: String) : Enumerable {
   ENHANCED("Enhanced"),
   DEFAULT("Default")
 }
 
+@OptimizedRecord
 data class VoiceRecord(
   @Field val identifier: String,
   @Field val name: String,

--- a/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
+++ b/packages/expo-splash-screen/android/src/main/java/expo/modules/splashscreen/SplashScreenModule.kt
@@ -5,7 +5,9 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import kotlinx.coroutines.launch
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class SplashScreenOptions : Record {
   @Field
   val duration: Long = 400L

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLRecords.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLRecords.kt
@@ -5,7 +5,9 @@ package expo.modules.sqlite
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal data class Query(
   @Field
   val sql: String,

--- a/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteOptions.kt
+++ b/packages/expo-sqlite/android/src/main/java/expo/modules/sqlite/SQLiteOptions.kt
@@ -4,7 +4,9 @@ package expo.modules.sqlite
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal data class OpenDatabaseOptions(
   @Field
   val enableChangeListener: Boolean = false,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/AlertDialogView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/AlertDialogView.kt
@@ -10,7 +10,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class AlertDialogColors(
   @Field val containerColor: Color? = null,
   @Field val iconContentColor: Color? = null,
@@ -18,6 +20,7 @@ data class AlertDialogColors(
   @Field val textContentColor: Color? = null
 ) : Record
 
+@OptimizedRecord
 data class ExpoDialogProperties(
   @Field val dismissOnBackPress: Boolean = true,
   @Field val dismissOnClickOutside: Boolean = true,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/AnimatedVisibilityView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/AnimatedVisibilityView.kt
@@ -23,6 +23,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
 // region Transition types
 
@@ -46,6 +47,7 @@ enum class ExitTransitionType(val value: String) : Enumerable {
   SCALE_OUT("scaleOut")
 }
 
+@OptimizedRecord
 data class EnterTransitionRecord(
   @Field val type: EnterTransitionType = EnterTransitionType.FADE_IN,
   @Field val initialAlpha: Float? = null,
@@ -54,6 +56,7 @@ data class EnterTransitionRecord(
   @Field val initialScale: Float? = null
 ) : Record
 
+@OptimizedRecord
 data class ExitTransitionRecord(
   @Field val type: ExitTransitionType = ExitTransitionType.FADE_OUT,
   @Field val targetAlpha: Float? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -18,7 +18,9 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.AsyncFunctionHandle
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ModalBottomSheetPropertiesRecord(
   @Field val shouldDismissOnBackPress: Boolean = true,
   @Field val shouldDismissOnClickOutside: Boolean = true

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CardView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CardView.kt
@@ -13,12 +13,15 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class CardColors(
   @Field val containerColor: Color? = null,
   @Field val contentColor: Color? = null
 ) : Record
 
+@OptimizedRecord
 data class CardBorder(
   @Field val width: Float = 1f,
   @Field val color: Color? = null

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CarouselView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CarouselView.kt
@@ -18,12 +18,14 @@ import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class FlingBehaviorType(val value: String) : Enumerable {
   SINGLE_ADVANCE("singleAdvance"),
   NO_SNAP("noSnap")
 }
 
+@OptimizedRecord
 class PaddingValuesRecord : Record {
   @Field val start: Float? = null
   @Field val top: Float? = null

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CheckboxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CheckboxView.kt
@@ -11,7 +11,9 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class CheckboxColors(
   @Field val checkedColor: Color? = null,
   @Field val disabledCheckedColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ChipView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ChipView.kt
@@ -19,9 +19,12 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 open class ChipPressedEvent : Record, Serializable
 
+@OptimizedRecord
 class AssistChipColors : Record {
   @Field val containerColor: Color? = null
   @Field val labelColor: Color? = null
@@ -29,6 +32,7 @@ class AssistChipColors : Record {
   @Field val trailingIconContentColor: Color? = null
 }
 
+@OptimizedRecord
 class FilterChipColors : Record {
   @Field val containerColor: Color? = null
   @Field val labelColor: Color? = null
@@ -39,6 +43,7 @@ class FilterChipColors : Record {
   @Field val selectedTrailingIconColor: Color? = null
 }
 
+@OptimizedRecord
 class InputChipColors : Record {
   @Field val containerColor: Color? = null
   @Field val labelColor: Color? = null
@@ -50,12 +55,14 @@ class InputChipColors : Record {
   @Field val selectedTrailingIconColor: Color? = null
 }
 
+@OptimizedRecord
 class SuggestionChipColors : Record {
   @Field val containerColor: Color? = null
   @Field val labelColor: Color? = null
   @Field val iconContentColor: Color? = null
 }
 
+@OptimizedRecord
 class ChipBorder : Record {
   @Field val width: Float = 1f
   @Field val color: Color? = null

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
@@ -28,7 +28,9 @@ import expo.modules.kotlin.views.FunctionalComposableScope
 import java.util.Calendar
 import java.util.Date
 import android.graphics.Color as AndroidColor
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class DatePickerResult(
   @Field
   val date: Long?
@@ -54,6 +56,7 @@ enum class Variant(val value: String) : Enumerable {
   }
 }
 
+@OptimizedRecord
 class DateTimePickerColorOverrides : Record {
   // DatePicker colors
   @Field val containerColor: AndroidColor? = null
@@ -97,6 +100,7 @@ class DateTimePickerColorOverrides : Record {
   @Field val timeSelectorUnselectedContentColor: AndroidColor? = null
 }
 
+@OptimizedRecord
 class SelectableDatesRecord : Record {
   @Field val start: Long? = null
   @Field val end: Long? = null

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
@@ -42,6 +42,7 @@ import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
+import expo.modules.kotlin.types.OptimizedRecord
 
 internal enum class ExpoLayoutDirection(val value: String) : Enumerable {
   LeftToRight("leftToRight"),
@@ -249,6 +250,7 @@ internal class HostView(context: Context, appContext: AppContext) :
   }
 }
 
+@OptimizedRecord
 internal data class LayoutContentEvent(
   @Field
   val width: Double?,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyColumnView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyColumnView.kt
@@ -23,7 +23,9 @@ import expo.modules.kotlin.views.ExpoComposeView
 import expo.modules.ui.convertibles.HorizontalAlignment
 import expo.modules.ui.convertibles.VerticalArrangement
 import expo.modules.ui.convertibles.toComposeArrangement
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ContentPadding(
   @Field val start: Int = 0,
   @Field val top: Int = 0,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ListItemView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ListItemView.kt
@@ -3,14 +3,15 @@ package expo.modules.ui
 import android.graphics.Color
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ListItemColors(
   @Field val containerColor: Color? = null,
   @Field val contentColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ModifierRegistry.kt
@@ -61,6 +61,7 @@ import expo.modules.ui.convertibles.AlignmentType
 import expo.modules.ui.convertibles.CompositingStrategyType
 import expo.modules.ui.convertibles.GraphicsLayerParams
 import expo.modules.ui.convertibles.resolveAnimatable
+import expo.modules.kotlin.types.OptimizedRecord
 
 typealias ModifierType = Map<String, Any?>
 typealias ModifierList = List<ModifierType>
@@ -69,10 +70,12 @@ typealias ModifierFactory = @Composable (ModifierType, ComposableScope?, AppCont
 
 // region Modifier Params
 
+@OptimizedRecord
 internal data class PaddingAllParams(
   @Field val all: Int = 0
 ) : Record
 
+@OptimizedRecord
 internal data class PaddingParams(
   @Field val start: Int = 0,
   @Field val top: Int = 0,
@@ -80,86 +83,106 @@ internal data class PaddingParams(
   @Field val bottom: Int = 0
 ) : Record
 
+@OptimizedRecord
 internal data class SizeParams(
   @Field val width: Int = 0,
   @Field val height: Int = 0
 ) : Record
 
+@OptimizedRecord
 internal data class FillMaxSizeParams(
   @Field val fraction: Float = 1.0f
 ) : Record
 
+@OptimizedRecord
 internal data class FillMaxWidthParams(
   @Field val fraction: Float = 1.0f
 ) : Record
 
+@OptimizedRecord
 internal data class FillMaxHeightParams(
   @Field val fraction: Float = 1.0f
 ) : Record
 
+@OptimizedRecord
 internal data class WidthParams(
   @Field val width: Int = 0
 ) : Record
 
+@OptimizedRecord
 internal data class HeightParams(
   @Field val height: Int = 0
 ) : Record
 
+@OptimizedRecord
 internal data class WrapContentWidthParams(
   @Field val alignment: AlignmentType? = null
 ) : Record
 
+@OptimizedRecord
 internal data class WrapContentHeightParams(
   @Field val alignment: AlignmentType? = null
 ) : Record
 
+@OptimizedRecord
 internal data class OffsetParams(
   @Field val x: Int = 0,
   @Field val y: Int = 0
 ) : Record
 
+@OptimizedRecord
 internal data class BackgroundParams(
   @Field val color: Color? = null
 ) : Record
 
+@OptimizedRecord
 internal data class BorderParams(
   @Field val borderWidth: Int = 1,
   @Field val borderColor: Color? = null
 ) : Record
 
+@OptimizedRecord
 internal data class ShadowParams(
   @Field val elevation: Int = 0
 ) : Record
 
+@OptimizedRecord
 internal data class AlphaParams(
   @Field val alpha: Float = 1.0f
 ) : Record
 
+@OptimizedRecord
 internal data class BlurParams(
   @Field val radius: Int = 0
 ) : Record
 
+@OptimizedRecord
 internal data class RotateParams(
   @Field val degrees: Float = 0f
 ) : Record
 
+@OptimizedRecord
 internal data class ZIndexParams(
   @Field val index: Float = 0f
 ) : Record
 
+@OptimizedRecord
 internal data class AnimateContentSizeParams(
   @Field val dampingRatio: Float = Spring.DampingRatioNoBouncy,
   @Field val stiffness: Float = Spring.StiffnessMedium
 ) : Record
 
+@OptimizedRecord
 internal data class WeightParams(
   @Field val weight: Float = 1f
 ) : Record
 
+@OptimizedRecord
 internal data class AlignParams(
   @Field val alignment: AlignmentType? = null
 ) : Record
 
+@OptimizedRecord
 internal data class TestIDParams(
   @Field val testID: String? = null
 ) : Record
@@ -172,6 +195,7 @@ internal enum class BuiltinShapeType(val value: String) : Enumerable {
   MATERIAL("material")
 }
 
+@OptimizedRecord
 internal data class BuiltinShapeRecord(
   @Field val type: BuiltinShapeType = BuiltinShapeType.RECTANGLE,
   @Field val radius: Float? = null,
@@ -182,20 +206,24 @@ internal data class BuiltinShapeRecord(
   @Field val name: MaterialShapeType? = null
 ) : Record
 
+@OptimizedRecord
 internal data class ClipParams(
   @Field val shape: BuiltinShapeRecord? = null
 ) : Record
 
+@OptimizedRecord
 internal data class SelectableParams(
   @Field val selected: Boolean = false,
   @Field val role: String? = null
 ) : Record
 
+@OptimizedRecord
 internal data class OnVisibilityChangedParams(
   @Field val minDurationMs: Long = 0,
   @Field val minFractionVisible: Float = 1f
 ) : Record
 
+@OptimizedRecord
 internal data class ClickableParams(
   @Field val indication: Boolean = true
 ) : Record
@@ -207,6 +235,7 @@ internal enum class SemanticRoleType(val value: String) : Enumerable {
   TAB("tab")
 }
 
+@OptimizedRecord
 internal data class ToggleableParams(
   @Field val value: Boolean = false,
   @Field val role: SemanticRoleType? = null

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
@@ -18,9 +18,11 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
 // region LinearProgressIndicator
 
+@OptimizedRecord
 class DrawStopIndicatorConfig : Record {
   @Field val color: Color? = null
   @Field val strokeCap: String? = null

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PullToRefreshBoxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PullToRefreshBoxView.kt
@@ -10,13 +10,14 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.ui.convertibles.ContentAlignment
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class PullToRefreshIndicatorProps(
   @Field val color: Color? = null,
   @Field val containerColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedButtonView.kt
@@ -13,7 +13,9 @@ import expo.modules.kotlin.records.Record
 
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class SegmentedButtonColors(
   @Field val activeBorderColor: Color? = null,
   @Field val activeContentColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ShapeView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ShapeView.kt
@@ -28,6 +28,7 @@ import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import android.graphics.Color as GraphicsColor
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class ShapeType(val value: String) : Enumerable {
   STAR("star"),
@@ -39,6 +40,7 @@ enum class ShapeType(val value: String) : Enumerable {
   ROUNDED_CORNER("roundedCorner")
 }
 
+@OptimizedRecord
 data class CornerRadii(
   @Field val topStart: Float = 0f,
   @Field val topEnd: Float = 0f,
@@ -142,6 +144,7 @@ private fun createRoundedCornerPath(size: Size, cornerRadii: CornerRadii?, densi
   }
 }
 
+@OptimizedRecord
 data class ShapeRecord(
   @Field
   val cornerRounding: Float = 0.0f,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
@@ -16,7 +16,9 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.viewevent.getValue
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class SliderColors : Record {
   @Field
   val thumbColor: Color? = null
@@ -44,6 +46,7 @@ data class SliderProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps
 
+@OptimizedRecord
 data class SliderValueChangedEvent(
   @Field val value: Float
 ) : Record

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SurfaceView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SurfaceView.kt
@@ -12,8 +12,10 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
 
+@OptimizedRecord
 data class SurfaceBorder(
   @Field val width: Float = 1f,
   @Field val color: Color? = null

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
@@ -9,11 +9,14 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 open class CheckedChangeEvent(
   @Field open val value: Boolean = false
 ) : Record, Serializable
 
+@OptimizedRecord
 data class SwitchColors(
   @Field val checkedThumbColor: Color? = null,
   @Field val checkedTrackColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
@@ -25,6 +25,7 @@ import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.AsyncFunctionHandle
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
 // region Records
 
@@ -33,6 +34,7 @@ enum class TextFieldVariant(val value: String) : Enumerable {
   OUTLINED("outlined"),
 }
 
+@OptimizedRecord
 data class TextFieldKeyboardOptionsRecord(
   @Field val capitalization: String? = null,
   @Field val autoCorrectEnabled: Boolean? = null,
@@ -40,6 +42,7 @@ data class TextFieldKeyboardOptionsRecord(
   @Field val imeAction: String? = null,
 ) : Record
 
+@OptimizedRecord
 data class TextFieldColorsRecord(
   // Text
   @Field val focusedTextColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
@@ -26,6 +26,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class TextFontWeight(val value: String) : Enumerable {
   NORMAL("normal"),
@@ -146,6 +147,7 @@ fun resolveFontFamily(name: String?, context: Context): FontFamily? {
   }
 }
 
+@OptimizedRecord
 data class TextShadowRecord(
   @Field val color: Color? = null,
   @Field val offsetX: Float? = null,
@@ -219,6 +221,7 @@ interface TextSpanStyle {
   val shadow: TextShadowRecord?
 }
 
+@OptimizedRecord
 data class TextSpanRecord(
   @Field override val text: String = "",
   @Field val children: List<TextSpanRecord>? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ToggleButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ToggleButtonView.kt
@@ -15,7 +15,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ToggleButtonColors(
   @Field val containerColor: Color? = null,
   @Field val contentColor: Color? = null,
@@ -32,6 +34,7 @@ data class ToggleButtonProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps
 
+@OptimizedRecord
 data class ToggleButtonValueChangeEvent(
   @Field val checked: Boolean = false
 ) : Record

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/Utils.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/Utils.kt
@@ -42,6 +42,8 @@ fun getImageVector(icon: String?): ImageVector? {
   }
 }
 
+// TODO(@lukmccall): Make it work with introspectable
+//@Introspectable
 data class GenericEventPayload1<T>(
   @Field val value: T
 ) : Record

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
@@ -20,9 +20,12 @@ import expo.modules.ui.ShapeRecord
 import expo.modules.ui.compose
 import expo.modules.ui.shapeFromShapeRecord
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 open class ButtonPressedEvent() : Record, Serializable
 
+@OptimizedRecord
 class ButtonColors : Record {
   @Field val containerColor: Color? = null
   @Field val contentColor: Color? = null
@@ -30,6 +33,7 @@ class ButtonColors : Record {
   @Field val disabledContentColor: Color? = null
 }
 
+@OptimizedRecord
 class ContentPaddingRecord : Record {
   @Field val start: Double? = null
   @Field val top: Double? = null

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/AnimationSpecParams.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/AnimationSpecParams.kt
@@ -15,6 +15,7 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.recordFromMap
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 internal enum class EasingType(val value: String) : Enumerable {
   LINEAR("linear"),
@@ -32,6 +33,7 @@ internal enum class EasingType(val value: String) : Enumerable {
   }
 }
 
+@OptimizedRecord
 internal data class SpringSpecParams(
   @Field val dampingRatio: Float = Spring.DampingRatioNoBouncy,
   @Field val stiffness: Float = Spring.StiffnessMedium,
@@ -44,6 +46,7 @@ internal data class SpringSpecParams(
   )
 }
 
+@OptimizedRecord
 internal data class TweenSpecParams(
   @Field val durationMillis: Int = 300,
   @Field val delayMillis: Int = 0,
@@ -56,12 +59,14 @@ internal data class TweenSpecParams(
   )
 }
 
+@OptimizedRecord
 internal data class SnapSpecParams(
   @Field val delayMillis: Int = 0
 ) : Record {
   fun toAnimationSpec(): AnimationSpec<Float> = snap(delayMillis = delayMillis)
 }
 
+@OptimizedRecord
 internal data class KeyframesSpecParams(
   @Field val durationMillis: Int = 300,
   @Field val delayMillis: Int = 0

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/Arrangement.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/Arrangement.kt
@@ -6,6 +6,7 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Either
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 
 typealias HorizontalArrangement = Either<HorizontalArrangementDefault, HorizontalArrangementCustom>
 
@@ -29,6 +30,7 @@ enum class HorizontalArrangementDefault(val value: String) : Enumerable {
   }
 }
 
+@OptimizedRecord
 data class HorizontalArrangementCustom(
   @Field val spacedBy: Int? = null
 ) : Record
@@ -61,6 +63,7 @@ enum class VerticalArrangementDefault(val value: String) : Enumerable {
   }
 }
 
+@OptimizedRecord
 data class VerticalArrangementCustom(
   @Field val spacedBy: Int? = null
 ) : Record

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/GraphicsLayerParams.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/convertibles/GraphicsLayerParams.kt
@@ -5,6 +5,7 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.ui.BuiltinShapeRecord
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class CompositingStrategyType(val value: String) : Enumerable {
   AUTO("auto"),
@@ -12,6 +13,7 @@ enum class CompositingStrategyType(val value: String) : Enumerable {
   MODULATE("modulate")
 }
 
+@OptimizedRecord
 internal data class GraphicsLayerParams(
   @Field val cameraDistance: Float = 8f,
   @Field val transformOriginX: Float = 0.5f,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/icon/IconView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/icon/IconView.kt
@@ -35,7 +35,9 @@ import expo.modules.ui.ExpoUIModule
 import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.compose
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class Source(
   @Field val uri: String,
   @Field val width: Int = 0,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuItem.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuItem.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.MenuDefaults
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.ui.UIComposableScope
 import expo.modules.kotlin.views.FunctionalComposableScope
@@ -14,6 +15,7 @@ import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.composeOrNull
 import expo.modules.ui.findChildSlotView
 
+@OptimizedRecord
 class DropdownMenuItemColors : Record {
   @Field val textColor: Color? = null
   @Field val leadingIconColor: Color? = null

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.withContext
 import java.io.File
 import java.lang.ref.WeakReference
 import java.util.Date
+import expo.modules.kotlin.types.OptimizedRecord
 
 enum class UpdatesJSEvent(val eventName: String) : Enumerable {
   StateChange("Expo.nativeUpdatesStateChangeEvent")
@@ -226,6 +227,7 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
     sendEvent(UpdatesJSEvent.StateChange, Bundle().apply { putBundle("context", context.bundle) })
   }
 
+  @OptimizedRecord
   internal data class UpdatesConfigurationOverrideParam(
     @Field val updateUrl: Uri,
     @Field val requestHeaders: Map<String, String>

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/reloadscreen/ReloadScreenConfiguration.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/reloadscreen/ReloadScreenConfiguration.kt
@@ -5,7 +5,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
 import androidx.core.graphics.toColorInt
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ReloadScreenOptions(
   @Field val backgroundColor: String?,
   @Field val image: ReloadScreenImageSource?,
@@ -15,6 +17,7 @@ data class ReloadScreenOptions(
   @Field val spinner: SpinnerOptions?
 ) : Record
 
+@OptimizedRecord
 data class ReloadScreenImageSource(
   @Field val url: Uri? = null,
   @Field val width: Double? = null,
@@ -22,6 +25,7 @@ data class ReloadScreenImageSource(
   @Field val scale: Double? = null
 ) : Record
 
+@OptimizedRecord
 data class SpinnerOptions(
   @Field val enabled: Boolean? = null,
   @Field val color: String? = null,

--- a/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailOptions.kt
+++ b/packages/expo-video-thumbnails/android/src/main/java/expo/modules/videothumbnails/VideoThumbnailOptions.kt
@@ -2,7 +2,9 @@ package expo.modules.videothumbnails
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class VideoThumbnailOptions(
   @Field
   val quality: Double = 1.0,
@@ -14,6 +16,7 @@ data class VideoThumbnailOptions(
   val headers: Map<String, String> = emptyMap()
 ) : Record
 
+@OptimizedRecord
 data class VideoThumbnailResult(
   @Field
   val uri: String,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/BufferOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/BufferOptions.kt
@@ -6,8 +6,10 @@ import expo.modules.kotlin.records.Record
 import expo.modules.video.player.DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS
 import expo.modules.video.player.DefaultLoadControl.DEFAULT_PRIORITIZE_TIME_OVER_SIZE_THRESHOLDS
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
 @UnstableApi
+@OptimizedRecord
 class BufferOptions(
   @Field var preferredForwardBufferDuration: Double? = null,
   @Field var maxBufferBytes: Long = 0,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/ButtonOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/ButtonOptions.kt
@@ -2,7 +2,9 @@ package expo.modules.video.records
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class ButtonOptions(
   @Field val showNext: Boolean = false,
   @Field val showPrevious: Boolean = false,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/DRMOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/DRMOptions.kt
@@ -5,7 +5,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.video.enums.DRMType
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class DRMOptions(
   @Field var type: DRMType = DRMType.WIDEVINE,
   @Field var licenseServer: String? = null,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/FullscreenOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/FullscreenOptions.kt
@@ -4,7 +4,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.video.enums.FullscreenOrientation
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class FullscreenOptions(
   @Field val enable: Boolean = true,
   @Field val orientation: FullscreenOrientation = FullscreenOrientation.DEFAULT,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/PlaybackError.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/PlaybackError.kt
@@ -4,7 +4,9 @@ import androidx.media3.common.PlaybackException
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class PlaybackError(
   @Field var message: String? = null
 ) : Record, Serializable {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/PlayerBuilderOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/PlayerBuilderOptions.kt
@@ -5,8 +5,10 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
 import kotlin.time.Duration
+import expo.modules.kotlin.types.OptimizedRecord
 
 @UnstableApi
+@OptimizedRecord
 class PlayerBuilderOptions(
   @Field var seekBackwardIncrement: Duration? = null,
   @Field var seekForwardIncrement: Duration? = null

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/ScrubbingModeOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/ScrubbingModeOptions.kt
@@ -6,8 +6,10 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.Field
 import expo.modules.video.player.VideoPlayer
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
 @UnstableApi
+@OptimizedRecord
 class ScrubbingModeOptions(
   @Field var scrubbingModeEnabled: Boolean = false,
   @Field var increaseCodecOperatingRate: Boolean = true,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/SeekTolerance.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/SeekTolerance.kt
@@ -7,8 +7,10 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.video.player.VideoPlayer
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
 @UnstableApi
+@OptimizedRecord
 class SeekTolerance(
   @Field var toleranceBefore: Double = 0.0,
   @Field var toleranceAfter: Double = 0.0

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/Tracks.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/Tracks.kt
@@ -8,7 +8,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
 import java.util.Locale
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class SubtitleTrack(
   @Field val id: String,
   @Field val language: String?,
@@ -39,6 +41,7 @@ class SubtitleTrack(
   }
 }
 
+@OptimizedRecord
 class AudioTrack(
   @Field val id: String,
   @Field val language: String?,
@@ -70,6 +73,7 @@ class AudioTrack(
 }
 
 @OptIn(UnstableApi::class)
+@OptimizedRecord
 class VideoTrack(
   @Field val id: String,
   @Field val url: Uri?,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoMetadata.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoMetadata.kt
@@ -4,7 +4,9 @@ import android.net.Uri
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class VideoMetadata(
   @Field var title: String? = null,
   @Field var artist: String? = null,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSize.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSize.kt
@@ -4,7 +4,9 @@ import androidx.media3.common.Format
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 data class VideoSize(
   @Field val width: Int = 0,
   @Field val height: Int = 0

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoSource.kt
@@ -18,8 +18,10 @@ import expo.modules.video.UnsupportedDRMTypeException
 import expo.modules.video.buildExpoVideoMediaSource
 import expo.modules.video.enums.ContentType
 import java.io.Serializable
+import expo.modules.kotlin.types.OptimizedRecord
 
 @OptIn(UnstableApi::class)
+@OptimizedRecord
 class VideoSource(
   @Field var uri: Uri? = null,
   @Field var drm: DRMOptions? = null,

--- a/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoThumbnailOptions.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/records/VideoThumbnailOptions.kt
@@ -2,7 +2,9 @@ package expo.modules.video.records
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 class VideoThumbnailOptions(
   @Field val maxWidth: Int? = null,
   @Field val maxHeight: Int? = null

--- a/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserOptions.kt
+++ b/packages/expo-web-browser/android/src/main/java/expo/modules/webbrowser/WebBrowserOptions.kt
@@ -2,7 +2,9 @@ package expo.modules.webbrowser
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal data class OpenBrowserOptions(
   @Field val toolbarColor: Int? = null,
   @Field val secondaryToolbarColor: Int? = null,

--- a/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequestInit.kt
+++ b/packages/expo/android/src/main/java/expo/modules/fetch/NativeRequestInit.kt
@@ -4,7 +4,9 @@ package expo.modules.fetch
 
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.types.OptimizedRecord
 
+@OptimizedRecord
 internal data class NativeRequestInit(
   @Field val credentials: NativeRequestCredentials = NativeRequestCredentials.INCLUDE,
   @Field val headers: List<Pair<String, String>> = emptyList(),


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/44803.
Annotates all `Records` with the `OptimizedRecord` to reduce reflection usage by Expo Modules API.

# Test Plan

- bare-expo (debug and release) ✅ 