### PR TITLE
[tools] Enable unit tests for expo-modules-jsi package

### DIFF
--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -75,6 +75,11 @@ export type ExpoModuleConfig = {
     podName?: string;
     podspecPath?: string;
   };
+  apple?: {
+    subdirectory?: string;
+    podName?: string;
+    podspecPath?: string | string[];
+  };
   android?: {
     subdirectory?: string;
     name?: string;
@@ -152,10 +157,18 @@ export class Package {
       return this.expoModuleConfig.ios.podspecPath;
     }
 
-    // Obtain podspecName by looking for podspecs in both package's root directory and ios subdirectory.
-    const [podspecPath] = glob.sync(`{*,${this.iosSubdirectory}/*}.podspec`, {
-      cwd: this.path,
-    });
+    const applePodspecPath = this.expoModuleConfig?.apple?.podspecPath;
+    if (applePodspecPath) {
+      return Array.isArray(applePodspecPath) ? applePodspecPath[0] : applePodspecPath;
+    }
+
+    // Look for podspecs in the package root and both iOS-style subdirectories.
+    const [podspecPath] = glob.sync(
+      `{*,${this.iosSubdirectory}/*,${this.appleSubdirectory}/*}.podspec`,
+      {
+        cwd: this.path,
+      }
+    );
 
     return podspecPath || null;
   }
@@ -180,6 +193,10 @@ export class Package {
 
   get iosSubdirectory(): string {
     return this.expoModuleConfig?.ios?.subdirectory ?? 'ios';
+  }
+
+  get appleSubdirectory(): string {
+    return this.expoModuleConfig?.apple?.subdirectory ?? 'apple';
   }
 
   get androidSubdirectory(): string {

--- a/tools/src/commands/IosNativeUnitTests.ts
+++ b/tools/src/commands/IosNativeUnitTests.ts
@@ -30,20 +30,6 @@ export async function iosNativeUnitTests({ packages }: { packages?: string }) {
   const targetsToTest: string[] = [];
   const packagesToTest: string[] = [];
   for (const pkg of allPackages) {
-    if (pkg.packageName === 'expo-modules-core') {
-      if (packageNamesFilter.length > 0 && !packageNamesFilter.includes(pkg.packageName)) {
-        continue;
-      }
-      // @tsapeta @barthap: `expo-modules-core` contains multiple podspecs (Core, JSI, Worklets).
-      // This breaks `expotools` test discovery because it often resolves the wrong `podspecPath`.
-      // We manually include the core tests here as a workaround. If new podspecs are added
-      // to this package, they must be manually registered here.
-      targetsToTest.push(`ExpoModulesCore-Unit-Tests`);
-      targetsToTest.push(`ExpoModulesJSI-Unit-Tests`);
-      packagesToTest.push(pkg.packageName);
-      continue;
-    }
-
     if (!pkg.podspecName || !pkg.podspecPath || !(await pkg.hasNativeTestsAsync('ios'))) {
       if (packageNamesFilter.includes(pkg.packageName)) {
         throw new Error(`The package ${pkg.packageName} does not include iOS unit tests.`);


### PR DESCRIPTION
## Why

`expotools` skipped generic podspec discovery for `expo-modules-core` because the package ships multiple podspecs (`ExpoModulesCore`, `ExpoModulesJSI`, `ExpoModulesWorklets`) and the glob-based resolver would pick the wrong one. The previous workaround hardcoded `ExpoModulesCore-Unit-Tests` and `ExpoModulesJSI-Unit-Tests` directly in `IosNativeUnitTests.ts`, which meant every new podspec had to be manually registered there.

Note that this PR doesn't actually enable `expo-modules-jsi` tests on the CI yet because this package is not integrated yet. It'll be part of #44337.

## What

- Teach `Packages.ts` about the `apple` platform block in `expo-module.config.json`, including a `podspecPath` that accepts either a string or an array of paths.
- Fall back to globbing `apple/*.podspec` alongside `ios/*.podspec` when no explicit path is configured.
- Drop the `expo-modules-core` special case from `IosNativeUnitTests.ts`; discovery now flows through the standard config.

## Test plan

- `et ios-native-unit-tests --packages expo-modules-core` runs Core + JSI targets.
- `et ios-native-unit-tests` still discovers other packages with iOS tests.