### PR TITLE
[brownfield] Support registering custom turbo modules from the hosting app

### DIFF
--- a/.github/workflows/test-suite-brownfield-isolated.yml
+++ b/.github/workflows/test-suite-brownfield-isolated.yml
@@ -167,7 +167,7 @@ jobs:
       - name: 🚇 Start Metro server
         run: |
           pnpm start --clear &
-          npx wait-on http://localhost:8081 --timeout 60000
+          npx wait-on http://localhost:8081/status --timeout 60000
         working-directory: apps/brownfield-tester/expo-app
       - name: 🧪 Run e2e tests (Debug)
         uses: ./.github/actions/use-android-emulator

--- a/apps/brownfield-tester/expo-app/src/app/apis/index.tsx
+++ b/apps/brownfield-tester/expo-app/src/app/apis/index.tsx
@@ -4,7 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { ActionButton } from '@/components';
 
-type Screen = 'communication' | 'dev-menu' | 'navigation' | 'state';
+type Screen = 'communication' | 'dev-menu' | 'native-modules' | 'navigation' | 'state';
 
 const Index = () => {
   const router = useRouter();
@@ -38,6 +38,14 @@ const Index = () => {
         description="State API"
         onPress={() => navigateToScreen('state')}
         testID="apis-state"
+      />
+      <ActionButton
+        type="link"
+        icon="cpu"
+        title="Native Modules"
+        description="Custom native modules from the hosting app"
+        onPress={() => navigateToScreen('native-modules')}
+        testID="apis-native-modules"
       />
       <ActionButton
         type="link"

--- a/apps/brownfield-tester/expo-app/src/app/apis/native-modules.tsx
+++ b/apps/brownfield-tester/expo-app/src/app/apis/native-modules.tsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { View, StyleSheet, Text, TurboModuleRegistry } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+import { ActionButton, Header } from '@/components';
+
+const BrownfieldTestModule = TurboModuleRegistry.get('BrownfieldTestModule');
+
+const NativeModules = () => {
+  const [greeting, setGreeting] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const isAvailable = BrownfieldTestModule != null;
+
+  const callGreet = async () => {
+    try {
+      const result = await BrownfieldTestModule?.getGreeting('Expo');
+      setGreeting(result);
+      setError(null);
+    } catch (e: any) {
+      setError(e.message);
+      setGreeting(null);
+    }
+  };
+
+  return (
+    <SafeAreaView>
+      <Header title="Native Modules" />
+      <View style={styles.container}>
+        <Text style={styles.title}>Module status</Text>
+        <Text
+          style={[styles.status, { color: isAvailable ? 'lightgreen' : 'salmon' }]}
+          testID="native-modules-status">
+          BrownfieldTestModule: {isAvailable ? 'Available' : 'Not available'}
+        </Text>
+      </View>
+      <ActionButton
+        title="Call getGreeting('Expo')"
+        description="Calls the custom native module registered by the hosting app"
+        icon="terminal"
+        onPress={callGreet}
+        testID="native-modules-greet"
+      />
+      {greeting && (
+        <View style={styles.container}>
+          <Text style={styles.title}>Result</Text>
+          <Text style={styles.result} testID="native-modules-result">
+            {greeting}
+          </Text>
+        </View>
+      )}
+      {error && (
+        <View style={styles.container}>
+          <Text style={styles.title}>Error</Text>
+          <Text style={[styles.result, { color: 'salmon' }]} testID="native-modules-error">
+            {error}
+          </Text>
+        </View>
+      )}
+    </SafeAreaView>
+  );
+};
+
+export default NativeModules;
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    gap: 8,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  status: {
+    fontSize: 14,
+    fontWeight: '500',
+    fontFamily: 'monospace',
+  },
+  result: {
+    borderRadius: 8,
+    padding: 16,
+    backgroundColor: '#121212',
+    fontSize: 14,
+    fontWeight: '400',
+    color: 'lightgreen',
+    fontFamily: 'monospace',
+    lineHeight: 20,
+  },
+});

