### PR TITLE
[docs] Update S3 references to GCS

### DIFF
--- a/docs/pages/build-reference/android-builds.mdx
+++ b/docs/pages/build-reference/android-builds.mdx
@@ -18,7 +18,7 @@ The first phase happens on your computer. EAS CLI is in charge of completing the
    - Depending on the value of `builds.android.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're prompted to generate a new keystore.
 
 1. Create a tarball containing a copy of the repository. Actual behavior depends on the [VCS workflow](https://expo.fyi/eas-vcs-workflow) you are using.
-1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
+1. Upload the project tarball to a private Google Cloud Storage (GCS) bucket and send the build request to EAS Build.
 
 ### Remote steps
 
@@ -27,7 +27,7 @@ Next, this is what happens when EAS Build picks up your request:
 1. Create a new Docker container for the build.
    - Every build gets its own fresh container with all build tools installed there (Java JDK, Android SDK, NDK, and so on).
 
-1. Download the project tarball from a private AWS S3 bucket and unpack it.
+1. Download the project tarball from a private GCS bucket and unpack it.
 1. [Create **.npmrc**](/build-reference/private-npm-packages) if `NPM_TOKEN` is set.
 1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if `yarn.lock` exists).
@@ -42,13 +42,13 @@ Next, this is what happens when EAS Build picks up your request:
 
 1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from **package.json** if defined.
 1. Store a cache of files and directories defined in the [build profile](/build/eas-json/). Subsequent builds will restore this cache.
-1. Upload the application archive to AWS S3.
+1. Upload the application archive to GCS.
    - The artifact path can be configured in **eas.json** at `builds.android.PROFILE_NAME.applicationArchivePath`. It defaults to `android/app/build/outputs/**/*.{apk,aab}`. We're using [glob patterns](https://github.com/isaacs/node-glob#glob-primer) for pattern matching.
 
 1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
 1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.
 1. Run the `eas-build-on-complete` script from **package.json** if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
-1. Upload the build artifacts archive to a private AWS S3 bucket if `buildArtifactPaths` is specified in the build profile.
+1. Upload the build artifacts archive to a private GCS bucket if `buildArtifactPaths` is specified in the build profile.
 
 ## Project auto-configuration
 

--- a/docs/pages/build-reference/ios-builds.mdx
+++ b/docs/pages/build-reference/ios-builds.mdx
@@ -19,7 +19,7 @@ The first phase happens on your computer. EAS CLI is in charge of completing the
 
 1. **Bare** projects require an additional step: check whether the Xcode project is configured to be buildable on the EAS servers (to ensure the correct bundle identifier and Apple Team ID are set).
 1. Create the tarball containing a copy of the repository. Actual behavior depends on the [VCS workflow](https://expo.fyi/eas-vcs-workflow) you are using.
-1. Upload the project tarball to a private AWS S3 bucket and send the build request to EAS Build.
+1. Upload the project tarball to a private Google Cloud Storage (GCS) bucket and send the build request to EAS Build.
 
 ### Remote steps
 
@@ -28,7 +28,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. Create a new macOS VM for the build.
    - Every build gets its own fresh macOS VM with all build tools installed there (Xcode, Fastlane, and so on).
 
-1. Download the project tarball from a private AWS S3 bucket and unpack it.
+1. Download the project tarball from a private GCS bucket and unpack it.
 1. [Create **.npmrc**](/build-reference/private-npm-packages) if `NPM_TOKEN` is set.
 1. Run the `eas-build-pre-install` script from **package.json** if defined.
 1. Run `npm install` in the project root (or `yarn install` if **yarn.lock** exists).
@@ -48,13 +48,13 @@ In this next phase, this is what happens when EAS Build picks up your request:
 1. Run `fastlane gym` in the **ios** directory.
 1. **Deprecated:** Run the `eas-build-pre-upload-artifacts` script from **package.json** if defined.
 1. Store a cache of files and directories defined in the [build profile](/build/eas-json). **Podfile.lock** is cached by default. Subsequent builds will restore this cache.
-1. Upload the application archive to a private AWS S3 bucket.
+1. Upload the application archive to a private GCS bucket.
    - The artifact path can be configured in **eas.json** at `builds.ios.PROFILE_NAME.applicationArchivePath`. It defaults to **ios/build/App.ipa**. You can specify a glob-like pattern for `applicationArchivePath`. We're using [glob patterns](https://github.com/isaacs/node-glob#glob-primer) for pattern matching.
 
 1. If the build was successful: run the `eas-build-on-success` script from **package.json** if defined.
 1. If the build failed: run the `eas-build-on-error` script from **package.json** if defined.
 1. Run the `eas-build-on-complete` script from **package.json** if defined. The `EAS_BUILD_STATUS` env variable is set to either `finished` or `errored`.
-1. Upload the build artifacts archive to a private AWS S3 bucket if `buildArtifactPaths` is specified in the build profile.
+1. Upload the build artifacts archive to a private GCS bucket if `buildArtifactPaths` is specified in the build profile.
 
 ## Building iOS projects with Fastlane
 


### PR DESCRIPTION
# Why

EAS Build and Workflows now use GCS for temporary storage of source tarballs while jobs are processed.

# How

Update S3 to GCS

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
