### PR TITLE
[precompiled] Bump iOS platform version

### DIFF
--- a/packages/expo-age-range/spm.config.json
+++ b/packages/expo-age-range/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoAgeRange",
       "podName": "ExpoAgeRange",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-app-integrity/spm.config.json
+++ b/packages/expo-app-integrity/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoAppIntegrity",
       "podName": "ExpoAppIntegrity",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-apple-authentication/spm.config.json
+++ b/packages/expo-apple-authentication/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoAppleAuthentication",
       "podName": "ExpoAppleAuthentication",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-application/spm.config.json
+++ b/packages/expo-application/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EXApplication",
       "podName": "EXApplication",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-asset/spm.config.json
+++ b/packages/expo-asset/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoAsset",
       "podName": "ExpoAsset",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-audio/spm.config.json
+++ b/packages/expo-audio/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoAudio",
       "podName": "ExpoAudio",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-background-fetch/spm.config.json
+++ b/packages/expo-background-fetch/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoBackgroundFetch",
       "podName": "ExpoBackgroundFetch",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-background-task/spm.config.json
+++ b/packages/expo-background-task/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoBackgroundTask",
       "podName": "ExpoBackgroundTask",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-battery/spm.config.json
+++ b/packages/expo-battery/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoBattery",
       "podName": "ExpoBattery",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-blob/spm.config.json
+++ b/packages/expo-blob/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoBlob",
       "podName": "ExpoBlob",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-blur/spm.config.json
+++ b/packages/expo-blur/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoBlur",
       "podName": "ExpoBlur",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-brightness/spm.config.json
+++ b/packages/expo-brightness/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoBrightness",
       "podName": "ExpoBrightness",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-brownfield/spm.config.json
+++ b/packages/expo-brownfield/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoBrownfield",
       "podName": "ExpoBrownfield",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-calendar/spm.config.json
+++ b/packages/expo-calendar/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoCalendar",
       "podName": "ExpoCalendar",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-camera/spm.config.json
+++ b/packages/expo-camera/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoCamera",
       "podName": "ExpoCamera",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",