--- a/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/BrownfieldTestModule.kt
+++ b/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/BrownfieldTestModule.kt
@@ -1,0 +1,15 @@
+package dev.expo.brownfieldintegratedtester
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class BrownfieldTestModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+  override fun getName() = "BrownfieldTestModule"
+
+  @ReactMethod
+  fun getGreeting(name: String, promise: Promise) {
+    promise.resolve("Hello, $name! From the Android hosting app.")
+  }
+}

--- a/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/BrownfieldTestPackage.kt
+++ b/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/BrownfieldTestPackage.kt
@@ -1,0 +1,16 @@
+package dev.expo.brownfieldintegratedtester
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class BrownfieldTestPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+    return listOf(BrownfieldTestModule(reactContext))
+  }
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+    return emptyList()
+  }
+}

--- a/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/MainActivity.kt
+++ b/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/MainActivity.kt
@@ -19,7 +19,7 @@ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 class MainActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        ReactNativeHostManager.shared.initialize(this.application)
+        ReactNativeHostManager.shared.initialize(this.application, listOf(BrownfieldTestPackage()))
 
         val rootLayout =
             LinearLayout(this).apply {

--- a/apps/brownfield-tester/isolated/ios/BrownfieldIntegratedTester.xcodeproj/project.pbxproj
+++ b/apps/brownfield-tester/isolated/ios/BrownfieldIntegratedTester.xcodeproj/project.pbxproj
@@ -7,11 +7,16 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		87CFC9372F45EAA300AE56E3 /* expoappbrownfield.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87CFC9362F45EAA300AE56E3 /* expoappbrownfield.xcframework */; };
-		87CFC9382F45EAA300AE56E3 /* expoappbrownfield.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 87CFC9362F45EAA300AE56E3 /* expoappbrownfield.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		87F2AEBF2F4894F90099B7BE /* hermes.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 87F2AEBE2F4894F90099B7BE /* hermes.xcframework */; };
-		87F2AEC02F4894F90099B7BE /* hermes.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 87F2AEBE2F4894F90099B7BE /* hermes.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C06E21222F96D08600F8E5AA /* hermesvm.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C06E211D2F96D06E00F8E5AA /* hermesvm.xcframework */; };
+		C06E21232F96D08600F8E5AA /* hermesvm.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C06E211D2F96D06E00F8E5AA /* hermesvm.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C06E21242F96D08600F8E5AA /* React.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C06E211E2F96D06E00F8E5AA /* React.xcframework */; };
+		C06E21252F96D08600F8E5AA /* React.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C06E211E2F96D06E00F8E5AA /* React.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C06E21262F96D08600F8E5AA /* ReactNativeDependencies.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C06E211F2F96D06E00F8E5AA /* ReactNativeDependencies.xcframework */; };
+		C06E21272F96D08600F8E5AA /* ReactNativeDependencies.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C06E211F2F96D06E00F8E5AA /* ReactNativeDependencies.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		C06E212A2F96D43700F8E5AA /* expoappbrownfield.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C06E21282F96D43200F8E5AA /* expoappbrownfield.xcframework */; };
+		C06E212B2F96D43700F8E5AA /* expoappbrownfield.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C06E21282F96D43200F8E5AA /* expoappbrownfield.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		87CFC9392F45EAA300AE56E3 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -19,6 +24,10 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				C06E21252F96D08600F8E5AA /* React.xcframework in Embed Frameworks */,
+				C06E212B2F96D43700F8E5AA /* expoappbrownfield.xcframework in Embed Frameworks */,
+				C06E21232F96D08600F8E5AA /* hermesvm.xcframework in Embed Frameworks */,
+				C06E21272F96D08600F8E5AA /* ReactNativeDependencies.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -35,24 +44,11 @@
 		};
 /* End PBXCopyFilesBuildPhase section */
 
-/* Begin PBXCopyFilesBuildPhase section */
-		87CFC9392F45EAA300AE56E3 /* Embed Frameworks */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 10;
-			files = (
-				87F2AEC02F4894F90099B7BE /* hermes.xcframework in Embed Frameworks */,
-				87CFC9382F45EAA300AE56E3 /* expoappbrownfield.xcframework in Embed Frameworks */,
-			);
-			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
-
 /* Begin PBXFileReference section */
