### PR TITLE
[widgets][plugin] Fix "extension CFBundleVersion not synced with main app"

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Add support for `React.Fragment`. ([#43833](https://github.com/expo/expo/pull/43833) by [@jakex7](https://github.com/jakex7))
 - Add Button children support. ([#43832](https://github.com/expo/expo/pull/43832) by [@jakex7](https://github.com/jakex7))
 - Remove unused `Compression` related code. ([#43981](https://github.com/expo/expo/pull/43981) by [@jakex7](https://github.com/jakex7))
+- [plugin] Fix "extension CFBundleVersion not synced with main app" ([#44928](https://github.com/expo/expo/pull/44928) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
+++ b/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
@@ -56,7 +56,7 @@ const withWidgetSourceFiles = (config, { widgets, targetName, onFilesGenerated, 
             'com.apple.security.application-groups': [groupIdentifier],
         };
         fs.writeFileSync(entitlementsPath, plist_1.default.build(entitlementsContent));
-        const infoPlistPath = createInfoPlist(groupIdentifier, targetDirectory);
+        const infoPlistPath = createInfoPlist(groupIdentifier, targetDirectory, config.ios?.version ?? config.version ?? '1.0', config.ios?.buildNumber ?? '1');
         const indexSwiftPath = createIndexSwift(widgets, targetDirectory);
         const widgetSwiftPaths = widgets.map((widget) => createWidgetSwift(widget, targetDirectory));
         onFilesGenerated([entitlementsPath, infoPlistPath, indexSwiftPath, ...widgetSwiftPaths]);
@@ -91,9 +91,9 @@ const createWidgetSwift = (widget, targetPath) => {
     fs.writeFileSync(widgetFilePath, widgetSwift(widget));
     return widgetFilePath;
 };
-const createInfoPlist = (groupIdentifier, targetPath) => {
+const createInfoPlist = (groupIdentifier, targetPath, marketingVersion, bundleVersion) => {
     const infoPlistPath = `${targetPath}/Info.plist`;
-    fs.writeFileSync(infoPlistPath, infoPlist(groupIdentifier));
+    fs.writeFileSync(infoPlistPath, infoPlist(groupIdentifier, marketingVersion, bundleVersion));
     return infoPlistPath;
 };
 const addIndexSwiftChunk = (widgets, index, isLastChunk) => `
@@ -120,7 +120,7 @@ struct ${widget.name}: Widget {
     .supportedFamilies([.${widget.supportedFamilies.join(', .')}])${widget.contentMarginsDisabled ? '\n    .contentMarginsDisabled()' : ''}
   }
 }`;
-const infoPlist = (groupIdentifier) => `<?xml version="1.0" encoding="UTF-8"?>
+const infoPlist = (groupIdentifier, marketingVersion, bundleVersion) => `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -131,6 +131,10 @@ const infoPlist = (groupIdentifier) => `<?xml version="1.0" encoding="UTF-8"?>
 	</dict>
   <key>ExpoWidgetsAppGroupIdentifier</key>
   <string>${groupIdentifier}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${marketingVersion}</string>
+	<key>CFBundleVersion</key>
+	<string>${bundleVersion}</string>
 </dict>
 </plist>
 `;

--- a/packages/expo-widgets/plugin/build/xcode/withTargetXcodeProject.js
+++ b/packages/expo-widgets/plugin/build/xcode/withTargetXcodeProject.js
@@ -12,14 +12,13 @@ const withTargetXcodeProject = (config, { targetName, bundleIdentifier, deployme
     const xcodeProject = config.modResults;
     const targetUuid = xcodeProject.generateUuid();
     const groupName = 'Embed Foundation Extensions';
-    const marketingVersion = config.version;
     const xCConfigurationList = (0, addXCConfigurationList_1.addXCConfigurationList)(xcodeProject, {
         targetName,
-        currentProjectVersion: config.ios.buildNumber || '1',
         bundleIdentifier,
         deploymentTarget,
-        marketingVersion,
         appleTeamId,
+        marketingVersion: '1.0',
+        currentProjectVersion: '1',
     });
     const productFile = (0, addProductFile_1.addProductFile)(xcodeProject, {
         targetName,

--- a/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
@@ -33,7 +33,12 @@ const withWidgetSourceFiles: ConfigPlugin<WidgetSourceFilesProps> = (
       };
       fs.writeFileSync(entitlementsPath, plist.build(entitlementsContent));
 
-      const infoPlistPath = createInfoPlist(groupIdentifier, targetDirectory);
+      const infoPlistPath = createInfoPlist(
+        groupIdentifier,
+        targetDirectory,
+        config.ios?.version ?? config.version ?? '1.0',
+        config.ios?.buildNumber ?? '1'
+      );
       const indexSwiftPath = createIndexSwift(widgets, targetDirectory);
       const widgetSwiftPaths = widgets.map((widget) => createWidgetSwift(widget, targetDirectory));
 
@@ -74,9 +79,14 @@ const createWidgetSwift = (widget: WidgetConfig, targetPath: string): string => 
   return widgetFilePath;
 };
 
-const createInfoPlist = (groupIdentifier: string, targetPath: string): string => {
+const createInfoPlist = (
+  groupIdentifier: string,
+  targetPath: string,
+  marketingVersion: string,
+  bundleVersion: string
+): string => {
   const infoPlistPath = `${targetPath}/Info.plist`;
-  fs.writeFileSync(infoPlistPath, infoPlist(groupIdentifier));
+  fs.writeFileSync(infoPlistPath, infoPlist(groupIdentifier, marketingVersion, bundleVersion));
   return infoPlistPath;
 };
 
@@ -110,7 +120,11 @@ struct ${widget.name}: Widget {
   }
 }`;
 
-const infoPlist = (groupIdentifier: string) => `<?xml version="1.0" encoding="UTF-8"?>
+const infoPlist = (
+  groupIdentifier: string,
+  marketingVersion: string,
+  bundleVersion: string
+) => `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -121,6 +135,10 @@ const infoPlist = (groupIdentifier: string) => `<?xml version="1.0" encoding="UT
 	</dict>
   <key>ExpoWidgetsAppGroupIdentifier</key>
   <string>${groupIdentifier}</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${marketingVersion}</string>
+	<key>CFBundleVersion</key>
+	<string>${bundleVersion}</string>
 </dict>
 </plist>
 `;

--- a/packages/expo-widgets/plugin/src/xcode/withTargetXcodeProject.ts
+++ b/packages/expo-widgets/plugin/src/xcode/withTargetXcodeProject.ts
@@ -24,15 +24,14 @@ const withTargetXcodeProject: ConfigPlugin<TargetXcodeProjectProps> = (
     const xcodeProject = config.modResults;
     const targetUuid = xcodeProject.generateUuid();
     const groupName = 'Embed Foundation Extensions';
-    const marketingVersion = config.version;
 
     const xCConfigurationList = addXCConfigurationList(xcodeProject, {
       targetName,
-      currentProjectVersion: config.ios!.buildNumber || '1',
       bundleIdentifier,
       deploymentTarget,
-      marketingVersion,
       appleTeamId,
+      marketingVersion: '1.0',
+      currentProjectVersion: '1',
     });
 
     const productFile = addProductFile(xcodeProject, {


### PR DESCRIPTION
# Why

First try to fix #43740

# How

Instead of hardcoding versions in project configuration, use dynamic values from `info.plist`. 
https://github.com/expo/eas-cli/blob/84b09c4a28ac050e56333c40048289543d1bbe44/packages/eas-cli/src/build/ios/version.ts#L239

# Test Plan

Release a canary and run `eas build`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
