### PR TITLE
[bare-expo] use react-native core api to set appearance

### DIFF
--- a/apps/common/ThemeProvider.tsx
+++ b/apps/common/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 import { darkTheme, lightTheme } from '@expo/styleguide-base';
-import React, { createContext, useState, useContext, PropsWithChildren } from 'react';
-import { useColorScheme } from 'react-native';
+import React, { createContext, useContext, PropsWithChildren } from 'react';
+import { useColorScheme, Appearance } from 'react-native';
 
 export type ThemeName = 'light' | 'dark';
 export type ThemeType = typeof lightTheme | typeof darkTheme;
@@ -19,23 +19,15 @@ export const ThemeContext = createContext<ThemeContextType>({
 
 export function ThemeProvider({ children }: PropsWithChildren) {
   const systemColorScheme = useColorScheme();
-  const defaultTheme = systemColorScheme !== 'unspecified' ? systemColorScheme : 'light';
-  const [currentThemeName, setCurrentThemeName] = useState<ThemeName>(defaultTheme);
-  const [currentTheme, setCurrentTheme] = useState<ThemeType>(
-    defaultTheme === 'dark' ? darkTheme : lightTheme
-  );
-
-  function setTheme(name: ThemeName) {
-    setCurrentThemeName(name);
-    setCurrentTheme(name === 'dark' ? darkTheme : lightTheme);
-  }
+  const currentThemeName = systemColorScheme !== 'unspecified' ? systemColorScheme : 'light';
+  const currentTheme = currentThemeName === 'dark' ? darkTheme : lightTheme;
 
   return (
     <ThemeContext.Provider
       value={{
         name: currentThemeName,
         theme: currentTheme,
-        setTheme,
+        setTheme: Appearance.setColorScheme,
       }}>
       {children}
     </ThemeContext.Provider>

--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -1,8 +1,8 @@
-import { ThemeProvider } from 'ThemeProvider';
 import * as SplashScreen from 'expo-splash-screen';
 import * as React from 'react';
 import { Platform, StatusBar } from 'react-native';
 
+import { ThemeProvider, useTheme } from '../common/ThemeProvider';
 import RootNavigation from './src/navigation/RootNavigation';
 import loadAssetsAsync from './src/utilities/loadAssetsAsync';
 
@@ -31,13 +31,25 @@ function useSplashScreen(loadingFunction: () => Promise<void>) {
   return isLoadingCompleted;
 }
 
-export default function App() {
+function AppContent() {
+  const { name } = useTheme();
   const isLoadingCompleted = useSplashScreen(async () => {
-    if (Platform.OS === 'ios') {
-      StatusBar.setBarStyle('dark-content', false);
-    }
     await loadAssetsAsync();
   });
 
-  return <ThemeProvider>{isLoadingCompleted ? <RootNavigation /> : null}</ThemeProvider>;
+  React.useEffect(() => {
+    if (Platform.OS === 'ios') {
+      StatusBar.setBarStyle(name === 'dark' ? 'light-content' : 'dark-content', true);
+    }
+  }, [name]);
+
+  return isLoadingCompleted ? <RootNavigation /> : null;
+}
+
+export default function App() {
+  return (
+    <ThemeProvider>
+      <AppContent />
+    </ThemeProvider>
+  );
 }

--- a/apps/native-component-list/App.tsx
+++ b/apps/native-component-list/App.tsx
@@ -32,16 +32,16 @@ function useSplashScreen(loadingFunction: () => Promise<void>) {
 }
 
 function AppContent() {
-  const { name } = useTheme();
+  const { name: themeName } = useTheme();
   const isLoadingCompleted = useSplashScreen(async () => {
     await loadAssetsAsync();
   });
 
   React.useEffect(() => {
     if (Platform.OS === 'ios') {
-      StatusBar.setBarStyle(name === 'dark' ? 'light-content' : 'dark-content', true);
+      StatusBar.setBarStyle(themeName === 'dark' ? 'light-content' : 'dark-content', true);
     }
-  }, [name]);
+  }, [themeName]);
 
   return isLoadingCompleted ? <RootNavigation /> : null;
 }

--- a/apps/native-component-list/src/components/ExpoAPIIcon.tsx
+++ b/apps/native-component-list/src/components/ExpoAPIIcon.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Image, ImageStyle } from 'react-native';
 
+import { useTheme } from '../../../common/ThemeProvider';
 import Icons from '../constants/Icons';
 
 type Props = {
@@ -9,8 +10,14 @@ type Props = {
 };
 
 const ExpoAPIIcon = ({ name, style }: Props) => {
+  const { theme } = useTheme();
   const icon = React.useMemo(() => (Icons[name] || Icons.Default)(), [name]);
-  return <Image source={icon} style={[{ width: 24, height: 24 }, style]} />;
+  return (
+    <Image
+      source={icon}
+      style={[{ width: 24, height: 24, tintColor: theme.text.default }, style]}
+    />
+  );
 };
 
 export default ExpoAPIIcon;

--- a/apps/native-component-list/src/components/SearchBar.tsx
+++ b/apps/native-component-list/src/components/SearchBar.tsx
@@ -1,28 +1,19 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import React from 'react';
-import { StyleSheet, TextInput, TextStyle, TouchableOpacity, View, Platform } from 'react-native';
+import { StyleSheet, TextInput, TouchableOpacity, View, Platform } from 'react-native';
 
-import { Colors } from '../constants';
+import { useTheme } from '../../../common/ThemeProvider';
 
 export default function SearchBar({
-  selectionColor,
-  tintColor = Colors.tintColor,
-  placeholderTextColor = '#ccc',
-  underlineColorAndroid = '#ccc',
-  textColor,
   onSubmit,
   onChangeQuery,
   initialValue = '',
 }: {
   initialValue?: string;
-  selectionColor?: string;
-  tintColor: string;
-  placeholderTextColor?: string;
-  underlineColorAndroid?: string;
-  textColor?: string;
   onSubmit?: (query: string) => void;
   onChangeQuery?: (query: string) => void;
 }) {
+  const { theme } = useTheme();
   const [text, setText] = React.useState(initialValue);
   const _textInput = React.useRef<TextInput>(null);
 
@@ -45,25 +36,19 @@ export default function SearchBar({
     _textInput.current?.blur();
   };
 
-  const searchInputStyle: TextStyle = {};
-  if (textColor) {
-    searchInputStyle.color = textColor;
-  }
-
   return (
     <View style={styles.container}>
       <TextInput
         ref={_textInput}
         placeholder="Search"
-        placeholderTextColor={placeholderTextColor}
+        placeholderTextColor={theme.text.quaternary}
         value={text}
         autoCapitalize="none"
         autoCorrect={false}
-        selectionColor={selectionColor}
-        underlineColorAndroid={underlineColorAndroid}
+        underlineColorAndroid={theme.background.default}
         onSubmitEditing={_handleSubmit}
         onChangeText={_handleChangeText}
-        style={[styles.searchInput, searchInputStyle]}
+        style={styles.searchInput}
       />
       <View style={{ width: 50, alignItems: 'center', justifyContent: 'center' }}>
         {text ? (
@@ -71,7 +56,7 @@ export default function SearchBar({
             onPress={_handleClear}
             hitSlop={{ top: 15, left: 10, right: 15, bottom: 15 }}
             style={{ padding: 5 }}>
-            <Ionicons name="close" size={25} color={tintColor} />
+            <Ionicons name="close" size={25} color={theme.icon.info} />
           </TouchableOpacity>
         ) : null}
       </View>

--- a/apps/native-component-list/src/navigation/MainTabNavigator.tsx
+++ b/apps/native-component-list/src/navigation/MainTabNavigator.tsx
@@ -5,7 +5,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import Screens from './MainNavigators';
 import createTabNavigator from './createTabNavigator';
-import { Colors } from '../constants';
+import { useTheme } from '../../../common/ThemeProvider';
 
 const Tab = createTabNavigator();
 
@@ -14,6 +14,7 @@ const Drawer = createDrawerNavigator();
 export default function MainTabbedNavigator(props: any) {
   const { width } = useWindowDimensions();
   const { left } = useSafeAreaInsets();
+  const { theme } = useTheme();
   const isMobile = width <= 640;
   const isTablet = !isMobile && width <= 960;
   const isLargeScreen = !isTablet && !isMobile;
@@ -30,21 +31,21 @@ export default function MainTabbedNavigator(props: any) {
         // or material-bottom-tabs navigator
         // material-bottom-tabs props
         shifting
-        activeTintColor={Colors.tabIconSelected}
-        inactiveTintColor={Colors.tabIconDefault}
+        activeTintColor={theme.icon.info}
+        inactiveTintColor={theme.icon.default}
         barStyle={{
-          backgroundColor: Colors.tabBar,
+          backgroundColor: theme.background.default,
           borderTopWidth: StyleSheet.hairlineWidth,
-          borderTopColor: Colors.tabIconDefault,
+          borderTopColor: theme.border.secondary,
         }}
         // bottom-tabs props
         screenOptions={{
           headerShown: false,
-          tabBarActiveTintColor: Colors.tabIconSelected,
-          tabBarInactiveTintColor: Colors.tabIconDefault,
+          tabBarActiveTintColor: theme.icon.info,
+          tabBarInactiveTintColor: theme.icon.default,
           tabBarStyle: [
             {
-              backgroundColor: Colors.tabBar,
+              backgroundColor: theme.background.default,
             },
           ],
         }}>

--- a/apps/native-component-list/src/navigation/RootNavigation.tsx
+++ b/apps/native-component-list/src/navigation/RootNavigation.tsx
@@ -1,4 +1,9 @@
-import { LinkingOptions, NavigationContainer } from '@react-navigation/native';
+import {
+  DarkTheme,
+  DefaultTheme,
+  LinkingOptions,
+  NavigationContainer,
+} from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import * as Linking from 'expo-linking';
 import * as React from 'react';
@@ -7,6 +12,7 @@ import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import MainNavigators from './MainNavigators';
 import MainTabNavigator from './MainTabNavigator';
+import { useTheme } from '../../../common/ThemeProvider';
 import RedirectScreen from '../screens/RedirectScreen';
 import SearchScreen from '../screens/SearchScreen';
 
@@ -33,9 +39,13 @@ export const linking: LinkingOptions<object> = {
 };
 
 export default function RootNavigation() {
+  const { name } = useTheme();
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <NavigationContainer linking={linking} fallback={<Text>Loading…</Text>}>
+      <NavigationContainer
+        linking={linking}
+        fallback={<Text>Loading…</Text>}
+        theme={name === 'dark' ? DarkTheme : DefaultTheme}>
         <Switch.Navigator screenOptions={{ presentation: 'modal', headerShown: false }}>
           <Switch.Screen name="main" component={MainTabNavigator} />
           <Switch.Screen name="redirect" component={RedirectScreen} />

--- a/apps/native-component-list/src/navigation/RootNavigation.tsx
+++ b/apps/native-component-list/src/navigation/RootNavigation.tsx
@@ -39,13 +39,13 @@ export const linking: LinkingOptions<object> = {
 };
 
 export default function RootNavigation() {
-  const { name } = useTheme();
+  const { name: themeName } = useTheme();
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <NavigationContainer
         linking={linking}
         fallback={<Text>Loading…</Text>}
-        theme={name === 'dark' ? DarkTheme : DefaultTheme}>
+        theme={themeName === 'dark' ? DarkTheme : DefaultTheme}>
         <Switch.Navigator screenOptions={{ presentation: 'modal', headerShown: false }}>
           <Switch.Screen name="main" component={MainTabNavigator} />
           <Switch.Screen name="redirect" component={RedirectScreen} />

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -18,6 +18,8 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { ScreenConfig } from 'src/types/ScreenConfig';
 import { getScreenIdForLinking } from 'test-suite/screens/getScreenIdForLinking';
 
+import { useTheme } from '../../../common/ThemeProvider';
+
 export interface ListElement {
   screenName?: string;
   name: string;
@@ -64,6 +66,7 @@ function LinkButton({
   disabled?: boolean;
   children?: React.ReactNode;
 }) {
+  const { theme } = useTheme();
   const { buildAction } = useLinkBuilder();
   const action: NavigationAction = buildAction(href);
 
@@ -86,7 +89,7 @@ function LinkButton({
         {...rest}
         style={[
           {
-            backgroundColor: isPressed ? '#dddddd' : undefined,
+            backgroundColor: isPressed ? theme.background.hover : undefined,
           },
           rest.style,
         ]}>
@@ -96,13 +99,19 @@ function LinkButton({
   }
 
   return (
-    <TouchableHighlight underlayColor="#dddddd" onPress={onPress} {...props} {...rest}>
+    <TouchableHighlight
+      underlayColor={theme.background.hover}
+      onPress={onPress}
+      {...props}
+      {...rest}>
       {children}
     </TouchableHighlight>
   );
 }
 
 export default function ComponentListScreen(props: Props) {
+  const { theme } = useTheme();
+
   React.useEffect(() => {
     StatusBar.setHidden(false);
   }, []);
@@ -119,14 +128,14 @@ export default function ComponentListScreen(props: Props) {
       <LinkButton
         disabled={!isAvailable}
         href={route ?? screenName ?? exampleName}
-        style={[styles.rowTouchable]}>
+        style={[styles.rowTouchable, { borderBottomColor: theme.border.secondary }]}>
         <View
           pointerEvents="none"
           style={[styles.row, !isAvailable && styles.disabledRow, { paddingRight: 10 + right }]}>
           {props.renderItemRight && props.renderItemRight(item)}
-          <Text style={styles.rowLabel}>{exampleName}</Text>
+          <Text style={[styles.rowLabel, { color: theme.text.default }]}>{exampleName}</Text>
           <Text style={styles.rowDecorator}>
-            <Ionicons name="chevron-forward" size={18} color="#595959" />
+            <Ionicons name="chevron-forward" size={18} color={theme.icon.secondary} />
           </Text>
         </View>
       </LinkButton>
@@ -156,7 +165,10 @@ export default function ComponentListScreen(props: Props) {
       removeClippedSubviews={false}
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
-      contentContainerStyle={{ backgroundColor: '#fff', paddingBottom: isMobile ? 0 : bottom }}
+      style={{ backgroundColor: theme.background.screen }}
+      contentContainerStyle={{
+        paddingBottom: isMobile ? 0 : bottom,
+      }}
       data={sortedApis}
       keyExtractor={keyExtractor}
       renderItem={renderExampleSection}
@@ -182,7 +194,6 @@ const styles = StyleSheet.create({
   },
   rowTouchable: {
     borderBottomWidth: 1.0 / PixelRatio.get(),
-    borderBottomColor: '#dddddd',
   },
   disabledRow: {
     opacity: 0.3,

--- a/apps/native-component-list/src/screens/SearchScreen.tsx
+++ b/apps/native-component-list/src/screens/SearchScreen.tsx
@@ -1,66 +1,39 @@
-import { HeaderBackButton } from '@react-navigation/elements';
 import { createNativeStackNavigator, NativeStackScreenProps } from '@react-navigation/native-stack';
-import { useTheme } from 'ThemeProvider';
 import Fuse from 'fuse.js';
 import React from 'react';
-import { Animated, Platform, StyleSheet, View } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import ComponentListScreen from './ComponentListScreen';
+import { useTheme } from '../../../common/ThemeProvider';
 import ExpoAPIIcon from '../components/ExpoAPIIcon';
-import SearchBar from '../components/SearchBar';
 import { screenApiItems as ApiScreenApiItems } from '../navigation/ExpoApisStackNavigator';
 import { screenApiItems as ComponentScreenApiItems } from '../navigation/ExpoComponentsStackNavigator';
 
 const fuse = new Fuse(ApiScreenApiItems.concat(ComponentScreenApiItems), { keys: ['name'] });
 
-const APPBAR_HEIGHT = Platform.OS === 'ios' ? 50 : 56;
-const TITLE_OFFSET = Platform.OS === 'ios' ? 70 : 56;
+function SearchScreen({ navigation }: NativeStackScreenProps<SearchStack, 'search'>) {
+  const { theme } = useTheme();
+  const [query, setQuery] = React.useState('');
 
-function Header({
-  children,
-  backButton,
-  tintColor,
-  navigation,
-}: {
-  children?: React.ReactNode;
-  backButton?: boolean;
-  tintColor?: string;
-  navigation: any;
-}) {
-  const { top } = useSafeAreaInsets();
-  // @todo: this is static and we don't know if it's visible or not on iOS.
-  // need to use a more reliable and cross-platform API when one exists, like
-  // LayoutContext. We also don't know if it's translucent or not on Android
-  // and depend on react-native-safe-area-context to tell us.
-  const STATUSBAR_HEIGHT = top || 8;
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerSearchBarOptions: {
+        placeholder: 'Search',
+        autoFocus: true,
+        textColor: theme.text.default,
+        tintColor: theme.icon.info,
+        headerIconColor: theme.icon.secondary,
+        hintTextColor: theme.text.quaternary,
+        onChangeText: (event: { nativeEvent: { text: string } }) =>
+          setQuery(event.nativeEvent.text),
+        onCancelButtonPress: () => navigation.goBack(),
+      },
+    });
+  }, [navigation, theme]);
 
-  return (
-    <Animated.View
-      style={[
-        styles.container,
-        { paddingTop: STATUSBAR_HEIGHT, height: STATUSBAR_HEIGHT + APPBAR_HEIGHT },
-      ]}>
-      <View style={styles.appBar}>
-        <View style={[StyleSheet.absoluteFill, { flexDirection: 'row' }]}>
-          {backButton && (
-            <HeaderBackButton
-              onPress={() => navigation.goBack()}
-              pressColor={tintColor || '#fff'}
-              tintColor={tintColor}
-            />
-          )}
-          {children}
-        </View>
-      </View>
-    </Animated.View>
-  );
-}
-
-function SearchScreen({ route }: NativeStackScreenProps<SearchStack, 'search'>) {
-  const query = route?.params?.q ?? '';
-
-  const apis = React.useMemo(() => fuse.search(query).map(({ item }) => item), [query]);
+  const apis = React.useMemo(() => {
+    if (!query) return [];
+    return fuse.search(query).map(({ item }) => item);
+  }, [query]);
 
   const renderItemRight = React.useCallback(
     ({ name }: { name: string }) => (
@@ -73,7 +46,7 @@ function SearchScreen({ route }: NativeStackScreenProps<SearchStack, 'search'>) 
 }
 
 type SearchStack = {
-  search: { q?: string };
+  search: undefined;
 };
 
 const Stack = createNativeStackNavigator<SearchStack>();
@@ -81,80 +54,13 @@ const Stack = createNativeStackNavigator<SearchStack>();
 export default function SearchScreenStack() {
   const { theme } = useTheme();
   return (
-    <Stack.Navigator>
-      <Stack.Screen
-        name="search"
-        component={SearchScreen}
-        options={({ navigation, route }) => ({
-          header: () => (
-            <Header
-              navigation={navigation}
-              tintColor={theme.icon.info}
-              backButton={Platform.OS === 'android'}>
-              <SearchBar
-                initialValue={route?.params?.q ?? ''}
-                onChangeQuery={(q) => navigation.setParams({ q })}
-                underlineColorAndroid="#fff"
-                tintColor={theme.text.info}
-              />
-            </Header>
-          ),
-        })}
-      />
+    <Stack.Navigator
+      screenOptions={{
+        headerStyle: { backgroundColor: theme.background.default },
+        headerTintColor: theme.icon.info,
+        headerTitleStyle: { color: theme.text.default },
+      }}>
+      <Stack.Screen name="search" component={SearchScreen} options={{ title: 'Search' }} />
     </Stack.Navigator>
   );
 }
-
-const styles = {
-  container: {
-    backgroundColor: '#fff',
-
-    ...Platform.select({
-      ios: {
-        borderBottomWidth: StyleSheet.hairlineWidth,
-        borderBottomColor: '#A7A7AA',
-      },
-      default: {
-        shadowColor: 'black',
-        shadowOpacity: 0.1,
-        shadowRadius: StyleSheet.hairlineWidth,
-        shadowOffset: {
-          width: 0,
-          height: StyleSheet.hairlineWidth,
-        },
-        elevation: 4,
-      },
-    }),
-  },
-  appBar: {
-    flex: 1,
-  },
-  header: {
-    flexDirection: 'row',
-  },
-  item: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'transparent',
-  },
-  title: {
-    bottom: 0,
-    left: TITLE_OFFSET,
-    right: TITLE_OFFSET,
-    top: 0,
-    position: 'absolute',
-    alignItems: Platform.OS === 'ios' ? 'center' : 'flex-start',
-  },
-  left: {
-    left: 0,
-    bottom: 0,
-    top: 0,
-    position: 'absolute',
-  },
-  right: {
-    right: 0,
-    bottom: 0,
-    top: 0,
-    position: 'absolute',
-  },
-};

--- a/apps/test-suite/App.js
+++ b/apps/test-suite/App.js
@@ -1,9 +1,9 @@
-import { NavigationContainer } from '@react-navigation/native';
+import { NavigationContainer, DarkTheme, DefaultTheme } from '@react-navigation/native';
 import * as Linking from 'expo-linking';
 import * as React from 'react';
 
 import { TestStackNavigator } from './TestStackNavigator';
-import { ThemeProvider } from '../common/ThemeProvider';
+import { ThemeProvider, useTheme } from '../common/ThemeProvider';
 import { routeNames } from './constants/routeNames';
 
 const linking = {
@@ -16,10 +16,17 @@ const linking = {
   },
 };
 
-export default () => (
-  <ThemeProvider>
-    <NavigationContainer linking={linking}>
+function AppContent() {
+  const { name } = useTheme();
+  return (
+    <NavigationContainer linking={linking} theme={name === 'dark' ? DarkTheme : DefaultTheme}>
       <TestStackNavigator />
     </NavigationContainer>
+  );
+}
+
+export default () => (
+  <ThemeProvider>
+    <AppContent />
   </ThemeProvider>
 );

--- a/apps/test-suite/App.js
+++ b/apps/test-suite/App.js
@@ -17,9 +17,9 @@ const linking = {
 };
 
 function AppContent() {
-  const { name } = useTheme();
+  const { name: themeName } = useTheme();
   return (
-    <NavigationContainer linking={linking} theme={name === 'dark' ? DarkTheme : DefaultTheme}>
+    <NavigationContainer linking={linking} theme={themeName === 'dark' ? DarkTheme : DefaultTheme}>
       <TestStackNavigator />
     </NavigationContainer>
   );

--- a/apps/test-suite/components/Portal.js
+++ b/apps/test-suite/components/Portal.js
@@ -1,14 +1,22 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
 
+import { useTheme } from '../../common/ThemeProvider';
+
 export default function Portal({ isVisible, children }) {
+  const { theme } = useTheme();
+
   if (!children) {
     return null;
   }
 
   return (
     <View
-      style={[StyleSheet.absoluteFill, styles.container, { opacity: isVisible ? 0.5 : 0 }]}
+      style={[
+        StyleSheet.absoluteFill,
+        styles.container,
+        { backgroundColor: theme.background.default, opacity: isVisible ? 0.5 : 0 },
+      ]}
       pointerEvents="none">
       {children}
     </View>
@@ -19,6 +27,5 @@ const styles = StyleSheet.create({
   container: {
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: 'rgb(255, 255, 255)',
   },
 });

--- a/apps/test-suite/components/Suites.js
+++ b/apps/test-suite/components/Suites.js
@@ -11,7 +11,7 @@ export default function Suites({ suites, done, numFailed, results, selectionQuer
 
   return (
     <FlatList
-      style={styles.list}
+      style={[styles.list, { backgroundColor: theme.background.screen }]}
       contentContainerStyle={styles.contentContainerStyle}
       data={[...suites]}
       keyExtractor={(item) => item.get('result').get('id')}
@@ -46,7 +46,6 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   headerContainer: {
-    backgroundColor: '#fff',
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
 });

--- a/apps/test-suite/screens/SelectScreen.tsx
+++ b/apps/test-suite/screens/SelectScreen.tsx
@@ -1,16 +1,7 @@
 import { Checkbox } from 'expo-checkbox';
 import Constants from 'expo-constants';
 import * as React from 'react';
-import {
-  type EmitterSubscription,
-  Alert,
-  FlatList,
-  Linking,
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-} from 'react-native';
+import { Alert, FlatList, Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTheme } from '../../common/ThemeProvider';
@@ -23,40 +14,44 @@ import {
 import PlatformTouchable from '../components/PlatformTouchable';
 import { routeNames } from '../constants/routeNames';
 
-function ListItem({ title, onPressItem, selected, id }) {
+function ListItem({
+  title,
+  onPressItem,
+  selectedSet,
+  id,
+}: {
+  title: string;
+  onPressItem: (id: string) => void;
+  selectedSet: Set<string>;
+  id: string;
+}) {
   const { theme } = useTheme();
   const onPress = () => onPressItem(id);
 
   return (
     <PlatformTouchable onPress={onPress}>
       <View style={[styles.listItem, { borderBottomColor: theme.border.secondary }]}>
-        <Text style={styles.label}>{title}</Text>
+        <Text style={[styles.label, { color: theme.text.default }]}>{title}</Text>
         <View style={{ pointerEvents: 'none' }}>
-          <Checkbox color={theme.icon.info} value={selected} />
+          <Checkbox color={theme.icon.info} value={selectedSet.has(id)} />
         </View>
       </View>
     </PlatformTouchable>
   );
 }
 
-export default class SelectScreen extends React.PureComponent<
-  { navigation: any },
-  { selected: Set<string>; modules: Module[] }
-> {
-  state = {
-    selected: new Set<string>(),
-    modules: [],
-  };
-  _openUrlSubscription: EmitterSubscription = null;
+export default function SelectScreen({ navigation }) {
+  const { theme } = useTheme();
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const selectedRef = React.useRef(selected);
+  selectedRef.current = selected;
+  const [modules, setModules] = React.useState<Module[]>([]);
 
-  constructor(props) {
-    super(props);
-
+  React.useEffect(() => {
     if (global.ErrorUtils) {
       const originalErrorHandler = global.ErrorUtils.getGlobalHandler();
 
       global.ErrorUtils.setGlobalHandler((error, isFatal) => {
-        // Prevent optionalRequire from failing
         if (
           isFatal &&
           (error.message.includes('Native module cannot be null') ||
@@ -70,131 +65,114 @@ export default class SelectScreen extends React.PureComponent<
         }
       });
     }
-  }
+  }, []);
 
-  componentWillUnmount() {
-    if (this._openUrlSubscription != null) {
-      this._openUrlSubscription?.remove();
-      this._openUrlSubscription = null;
-    }
-  }
+  const handleOpenURL = React.useCallback(
+    ({ url }: { url: string }) => {
+      url = url || '';
+      // TODO: Use Expo Linking library once parseURL is implemented for web
+      if (url.includes(`/${routeNames.select}/`)) {
+        const selectedTests = url.split('/').pop();
+        if (selectedTests) {
+          const tests = getSelectedTestNames(selectedTests);
+          const query = createQueryString(tests);
+          navigation.navigate(routeNames.run, { tests: query });
+          return;
+        }
+      }
 
-  checkLinking = (incomingTests: string) => {
-    const tests = getSelectedTestNames(incomingTests);
-    const query = createQueryString(tests);
-    this.props.navigation.navigate(routeNames.run, { tests: query });
-  };
-
-  _handleOpenURL = ({ url }: { url: string }) => {
-    url = url || '';
-    // TODO: Use Expo Linking library once parseURL is implemented for web
-    if (url.includes(`/${routeNames.select}/`)) {
-      const selectedTests = url.split('/').pop();
-      if (selectedTests) {
-        this.checkLinking(selectedTests);
+      if (url.includes('/all')) {
+        const query = createQueryString(getTestModules().map((m) => m.name));
+        navigation.navigate(routeNames.run, { tests: query });
         return;
       }
-    }
 
-    if (url.includes('/all')) {
-      // Test all available modules
-      const query = createQueryString(getTestModules().map((m) => m.name));
+      // Application wasn't started from a deep link which we handle. So, we can load test modules.
+      setModules(getTestModules());
+    },
+    [navigation]
+  );
 
-      this.props.navigation.navigate(routeNames.run, {
-        tests: query,
-      });
-      return;
-    }
-
-    // Application wasn't started from a deep link which we handle. So, we can load test modules.
-    this._loadTestModules();
-  };
-
-  _loadTestModules = () => {
-    this.setState({
-      modules: getTestModules(),
-    });
-  };
-
-  componentDidMount() {
-    this._openUrlSubscription = Linking.addEventListener('url', this._handleOpenURL);
+  React.useEffect(() => {
+    const subscription = Linking.addEventListener('url', handleOpenURL);
 
     Linking.getInitialURL()
       .then((url) => {
-        this._handleOpenURL({ url });
+        handleOpenURL({ url });
       })
       .catch((err) => console.error('Failed to load initial URL', err));
-  }
 
-  _keyExtractor = ({ name }) => name;
+    return () => {
+      subscription?.remove();
+    };
+  }, [handleOpenURL]);
 
-  _onPressItem = (id) => {
-    this.setState((state) => {
-      const selected = new Set(state.selected);
-      if (selected.has(id)) selected.delete(id);
-      else selected.add(id);
-      return { selected };
+  const keyExtractor = React.useCallback(({ name }) => name, []);
+
+  const onPressItem = React.useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
     });
-  };
+  }, []);
 
-  _renderItem = ({ item }: { item: Module }) => {
-    const { name } = item;
-    const id = getScreenIdForLinking(item);
-    return (
-      <ListItem
-        id={id}
-        onPressItem={this._onPressItem}
-        selected={this.state.selected.has(id)}
-        title={name}
-      />
-    );
-  };
+  const renderItem = React.useCallback(
+    ({ item }: { item: Module }) => {
+      const { name } = item;
+      const id = getScreenIdForLinking(item);
+      return (
+        <ListItem
+          id={id}
+          onPressItem={onPressItem}
+          selectedSet={selectedRef.current}
+          title={name}
+        />
+      );
+    },
+    [onPressItem]
+  );
 
-  _selectAll = () => {
-    this.setState((prevState) => {
-      if (prevState.selected.size === prevState.modules.length) {
-        return { selected: new Set<string>() };
+  const selectAll = React.useCallback(() => {
+    setSelected((prev) => {
+      if (prev.size === modules.length) {
+        return new Set<string>();
       }
-      const selected = new Set<string>(prevState.modules.map(getScreenIdForLinking));
-      return { selected };
+      return new Set<string>(modules.map(getScreenIdForLinking));
     });
-  };
+  }, [modules]);
 
-  _navigateToTests = () => {
-    const { selected } = this.state;
+  const navigateToTests = React.useCallback(() => {
     if (selected.size === 0) {
       Alert.alert('Cannot Run Tests', 'You must select at least one test to run.');
     } else {
       const query = createQueryString(Array.from(selected.values()));
-
-      this.props.navigation.navigate(routeNames.run, { tests: query });
+      navigation.navigate(routeNames.run, { tests: query });
     }
-  };
+  }, [selected, navigation]);
 
-  render() {
-    const { selected, modules } = this.state;
-    const allSelected = selected.size === modules.length;
-    const buttonTitle = allSelected ? 'Deselect All' : 'Select All';
+  const allSelected = selected.size === modules.length;
+  const buttonTitle = allSelected ? 'Deselect All' : 'Select All';
 
-    return (
-      <>
-        <FlatList<Module>
-          data={modules}
-          contentContainerStyle={{ backgroundColor: '#fff' }}
-          extraData={this.state}
-          keyExtractor={this._keyExtractor}
-          renderItem={this._renderItem}
-          initialNumToRender={15}
-        />
-        <Footer
-          buttonTitle={buttonTitle}
-          canRunTests={selected.size}
-          onRun={this._navigateToTests}
-          onToggle={this._selectAll}
-        />
-      </>
-    );
-  }
+  return (
+    <>
+      <FlatList<Module>
+        data={modules}
+        extraData={selected}
+        keyExtractor={keyExtractor}
+        renderItem={renderItem}
+        initialNumToRender={15}
+        style={{ backgroundColor: theme.background.screen }}
+      />
+      <Footer
+        buttonTitle={buttonTitle}
+        canRunTests={selected.size}
+        onRun={navigateToTests}
+        onToggle={selectAll}
+      />
+    </>
+  );
 }
 
 function Footer({ buttonTitle, canRunTests, onToggle, onRun }) {
@@ -245,9 +223,6 @@ function FooterButton({ title, style, ...props }) {
 const HORIZONTAL_MARGIN = 20;
 
 const styles = StyleSheet.create({
-  mainContainer: {
-    flex: 1,
-  },
   footerButtonTitle: {
     fontSize: 16,
   },
@@ -265,7 +240,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   label: {
-    color: 'black',
     fontSize: 16,
   },
   buttonRow: {
@@ -273,9 +247,5 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     borderTopWidth: StyleSheet.hairlineWidth,
-    backgroundColor: 'white',
-  },
-  contentContainerStyle: {
-    paddingBottom: 128,
   },
 });


### PR DESCRIPTION
# Why

In expo-ui I noticed that bare expo's dark mode (or rather, colors in general) isn't working the way it should because we were "faking" dark / light mode in JS.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- use `Appearance.setColorScheme `in `apps/common/ThemeProvider.tsx` - that's the main change
- replace hardcoded colors with themed colors in lists. Individual screens still use whatever background they define

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- bare expo on ios and android

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)