-		87CFC9362F45EAA300AE56E3 /* expoappbrownfield.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = expoappbrownfield.xcframework; path = ../../../artifacts/expoappbrownfield.xcframework; sourceTree = "<group>"; };
-		87F2AEBE2F4894F90099B7BE /* hermes.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = hermes.xcframework; path = ../../../artifacts/hermes.xcframework; sourceTree = "<group>"; };
+		C06E211D2F96D06E00F8E5AA /* hermesvm.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = hermesvm.xcframework; sourceTree = "<group>"; };
+		C06E211E2F96D06E00F8E5AA /* React.xcframework */ = {isa = PBXFileReference; expectedSignature = "SelfSigned:BEEAE960B121B398BB228BD547298BD461DFFFD862BD3AD794A38F6D426F6741"; lastKnownFileType = wrapper.xcframework; path = React.xcframework; sourceTree = "<group>"; };
+		C06E211F2F96D06E00F8E5AA /* ReactNativeDependencies.xcframework */ = {isa = PBXFileReference; expectedSignature = "SelfSigned:BEEAE960B121B398BB228BD547298BD461DFFFD862BD3AD794A38F6D426F6741"; lastKnownFileType = wrapper.xcframework; path = ReactNativeDependencies.xcframework; sourceTree = "<group>"; };
+		C06E21282F96D43200F8E5AA /* expoappbrownfield.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = expoappbrownfield.xcframework; sourceTree = "<group>"; };
 		C0AD19F12F180368005A1DBD /* BrownfieldIntegratedTester.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BrownfieldIntegratedTester.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -69,8 +65,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				87F2AEBF2F4894F90099B7BE /* hermes.xcframework in Frameworks */,
-				87CFC9372F45EAA300AE56E3 /* expoappbrownfield.xcframework in Frameworks */,
+				C06E21242F96D08600F8E5AA /* React.xcframework in Frameworks */,
+				C06E212A2F96D43700F8E5AA /* expoappbrownfield.xcframework in Frameworks */,
+				C06E21222F96D08600F8E5AA /* hermesvm.xcframework in Frameworks */,
+				C06E21262F96D08600F8E5AA /* ReactNativeDependencies.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -80,8 +78,10 @@
 		87CFC9352F45EAA300AE56E3 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				87F2AEBE2F4894F90099B7BE /* hermes.xcframework */,
