### PR TITLE
[android][audio] [sdk-53] Fix silent playback after non-media focus release

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Request media audio focus on `AudioPlayer`'s ExoPlayer so playback actually starts after another component held non-media audio focus (e.g. a recording library that grabbed `STREAM_VOICE_CALL` focus). Previously `AudioAttributes.DEFAULT, false` caused the player to report `playing=true` while streaming to a dead output and auto-unload within ~200 ms, silently dropping short TTS clips. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@louiscavalcante](https://github.com/louiscavalcante))
+- [Android] Set `AudioAttributes` to `USAGE_MEDIA` on `AudioPlayer`'s ExoPlayer so Android routes the AudioTrack to `STREAM_MUSIC` after a peer component releases non-media audio focus (e.g. a recording library that held `STREAM_VOICE_CALL` focus). Previously `AudioAttributes.DEFAULT` declared `USAGE_UNKNOWN`, leaving the AudioTrack pinned to a stale voice-call sink — the player reported `playing=true` with `currentTime=0` before auto-unloading within ~200 ms. ([#44869](https://github.com/expo/expo/pull/44869) by [@louiscavalcante](https://github.com/louiscavalcante))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Request media audio focus on `AudioPlayer`'s ExoPlayer so playback actually starts after another component held non-media audio focus (e.g. a recording library that grabbed `STREAM_VOICE_CALL` focus). Previously `AudioAttributes.DEFAULT, false` caused the player to report `playing=true` while streaming to a dead output and auto-unload within ~200 ms, silently dropping short TTS clips. ([#PR_NUMBER](https://github.com/expo/expo/pull/PR_NUMBER) by [@louiscavalcante](https://github.com/louiscavalcante))
+
 ### 💡 Others
 
 ## 0.4.9 — 2025-08-22

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -39,7 +39,22 @@ class AudioPlayer(
 ) : SharedRef<ExoPlayer>(
   ExoPlayer.Builder(context)
     .setLooper(context.mainLooper)
-    .setAudioAttributes(AudioAttributes.DEFAULT, false)
+    // USAGE_MEDIA + handleAudioFocus=true so ExoPlayer actually requests
+    // audio focus. `AudioAttributes.DEFAULT, false` declared USAGE_UNKNOWN
+    // and never asked for focus — after any other component released focus
+    // on a non-media stream (e.g. a third-party recording library
+    // abandoning STREAM_VOICE_CALL focus on stop), playback would report
+    // playing=true but stream to a dead output: currentTime never advanced
+    // and the player auto-unloaded within ~200 ms, silently dropping short
+    // TTS clips. Speech content type is the right default for this
+    // module's primary use (text-to-speech and short UI clips).
+    .setAudioAttributes(
+      AudioAttributes.Builder()
+        .setUsage(C.USAGE_MEDIA)
+        .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
+        .build(),
+      true
+    )
     .build(),
   appContext
 ) {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -39,21 +39,12 @@ class AudioPlayer(
 ) : SharedRef<ExoPlayer>(
   ExoPlayer.Builder(context)
     .setLooper(context.mainLooper)
-    // USAGE_MEDIA + handleAudioFocus=true so ExoPlayer actually requests
-    // audio focus. `AudioAttributes.DEFAULT, false` declared USAGE_UNKNOWN
-    // and never asked for focus — after any other component released focus
-    // on a non-media stream (e.g. a third-party recording library
-    // abandoning STREAM_VOICE_CALL focus on stop), playback would report
-    // playing=true but stream to a dead output: currentTime never advanced
-    // and the player auto-unloaded within ~200 ms, silently dropping short
-    // TTS clips. Speech content type is the right default for this
-    // module's primary use (text-to-speech and short UI clips).
     .setAudioAttributes(
       AudioAttributes.Builder()
         .setUsage(C.USAGE_MEDIA)
-        .setContentType(C.AUDIO_CONTENT_TYPE_SPEECH)
+        .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
         .build(),
-      true
+      false
     )
     .build(),
   appContext


### PR DESCRIPTION
> Narrowed version of the fix previously posted on this PR. Updated per reviewer feedback (@alanjhughes — thanks; `handleAudioFocus` now stays `false` so `AudioModule` keeps owning focus). The remaining change is a stream-routing correction that isn't reachable from `setAudioModeAsync`.

# Why

`AudioPlayer.kt` builds its `ExoPlayer` with:

```kotlin
.setAudioAttributes(AudioAttributes.DEFAULT, false)
```

`AudioAttributes.DEFAULT` declares `USAGE_UNKNOWN` / `CONTENT_TYPE_UNKNOWN`, so Android's AudioPolicy service can't unambiguously resolve routing for the internal `AudioTrack`. After a peer component in the app holds audio focus on a non-media stream — e.g. a third-party recording module that grabbed `STREAM_VOICE_CALL` focus for speech capture and abandoned it on stop — the audio state is left biased toward the voice-call output. A subsequent ExoPlayer `play()` opens its AudioTrack against that stale sink: `playing=true`, nothing renders.

In a real SDK 53 app doing STT-then-TTS with such a recorder, I consistently observed:

```
[log] status isLoaded=true  playing=false currentTime=0 duration=0.94
[log] player.play() called
[log] status isLoaded=true  playing=true  currentTime=0
[log] status isLoaded=true  playing=true  currentTime=0
[log] status isLoaded=true  playing=true  currentTime=0
[log] status isLoaded=false playing=false currentTime=0   ← auto-unloaded
```

`currentTime` never advanced and nothing came out of the speaker. Longer clips happened to survive the transition and play audibly; short clips (<1 s — typical TTS acknowledgments like "Confirma?", "Salvando…") never emitted audible output.

Audio focus itself is not the problem — `AudioModule.requestAudioFocus()` is already invoked from `Function("play")` before `player.ref.play()`, and focus is granted (ringer normal, `shouldPlayInSilentMode` true). The bug is purely about stream routing: the AudioTrack needs a non-ambiguous usage hint.

# How

Declare `USAGE_MEDIA` on the ExoPlayer's audio attributes so Android resolves the AudioTrack to `STREAM_MUSIC`. Keep `handleAudioFocus = false` — focus stays owned by `AudioModule.requestAudioFocus()` (configurable via `setAudioModeAsync`'s `interruptionMode`), matching the module's existing design.

```kotlin
.setAudioAttributes(
  AudioAttributes.Builder()
    .setUsage(C.USAGE_MEDIA)
    .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
    .build(),
  false
)
```

`CONTENT_TYPE_MUSIC` matches what `AudioModule.requestAudioFocus()` already declares when building its `AudioFocusRequest`, so the focus listener and the player's AudioTrack stay aligned. It's also a safer default for a general-purpose audio player than `CONTENT_TYPE_SPEECH` — on some OEMs `SPEECH` triggers speech-enhancement filters that would be wrong for music playback.

After this change:
- Playback `currentTime` advances.
- `didJustFinish` fires reliably on clip end.
- Post-capture TTS playback just works.

# Test Plan

- [x] Verified the stock SDK 53 build reproduces the bug on a physical Android device.
- [x] Applied this narrowed patch via `patch-package` against `expo-audio@0.4.9` and rebuilt the dev client. Confirmed on device:
  - `status playing=true` transitions now have `currentTime` advancing each 100 ms `playbackStatusUpdate`.
  - `didJustFinish` fires on clip end (previously never).
  - Audio is audible for both short and long clips across repeated STT → TTS turns.
  - No regression for standalone playback (no prior STT): audio plays the same as before.
  - `setAudioModeAsync({ shouldRouteThroughEarpiece: true })` still routes through the earpiece (the `AudioModule.updatePlaySoundThroughEarpiece` path is untouched).
  - `setAudioModeAsync({ interruptionMode: ... })` still governs focus behaviour exactly as before — `AudioModule` remains the sole focus owner.
- [x] TypeScript compile clean (`expo-module build` watch pass: *Found 0 errors*). No TS changes in this commit.
- [x] `pnpm lint` clean in `packages/expo-audio`.
- [x] `pnpm test` matches the baseline — `packages/expo-audio` has no `__tests__` directory; on-device coverage lives in `apps/test-suite/tests/Audio.ts` and is left for reviewer's CI run.

# Possible Side Effects

- Android only; iOS path unchanged.
- Focus ownership, interruption behaviour, and `AudioModule` state are all unchanged — `handleAudioFocus` stays `false`, so ExoPlayer does not register its own focus listener and does not interfere with the module's focus-request flow.
- No public API change.
- Observable shift is Android's AudioPolicy service routing the AudioTrack to `STREAM_MUSIC` unambiguously, which is what any media player should be doing.

# Relation to `main`

A corresponding PR against `main` carrying the same narrowed change will be opened separately (the original attempt, #44868, was pushed from the wrong head branch and is being closed / reopened). Posting this backport so SDK 53 users don't have to hold a `patch-package` workaround until they upgrade.