### PR TITLE
[android][cli] Target only one compatible architecture

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Target only the first compatible device architecture during Android debug builds to speed up build time. ([#44907](https://github.com/expo/expo/pull/44907) by [@AntoineThibi](https://github.com/AntoineThibi))
+
 ## 56.1.2 — 2026-05-12
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- Target only the first compatible device architecture during Android debug builds to speed up build time. ([#44907](https://github.com/expo/expo/pull/44907) by [@AntoineThibi](https://github.com/AntoineThibi))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/run/android/__tests__/resolveGradlePropsAsync-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveGradlePropsAsync-test.ts
@@ -90,7 +90,7 @@ describe(resolveGradlePropsAsync, () => {
     });
   });
 
-  it(`returns the device architectures in a comma separated string`, async () => {
+  it(`returns the first compatible device architecture in a string`, async () => {
     jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([testDevice]);
     jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([DeviceABI.armeabiV7a, DeviceABI.x86]);
 
@@ -99,28 +99,23 @@ describe(resolveGradlePropsAsync, () => {
       appName: 'app',
       buildType: 'debug',
       flavors: [],
-      architectures: 'armeabi-v7a,x86',
+      architectures: 'armeabi-v7a',
     });
   });
 
-  it(`returns unique device ABIs`, async () => {
+  it(`returns compatible device ABI`, async () => {
     jest.mocked(getAttachedDevicesAsync).mockResolvedValueOnce([testDevice]);
-    jest
-      .mocked(getDeviceABIsAsync)
-      .mockResolvedValueOnce([
-        DeviceABI.x86,
-        DeviceABI.arm64v8a,
-        DeviceABI.arm64v8a,
-        DeviceABI.x8664,
-        DeviceABI.x8664,
-      ]);
+    jest.mocked(getDeviceABIsAsync).mockResolvedValueOnce([
+      DeviceABI.armeabi, // Not supported, should be ignored
+      DeviceABI.arm64v8a,
+    ]);
 
     expect(await resolveGradlePropsAsync('/', {}, testDevice)).toEqual({
       apkVariantDirectory: '/android/app/build/outputs/apk/debug',
       appName: 'app',
       buildType: 'debug',
       flavors: [],
-      architectures: 'x86,arm64-v8a,x86_64',
+      architectures: 'arm64-v8a',
     });
   });
 });

--- a/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
+++ b/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
@@ -65,11 +65,11 @@ export async function resolveGradlePropsAsync(
     buildType,
     flavors: parts.map((v) => v.toLowerCase()),
     apkVariantDirectory,
-    architectures: await getConnectedDeviceABIS(buildType, device, options.allArch),
+    architectures: await getConnectedDeviceABI(buildType, device, options.allArch),
   };
 }
 
-async function getConnectedDeviceABIS(
+async function getConnectedDeviceABI(
   buildType: string,
   device: Device,
   allArch?: boolean
@@ -83,6 +83,5 @@ async function getConnectedDeviceABIS(
 
   const abis = await getDeviceABIsAsync(device);
 
-  const validAbis = abis.filter((abi) => VALID_ARCHITECTURES.includes(abi));
-  return validAbis.filter((abi, i, arr) => arr.indexOf(abi) === i).join(',');
+  return abis.find((abi) => VALID_ARCHITECTURES.includes(abi)) ?? '';
 }

--- a/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
+++ b/packages/@expo/cli/src/run/android/resolveGradlePropsAsync.ts
@@ -64,11 +64,11 @@ export async function resolveGradlePropsAsync(
     buildType,
     flavors: parts.map((v) => v.toLowerCase()),
     apkVariantDirectory,
-    architectures: await getConnectedDeviceABIS(buildType, device, options.allArch),
+    architectures: await getConnectedDeviceABI(buildType, device, options.allArch),
   };
 }
 
-async function getConnectedDeviceABIS(
+async function getConnectedDeviceABI(
   buildType: string,
   device: Device,
   allArch?: boolean
@@ -82,6 +82,5 @@ async function getConnectedDeviceABIS(
 
   const abis = await getDeviceABIsAsync(device);
 
-  const validAbis = abis.filter((abi) => VALID_ARCHITECTURES.includes(abi));
-  return validAbis.filter((abi, i, arr) => arr.indexOf(abi) === i).join(',');
+  return abis.find((abi) => VALID_ARCHITECTURES.includes(abi)) ?? '';
 }


### PR DESCRIPTION
# Why

Devices can be compatible with multiple architecture (Samsungs phone for example are often compatible with arm64-v8a, armeabi-v7a and armeabi). In the current implementation, debug build are for all compatible architecture (in this case, arm64-v8a and armeabi-v7a), leading for slower debug build. 

# How

This fix modify the `getConnectedDeviceABI` function to build only for the first compatible architecture.

# Test Plan

- [x] Building on a device with multiple architectures
- [x] Building on a device with a single architecture
- [x] Updating unit test of the function


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
