### PR TITLE
[ios][build-properties] Fix fmt consteval errors when building from source on Xcode 26+

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix `fmt` consteval compilation errors when building React Native from source with Xcode 26+. ([#44229](https://github.com/expo/expo/issues/44229) by [@Nedunchezhiyan-M](https://github.com/Nedunchezhiyan-M))
+
 ### 💡 Others
 
 - Mark `ios.deploymentTarget` as deprecated in favor of the built-in `ios.deploymentTarget` property (SDK 56 and greater). ([#43700](https://github.com/expo/expo/pull/43700) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-build-properties/build/ios.d.ts
+++ b/packages/expo-build-properties/build/ios.d.ts
@@ -4,3 +4,5 @@ export declare const withIosBuildProperties: ConfigPlugin<PluginConfigType>;
 /** @deprecated use built-in `ios.deploymentTarget` property instead. */
 export declare const withIosDeploymentTarget: ConfigPlugin<PluginConfigType>;
 export declare const withIosInfoPlist: ConfigPlugin<PluginConfigType>;
+export declare function addFmtConstevalFix(podfile: string): string;
+export declare const withIosFmtConsteval: ConfigPlugin<PluginConfigType>;

--- a/packages/expo-build-properties/build/ios.js
+++ b/packages/expo-build-properties/build/ios.js
@@ -1,7 +1,43 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.withIosInfoPlist = exports.withIosDeploymentTarget = exports.withIosBuildProperties = void 0;
+exports.withIosFmtConsteval = exports.withIosInfoPlist = exports.withIosDeploymentTarget = exports.withIosBuildProperties = void 0;
+exports.addFmtConstevalFix = addFmtConstevalFix;
 const config_plugins_1 = require("expo/config-plugins");
+const fs = __importStar(require("fs"));
+const path = __importStar(require("path"));
 const pluginConfig_1 = require("./pluginConfig");
 const { createBuildPodfilePropsConfigPlugin } = config_plugins_1.IOSConfig.BuildProperties;
 exports.withIosBuildProperties = createBuildPodfilePropsConfigPlugin([
@@ -66,6 +102,51 @@ const withIosInfoPlist = (config, props) => {
     return config;
 };
 exports.withIosInfoPlist = withIosInfoPlist;
+const FMT_CONSTEVAL_FIX_MARKER = 'FMT_USE_CONSTEVAL=0';
+const FMT_CONSTEVAL_FIX_SNIPPET = `
+    # Fix fmt consteval compilation errors with Apple Clang in Xcode 26+
+    installer.pods_project.targets.select { |t| t.name == 'fmt' }.each do |t|
+      t.build_configurations.each do |c|
+        flags = c.build_settings['OTHER_CPLUSPLUSFLAGS'] || '$(inherited)'
+        unless flags.include?('FMT_USE_CONSTEVAL')
+          c.build_settings['OTHER_CPLUSPLUSFLAGS'] = "\#{flags} -DFMT_USE_CONSTEVAL=0"
+        end
+      end
+    end`;
+function addFmtConstevalFix(podfile) {
+    if (podfile.includes(FMT_CONSTEVAL_FIX_MARKER)) {
+        return podfile;
+    }
+    const lines = podfile.split('\n');
+    const postInstallIndex = lines.findIndex((line) => line.includes('post_install do |installer|'));
+    if (postInstallIndex === -1) {
+        return podfile;
+    }
+    const insertBefore = lines.findIndex((line, index) => line.trim() === 'end' && index > postInstallIndex);
+    if (insertBefore === -1) {
+        return podfile;
+    }
+    lines.splice(insertBefore, 0, FMT_CONSTEVAL_FIX_SNIPPET);
+    return lines.join('\n');
+}
+const withIosFmtConsteval = (config, props) => {
+    if (!(0, pluginConfig_1.resolveConfigValue)(props, 'ios', 'buildReactNativeFromSource')) {
+        return config;
+    }
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'ios',
+        async (config) => {
+            const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+            if (!fs.existsSync(podfilePath)) {
+                return config;
+            }
+            const podfile = fs.readFileSync(podfilePath, 'utf8');
+            fs.writeFileSync(podfilePath, addFmtConstevalFix(podfile), 'utf8');
+            return config;
+        },
+    ]);
+};
+exports.withIosFmtConsteval = withIosFmtConsteval;
 const withIosReactNativeReleaseLevel = (config, { reactNativeReleaseLevel }) => {
     return (0, config_plugins_1.withInfoPlist)(config, (config) => {
         config.modResults['ReactNativeReleaseLevel'] = reactNativeReleaseLevel;

--- a/packages/expo-build-properties/build/withBuildProperties.js
+++ b/packages/expo-build-properties/build/withBuildProperties.js
@@ -28,6 +28,7 @@ const withBuildProperties = (config, props) => {
     config = (0, ios_1.withIosBuildProperties)(config, pluginConfig);
     config = (0, ios_1.withIosDeploymentTarget)(config, pluginConfig);
     config = (0, ios_1.withIosInfoPlist)(config, pluginConfig);
+    config = (0, ios_1.withIosFmtConsteval)(config, pluginConfig);
     return config;
 };
 exports.withBuildProperties = withBuildProperties;

--- a/packages/expo-build-properties/src/__tests__/ios-fmt-test.ts
+++ b/packages/expo-build-properties/src/__tests__/ios-fmt-test.ts
@@ -1,0 +1,60 @@
+jest.mock('expo/config-plugins', () => {
+  const plugins = jest.requireActual('expo/config-plugins');
+  return {
+    ...plugins,
+    withDangerousMod: jest.fn().mockImplementation((config) => config),
+  };
+});
+
+import { addFmtConstevalFix } from '../ios';
+
+const PODFILE_WITH_POST_INSTALL = `\
+platform :ios, podfile_properties['ios.deploymentTarget'] || '16.4'
+
+# ... other pods ...
+
+post_install do |installer|
+  react_native_post_install(
+    installer,
+    config[:reactNativePath],
+    :mac_catalyst_enabled => false,
+  )
+end
+`;
+
+const PODFILE_WITHOUT_POST_INSTALL = `\
+platform :ios, podfile_properties['ios.deploymentTarget'] || '16.4'
+
+# no post_install block
+`;
+
+describe(addFmtConstevalFix, () => {
+  it('injects FMT_USE_CONSTEVAL=0 flag inside post_install block', () => {
+    const result = addFmtConstevalFix(PODFILE_WITH_POST_INSTALL);
+    expect(result).toContain('FMT_USE_CONSTEVAL=0');
+    expect(result).toContain("t.name == 'fmt'");
+    expect(result).toContain('OTHER_CPLUSPLUSFLAGS');
+  });
+
+  it('places the fix inside the post_install block (before closing end)', () => {
+    const result = addFmtConstevalFix(PODFILE_WITH_POST_INSTALL);
+    const postInstallIdx = result.indexOf('post_install do |installer|');
+    const fmtFixIdx = result.indexOf('FMT_USE_CONSTEVAL=0');
+    const closingEndIdx = result.lastIndexOf('\nend\n');
+    expect(fmtFixIdx).toBeGreaterThan(postInstallIdx);
+    expect(fmtFixIdx).toBeLessThan(closingEndIdx);
+  });
+
+  it('is idempotent — does not inject twice', () => {
+    const once = addFmtConstevalFix(PODFILE_WITH_POST_INSTALL);
+    const twice = addFmtConstevalFix(once);
+    expect(once).toEqual(twice);
+    const count = (twice.match(/FMT_USE_CONSTEVAL=0/g) ?? []).length;
+    expect(count).toBe(1);
+  });
+
+  it('returns the original podfile unchanged when post_install block is absent', () => {
+    const result = addFmtConstevalFix(PODFILE_WITHOUT_POST_INSTALL);
+    expect(result).toEqual(PODFILE_WITHOUT_POST_INSTALL);
+  });
+});

--- a/packages/expo-build-properties/src/ios.ts
+++ b/packages/expo-build-properties/src/ios.ts
@@ -2,9 +2,12 @@ import {
   ConfigPlugin,
   IOSConfig,
   XcodeProject,
+  withDangerousMod,
   withInfoPlist,
   withXcodeProject,
 } from 'expo/config-plugins';
+import * as fs from 'fs';
+import * as path from 'path';
 
 import { PluginConfigType, resolveConfigValue } from './pluginConfig';
 
@@ -80,6 +83,57 @@ export const withIosInfoPlist: ConfigPlugin<PluginConfigType> = (config, props) 
   }
 
   return config;
+};
+
+const FMT_CONSTEVAL_FIX_MARKER = 'FMT_USE_CONSTEVAL=0';
+const FMT_CONSTEVAL_FIX_SNIPPET = `
+    # Fix fmt consteval compilation errors with Apple Clang in Xcode 26+
+    installer.pods_project.targets.select { |t| t.name == 'fmt' }.each do |t|
+      t.build_configurations.each do |c|
+        flags = c.build_settings['OTHER_CPLUSPLUSFLAGS'] || '$(inherited)'
+        unless flags.include?('FMT_USE_CONSTEVAL')
+          c.build_settings['OTHER_CPLUSPLUSFLAGS'] = "\#{flags} -DFMT_USE_CONSTEVAL=0"
+        end
+      end
+    end`;
+
+export function addFmtConstevalFix(podfile: string): string {
+  if (podfile.includes(FMT_CONSTEVAL_FIX_MARKER)) {
+    return podfile;
+  }
+  const lines = podfile.split('\n');
+  const postInstallIndex = lines.findIndex((line) =>
+    line.includes('post_install do |installer|')
+  );
+  if (postInstallIndex === -1) {
+    return podfile;
+  }
+  const insertBefore = lines.findIndex(
+    (line, index) => line.trim() === 'end' && index > postInstallIndex
+  );
+  if (insertBefore === -1) {
+    return podfile;
+  }
+  lines.splice(insertBefore, 0, FMT_CONSTEVAL_FIX_SNIPPET);
+  return lines.join('\n');
+}
+
+export const withIosFmtConsteval: ConfigPlugin<PluginConfigType> = (config, props) => {
+  if (!resolveConfigValue(props, 'ios', 'buildReactNativeFromSource')) {
+    return config;
+  }
+  return withDangerousMod(config, [
+    'ios',
+    async (config) => {
+      const podfilePath = path.join(config.modRequest.platformProjectRoot, 'Podfile');
+      if (!fs.existsSync(podfilePath)) {
+        return config;
+      }
+      const podfile = fs.readFileSync(podfilePath, 'utf8');
+      fs.writeFileSync(podfilePath, addFmtConstevalFix(podfile), 'utf8');
+      return config;
+    },
+  ]);
 };
 
 const withIosReactNativeReleaseLevel: ConfigPlugin<{

--- a/packages/expo-build-properties/src/withBuildProperties.ts
+++ b/packages/expo-build-properties/src/withBuildProperties.ts
@@ -9,7 +9,12 @@ import {
   withAndroidQueries,
   withAndroidSettingsGradle,
 } from './android';
-import { withIosBuildProperties, withIosDeploymentTarget, withIosInfoPlist } from './ios';
+import {
+  withIosBuildProperties,
+  withIosDeploymentTarget,
+  withIosFmtConsteval,
+  withIosInfoPlist,
+} from './ios';
 import { PluginConfigType, validateConfig } from './pluginConfig';
 
 /**
@@ -39,6 +44,7 @@ export const withBuildProperties: ConfigPlugin<PluginConfigType> = (config, prop
   config = withIosBuildProperties(config, pluginConfig);
   config = withIosDeploymentTarget(config, pluginConfig);
   config = withIosInfoPlist(config, pluginConfig);
+  config = withIosFmtConsteval(config, pluginConfig);
 
   return config;
 };


### PR DESCRIPTION
# Why

Fixes #44229

`fmt 11.0.2` (bundled with React Native via `third-party-podspecs/fmt.podspec`) defines `FMT_USE_CONSTEVAL=1` when it detects Clang ≥ 11. Apple Clang shipped with **Xcode 26** enforces stricter `consteval` evaluation rules, causing 5 compilation errors in `format-inl.h` for any project that builds React Native from source (`buildReactNativeFromSource: true`). Prebuilt binary users are unaffected.

# How

Added `withIosFmtConsteval` to `expo-build-properties/src/ios.ts`. When `buildReactNativeFromSource` is `true`, the plugin uses `withDangerousMod` to inject a Ruby snippet into the Podfile's `post_install` block:

```ruby
installer.pods_project.targets.select { |t| t.name == 'fmt' }.each do |t|
  t.build_configurations.each do |c|
    flags = c.build_settings['OTHER_CPLUSPLUSFLAGS'] || '$(inherited)'
    unless flags.include?('FMT_USE_CONSTEVAL')
      c.build_settings['OTHER_CPLUSPLUSFLAGS'] = "\#{flags} -DFMT_USE_CONSTEVAL=0"
    end
  end
end
```

This disables the consteval path that Xcode 26's Apple Clang rejects, scoped only to the `fmt` pod. The injection is idempotent (skips if marker already present) and is a no-op when `buildReactNativeFromSource` is `false` or unset.

# Test Plan

1. Create a new Expo app with `expo-build-properties` and set `ios.buildReactNativeFromSource: true`
2. Run `npx expo prebuild --platform ios`
3. Verify the injected snippet appears in the generated `ios/Podfile` inside `post_install`
4. Run `npx expo run:ios` on Xcode 26.4 — build should succeed without `fmt` consteval errors

Unit tests cover: injection, idempotency, no-op when `post_install` block is absent.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)