### PR TITLE
[android][permissions] Fix status incorrectly denied after 'Ask every time' reset

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -21,6 +21,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Add async/await overload for StaticAsyncFunction ([#44471](https://github.com/expo/expo/pull/44471) by [@Wenszel](https://github.com/Wenszel))
+- [android] Fix permission status incorrectly showing `denied/canAskAgain=false` after user resets permission to "Ask every time" in system Settings. ([#44180](https://github.com/expo/expo/pull/44180) by [@Nedunchezhiyan-M](https://github.com/Nedunchezhiyan-M))
 - [iOS] Fixed looking up the `EXConstants.bundle` from the main bundle to allow running with precompiled XCFrameworks. ([#44551](https://github.com/expo/expo/pull/44551) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider. ([#44550](https://github.com/expo/expo/pull/44550) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed view lookup in bridgeless mode by using `ExpoHostWrapper` instead of `reactBridge.uiManager`. ([#44375](https://github.com/expo/expo/pull/44375) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
@@ -27,6 +27,7 @@ import java.util.Queue
 
 private const val PERMISSIONS_REQUEST: Int = 13
 private const val PREFERENCE_FILENAME = "expo.modules.permissions.asked"
+private const val PERMANENTLY_DENIED_SUFFIX = "_permanently_denied"
 
 open class PermissionsService(val context: Context) : InternalModule, Permissions, LifecycleEventListener {
   private var mActivityProvider: ActivityProvider? = null
@@ -42,6 +43,22 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
   private lateinit var mAskedPermissionsCache: SharedPreferences
 
   private fun didAsk(permission: String): Boolean = mAskedPermissionsCache.getBoolean(permission, false)
+
+  private fun isPermanentlyDenied(permission: String): Boolean =
+    mAskedPermissionsCache.getBoolean("$permission$PERMANENTLY_DENIED_SUFFIX", false)
+
+  private fun updatePermanentDenialState(permissions: Array<out String>, grantResults: IntArray) {
+    mAskedPermissionsCache.edit(commit = true) {
+      permissions.zip(grantResults.toList()).forEach { (permission, result) ->
+        val key = "$permission$PERMANENTLY_DENIED_SUFFIX"
+        when {
+          result == PackageManager.PERMISSION_GRANTED -> putBoolean(key, false)
+          canAskAgain(permission) -> putBoolean(key, false)
+          else -> putBoolean(key, true)
+        }
+      }
+    }
+  }
 
   private fun addToAskedPermissionsCache(permissions: Array<out String>) {
     mAskedPermissionsCache.edit(commit = true) {
@@ -228,18 +245,16 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
   }
 
   private fun getPermissionResponseFromNativeResponse(permission: String, result: Int): PermissionsResponse {
+    val showRationale = canAskAgain(permission)
     val status = when {
       result == PackageManager.PERMISSION_GRANTED -> PermissionsStatus.GRANTED
-      didAsk(permission) -> PermissionsStatus.DENIED
+      showRationale -> PermissionsStatus.DENIED
+      isPermanentlyDenied(permission) -> PermissionsStatus.DENIED
       else -> PermissionsStatus.UNDETERMINED
     }
     return PermissionsResponse(
       status,
-      if (status == PermissionsStatus.DENIED) {
-        canAskAgain(permission)
-      } else {
-        true
-      }
+      if (status == PermissionsStatus.DENIED) showRationale else true
     )
   }
 
@@ -275,6 +290,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
     return PermissionListener { requestCode, receivePermissions, grantResults ->
       if (requestCode == PERMISSIONS_REQUEST) {
         synchronized(this@PermissionsService) {
+          updatePermanentDenialState(receivePermissions, grantResults)
           val currentListener = requireNotNull(mCurrentPermissionListener)
           currentListener.onResult(parseNativeResult(receivePermissions, grantResults))
           mCurrentPermissionListener = null


### PR DESCRIPTION
# Why

When a user grants a permission then goes to Android System Settings and changes it to **\"Ask every time\"**, the app incorrectly reports the permission as `{ status: 'denied', canAskAgain: false }` instead of `{ status: 'undetermined', canAskAgain: true }`.

**Root cause:** The `PermissionsService` uses a `didAsk` SharedPreferences cache to distinguish `UNDETERMINED` (never asked) from `DENIED` (asked before). However, this cache is never cleared. When Android revokes a permission via \"Ask every time\", `checkSelfPermission` returns `DENIED` and `shouldShowRequestPermissionRationale` returns `false` — because Android treats the revoked state as \"fresh\" (equivalent to never asked). The old logic mapped `didAsk=true + showRationale=false → DENIED, canAskAgain=false`, incorrectly treating a revoked permission as permanently denied.

Fixes #44180

# How

Replace the `didAsk`-based status check with a `isPermanentlyDenied` flag (stored as a suffixed key in the same SharedPreferences file):

- The flag is **set to `true`** only inside actual permission-request callbacks (not passive `getPermissions` checks), when the result is `DENIED` and `shouldShowRequestPermissionRationale` is `false` — indicating the user selected \"Don't ask again\"
- The flag is **cleared to `false`** when the request returns `GRANTED`
- In `getPermissionResponseFromNativeResponse`, `isPermanentlyDenied` replaces `didAsk` for determining whether to report `DENIED` vs `UNDETERMINED`

**Scenario coverage:**

| Scenario | Old result | New result |
|---|---|---|
| Never asked | UNDETERMINED, canAskAgain=true ✓ | UNDETERMINED, canAskAgain=true ✓ |
| Denied once (without "Don't ask again") | DENIED, canAskAgain=true ✓ | DENIED, canAskAgain=true ✓ |
| Denied with "Don't ask again" | DENIED, canAskAgain=false ✓ | DENIED, canAskAgain=false ✓ |
| **Granted → "Ask every time" reset** | **DENIED, canAskAgain=false ✗** | **UNDETERMINED, canAskAgain=true ✓** |

# Test Plan

1. Build a development build with a package that uses Android runtime permissions (e.g. `expo-audio`)
2. Request the microphone permission — grant it
3. Go to Android Settings → App → Permissions → Microphone → set **"Ask every time"**
4. Return to the app and call `Audio.getPermissionsAsync()` (or equivalent)
5. **Before fix:** `{ status: 'denied', canAskAgain: false }` ← incorrect
6. **After fix:** `{ status: 'undetermined', canAskAgain: true }` ← correct
7. Request the permission again — the system dialog should appear

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)