### PR TITLE
[docs] Update EAS CLI reference to 18.7.0

### DIFF
--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.6.0
+cliVersion: 18.7.0
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-04-14T07:27:57.281Z",
-    "cliVersion": "18.6.0"
+    "fetchedAt": "2026-04-17T20:40:01.287Z",
+    "cliVersion": "18.7.0"
   },
   "totalCommands": 102,
   "commands": [
@@ -84,7 +84,7 @@
     {
       "command": "eas build:dev",
       "description": "run dev client simulator/emulator build with matching fingerprint or create a new one",
-      "usage": "USAGE\n  $ eas build:dev [-p ios|android] [-e PROFILE_NAME] [--skip-build-if-not-found]\n\nFLAGS\n  -e, --profile=PROFILE_NAME     Name of the build profile from eas.json. It must be a profile allowing to create\n                                 emulator/simulator internal distribution dev client builds. The \"development-simulator\"\n                                 build profile will be selected by default.\n  -p, --platform=<option>        <options: ios|android>\n      --skip-build-if-not-found  Skip build if no successful build with matching fingerprint is found.\n\nDESCRIPTION\n  run dev client simulator/emulator build with matching fingerprint or create a new one"
+      "usage": "USAGE\n  $ eas build:dev [-p ios|android] [-e PROFILE_NAME] [--skip-build-if-not-found] [--skip-bundler]\n\nFLAGS\n  -e, --profile=PROFILE_NAME     Name of the build profile from eas.json. It must be a profile allowing to create\n                                 emulator/simulator internal distribution dev client builds. The \"development-simulator\"\n                                 build profile will be selected by default.\n  -p, --platform=<option>        <options: ios|android>\n      --skip-build-if-not-found  Skip build if no successful build with matching fingerprint is found.\n      --skip-bundler             Install and run the development build without starting the bundler server.\n\nDESCRIPTION\n  run dev client simulator/emulator build with matching fingerprint or create a new one"
     },
     {
       "command": "eas build:download",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update EAS CLI reference to 18.7.0. Adds ` --skip-bundler ` option to `eas build:dev`.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Running `yarn run eas-cli-sync`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run the docs app locally or see diff.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