@@ -38,7 +38,7 @@
       "name": "ExpoCameraBarcodeScanning",
       "podName": "ExpoCameraBarcodeScanning",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "autolinkWhen": {
         "podfileProperty": "expo.camera.barcode-scanner-enabled",

--- a/packages/expo-cellular/spm.config.json
+++ b/packages/expo-cellular/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoCellular",
       "podName": "ExpoCellular",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-clipboard/spm.config.json
+++ b/packages/expo-clipboard/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoClipboard",
       "podName": "ExpoClipboard",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-contacts/spm.config.json
+++ b/packages/expo-contacts/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoContacts",
       "podName": "ExpoContacts",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-crypto/spm.config.json
+++ b/packages/expo-crypto/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoCrypto",
       "podName": "ExpoCrypto",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-device/spm.config.json
+++ b/packages/expo-device/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoDevice",
       "podName": "ExpoDevice",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-document-picker/spm.config.json
+++ b/packages/expo-document-picker/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoDocumentPicker",
       "podName": "ExpoDocumentPicker",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-eas-client/spm.config.json
+++ b/packages/expo-eas-client/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EASClient",
       "podName": "EASClient",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-file-system/spm.config.json
+++ b/packages/expo-file-system/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoFileSystem",
       "podName": "ExpoFileSystem",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-font/spm.config.json
+++ b/packages/expo-font/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoFont",
       "podName": "ExpoFont",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-glass-effect/spm.config.json
+++ b/packages/expo-glass-effect/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoGlassEffect",
       "podName": "ExpoGlassEffect",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-haptics/spm.config.json
+++ b/packages/expo-haptics/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoHaptics",
       "podName": "ExpoHaptics",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-image-manipulator/spm.config.json
+++ b/packages/expo-image-manipulator/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoImageManipulator",
       "podName": "ExpoImageManipulator",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-image-picker/spm.config.json
+++ b/packages/expo-image-picker/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoImagePicker",
       "podName": "ExpoImagePicker",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-image/spm.config.json
+++ b/packages/expo-image/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoImage",
       "podName": "ExpoImage",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-json-utils/spm.config.json
+++ b/packages/expo-json-utils/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EXJSONUtils",
       "podName": "EXJSONUtils",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [],
       "targets": [

--- a/packages/expo-keep-awake/spm.config.json
+++ b/packages/expo-keep-awake/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoKeepAwake",
       "podName": "ExpoKeepAwake",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-linear-gradient/spm.config.json
+++ b/packages/expo-linear-gradient/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoLinearGradient",
       "podName": "ExpoLinearGradient",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-linking/spm.config.json
+++ b/packages/expo-linking/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoLinking",
       "podName": "ExpoLinking",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-live-photo/spm.config.json
+++ b/packages/expo-live-photo/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoLivePhoto",
       "podName": "ExpoLivePhoto",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-local-authentication/spm.config.json
+++ b/packages/expo-local-authentication/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoLocalAuthentication",
       "podName": "ExpoLocalAuthentication",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-localization/spm.config.json
+++ b/packages/expo-localization/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoLocalization",
       "podName": "ExpoLocalization",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-location/spm.config.json
+++ b/packages/expo-location/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoLocation",
       "podName": "ExpoLocation",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-mail-composer/spm.config.json
+++ b/packages/expo-mail-composer/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoMailComposer",
       "podName": "ExpoMailComposer",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-manifests/spm.config.json
+++ b/packages/expo-manifests/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EXManifests",
       "podName": "EXManifests",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-maps/spm.config.json
+++ b/packages/expo-maps/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoMaps",
       "podName": "ExpoMaps",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-media-library/spm.config.json
+++ b/packages/expo-media-library/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoMediaLibrary",
       "podName": "ExpoMediaLibrary",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-mesh-gradient/spm.config.json
+++ b/packages/expo-mesh-gradient/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoMeshGradient",
       "podName": "ExpoMeshGradient",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/@react-native-async-storage/async-storage/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/@react-native-async-storage/async-storage/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNCAsyncStorage",
             "codegenName": "rnasyncstorage",
             "platforms": [
-                "iOS(.v15)"
+                "iOS(.v16)"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "react-native-skia",
             "codegenName": "rnskia",
             "platforms": [
-                "iOS(.v15)"
+                "iOS(.v16)"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNReanimated",
             "codegenName": "rnreanimated",
             "platforms": [
-                "iOS(.v15)"
+                "iOS(.v16)"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-safe-area-context/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-safe-area-context/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "react-native-safe-area-context",
             "codegenName": "safeareacontext",
             "platforms": [
-                "iOS(.v15)"
+                "iOS(.v16)"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-screens/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNScreens",
             "codegenName": "rnscreens",
             "platforms": [
-                "iOS(.v15)"
+                "iOS(.v16)"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-svg/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-svg/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNSVG",
             "codegenName": "rnsvg",
             "platforms": [
-                "iOS(.v15)"
+                "iOS(.v16)"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
@@ -6,7 +6,7 @@
             "podName": "RNWorklets",
             "codegenName": "rnworklets",
             "platforms": [
-                "iOS(.v15)"
+                "iOS(.v16)"
             ],
             "externalDependencies": [
                 "ReactNativeDependencies",

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoModulesCore",
       "podName": "ExpoModulesCore",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-network/spm.config.json
+++ b/packages/expo-network/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoNetwork",
       "podName": "ExpoNetwork",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-notifications/spm.config.json
+++ b/packages/expo-notifications/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoNotifications",
       "podName": "ExpoNotifications",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-print/spm.config.json
+++ b/packages/expo-print/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoPrint",
       "podName": "ExpoPrint",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-screen-capture/spm.config.json
+++ b/packages/expo-screen-capture/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoScreenCapture",
       "podName": "ExpoScreenCapture",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-secure-store/spm.config.json
+++ b/packages/expo-secure-store/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSecureStore",
       "podName": "ExpoSecureStore",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-sensors/spm.config.json
+++ b/packages/expo-sensors/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSensors",
       "podName": "ExpoSensors",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-sharing/spm.config.json
+++ b/packages/expo-sharing/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSharing",
       "podName": "ExpoSharing",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-sms/spm.config.json
+++ b/packages/expo-sms/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSMS",
       "podName": "ExpoSMS",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-speech/spm.config.json
+++ b/packages/expo-speech/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSpeech",
       "podName": "ExpoSpeech",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-splash-screen/spm.config.json
+++ b/packages/expo-splash-screen/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSplashScreen",
       "podName": "ExpoSplashScreen",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-sqlite/spm.config.json
+++ b/packages/expo-sqlite/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSQLite",
       "podName": "ExpoSQLite",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-store-review/spm.config.json
+++ b/packages/expo-store-review/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoStoreReview",
       "podName": "ExpoStoreReview",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-structured-headers/spm.config.json
+++ b/packages/expo-structured-headers/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EXStructuredHeaders",
       "podName": "EXStructuredHeaders",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [],
       "targets": [

--- a/packages/expo-symbols/spm.config.json
+++ b/packages/expo-symbols/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSymbols",
       "podName": "ExpoSymbols",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-system-ui/spm.config.json
+++ b/packages/expo-system-ui/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoSystemUI",
       "podName": "ExpoSystemUI",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-tracking-transparency/spm.config.json
+++ b/packages/expo-tracking-transparency/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoTrackingTransparency",
       "podName": "ExpoTrackingTransparency",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-ui/spm.config.json
+++ b/packages/expo-ui/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoUI",
       "podName": "ExpoUI",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-updates-interface/spm.config.json
+++ b/packages/expo-updates-interface/spm.config.json
@@ -5,7 +5,7 @@
       "name": "EXUpdatesInterface",
       "podName": "EXUpdatesInterface",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-video-thumbnails/spm.config.json
+++ b/packages/expo-video-thumbnails/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoVideoThumbnails",
       "podName": "ExpoVideoThumbnails",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-video/spm.config.json
+++ b/packages/expo-video/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoVideo",
       "podName": "ExpoVideo",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-web-browser/spm.config.json
+++ b/packages/expo-web-browser/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoWebBrowser",
       "podName": "ExpoWebBrowser",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/expo-widgets/spm.config.json
+++ b/packages/expo-widgets/spm.config.json
@@ -5,7 +5,7 @@
       "name": "ExpoWidgets",
       "podName": "ExpoWidgets",
       "platforms": [
-        "iOS(.v15)"
+        "iOS(.v16)"
       ],
       "externalDependencies": [
         "ReactNativeDependencies",

--- a/packages/unimodules-app-loader/spm.config.json
+++ b/packages/unimodules-app-loader/spm.config.json
@@ -4,9 +4,7 @@
     {
       "name": "UMAppLoader",
       "podName": "UMAppLoader",
-      "platforms": [
-        "iOS(.v15)"
-      ],
+      "platforms": ["iOS(.v16)"],
       "externalDependencies": [],
       "targets": [
         {
@@ -16,13 +14,8 @@
           "pattern": "**/*.m",
           "headerPattern": "**/*.h",
           "dependencies": [],
-          "linkedFrameworks": [
-            "Foundation",
-            "UIKit"
-          ],
-          "includeDirectories": [
-            "."
-          ]
+          "linkedFrameworks": ["Foundation", "UIKit"],
+          "includeDirectories": ["."]
         }
       ]
     }

--- a/tools/src/prebuilds/SPMBuild.ts
+++ b/tools/src/prebuilds/SPMBuild.ts
@@ -427,6 +427,7 @@ export const getBuildPlatformsFromProductPlatform = (
 ): BuildPlatform[] => {
   switch (platform) {
     case 'iOS(.v15)':
+    case 'iOS(.v16)':
       return ['iOS', 'iOS Simulator'];
     case 'macOS(.v11)':
       return ['macOS'];
@@ -796,7 +797,7 @@ let package = Package(
     name: "${dep.productName}-standalone",
 
     platforms: [
-        .iOS(.v15)
+        .iOS(.v16)
     ],
 
     products: [

--- a/tools/src/prebuilds/SPMConfig.types.ts
+++ b/tools/src/prebuilds/SPMConfig.types.ts
@@ -196,7 +196,12 @@ export type BuildPlatform =
 /**
  * Product platforms to emit to Package.swift
  */
-export type ProductPlatform = 'iOS(.v15)' | 'macOS(.v11)' | 'tvOS(.v15)' | 'macCatalyst(.v15)';
+export type ProductPlatform =
+  | 'iOS(.v15)'
+  | 'iOS(.v16)'
+  | 'macOS(.v11)'
+  | 'tvOS(.v15)'
+  | 'macCatalyst(.v15)';
 
 /**
  * A Swift Package product definition

--- a/tools/src/prebuilds/schemas/spm.config.schema.json
+++ b/tools/src/prebuilds/schemas/spm.config.schema.json
@@ -93,6 +93,7 @@
             "description": "Supported platform versions",
             "enum": [
                 "iOS(.v15)",
+                "iOS(.v16)",
                 "macOS(.v11)",
                 "tvOS(.v15)",
                 "macCatalyst(.v15)",


### PR DESCRIPTION
# Why
Publishing canaries is currently failing because building expo-modules-core xcframework is failing. #44630 added more color support but uses the `Regex` api which is only available on ios 16+. Because the spm.configs still use `.v15` this causes the build to fail.

# How
Main now targets 16.4 as the min deployment target so we should bump this in the spm.config

# Test Plan
`et prebuild-packages` succeeds
