### PR TITLE
[brownfield][iOS] Support rendering multiple ReactNativeView simultaneously

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added `Expo.plist` to the brownfield framework target. ([#44645](https://github.com/expo/expo/pull/44645) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Add `DEFINE_MODULES=TRUE` build setting ([#44672](https://github.com/expo/expo/pull/44672) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [ios] Fix loading assets in brownfield. ([#44724](https://github.com/expo/expo/pull/44724) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Support rendering multiple ReactNativeView simultaneously ([#44891](https://github.com/expo/expo/pull/44891) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
@@ -15,8 +15,8 @@ public class ReactNativeHostManager {
 
   private var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
   private var reactNativeFactory: RCTReactNativeFactory?
-  private var firstLoad: Bool = true
   private var firstLoadInitialized: Bool = false
+  private var devMenuInitialized: Bool = false
 
   /**
    * Initializes ReactNativeHostManager instance
@@ -41,17 +41,13 @@ public class ReactNativeHostManager {
     initialProps: [AnyHashable: Any]?,
     launchOptions: [AnyHashable: Any]?
   ) throws -> UIView {
-    if !(firstLoad && firstLoadInitialized) {
-      cleanupPreviousInstance()
-      initializeInstance()
+    guard firstLoadInitialized, let reactNativeFactory else {
+      fatalError(
+        "loadView called before initialize(). Call ReactNativeHostManager.shared.initialize() first."
+      )
     }
 
-    guard let reactNativeFactory else {
-      fatalError("Trying to load view without initializing reactNativeFactory")
-    }
-
-    firstLoad = false
-    setupDevMenu(moduleName)
+    setupDevMenu()
 
     return reactNativeFactory.rootViewFactory.view(
       withModuleName: moduleName,
@@ -80,17 +76,26 @@ public class ReactNativeHostManager {
       reactNativeDelegate = nil
       reactNativeFactory = nil
     }
+    devMenuInitialized = false
   }
 
   /**
    * Starts React Native (which initializes delegates) and
    * fetches and updates the manifest for dev menu if dev menu is
-   * available
+   * available. Runs at most once per factory — calling startReactNative
+   * multiple times on the same factory would duplicate delegate setup.
    */
-  private func setupDevMenu(_ moduleName: String) {
+  private func setupDevMenu() {
+    #if DEBUG && canImport(EXDevMenu)
+    if devMenuInitialized {
+      return
+    }
+
     guard let reactNativeFactory else {
       fatalError("Trying to setup dev menu without initialized reactNativeFactory")
     }
+
+    devMenuInitialized = true
 
     // Needed to set up delegates (e.g. for expo-dev-menu)
     reactNativeFactory.startReactNative(
@@ -99,7 +104,6 @@ public class ReactNativeHostManager {
       launchOptions: nil
     )
 
-    #if DEBUG && canImport(EXDevMenu)
     ManifestProvider.fetchManifest(bundleURL: reactNativeDelegate?.bundleURL()) { json, url in
       if let json, let url {
         let manifest = ManifestFactory.manifest(forManifestJSON: json)


### PR DESCRIPTION
# Why

In brownfield apps, mounting multiple `ReactNativeView` instances on the same screen (e.g. two inline custom components) causes only one of them to render  

This happens because `ReactNativeHostManager.loadView` tears down and recreates the entire `RCTReactNativeFactory` on every call after the first. When two views mount simultaneously, the second `loadView` call destroys the factory that the first view is bound to, leaving it detached from the React host. 

# How

Update the ReactNativeHostManager to reuse a single factory across all views and gate `setupDevMenu` to run once per factory.  
# Test Plan

Build `brownfield-tester` on iOS and verify that both the `custom-component` section and the full RN app are rendered

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
