### PR TITLE
[create-expo-module] Add `addPlatformSupport` subcommand

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -1,10 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 
+import os from 'os';
+
 import {
   createFakeProject,
   createTestPath,
   ensureFolderExists,
+  execute,
   executePassing,
   expectFileExists,
   expectFileNotExists,
@@ -555,5 +558,336 @@ describe('non-interactive defaults warning', () => {
     const packageJson = readJson(projectName, 'package.json');
     expect(packageJson.license).toBe('Apache-2.0');
     expect(packageJson.version).toBe('2.0.0');
+  });
+});
+
+describe('add-platform-support', () => {
+  const localTemplatePath = path.resolve(__dirname, '../../../expo-module-template');
+
+  /**
+   * Creates a local module inside a fake Expo project using --local.
+   * Returns the absolute path to the created module directory.
+   */
+  async function createLocalModule(
+    projectPath: string,
+    slug: string,
+    platforms: string[],
+    features: string[] = []
+  ): Promise<string> {
+    const moduleName =
+      slug.charAt(0).toUpperCase() +
+      slug.slice(1).replace(/-./g, (m) => (m[1] ?? '').toUpperCase());
+    const args = [
+      '--local',
+      slug,
+      '--name',
+      moduleName,
+      '--package',
+      `expo.modules.${slug.replace(/-/g, '')}`,
+      '--platform',
+      ...platforms,
+      '--source',
+      localTemplatePath,
+    ];
+    if (features.length > 0) {
+      args.push('--features', ...features);
+    }
+    await executePassing(args, { cwd: projectPath });
+    return path.join(projectPath, 'modules', slug);
+  }
+
+  it('adds android support to an apple-only module with Function and AsyncFunction', async () => {
+    const project = createFakeProject('aps-fn-project');
+    const modulePath = await createLocalModule(project, 'aps-fn', ['apple'], [
+      'Function',
+      'AsyncFunction',
+    ]);
+
+    await executePassing([
+      'add-platform-support',
+      modulePath,
+      '--platform',
+      'android',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    expect(fs.existsSync(path.join(modulePath, 'android'))).toBe(true);
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(modulePath, 'expo-module.config.json'), 'utf-8')
+    );
+    expect(config.platforms).toContain('android');
+    expect(config.android).toBeDefined();
+
+    // Find the Kotlin module file and check it has the expected snippets
+    const pkgDir = path.join(
+      modulePath,
+      'android',
+      'src',
+      'main',
+      'java',
+      'expo',
+      'modules',
+      'apsfn'
+    );
+    const ktFiles = fs.readdirSync(pkgDir);
+    const moduleKt = ktFiles.find((f) => f.endsWith('Module.kt'))!;
+    const ktContent = fs.readFileSync(path.join(pkgDir, moduleKt), 'utf-8');
+    expect(ktContent).toContain('Function(');
+    expect(ktContent).toContain('AsyncFunction(');
+  });
+
+  it('adds apple support to an android-only module with View and ViewEvent', async () => {
+    const project = createFakeProject('aps-view-project');
+    const modulePath = await createLocalModule(project, 'aps-view', ['android'], [
+      'View',
+      'ViewEvent',
+    ]);
+
+    await executePassing([
+      'add-platform-support',
+      modulePath,
+      '--platform',
+      'apple',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    expect(fs.existsSync(path.join(modulePath, 'ios'))).toBe(true);
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(modulePath, 'expo-module.config.json'), 'utf-8')
+    );
+    expect(config.platforms).toContain('apple');
+    expect(config.apple).toBeDefined();
+
+    const swiftContent = fs.readFileSync(
+      path.join(modulePath, 'ios', 'ApsViewModule.swift'),
+      'utf-8'
+    );
+    expect(swiftContent).toContain('View(');
+  });
+
+  it('adds android support to an apple-only module with SharedObject', async () => {
+    const project = createFakeProject('aps-so-project');
+    const modulePath = await createLocalModule(project, 'aps-so', ['apple'], ['SharedObject']);
+
+    await executePassing([
+      'add-platform-support',
+      modulePath,
+      '--platform',
+      'android',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    expect(fs.existsSync(path.join(modulePath, 'android'))).toBe(true);
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(modulePath, 'expo-module.config.json'), 'utf-8')
+    );
+    expect(config.platforms).toContain('android');
+
+    const pkgDir = path.join(
+      modulePath,
+      'android',
+      'src',
+      'main',
+      'java',
+      'expo',
+      'modules',
+      'apsso'
+    );
+    const ktFiles = fs.readdirSync(pkgDir);
+    const soKt = ktFiles.find((f) => f.includes('SharedObject'));
+    expect(soKt).toBeDefined();
+  });
+
+  it('adds web support to an apple-only module and updates .web.ts from stub to implementation', async () => {
+    const project = createFakeProject('aps-web-project');
+    const modulePath = await createLocalModule(project, 'aps-web', ['apple'], ['Function']);
+
+    await executePassing([
+      'add-platform-support',
+      modulePath,
+      '--platform',
+      'web',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const config = JSON.parse(
+      fs.readFileSync(path.join(modulePath, 'expo-module.config.json'), 'utf-8')
+    );
+    expect(config.platforms).toContain('web');
+
+    const webContent = fs.readFileSync(
+      path.join(modulePath, 'src', 'ApsWebModule.web.ts'),
+      'utf-8'
+    );
+    expect(webContent).not.toContain('not available on the web platform');
+  });
+
+  it('does not overwrite existing wrapper files when adding a native platform to a web-enabled module', async () => {
+    const project = createFakeProject('aps-preserve-project');
+    const modulePath = await createLocalModule(project, 'aps-preserve', ['apple', 'web'], ['View']);
+    const wrapperPath = path.join(modulePath, 'src', 'ApsPreserveView.tsx');
+    const webViewPath = path.join(modulePath, 'src', 'ApsPreserveView.web.tsx');
+    const wrapperSentinel = '// custom wrapper change';
+    const webViewSentinel = '// custom web view change';
+
+    fs.writeFileSync(wrapperPath, `${wrapperSentinel}\n`);
+    fs.writeFileSync(webViewPath, `${webViewSentinel}\n`);
+
+    await executePassing([
+      'add-platform-support',
+      modulePath,
+      '--platform',
+      'android',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    expect(fs.readFileSync(wrapperPath, 'utf-8')).toBe(`${wrapperSentinel}\n`);
+    expect(fs.readFileSync(webViewPath, 'utf-8')).toBe(`${webViewSentinel}\n`);
+  });
+
+  it('uses the module source declaration as the public module name when no native implementation exists', async () => {
+    const project = createFakeProject('aps-name-fallback-project');
+    const modulePath = await createLocalModule(project, 'aps-name-fallback', ['web']);
+    const moduleTsPath = path.join(modulePath, 'src', 'ApsNameFallbackModule.ts');
+
+    fs.writeFileSync(
+      moduleTsPath,
+      `import { requireNativeModule } from 'expo';
+
+type NativeModuleShape = {
+  hello(): string;
+};
+
+export default requireNativeModule<NativeModuleShape>('ExpoImage');
+`,
+      'utf8'
+    );
+
+    await executePassing([
+      'add-platform-support',
+      modulePath,
+      '--platform',
+      'apple',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const swiftContent = fs.readFileSync(
+      path.join(modulePath, 'ios', 'ApsNameFallbackModule.swift'),
+      'utf-8'
+    );
+    expect(swiftContent).toContain('Name("ExpoImage")');
+  });
+
+  it('aborts when the requested platform is already supported', async () => {
+    const project = createFakeProject('aps-conflict-project');
+    const modulePath = await createLocalModule(project, 'aps-conflict', ['apple', 'android']);
+
+    let thrownError: any;
+    try {
+      await execute([
+        'add-platform-support',
+        modulePath,
+        '--platform',
+        'android',
+        '--source',
+        localTemplatePath,
+      ]);
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError?.status).not.toBe(0);
+    // android should not be duplicated in config
+    const config = JSON.parse(
+      fs.readFileSync(path.join(modulePath, 'expo-module.config.json'), 'utf-8')
+    );
+    expect(config.platforms.filter((p: string) => p === 'android')).toHaveLength(1);
+  });
+
+  it('aborts all-or-nothing when one of the requested platforms already exists', async () => {
+    const project = createFakeProject('aps-partial-project');
+    const modulePath = await createLocalModule(project, 'aps-partial', ['apple']);
+
+    let thrownError: any;
+    try {
+      await execute([
+        'add-platform-support',
+        modulePath,
+        '--platform',
+        'android',
+        'apple',
+        '--source',
+        localTemplatePath,
+      ]);
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError?.status).not.toBe(0);
+    // android must NOT have been added (all-or-nothing)
+    expect(fs.existsSync(path.join(modulePath, 'android'))).toBe(false);
+  });
+
+  it('throws in non-interactive (CI) mode when --platform is not provided', async () => {
+    const project = createFakeProject('aps-noninteractive-project');
+    const modulePath = await createLocalModule(project, 'aps-ni', ['apple']);
+
+    let thrownError: any;
+    try {
+      // execute() already sets CI=1, so non-interactive mode is active
+      await execute([
+        'add-platform-support',
+        modulePath,
+        '--source',
+        localTemplatePath,
+      ]);
+    } catch (e) {
+      thrownError = e;
+    }
+    expect(thrownError?.status).not.toBe(0);
+  });
+
+  it('uses --features flag to override auto-detected features', async () => {
+    const project = createFakeProject('aps-features-flag-project');
+    // Module has Function + AsyncFunction in native source
+    const modulePath = await createLocalModule(project, 'aps-ff', ['apple'], [
+      'Function',
+      'AsyncFunction',
+    ]);
+
+    // But we override with just View when adding android
+    await executePassing([
+      'add-platform-support',
+      modulePath,
+      '--platform',
+      'android',
+      '--features',
+      'View',
+      '--source',
+      localTemplatePath,
+    ]);
+
+    const pkgDir = path.join(
+      modulePath,
+      'android',
+      'src',
+      'main',
+      'java',
+      'expo',
+      'modules',
+      'apsff'
+    );
+    const ktFiles = fs.readdirSync(pkgDir);
+    const moduleKt = ktFiles.find((f) => f.endsWith('Module.kt'))!;
+    const ktContent = fs.readFileSync(path.join(pkgDir, moduleKt), 'utf-8');
+    expect(ktContent).toContain('View(');
+    expect(ktContent).not.toContain('AsyncFunction(');
   });
 });

--- a/packages/create-expo-module/src/__tests__/featureDetection-test.ts
+++ b/packages/create-expo-module/src/__tests__/featureDetection-test.ts
@@ -1,0 +1,190 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { detectFeaturesFromContent, findModuleDefinitionFile } from '../featureDetection';
+
+describe('detectFeaturesFromContent', () => {
+  it('detects Constant', () => {
+    const { features } = detectFeaturesFromContent(`
+      public func definition() -> ModuleDefinition {
+        Constant("PI") {
+      }
+    `);
+    expect(features).toContain('Constant');
+    expect(features).not.toContain('Function');
+  });
+
+  it('detects Function without also detecting AsyncFunction', () => {
+    const { features } = detectFeaturesFromContent(`
+      Function("hello") { return "Hello world!" }
+    `);
+    expect(features).toContain('Function');
+    expect(features).not.toContain('AsyncFunction');
+  });
+
+  it('detects AsyncFunction without also detecting Function', () => {
+    const { features } = detectFeaturesFromContent(`
+      AsyncFunction("setValueAsync") { (value: String) in }
+    `);
+    expect(features).toContain('AsyncFunction');
+    expect(features).not.toContain('Function');
+  });
+
+  it('detects DSL calls when there is whitespace before the opening parenthesis', () => {
+    const { features, sharedObjectName } = detectFeaturesFromContent(`
+      Constant ("PI") { }
+      AsyncFunction ("setValueAsync") { (value: String) in }
+      Events ("onChange")
+      Class (MyModuleModuleSharedObject.self) { }
+    `);
+    expect(features).toContain('Constant');
+    expect(features).toContain('AsyncFunction');
+    expect(features).toContain('Event');
+    expect(features).toContain('SharedObject');
+    expect(sharedObjectName).toBe('MyModuleModuleSharedObject');
+  });
+
+  it('detects Event at module level', () => {
+    const { features } = detectFeaturesFromContent(`
+      Events("onChange")
+    `);
+    expect(features).toContain('Event');
+    expect(features).not.toContain('ViewEvent');
+  });
+
+  it('detects View without ViewEvent when no Events inside', () => {
+    const { features } = detectFeaturesFromContent(`
+      View(MyModuleView.self) {
+      }
+    `);
+    expect(features).toContain('View');
+    expect(features).not.toContain('ViewEvent');
+    expect(features).not.toContain('Event');
+  });
+
+  it('detects ViewEvent from Events inside a View block', () => {
+    const { features } = detectFeaturesFromContent(`
+      View(MyModuleView.self) {
+        Events("onTap")
+      }
+    `);
+    expect(features).toContain('View');
+    expect(features).toContain('ViewEvent');
+    expect(features).not.toContain('Event');
+  });
+
+  it('detects Event at module level and ViewEvent inside View block simultaneously', () => {
+    const { features } = detectFeaturesFromContent(`
+      Events("onChange")
+      View(MyModuleView.self) {
+        Events("onTap")
+      }
+    `);
+    expect(features).toContain('Event');
+    expect(features).toContain('View');
+    expect(features).toContain('ViewEvent');
+  });
+
+  it('detects SharedObject and extracts class name from Swift syntax', () => {
+    const { features, sharedObjectName } = detectFeaturesFromContent(`
+      Class(MyModuleModuleSharedObject.self) {
+        Constructor { () -> MyModuleModuleSharedObject in
+          return MyModuleModuleSharedObject()
+        }
+      }
+    `);
+    expect(features).toContain('SharedObject');
+    expect(sharedObjectName).toBe('MyModuleModuleSharedObject');
+  });
+
+  it('detects SharedObject and extracts class name from Kotlin syntax', () => {
+    const { features, sharedObjectName } = detectFeaturesFromContent(`
+      Class(MyModuleModuleSharedObject::class) {
+      }
+    `);
+    expect(features).toContain('SharedObject');
+    expect(sharedObjectName).toBe('MyModuleModuleSharedObject');
+  });
+
+  it('ignores commented-out keywords', () => {
+    const { features } = detectFeaturesFromContent(`
+      // Function("commented") { }
+      // Constants(["PI": 3.14])
+      AsyncFunction("real") { (value: String) in }
+    `);
+    expect(features).not.toContain('Constant');
+    expect(features).not.toContain('Function');
+    expect(features).toContain('AsyncFunction');
+  });
+
+  it('returns empty results for empty content', () => {
+    const { features, sharedObjectName } = detectFeaturesFromContent('');
+    expect(features).toHaveLength(0);
+    expect(sharedObjectName).toBeNull();
+  });
+
+  it('does not treat UIView( as a View feature', () => {
+    const { features } = detectFeaturesFromContent(`
+      let v = UIView(frame: .zero)
+    `);
+    expect(features).not.toContain('View');
+  });
+
+  it('detects ViewEvent when View opening brace is on same line as a prior closing brace', () => {
+    const { features } = detectFeaturesFromContent(`
+      } View(MyModuleView.self) {
+        Events("onTap")
+      }
+    `);
+    expect(features).toContain('View');
+    expect(features).toContain('ViewEvent');
+    expect(features).not.toContain('Event');
+  });
+});
+
+describe('findModuleDefinitionFile', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'feat-detect-'));
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('finds ModuleDefinition file in ios/ for apple platform', async () => {
+    const iosDir = path.join(tmpDir, 'ios');
+    await fs.promises.mkdir(iosDir);
+    await fs.promises.writeFile(
+      path.join(iosDir, 'MyModule.swift'),
+      'public func definition() -> ModuleDefinition { Name("MyModule") }'
+    );
+    const result = await findModuleDefinitionFile(tmpDir, 'apple');
+    expect(result).toBe(path.join(iosDir, 'MyModule.swift'));
+  });
+
+  it('finds ModuleDefinition file nested in android/src/ for android platform', async () => {
+    const srcDir = path.join(tmpDir, 'android', 'src', 'main', 'java', 'expo', 'modules', 'mymod');
+    await fs.promises.mkdir(srcDir, { recursive: true });
+    await fs.promises.writeFile(
+      path.join(srcDir, 'MyModModule.kt'),
+      'override fun definition() = ModuleDefinition { Name("MyMod") }'
+    );
+    const result = await findModuleDefinitionFile(tmpDir, 'android');
+    expect(result).toBe(path.join(srcDir, 'MyModModule.kt'));
+  });
+
+  it('returns null when no file contains ModuleDefinition', async () => {
+    await fs.promises.mkdir(path.join(tmpDir, 'ios'));
+    await fs.promises.writeFile(path.join(tmpDir, 'ios', 'Other.swift'), 'class Other {}');
+    const result = await findModuleDefinitionFile(tmpDir, 'apple');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when platform directory does not exist', async () => {
+    const result = await findModuleDefinitionFile(tmpDir, 'apple');
+    expect(result).toBeNull();
+  });
+});

--- a/packages/create-expo-module/src/__tests__/featureDetection-test.ts
+++ b/packages/create-expo-module/src/__tests__/featureDetection-test.ts
@@ -187,4 +187,16 @@ describe('findModuleDefinitionFile', () => {
     const result = await findModuleDefinitionFile(tmpDir, 'apple');
     expect(result).toBeNull();
   });
+
+  it('skips generated directories when searching for module definitions', async () => {
+    const iosDir = path.join(tmpDir, 'ios');
+    await fs.promises.mkdir(path.join(iosDir, 'build'), { recursive: true });
+    await fs.promises.writeFile(
+      path.join(iosDir, 'build', 'StaleModule.swift'),
+      'public func definition() -> ModuleDefinition { Name("StaleModule") }'
+    );
+
+    const result = await findModuleDefinitionFile(tmpDir, 'apple');
+    expect(result).toBeNull();
+  });
 });

--- a/packages/create-expo-module/src/__tests__/templateUtils-test.ts
+++ b/packages/create-expo-module/src/__tests__/templateUtils-test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { getGeneratedWebStubSentinel, updateWebStub } from '../templateUtils';
+import type { SubstitutionData } from '../types';
+
+const mockData: SubstitutionData = {
+  project: {
+    slug: 'my-module',
+    name: 'MyModule',
+    version: '0.1.0',
+    description: 'Test',
+    package: 'expo.modules.mymodule',
+    moduleName: 'MyModuleModule',
+    viewName: 'MyModuleView',
+    sharedObjectName: 'MyModuleModuleSharedObject',
+    platforms: ['apple', 'web'],
+    features: [],
+  },
+  author: 'Test',
+  license: 'MIT',
+  repo: 'https://github.com/test/test',
+  type: 'standalone',
+};
+
+async function writeMinimalWebTemplate(templateDir: string) {
+  await fs.promises.mkdir(path.join(templateDir, 'src'), { recursive: true });
+  await fs.promises.mkdir(path.join(templateDir, 'snippets'), { recursive: true });
+  await fs.promises.writeFile(
+    path.join(templateDir, 'src', '{%- project.moduleName %}.web.ts'),
+    'export default class <%- project.moduleName %> {}\n'
+  );
+}
+
+describe('updateWebStub', () => {
+  let tmpDir: string;
+  let templateDir: string;
+  let targetDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'template-utils-'));
+    templateDir = path.join(tmpDir, 'template');
+    targetDir = path.join(tmpDir, 'target');
+    await writeMinimalWebTemplate(templateDir);
+    await fs.promises.mkdir(path.join(targetDir, 'src'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('refuses to overwrite a custom web implementation', async () => {
+    const webFile = path.join(targetDir, 'src', 'MyModuleModule.web.ts');
+    await fs.promises.writeFile(webFile, 'export default class CustomWebModule {}\n');
+
+    await expect(updateWebStub(templateDir, targetDir, mockData)).rejects.toThrow(
+      'does not look like the generated web stub'
+    );
+  });
+
+  it('overwrites the generated web stub', async () => {
+    const webFile = path.join(targetDir, 'src', 'MyModuleModule.web.ts');
+    await fs.promises.writeFile(
+      webFile,
+      `// ${getGeneratedWebStubSentinel(mockData.project.moduleName)}.\n`
+    );
+
+    await updateWebStub(templateDir, targetDir, mockData);
+
+    await expect(fs.promises.readFile(webFile, 'utf8')).resolves.toBe(
+      'export default class MyModuleModule {}\n'
+    );
+  });
+});

--- a/packages/create-expo-module/src/addPlatformSupport.ts
+++ b/packages/create-expo-module/src/addPlatformSupport.ts
@@ -1,0 +1,526 @@
+import chalk from 'chalk';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import prompts from 'prompts';
+
+import { detectFeaturesFromFile, findModuleDefinitionFile } from './featureDetection';
+import { resolveFeatures, type Feature } from './features';
+import { formatRunCommand, resolvePackageManager } from './packageManager';
+import { ALL_PLATFORMS, type Platform } from './prompts';
+import { copyNativeFileSnippets, copyWebFileSnippets } from './snippets';
+import {
+  buildAugmentedData,
+  copyTemplateFiles,
+  downloadPackageAsync,
+  handleSuffix,
+  slugToAndroidPackage,
+  updateWebStub,
+} from './templateUtils';
+import type { LocalSubstitutionData, SubstitutionData } from './types';
+import { newStep } from './utils/ora';
+
+const CWD = process.env.INIT_CWD || process.cwd();
+
+function isInteractive(): boolean {
+  const ci = process.env.CI;
+  if (ci === '1' || ci?.toLowerCase() === 'true') return false;
+  if (process.env.EXPO_NONINTERACTIVE) return false;
+  if (!process.stdin.isTTY) return false;
+  return true;
+}
+
+type ExistingModuleInfo = {
+  slug: string;
+  /** Base name without "Module" suffix, e.g. "ApsView" */
+  name: string;
+  /** Full module name, e.g. "ApsViewModule" */
+  moduleName: string;
+  /** Android package, e.g. "expo.modules.apsview" */
+  packageName: string;
+  platforms: Platform[];
+  isLocal: boolean;
+  version: string;
+  description: string;
+  author: string;
+  license: string;
+  repo: string;
+};
+
+const nativeModuleNamePattern = /Name\s*\(\s*["']([^"']+)["']\s*\)/;
+const moduleSourceNamePatterns = [
+  /globalThis\.expo\?\.\s*modules\?\.\s*\[\s*(["'`])([^"'`]+)\1\s*\]/,
+  /requireNativeModule(?:<[\s\S]*?>)?\(\s*(["'`])([^"'`]+)\1\s*\)/,
+  /requireOptionalNativeModule(?:<[\s\S]*?>)?\(\s*(["'`])([^"'`]+)\1\s*\)/,
+  /registerWebModule\s*\(\s*[^,]+,\s*(["'`])([^"'`]+)\1\s*\)/,
+] as const;
+
+export function detectPublicModuleNameFromNativeContent(content: string): string | null {
+  const moduleDefinitionIndex = content.indexOf('ModuleDefinition');
+  const searchContent = moduleDefinitionIndex >= 0 ? content.slice(moduleDefinitionIndex) : content;
+  return searchContent.match(nativeModuleNamePattern)?.[1] ?? null;
+}
+
+export function detectPublicModuleNameFromModuleSourceContent(content: string): string | null {
+  for (const pattern of moduleSourceNamePatterns) {
+    const match = content.match(pattern);
+    if (match?.[2]) {
+      return match[2];
+    }
+  }
+  return null;
+}
+
+async function findModuleSourceFiles(moduleRoot: string): Promise<string[]> {
+  const srcRoot = path.join(moduleRoot, 'src');
+  const sourceFiles: string[] = [];
+
+  async function visit(dir: string): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__') {
+          continue;
+        }
+        await visit(entryPath);
+        continue;
+      }
+
+      if (
+        !/\.(ts|tsx|js|jsx)$/.test(entry.name) ||
+        entry.name.endsWith('.d.ts') ||
+        entry.name.includes('.test.') ||
+        entry.name.includes('.spec.') ||
+        entry.name.endsWith('.types.ts')
+      ) {
+        continue;
+      }
+      sourceFiles.push(entryPath);
+    }
+  }
+
+  await visit(srcRoot);
+  return sourceFiles.sort((left, right) => {
+    const leftRelative = path.relative(srcRoot, left);
+    const rightRelative = path.relative(srcRoot, right);
+    const leftDepth = leftRelative.split(path.sep).length;
+    const rightDepth = rightRelative.split(path.sep).length;
+    if (leftDepth !== rightDepth) {
+      return leftDepth - rightDepth;
+    }
+    return leftRelative.localeCompare(rightRelative);
+  });
+}
+
+async function detectPublicModuleNameFromModuleSourceFiles(
+  moduleRoot: string
+): Promise<string | null> {
+  const sourceFiles = await findModuleSourceFiles(moduleRoot);
+
+  for (const filePath of sourceFiles) {
+    const content = await fs.promises.readFile(filePath, 'utf8');
+    const moduleName = detectPublicModuleNameFromModuleSourceContent(content);
+    if (moduleName) {
+      return moduleName;
+    }
+  }
+
+  return null;
+}
+
+async function readExistingModuleInfo(moduleRoot: string): Promise<ExistingModuleInfo> {
+  const configPath = path.join(moduleRoot, 'expo-module.config.json');
+  const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+
+  const platforms: Platform[] = ((config.platforms ?? []) as string[]).filter((p): p is Platform =>
+    (ALL_PLATFORMS as readonly string[]).includes(p)
+  );
+
+  const appleModule: string | undefined = config.apple?.modules?.[0];
+  const androidClass: string | undefined = config.android?.modules?.[0];
+
+  let moduleName: string;
+  if (appleModule) {
+    moduleName = appleModule;
+  } else if (androidClass) {
+    moduleName = androidClass.split('.').pop()!;
+  } else {
+    // Web-only module: derive a conventional module name from the directory name
+    const base = path.basename(moduleRoot);
+    moduleName =
+      base.charAt(0).toUpperCase() +
+      base.slice(1).replace(/-./g, (m) => (m[1] ?? '').toUpperCase()) +
+      'Module';
+  }
+
+  // Determine project.name from the *.types.ts file in src/.
+  let name: string;
+  try {
+    const srcFiles = await fs.promises.readdir(path.join(moduleRoot, 'src'));
+    const typesFile = srcFiles.find((f) => f.endsWith('.types.ts'));
+    name = typesFile ? typesFile.replace(/\.types\.ts$/, '') : moduleName;
+  } catch {
+    name = moduleName;
+  }
+
+  let packageName: string;
+  if (androidClass) {
+    packageName = androidClass.split('.').slice(0, -1).join('.');
+  } else {
+    packageName = slugToAndroidPackage(path.basename(moduleRoot));
+  }
+
+  const packageJsonPath = path.join(moduleRoot, 'package.json');
+  const isLocal = !fs.existsSync(packageJsonPath);
+
+  let pkgJson: any = null;
+  if (!isLocal) {
+    pkgJson = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf-8'));
+  }
+
+  const slug = isLocal ? path.basename(moduleRoot) : (pkgJson?.name ?? path.basename(moduleRoot));
+
+  let version = '0.1.0';
+  let description = '';
+  let author = '';
+  let license = 'MIT';
+  let repo = '';
+
+  if (pkgJson) {
+    version = pkgJson.version ?? '0.1.0';
+    description = pkgJson.description ?? '';
+    license = pkgJson.license ?? 'MIT';
+    repo =
+      typeof pkgJson.repository === 'string' ? pkgJson.repository : (pkgJson.repository?.url ?? '');
+    if (typeof pkgJson.author === 'string') {
+      author = pkgJson.author;
+    } else if (pkgJson.author?.name) {
+      const a = pkgJson.author;
+      author = `${a.name}${a.email ? ` <${a.email}>` : ''}${a.url ? ` (${a.url})` : ''}`;
+    }
+  }
+
+  return {
+    slug,
+    name,
+    moduleName,
+    packageName,
+    platforms,
+    isLocal,
+    version,
+    description,
+    author,
+    license,
+    repo,
+  };
+}
+
+function buildSubstitutionData(
+  info: ExistingModuleInfo,
+  newPlatforms: Platform[],
+  features: Feature[],
+  sharedObjectName: string | null
+): SubstitutionData | LocalSubstitutionData {
+  const allPlatforms = [...info.platforms, ...newPlatforms];
+  const resolvedSharedObjectName = sharedObjectName ?? `${info.moduleName}SharedObject`;
+
+  const project = {
+    slug: info.slug,
+    name: info.name,
+    package: info.packageName,
+    moduleName: info.moduleName,
+    viewName: handleSuffix(info.name, 'View'),
+    sharedObjectName: resolvedSharedObjectName,
+    platforms: allPlatforms,
+    features,
+  };
+
+  if (info.isLocal) {
+    return { project, type: 'local' };
+  }
+
+  return {
+    project: { ...project, version: info.version, description: info.description },
+    author: info.author,
+    license: info.license,
+    repo: info.repo,
+    type: 'standalone',
+  };
+}
+
+async function updateModuleConfig(
+  configPath: string,
+  newPlatforms: Platform[],
+  data: SubstitutionData | LocalSubstitutionData
+): Promise<void> {
+  const config = JSON.parse(await fs.promises.readFile(configPath, 'utf-8'));
+  config.platforms = [...(config.platforms ?? []), ...newPlatforms];
+
+  for (const platform of newPlatforms) {
+    if (platform === 'apple') {
+      config.apple = { modules: [data.project.moduleName] };
+    } else if (platform === 'android') {
+      config.android = { modules: [`${data.project.package}.${data.project.moduleName}`] };
+    }
+    // web: no native config block needed
+  }
+
+  await fs.promises.writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+export type AddPlatformSupportOptions = {
+  platform?: string[];
+  features?: string[];
+  source?: string;
+};
+
+export async function addPlatformSupport(
+  modulePathArg: string | undefined,
+  options: AddPlatformSupportOptions
+): Promise<void> {
+  const moduleRoot = modulePathArg ? path.resolve(CWD, modulePathArg) : CWD;
+  const configPath = path.join(moduleRoot, 'expo-module.config.json');
+
+  if (!fs.existsSync(configPath)) {
+    console.error(
+      chalk.red(
+        `❌ Could not find expo-module.config.json in ${moduleRoot}.\n` +
+          `   Run this command from the module's root directory, or pass the path as an argument:\n` +
+          `   npx create-expo-module add-platform-support <path-to-module>`
+      )
+    );
+    process.exit(1);
+  }
+
+  let moduleInfo: ExistingModuleInfo;
+  try {
+    moduleInfo = await readExistingModuleInfo(moduleRoot);
+  } catch (e: any) {
+    console.error(chalk.red(`❌ Failed to read module configuration: ${e.message}`));
+    process.exit(1);
+  }
+
+  const existingNativePlatform = moduleInfo.platforms.find(
+    (p): p is 'apple' | 'android' => p === 'apple' || p === 'android'
+  );
+  let moduleDefinitionFile: string | null = null;
+
+  if (existingNativePlatform) {
+    moduleDefinitionFile = await findModuleDefinitionFile(moduleRoot, existingNativePlatform);
+    if (!moduleDefinitionFile) {
+      console.error(
+        chalk.red(
+          `❌ Could not find a module definition file in ` +
+            `${existingNativePlatform === 'apple' ? 'ios/' : 'android/src/'}.\n` +
+            `   This command only works with modules using the Expo Modules API DSL.\n` +
+            `   Older module formats are not supported.`
+        )
+      );
+      process.exit(1);
+    }
+  }
+
+  const availablePlatforms = ALL_PLATFORMS.filter((p) => !moduleInfo.platforms.includes(p));
+
+  if (availablePlatforms.length === 0) {
+    console.log(chalk.yellow('ℹ️  All platforms are already supported by this module.'));
+    return;
+  }
+
+  let platformsToAdd: Platform[];
+  const interactive = isInteractive();
+
+  if (options.platform && options.platform.length > 0) {
+    const invalid = options.platform.filter(
+      (p) => !(ALL_PLATFORMS as readonly string[]).includes(p)
+    );
+    if (invalid.length > 0) {
+      console.error(
+        chalk.red(
+          `❌ Invalid platform(s): ${invalid.join(', ')}. Valid values: ${ALL_PLATFORMS.join(', ')}.`
+        )
+      );
+      process.exit(1);
+    }
+    const conflicts = options.platform.filter((p) => moduleInfo.platforms.includes(p as Platform));
+    if (conflicts.length > 0) {
+      console.error(
+        chalk.red(
+          `❌ The following platform(s) are already supported: ${conflicts.join(', ')}.\n` +
+            `   No changes were made.`
+        )
+      );
+      process.exit(1);
+    }
+    platformsToAdd = options.platform as Platform[];
+  } else if (!interactive) {
+    console.error(
+      chalk.red(
+        `❌ --platform is required in non-interactive mode.\n` +
+          `   Available: ${availablePlatforms.join(', ')}\n` +
+          `   Example: npx create-expo-module add-platform-support --platform ${availablePlatforms[0]}`
+      )
+    );
+    process.exit(1);
+  } else {
+    const result = await prompts(
+      {
+        type: 'multiselect',
+        name: 'platforms',
+        message: 'Which platforms would you like to add?',
+        choices: availablePlatforms.map((p) => ({ title: p, value: p, selected: false })),
+        min: 1,
+        hint: '- Space to select. Enter to confirm.',
+      },
+      { onCancel: () => process.exit(0) }
+    );
+    platformsToAdd = result.platforms;
+  }
+
+  for (const platform of platformsToAdd) {
+    if (platform === 'web') continue;
+    const dir = path.join(moduleRoot, platform === 'apple' ? 'ios' : 'android');
+    if (fs.existsSync(dir)) {
+      const stat = fs.statSync(dir);
+      console.error(
+        chalk.red(
+          `❌ ${dir} already exists as a ${stat.isDirectory() ? 'directory' : 'file'}.\n` +
+            `   Cannot add ${platform === 'apple' ? 'Apple' : 'Android'} platform support without overwriting existing files.\n` +
+            `   No changes were made.`
+        )
+      );
+      process.exit(1);
+    }
+  }
+
+  let detectedFeatures: Feature[];
+  let sharedObjectName: string | null = null;
+
+  if (options.features && options.features.length > 0) {
+    detectedFeatures = resolveFeatures(options.features);
+  } else if (moduleDefinitionFile) {
+    const detected = await detectFeaturesFromFile(moduleDefinitionFile!);
+    detectedFeatures = detected.features;
+    sharedObjectName = detected.sharedObjectName;
+    if (detectedFeatures.length === 0) {
+      console.warn(
+        chalk.yellow(
+          '⚠️  No features detected in the module definition. Generating a minimal scaffold.'
+        )
+      );
+    }
+  } else {
+    // Web-only module adding a native platform: no ModuleDefinition to scan.
+    detectedFeatures = [];
+    console.log(chalk.dim('No native module definition found. Generating minimal scaffold.'));
+  }
+
+  const detectedPublicModuleName =
+    (moduleDefinitionFile
+      ? detectPublicModuleNameFromNativeContent(
+          await fs.promises.readFile(moduleDefinitionFile, 'utf8')
+        )
+      : null) ?? (await detectPublicModuleNameFromModuleSourceFiles(moduleRoot));
+
+  if (detectedPublicModuleName) {
+    moduleInfo.name = detectedPublicModuleName;
+  }
+
+  const data = buildSubstitutionData(
+    moduleInfo,
+    platformsToAdd,
+    detectedFeatures,
+    sharedObjectName
+  );
+
+  let templatePath: string;
+  let templateTempDir: string | null = null;
+
+  if (options.source) {
+    templatePath = path.resolve(CWD, options.source);
+  } else {
+    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'add-platform-support-'));
+    templateTempDir = tempDir;
+    templatePath = await downloadPackageAsync(tempDir, moduleInfo.isLocal);
+  }
+
+  try {
+    const snippetsDir = path.join(templatePath, 'snippets');
+    const augmentedData = await buildAugmentedData(snippetsDir, data);
+
+    const nativePlatforms = platformsToAdd.filter(
+      (p): p is 'apple' | 'android' => p === 'apple' || p === 'android'
+    );
+    if (nativePlatforms.length > 0) {
+      await newStep('Adding platform files', async (step) => {
+        await copyTemplateFiles(templatePath, moduleRoot, augmentedData, {
+          platforms: nativePlatforms,
+          platformsOnly: true,
+          moduleType: moduleInfo.isLocal ? 'local' : 'standalone',
+        });
+        const dataForNewPlatforms = {
+          ...data,
+          project: { ...data.project, platforms: nativePlatforms },
+        } as SubstitutionData | LocalSubstitutionData;
+        await copyNativeFileSnippets(
+          snippetsDir,
+          detectedFeatures,
+          dataForNewPlatforms,
+          moduleRoot
+        );
+        step.succeed('Added platform files');
+      });
+    }
+
+    if (platformsToAdd.includes('web')) {
+      await newStep('Updating web implementation', async (step) => {
+        await updateWebStub(templatePath, moduleRoot, data);
+        const dataWithWeb = {
+          ...data,
+          project: { ...data.project, platforms: ['web'] as Platform[] },
+        } as SubstitutionData | LocalSubstitutionData;
+        await copyWebFileSnippets(snippetsDir, detectedFeatures, dataWithWeb, moduleRoot);
+        step.succeed('Updated web implementation');
+      });
+    }
+
+    await newStep('Updating expo-module.config.json', async (step) => {
+      await updateModuleConfig(configPath, platformsToAdd, data);
+      step.succeed('Updated expo-module.config.json');
+    });
+  } finally {
+    if (templateTempDir) {
+      await fs.promises.rm(templateTempDir, { recursive: true, force: true });
+    }
+  }
+
+  console.log();
+  console.log(`✅ Successfully added ${platformsToAdd.join(', ')} support to the module.`);
+  if (detectedFeatures.length > 0) {
+    console.log(chalk.dim(`   Scaffolded features: ${detectedFeatures.join(', ')}`));
+  }
+
+  const packageManager = resolvePackageManager();
+  const nativeOpenCommands = platformsToAdd
+    .filter(
+      (platform): platform is 'apple' | 'android' => platform === 'apple' || platform === 'android'
+    )
+    .map((platform) =>
+      platform === 'apple'
+        ? formatRunCommand(packageManager, 'open:ios')
+        : formatRunCommand(packageManager, 'open:android')
+    );
+
+  if (nativeOpenCommands.length > 0) {
+    console.log(
+      chalk.dim(`   To write the native implementation, use ${nativeOpenCommands.join(' or ')}.`)
+    );
+  }
+}

--- a/packages/create-expo-module/src/addPlatformSupport.ts
+++ b/packages/create-expo-module/src/addPlatformSupport.ts
@@ -18,17 +18,10 @@ import {
   updateWebStub,
 } from './templateUtils';
 import type { LocalSubstitutionData, SubstitutionData } from './types';
+import { isInteractive } from './utils/env';
 import { newStep } from './utils/ora';
 
 const CWD = process.env.INIT_CWD || process.cwd();
-
-function isInteractive(): boolean {
-  const ci = process.env.CI;
-  if (ci === '1' || ci?.toLowerCase() === 'true') return false;
-  if (process.env.EXPO_NONINTERACTIVE) return false;
-  if (!process.stdin.isTTY) return false;
-  return true;
-}
 
 type ExistingModuleInfo = {
   slug: string;
@@ -281,147 +274,166 @@ export type AddPlatformSupportOptions = {
   source?: string;
 };
 
-export async function addPlatformSupport(
-  modulePathArg: string | undefined,
-  options: AddPlatformSupportOptions
-): Promise<void> {
-  const moduleRoot = modulePathArg ? path.resolve(CWD, modulePathArg) : CWD;
-  const configPath = path.join(moduleRoot, 'expo-module.config.json');
+type TemplatePathInfo = {
+  templatePath: string;
+  templateTempDir: string | null;
+};
 
+function exitWithError(message: string): never {
+  console.error(chalk.red(message));
+  process.exit(1);
+}
+
+async function readModuleInfoOrExit(
+  moduleRoot: string,
+  configPath: string
+): Promise<ExistingModuleInfo> {
   if (!fs.existsSync(configPath)) {
-    console.error(
-      chalk.red(
-        `❌ Could not find expo-module.config.json in ${moduleRoot}.\n` +
-          `   Run this command from the module's root directory, or pass the path as an argument:\n` +
-          `   npx create-expo-module add-platform-support <path-to-module>`
-      )
+    exitWithError(
+      `❌ Could not find expo-module.config.json in ${moduleRoot}.\n` +
+        `   Run this command from the module's root directory, or pass the path as an argument:\n` +
+        `   npx create-expo-module add-platform-support <path-to-module>`
     );
-    process.exit(1);
   }
 
-  let moduleInfo: ExistingModuleInfo;
   try {
-    moduleInfo = await readExistingModuleInfo(moduleRoot);
+    return await readExistingModuleInfo(moduleRoot);
   } catch (e: any) {
-    console.error(chalk.red(`❌ Failed to read module configuration: ${e.message}`));
-    process.exit(1);
+    exitWithError(`❌ Failed to read module configuration: ${e.message}`);
   }
+}
 
+async function findExistingModuleDefinitionFile(
+  moduleRoot: string,
+  moduleInfo: ExistingModuleInfo
+): Promise<string | null> {
   const existingNativePlatform = moduleInfo.platforms.find(
     (p): p is 'apple' | 'android' => p === 'apple' || p === 'android'
   );
-  let moduleDefinitionFile: string | null = null;
 
   if (existingNativePlatform) {
-    moduleDefinitionFile = await findModuleDefinitionFile(moduleRoot, existingNativePlatform);
+    const moduleDefinitionFile = await findModuleDefinitionFile(moduleRoot, existingNativePlatform);
     if (!moduleDefinitionFile) {
-      console.error(
-        chalk.red(
-          `❌ Could not find a module definition file in ` +
-            `${existingNativePlatform === 'apple' ? 'ios/' : 'android/src/'}.\n` +
-            `   This command only works with modules using the Expo Modules API DSL.\n` +
-            `   Older module formats are not supported.`
-        )
+      exitWithError(
+        `❌ Could not find a module definition file in ` +
+          `${existingNativePlatform === 'apple' ? 'ios/' : 'android/src/'}.\n` +
+          `   This command only works with modules using the Expo Modules API DSL.\n` +
+          `   Older module formats are not supported.`
       );
-      process.exit(1);
     }
+    return moduleDefinitionFile;
   }
 
+  return null;
+}
+
+async function resolvePlatformsToAdd(
+  moduleInfo: ExistingModuleInfo,
+  options: AddPlatformSupportOptions
+): Promise<Platform[] | null> {
   const availablePlatforms = ALL_PLATFORMS.filter((p) => !moduleInfo.platforms.includes(p));
 
   if (availablePlatforms.length === 0) {
     console.log(chalk.yellow('ℹ️  All platforms are already supported by this module.'));
-    return;
+    return null;
   }
-
-  let platformsToAdd: Platform[];
-  const interactive = isInteractive();
 
   if (options.platform && options.platform.length > 0) {
     const invalid = options.platform.filter(
       (p) => !(ALL_PLATFORMS as readonly string[]).includes(p)
     );
     if (invalid.length > 0) {
-      console.error(
-        chalk.red(
-          `❌ Invalid platform(s): ${invalid.join(', ')}. Valid values: ${ALL_PLATFORMS.join(', ')}.`
-        )
+      exitWithError(
+        `❌ Invalid platform(s): ${invalid.join(', ')}. Valid values: ${ALL_PLATFORMS.join(', ')}.`
       );
-      process.exit(1);
     }
     const conflicts = options.platform.filter((p) => moduleInfo.platforms.includes(p as Platform));
     if (conflicts.length > 0) {
-      console.error(
-        chalk.red(
-          `❌ The following platform(s) are already supported: ${conflicts.join(', ')}.\n` +
-            `   No changes were made.`
-        )
+      exitWithError(
+        `❌ The following platform(s) are already supported: ${conflicts.join(', ')}.\n` +
+          `   No changes were made.`
       );
-      process.exit(1);
     }
-    platformsToAdd = options.platform as Platform[];
-  } else if (!interactive) {
-    console.error(
-      chalk.red(
-        `❌ --platform is required in non-interactive mode.\n` +
-          `   Available: ${availablePlatforms.join(', ')}\n` +
-          `   Example: npx create-expo-module add-platform-support --platform ${availablePlatforms[0]}`
-      )
-    );
-    process.exit(1);
-  } else {
-    const result = await prompts(
-      {
-        type: 'multiselect',
-        name: 'platforms',
-        message: 'Which platforms would you like to add?',
-        choices: availablePlatforms.map((p) => ({ title: p, value: p, selected: false })),
-        min: 1,
-        hint: '- Space to select. Enter to confirm.',
-      },
-      { onCancel: () => process.exit(0) }
-    );
-    platformsToAdd = result.platforms;
+    return options.platform as Platform[];
   }
 
+  if (!isInteractive()) {
+    exitWithError(
+      `❌ --platform is required in non-interactive mode.\n` +
+        `   Available: ${availablePlatforms.join(', ')}\n` +
+        `   Example: npx create-expo-module add-platform-support --platform ${availablePlatforms[0]}`
+    );
+  }
+
+  const result = await prompts(
+    {
+      type: 'multiselect',
+      name: 'platforms',
+      message: 'Which platforms would you like to add?',
+      choices: availablePlatforms.map((p) => ({ title: p, value: p, selected: false })),
+      min: 1,
+      hint: '- Space to select. Enter to confirm.',
+    },
+    { onCancel: () => process.exit(0) }
+  );
+  return result.platforms;
+}
+
+function ensureNativePlatformTargetsAvailable(
+  moduleRoot: string,
+  platformsToAdd: Platform[]
+): void {
   for (const platform of platformsToAdd) {
     if (platform === 'web') continue;
     const dir = path.join(moduleRoot, platform === 'apple' ? 'ios' : 'android');
     if (fs.existsSync(dir)) {
       const stat = fs.statSync(dir);
-      console.error(
-        chalk.red(
-          `❌ ${dir} already exists as a ${stat.isDirectory() ? 'directory' : 'file'}.\n` +
-            `   Cannot add ${platform === 'apple' ? 'Apple' : 'Android'} platform support without overwriting existing files.\n` +
-            `   No changes were made.`
-        )
+      exitWithError(
+        `❌ ${dir} already exists as a ${stat.isDirectory() ? 'directory' : 'file'}.\n` +
+          `   Cannot add ${platform === 'apple' ? 'Apple' : 'Android'} platform support without overwriting existing files.\n` +
+          `   No changes were made.`
       );
-      process.exit(1);
     }
   }
+}
 
-  let detectedFeatures: Feature[];
-  let sharedObjectName: string | null = null;
-
+async function resolveDetectedFeatures(
+  moduleDefinitionFile: string | null,
+  options: AddPlatformSupportOptions
+): Promise<{ detectedFeatures: Feature[]; sharedObjectName: string | null }> {
   if (options.features && options.features.length > 0) {
-    detectedFeatures = resolveFeatures(options.features);
-  } else if (moduleDefinitionFile) {
-    const detected = await detectFeaturesFromFile(moduleDefinitionFile!);
-    detectedFeatures = detected.features;
-    sharedObjectName = detected.sharedObjectName;
-    if (detectedFeatures.length === 0) {
+    return { detectedFeatures: resolveFeatures(options.features), sharedObjectName: null };
+  }
+
+  if (moduleDefinitionFile) {
+    const { features, sharedObjectName } = await detectFeaturesFromFile(moduleDefinitionFile);
+    if (features.length === 0) {
       console.warn(
         chalk.yellow(
           '⚠️  No features detected in the module definition. Generating a minimal scaffold.'
         )
       );
+    } else {
+      console.log(
+        chalk.dim(
+          `Detected features from ${path.relative(CWD, moduleDefinitionFile)} (best effort). ` +
+            'Use --features to override.'
+        )
+      );
     }
-  } else {
-    // Web-only module adding a native platform: no ModuleDefinition to scan.
-    detectedFeatures = [];
-    console.log(chalk.dim('No native module definition found. Generating minimal scaffold.'));
+    return { detectedFeatures: features, sharedObjectName };
   }
 
+  // Web-only module adding a native platform: no ModuleDefinition to scan.
+  console.log(chalk.dim('No native module definition found. Generating minimal scaffold.'));
+  return { detectedFeatures: [], sharedObjectName: null };
+}
+
+async function updatePublicModuleNameFromSources(
+  moduleInfo: ExistingModuleInfo,
+  moduleRoot: string,
+  moduleDefinitionFile: string | null
+): Promise<void> {
   const detectedPublicModuleName =
     (moduleDefinitionFile
       ? detectPublicModuleNameFromNativeContent(
@@ -432,6 +444,125 @@ export async function addPlatformSupport(
   if (detectedPublicModuleName) {
     moduleInfo.name = detectedPublicModuleName;
   }
+}
+
+async function resolveTemplatePath(
+  options: AddPlatformSupportOptions,
+  moduleInfo: ExistingModuleInfo
+): Promise<TemplatePathInfo> {
+  if (options.source) {
+    const templatePath = path.resolve(CWD, options.source);
+    if (!fs.existsSync(templatePath)) {
+      exitWithError(
+        `❌ Template source directory does not exist: ${templatePath}.\n` +
+          `   Check the --source path and try again.`
+      );
+    }
+    if (!fs.statSync(templatePath).isDirectory()) {
+      exitWithError(
+        `❌ Template source is not a directory: ${templatePath}.\n` +
+          `   Pass the root directory of an expo-module-template package.`
+      );
+    }
+    return { templatePath, templateTempDir: null };
+  }
+
+  const templateTempDir = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'add-platform-support-')
+  );
+  const templatePath = await downloadPackageAsync(templateTempDir, moduleInfo.isLocal);
+  return { templatePath, templateTempDir };
+}
+
+async function addNativePlatformFiles(
+  templatePath: string,
+  moduleRoot: string,
+  moduleInfo: ExistingModuleInfo,
+  platformsToAdd: Platform[],
+  detectedFeatures: Feature[],
+  data: SubstitutionData | LocalSubstitutionData
+): Promise<void> {
+  const nativePlatforms = platformsToAdd.filter(
+    (p): p is 'apple' | 'android' => p === 'apple' || p === 'android'
+  );
+  if (nativePlatforms.length === 0) {
+    return;
+  }
+
+  const snippetsDir = path.join(templatePath, 'snippets');
+  const augmentedData = await buildAugmentedData(snippetsDir, data);
+  await newStep('Adding platform files', async (step) => {
+    await copyTemplateFiles(templatePath, moduleRoot, augmentedData, {
+      platforms: nativePlatforms,
+      platformsOnly: true,
+      moduleType: moduleInfo.isLocal ? 'local' : 'standalone',
+    });
+    const dataForNewPlatforms = {
+      ...data,
+      project: { ...data.project, platforms: nativePlatforms },
+    } as SubstitutionData | LocalSubstitutionData;
+    await copyNativeFileSnippets(snippetsDir, detectedFeatures, dataForNewPlatforms, moduleRoot);
+    step.succeed('Added platform files');
+  });
+}
+
+async function addWebPlatformFiles(
+  templatePath: string,
+  moduleRoot: string,
+  platformsToAdd: Platform[],
+  detectedFeatures: Feature[],
+  data: SubstitutionData | LocalSubstitutionData
+): Promise<void> {
+  if (!platformsToAdd.includes('web')) {
+    return;
+  }
+
+  const snippetsDir = path.join(templatePath, 'snippets');
+  await newStep('Updating web implementation', async (step) => {
+    await updateWebStub(templatePath, moduleRoot, data);
+    const dataWithWeb = {
+      ...data,
+      project: { ...data.project, platforms: ['web'] as Platform[] },
+    } as SubstitutionData | LocalSubstitutionData;
+    await copyWebFileSnippets(snippetsDir, detectedFeatures, dataWithWeb, moduleRoot);
+    step.succeed('Updated web implementation');
+  });
+}
+
+function getNativeOpenCommands(platformsToAdd: Platform[]): string[] {
+  const packageManager = resolvePackageManager();
+  return platformsToAdd
+    .filter(
+      (platform): platform is 'apple' | 'android' => platform === 'apple' || platform === 'android'
+    )
+    .map((platform) =>
+      platform === 'apple'
+        ? formatRunCommand(packageManager, 'open:ios')
+        : formatRunCommand(packageManager, 'open:android')
+    );
+}
+
+export async function addPlatformSupport(
+  modulePathArg: string | undefined,
+  options: AddPlatformSupportOptions
+): Promise<void> {
+  const moduleRoot = modulePathArg ? path.resolve(CWD, modulePathArg) : CWD;
+  const configPath = path.join(moduleRoot, 'expo-module.config.json');
+  const moduleInfo = await readModuleInfoOrExit(moduleRoot, configPath);
+  const moduleDefinitionFile = await findExistingModuleDefinitionFile(moduleRoot, moduleInfo);
+  const platformsToAdd = await resolvePlatformsToAdd(moduleInfo, options);
+  if (!platformsToAdd) {
+    return;
+  }
+
+  ensureNativePlatformTargetsAvailable(moduleRoot, platformsToAdd);
+
+  const { detectedFeatures, sharedObjectName } = await resolveDetectedFeatures(
+    moduleDefinitionFile,
+    options
+  );
+
+  await updatePublicModuleNameFromSources(moduleInfo, moduleRoot, moduleDefinitionFile);
 
   const data = buildSubstitutionData(
     moduleInfo,
@@ -439,57 +570,18 @@ export async function addPlatformSupport(
     detectedFeatures,
     sharedObjectName
   );
-
-  let templatePath: string;
-  let templateTempDir: string | null = null;
-
-  if (options.source) {
-    templatePath = path.resolve(CWD, options.source);
-  } else {
-    const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'add-platform-support-'));
-    templateTempDir = tempDir;
-    templatePath = await downloadPackageAsync(tempDir, moduleInfo.isLocal);
-  }
+  const { templatePath, templateTempDir } = await resolveTemplatePath(options, moduleInfo);
 
   try {
-    const snippetsDir = path.join(templatePath, 'snippets');
-    const augmentedData = await buildAugmentedData(snippetsDir, data);
-
-    const nativePlatforms = platformsToAdd.filter(
-      (p): p is 'apple' | 'android' => p === 'apple' || p === 'android'
+    await addNativePlatformFiles(
+      templatePath,
+      moduleRoot,
+      moduleInfo,
+      platformsToAdd,
+      detectedFeatures,
+      data
     );
-    if (nativePlatforms.length > 0) {
-      await newStep('Adding platform files', async (step) => {
-        await copyTemplateFiles(templatePath, moduleRoot, augmentedData, {
-          platforms: nativePlatforms,
-          platformsOnly: true,
-          moduleType: moduleInfo.isLocal ? 'local' : 'standalone',
-        });
-        const dataForNewPlatforms = {
-          ...data,
-          project: { ...data.project, platforms: nativePlatforms },
-        } as SubstitutionData | LocalSubstitutionData;
-        await copyNativeFileSnippets(
-          snippetsDir,
-          detectedFeatures,
-          dataForNewPlatforms,
-          moduleRoot
-        );
-        step.succeed('Added platform files');
-      });
-    }
-
-    if (platformsToAdd.includes('web')) {
-      await newStep('Updating web implementation', async (step) => {
-        await updateWebStub(templatePath, moduleRoot, data);
-        const dataWithWeb = {
-          ...data,
-          project: { ...data.project, platforms: ['web'] as Platform[] },
-        } as SubstitutionData | LocalSubstitutionData;
-        await copyWebFileSnippets(snippetsDir, detectedFeatures, dataWithWeb, moduleRoot);
-        step.succeed('Updated web implementation');
-      });
-    }
+    await addWebPlatformFiles(templatePath, moduleRoot, platformsToAdd, detectedFeatures, data);
 
     await newStep('Updating expo-module.config.json', async (step) => {
       await updateModuleConfig(configPath, platformsToAdd, data);
@@ -507,17 +599,7 @@ export async function addPlatformSupport(
     console.log(chalk.dim(`   Scaffolded features: ${detectedFeatures.join(', ')}`));
   }
 
-  const packageManager = resolvePackageManager();
-  const nativeOpenCommands = platformsToAdd
-    .filter(
-      (platform): platform is 'apple' | 'android' => platform === 'apple' || platform === 'android'
-    )
-    .map((platform) =>
-      platform === 'apple'
-        ? formatRunCommand(packageManager, 'open:ios')
-        : formatRunCommand(packageManager, 'open:android')
-    );
-
+  const nativeOpenCommands = getNativeOpenCommands(platformsToAdd);
   if (nativeOpenCommands.length > 0) {
     console.log(
       chalk.dim(`   To write the native implementation, use ${nativeOpenCommands.join(' or ')}.`)

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -1,7 +1,6 @@
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import { Command, Option } from 'commander';
-import ejs from 'ejs';
 import fs from 'node:fs';
 import path from 'node:path';
 import prompts from 'prompts';
@@ -40,6 +39,7 @@ import {
 } from './templateUtils';
 import type { CommandOptions, Feature, LocalSubstitutionData, SubstitutionData } from './types';
 import { buildDefaultsWarning } from './utils/defaults';
+import { isInteractive } from './utils/env';
 import { findGitHubEmail, findMyName } from './utils/git';
 import { findGitHubUserFromEmail, guessRepoUrl } from './utils/github';
 import { newStep } from './utils/ora';
@@ -54,27 +54,6 @@ const CWD = process.env.INIT_CWD || process.cwd();
 const DOCS_URL = 'https://docs.expo.dev/modules';
 
 const FYI_LOCAL_DIR = 'https://expo.fyi/expo-module-local-autolinking.md';
-
-/**
- * Determines if we're in an interactive environment.
- * Non-interactive when: CI=1/true or non-TTY stdin.
- */
-function isInteractive(): boolean {
-  const ci = process.env.CI;
-  if (ci === '1' || ci?.toLowerCase() === 'true') {
-    return false;
-  }
-  // Check for Expo's own non-interactive flag, used across expo-module-scripts and @expo/cli
-  // to force non-interactive mode in sub-processes (e.g. during `prepare` or `prepublishOnly`)
-  if (process.env.EXPO_NONINTERACTIVE) {
-    return false;
-  }
-  // Check for TTY
-  if (!process.stdin.isTTY) {
-    return false;
-  }
-  return true;
-}
 
 /**
  * Converts a slug to a native module name (PascalCase).
@@ -909,8 +888,8 @@ program
   .command('add-platform-support [path]')
   .description(
     'Add platform support to an existing Expo module. ' +
-      'For example, add Android to an iOS-only module.' +
-      'This command should be ran from the root directory of an expo-module'
+      'For example, add Android to an iOS-only module. ' +
+      'Run from the module root, or pass the path as the first argument.'
   )
   .option(
     '-p, --platform <platforms...>',
@@ -918,7 +897,7 @@ program
   )
   .option(
     '--features <features...>',
-    `Override auto-detected features. Values: ${ALL_FEATURES.join(', ')}.`
+    `Override best-effort feature detection. Values: ${ALL_FEATURES.join(', ')}.`
   )
   .option(
     '-s, --source <source_dir>',

--- a/packages/create-expo-module/src/create-expo-module.ts
+++ b/packages/create-expo-module/src/create-expo-module.ts
@@ -3,11 +3,11 @@ import chalk from 'chalk';
 import { Command, Option } from 'commander';
 import ejs from 'ejs';
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import prompts from 'prompts';
 import validateNpmPackage from 'validate-npm-package-name';
 
+import { addPlatformSupport } from './addPlatformSupport';
 import { ensureSafeModuleName } from './appleFrameworks';
 import { createExampleApp } from './createExampleApp';
 import { ALL_FEATURES, resolveFeatures } from './features';
@@ -29,55 +29,26 @@ import {
   getSubstitutionDataPrompts,
   type Platform,
 } from './prompts';
-import {
-  buildAppSnippets,
-  buildModuleSnippets,
-  buildViewSnippets,
-  buildWebModuleSnippets,
-  copyFileSnippets,
-} from './snippets';
+import { copyFileSnippets } from './snippets';
 import { eventCreateExpoModule, getTelemetryClient, logEventAsync } from './telemetry';
+import {
+  buildAugmentedData,
+  copyTemplateFiles,
+  downloadPackageAsync,
+  handleSuffix,
+  slugToAndroidPackage,
+} from './templateUtils';
 import type { CommandOptions, Feature, LocalSubstitutionData, SubstitutionData } from './types';
 import { buildDefaultsWarning } from './utils/defaults';
-import { env } from './utils/env';
 import { findGitHubEmail, findMyName } from './utils/git';
 import { findGitHubUserFromEmail, guessRepoUrl } from './utils/github';
 import { newStep } from './utils/ora';
-import { extractLocalTarball } from './utils/tar';
 
 const debug = require('debug')('create-expo-module:main') as typeof console.log;
 const packageJson = require('../package.json');
 
 // `yarn run` may change the current working dir, then we should use `INIT_CWD` env.
 const CWD = process.env.INIT_CWD || process.cwd();
-
-// Ignore some paths. Especially `package.json` as it is rendered
-// from `$package.json` file instead of the original one.
-const IGNORES_PATHS = [
-  '.DS_Store',
-  'build',
-  'node_modules',
-  'package.json',
-  '.npmignore',
-  '.gitignore',
-  'snippets',
-];
-
-// Files and top-level directories that only belong in standalone npm modules.
-// When generating a local module, these are skipped so the host project's tooling is used instead.
-const LOCAL_EXCLUDED_FILES = new Set([
-  '$package.json',
-  '$CHANGELOG.md',
-  '$.gitignore',
-  '$.npmignore',
-  '$.prettierrc',
-  'babel.config.js',
-  'eslint.config.cjs',
-  'tsconfig.json',
-  'README.md',
-  path.join('src', 'index.ts'),
-]);
-const LOCAL_EXCLUDED_DIRS = new Set(['example', 'internal']);
 
 // Url to the documentation on Expo Modules
 const DOCS_URL = 'https://docs.expo.dev/modules';
@@ -113,17 +84,6 @@ function slugToModuleName(slug: string): string {
     .replace(/^@/, '')
     .replace(/^./, (match) => match.toUpperCase())
     .replace(/\W+(\w)/g, (_, p1) => p1.toUpperCase());
-}
-
-/**
- * Converts a slug to an Android package name.
- */
-function slugToAndroidPackage(slug: string): string {
-  const namespace = slug
-    .replace(/\W/g, '')
-    .replace(/^(expo|reactnative)/, '')
-    .toLowerCase();
-  return `expo.modules.${namespace}`;
 }
 
 /**
@@ -486,158 +446,6 @@ async function resolvePackageManagerAsync(
 }
 
 /**
- * Recursively scans for the files within the directory. Returned paths are relative to the `root` path.
- */
-async function getFilesAsync(root: string, dir: string | null = null): Promise<string[]> {
-  const files: string[] = [];
-  const baseDir = dir ? path.join(root, dir) : root;
-
-  for (const file of await fs.promises.readdir(baseDir)) {
-    const relativePath = dir ? path.join(dir, file) : file;
-
-    if (IGNORES_PATHS.includes(relativePath) || IGNORES_PATHS.includes(file)) {
-      continue;
-    }
-
-    const fullPath = path.join(baseDir, file);
-    const stat = await fs.promises.lstat(fullPath);
-    if (stat.isDirectory()) {
-      files.push(...(await getFilesAsync(root, relativePath)));
-    } else {
-      files.push(relativePath);
-    }
-  }
-  return files;
-}
-
-/**
- * Downloads a package tarball using `npm pack` and returns the filename.
- */
-async function npmPackAsync(packageName: string, cwd: string): Promise<string> {
-  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-  const cmd = ['pack', packageName, '--json'];
-  const cmdString = `${npm} ${cmd.join(' ')}`;
-  debug('Run:', cmdString, `(cwd: ${cwd})`);
-
-  let results: string;
-  try {
-    results = (await spawnAsync(npm, cmd, { cwd })).stdout?.trim();
-  } catch (error: any) {
-    if (error?.stderr?.match(/npm ERR! code E404/)) {
-      const pkg =
-        error.stderr.match(/npm ERR! 404\s+'(.*)' is not in this registry\./)?.[1] ?? error.stderr;
-      throw new Error(`NPM package not found: ` + pkg);
-    }
-    throw error;
-  }
-
-  if (!results) {
-    throw new Error(`No output from "${cmdString}"`);
-  }
-
-  try {
-    const json = JSON.parse(results);
-    if (!Array.isArray(json) || !json[0]?.filename) {
-      throw new Error(`Invalid response from npm: ${results}`);
-    }
-    return json[0].filename;
-  } catch (error: any) {
-    throw new Error(
-      `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: ${error.message}`
-    );
-  }
-}
-
-/**
- * Gets expo SDK version major from the local package.json.
- */
-async function getLocalSdkMajorVersion(): Promise<string | null> {
-  const path = require.resolve('expo/package.json', { paths: [process.cwd()] });
-  if (!path) {
-    return null;
-  }
-  const { version } = require(path) ?? {};
-  return version?.split('.')[0] ?? null;
-}
-
-/**
- * Selects correct version of the template based on the SDK version for local modules and EXPO_BETA flag.
- */
-async function getTemplateVersion(isLocal: boolean) {
-  if (env.EXPO_BETA) {
-    return 'next';
-  }
-  if (!isLocal) {
-    return 'latest';
-  }
-  try {
-    const sdkVersionMajor = await getLocalSdkMajorVersion();
-    return sdkVersionMajor ? `sdk-${sdkVersionMajor}` : 'latest';
-  } catch {
-    console.log();
-    console.warn(
-      chalk.yellow(
-        "Couldn't determine the SDK version from the local project, using `latest` as the template version."
-      )
-    );
-    return 'latest';
-  }
-}
-
-/**
- * Downloads the template from NPM registry.
- */
-async function downloadPackageAsync(targetDir: string, isLocal = false): Promise<string> {
-  return await newStep('Downloading module template from npm', async (step) => {
-    const templateVersion = await getTemplateVersion(isLocal);
-    const packageName = 'expo-module-template';
-    const tmpDir = path.join(os.tmpdir(), '.create-expo-module');
-
-    await fs.promises.mkdir(tmpDir, { recursive: true });
-
-    let filename: string;
-    try {
-      filename = await npmPackAsync(`${packageName}@${templateVersion}`, tmpDir);
-    } catch {
-      console.log();
-      console.warn(
-        chalk.yellow(
-          "Couldn't download the versioned template from npm, falling back to the latest version."
-        )
-      );
-      filename = await npmPackAsync(`${packageName}@latest`, tmpDir);
-    }
-
-    await extractLocalTarball({
-      filePath: path.join(tmpDir, filename),
-      dir: targetDir,
-    });
-
-    await fs.promises.rm(tmpDir, { recursive: true, force: true });
-
-    step.succeed('Downloaded module template from npm registry.');
-
-    return path.join(targetDir, 'package');
-  });
-}
-
-function handleSuffix(name: string, suffix: string): string {
-  if (name.endsWith(suffix)) {
-    return name;
-  }
-  return `${name}${suffix}`;
-}
-
-/**
- * Maps template top-level directory names to the platform name in `expo-module.config.json`.
- * Files under these directories are only copied when the corresponding platform is selected.
- */
-const TEMPLATE_DIR_TO_PLATFORM: Record<string, Platform> = {
-  ios: 'apple',
-  android: 'android',
-};
-
-/**
  * Creates the module based on the `ejs` template (e.g. `expo-module-template` package).
  */
 async function createModuleFromTemplate(
@@ -646,107 +454,13 @@ async function createModuleFromTemplate(
   data: SubstitutionData | LocalSubstitutionData
 ) {
   const snippetsDir = path.join(templatePath, 'snippets');
-  const features = data.project.features;
-
-  // Build view-level snippets first (used inside the View() block)
-  const [viewSnippetsSwift, viewSnippetsKt] = await Promise.all([
-    buildViewSnippets(snippetsDir, features, data, 'swift'),
-    buildViewSnippets(snippetsDir, features, data, 'kt'),
-  ]);
-
-  // Build module-level snippets, passing the view snippets for injection
-  const [moduleSnippetsSwift, moduleSnippetsKt] = await Promise.all([
-    buildModuleSnippets(snippetsDir, features, data, 'swift', viewSnippetsSwift),
-    buildModuleSnippets(snippetsDir, features, data, 'kt', viewSnippetsKt),
-  ]);
-
-  // Build web module snippets and helpers
-  const webEventImport = features.includes('Event')
-    ? `\nimport { ${data.project.moduleName}Events } from './${data.project.name}.types';\n`
-    : '';
-  const webEventType = features.includes('Event') ? `${data.project.moduleName}Events` : '{}';
-  const webModuleSnippets = await buildWebModuleSnippets(snippetsDir, features, data);
-
-  // Build combined module import line for App.tsx
-  const needsDefaultImport = features.some((f) =>
-    (['Constant', 'Function', 'AsyncFunction', 'Event'] as string[]).includes(f)
-  );
-  const moduleNamedImports: string[] = [];
-  if (features.includes('View')) moduleNamedImports.push(data.project.viewName);
-  if (features.includes('SharedObject'))
-    moduleNamedImports.push(`use${data.project.sharedObjectName}`);
-
-  let appModuleCombinedImport = '';
-  if (needsDefaultImport || moduleNamedImports.length > 0) {
-    const parts: string[] = [];
-    if (needsDefaultImport) parts.push(data.project.name);
-    if (moduleNamedImports.length > 0) parts.push(`{ ${moduleNamedImports.join(', ')} }`);
-    appModuleCombinedImport = `import ${parts.join(', ')} from '${data.project.slug}';\n`;
-  }
-
-  const [appReactImportSnippets, appExternalImportSnippets, appHookSnippets, appJSXSnippets] =
-    await Promise.all([
-      buildAppSnippets(snippetsDir, features, data, 'react-imports'),
-      buildAppSnippets(snippetsDir, features, data, 'external-imports'),
-      buildAppSnippets(snippetsDir, features, data, 'hooks'),
-      buildAppSnippets(snippetsDir, features, data, 'jsx'),
-    ]);
-
-  const augmentedData = {
-    ...data,
-    moduleSnippetsSwift,
-    moduleSnippetsKt,
-    viewSnippetsSwift,
-    viewSnippetsKt,
-    webEventImport,
-    webEventType,
-    webModuleSnippets,
-    appModuleCombinedImport,
-    appExternalImportSnippets,
-    appReactImportSnippets,
-    appHookSnippets,
-    appJSXSnippets,
-  };
-
-  const files = await getFilesAsync(templatePath);
-
-  for (const file of files) {
-    // Skip platform-specific directories when the platform was not selected.
-    const topLevelDir = file.split(path.sep)[0] ?? '';
-    const requiredPlatform = TEMPLATE_DIR_TO_PLATFORM[topLevelDir];
-    if (requiredPlatform && !data.project.platforms.includes(requiredPlatform)) {
-      continue;
-    }
-
-    // Skip standalone-only files and directories for local modules.
-    if (data.type === 'local') {
-      if (LOCAL_EXCLUDED_FILES.has(file) || LOCAL_EXCLUDED_DIRS.has(topLevelDir)) {
-        continue;
-      }
-    }
-
-    const renderedRelativePath = ejs.render(file.replace(/^\$/, ''), augmentedData, {
-      openDelimiter: '{',
-      closeDelimiter: '}',
-      escape: (value: string) => value.replace(/\./g, path.sep),
-    });
-    const fromPath = path.join(templatePath, file);
-    const toPath = path.join(targetPath, renderedRelativePath);
-    const template = await fs.promises.readFile(fromPath, 'utf8');
-    const renderedContent = ejs.render(template, augmentedData);
-
-    if (!fs.existsSync(path.dirname(toPath))) {
-      await fs.promises.mkdir(path.dirname(toPath), { recursive: true });
-    }
-    await fs.promises.writeFile(toPath, renderedContent, 'utf8');
-  }
-
-  await copyFileSnippets(
-    snippetsDir,
-    features,
-    augmentedData as SubstitutionData | LocalSubstitutionData,
-    targetPath
-  );
+  const augmentedData = await buildAugmentedData(snippetsDir, data);
+  await copyTemplateFiles(templatePath, targetPath, augmentedData, {
+    platforms: data.project.platforms,
+    platformsOnly: false,
+    moduleType: data.type,
+  });
+  await copyFileSnippets(snippetsDir, data.project.features, data, targetPath);
 }
 
 async function createGitRepositoryAsync(targetDir: string) {
@@ -1140,6 +854,8 @@ function printFurtherLocalInstructions(
 
 const program = new Command();
 
+program.enablePositionalOptions();
+
 program
   .name(packageJson.name)
   .version(packageJson.version)
@@ -1188,6 +904,27 @@ program
     ).choices([...PACKAGE_MANAGERS])
   )
   .action(main);
+
+program
+  .command('add-platform-support [path]')
+  .description(
+    'Add platform support to an existing Expo module. ' +
+      'For example, add Android to an iOS-only module.' +
+      'This command should be ran from the root directory of an expo-module'
+  )
+  .option(
+    '-p, --platform <platforms...>',
+    `Platforms to add. Available values: ${ALL_PLATFORMS.join(', ')}.`
+  )
+  .option(
+    '--features <features...>',
+    `Override auto-detected features. Values: ${ALL_FEATURES.join(', ')}.`
+  )
+  .option(
+    '-s, --source <source_dir>',
+    'Local path to the template. By default it downloads `expo-module-template` from NPM.'
+  )
+  .action(addPlatformSupport);
 
 program.hook('postAction', async () => {
   await getTelemetryClient().flush?.();

--- a/packages/create-expo-module/src/featureDetection.ts
+++ b/packages/create-expo-module/src/featureDetection.ts
@@ -8,6 +8,7 @@ const functionPattern = /(?:^|\s)Function\s*\(/;
 const eventsPattern = /(?:^|\s)Events\s*\(/;
 const classPattern = /(?:^|\s)Class\s*\(/;
 const classNamePattern = /Class\s*\((\w+)(?:\.self|::class)/;
+const IGNORED_SEARCH_DIRS = new Set(['build', 'Pods', '.gradle', 'node_modules', 'DerivedData']);
 
 export type DetectedFeatures = {
   features: Feature[];
@@ -133,6 +134,9 @@ async function findFileWithContent(
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
     if (entry.isDirectory()) {
+      if (IGNORED_SEARCH_DIRS.has(entry.name)) {
+        continue;
+      }
       const result = await findFileWithContent(fullPath, ext, needle);
       if (result) return result;
     } else if (entry.name.endsWith(ext)) {

--- a/packages/create-expo-module/src/featureDetection.ts
+++ b/packages/create-expo-module/src/featureDetection.ts
@@ -1,0 +1,144 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { Feature } from './features';
+
+const asyncFunctionPattern = /(?:^|\s)AsyncFunction\s*\(/;
+const functionPattern = /(?:^|\s)Function\s*\(/;
+const eventsPattern = /(?:^|\s)Events\s*\(/;
+const classPattern = /(?:^|\s)Class\s*\(/;
+const classNamePattern = /Class\s*\((\w+)(?:\.self|::class)/;
+
+export type DetectedFeatures = {
+  features: Feature[];
+  /** Class name extracted from `Class(Name.self)` or `Class(Name::class)`, or null. */
+  sharedObjectName: string | null;
+};
+
+/**
+ * Reads a native module definition file and detects which Expo Modules API
+ * features it uses.
+ */
+export async function detectFeaturesFromFile(filePath: string): Promise<DetectedFeatures> {
+  const content = await fs.promises.readFile(filePath, 'utf-8');
+  return detectFeaturesFromContent(content);
+}
+
+/**
+ * Parses module definition content to detect features.
+ * Exported for unit testing.
+ */
+export function detectFeaturesFromContent(content: string): DetectedFeatures {
+  const lines = content.split('\n');
+  const features = new Set<Feature>();
+  let sharedObjectName: string | null = null;
+
+  type ViewBlockState = 'NOT_IN_VIEW' | 'WAITING_FOR_OPEN' | 'IN_VIEW';
+
+  let braceDepth = 0;
+  let viewBlockState: ViewBlockState = 'NOT_IN_VIEW';
+  let viewBlockEntryBraceDepth = -1; // braceDepth when View block { was seen
+
+  for (const line of lines) {
+    // Strip inline comments and surrounding whitespace.
+    const stripped = line.replace(/\/\/.*$/, '').trim();
+    if (!stripped) continue;
+
+    // The DSL uses `Constant("name") { ... }` (singular) per snippet templates.
+    // Match only at statement position to avoid false positives.
+    if (/(?:^|\s)Constant\s*\(/.test(stripped)) {
+      features.add('Constant');
+    }
+    // AsyncFunction must be checked before Function to avoid false positives.
+    if (asyncFunctionPattern.test(stripped)) {
+      features.add('AsyncFunction');
+    } else if (functionPattern.test(stripped)) {
+      features.add('Function');
+    }
+
+    // Require View( to be at the start of a statement or preceded by whitespace
+    // to avoid false positives from UIView(, NSView(, ScrollView(, etc.
+    if (/(?:^|\s)View\s*\(/.test(stripped)) {
+      features.add('View');
+      viewBlockState = 'WAITING_FOR_OPEN';
+    }
+
+    if (eventsPattern.test(stripped)) {
+      if (viewBlockState === 'IN_VIEW') {
+        features.add('ViewEvent');
+      } else {
+        features.add('Event');
+      }
+    }
+
+    if (classPattern.test(stripped)) {
+      features.add('SharedObject');
+      // Extract: Class(MyName.self) or Class(MyName::class)
+      const match = stripped.match(classNamePattern);
+      if (match?.[1]) {
+        sharedObjectName = match[1];
+      }
+    }
+
+    // ── Update brace depth ───────────────────────────────────────────────
+    const opens = (stripped.match(/\{/g) ?? []).length;
+    const closes = (stripped.match(/\}/g) ?? []).length;
+    braceDepth += opens - closes;
+
+    // Transition from WAITING_FOR_OPEN to IN_VIEW once we see a { on this line.
+    if (viewBlockState === 'WAITING_FOR_OPEN' && opens > 0) {
+      viewBlockState = 'IN_VIEW';
+      viewBlockEntryBraceDepth = braceDepth;
+    }
+
+    // Exit view block when depth drops below where it was when the block opened.
+    if (viewBlockState === 'IN_VIEW' && braceDepth < viewBlockEntryBraceDepth) {
+      viewBlockState = 'NOT_IN_VIEW';
+      viewBlockEntryBraceDepth = -1;
+    }
+  }
+
+  return { features: Array.from(features), sharedObjectName };
+}
+
+/**
+ * Searches a module's platform directory for the file containing `ModuleDefinition`.
+ * Returns the absolute path or null if not found.
+ *
+ * apple → scans ios/**\/*.swift
+ * android → scans android/src/**\/*.kt
+ */
+export async function findModuleDefinitionFile(
+  moduleRoot: string,
+  platform: 'apple' | 'android'
+): Promise<string | null> {
+  const searchDir =
+    platform === 'apple' ? path.join(moduleRoot, 'ios') : path.join(moduleRoot, 'android', 'src');
+
+  const ext = platform === 'apple' ? '.swift' : '.kt';
+  return findFileWithContent(searchDir, ext, 'ModuleDefinition');
+}
+
+async function findFileWithContent(
+  dir: string,
+  ext: string,
+  needle: string
+): Promise<string | null> {
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(dir, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const result = await findFileWithContent(fullPath, ext, needle);
+      if (result) return result;
+    } else if (entry.name.endsWith(ext)) {
+      const content = await fs.promises.readFile(fullPath, 'utf-8');
+      if (content.includes(needle)) return fullPath;
+    }
+  }
+  return null;
+}

--- a/packages/create-expo-module/src/snippets.ts
+++ b/packages/create-expo-module/src/snippets.ts
@@ -192,21 +192,19 @@ const FILE_SNIPPET_SPECS: FileSnippetSpec[] = [
   },
 ];
 
-/**
- * Copies whole-file snippets (view classes, SharedObject classes) to the target directory.
- */
-export async function copyFileSnippets(
+async function copySnippetsInternal(
   snippetsDir: string,
   features: string[],
   data: AnySubstitutionData,
-  targetDir: string
+  targetDir: string,
+  filter: (spec: (typeof FILE_SNIPPET_SPECS)[0]) => boolean
 ): Promise<void> {
   const selectedPlatforms: string[] = data.project.platforms;
 
   for (const spec of FILE_SNIPPET_SPECS) {
     if (!features.includes(spec.feature)) continue;
-    if (spec.platform === 'apple' && !selectedPlatforms.includes('apple')) continue;
-    if (spec.platform === 'android' && !selectedPlatforms.includes('android')) continue;
+    if (spec.platform && !selectedPlatforms.includes(spec.platform)) continue;
+    if (!filter(spec)) continue;
 
     const template = await readSnippet(snippetsDir, spec.feature, spec.source);
     if (!template) continue;
@@ -218,3 +216,12 @@ export async function copyFileSnippets(
     await fs.promises.writeFile(destPath, rendered, 'utf8');
   }
 }
+
+export const copyFileSnippets = (s: string, f: string[], d: AnySubstitutionData, t: string) =>
+  copySnippetsInternal(s, f, d, t, () => true);
+
+export const copyNativeFileSnippets = (s: string, f: string[], d: AnySubstitutionData, t: string) =>
+  copySnippetsInternal(s, f, d, t, (spec) => !!spec.platform);
+
+export const copyWebFileSnippets = (s: string, f: string[], d: AnySubstitutionData, t: string) =>
+  copySnippetsInternal(s, f, d, t, (spec) => spec.source.includes('.web.'));

--- a/packages/create-expo-module/src/snippets.ts
+++ b/packages/create-expo-module/src/snippets.ts
@@ -217,11 +217,26 @@ async function copySnippetsInternal(
   }
 }
 
-export const copyFileSnippets = (s: string, f: string[], d: AnySubstitutionData, t: string) =>
-  copySnippetsInternal(s, f, d, t, () => true);
+export const copyFileSnippets = (
+  snippetsDir: string,
+  features: string[],
+  data: AnySubstitutionData,
+  targetDir: string
+) => copySnippetsInternal(snippetsDir, features, data, targetDir, () => true);
 
-export const copyNativeFileSnippets = (s: string, f: string[], d: AnySubstitutionData, t: string) =>
-  copySnippetsInternal(s, f, d, t, (spec) => !!spec.platform);
+export const copyNativeFileSnippets = (
+  snippetsDir: string,
+  features: string[],
+  data: AnySubstitutionData,
+  targetDir: string
+) => copySnippetsInternal(snippetsDir, features, data, targetDir, (spec) => !!spec.platform);
 
-export const copyWebFileSnippets = (s: string, f: string[], d: AnySubstitutionData, t: string) =>
-  copySnippetsInternal(s, f, d, t, (spec) => spec.source.includes('.web.'));
+export const copyWebFileSnippets = (
+  snippetsDir: string,
+  features: string[],
+  data: AnySubstitutionData,
+  targetDir: string
+) =>
+  copySnippetsInternal(snippetsDir, features, data, targetDir, (spec) =>
+    spec.source.includes('.web.')
+  );

--- a/packages/create-expo-module/src/templateUtils.ts
+++ b/packages/create-expo-module/src/templateUtils.ts
@@ -1,0 +1,360 @@
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import ejs from 'ejs';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { Platform } from './prompts';
+import {
+  buildAppSnippets,
+  buildModuleSnippets,
+  buildViewSnippets,
+  buildWebModuleSnippets,
+} from './snippets';
+import type { LocalSubstitutionData, SubstitutionData } from './types';
+import { env } from './utils/env';
+import { newStep } from './utils/ora';
+import { extractLocalTarball } from './utils/tar';
+
+const debug = require('debug')('create-expo-module:main') as typeof console.log;
+
+// Ignore some paths. Especially `package.json` as it is rendered
+// from `$package.json` file instead of the original one.
+export const IGNORES_PATHS = [
+  '.DS_Store',
+  'build',
+  'node_modules',
+  'package.json',
+  '.npmignore',
+  '.gitignore',
+  'snippets',
+];
+
+// Files and top-level directories that only belong in standalone npm modules.
+// When generating a local module, these are skipped so the host project's tooling is used instead.
+export const LOCAL_EXCLUDED_FILES = new Set([
+  '$package.json',
+  '$CHANGELOG.md',
+  '$.gitignore',
+  '$.npmignore',
+  '$.prettierrc',
+  'babel.config.js',
+  'eslint.config.cjs',
+  'tsconfig.json',
+  'README.md',
+  path.join('src', 'index.ts'),
+]);
+export const LOCAL_EXCLUDED_DIRS = new Set(['example', 'internal']);
+
+/**
+ * Maps template top-level directory names to the platform name in `expo-module.config.json`.
+ * Files under these directories are only copied when the corresponding platform is selected.
+ */
+export const TEMPLATE_DIR_TO_PLATFORM: Record<string, Platform> = {
+  ios: 'apple',
+  android: 'android',
+};
+
+export function handleSuffix(name: string, suffix: string): string {
+  if (name.endsWith(suffix)) {
+    return name;
+  }
+  return `${name}${suffix}`;
+}
+
+/**
+ * Converts a slug to an Android package name.
+ */
+export function slugToAndroidPackage(slug: string): string {
+  const namespace = slug
+    .replace(/\W/g, '')
+    .replace(/^(expo|reactnative)/, '')
+    .toLowerCase();
+  return `expo.modules.${namespace}`;
+}
+
+/**
+ * Recursively scans for the files within the directory. Returned paths are relative to the `root` path.
+ */
+export async function getFilesAsync(root: string, dir: string | null = null): Promise<string[]> {
+  const files: string[] = [];
+  const baseDir = dir ? path.join(root, dir) : root;
+
+  for (const file of await fs.promises.readdir(baseDir)) {
+    const relativePath = dir ? path.join(dir, file) : file;
+
+    if (IGNORES_PATHS.includes(relativePath) || IGNORES_PATHS.includes(file)) {
+      continue;
+    }
+
+    const fullPath = path.join(baseDir, file);
+    const stat = await fs.promises.lstat(fullPath);
+    if (stat.isDirectory()) {
+      files.push(...(await getFilesAsync(root, relativePath)));
+    } else {
+      files.push(relativePath);
+    }
+  }
+  return files;
+}
+
+/**
+ * Downloads a package tarball using `npm pack` and returns the filename.
+ */
+async function npmPackAsync(packageName: string, cwd: string): Promise<string> {
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+  const cmd = ['pack', packageName, '--json'];
+  const cmdString = `${npm} ${cmd.join(' ')}`;
+  debug('Run:', cmdString, `(cwd: ${cwd})`);
+
+  let results: string;
+  try {
+    results = (await spawnAsync(npm, cmd, { cwd })).stdout?.trim();
+  } catch (error: any) {
+    if (error?.stderr?.match(/npm ERR! code E404/)) {
+      const pkg =
+        error.stderr.match(/npm ERR! 404\s+'(.*)' is not in this registry\./)?.[1] ?? error.stderr;
+      throw new Error(`NPM package not found: ` + pkg);
+    }
+    throw error;
+  }
+
+  if (!results) {
+    throw new Error(`No output from "${cmdString}"`);
+  }
+
+  try {
+    const json = JSON.parse(results);
+    if (!Array.isArray(json) || !json[0]?.filename) {
+      throw new Error(`Invalid response from npm: ${results}`);
+    }
+    return json[0].filename;
+  } catch (error: any) {
+    throw new Error(
+      `Could not parse JSON returned from "${cmdString}".\n\n${results}\n\nError: ${error.message}`
+    );
+  }
+}
+
+/**
+ * Gets expo SDK version major from the local package.json.
+ */
+async function getLocalSdkMajorVersion(): Promise<string | null> {
+  const path = require.resolve('expo/package.json', { paths: [process.cwd()] });
+  if (!path) {
+    return null;
+  }
+  const { version } = require(path) ?? {};
+  return version?.split('.')[0] ?? null;
+}
+
+/**
+ * Selects correct version of the template based on the SDK version for local modules and EXPO_BETA flag.
+ */
+async function getTemplateVersion(isLocal: boolean) {
+  if (env.EXPO_BETA) {
+    return 'next';
+  }
+  if (!isLocal) {
+    return 'latest';
+  }
+  try {
+    const sdkVersionMajor = await getLocalSdkMajorVersion();
+    return sdkVersionMajor ? `sdk-${sdkVersionMajor}` : 'latest';
+  } catch {
+    console.log();
+    console.warn(
+      chalk.yellow(
+        "Couldn't determine the SDK version from the local project, using `latest` as the template version."
+      )
+    );
+    return 'latest';
+  }
+}
+
+/**
+ * Downloads the template from NPM registry.
+ */
+export async function downloadPackageAsync(targetDir: string, isLocal = false): Promise<string> {
+  return await newStep('Downloading module template from npm', async (step) => {
+    const templateVersion = await getTemplateVersion(isLocal);
+    const packageName = 'expo-module-template';
+    const tmpDir = path.join(os.tmpdir(), '.create-expo-module');
+
+    await fs.promises.mkdir(tmpDir, { recursive: true });
+
+    let filename: string;
+    try {
+      filename = await npmPackAsync(`${packageName}@${templateVersion}`, tmpDir);
+    } catch {
+      console.log();
+      console.warn(
+        chalk.yellow(
+          "Couldn't download the versioned template from npm, falling back to the latest version."
+        )
+      );
+      filename = await npmPackAsync(`${packageName}@latest`, tmpDir);
+    }
+
+    await extractLocalTarball({
+      filePath: path.join(tmpDir, filename),
+      dir: targetDir,
+    });
+
+    await fs.promises.rm(tmpDir, { recursive: true, force: true });
+
+    step.succeed('Downloaded module template from npm registry.');
+
+    return path.join(targetDir, 'package');
+  });
+}
+
+/**
+ * Builds the augmented substitution data object by rendering all snippet slots.
+ * Extracted from `createModuleFromTemplate` for reuse.
+ */
+export async function buildAugmentedData(
+  snippetsDir: string,
+  data: SubstitutionData | LocalSubstitutionData
+) {
+  const features = data.project.features;
+
+  // Build view-level snippets first (used inside the View() block)
+  const [viewSnippetsSwift, viewSnippetsKt] = await Promise.all([
+    buildViewSnippets(snippetsDir, features, data, 'swift'),
+    buildViewSnippets(snippetsDir, features, data, 'kt'),
+  ]);
+
+  // Build module-level snippets, passing the view snippets for injection
+  const [moduleSnippetsSwift, moduleSnippetsKt] = await Promise.all([
+    buildModuleSnippets(snippetsDir, features, data, 'swift', viewSnippetsSwift),
+    buildModuleSnippets(snippetsDir, features, data, 'kt', viewSnippetsKt),
+  ]);
+
+  // Build web module snippets and helpers
+  const webEventImport = features.includes('Event')
+    ? `\nimport { ${data.project.moduleName}Events } from './${data.project.name}.types';\n`
+    : '';
+  const webEventType = features.includes('Event') ? `${data.project.moduleName}Events` : '{}';
+  const webModuleSnippets = await buildWebModuleSnippets(snippetsDir, features, data);
+
+  // Build combined module import line for App.tsx
+  const needsDefaultImport = features.some((f) =>
+    (['Constant', 'Function', 'AsyncFunction', 'Event'] as string[]).includes(f)
+  );
+  const moduleNamedImports: string[] = [];
+  if (features.includes('View')) moduleNamedImports.push(data.project.viewName);
+  if (features.includes('SharedObject'))
+    moduleNamedImports.push(`use${data.project.sharedObjectName}`);
+
+  let appModuleCombinedImport = '';
+  if (needsDefaultImport || moduleNamedImports.length > 0) {
+    const parts: string[] = [];
+    if (needsDefaultImport) parts.push(data.project.name);
+    if (moduleNamedImports.length > 0) parts.push(`{ ${moduleNamedImports.join(', ')} }`);
+    appModuleCombinedImport = `import ${parts.join(', ')} from '${data.project.slug}';\n`;
+  }
+
+  const [appReactImportSnippets, appExternalImportSnippets, appHookSnippets, appJSXSnippets] =
+    await Promise.all([
+      buildAppSnippets(snippetsDir, features, data, 'react-imports'),
+      buildAppSnippets(snippetsDir, features, data, 'external-imports'),
+      buildAppSnippets(snippetsDir, features, data, 'hooks'),
+      buildAppSnippets(snippetsDir, features, data, 'jsx'),
+    ]);
+
+  return {
+    ...data,
+    moduleSnippetsSwift,
+    moduleSnippetsKt,
+    viewSnippetsSwift,
+    viewSnippetsKt,
+    webEventImport,
+    webEventType,
+    webModuleSnippets,
+    appModuleCombinedImport,
+    appExternalImportSnippets,
+    appReactImportSnippets,
+    appHookSnippets,
+    appJSXSnippets,
+  };
+}
+
+/**
+ * Copies template files to the target directory.
+ */
+export async function copyTemplateFiles(
+  templatePath: string,
+  targetPath: string,
+  augmentedData: Awaited<ReturnType<typeof buildAugmentedData>>,
+  options: {
+    platforms: Platform[];
+    platformsOnly?: boolean;
+    moduleType: 'standalone' | 'local';
+  }
+): Promise<void> {
+  const { platforms, platformsOnly = false, moduleType } = options;
+  const files = await getFilesAsync(templatePath);
+
+  for (const file of files) {
+    // Skip platform-specific directories when the platform was not selected.
+    const topLevelDir = file.split(path.sep)[0] ?? '';
+    const requiredPlatform = TEMPLATE_DIR_TO_PLATFORM[topLevelDir];
+
+    if (platformsOnly) {
+      if (!requiredPlatform || !platforms.includes(requiredPlatform)) continue;
+    } else {
+      if (requiredPlatform && !platforms.includes(requiredPlatform)) continue;
+      if (moduleType === 'local') {
+        if (LOCAL_EXCLUDED_FILES.has(file) || LOCAL_EXCLUDED_DIRS.has(topLevelDir)) continue;
+      }
+    }
+
+    const renderedRelativePath = ejs.render(file.replace(/^\$/, ''), augmentedData, {
+      openDelimiter: '{',
+      closeDelimiter: '}',
+      escape: (value: string) => value.replace(/\./g, path.sep),
+    });
+    const fromPath = path.join(templatePath, file);
+    const toPath = path.join(targetPath, renderedRelativePath);
+    const template = await fs.promises.readFile(fromPath, 'utf8');
+    const renderedContent = ejs.render(template, augmentedData);
+
+    if (!fs.existsSync(path.dirname(toPath))) {
+      await fs.promises.mkdir(path.dirname(toPath), { recursive: true });
+    }
+    await fs.promises.writeFile(toPath, renderedContent, 'utf8');
+  }
+}
+
+/**
+ * Re-renders the .web.ts stub as a full web implementation using the provided data.
+ * Called when adding `web` to a module that already has native platforms.
+ */
+export async function updateWebStub(
+  templatePath: string,
+  targetDir: string,
+  data: SubstitutionData | LocalSubstitutionData
+): Promise<void> {
+  const snippetsDir = path.join(templatePath, 'snippets');
+  const augmentedData = await buildAugmentedData(snippetsDir, data);
+
+  // Template filename uses EJS: src/{%- project.moduleName %}.web.ts
+  const templateRelFile = path.join('src', `{%- project.moduleName %}.web.ts`);
+  const renderedFileName = ejs.render(templateRelFile.replace(/^\$/, ''), augmentedData, {
+    openDelimiter: '{',
+    closeDelimiter: '}',
+    escape: (value: string) => value.replace(/\./g, path.sep),
+  });
+
+  const fromPath = path.join(templatePath, templateRelFile);
+  const toPath = path.join(targetDir, renderedFileName);
+  const template = await fs.promises.readFile(fromPath, 'utf8');
+  const renderedContent = ejs.render(template, augmentedData);
+
+  if (!fs.existsSync(path.dirname(toPath))) {
+    await fs.promises.mkdir(path.dirname(toPath), { recursive: true });
+  }
+  await fs.promises.writeFile(toPath, renderedContent, 'utf8');
+}

--- a/packages/create-expo-module/src/templateUtils.ts
+++ b/packages/create-expo-module/src/templateUtils.ts
@@ -56,6 +56,10 @@ export const TEMPLATE_DIR_TO_PLATFORM: Record<string, Platform> = {
   android: 'android',
 };
 
+export function getGeneratedWebStubSentinel(moduleName: string): string {
+  return `${moduleName} is not available on the web platform`;
+}
+
 export function handleSuffix(name: string, suffix: string): string {
   if (name.endsWith(suffix)) {
     return name;
@@ -350,6 +354,17 @@ export async function updateWebStub(
 
   const fromPath = path.join(templatePath, templateRelFile);
   const toPath = path.join(targetDir, renderedFileName);
+  if (fs.existsSync(toPath)) {
+    const currentContent = await fs.promises.readFile(toPath, 'utf8');
+    const sentinel = getGeneratedWebStubSentinel(data.project.moduleName);
+    if (!currentContent.includes(sentinel)) {
+      throw new Error(
+        `Refusing to overwrite ${toPath} because it does not look like the generated web stub.\n` +
+          `Move your custom web implementation or restore the generated "${sentinel}" stub before running this command.`
+      );
+    }
+  }
+
   const template = await fs.promises.readFile(fromPath, 'utf8');
   const renderedContent = ejs.render(template, augmentedData);
 

--- a/packages/create-expo-module/src/utils/env.ts
+++ b/packages/create-expo-module/src/utils/env.ts
@@ -22,3 +22,21 @@ export const env = {
     return boolish('EXPO_LOCAL', false);
   },
 };
+
+/**
+ * Determines if we're in an interactive environment.
+ * Non-interactive when: CI=1/true, Expo's non-interactive flag is set, or stdin is non-TTY.
+ */
+export function isInteractive(): boolean {
+  const ci = process.env.CI;
+  if (ci === '1' || ci?.toLowerCase() === 'true') {
+    return false;
+  }
+  if (process.env.EXPO_NONINTERACTIVE) {
+    return false;
+  }
+  if (!process.stdin.isTTY) {
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
# Why

Allows users to add support for other platforms to existing expo modules.

# How
Add `addPlatformSupport` subcommand.
The script detects the available platforms, then does an analysis of the DSL to find features used in the module. Based on that, selected features are chosen from the template and added into the project.
The template snippets are shared with base `create-expo-module` command.

# Test Plan

Tested by adding e2e tests and running in existing modules such as `expo-image` and `expo-video` after removing `ios` directories from them.
