### PR TITLE
fix(cli): compare installed version in prebuild, not package.json spec

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### 🐛 Bug fixes
 
-- Compare the installed version of `react-native` / `expo` against the recommended version during prebuild, instead of the raw `package.json` spec. Fixes misleading warnings for pnpm catalogs, yarn/pnpm workspaces, npm aliases, and other non-semver specifiers. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@hknakn](https://github.com/hknakn))
+- Compare the installed version of `react-native` / `expo` against the recommended version during prebuild, instead of the raw `package.json` spec. Fixes misleading warnings for pnpm catalogs, yarn/pnpm workspaces, npm aliases, and other non-semver specifiers. ([#44880](https://github.com/expo/expo/pull/44880) by [@hknakn](https://github.com/hknakn))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- Compare the installed version of `react-native` / `expo` against the recommended version during prebuild, instead of the raw `package.json` spec. Fixes misleading warnings for pnpm catalogs, yarn/pnpm workspaces, npm aliases, and other non-semver specifiers. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@hknakn](https://github.com/hknakn))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -217,7 +217,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
-- Compare the installed version of `react-native` / `expo` against the recommended version during prebuild, instead of the raw `package.json` spec. Fixes misleading warnings for pnpm catalogs, yarn/pnpm workspaces, npm aliases, and other non-semver specifiers. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@hknakn](https://github.com/hknakn))
+- Compare the installed version of `react-native` / `expo` against the recommended version during prebuild, instead of the raw `package.json` spec. Fixes misleading warnings for pnpm catalogs, yarn/pnpm workspaces, npm aliases, and other non-semver specifiers. ([#44880](https://github.com/expo/expo/pull/44880) by [@hknakn](https://github.com/hknakn))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -217,6 +217,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
+- Compare the installed version of `react-native` / `expo` against the recommended version during prebuild, instead of the raw `package.json` spec. Fixes misleading warnings for pnpm catalogs, yarn/pnpm workspaces, npm aliases, and other non-semver specifiers. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@hknakn](https://github.com/hknakn))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Compare the installed version of `react-native` / `expo` against the recommended version during prebuild, instead of the raw `package.json` spec. Fixes misleading warnings for pnpm catalogs, yarn/pnpm workspaces, npm aliases, and other non-semver specifiers. ([#44880](https://github.com/expo/expo/pull/44880) by [@hknakn](https://github.com/hknakn))
+
 ### 💡 Others
 
 ## 56.1.12 — 2026-05-26
@@ -217,7 +219,6 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
-- Compare the installed version of `react-native` / `expo` against the recommended version during prebuild, instead of the raw `package.json` spec. Fixes misleading warnings for pnpm catalogs, yarn/pnpm workspaces, npm aliases, and other non-semver specifiers. ([#44880](https://github.com/expo/expo/pull/44880) by [@hknakn](https://github.com/hknakn))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 
 import * as Log from '../../log';
 import { isModuleSymlinked } from '../../utils/isModuleSymlinked';
+import { resolveInstalledVersion } from '../../utils/resolveInstalledVersion';
 import {
   hashForDependencyMap,
   updatePkgDependencies,
@@ -11,6 +12,7 @@ import {
 } from '../updatePackageJson';
 
 jest.mock('../../utils/isModuleSymlinked');
+jest.mock('../../utils/resolveInstalledVersion');
 jest.mock('../../log');
 
 describe(hashForDependencyMap, () => {
@@ -24,6 +26,19 @@ describe(hashForDependencyMap, () => {
 describe(updatePackageJSONAsync, () => {
   beforeAll(() => {
     (isModuleSymlinked as any).mockImplementation(() => false);
+    // Return the project's spec string so existing tests (which use matching versions
+    // between pkg and template) still resolve to "installed === recommended" and emit no warning.
+    (resolveInstalledVersion as any).mockImplementation(
+      (_projectRoot: string, packageName: string) => {
+        if (packageName === 'expo') {
+          return '1.0.0';
+        }
+        if (packageName === 'react-native') {
+          return '0.1.0';
+        }
+        return null;
+      }
+    );
   });
 
   it(`has no changes`, async () => {
@@ -147,6 +162,13 @@ describe(updatePackageJSONAsync, () => {
 describe(updatePkgDependencies, () => {
   beforeAll(() => {
     (isModuleSymlinked as any).mockImplementation(() => false);
+    // Return a non-null value so the version-check path runs. The existing tests
+    // use non-semver sentinel strings (e.g. 'version-from-project'), so
+    // `semver.satisfies` throws and the safe wrapper returns false — triggering the
+    // warning exactly as the previous `semver.intersects`-based logic did.
+    (resolveInstalledVersion as any).mockImplementation(
+      (_projectRoot: string, packageName: string) => `installed-${packageName}`
+    );
   });
   const requiredPackages = {
     react: 'version-from-template-required-1',

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -291,6 +291,49 @@ describe(updatePkgDependencies, () => {
   });
 });
 
+describe(`${updatePkgDependencies.name} installed-version warning`, () => {
+  beforeEach(() => {
+    (isModuleSymlinked as any).mockImplementation(() => false);
+  });
+
+  function runWithInstalledVersion(installedVersion: string | null, recommendedRange: string) {
+    (resolveInstalledVersion as any).mockImplementation(() => installedVersion);
+    updatePkgDependencies('fake path', {
+      pkg: {
+        // Non-semver spec — the kind that misfired against the old `semver.intersects` check.
+        dependencies: { 'react-native': 'catalog:mobile' },
+        devDependencies: {},
+      },
+      templatePkg: {
+        dependencies: { 'react-native': recommendedRange },
+        devDependencies: {},
+      },
+    });
+  }
+
+  it(`does not warn when the installed version satisfies the recommended range, even for a non-semver spec`, () => {
+    runWithInstalledVersion('0.83.4', '0.83.4');
+    expect(Log.warn).not.toHaveBeenCalled();
+  });
+
+  it(`does not warn when the package is not installed yet (resolveInstalledVersion returns null)`, () => {
+    runWithInstalledVersion(null, '0.83.4');
+    expect(Log.warn).not.toHaveBeenCalled();
+  });
+
+  it(`warns with the resolved installed version, not the package.json spec`, () => {
+    runWithInstalledVersion('0.82.0', '0.83.4');
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`${chalk.bold('react-native@0.82.0')}`)
+    );
+    expect(Log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(`recommended ${chalk.bold('react-native@0.83.4')}`)
+    );
+    // The raw catalog spec must never reach the warning message.
+    expect(Log.warn).not.toHaveBeenCalledWith(expect.stringContaining('catalog:mobile'));
+  });
+});
+
 describe(updatePkgScripts, () => {
   it(`modifies the default Expo project values`, () => {
     const pkg = {

--- a/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
+++ b/packages/@expo/cli/src/prebuild/__tests__/updatePackageJson-test.ts
@@ -26,19 +26,9 @@ describe(hashForDependencyMap, () => {
 describe(updatePackageJSONAsync, () => {
   beforeAll(() => {
     (isModuleSymlinked as any).mockImplementation(() => false);
-    // Return the project's spec string so existing tests (which use matching versions
-    // between pkg and template) still resolve to "installed === recommended" and emit no warning.
-    (resolveInstalledVersion as any).mockImplementation(
-      (_projectRoot: string, packageName: string) => {
-        if (packageName === 'expo') {
-          return '1.0.0';
-        }
-        if (packageName === 'react-native') {
-          return '0.1.0';
-        }
-        return null;
-      }
-    );
+    // Simulate "module not installed" so the version check is skipped. These tests
+    // don't assert on Log.warn — they exercise dependency merging and script updates.
+    (resolveInstalledVersion as any).mockImplementation(() => null);
   });
 
   it(`has no changes`, async () => {

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -3,11 +3,12 @@ import chalk from 'chalk';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { intersects as semverIntersects, Range as SemverRange } from 'semver';
+import { satisfies as semverSatisfies } from 'semver';
 
 import * as Log from '../log';
 import { isModuleSymlinked } from '../utils/isModuleSymlinked';
 import { logNewSection } from '../utils/ora';
+import { resolveInstalledVersion } from '../utils/resolveInstalledVersion';
 
 export type DependenciesMap = { [key: string]: string | number };
 
@@ -165,16 +166,19 @@ export function updatePkgDependencies(
         continue;
       }
 
-      // Warn users for outdated dependencies when prebuilding
-      const hasRecommendedVersion = versionRangesIntersect(
-        pkg.dependencies[dependencyKey],
-        String(defaultDependencies[dependencyKey]),
-        true
-      );
-      if (!hasRecommendedVersion) {
+      // Warn users for outdated dependencies when prebuilding. Compare against the
+      // actually-installed version rather than the raw `package.json` spec so that
+      // indirect specifiers (pnpm catalogs, workspace:*, npm: aliases, file:/link:/
+      // portal:/patch:, git refs, tarballs, etc.) don't trigger a misleading warning.
+      // If the module isn't installed yet (prebuild can run pre-install), skip —
+      // the spec string may not be valid semver and a false warning is worse than
+      // none; the check will re-run correctly after install.
+      const recommendedRange = String(defaultDependencies[dependencyKey]);
+      const installedVersion = resolveInstalledVersion(projectRoot, dependencyKey);
+      if (installedVersion && !versionSatisfies(installedVersion, recommendedRange)) {
         nonRecommendedPackages.push([
-          `${dependencyKey}@${pkg.dependencies[dependencyKey]}`,
-          `${dependencyKey}@${defaultDependencies[dependencyKey]}`,
+          `${dependencyKey}@${installedVersion}`,
+          `${dependencyKey}@${recommendedRange}`,
         ]);
       }
     }
@@ -286,16 +290,12 @@ export function createFileHash(contents: string): string {
 }
 
 /**
- * Determine if two semver ranges are overlapping or intersecting.
- * This is a safe version of `semver.intersects` that does not throw.
+ * Determine if a version satisfies a semver range.
+ * This is a safe version of `semver.satisfies` that does not throw.
  */
-function versionRangesIntersect(
-  rangeA: string | SemverRange,
-  rangeB: string | SemverRange,
-  includePrerelease: boolean = false
-) {
+function versionSatisfies(version: string, range: string): boolean {
   try {
-    return semverIntersects(rangeA, rangeB, { includePrerelease });
+    return semverSatisfies(version, range, { includePrerelease: true });
   } catch {
     return false;
   }

--- a/packages/@expo/cli/src/prebuild/updatePackageJson.ts
+++ b/packages/@expo/cli/src/prebuild/updatePackageJson.ts
@@ -4,12 +4,12 @@ import chalk from 'chalk';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import type { Range as SemverRange } from 'semver';
-import { intersects as semverIntersects } from 'semver';
+import { satisfies as semverSatisfies } from 'semver';
 
 import * as Log from '../log';
 import { isModuleSymlinked } from '../utils/isModuleSymlinked';
 import { logNewSection } from '../utils/ora';
+import { resolveInstalledVersion } from '../utils/resolveInstalledVersion';
 
 export type DependenciesMap = { [key: string]: string | number };
 
@@ -167,16 +167,19 @@ export function updatePkgDependencies(
         continue;
       }
 
-      // Warn users for outdated dependencies when prebuilding
-      const hasRecommendedVersion = versionRangesIntersect(
-        pkg.dependencies[dependencyKey],
-        String(defaultDependencies[dependencyKey]),
-        true
-      );
-      if (!hasRecommendedVersion) {
+      // Warn users for outdated dependencies when prebuilding. Compare against the
+      // actually-installed version rather than the raw `package.json` spec so that
+      // indirect specifiers (pnpm catalogs, workspace:*, npm: aliases, file:/link:/
+      // portal:/patch:, git refs, tarballs, etc.) don't trigger a misleading warning.
+      // If the module isn't installed yet (prebuild can run pre-install), skip —
+      // the spec string may not be valid semver and a false warning is worse than
+      // none; the check will re-run correctly after install.
+      const recommendedRange = String(defaultDependencies[dependencyKey]);
+      const installedVersion = resolveInstalledVersion(projectRoot, dependencyKey);
+      if (installedVersion && !versionSatisfies(installedVersion, recommendedRange)) {
         nonRecommendedPackages.push([
-          `${dependencyKey}@${pkg.dependencies[dependencyKey]}`,
-          `${dependencyKey}@${defaultDependencies[dependencyKey]}`,
+          `${dependencyKey}@${installedVersion}`,
+          `${dependencyKey}@${recommendedRange}`,
         ]);
       }
     }
@@ -288,16 +291,12 @@ export function createFileHash(contents: string): string {
 }
 
 /**
- * Determine if two semver ranges are overlapping or intersecting.
- * This is a safe version of `semver.intersects` that does not throw.
+ * Determine if a version satisfies a semver range.
+ * This is a safe version of `semver.satisfies` that does not throw.
  */
-function versionRangesIntersect(
-  rangeA: string | SemverRange,
-  rangeB: string | SemverRange,
-  includePrerelease: boolean = false
-) {
+function versionSatisfies(version: string, range: string): boolean {
   try {
-    return semverIntersects(rangeA, rangeB, { includePrerelease });
+    return semverSatisfies(version, range, { includePrerelease: true });
   } catch {
     return false;
   }

--- a/packages/@expo/cli/src/utils/__tests__/resolveInstalledVersion-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/resolveInstalledVersion-test.ts
@@ -1,0 +1,65 @@
+import { vol } from 'memfs';
+import resolveFrom from 'resolve-from';
+
+import { resolveInstalledVersion } from '../resolveInstalledVersion';
+
+afterEach(() => {
+  vol.reset();
+});
+
+const projectRoot = '/fake/project';
+
+describe(resolveInstalledVersion, () => {
+  it('returns the version from an installed package', () => {
+    vol.fromJSON(
+      { 'node_modules/expo/package.json': JSON.stringify({ version: '1.0.0' }) },
+      projectRoot
+    );
+
+    expect(resolveInstalledVersion(projectRoot, 'expo')).toBe('1.0.0');
+  });
+
+  it('falls back to the path in the ERR_PACKAGE_PATH_NOT_EXPORTED error message', () => {
+    // Mock the Node error thrown when a package's `exports` map doesn't expose `./package.json`.
+    jest.mocked(resolveFrom).mockImplementationOnce(() => {
+      const error: any = new Error(
+        `Package subpath './package.json' is not defined by "exports" in ${projectRoot}/node_modules/expo/package.json`
+      );
+      error.code = 'ERR_PACKAGE_PATH_NOT_EXPORTED';
+      throw error;
+    });
+
+    vol.fromJSON(
+      {
+        'node_modules/expo/package.json': JSON.stringify({
+          version: '2.0.0',
+          exports: { '.': { require: './index.js' } },
+        }),
+      },
+      projectRoot
+    );
+
+    expect(resolveInstalledVersion(projectRoot, 'expo')).toBe('2.0.0');
+  });
+
+  it('returns null when the package is not installed', () => {
+    vol.fromJSON({}, projectRoot);
+
+    expect(resolveInstalledVersion(projectRoot, 'expo')).toBeNull();
+  });
+
+  it('returns null when the package.json is malformed', () => {
+    vol.fromJSON({ 'node_modules/expo/package.json': '{ not json' }, projectRoot);
+
+    expect(resolveInstalledVersion(projectRoot, 'expo')).toBeNull();
+  });
+
+  it('returns null when the package.json has no version field', () => {
+    vol.fromJSON(
+      { 'node_modules/expo/package.json': JSON.stringify({ name: 'expo' }) },
+      projectRoot
+    );
+
+    expect(resolveInstalledVersion(projectRoot, 'expo')).toBeNull();
+  });
+});

--- a/packages/@expo/cli/src/utils/resolveInstalledVersion.ts
+++ b/packages/@expo/cli/src/utils/resolveInstalledVersion.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+import resolveFrom from 'resolve-from';
+
+/**
+ * Resolve the installed version of a package by reading its `package.json`
+ * from `node_modules` relative to `projectRoot`.
+ *
+ * Returns `null` if the package isn't installed, its `package.json` is hidden
+ * by an `exports` map, or the file can't be parsed. This lets callers tell
+ * "installed, version X" apart from "not resolvable" so they can skip comparisons
+ * that would otherwise be made against a raw `package.json` spec string (which
+ * may be `catalog:`, `workspace:*`, `npm:alias@...`, `file:`, etc.).
+ */
+export function resolveInstalledVersion(projectRoot: string, packageName: string): string | null {
+  try {
+    const pkgJsonPath = resolveFrom.silent(projectRoot, `${packageName}/package.json`);
+    if (!pkgJsonPath) {
+      return null;
+    }
+    const version = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).version;
+    return typeof version === 'string' ? version : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/@expo/cli/src/utils/resolveInstalledVersion.ts
+++ b/packages/@expo/cli/src/utils/resolveInstalledVersion.ts
@@ -5,18 +5,33 @@ import resolveFrom from 'resolve-from';
  * Resolve the installed version of a package by reading its `package.json`
  * from `node_modules` relative to `projectRoot`.
  *
- * Returns `null` if the package isn't installed, its `package.json` is hidden
- * by an `exports` map, or the file can't be parsed. This lets callers tell
- * "installed, version X" apart from "not resolvable" so they can skip comparisons
- * that would otherwise be made against a raw `package.json` spec string (which
- * may be `catalog:`, `workspace:*`, `npm:alias@...`, `file:`, etc.).
+ * Returns `null` if the package isn't installed or the file can't be parsed.
+ * This lets callers tell "installed, version X" apart from "not resolvable" so
+ * they can skip comparisons that would otherwise be made against a raw
+ * `package.json` spec string (which may be `catalog:`, `workspace:*`,
+ * `npm:alias@...`, `file:`, etc.).
+ *
+ * Mirrors the `ERR_PACKAGE_PATH_NOT_EXPORTED` fallback in
+ * `resolvePackageVersionAsync` so packages whose `exports` map omits
+ * `./package.json` (common for newer libraries) still resolve correctly.
  */
 export function resolveInstalledVersion(projectRoot: string, packageName: string): string | null {
+  let pkgJsonPath: string | undefined;
   try {
-    const pkgJsonPath = resolveFrom.silent(projectRoot, `${packageName}/package.json`);
-    if (!pkgJsonPath) {
-      return null;
+    pkgJsonPath = resolveFrom(projectRoot, `${packageName}/package.json`);
+  } catch (error: any) {
+    // Packages with an `exports` map that doesn't expose `./package.json` throw
+    // `ERR_PACKAGE_PATH_NOT_EXPORTED`. Node embeds the absolute on-disk path of
+    // the package in the error message — extract it so we can still read the
+    // installed version. Mirrors `resolvePackageVersionAsync`.
+    if (error?.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+      pkgJsonPath = error.message.match(/("exports"|defined) in (.*)$/i)?.[2];
     }
+  }
+  if (!pkgJsonPath) {
+    return null;
+  }
+  try {
     const version = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).version;
     return typeof version === 'string' ? version : null;
   } catch {


### PR DESCRIPTION
# Why

`@expo/cli`'s prebuild step warns when `react-native` / `expo` look outdated vs. the template-recommended version. It reads the raw spec string from `package.json` and runs `semver.intersects(spec, recommended)` — wrapped in a `try/catch` that returns `false` on any parse error.

That check misfires for every indirect specifier, because none of them are valid semver ranges:

- **pnpm catalogs** — `"react-native": "catalog:mobile"`
- **yarn / pnpm workspaces** — `"react-native": "workspace:*"`
- **npm aliases** — `"react-native": "npm:react-native-tvos@0.83.2"`
- **`file:` / `link:` / `portal:` / `patch:` protocols**
- **git refs, URLs, tarballs**

The misleading output looks like this:

```
› Using react-native@catalog:mobile instead of recommended react-native@0.83.4.
```

…even when the actually-installed version is fine. Only the pre-check is wrong.

The spec-based check has a subtler failure mode too: a user can pin `"^0.83.2"` in `package.json` but have `0.82.0` actually installed (stale lockfile, cached install, workspace resolution override). Today the check says "fine"; the real app runs the wrong version.

# How

Stop comparing spec strings. Compare the **actually-installed version** (from `node_modules/<pkg>/package.json`, resolved via `resolve-from`) against the recommended range using `semver.satisfies`. One code path covers every indirection a package manager can invent, now and in the future.

- New helper `resolveInstalledVersion(projectRoot, pkg)` — sync sibling of the existing async `resolvePackageVersionAsync`. Uses `resolve-from.silent` + `fs.readFileSync`, returns `null` on any failure (missing package, `exports`-map block, malformed JSON). Sync to avoid threading async up through `updatePkgDependencies` and its callers. No new dependency — `resolve-from` is already a `@expo/cli` dep.
- `updatePackageJson.ts`: swap the spec-based `semver.intersects` call for an installed-version `semver.satisfies` lookup. If the module isn't installed yet (prebuild can run pre-install), skip silently — a false warning for a spec we can't parse is worse than no warning, and the check re-runs correctly after install. The warning now includes the concrete resolved version (`react-native@0.83.2`) instead of an uninterpretable spec string.
- Replaced the now-unused `versionRangesIntersect` helper with `versionSatisfies`, same safe `try/catch` shape.
- Left the `isModuleSymlinked` branch alone — it emits a different, correct message for linked packages and isn't affected by this bug.

### Behavior change matrix

| Scenario | Before | After |
|---|---|---|
| Plain semver, installed matches | no warning | no warning |
| Plain semver, installed outdated | warning with spec (`^0.82.0`) | warning with installed version (`0.82.0`) |
| Plain semver, installed older than spec pin | **no warning (wrong)** | warning with installed version |
| pnpm catalog, installed matches | **misleading warning (`catalog:mobile`)** | no warning |
| pnpm catalog, installed outdated | **misleading warning (`catalog:mobile`)** | warning with resolved version |
| `workspace:*` / `npm:alias` / `file:` / `link:` | **misleading warning** | no warning (or warning with resolved version) |
| Not installed yet | **misleading warning for non-semver specs** | no warning (silent skip) |

# Test Plan

**Unit tests** — existing `updatePackageJson-test.ts` suite still green (11/11). Added a `jest.mock('../../utils/resolveInstalledVersion')` with sensible defaults so the existing warning-emission assertions continue to work.

**Differential real-filesystem verification** — ran a script that builds a tmpdir for each scenario (real `package.json` + real `node_modules/react-native/package.json`) and invokes the compiled `updatePkgDependencies`, before and after the fix:

| Scenario | Pre-fix | Post-fix |
|---|---|---|
| pnpm catalog, installed matches | ❌ misleading warning `catalog:mobile` | ✅ no warning |
| pnpm catalog, installed outdated | ❌ misleading warning `catalog:mobile` | ✅ warns with `0.83.2` |
| pnpm catalog, not installed | ❌ misleading warning | ✅ skip silently |
| plain semver outdated | ❌ warns with spec `^0.82.0` | ✅ warns with installed `0.82.0` |
| plain semver matches | ✅ no warning | ✅ no warning |
| `workspace:*` spec, installed matches | ❌ misleading warning | ✅ no warning |

**Pre-fix: 1/6 · Post-fix: 6/6.**

**Manual repro** — against a real pnpm-catalog Expo project (`react-native: "catalog:mobile"`):

- Before: `› Using react-native@catalog:mobile instead of recommended react-native@0.83.4.` (installed version is fine)
- After: no warning

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)

---

cc @jakex7 (original author of the recommended-version output in #35941), @behenate (fixed a related edge case in #39298), @kitten (most recent touch on this file) — happy to adjust scope or split anything if helpful.