### PR TITLE
[android][image-picker] Fix UCrop overflow popup menu invisible in dark mode

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix UCrop overflow popup menu text invisible in dark mode by switching crop activity theme to `DayNight`. ([#44324](https://github.com/expo/expo/pull/44324) by [@Nedunchezhiyan-M](https://github.com/Nedunchezhiyan-M))
 - [android] Handle edge-to-edge display in crop activity. ([#44208](https://github.com/expo/expo/pull/44208) by [@zoontek](https://github.com/zoontek))
 - fix potential `null` mime type reported ([#43734](https://github.com/expo/expo/pull/43734) by [@vonovak](https://github.com/vonovak))
 - [android] fix cropper default colors in light mode ([#42437](https://github.com/expo/expo/pull/42437) by [@fobos531](https://github.com/fobos531))

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
 
     <activity
       android:name="expo.modules.imagepicker.ExpoCropImageActivity"
-      android:theme="@style/Base.Theme.AppCompat"
+      android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
       android:exported="false"
       tools:replace="android:exported" />
     <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->


### PR DESCRIPTION
# Why

The UCrop crop activity was using `Base.Theme.AppCompat` as its theme, which is a fixed-light theme that does not adapt to the device's night mode setting.

On Android 10+, the overflow popup menu (the ⋮ button showing "Flip Horizontal" / "Flip Vertical") is drawn in a separate popup window. This popup window can inherit system-level dark-mode colors (giving it a **dark background**), while the text color comes from the activity's fixed-light theme (**dark text**) — resulting in dark text on a dark background, making menu items completely invisible.

This is a partial regression from #42437, which correctly fixed the main toolbar colors but did not address the popup menu theming.

Related: #44324, #40089, upstream https://github.com/Yalantis/uCrop/issues/913

# How

Changed the `ExpoCropImageActivity` theme in `AndroidManifest.xml` from `Base.Theme.AppCompat` (always light, no night-mode adaptation) to `Theme.AppCompat.DayNight.NoActionBar` (adapts to the system night mode setting). This ensures:
- The popup menu background and text both switch correctly between light/dark modes
- Force-dark mode is automatically disabled (DayNight themes are already dark-mode-aware)
- The `NoActionBar` variant is used since `CropImageActivity` sets up its own toolbar via `setSupportActionBar()`

The programmatic color overrides in `ExpoCropImageActivity.applyCustomization()` continue to work as before.

# Test Plan

1. Open a project that uses `expo-image-picker` with image cropping enabled
2. Run on an Android device with **dark mode** enabled
3. Launch the image picker and select an image
4. In the UCrop activity, tap the ⋮ overflow button in the top-right corner
5. Verify the "Flip Horizontal" and "Flip Vertical" menu items are visible (light text on dark background)
6. Repeat with **light mode** — menu items should be visible (dark text on white background)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)