### PR TITLE
[template-default] Fix .gitignore referencing app-example instead of example

### DIFF
--- a/templates/expo-template-default/gitignore
+++ b/templates/expo-template-default/gitignore
@@ -36,7 +36,7 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 
-app-example
+example
 
 # generated native folders
 /ios


### PR DESCRIPTION
# Why

The `.gitignore` template in `create-expo-app` still references `app-example`, which was the old folder name used by the reset script. The reset script was updated to move boilerplate into `example/` instead. This was missed in #41983

# How

Updated the` .gitignore` template to reference `example` instead of `app-example` to match the current folder name used by the reset script.

# Test Plan

1. Create a new project with `pnpm create expo-app --template default@sdk-55`
2. Run `pnpm reset-project`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
