### PR TITLE
[docs] Align CONTRIBUTING guidance, PR Checklist and Stale link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -22,6 +22,8 @@ Please describe how you tested this change and how a reviewer could reproduce yo
 Please check the appropriate items below if they apply to your diff.
 -->
 
-- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
+- [ ] I added a `CHANGELOG.md` entry (in the modified package or the root `CHANGELOG.md`) and rebuilt modified package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
+- [ ] If I modified files in `packages/`, I ran `pnpm build`, `pnpm lint --fix` (and verified `pnpm lint` passes), and `pnpm test` in each modified package.
+- [ ] I removed all `console.log`s and commented out code blocks.
 - [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
 - [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -22,8 +22,6 @@ Please describe how you tested this change and how a reviewer could reproduce yo
 Please check the appropriate items below if they apply to your diff.
 -->
 
-- [ ] I added a `CHANGELOG.md` entry (in the modified package or the root `CHANGELOG.md`) and rebuilt modified package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
-- [ ] If I modified files in `packages/`, I ran `pnpm build`, `pnpm lint --fix` (and verified `pnpm lint` passes), and `pnpm test` in each modified package.
-- [ ] I removed all `console.log`s and commented out code blocks.
+- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
 - [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
 - [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ Note that we generally do not accept PRs that bump versions of native dependenci
 
 All modules should adhere to the style guides which can be found here:
 
-- [Creating Unimodules](guides/Creating%20Unimodules.md)
+- [Expo Module Infrastructure](guides/Expo%20Module%20Infrastructure.md)
 - [Expo JS Style Guide](guides/Expo%20JavaScript%20Style%20Guide.md) (also mostly applies to TypeScript)
 - [Updating Changelogs](guides/contributing/Updating%20Changelogs.md)
 
@@ -181,7 +181,7 @@ To keep CI green, please make sure of the following:
 
 ### If you edited the docs directory:
 
-  - Any change to the current SDK version should also be in the unversioned copy as well. Example:
+  - Any change to the current SDK version should also be in the unversioned copy as well. The current docs SDK version is defined in [`docs/package.json`](./docs/package.json), and the versioning workflow is described in [docs/README.md](./docs/README.md#update-latest-version-of-api-reference-docs). Example:
     - You fixed a typo in `docs/pages/versions/vXX.0.0/sdk/app-auth.md`
     - Ensure you copy that change to: `docs/pages/versions/unversioned/sdk/app-auth.md`
   - You don't need to run the docs tests locally. Just ensure the links you include aren't broken, the format is correct, and the changes are following our [writing style guide](/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,7 +181,7 @@ To keep CI green, please make sure of the following:
 
 ### If you edited the docs directory:
 
-  - Any change to the current SDK version should also be in the unversioned copy as well. The current docs SDK version is defined in [`docs/package.json`](./docs/package.json), and the versioning workflow is described in [docs/README.md](./docs/README.md#update-latest-version-of-api-reference-docs). Example:
+  - Any changes to docs for the current SDK version should also be applied to the unversioned copy. The current docs SDK version is defined in [`docs/package.json`](./docs/package.json), and the versioning workflow is described in [docs/README.md](./docs/README.md#update-latest-version-of-api-reference-docs). Example:
     - You fixed a typo in `docs/pages/versions/vXX.0.0/sdk/app-auth.md`
     - Ensure you copy that change to: `docs/pages/versions/unversioned/sdk/app-auth.md`
   - You don't need to run the docs tests locally. Just ensure the links you include aren't broken, the format is correct, and the changes are following our [writing style guide](/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).


### PR DESCRIPTION
# Why

Improve contributor experience by removing stale guidance and aligning the PR template checklist with the actual requirements in CONTRIBUTING.

This reduces avoidable review cycles caused by mismatched expectations.

# How

- Replaced the stale style guide link in CONTRIBUTING with an existing guide:
  - Creating Unimodules -> Expo Module Infrastructure
- Clarified docs contribution guidance in CONTRIBUTING by pointing to:
  - docs/package.json for current docs SDK version
  - docs/README.md section on updating latest API reference docs
- Updated PR checklist wording to match CONTRIBUTING requirements:
  - CHANGELOG.md naming and scope
  - package-level build/lint/test expectations
  - removal of console.log and commented-out code

# Test Plan

- Verified only intended files changed:
  - CONTRIBUTING.md
  - .github/PULL_REQUEST_TEMPLATE
- Validated markdown edits and links by inspection.
- Confirmed no diagnostics errors in edited files.

# Checklist

- [ ] I added a CHANGELOG.md entry and rebuilt package sources according to CONTRIBUTING before-submitting guidance.
- [x] This diff will work correctly for npx expo prebuild and EAS Build (no plugin/runtime behavior changes).
- [x] Conforms with the Documentation Writing Style Guide.