### PR TITLE
[android][expo-audio] Expose OGG output format and Opus audio encoder

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [iOS] Added `isLiveStream` option to `AudioLockScreenOptions` to hide duration and scrub bar for live streams. ([#43088](https://github.com/expo/expo/pull/43088) by [@robrechtme](https://github.com/robrechtme))
 - [android] Add support for playsInSilentMode ([#43117](https://github.com/expo/expo/pull/43117) by [@blazejkustra](https://github.com/blazejkustra))
 - Added `isLive`, `currentOffsetFromLive`, and `error` fields to `AudioStatus` for live stream detection and error handling. ([#44441](https://github.com/expo/expo/pull/44441) by [@alanjhughes](https://github.com/alanjhughes))
+- [android] Add `'ogg'` to `AndroidOutputFormat` and `'opus'` to `AndroidAudioEncoder`, mapped to `MediaRecorder.OutputFormat.OGG` / `MediaRecorder.AudioEncoder.OPUS` on API 29+. Enables crash-safe recordings on Android 10 and above. ([#44926](https://github.com/expo/expo/pull/44926) by [@pvinis](https://github.com/pvinis))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
@@ -60,12 +60,19 @@ enum class AndroidOutputFormat(val value: String) : Enumerable {
   AMR_WB("amrwb"),
   AAC_ADTS("aac_adts"),
   MPEG2TS("mpeg2ts"),
-  WEBM("webm");
+  WEBM("webm"),
+  OGG("ogg");
 
   fun toMediaOutputFormat(): Int {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       if (this == MPEG2TS) {
         return MediaRecorder.OutputFormat.MPEG_2_TS
+      }
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      if (this == OGG) {
+        return MediaRecorder.OutputFormat.OGG
       }
     }
 
@@ -88,15 +95,25 @@ enum class AndroidAudioEncoder(val value: String) : Enumerable {
   AMR_WB("amr_wb"),
   AAC("aac"),
   HE_AAC("he_aac"),
-  AAC_ELD("aac_eld");
+  AAC_ELD("aac_eld"),
+  OPUS("opus");
 
-  fun toMediaEncoding() = when (this) {
-    DEFAULT -> MediaRecorder.AudioEncoder.DEFAULT
-    AMR_NB -> MediaRecorder.AudioEncoder.AMR_NB
-    AMR_WB -> MediaRecorder.AudioEncoder.AMR_WB
-    AAC -> MediaRecorder.AudioEncoder.AAC
-    HE_AAC -> MediaRecorder.AudioEncoder.HE_AAC
-    AAC_ELD -> MediaRecorder.AudioEncoder.AAC_ELD
+  fun toMediaEncoding(): Int {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+      if (this == OPUS) {
+        return MediaRecorder.AudioEncoder.OPUS
+      }
+    }
+
+    return when (this) {
+      DEFAULT -> MediaRecorder.AudioEncoder.DEFAULT
+      AMR_NB -> MediaRecorder.AudioEncoder.AMR_NB
+      AMR_WB -> MediaRecorder.AudioEncoder.AMR_WB
+      AAC -> MediaRecorder.AudioEncoder.AAC
+      HE_AAC -> MediaRecorder.AudioEncoder.HE_AAC
+      AAC_ELD -> MediaRecorder.AudioEncoder.AAC_ELD
+      else -> MediaRecorder.AudioEncoder.DEFAULT
+    }
   }
 }
 

--- a/packages/expo-audio/src/Audio.types.ts
+++ b/packages/expo-audio/src/Audio.types.ts
@@ -321,7 +321,8 @@ export type AndroidOutputFormat =
   | 'amrwb'
   | 'aac_adts'
   | 'mpeg2ts'
-  | 'webm';
+  | 'webm'
+  | 'ogg';
 
 /**
  * Audio encoder options for Android recording.
@@ -331,7 +332,14 @@ export type AndroidOutputFormat =
  *
  * @platform android
  */
-export type AndroidAudioEncoder = 'default' | 'amr_nb' | 'amr_wb' | 'aac' | 'he_aac' | 'aac_eld';
+export type AndroidAudioEncoder =
+  | 'default'
+  | 'amr_nb'
+  | 'amr_wb'
+  | 'aac'
+  | 'he_aac'
+  | 'aac_eld'
+  | 'opus';
 
 /**
  * Bit rate strategies for audio encoding.


### PR DESCRIPTION
## Why

`expo-audio`'s `AndroidOutputFormat` and `AndroidAudioEncoder` unions are a strict subset of what `MediaRecorder` supports. `MediaRecorder.OutputFormat.OGG` and `MediaRecorder.AudioEncoder.OPUS` have been available since API 29 (Android 10, 2019) but are not reachable from JS. Exposing them unlocks two concrete wins that the current M4A/AAC-only path can't deliver:

1. **Crash-safe recordings.** M4A is an MP4 container — it needs the muxer to write a `moov` atom on `stop()`, and if the app is killed mid-recording the file is unplayable. OGG is self-describing at page granularity: every page is independently valid and carries its own CRC, so a killed recording remains playable up to the last complete page. This matters a lot for long recordings where losing the whole file to a crash is a harsh UX cost.
2. **Opus is substantially more efficient for voice than AAC.** 32 kbps mono Opus is effectively transparent for speech; a 20-minute recording is roughly 5 MB versus about 19 MB for AAC at the current defaults.

Corresponding feature request on Canny: <https://expo.canny.io/feature-requests/p/expo-audio-expose-ogg-output-format-and-opus-audio-encoder-on-android-api-29>.

## How

- Add `OGG("ogg")` to `AndroidOutputFormat` and `OPUS("opus")` to `AndroidAudioEncoder` in `AudioRecords.kt`.
- Map each to the corresponding `MediaRecorder` constant behind a `Build.VERSION.SDK_INT >= Q` guard, so older devices fall through to the existing default instead of breaking.
- Add `'ogg'` and `'opus'` to the corresponding TypeScript unions in `Audio.types.ts`.
- `toMediaEncoding()` changed from expression body to block body to fit the API 29 guard; behaviour is unchanged for all existing encoders.

## Example

```ts
import { useAudioRecorder } from 'expo-audio'

const recorder = useAudioRecorder({
  extension: '.ogg',
  sampleRate: 48000,
  numberOfChannels: 1,
  bitRate: 32000,
  android: { outputFormat: 'ogg', audioEncoder: 'opus' },
  ios: { /* unchanged */ },
  web: { /* unchanged */ },
})
```

## Test plan

- [ ] Record on an Android 10+ emulator/device with `outputFormat: 'ogg'` + `audioEncoder: 'opus'`, verify a playable `.ogg` file is produced and decodes correctly.
- [ ] Record on an Android 9 device, verify the existing M4A/AAC path is unaffected.
- [ ] Force-kill the app mid-recording on API 29+, confirm the resulting `.ogg` file is still playable up to the last page.
- [ ] Verify the other existing output formats (`mpeg4`, `webm`, `3gp`, `aac_adts`, etc.) still record correctly — no regressions from the expression-body → block-body change on `toMediaEncoding()`.

## Notes

The CHANGELOG entry currently links to PR #0 as a placeholder; happy to update it to this PR's number once assigned (or feel free to fix it during review).

I've been running this patch in production via \`patch-package\` for a React Native app that records long-form audio, and it's been working reliably on Android 10+ devices.