### PR TITLE
[docs] Fix Select trigger flicker by rendering selected option in SelectPrimitive.Value

### DIFF
--- a/docs/ui/components/Select.tsx
+++ b/docs/ui/components/Select.tsx
@@ -43,6 +43,9 @@ export function Select({
   disabled = false,
   size = 'md',
 }: SelectProps) {
+  const selectedOption = options?.find(option => option.id === value);
+  const IconComponent = selectedOption?.Icon;
+
   const selectComponent = (
     <SelectPrimitive.Root
       name={id}
@@ -68,14 +71,29 @@ export function Select({
             className
           )}
           {...{ 'data-testid': testID }}>
-          <SelectPrimitive.Value
-            placeholder={
-              <div className="text-quaternary text-left text-sm leading-tight whitespace-pre-wrap">
-                {placeholder}
-              </div>
-            }
-            aria-label={value}
-          />
+          <SelectPrimitive.Value placeholder={placeholder} aria-label={value}>
+            <span
+              className={mergeClasses(
+                'flex items-center gap-2 text-left text-sm leading-tight font-normal whitespace-nowrap',
+                size === 'lg' && 'text-lg'
+              )}>
+              {selectedOption?.leftSlot}
+              {IconComponent && (
+                <SelectPrimitive.Icon>
+                  <IconComponent className={mergeClasses('icon-sm', size === 'lg' && 'icon-md')} />
+                </SelectPrimitive.Icon>
+              )}
+              {selectedOption?.imageUrl && (
+                <img
+                  alt={String(selectedOption.id)}
+                  src={selectedOption.imageUrl}
+                  className="size-5 rounded-full"
+                />
+              )}
+              {selectedOption?.label}
+              {selectedOption?.rightSlot}
+            </span>
+          </SelectPrimitive.Value>
         </Button>
       </SelectPrimitive.Trigger>
       <SelectPrimitive.Portal>


### PR DESCRIPTION
# Why

`Select` trigger renders empty on first paint, briefly showing no label next to the chevron before hydration settles. Cause: `SelectPrimitive.Value` was self-closing with a `placeholder` prop only. Radix only renders `placeholder` when the value is unset — when a value is set, it expects the selected content as *children*. With no children, the trigger stays blank.

# How

Pass the selected option's content (`leftSlot`, `Icon`, `imageUrl`, `label`, `rightSlot`) as children of `SelectPrimitive.Value`. Placeholder stays as a fallback for the unset case.

`ThemeSelector` in docs was already clean (no `loaded`/`disabled` band-aid), so only `Select.tsx` needed changes.

# Test Plan

- [x] `yarn lint` passes (tsc / eslint / oxlint / format clean).
- [ ] Theme selector in the docs header renders "Auto" / "Light" / "Dark" immediately on hard refresh — no blank frame.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)