### PR TITLE
[JSI] Revise JavaScriptTypedArray API and fix its lifetime

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/TypedArray.cpp
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/TypedArray.cpp
@@ -23,36 +23,20 @@ TypedArrayKind getTypedArrayKindForName(const std::string &name) {
   return nameToKindMap.at(name);
 }
 
-TypedArray::TypedArray(jsi::Runtime &runtime, const jsi::Object &obj)
-    : jsi::Object(jsi::Value(runtime, obj).asObject(runtime)) {}
-
-TypedArrayKind TypedArray::getKind(jsi::Runtime &runtime) const {
-  auto constructorName = this->getPropertyAsObject(runtime, "constructor")
+TypedArrayKind getTypedArrayKind(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+  auto constructorName = jsObj.getPropertyAsObject(runtime, "constructor")
                              .getProperty(runtime, "name")
                              .asString(runtime)
                              .utf8(runtime);
   return getTypedArrayKindForName(constructorName);
-};
-
-size_t TypedArray::byteOffset(jsi::Runtime &runtime) const {
-  return static_cast<size_t>(getProperty(runtime, "byteOffset").asNumber());
 }
 
-size_t TypedArray::byteLength(jsi::Runtime &runtime) const {
-  return static_cast<size_t>(getProperty(runtime, "byteLength").asNumber());
-}
-
-jsi::ArrayBuffer TypedArray::getBuffer(jsi::Runtime &runtime) const {
-  auto buffer = getProperty(runtime, "buffer");
+jsi::ArrayBuffer getTypedArrayBuffer(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+  auto buffer = jsObj.getProperty(runtime, "buffer");
   if (buffer.isObject() && buffer.asObject(runtime).isArrayBuffer(runtime)) {
     return buffer.asObject(runtime).getArrayBuffer(runtime);
-  } else {
-    throw std::runtime_error("no ArrayBuffer attached");
   }
-}
-
-void* TypedArray::getRawPointer(jsi::Runtime &runtime) const {
-  return reinterpret_cast<void *>(getBuffer(runtime).data(runtime) + byteOffset(runtime));
+  throw std::runtime_error("no ArrayBuffer attached");
 }
 
 bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -124,13 +124,6 @@ inline jsi::Value valueFromArrayBuffer(jsi::Runtime &runtime, const jsi::ArrayBu
 }
 
 /**
- * Converts a `expo::TypedArray` to a `jsi::Value`.
- */
-inline jsi::Value valueFromTypedArray(jsi::Runtime &runtime, const TypedArray &typedArray) {
-  return jsi::Value(runtime, typedArray);
-}
-
-/**
  * Returns the size of the array buffer storage in bytes.
  */
 inline size_t arrayBufferSize(jsi::Runtime &runtime, const jsi::ArrayBuffer &arrayBuffer) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/TypedArray.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/TypedArray.h
@@ -26,24 +26,19 @@ enum class TypedArrayKind {
   BigUint64Array = 11,
 };
 
-class TypedArray : public jsi::Object {
- public:
-  TypedArray(jsi::Runtime &, const jsi::Object &);
-  TypedArray(TypedArray &&) noexcept = default;
-  TypedArray &operator=(TypedArray &&) noexcept = default;
-
-  TypedArrayKind getKind(jsi::Runtime &runtime) const;
-
-  size_t byteOffset(jsi::Runtime &runtime) const;
-
-  size_t byteLength(jsi::Runtime &runtime) const;
-
-  jsi::ArrayBuffer getBuffer(jsi::Runtime &runtime) const;
-
-  void* getRawPointer(jsi::Runtime &runtime) const;
-};
-
 bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
+
+/**
+ * Returns the `TypedArrayKind` of the given typed-array object, derived from its
+ * `constructor.name` (e.g. `Uint8Array`, `Float32Array`).
+ */
+TypedArrayKind getTypedArrayKind(jsi::Runtime &runtime, const jsi::Object &jsObj);
+
+/**
+ * Returns the underlying `ArrayBuffer` backing the given typed-array object.
+ * Throws if the object has no attached ArrayBuffer.
+ */
+jsi::ArrayBuffer getTypedArrayBuffer(jsi::Runtime &runtime, const jsi::Object &jsObj);
 
 } // namespace expo
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
@@ -5,24 +5,79 @@ internal import ExpoModulesJSI_Cxx
 
 public struct JavaScriptTypedArray: ~Copyable {
   internal weak let runtime: JavaScriptRuntime?
-  internal let pointee: expo.TypedArray
+  internal let pointee: facebook.jsi.Object
+
+  /**
+   The underlying `ArrayBuffer` backing this typed array. Stored alongside `pointee`
+   so that holding the Swift value keeps the backing store alive on the JS side —
+   the JS garbage collector cannot free the buffer while this reference exists.
+   */
+  internal let arrayBuffer: facebook.jsi.ArrayBuffer
 
   public let kind: Kind
 
-  init(_ runtime: JavaScriptRuntime, _ typedArray: consuming expo.TypedArray) {
+  init(_ runtime: JavaScriptRuntime, _ object: consuming facebook.jsi.Object) {
     self.runtime = runtime
-    self.pointee = typedArray
-    self.kind = Kind(rawValue: Int(pointee.getKind(runtime.pointee).rawValue))!
-    self.byteLength = Int(pointee.getProperty(runtime.pointee, "byteLength").getNumber())
-    self.byteOffset = Int(pointee.getProperty(runtime.pointee, "byteOffset").getNumber())
-    self.length = Int(pointee.getProperty(runtime.pointee, "length").getNumber())
+    self.kind = Kind(rawValue: Int(expo.getTypedArrayKind(runtime.pointee, object).rawValue))!
+    self.byteLength = Int(object.getProperty(runtime.pointee, "byteLength").getNumber())
+    self.byteOffset = Int(object.getProperty(runtime.pointee, "byteOffset").getNumber())
+    self.length = Int(object.getProperty(runtime.pointee, "length").getNumber())
+    self.arrayBuffer = expo.getTypedArrayBuffer(runtime.pointee, object)
+    self.pointee = object
   }
 
+  /**
+   Invokes the closure with a raw buffer pointer covering the typed array's bytes.
+   The pointer is valid only for the duration of the closure and must not escape it.
+   */
+  public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+    return try body(UnsafeRawBufferPointer(start: startPointer(), count: byteLength))
+  }
+
+  /**
+   Invokes the closure with a mutable raw buffer pointer covering the typed array's bytes.
+   Writes through the buffer are visible to JavaScript. The pointer is valid only for the duration of the closure.
+   */
+  public func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
+    return try body(UnsafeMutableRawBufferPointer(start: startPointer(), count: byteLength))
+  }
+
+  /**
+   Invokes the closure with a typed buffer pointer over the elements of the typed array.
+   The generic type must match the array's element type (e.g. `UInt8` for `Uint8Array`, `Int32` for `Int32Array`);
+   passing a mismatched type reinterprets the bytes and is a programmer error.
+   */
+  public func withUnsafeBufferPointer<T, R>(as type: T.Type, _ body: (UnsafeBufferPointer<T>) throws -> R) rethrows -> R {
+    return try withUnsafeBytes { bytes in
+      try body(bytes.bindMemory(to: T.self))
+    }
+  }
+
+  /**
+   Invokes the closure with a mutable typed buffer pointer over the elements of the typed array.
+   The generic type must match the array's element type. Writes through the buffer are visible to JavaScript.
+   */
+  public func withUnsafeMutableBufferPointer<T, R>(as type: T.Type, _ body: (UnsafeMutableBufferPointer<T>) throws -> R) rethrows -> R {
+    return try withUnsafeMutableBytes { bytes in
+      try body(bytes.bindMemory(to: T.self))
+    }
+  }
+
+  @available(*, deprecated, message: "Use `withUnsafeBytes`, `withUnsafeMutableBytes`, or their typed counterparts instead. Escaping the pointer risks a use-after-free once the typed array goes out of scope.")
   public func getUnsafeMutableRawPointer() -> UnsafeMutableRawPointer {
+    return UnsafeMutableRawPointer(startPointer())
+  }
+
+  /**
+   Returns a pointer to the first byte of the typed array's data — the beginning of the underlying
+   ArrayBuffer, advanced by `byteOffset`. The pointer is tied to the ArrayBuffer retained by this
+   value; it is only valid while this `JavaScriptTypedArray` is alive.
+   */
+  private func startPointer() -> UnsafeMutablePointer<UInt8> {
     guard let runtime else {
       FatalError.runtimeLost()
     }
-    return pointee.__getRawPointerUnsafe(runtime.pointee)
+    return expo.arrayBufferData(runtime.pointee, arrayBuffer).advanced(by: byteOffset)
   }
 
   // We need to redefine the C++ enum (see TypedArray.h) to expose it to Swift
@@ -71,8 +126,8 @@ public struct JavaScriptTypedArray: ~Copyable {
     guard let runtime else {
       FatalError.runtimeLost()
     }
-    let arrayBuffer = pointee.getPropertyAsObject(runtime.pointee, "buffer").getArrayBuffer(runtime.pointee)
-    return JavaScriptArrayBuffer(runtime, arrayBuffer)
+    let buffer = pointee.getPropertyAsObject(runtime.pointee, "buffer").getArrayBuffer(runtime.pointee)
+    return JavaScriptArrayBuffer(runtime, buffer)
   }
 
   /**
@@ -82,7 +137,7 @@ public struct JavaScriptTypedArray: ~Copyable {
     guard let runtime else {
       FatalError.runtimeLost()
     }
-    return JavaScriptValue(runtime, expo.valueFromTypedArray(runtime.pointee, pointee))
+    return JavaScriptValue(runtime, facebook.jsi.Value(runtime.pointee, pointee))
   }
 
   // MARK: - Providing JavaScriptObject API

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
@@ -63,11 +63,6 @@ public struct JavaScriptTypedArray: ~Copyable {
     }
   }
 
-  @available(*, deprecated, message: "Use `withUnsafeBytes`, `withUnsafeMutableBytes`, or their typed counterparts instead. Escaping the pointer risks a use-after-free once the typed array goes out of scope.")
-  public func getUnsafeMutableRawPointer() -> UnsafeMutableRawPointer {
-    return UnsafeMutableRawPointer(startPointer())
-  }
-
   /**
    Returns a pointer to the first byte of the typed array's data — the beginning of the underlying
    ArrayBuffer, advanced by `byteOffset`. The pointer is tied to the ArrayBuffer retained by this

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -313,7 +313,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
       FatalError.runtimeLost()
     }
     assert(isTypedArray(), "Value is not a typed array")
-    return JavaScriptTypedArray(runtime, expo.TypedArray(runtime.pointee, pointee.getObject(runtime.pointee)))
+    return JavaScriptTypedArray(runtime, pointee.getObject(runtime.pointee))
   }
 
   /**

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptTypedArrayTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptTypedArrayTests.swift
@@ -133,17 +133,18 @@ struct JavaScriptTypedArrayTests {
     #expect(typedArray.getProperty("length").getInt() == 7)
   }
 
-  // MARK: - getUnsafeMutableRawPointer
+  // MARK: - Direct memory access
 
   @Test
-  func `write through raw pointer is visible in JS`() throws {
+  func `writes through withUnsafeMutableBytes are visible in JS`() throws {
     let value = try runtime.eval("new Uint8Array(3)")
     let typedArray = value.getTypedArray()
-    let ptr = typedArray.getUnsafeMutableRawPointer()
 
-    ptr.storeBytes(of: 42, toByteOffset: 0, as: UInt8.self)
-    ptr.storeBytes(of: 99, toByteOffset: 1, as: UInt8.self)
-    ptr.storeBytes(of: 255, toByteOffset: 2, as: UInt8.self)
+    typedArray.withUnsafeMutableBytes { bytes in
+      bytes[0] = 42
+      bytes[1] = 99
+      bytes[2] = 255
+    }
 
     let result = try runtime.eval("val => [val[0], val[1], val[2]]").getFunction().call(arguments: value).getArray()
     #expect(result[0].getInt() == 42)
@@ -152,15 +153,78 @@ struct JavaScriptTypedArrayTests {
   }
 
   @Test
-  func `raw pointer reflects JS writes`() throws {
+  func `withUnsafeBytes reflects JS writes`() throws {
     let value = try runtime.eval("new Uint8Array([0, 0, 0])")
     let typedArray = value.getTypedArray()
-    let ptr = typedArray.getUnsafeMutableRawPointer()
 
     try runtime.eval("val => { val[1] = 77 }").getFunction().call(arguments: value)
 
-    let byte = ptr.load(fromByteOffset: 1, as: UInt8.self)
-    #expect(byte == 77)
+    typedArray.withUnsafeBytes { bytes in
+      #expect(bytes[1] == 77)
+    }
+  }
+
+  @Test
+  func `data survives JS garbage collection`() throws {
+    // Create the typed array and immediately drop any JS-side reference to it.
+    let typedArray = try runtime.eval("(() => new Uint8Array([1, 2, 3, 4]))()").getTypedArray()
+
+    // The backing ArrayBuffer should remain alive because `JavaScriptTypedArray` holds it.
+    try runtime.eval("gc() && gc() && gc()")
+
+    typedArray.withUnsafeBytes { bytes in
+      #expect(bytes[0] == 1)
+      #expect(bytes[3] == 4)
+    }
+  }
+
+  @Test
+  func `withUnsafeBufferPointer reads elements with typed access`() throws {
+    let typedArray = try runtime.eval("new Int32Array([-1, 2, -3, 4])").getTypedArray()
+
+    typedArray.withUnsafeBufferPointer(as: Int32.self) { elements in
+      #expect(elements.count == typedArray.length)
+      #expect(elements[0] == -1)
+      #expect(elements[1] == 2)
+      #expect(elements[2] == -3)
+      #expect(elements[3] == 4)
+    }
+  }
+
+  @Test
+  func `writes through withUnsafeMutableBufferPointer are visible in JS`() throws {
+    let value = try runtime.eval("new Int32Array(3)")
+    let typedArray = value.getTypedArray()
+
+    typedArray.withUnsafeMutableBufferPointer(as: Int32.self) { elements in
+      elements[0] = -100
+      elements[1] = 0
+      elements[2] = Int32.max
+    }
+
+    let result = try runtime.eval("val => [val[0], val[1], val[2]]").getFunction().call(arguments: value).getArray()
+    #expect(result[0].getInt() == -100)
+    #expect(result[1].getInt() == 0)
+    #expect(Int32(result[2].getInt()) == Int32.max)
+  }
+
+  @Test
+  func `withUnsafeBytes covers view range, not full buffer`() throws {
+    let typedArray = try runtime.eval("""
+      var buf = new ArrayBuffer(16);
+      new Uint8Array(buf).fill(0xAA);
+      new Uint8Array(buf, 4, 8)
+    """).getTypedArray()
+
+    #expect(typedArray.byteOffset == 4)
+    #expect(typedArray.byteLength == 8)
+
+    typedArray.withUnsafeBytes { bytes in
+      #expect(bytes.count == 8)
+      for byte in bytes {
+        #expect(byte == 0xAA)
+      }
+    }
   }
 
   // MARK: - asValue round-trip


### PR DESCRIPTION
## Summary

Revises `JavaScriptTypedArray` in `expo-modules-jsi` to fix a lifetime issue and introduce a safer, more Swift-idiomatic API for accessing the underlying memory.

### Lifetime fix

Previously `JavaScriptTypedArray` stored an `expo::TypedArray` and re-read `buffer`/`byteOffset` via JSI property accesses on every `getUnsafeMutableRawPointer()` call. This was fragile (crashed when called through `expo-modules-core`'s `TypedArray.rawPointer` lazy var) and leaked the buffer's lifetime — nothing prevented JS GC from freeing the backing store while Swift still held a pointer into it.

Now:
- ` pointee: facebook.jsi.Object` — kept for `asValue()` and `getProperty()`.
- `arrayBuffer: facebook.jsi.ArrayBuffer` — extracted at init. Retains the backing store for as long as the Swift value lives, so JS GC cannot free it underneath us.
- The raw pointer is derived as `arrayBufferData(arrayBuffer) + byteOffset` — one C++ call, no further JSI property reads.

The `expo::TypedArray` C++ class is removed and replaced by two free functions (`getTypedArrayKind`, `getTypedArrayBuffer`) that operate on a `jsi::Object` directly. `valueFromTypedArray` is also gone since it's no longer needed.

### New `withUnsafeBytes` family

`getUnsafeMutableRawPointer()` hands out an unbounded pointer that can (and did) outlive the typed array. Added Swift-idiomatic scoped alternatives:

- `withUnsafeBytes(_:)` / `withUnsafeMutableBytes(_:)` — scoped access to an `UnsafeRawBufferPointer`.
- `withUnsafeBufferPointer(as:_:)` / `withUnsafeMutableBufferPointer(as:_:)` — typed access matching the array's element type.

## Test plan

- [x] `JavaScriptTypedArrayTests` — new coverage for `withUnsafeBytes`/`withUnsafeMutableBytes`, typed buffer-pointer overloads, buffer-survives-GC via the stored `jsi::ArrayBuffer`, and `byteOffset`-aware views.
- [x] Existing tests (kind detection, properties, `getProperty`, `asValue` round-trip, `getArrayBuffer`) still pass unchanged.