### PR TITLE
[docs] add repack doc

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -508,6 +508,7 @@ export const eas = [
         makePage('build-reference/app-extensions.mdx'),
         makePage('build-reference/easignore.mdx'),
         makePage('build-reference/npx-testflight.mdx'),
+        makePage('build-reference/repack.mdx'),
         makePage('build-reference/limitations.mdx'),
       ],
       { expanded: false }

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -7,7 +7,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 [`@expo/repack-app`](https://www.npmjs.com/package/@expo/repack-app) is a CLI tool that repackages an existing Android APK, iOS IPA, or iOS **.app** bundle with an updated JavaScript bundle, assets, and app metadata — such as the app name, version, and bundle identifier — without performing a full native rebuild. It also handles Expo-specific concerns like the expo-updates manifest and embedded assets. Because no native compilation is involved, a repack is typically much faster than a full native build.
 
-To learn more about how fingerprint and repack work together to accelerate CI, see [Accelerating Continuous Integration with Fingerprint & Repack in EAS Workflows](https://expo.dev/blog/accelerating-continuous-integration-with-fingerprint-repack-in-eas-workflows).
+To learn more about how fingerprint and repack work together to accelerate CI, see [Accelerating Continuous Integration with Fingerprint and Repack in EAS Workflows](https://expo.dev/blog/accelerating-continuous-integration-with-fingerprint-repack-in-eas-workflows).
 
 ## Prerequisites
 
@@ -92,7 +92,7 @@ See the [iOS-specific options](#ios-specific-options) for the full list of signi
 
 EAS Workflows provides a pre-packaged `repack` job type that handles signing and build management automatically. See [EAS Workflows pre-packaged jobs](/eas/workflows/pre-packaged-jobs/#repack) for full syntax, parameters, and examples.
 
-## JS-bundle-only mode
+## `--js-bundle-only` mode
 
 By default, repack updates the JS bundle, assets, and native metadata (app name, version, bundle identifier, and the expo-updates manifest). Pass `--js-bundle-only` when you intentionally want to update only the JS bundle and leave all native config untouched.
 

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -1,0 +1,154 @@
+---
+title: Repack app
+description: Repackage an existing APK, IPA, or .app with an updated JS bundle without a full native rebuild.
+---
+
+import { Terminal } from '~/ui/components/Snippet';
+
+[`@expo/repack-app`](https://www.npmjs.com/package/@expo/repack-app) is a CLI tool that repackages an existing Android APK, iOS IPA, or iOS **.app** bundle with an updated JavaScript bundle, assets, and app metadata — such as the app name, version, and bundle identifier — without performing a full native rebuild. It also handles Expo-specific concerns like the expo-updates manifest and embedded assets. Because no native compilation is involved, a repack is typically much faster than a full native build.
+
+To learn more about how fingerprint and repack work together to accelerate CI, see [Accelerating Continuous Integration with Fingerprint & Repack in EAS Workflows](https://expo.dev/blog/accelerating-continuous-integration-with-fingerprint-repack-in-eas-workflows).
+
+## Prerequisites
+
+- An existing build artifact produced from your Expo project: an APK for Android; an IPA or **.app** bundle for iOS.
+- (Optional) Signing credentials if the repacked artifact needs to be installable on a device — see [Signing](#signing).
+
+## When to use repack
+
+Repack assumes the source binary's native side is unchanged since it was built. If you added a native dependency, changed a config plugin, or upgraded the Expo SDK, a repacked artifact will have JS that expects native APIs that do not exist, and will likely crash at runtime. Use [fingerprint](/versions/latest/sdk/fingerprint/) to compare the source binary's native identity against your current project — if the fingerprints match, repack is safe; if they differ, do a full native build instead.
+
+Repack is not a replacement for [EAS Update](/eas-update/introduction/). EAS Update ships a new JS bundle to apps that are already installed, and users see it on the next launch. Repack produces a new installable artifact. A good rule of thumb: use repack for internal testing (QA devices, testers, CI smoke tests) and use EAS Update to deliver JS changes to production users.
+
+## Standalone CLI usage
+
+Run the command from your project's root directory. At minimum, `--platform` and `--source-app` are required. The tool runs `npx expo export:embed` under the hood to produce a fresh JS bundle, swaps it into the source binary, and writes the output artifact.
+
+The output format always matches the `--source-app` input: an APK input produces an APK, an IPA produces an IPA, and a **.app** bundle produces a **.app** bundle.
+
+### Android
+
+<Terminal cmd={['$ npx @expo/repack-app --platform android --source-app MyApp.apk']} />
+
+### iOS
+
+Using an IPA:
+
+<Terminal cmd={['$ npx @expo/repack-app --platform ios --source-app MyApp.ipa']} />
+
+Using a **.app** bundle (for simulator builds — iOS device artifacts are always IPAs):
+
+<Terminal cmd={['$ npx @expo/repack-app --platform ios --source-app MyApp.app']} />
+
+## Signing
+
+To produce an artifact installable on a physical device, pass signing credentials alongside `--platform` and `--source-app`. Without them, the Android APK is output unsigned and the iOS IPA cannot be installed on a device. iOS **.app** bundles intended for the simulator do not need signing and can skip this step.
+
+If you do not already have signing credentials locally, see [App credentials](/app-signing/app-credentials/) for how to obtain a keystore (Android) or a signing identity and provisioning profile (iOS).
+
+### Android
+
+Re-sign the repacked APK with a keystore:
+
+<Terminal
+  cmd={[
+    '$ npx @expo/repack-app \\',
+    '  --platform android \\',
+    '  --source-app MyApp.apk \\',
+    '  --ks keystore.jks \\',
+    '  --ks-key-alias my-alias',
+  ]}
+  cmdCopy="npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias"
+/>
+
+See the [Android-specific options](#android-specific-options) for keystore password flags and other settings.
+
+### iOS
+
+Pass a signing identity and provisioning profile:
+
+> **Note**: iOS repacking supports ad-hoc and development signing only.
+
+<Terminal
+  cmd={[
+    '$ npx @expo/repack-app \\',
+    '  --platform ios \\',
+    '  --source-app MyApp.ipa \\',
+    '  --signing-identity "Apple Distribution: ..." \\',
+    '  --provisioning-profile /path/to/profile.mobileprovision',
+  ]}
+  cmdCopy='npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision'
+/>
+
+See the [iOS-specific options](#ios-specific-options) for the full list of signing flags.
+
+## Use cases
+
+- **QA cycles**: Distribute one base build to testers, then repack with JS fixes for each iteration without waiting for a native rebuild.
+- **CI optimization**: Build native once per fingerprint, then repack the JS bundle on every subsequent PR to cut wait times from minutes to seconds.
+- **Branch testing**: Test multiple JS branches against the same native binary to isolate JavaScript-only changes.
+
+## Usage in EAS Workflows
+
+EAS Workflows provides a pre-packaged `repack` job type that handles signing and build management automatically. See [EAS Workflows pre-packaged jobs](/eas/workflows/pre-packaged-jobs/#repack) for full syntax, parameters, and examples.
+
+## JS-bundle-only mode
+
+By default, repack updates the JS bundle, assets, and native metadata (app name, version, bundle identifier, and the expo-updates manifest). Pass `--js-bundle-only` when you intentionally want to update only the JS bundle and leave all native config untouched.
+
+<Terminal
+  cmd={[
+    '$ npx @expo/repack-app \\',
+    '  --platform android \\',
+    '  --source-app MyApp.apk \\',
+    '  --js-bundle-only',
+  ]}
+  cmdCopy="npx @expo/repack-app --platform android --source-app MyApp.apk --js-bundle-only"
+/>
+
+## Limitations
+
+- Repack is not recommended for production App Store or Play Store submissions. Production builds should go through the complete build pipeline for correct symbolication and signing.
+
+## CLI reference
+
+```text
+Usage: @expo/repack-app [options] [project-root]
+```
+
+### Arguments
+
+| Argument | Description |
+| --- | --- |
+| `[project-root]` | Path to the project root. Defaults to the current working directory. |
+
+### Options
+
+| Option | Description |
+| --- | --- |
+| `-p, --platform <platform>` | **Required.** Platform to repack the app for (`android` or `ios`). |
+| `--source-app <path>` | **Required.** Path to the source app (APK for Android; IPA or **.app** for iOS). The output format matches the input. |
+| `-o, --output <path>` | Path to the output artifact. Defaults to `repacked.apk`, `repacked.ipa`, or `repacked.app` in the project root, matching the source format. |
+| `-w, --working-directory <path>` | Path to the working directory for temporary files. |
+| `--skip-working-dir-cleanup` | Skip cleaning up the working directory after the repack completes. Useful for debugging. |
+| `-v, --verbose` | Enable verbose logging. |
+| `--js-bundle-only` | Only update the JS bundle and skip native config updates (such as app name, version, and other metadata). |
+| `--embed-bundle-assets` | Force running `npx expo export:embed` to generate the JS bundle and assets, even for debug builds where the bundle is normally loaded from a dev server. |
+| `--bundle-assets-sourcemap-output <path>` | Generate a source map at the specified path. Requires `--embed-bundle-assets`. |
+
+### Android-specific options
+
+| Option | Description |
+| --- | --- |
+| `--ks <path>` | Path to the keystore file. |
+| `--ks-pass <password>` | Keystore password. Defaults to `pass:android`. Supported formats: `pass:<password>`, `env:<name>`, `file:<file>`. |
+| `--ks-key-alias <alias>` | Keystore key alias. |
+| `--ks-key-pass <password>` | Keystore key password. Supported formats: `pass:<password>`, `env:<name>`, `file:<file>`. |
+| `--android-build-tools-dir <path>` | Path to the Android SDK build-tools directory. |
+
+### iOS-specific options
+
+| Option | Description |
+| --- | --- |
+| `--signing-identity <identity>` | Code signing identity. |
+| `--provisioning-profile <path>` | Path to a provisioning profile. Alternatively, a JSON-encoded value for multi-target apps (for example, when bundling app extensions). |

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -71,7 +71,11 @@ If you do not already have signing credentials locally, see [App credentials](/a
 
 <Tab label="Android">
 
-<Terminal cmd={['$ npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias']} />
+<Terminal
+  cmd={[
+    '$ npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias',
+  ]}
+/>
 
 See the [Android-specific options](#android-specific-options) for keystore password flags and other settings.
 
@@ -83,7 +87,11 @@ Pass a signing identity and provisioning profile:
 
 > **Note**: iOS repacking supports ad-hoc and development signing only.
 
-<Terminal cmd={['$ npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision']} />
+<Terminal
+  cmd={[
+    '$ npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision',
+  ]}
+/>
 
 See the [iOS-specific options](#ios-specific-options) for the full list of signing flags.
 

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -1,30 +1,30 @@
 ---
 title: Repack app
-description: Repackage an existing APK, IPA, or .app with an updated JS bundle without a full native rebuild.
+description: Repackage an existing APK, IPA, or .app with an updated JavaScript bundle without a full native rebuild.
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
 
-[`@expo/repack-app`](https://www.npmjs.com/package/@expo/repack-app) is a CLI tool that repackages an existing Android APK, iOS IPA, or iOS **.app** bundle with an updated JavaScript bundle, assets, and app metadata — such as the app name, version, and bundle identifier — without performing a full native rebuild. It also handles Expo-specific concerns like the expo-updates manifest and embedded assets. Because no native compilation is involved, a repack is typically much faster than a full native build.
+[`@expo/repack-app`](https://www.npmjs.com/package/@expo/repack-app) is a CLI tool that repackages an existing Android APK, iOS IPA, or iOS **.app** bundle without performing a full native build. It updates the existing artifact with a new JavaScript (JS) bundle, assets, and app metadata (such as, app name, version, and package name or bundle identifier). Since there is no native compilation involved, a repack is typically much faster than a full native build.
 
-To learn more about how fingerprint and repack work together to accelerate CI, see [Accelerating Continuous Integration with Fingerprint and Repack in EAS Workflows](https://expo.dev/blog/accelerating-continuous-integration-with-fingerprint-repack-in-eas-workflows).
+To learn more about how fingerprint and repack work together to accelerate CI, see [Accelerating Continuous Integration with Fingerprint and Repack in EAS Workflows](https://expo.dev/blog/accelerating-continuous-integration-with-fingerprint-repack-in-eas-workflows) blog post.
 
 ## Prerequisites
 
-- An existing build artifact produced from your Expo project: an APK for Android; an IPA or **.app** bundle for iOS.
-- (Optional) Signing credentials if the repacked artifact needs to be installable on a device — see [Signing](#signing).
+- An existing build artifact produced from your Expo project: an APK for Android, or an IPA or **.app** bundle for iOS.
+- (Optional) Signing credentials if the repacked artifact needs to be installable on a device. For more information, see [Signing](#signing).
 
 ## When to use repack
 
-Repack assumes the source binary's native side is unchanged since it was built. If you added a native dependency, changed a config plugin, or upgraded the Expo SDK, a repacked artifact will have JS that expects native APIs that do not exist, and will likely crash at runtime. Use [fingerprint](/versions/latest/sdk/fingerprint/) to compare the source binary's native identity against your current project — if the fingerprints match, repack is safe; if they differ, do a full native build instead.
+Repack assumes the source binary's native side is unchanged since it was built. If you added a native dependency, changed a [config plugin](/config-plugins/introduction/), or upgraded the Expo SDK, a repacked artifact will have JS that expects native APIs that do not exist, and will likely crash at runtime. Use [fingerprint](/versions/latest/sdk/fingerprint/) to compare the source binary's native identity against your current project. If the fingerprints match, then repack is safe. If they differ, do a full native build instead.
 
-Repack is not a replacement for [EAS Update](/eas-update/introduction/). EAS Update ships a new JS bundle to apps that are already installed, and users see it on the next launch. Repack produces a new installable artifact. A good rule of thumb: use repack for internal testing (QA devices, testers, CI smoke tests) and use EAS Update to deliver JS changes to production users.
+Repack is not a replacement for [EAS Update](/eas-update/introduction/). EAS Update ships a new JS bundle to apps that are already installed, and users see it on the next launch. Repack produces a new installable artifact. A good rule of thumb is to use repack for internal testing (QA devices, testers, CI smoke tests) and use EAS Update to deliver JS changes to production users.
 
 ## Standalone CLI usage
 
-Run the command from your project's root directory. At minimum, `--platform` and `--source-app` are required. The tool runs `npx expo export:embed` under the hood to produce a fresh JS bundle, swaps it into the source binary, and writes the output artifact.
+You need to run the commands specified for Android and iOS platforms below from your project's root directory. At minimum, `--platform` and `--source-app` are required. The tool runs `npx expo export:embed` under the hood to produce a fresh JS bundle, swaps it into the source binary, and writes the output artifact.
 
-The output format always matches the `--source-app` input: an APK input produces an APK, an IPA produces an IPA, and a **.app** bundle produces a **.app** bundle.
+The output format always matches the `--source-app` input. An APK input produces an APK, an IPA produces an IPA, and a **.app** bundle produces a **.app** bundle.
 
 ### Android
 
@@ -36,7 +36,7 @@ Using an IPA:
 
 <Terminal cmd={['$ npx @expo/repack-app --platform ios --source-app MyApp.ipa']} />
 
-Using a **.app** bundle (for simulator builds — iOS device artifacts are always IPAs):
+Using a **.app** bundle (for simulator builds, the iOS device artifacts are always IPAs):
 
 <Terminal cmd={['$ npx @expo/repack-app --platform ios --source-app MyApp.app']} />
 
@@ -70,14 +70,7 @@ Pass a signing identity and provisioning profile:
 > **Note**: iOS repacking supports ad-hoc and development signing only.
 
 <Terminal
-  cmd={[
-    '$ npx @expo/repack-app \\',
-    '  --platform ios \\',
-    '  --source-app MyApp.ipa \\',
-    '  --signing-identity "Apple Distribution: ..." \\',
-    '  --provisioning-profile /path/to/profile.mobileprovision',
-  ]}
-  cmdCopy='npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision'
+  cmd={[ '$ npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision',
 />
 
 See the [iOS-specific options](#ios-specific-options) for the full list of signing flags.
@@ -94,17 +87,9 @@ EAS Workflows provides a pre-packaged `repack` job type that handles signing and
 
 ## `--js-bundle-only` mode
 
-By default, repack updates the JS bundle, assets, and native metadata (app name, version, bundle identifier, and the expo-updates manifest). Pass `--js-bundle-only` when you intentionally want to update only the JS bundle and leave all native config untouched.
+By default, repack updates the JS bundle, assets, and app metadata (app name, version, bundle identifier, and the expo-updates manifest). Pass `--js-bundle-only` when you intentionally want to update only the JS bundle and leave all native config untouched.
 
-<Terminal
-  cmd={[
-    '$ npx @expo/repack-app \\',
-    '  --platform android \\',
-    '  --source-app MyApp.apk \\',
-    '  --js-bundle-only',
-  ]}
-  cmdCopy="npx @expo/repack-app --platform android --source-app MyApp.apk --js-bundle-only"
-/>
+<Terminal cmd={['$ npx @expo/repack-app --platform android --source-app MyApp.apk --js-bundle-only']} />
 
 ## Limitations
 
@@ -127,7 +112,7 @@ Usage: @expo/repack-app [options] [project-root]
 | Option                                    | Description                                                                                                                                              |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-p, --platform <platform>`               | **Required.** Platform to repack the app for (`android` or `ios`).                                                                                       |
-| `--source-app <path>`                     | **Required.** Path to the source app (APK for Android; IPA or **.app** for iOS). The output format matches the input.                                    |
+| `--source-app <path>`                     | **Required.** Path to the source app (APK for Android, or IPA or **.app** for iOS). The output format matches the input.                                    |
 | `-o, --output <path>`                     | Path to the output artifact. Defaults to `repacked.apk`, `repacked.ipa`, or `repacked.app` in the project root, matching the source format.              |
 | `-w, --working-directory <path>`          | Path to the working directory for temporary files.                                                                                                       |
 | `--skip-working-dir-cleanup`              | Skip cleaning up the working directory after the repack completes. Useful for debugging.                                                                 |

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -51,7 +51,9 @@ If you do not already have signing credentials locally, see [App credentials](/a
 Re-sign the repacked APK with a keystore:
 
 <Terminal
-  cmd={[ '$ npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias' ]}
+  cmd={[
+    '$ npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias',
+  ]}
 />
 
 See the [Android-specific options](#android-specific-options) for keystore password flags and other settings.
@@ -63,7 +65,9 @@ Pass a signing identity and provisioning profile:
 > **Note**: iOS repacking supports ad-hoc and development signing only.
 
 <Terminal
-  cmd={[ '$ npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision',
+  cmd={[
+    '$ npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision',
+  ]}
 />
 
 See the [iOS-specific options](#ios-specific-options) for the full list of signing flags.
@@ -82,7 +86,9 @@ EAS Workflows provides a pre-packaged `repack` job type that handles signing and
 
 By default, repack updates the JS bundle, assets, and app metadata (app name, version, bundle identifier, and the expo-updates manifest). Pass `--js-bundle-only` when you intentionally want to update only the JS bundle and leave all native config untouched.
 
-<Terminal cmd={['$ npx @expo/repack-app --platform android --source-app MyApp.apk --js-bundle-only']} />
+<Terminal
+  cmd={['$ npx @expo/repack-app --platform android --source-app MyApp.apk --js-bundle-only']}
+/>
 
 ## Limitations
 
@@ -105,7 +111,7 @@ Usage: @expo/repack-app [options] [project-root]
 | Option                                    | Description                                                                                                                                              |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `-p, --platform <platform>`               | **Required.** Platform to repack the app for (`android` or `ios`).                                                                                       |
-| `--source-app <path>`                     | **Required.** Path to the source app (APK for Android, or IPA or **.app** for iOS). The output format matches the input.                                    |
+| `--source-app <path>`                     | **Required.** Path to the source app (APK for Android, or IPA or **.app** for iOS). The output format matches the input.                                 |
 | `-o, --output <path>`                     | Path to the output artifact. Defaults to `repacked.apk`, `repacked.ipa`, or `repacked.app` in the project root, matching the source format.              |
 | `-w, --working-directory <path>`          | Path to the working directory for temporary files.                                                                                                       |
 | `--skip-working-dir-cleanup`              | Skip cleaning up the working directory after the repack completes. Useful for debugging.                                                                 |

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -109,7 +109,7 @@ By default, repack updates the JS bundle, assets, and app metadata (app name, ve
 
 ## Limitations
 
-- Repack is not recommended for production App Store or Play Store submissions. Production builds should go through the complete build pipeline for correct symbolication and signing.
+Repack is not recommended for production Google Play Store or Apple App Store submissions. Production builds should go through the complete build pipeline for correct symbolication and signing.
 
 ## CLI reference
 

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -51,14 +51,7 @@ If you do not already have signing credentials locally, see [App credentials](/a
 Re-sign the repacked APK with a keystore:
 
 <Terminal
-  cmd={[
-    '$ npx @expo/repack-app \\',
-    '  --platform android \\',
-    '  --source-app MyApp.apk \\',
-    '  --ks keystore.jks \\',
-    '  --ks-key-alias my-alias',
-  ]}
-  cmdCopy="npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias"
+  cmd={[ '$ npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias' ]}
 />
 
 See the [Android-specific options](#android-specific-options) for keystore password flags and other settings.

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -118,37 +118,37 @@ Usage: @expo/repack-app [options] [project-root]
 
 ### Arguments
 
-| Argument | Description |
-| --- | --- |
+| Argument         | Description                                                          |
+| ---------------- | -------------------------------------------------------------------- |
 | `[project-root]` | Path to the project root. Defaults to the current working directory. |
 
 ### Options
 
-| Option | Description |
-| --- | --- |
-| `-p, --platform <platform>` | **Required.** Platform to repack the app for (`android` or `ios`). |
-| `--source-app <path>` | **Required.** Path to the source app (APK for Android; IPA or **.app** for iOS). The output format matches the input. |
-| `-o, --output <path>` | Path to the output artifact. Defaults to `repacked.apk`, `repacked.ipa`, or `repacked.app` in the project root, matching the source format. |
-| `-w, --working-directory <path>` | Path to the working directory for temporary files. |
-| `--skip-working-dir-cleanup` | Skip cleaning up the working directory after the repack completes. Useful for debugging. |
-| `-v, --verbose` | Enable verbose logging. |
-| `--js-bundle-only` | Only update the JS bundle and skip native config updates (such as app name, version, and other metadata). |
-| `--embed-bundle-assets` | Force running `npx expo export:embed` to generate the JS bundle and assets, even for debug builds where the bundle is normally loaded from a dev server. |
-| `--bundle-assets-sourcemap-output <path>` | Generate a source map at the specified path. Requires `--embed-bundle-assets`. |
+| Option                                    | Description                                                                                                                                              |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-p, --platform <platform>`               | **Required.** Platform to repack the app for (`android` or `ios`).                                                                                       |
+| `--source-app <path>`                     | **Required.** Path to the source app (APK for Android; IPA or **.app** for iOS). The output format matches the input.                                    |
+| `-o, --output <path>`                     | Path to the output artifact. Defaults to `repacked.apk`, `repacked.ipa`, or `repacked.app` in the project root, matching the source format.              |
+| `-w, --working-directory <path>`          | Path to the working directory for temporary files.                                                                                                       |
+| `--skip-working-dir-cleanup`              | Skip cleaning up the working directory after the repack completes. Useful for debugging.                                                                 |
+| `-v, --verbose`                           | Enable verbose logging.                                                                                                                                  |
+| `--js-bundle-only`                        | Only update the JS bundle and skip native config updates (such as app name, version, and other metadata).                                                |
+| `--embed-bundle-assets`                   | Force running `npx expo export:embed` to generate the JS bundle and assets, even for debug builds where the bundle is normally loaded from a dev server. |
+| `--bundle-assets-sourcemap-output <path>` | Generate a source map at the specified path. Requires `--embed-bundle-assets`.                                                                           |
 
 ### Android-specific options
 
-| Option | Description |
-| --- | --- |
-| `--ks <path>` | Path to the keystore file. |
-| `--ks-pass <password>` | Keystore password. Defaults to `pass:android`. Supported formats: `pass:<password>`, `env:<name>`, `file:<file>`. |
-| `--ks-key-alias <alias>` | Keystore key alias. |
-| `--ks-key-pass <password>` | Keystore key password. Supported formats: `pass:<password>`, `env:<name>`, `file:<file>`. |
-| `--android-build-tools-dir <path>` | Path to the Android SDK build-tools directory. |
+| Option                             | Description                                                                                                       |
+| ---------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `--ks <path>`                      | Path to the keystore file.                                                                                        |
+| `--ks-pass <password>`             | Keystore password. Defaults to `pass:android`. Supported formats: `pass:<password>`, `env:<name>`, `file:<file>`. |
+| `--ks-key-alias <alias>`           | Keystore key alias.                                                                                               |
+| `--ks-key-pass <password>`         | Keystore key password. Supported formats: `pass:<password>`, `env:<name>`, `file:<file>`.                         |
+| `--android-build-tools-dir <path>` | Path to the Android SDK build-tools directory.                                                                    |
 
 ### iOS-specific options
 
-| Option | Description |
-| --- | --- |
-| `--signing-identity <identity>` | Code signing identity. |
+| Option                          | Description                                                                                                                            |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--signing-identity <identity>` | Code signing identity.                                                                                                                 |
 | `--provisioning-profile <path>` | Path to a provisioning profile. Alternatively, a JSON-encoded value for multi-target apps (for example, when bundling app extensions). |

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -4,6 +4,7 @@ description: Repackage an existing APK, IPA, or .app with an updated JavaScript 
 ---
 
 import { Terminal } from '~/ui/components/Snippet';
+import { Tabs, Tab } from '~/ui/components/Tabs';
 
 [`@expo/repack-app`](https://www.npmjs.com/package/@expo/repack-app) is a CLI tool that repackages an existing Android APK, iOS IPA, or iOS **.app** bundle without performing a full native build. It updates the existing artifact with a new JavaScript (JS) bundle, assets, and app metadata (such as, app name, version, and package name or bundle identifier). Since there is no native compilation involved, a repack is typically much faster than a full native build.
 
@@ -20,17 +21,29 @@ Repack assumes the source binary's native side is unchanged since it was built. 
 
 Repack is not a replacement for [EAS Update](/eas-update/introduction/). EAS Update ships a new JS bundle to apps that are already installed, and users see it on the next launch. Repack produces a new installable artifact. A good rule of thumb is to use repack for internal testing (QA devices, testers, CI smoke tests) and use EAS Update to deliver JS changes to production users.
 
-## Standalone CLI usage
+## Use cases
+
+- **QA cycles**: Distribute one base build to testers, then repack with JS fixes for each iteration without waiting for a native rebuild.
+- **CI optimization**: Build native once per fingerprint, then repack the JS bundle on every subsequent PR to cut wait times from minutes to seconds.
+- **Branch testing**: Test multiple JS branches against the same native binary to isolate JavaScript-only changes.
+
+## Usage
+
+### Standalone CLI
 
 You need to run the commands specified for Android and iOS platforms below from your project's root directory. At minimum, `--platform` and `--source-app` are required. The tool runs `npx expo export:embed` under the hood to produce a fresh JS bundle, swaps it into the source binary, and writes the output artifact.
 
 The output format always matches the `--source-app` input. An APK input produces an APK, an IPA produces an IPA, and a **.app** bundle produces a **.app** bundle.
 
-### Android
+<Tabs>
+
+<Tab label="Android">
 
 <Terminal cmd={['$ npx @expo/repack-app --platform android --source-app MyApp.apk']} />
 
-### iOS
+</Tab>
+
+<Tab label="iOS">
 
 Using an IPA:
 
@@ -40,47 +53,43 @@ Using a **.app** bundle (for simulator builds, the iOS device artifacts are alwa
 
 <Terminal cmd={['$ npx @expo/repack-app --platform ios --source-app MyApp.app']} />
 
+</Tab>
+
+</Tabs>
+
+### EAS Workflows
+
+EAS Workflows provides a pre-packaged `repack` job type that handles signing and build management automatically. See [EAS Workflows pre-packaged jobs](/eas/workflows/pre-packaged-jobs/#repack) for full syntax, parameters, and examples.
+
 ## Signing
 
 To produce an artifact installable on a physical device, pass signing credentials alongside `--platform` and `--source-app`. Without them, the Android APK is output unsigned and the iOS IPA cannot be installed on a device. iOS **.app** bundles intended for the simulator do not need signing and can skip this step.
 
 If you do not already have signing credentials locally, see [App credentials](/app-signing/app-credentials/) for how to obtain a keystore (Android) or a signing identity and provisioning profile (iOS).
 
-### Android
+<Tabs>
 
-Re-sign the repacked APK with a keystore:
+<Tab label="Android">
 
-<Terminal
-  cmd={[
-    '$ npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias',
-  ]}
-/>
+<Terminal cmd={['$ npx @expo/repack-app --platform android --source-app MyApp.apk --ks keystore.jks --ks-key-alias my-alias']} />
 
 See the [Android-specific options](#android-specific-options) for keystore password flags and other settings.
 
-### iOS
+</Tab>
+
+<Tab label="iOS">
 
 Pass a signing identity and provisioning profile:
 
 > **Note**: iOS repacking supports ad-hoc and development signing only.
 
-<Terminal
-  cmd={[
-    '$ npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision',
-  ]}
-/>
+<Terminal cmd={['$ npx @expo/repack-app --platform ios --source-app MyApp.ipa --signing-identity "Apple Distribution: ..." --provisioning-profile /path/to/profile.mobileprovision']} />
 
 See the [iOS-specific options](#ios-specific-options) for the full list of signing flags.
 
-## Use cases
+</Tab>
 
-- **QA cycles**: Distribute one base build to testers, then repack with JS fixes for each iteration without waiting for a native rebuild.
-- **CI optimization**: Build native once per fingerprint, then repack the JS bundle on every subsequent PR to cut wait times from minutes to seconds.
-- **Branch testing**: Test multiple JS branches against the same native binary to isolate JavaScript-only changes.
-
-## Usage in EAS Workflows
-
-EAS Workflows provides a pre-packaged `repack` job type that handles signing and build management automatically. See [EAS Workflows pre-packaged jobs](/eas/workflows/pre-packaged-jobs/#repack) for full syntax, parameters, and examples.
+</Tabs>
 
 ## `--js-bundle-only` mode
 


### PR DESCRIPTION
# Why

close ENG-20166

# How

add repack doc

# Test Plan

ci passed and preview at https://pr-44883.expo-docs.pages.dev/build-reference/repack/

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
