### PR TITLE
[ci] Add gradle files to ccache android key

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -178,7 +178,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ runner.temp }}/.ccache
-        key: ${{ runner.os }}-ccache-${{ hashFiles('pnpm-lock.yaml', 'packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h') }}
+        key: ${{ runner.os }}-ccache-${{ hashFiles('pnpm-lock.yaml', 'packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/build.gradle', 'packages/**/build.gradle.kts', 'packages/**/settings.gradle', 'packages/**/settings.gradle.kts', 'apps/bare-expo/**/build.gradle', 'apps/bare-expo/**/settings.gradle') }}
         restore-keys: ${{ runner.os }}-ccache-
 
     - name: 🔍️ Get cache key of Git LFS files


### PR DESCRIPTION
# Why

Changes to `build.gradle`, `settings.gradle`, and `settings.gradle.kts` cause the ccache hit rate to drop to 20%: [happened here](https://github.com/expo/expo/actions/runs/24215717376/job/70695748726?pr=44654) 

It's a problem for packages which compile C++: 
[Link to CI run with build.gradle change in package without C++ code which doesn't drop ccache](https://github.com/expo/expo/actions/runs/24565264203/job/71823931737?pr=44662)
and in BareExpo:
[Link to CI run with build.gradle change in bareexpo](https://github.com/expo/expo/actions/runs/24565966558/job/71826289966?pr=44662)

# How

Adds a broad regex for these files in the packages and in BareExpo - we could include only packages with C++ code, but later we would have to update the key every time we add a package with C++. It's rare, but updating the cache key on each change to these files is cheap since GitHub Actions cleans unused caches. 

# Test Plan

Green CI
Tested here: #44662