### PR TITLE
[ci] Trigger e2e on any `.gradle` file change

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -82,8 +82,9 @@ jobs:
         uses: ./.github/actions/detect-platform-change
         with:
           android-paths: >-
-            "packages/expo-modules-core/**/android/**",
             "packages/expo-modules-core/expo-module-gradle-plugin/**",
+            "packages/**/{settings,build}.gradle",
+            "packages/expo-modules-core/**/android/**",
             "packages/expo-modules-autolinking/**/android/**",
             "packages/expo/**/android/**",
             "packages/expo-constants/**/android/**",


### PR DESCRIPTION
# Why

Changes to a package's `build.gradle` or `settings.gradle` might impact other packages' e2e results, so we must run e2e tests every time.

# How

Adds `packages/**/{settings,build}.gradle` to e2e android-paths.  

# Test Plan
Green CI