### PR TITLE
[dev-laucher] improve button contrast in dark mode

### DIFF
--- a/packages/expo-dev-launcher/ios/SwiftUI/CrashReportView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/CrashReportView.swift
@@ -26,7 +26,7 @@ struct CrashReportView: View {
       Button(action: onDismiss) {
         Text("Close")
           .font(.headline)
-          .foregroundColor(.black)
+          .foregroundColor(.primary)
           .frame(maxWidth: .infinity)
           .padding()
 #if !os(tvOS) && !os(macOS)

--- a/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/ErrorView.swift
@@ -87,7 +87,7 @@ struct ErrorView: View {
         Button(action: onGoHome) {
           Text("Go home")
             .font(.headline)
-            .foregroundColor(.black)
+            .foregroundColor(.primary)
             .frame(maxWidth: .infinity)
             .padding()
             .background(Color.expoSystemGray5)
@@ -109,7 +109,7 @@ struct ErrorView: View {
         }) {
           Text(copied ? "Copied!" : "Copy")
             .font(.headline)
-            .foregroundColor(.black)
+            .foregroundColor(.primary)
             .frame(maxWidth: .infinity)
             .padding()
             .background(Color.expoSystemGray5)


### PR DESCRIPTION
# Why

- these buttons have bad contrast in dark mode

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

change text color. Maybe more could be done to improve dark mode appearance but this is a quick win.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)