### PR TITLE
[core] fix precompile ExpoModulesMacros

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -509,7 +509,6 @@ PODS:
     - ExpoModulesCore
   - ExpoModulesCore (55.0.12):
     - ExpoModulesJSI
-    - ExpoModulesMacros
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -534,7 +533,6 @@ PODS:
     - Yoga
   - ExpoModulesCore/Tests (55.0.12):
     - ExpoModulesJSI
-    - ExpoModulesMacros
     - ExpoModulesTestCore
     - hermes-engine
     - RCTRequired
@@ -568,8 +566,6 @@ PODS:
     - React-Core
     - React-runtimescheduler
     - ReactCommon
-  - ExpoModulesMacros (0.0.7)
-  - ExpoModulesMacros/Tests (0.0.7)
   - ExpoModulesTestCore (55.0.2):
     - ExpoModulesCore
     - Nimble (~> 13.0.0)
@@ -3314,8 +3310,6 @@ DEPENDENCIES:
   - ExpoModulesCore/Tests (from `../../../packages/expo-modules-core`)
   - ExpoModulesJSI (from `../../../packages/expo-modules-core`)
   - ExpoModulesJSI/Tests (from `../../../packages/expo-modules-core`)
-  - "ExpoModulesMacros (from `../../../node_modules/.pnpm/@expo+expo-modules-macros-plugin@0.0.7/node_modules/@expo/expo-modules-macros-plugin/apple`)"
-  - "ExpoModulesMacros/Tests (from `../../../node_modules/.pnpm/@expo+expo-modules-macros-plugin@0.0.7/node_modules/@expo/expo-modules-macros-plugin/apple`)"
   - ExpoModulesTestCore (from `../../../packages/expo-modules-test-core/ios`)
   - ExpoModulesWorklets (from `../../../packages/expo-modules-core`)
   - ExpoNetwork (from `../../../packages/expo-network/ios`)
@@ -3630,9 +3624,6 @@ EXTERNAL SOURCES:
   ExpoModulesJSI:
     inhibit_warnings: false
     :path: "../../../packages/expo-modules-core"
-  ExpoModulesMacros:
-    inhibit_warnings: false
-    :path: "../../../node_modules/.pnpm/@expo+expo-modules-macros-plugin@0.0.7/node_modules/@expo/expo-modules-macros-plugin/apple"
   ExpoModulesTestCore:
     :path: "../../../packages/expo-modules-test-core/ios"
   ExpoModulesWorklets:
@@ -3966,9 +3957,8 @@ SPEC CHECKSUMS:
   ExpoMaps: 94294944cff46ad1170ce4f92800adecbcdd04ac
   ExpoMediaLibrary: 2fbddcb06042f43076cf5e495e8237ec2ab95726
   ExpoMeshGradient: 93cf09380e6d86cd7a525da26dfddab2620a8421
-  ExpoModulesCore: 175c54e26f394abfc6da4371b3fb4f8d2d0716c8
+  ExpoModulesCore: a3dfc5e19028675ac402beedd870eae5a6d4a4d2
   ExpoModulesJSI: 793687b04cbaa73ee8548bfdbcfba85954d1b2b5
