### PR TITLE
[android][image-picker] Fix UCrop overflow menu invisible on dark-themed devices

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [android] Handle edge-to-edge display in crop activity. ([#44208](https://github.com/expo/expo/pull/44208) by [@zoontek](https://github.com/zoontek))
 - fix potential `null` mime type reported ([#43734](https://github.com/expo/expo/pull/43734) by [@vonovak](https://github.com/vonovak))
 - [android] fix cropper default colors in light mode ([#42437](https://github.com/expo/expo/pull/42437) by [@fobos531](https://github.com/fobos531))
+- [android] Fix UCrop overflow menu (Flip Horizontal / Flip Vertical) invisible on dark-themed devices by switching crop activity theme to `DayNight`. ([#44324](https://github.com/expo/expo/issues/44324) by [@Nedunchezhiyan-M](https://github.com/Nedunchezhiyan-M))
 - [iOS] Fix `base64` result not being a JPEG data. ([#43806](https://github.com/expo/expo/pull/43806) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
 
     <activity
       android:name="expo.modules.imagepicker.ExpoCropImageActivity"
-      android:theme="@style/Base.Theme.AppCompat"
+      android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"
       android:exported="false"
       tools:replace="android:exported" />
     <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->


### PR DESCRIPTION
# Why

Fixes #44324

PR #42437 fixed the UCrop toolbar button colors but the activity theme was left as `@style/Base.Theme.AppCompat` — a forced-light theme that ignores the system day/night mode. On Android 10+ with dark mode enabled, the overflow popup menu (⋮ button → Flip Horizontal / Flip Vertical) gets a dark system background but inherits light-theme text color from the activity, making the menu items invisible (dark text on dark background).

# How

Change the `ExpoCropImageActivity` theme from `@style/Base.Theme.AppCompat` to `@style/Theme.AppCompat.DayNight.NoActionBar`.

- `DayNight` causes both the popup background **and** text color to adapt together to the system day/night setting, fixing the contrast mismatch.
- `NoActionBar` preserves the existing behavior (the crop activity manages its own toolbar).
- The existing custom color resources (`values/colors.xml` and `values-night/colors.xml`) for the toolbar continue to work unchanged via `applyCustomization()`.

# Test Plan

1. Set device to **dark mode** (Android Settings → Display → Dark theme)
2. Install a dev build with `expo-image-picker`
3. Call `launchImageLibraryAsync` with `allowsEditing: true`
4. Select any image — the UCrop editor opens
5. Tap the **⋮** (overflow) button in the top-right toolbar

**Before:** Menu items (Flip Horizontal, Flip Vertical) are invisible — dark text on dark background.
**After:** Menu items are clearly visible in both light and dark mode.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)