-				87CFC9362F45EAA300AE56E3 /* expoappbrownfield.xcframework */,
+				C06E21282F96D43200F8E5AA /* expoappbrownfield.xcframework */,
+				C06E211D2F96D06E00F8E5AA /* hermesvm.xcframework */,
+				C06E211E2F96D06E00F8E5AA /* React.xcframework */,
+				C06E211F2F96D06E00F8E5AA /* ReactNativeDependencies.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/apps/brownfield-tester/isolated/ios/BrownfieldIntegratedTester/BrownfieldIntegratedTesterApp.swift
+++ b/apps/brownfield-tester/isolated/ios/BrownfieldIntegratedTester/BrownfieldIntegratedTesterApp.swift
@@ -6,7 +6,11 @@ struct BrownfieldIntegratedTesterApp: App {
     @UIApplicationDelegateAdaptor var delegate: ExpoBrownfieldAppDelegate
 
     init() {
-      ReactNativeHostManager.shared.initialize()
+      ReactNativeHostManager.shared.initialize(
+        turboModuleClasses: [
+          "BrownfieldTestModule": NSClassFromString("BrownfieldTestModule")!
+        ]
+      )
     }
     var body: some Scene {
         WindowGroup {

--- a/apps/brownfield-tester/isolated/ios/BrownfieldIntegratedTester/BrownfieldTestModule.m
+++ b/apps/brownfield-tester/isolated/ios/BrownfieldIntegratedTester/BrownfieldTestModule.m
@@ -1,0 +1,49 @@
+#import <Foundation/Foundation.h>
+
+// Forward-declared React types. The React.xcframework is linked but its
+// headers require a VFS overlay to import, so we declare the minimal
+// types needed to define a bridge module directly.
+typedef void (^RCTPromiseResolveBlock)(id result);
+typedef void (^RCTPromiseRejectBlock)(NSString *code, NSString *message, NSError *error);
+
+typedef struct RCTMethodInfo {
+  const char *const jsName;
+  const char *const objcName;
+  const BOOL isSync;
+} RCTMethodInfo;
+
+@protocol RCTBridgeModule <NSObject>
++ (NSString *)moduleName;
+@optional
++ (BOOL)requiresMainQueueSetup;
+@end
+
+@interface BrownfieldTestModule : NSObject <RCTBridgeModule>
+@end
+
+@implementation BrownfieldTestModule
+
++ (NSString *)moduleName {
+  return @"BrownfieldTestModule";
+}
+
++ (BOOL)requiresMainQueueSetup {
+  return NO;
+}
+
++ (const RCTMethodInfo *)__rct_export__getGreeting {
+  static RCTMethodInfo info = {
+    "",
+    "getGreeting:(NSString *)name resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject",
+    NO
+  };
+  return &info;
+}
+
+- (void)getGreeting:(NSString *)name
+            resolve:(RCTPromiseResolveBlock)resolve
+             reject:(RCTPromiseRejectBlock)reject {
+  resolve([NSString stringWithFormat:@"Hello, %@! From the iOS hosting app.", name]);
+}
+
+@end

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [iOS] Add `DEFINE_MODULES=TRUE` build setting ([#44672](https://github.com/expo/expo/pull/44672) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [ios] Fix loading assets in brownfield. ([#44724](https://github.com/expo/expo/pull/44724) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Support rendering multiple ReactNativeView simultaneously ([#44891](https://github.com/expo/expo/pull/44891) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- Support registering custom turbo modules from the hosting app ([#44929](https://github.com/expo/expo/pull/44929) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
+++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import com.facebook.react.PackageList
 import com.facebook.react.ReactHost
+import com.facebook.react.ReactPackage
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
 import com.facebook.react.common.ReleaseLevel
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
@@ -23,7 +24,7 @@ class ReactNativeHostManager {
     return reactHost
   }
 
-  fun initialize(application: Application) {
+  fun initialize(application: Application, additionalPackages: List<ReactPackage> = emptyList()) {
     if (reactHost != null) {
       return
     }
@@ -59,13 +60,13 @@ class ReactNativeHostManager {
 
     reactHost = ExpoReactHostFactory.getDefaultReactHost(
       context = application.applicationContext,
-      packageList = PackageList(application).packages
+      packageList = PackageList(application).packages + additionalPackages
     )
   }
 }
 
-fun Activity.showReactNativeFragment(rootComponent: String = "main") {
-  ReactNativeHostManager.shared.initialize(this.application)
+fun Activity.showReactNativeFragment(rootComponent: String = "main", additionalPackages: List<ReactPackage> = emptyList()) {
+  ReactNativeHostManager.shared.initialize(this.application, additionalPackages)
   val fragment = ReactNativeFragment.createFragmentHost(this, rootComponent)
   setContentView(fragment)
   setUpNativeBackHandling()

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeDelegate.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeDelegate.swift
@@ -2,6 +2,20 @@ internal import Expo
 internal import React
 
 class ReactNativeDelegate: ExpoReactNativeFactoryDelegate {
+  private let turboModuleClasses: [String: AnyClass]
+  init(
+    turboModuleClasses: [String: AnyClass] = [:]
+  ) {
+    self.turboModuleClasses = turboModuleClasses
+    super.init()
+  }
+
+  @objc(getModuleClassFromName:)
+  func getModuleClass(fromName name: UnsafePointer<CChar>!) -> AnyClass? {
+    let moduleName = String(cString: name)
+    return turboModuleClasses[moduleName]
+  }
+
   // Extension point for config-plugins
   override func sourceURL(for bridge: RCTBridge) -> URL? {
     // Needed to return the correct URL for expo-dev-client

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
@@ -23,9 +23,7 @@ public class ReactNativeHostManager {
    * Initializes ReactNativeHostManager instance
    * Instance can be initialized only once
    */