-  ExpoModulesMacros: 6e01118aed19527180871e271177089c34d90dd2
   ExpoModulesTestCore: 62ce59e8c8162b449e65467e0421240256ba6732
   ExpoModulesWorklets: fe2384a395429f5148f20204d229fb50926f9392
   ExpoNetwork: 15d026c5c28251e0810849c8c01ebc9bc73ad007

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [iOS] Add early escape in generateModulesProviderAsync to avoid touching files that hasn't changed ([#44289](https://github.com/expo/expo/pull/44289) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Added `@OptimizedFunction` macros support for Expo modules. ([#44262](https://github.com/expo/expo/pull/44262) by [@kudo](https://github.com/kudo))
 - [iOS] Add more detailed warnings when a package is not linked due to a mismatch between project and package deployment target. ([#44200](https://github.com/expo/expo/pull/44200) by [@behenate](https://github.com/behenate))
+- Fixed `ExpoModulesMacros` precompiling. ([#44863](https://github.com/expo/expo/pull/44863) by [@kudo](https://github.com/kudo))
 
 ## 55.0.8 — 2026-02-25
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -795,6 +795,11 @@ module Expo
         installer.pods_project.save
       end
 
+      # Returns the package_root for a given pod name, or nil if not found.
+      def package_root_for(pod_name)
+        pod_lookup_map[pod_name]&.dig(:package_root)
+      end
+
       private
 
       # ──────────────────────────────────────────────────────────────────────

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -134,14 +134,16 @@ module Expo
 
     # Integrates the core macro plugins into the targets.
     def self.integrate_core_macro_plugins(targets)
+      macro_flags = nil
       targets.each do |target|
-        macros_pod_target = target.pod_targets.find { |pod_target| pod_target.name == 'ExpoModulesMacros' }
-        if macros_pod_target.nil?
-          Pod::UI.warn("[Expo] Skipping integration of core macro plugins for target '#{target.name}' because ExpoModuleOptimizedMacros pod target not found")
-          return
+        unless macro_flags
+          core_pod_target = target.pod_targets.find { |pod_target| pod_target.name == 'ExpoModulesCore' }
+          core_src_root = Expo::PrecompiledModules.package_root_for('ExpoModulesCore') ||
+            File.realpath(core_pod_target.sandbox.pod_dir(core_pod_target.root_spec.name).to_s)
+          macros_plugin_dir = File.join(core_src_root, 'node_modules', '@expo', 'expo-modules-macros-plugin', 'apple')
+          macro_flags = "-Xfrontend -load-plugin-executable -Xfrontend \"#{macros_plugin_dir}/ExpoModulesMacros-tool#ExpoModulesMacros\""
         end
-        macros_src_root = macros_pod_target.pod_target_srcroot
-        macro_flags = "-Xfrontend -load-plugin-executable -Xfrontend \"#{macros_src_root}/ExpoModulesMacros-tool#ExpoModulesMacros\""
+
         target.pod_targets.each do |pod_target|
           has_core_dependency = pod_target.dependencies.find { |dependency| dependency == 'ExpoModulesCore' }
           next unless has_core_dependency

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -52,6 +52,7 @@
 - [iOS] Added broader colors support to convertibles. ([#44630](https://github.com/expo/expo/pull/44630) by [@kudo](https://github.com/kudo))
 - Throwing error when converting invalid color array. ([#44734](https://github.com/expo/expo/pull/44734) by [@kudo](https://github.com/kudo))
 - [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
+- Fixed `ExpoModulesMacros` precompiling. ([#44863](https://github.com/expo/expo/pull/44863) by [@kudo](https://github.com/kudo))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -104,8 +104,6 @@ Pod::Spec.new do |s|
     s.dependency 'React-jsc'
   end
 
-  s.dependency 'ExpoModulesMacros'
-
   s.dependency 'React-Core'
   s.dependency 'ReactCommon/turbomodule/core'
   s.dependency 'React-NativeModulesApple'

--- a/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
@@ -1,6 +1,27 @@
+
 /**
- * Re-export the `@OptimizedFunction` or other macros from the standalone macros plugin package
- * (`@expo/expo-modules-macros-plugin`). This allows module authors to use the macro
- * by importing ExpoModulesCore alone, without adding a direct dependency on the plugin package.
+ Declares macro signatures whose implementations are provided by the `@expo/expo-modules-macros-plugin` binary.
+ Keep in sync with `@expo/expo-modules-macros-plugin/apple/Sources/ExpoModulesOptimized/ExpoModulesOptimized.swift`.
  */
-@_exported import ExpoModulesMacros
+
+// MARK: - Macro declarations
+
+/// An attached macro that generates an optimized synchronous function descriptor.
+/// Creates a peer function that returns `OptimizedFunctionDescriptor`, for use with
+/// the `Function("name", descriptor)` overload in ModuleDefinition result builders.
+///
+/// Usage:
+///
+///     @OptimizedFunction
+///     private func addNumbers(a: Double, b: Double) -> Double {
+///         return a + b
+///     }
+///
+///     // In definition():
+///     Function("addNumbers", addNumbers())
+///
+/// The generated peer function uses the optimized JSI bridge path with
+/// @convention(block) closures for maximum performance.
+@attached(peer, names: arbitrary)
+public macro OptimizedFunction() =
+  #externalMacro(module: "ExpoModulesMacros", type: "OptimizedFunctionAttachedMacro")

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -55,7 +55,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/expo-modules-macros-plugin": "~0.0.7",
+    "@expo/expo-modules-macros-plugin": "~0.0.8",
     "invariant": "^2.2.4"
   },
   "peerDependencies": {

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -122,8 +122,7 @@
             "Tests/**",
             "BridgeModule/**",
             "Views/**",
-            "Worklets/**",
-            "Core/ExpoModulesMacros.swift"
+            "Worklets/**"
           ],
           "dependencies": [
             "Hermes",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4614,8 +4614,8 @@ importers:
   packages/expo-modules-core:
     dependencies:
       '@expo/expo-modules-macros-plugin':
-        specifier: ~0.0.7
-        version: 0.0.7
+        specifier: ~0.0.8
+        version: 0.0.8
       invariant:
         specifier: ^2.2.4
         version: 2.2.4
@@ -7049,8 +7049,8 @@ packages:
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
 
-  '@expo/expo-modules-macros-plugin@0.0.7':
-    resolution: {integrity: sha512-PPgH9LjbArypVY0f0suCXq4uzBZLs2PxF34N9lSqyuPuG7X65sAeqkFOOwsV/iL7RnA2OPOTdN6fBUKvUoylVg==}
+  '@expo/expo-modules-macros-plugin@0.0.8':
+    resolution: {integrity: sha512-ZHH+Hgle/ZyVfTSd9L+ON/0a7BouMEQ3wJKGmOilPLYMTjx5NOcbNZVaJ3iAHKCplvDIHHjPdmqVPorWMHm19A==}
 
   '@expo/json-file@8.3.3':
     resolution: {integrity: sha512-eZ5dld9AD0PrVRiIWpRkm5aIoWBw3kAyd8VkuWEy92sEthBKDDDHAnK2a0dw0Eil6j7rK7lS/Qaq/Zzngv2h5A==}
@@ -16733,7 +16733,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/expo-modules-macros-plugin@0.0.7': {}
+  '@expo/expo-modules-macros-plugin@0.0.8': {}
 
   '@expo/json-file@8.3.3':
     dependencies:


### PR DESCRIPTION
# Why

fix precompile `ExpoModulesMacros`

# How

- re-export `ExpoModulesMacros` doesn't work on precompiled expo-modules-core. this pr tries to manually maintain/sync the content of `ExpoModulesMacros.swift`. added comment to remind if we have new macros, we should update the file.
- bump `@expo/expo-modules-macros-plugin` that removed autolinking. (we don't re-export it so we can drop it)
- because we don't have `ExpoModulesMacros` pod now, we also change the logic to search the plugin directory

# Test Plan

- try bare-expo with and without precomiled expo-modules-core.
- i encountered some other problem that is unrelated to macros. i commented out when testing fwiw
  - we hardcoded ios 15 support and precompiling expo-modules-core failed. i changed it to ios 16. (we use `RegexBuilder` that requires ios 16 now)
  - having xcode compiler crash when building expo-ui and precompiled expo-modules-core. i tried to unlink expo-ui for testing.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
