### PR TITLE
[expo-image][iOS] Disable user interaction on ImageView by default

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Fixed `contentPosition` misalignment by using the unrounded cover/contain layout size for offset math. ([#44497](https://github.com/expo/expo/pull/44497) by [@alicenoknow](https://github.com/alicenoknow))
 - [Android] Apply `ApplicationVersionSignature` to local resource URIs (`res:/` scheme) to prevent stale cached images after app updates. by [@linkeryoon](https://github.com/linkeryoon) ([#44355](https://github.com/expo/expo/pull/44355) by [@Yoon-Hae-Min](https://github.com/Yoon-Hae-Min))
 - Added `tintColor` option to `ImageLoadOptions`. This resolves [#42007](https://github.com/expo/expo/issues/42007). ([#42821](https://github.com/expo/expo/pull/42821)) by [@HubertBer](https://github.com/HubertBer).
+- [iOS] Fixed `Image` swallowing touches intended for ancestor gesture recognizers (e.g. a surrounding `Pressable`) by disabling user interaction on the underlying `ExpoView`, matching `UIImageView`'s default. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@janicduplessis](https://github.com/janicduplessis))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -117,6 +117,15 @@ public final class ImageView: ExpoView {
   public required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
 
+    // Match `UIImageView`'s default so the image view does not intercept
+    // touches intended for ancestor gesture recognizers. `ExpoView`
+    // inherits from `UIView`, whose default `isUserInteractionEnabled` is
+    // `true` — which causes hit-testing to stop at the image and prevents
+    // a surrounding `Pressable` (especially ones that rely on
+    // `react-native-gesture-handler` for press detection, such as
+    // Tamagui's native `Pressable`) from receiving taps.
+    isUserInteractionEnabled = false
+
     clipsToBounds = true
     sdImageView.contentMode = contentFit.toContentMode()
     sdImageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -117,13 +117,9 @@ public final class ImageView: ExpoView {
   public required init(appContext: AppContext? = nil) {
     super.init(appContext: appContext)
 
-    // Match `UIImageView`'s default so the image view does not intercept
-    // touches intended for ancestor gesture recognizers. `ExpoView`
-    // inherits from `UIView`, whose default `isUserInteractionEnabled` is
-    // `true` — which causes hit-testing to stop at the image and prevents
-    // a surrounding `Pressable` (especially ones that rely on
-    // `react-native-gesture-handler` for press detection, such as
-    // Tamagui's native `Pressable`) from receiving taps.
+    // Match RN's `<Image>`, which inherits from `UIImageView` and defaults
+    // `isUserInteractionEnabled` to `false`.
+    // https://github.com/facebook/react-native/blob/2c0ae274825ab752b9831c12d231b7a55585f79d/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.h
     isUserInteractionEnabled = false
 
     clipsToBounds = true


### PR DESCRIPTION
# Why

Wrapping `<Image>` from `expo-image` in a surrounding `Pressable` (or any ancestor gesture recognizer) on iOS silently swallows taps. Replacing `expo-image` with React Native's built-in `<Image>` fixes it. This regressed our chat-image lightbox after upgrading to Expo 54 and isn't easy to work around in userland — every consumer has to remember to set `pointerEvents="none"` on the image.

Root cause: `ExpoView` extends `UIView`, whose default `isUserInteractionEnabled` is `true`. `UIImageView` (what RN's `<Image>` uses) defaults it to `false`, so taps fall through to ancestors. `expo-image`'s `ImageView` never overrides this, so its wrapping view participates in hit-testing and prevents ancestor gesture recognizers from firing on a tap.

I'm aware this behavior can also surface through `react-native-gesture-handler` v2 (Tamagui's native `Pressable` uses RNGH under the hood), so users combining that stack with `expo-image` are especially likely to hit it. But the problem isn't RNGH-specific — the `UIImageView` vs `UIView` default is the underlying asymmetry.

# How

Set `isUserInteractionEnabled = false` on `ImageView` in `init(appContext:)` so it matches `UIImageView`'s default. Touches fall through to ancestor gesture recognizers unless the consumer opts back in (e.g. by toggling it on from their own code for VoiceOver/Live Text interaction).

No user-visible behavior for existing apps aside from fixing the "tap does nothing" case:
- The image itself has no `onPress`-type props, so nothing was reacting to direct taps before anyway.
- `accessible` / `accessibilityLabel` continue to work — they set `isAccessibilityElement`, which is independent of `isUserInteractionEnabled`.
- `enableLiveTextInteraction` attaches an `ImageAnalysisInteraction` to `sdImageView`. I tested this with the flag enabled and VisionKit interactions still work because `UIInteraction`s don't require the hosting `ExpoView` to have interaction enabled (the interaction is attached to `sdImageView`, which is a `UIImageView` subclass). If maintainers want to be extra defensive, `enableLiveTextInteraction.didSet` could flip this flag — happy to add that if desired.

# Test Plan

- Reproduction: `<Pressable onPress={...}><Image source={...} /></Pressable>` on iOS with RN or RNGH-backed Pressable. Before this change, `onPress` never fires. After, it fires as expected.
- Verified on iOS Simulator (iPhone 16, iOS 26 preview) inside a consumer app (Tlon Messenger) that uses Tamagui v2 + RNGH-backed Pressables.
- Verified `accessible={true}` still marks the image as an accessibility element.
- Did not retest `enableLiveTextInteraction` end-to-end on a device — happy to verify or extend the patch if that path is known to require `isUserInteractionEnabled = true` on the outer view.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). _N/A — iOS-only Swift change in the view init._
- [x] Conforms with the Documentation Writing Style Guide