-  public func initialize(
-    turboModuleClasses: [String: AnyClass] = [:]
-  ) {
+  public func initialize(turboModuleClasses: [String: AnyClass] = [:]) {
     if firstLoadInitialized {
       return
     }
@@ -64,9 +62,7 @@ public class ReactNativeHostManager {
   * Initializes a React Native instance
   */
   public func initializeInstance() {
-    let delegate = ReactNativeDelegate(
-      turboModuleClasses: turboModuleClasses
-    )
+    let delegate = ReactNativeDelegate(turboModuleClasses: turboModuleClasses)
     reactNativeFactory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
     reactNativeDelegate = delegate

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
@@ -17,16 +17,20 @@ public class ReactNativeHostManager {
   private var reactNativeFactory: RCTReactNativeFactory?
   private var firstLoadInitialized: Bool = false
   private var devMenuInitialized: Bool = false
+  private var turboModuleClasses: [String: AnyClass] = [:]
 
   /**
    * Initializes ReactNativeHostManager instance
    * Instance can be initialized only once
    */
-  public func initialize() {
+  public func initialize(
+    turboModuleClasses: [String: AnyClass] = [:]
+  ) {
     if firstLoadInitialized {
       return
     }
 
+    self.turboModuleClasses = turboModuleClasses
     firstLoadInitialized = true
     initializeInstance()
     // Ensure this won't get stripped by the Swift compiler
@@ -60,7 +64,9 @@ public class ReactNativeHostManager {
   * Initializes a React Native instance
   */
   public func initializeInstance() {
-    let delegate = ReactNativeDelegate()
+    let delegate = ReactNativeDelegate(
+      turboModuleClasses: turboModuleClasses
+    )
     reactNativeFactory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
     reactNativeDelegate = delegate

--- a/packages/expo-brownfield/plugin/templates/patches/ReactNativeHostManager.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/ReactNativeHostManager.patch
@@ -21,7 +21,7 @@ index a9fbbe7d70..f7561327e7 100644
    companion object {
 @@ -61,13 +71,44 @@ class ReactNativeHostManager {
        context = application.applicationContext,
-       packageList = PackageList(application).packages
+       packageList = PackageList(application).packages + additionalPackages
      )
 +
 +    if (BuildConfig.DEBUG) {
@@ -36,8 +36,8 @@ index a9fbbe7d70..f7561327e7 100644
    }
  }
  
- fun Activity.showReactNativeFragment(rootComponent: String = "main") {
-   ReactNativeHostManager.shared.initialize(this.application)
+ fun Activity.showReactNativeFragment(rootComponent: String = "main", additionalPackages: List<ReactPackage> = emptyList()) {
+   ReactNativeHostManager.shared.initialize(this.application, additionalPackages)
 -  val fragment = ReactNativeFragment.createFragmentHost(this, rootComponent)
 -  setContentView(fragment)
 +


### PR DESCRIPTION
# Why

Brownfield apps often have existing native modules (e.g., analytics, auth, proprietary SDKs) and we got a request to allow users to expose them to the React Native surface. Currently, only auto-linked Expo modules are available. This adds an API for hosting apps to register their own turbo modules and native components during brownfield initialization.

# How
 
On Android: Added an `additionalPackages: List<ReactPackage>` parameter to `ReactNativeHostManager.initialize()` and `Activity.showReactNativeFragment()`. The provided packages are concatenated with the autolinking-generated `PackageList` and passed to `ExpoReactHostFactory.getDefaultReactHost()`. `ReactPackage` is the idiomatic Android mechanism and covers both turbo modules and view managers.

On iOS: Added `turboModuleClasses` and `thirdPartyFabricComponents` parameters to `ReactNativeHostManager.initialize()`, forwarded to `ReactNativeDelegate`. The delegate implements:
- `getModuleClassFromName:` (via `@objc` annotation to match the ObjC selector hidden behind `#if defined(__cplusplus)`) for turbo module class resolution ones

Both platforms default to empty collections, so this does not introduce any breaking changes.

# Test Plan

- Register a custom `ReactPackage` on Android via `additionalPackages` and verify the module is accessible from JS through `TurboModuleRegistry`
- Register a custom turbo module class on iOS via `turboModuleClasses` and verify it's accessible from JS
- Verify existing autolinked modules still work on both platforms (no regressions)
- Test in both integrated and isolated brownfield modes


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
