### PR TITLE
[dev-launcher] enable submitting packager url with enter key

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -31,6 +31,7 @@
 
 ### 💡 Others
 
+- Improved URL input in the launcher home screen. ([#44886](https://github.com/expo/expo/pull/44886) by [@vonovak](https://github.com/vonovak))
 - Align dev launcher labels across iOS and Android. ([#44720](https://github.com/expo/expo/pull/44720) by [@vonovak](https://github.com/vonovak))
 - Removed `DevLauncherExpoActivityConfigurator`. System bars configuration is now handled by the `expo-status-bar` and `expo-navigation-bar` modules. ([#44469](https://github.com/expo/expo/pull/44469) by [@zoontek](https://github.com/zoontek))
 - Enforce transparent status bar and navigation bar on Android, remove unused `backgroundColor` / `translucent` options handling. ([#43518](https://github.com/expo/expo/pull/43518) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ActionButton.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ActionButton.kt
@@ -26,12 +26,14 @@ fun ActionButton(
   textStyle: TextStyle = NewAppTheme.font.lg.merge(
     fontWeight = FontWeight.SemiBold
   ),
+  enabled: Boolean = true,
   onClick: () -> Unit = {}
 ) {
   Button(
     onClick = onClick,
+    enabled = enabled,
     shape = RoundedCornerShape(borderRadius),
-    backgroundColor = background,
+    backgroundColor = if (enabled) background else background.copy(alpha = 0.5f),
     indication = ripple(color = foreground)
   ) {
     Box(

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
@@ -19,8 +19,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
@@ -63,6 +69,13 @@ fun ServerUrlInput(
       singleLine = true,
       modifier = Modifier
         .fillMaxWidth()
+        .onPreviewKeyEvent { event ->
+          val isEnterRelease = event.key == Key.Enter && event.type == KeyEventType.KeyUp
+          if (isEnterRelease) {
+            connectToURL()
+          }
+          isEnterRelease
+        }
         .border(
           width = 1.dp,
           shape = RoundedCornerShape(NewAppTheme.borderRadius.xl),
@@ -74,10 +87,11 @@ fun ServerUrlInput(
       keyboardOptions = KeyboardOptions(
         capitalization = KeyboardCapitalization.None,
         autoCorrectEnabled = false,
-        keyboardType = KeyboardType.Uri
+        keyboardType = KeyboardType.Uri,
+        imeAction = ImeAction.Go
       ),
       keyboardActions = KeyboardActions(
-        onDone = { connectToURL() }
+        onGo = { connectToURL() }
       ),
       cursorBrush = SolidColor(NewAppTheme.colors.text.default.copy(alpha = 0.9f))
     ) {
@@ -101,6 +115,7 @@ fun ServerUrlInput(
       textStyle = NewAppTheme.font.md.merge(
         fontWeight = FontWeight.SemiBold
       ),
+      enabled = url.isNotEmpty(),
       onClick = { connectToURL() }
     )
   }

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -22,6 +22,8 @@ private func sanitizeUrlString(_ urlString: String) -> String? {
   return sanitizedUrl
 }
 
+private let urlInputAnimation = Animation.easeInOut(duration: 0.3)
+
 struct DevServersView: View {
   @EnvironmentObject var viewModel: DevLauncherViewModel
   @Binding var showingInfoDialog: Bool
@@ -33,7 +35,7 @@ struct DevServersView: View {
       let sanitizedURL = sanitizeUrlString(urlText)
       if let validURL = sanitizedURL {
         viewModel.openApp(url: validURL)
-        withAnimation(.easeInOut(duration: 0.3)) {
+        withAnimation(urlInputAnimation) {
           showingURLInput = false
         }
         urlText = ""
@@ -76,13 +78,14 @@ struct DevServersView: View {
   private var enterUrl: some View {
     VStack(spacing: 20) {
       Button {
-        withAnimation(.easeInOut(duration: 0.3)) {
+        withAnimation(urlInputAnimation) {
           showingURLInput.toggle()
         }
       } label: {
         HStack {
-          Image(systemName: showingURLInput ? "chevron.down" : "chevron.right")
+          Image(systemName: "chevron.right")
             .font(.headline)
+            .rotationEffect(.degrees(showingURLInput ? 90 : 0))
           Text("Enter URL manually")
             #if os(tvOS)
             .font(.system(size: 28))
@@ -98,6 +101,10 @@ struct DevServersView: View {
 
       if showingURLInput {
         TextField("exp://", text: $urlText)
+          .onSubmit {
+            connectToURL()
+          }
+          .submitLabel(.go)
         #if !os(macOS)
           .autocapitalization(.none)
         #endif
@@ -116,7 +123,7 @@ struct DevServersView: View {
         connectButton
       }
     }
-    .animation(.easeInOut, value: showingURLInput)
+    .animation(urlInputAnimation, value: showingURLInput)
     .padding()
     .background(showingURLInput ?
       Color.expoSecondarySystemBackground :


### PR DESCRIPTION
# Why

The dev launcher URL input didn't submit on Enter key press and had tiny UX issues (jerky chevron animation on iOS, Connect button enabled on empty input on Android).

# How

- Android: added `onPreviewKeyEvent` to handle hardware Enter key, set `ImeAction.Go` for the soft keyboard, and disabled the Connect button when input is empty.
- iOS: added `.onSubmit` and `.submitLabel(.go)` to the TextField, replaced chevron icon swap with a smooth rotation.

# Test Plan

1. Open the dev launcher home screen on Android and iOS.
2. Tap "Enter URL manually" — verify the chevron rotates smoothly on iOS.
3. Type a URL and press Enter — verify it submits on both platforms.
4. Clear the input — verify the Connect button is visually disabled on Android.
5. Press Enter on empty input — verify nothing happens.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)