### PR TITLE
[cli] Migrate to first-party OAuth flow

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- Migrate `expo login --browser`/`--sso` to OAuth 2.0 authorization code flow with PKCE. ([#44938](https://github.com/expo/expo/pull/44938) by [@byronkarlen](https://github.com/byronkarlen))
 - Deserialize new `@expo/metro-config` packed source-map format and update to use new source-map representation internally ([#45594](https://github.com/expo/expo/pull/45594) by [@kitten](https://github.com/kitten))
 
 ## 56.1.0 — 2026-05-08

--- a/packages/@expo/cli/src/api/endpoint.ts
+++ b/packages/@expo/cli/src/api/endpoint.ts
@@ -16,7 +16,7 @@ export function getExpoWebsiteBaseUrl(): string {
   if (env.EXPO_STAGING) {
     return `https://staging.expo.dev`;
   } else if (env.EXPO_LOCAL) {
-    return `http://127.0.0.1:3001`;
+    return `http://expo.test`;
   } else {
     return `https://expo.dev`;
   }

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -46,10 +46,7 @@ async function exchangeCodeForSessionSecretAsync({
     await response.json()
   );
   if (!sessionSecret) {
-    throw new CommandError(
-      'BROWSER_AUTH',
-      'Failed to obtain session secret from token exchange.'
-    );
+    throw new CommandError('BROWSER_AUTH', 'Failed to obtain session secret from token exchange.');
   }
   return sessionSecret;
 }

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -1,10 +1,58 @@
 import assert from 'assert';
 import openBrowserAsync from 'better-opn';
+import crypto from 'crypto';
 import http from 'http';
 import { Socket } from 'node:net';
-import querystring from 'querystring';
 
 import * as Log from '../../log';
+import { CommandError } from '../../utils/errors';
+import { fetchAsync, getResponseDataOrThrow } from '../rest/client';
+
+const CLIENT_ID = 'expo-cli';
+
+function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+function generateCodeChallenge(codeVerifier: string): string {
+  return crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+}
+
+function generateState(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+async function exchangeCodeForSessionSecretAsync({
+  code,
+  codeVerifier,
+  redirectUri,
+}: {
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+}): Promise<string> {
+  const response = await fetchAsync('auth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+      client_id: CLIENT_ID,
+    }),
+  });
+  const { session_secret: sessionSecret } = getResponseDataOrThrow<{ session_secret?: string }>(
+    await response.json()
+  );
+  if (!sessionSecret) {
+    throw new CommandError(
+      'BROWSER_AUTH',
+      'Failed to obtain session secret from token exchange.'
+    );
+  }
+  return sessionSecret;
+}
 
 export async function getSessionUsingBrowserAuthFlowAsync({
   expoWebsiteUrl,
@@ -15,13 +63,28 @@ export async function getSessionUsingBrowserAuthFlowAsync({
 }): Promise<string> {
   const scheme = 'http';
   const hostname = 'localhost';
-  const path = '/auth/callback';
+  const callbackPath = '/auth/callback';
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const buildRedirectUri = (port: number): string =>
+    `${scheme}://${hostname}:${port}${callbackPath}`;
 
   const buildExpoLoginUrl = (port: number, sso: boolean): string => {
-    const params = querystring.stringify({
-      confirm_account: 'true',
-      app_redirect_uri: `${scheme}://${hostname}:${port}${path}`,
-    });
+    // Note: we avoid URLSearchParams here because better-opn calls encodeURI()
+    // on the URL before passing it to AppleScript, which would double-encode
+    // the percent-encoded values from URLSearchParams.toString().
+    const params = [
+      `client_id=${CLIENT_ID}`,
+      `redirect_uri=${buildRedirectUri(port)}`,
+      `response_type=code`,
+      `code_challenge=${codeChallenge}`,
+      `code_challenge_method=S256`,
+      `state=${state}`,
+      `confirm_account=true`,
+    ].join('&');
     return `${expoWebsiteUrl}${sso ? '/sso-login' : '/login'}?${params}`;
   };
 
@@ -42,22 +105,39 @@ export async function getSessionUsingBrowserAuthFlowAsync({
             }
           };
 
-          try {
-            if (!(request.method === 'GET' && request.url?.includes('/auth/callback'))) {
-              throw new Error('Unexpected login response.');
+          const handleRequestAsync = async (): Promise<void> => {
+            if (!(request.method === 'GET' && request.url?.includes(callbackPath))) {
+              throw new CommandError('BROWSER_AUTH', 'Unexpected login response.');
             }
             const url = new URL(request.url, `http:${request.headers.host}`);
-            const sessionSecret = url.searchParams.get('session_secret');
+            const code = url.searchParams.get('code');
+            const returnedState = url.searchParams.get('state');
 
-            if (!sessionSecret) {
-              throw new Error('Request missing session_secret search parameter.');
+            if (!code) {
+              throw new CommandError('BROWSER_AUTH', 'Request missing code search parameter.');
             }
+            if (returnedState !== state) {
+              throw new CommandError('BROWSER_AUTH', 'State mismatch. Possible CSRF attack.');
+            }
+
+            const address = server.address();
+            assert(address !== null && typeof address === 'object');
+            const redirectUri = buildRedirectUri(address.port);
+
+            const sessionSecret = await exchangeCodeForSessionSecretAsync({
+              code,
+              codeVerifier,
+              redirectUri,
+            });
+
             resolve(sessionSecret);
             redirectAndCleanup('success');
-          } catch (error) {
+          };
+
+          handleRequestAsync().catch((error) => {
             redirectAndCleanup('error');
             reject(error);
-          }
+          });
         }
       );
 
@@ -71,6 +151,9 @@ export async function getSessionUsingBrowserAuthFlowAsync({
         );
         const port = address.port;
         const authorizeUrl = buildExpoLoginUrl(port, sso);
+        Log.log(
+          `If your browser doesn't automatically open, visit this link to log in: ${authorizeUrl}`
+        );
         openBrowserAsync(authorizeUrl);
       });
 

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -1,10 +1,58 @@
 import assert from 'assert';
 import openBrowserAsync from 'better-opn';
+import crypto from 'crypto';
 import http from 'http';
 import type { Socket } from 'node:net';
-import querystring from 'querystring';
 
 import * as Log from '../../log';
+import { CommandError } from '../../utils/errors';
+import { fetchAsync, getResponseDataOrThrow } from '../rest/client';
+
+const CLIENT_ID = 'expo-cli';
+
+function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+function generateCodeChallenge(codeVerifier: string): string {
+  return crypto.createHash('sha256').update(codeVerifier).digest('base64url');
+}
+
+function generateState(): string {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+async function exchangeCodeForSessionSecretAsync({
+  code,
+  codeVerifier,
+  redirectUri,
+}: {
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+}): Promise<string> {
+  const response = await fetchAsync('auth/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+      code_verifier: codeVerifier,
+      client_id: CLIENT_ID,
+    }),
+  });
+  const { session_secret: sessionSecret } = getResponseDataOrThrow<{ session_secret?: string }>(
+    await response.json()
+  );
+  if (!sessionSecret) {
+    throw new CommandError(
+      'BROWSER_AUTH',
+      'Failed to obtain session secret from token exchange.'
+    );
+  }
+  return sessionSecret;
+}
 
 export async function getSessionUsingBrowserAuthFlowAsync({
   expoWebsiteUrl,
@@ -15,13 +63,28 @@ export async function getSessionUsingBrowserAuthFlowAsync({
 }): Promise<string> {
   const scheme = 'http';
   const hostname = 'localhost';
-  const path = '/auth/callback';
+  const callbackPath = '/auth/callback';
+
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+  const state = generateState();
+
+  const buildRedirectUri = (port: number): string =>
+    `${scheme}://${hostname}:${port}${callbackPath}`;
 
   const buildExpoLoginUrl = (port: number, sso: boolean): string => {
-    const params = querystring.stringify({
-      confirm_account: 'true',
-      app_redirect_uri: `${scheme}://${hostname}:${port}${path}`,
-    });
+    // Note: we avoid URLSearchParams here because better-opn calls encodeURI()
+    // on the URL before passing it to AppleScript, which would double-encode
+    // the percent-encoded values from URLSearchParams.toString().
+    const params = [
+      `client_id=${CLIENT_ID}`,
+      `redirect_uri=${buildRedirectUri(port)}`,
+      `response_type=code`,
+      `code_challenge=${codeChallenge}`,
+      `code_challenge_method=S256`,
+      `state=${state}`,
+      `confirm_account=true`,
+    ].join('&');
     return `${expoWebsiteUrl}${sso ? '/sso-login' : '/login'}?${params}`;
   };
 
@@ -42,22 +105,39 @@ export async function getSessionUsingBrowserAuthFlowAsync({
             }
           };
 
-          try {
-            if (!(request.method === 'GET' && request.url?.includes('/auth/callback'))) {
-              throw new Error('Unexpected login response.');
+          const handleRequestAsync = async (): Promise<void> => {
+            if (!(request.method === 'GET' && request.url?.includes(callbackPath))) {
+              throw new CommandError('BROWSER_AUTH', 'Unexpected login response.');
             }
             const url = new URL(request.url, `http:${request.headers.host}`);
-            const sessionSecret = url.searchParams.get('session_secret');
+            const code = url.searchParams.get('code');
+            const returnedState = url.searchParams.get('state');
 
-            if (!sessionSecret) {
-              throw new Error('Request missing session_secret search parameter.');
+            if (!code) {
+              throw new CommandError('BROWSER_AUTH', 'Request missing code search parameter.');
             }
+            if (returnedState !== state) {
+              throw new CommandError('BROWSER_AUTH', 'State mismatch. Possible CSRF attack.');
+            }
+
+            const address = server.address();
+            assert(address !== null && typeof address === 'object');
+            const redirectUri = buildRedirectUri(address.port);
+
+            const sessionSecret = await exchangeCodeForSessionSecretAsync({
+              code,
+              codeVerifier,
+              redirectUri,
+            });
+
             resolve(sessionSecret);
             redirectAndCleanup('success');
-          } catch (error) {
+          };
+
+          handleRequestAsync().catch((error) => {
             redirectAndCleanup('error');
             reject(error);
-          }
+          });
         }
       );
 
@@ -71,6 +151,9 @@ export async function getSessionUsingBrowserAuthFlowAsync({
         );
         const port = address.port;
         const authorizeUrl = buildExpoLoginUrl(port, sso);
+        Log.log(
+          `If your browser doesn't automatically open, visit this link to log in: ${authorizeUrl}`
+        );
         openBrowserAsync(authorizeUrl);
       });
 


### PR DESCRIPTION
# Why
Parity with https://github.com/expo/eas-cli/pull/3398 - we want to use the new auth flow provided by website/www. This PR depends on https://github.com/expo/universe/pull/26792.

# How
Mirrored the OAuth 2.0 authorization code flow with PKCE from [eas-cli#3542](https://github.com/expo/eas-cli/pull/3542) into `getSessionUsingBrowserAuthFlowAsync`:
  - On login, generate `code_verifier`, `state` `code_challenge`/`code_verifier` per OAuth2.1
  - Open the browser to `${websiteUrl}${sso ? '/sso-login' :
  '/login'}?<oauth-params>
  - On the local callback, validate the returned `state` against the generated one, then exchange the `code` for session secret
  - `--browser` and `--sso` continue to share the same launcher — the only difference is the website route (`/login` vs `/sso-login`).

Also updated `getExpoWebsiteBaseUrl()` to return `http://expo.test` under `EXPO_LOCAL` (matching eas-cli), so the local Next.js dev server can correctly serve its asset chunks under the expected `Host` header.

# Test Plan
Made sure --browser works for both regular users and sso users, both when already logged in on website and not already logged in.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
