### PR TITLE
[docs] Clarify how to generate the bundle when checking bundle sizes for updates bandwidth estimates

### DIFF
--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -39,7 +39,7 @@ Look in the **dist/\_expo/static/js** directory. There will be **android** and *
 
 These files have long names that include a hash. For the sake of this exercise, rename the file you would like to analyze to **bundle.hbc**.
 
-To determine the actual compressed size of your Hermes bundle, which is how large it will be when downloaded by users, run the following commands:
+To determine the actual compressed size of your Hermes bundle, which is how large it will be when downloaded by app users, run the following commands:
 
 <Terminal
   cmd={[

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -37,7 +37,7 @@ Start by generating your uncompressed production bundle with the following comma
 
 Look in the **dist/\_expo/static/js** directory. There will be **android** and **ios** folders with a **.hbc** file in each. The size of the **.hbc** file is the uncompressed size of your Hermes bundle. Note that Android and iOS bundles may differ in size, especially if you make use of platform-specific code files.
 
-These files have long names that include a hash. For the sake of this exercise, rename the file you would like to analyze to **bundle.hbc**.
+These files have long names that include a hash. For this example, rename the file you would like to analyze to **bundle.hbc**.
 
 To determine the actual compressed size of your Hermes bundle, which is how large it will be when downloaded by app users, run the following commands:
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -33,14 +33,9 @@ Given a bandwidth allocation, we estimate how many updates can be downloaded in 
 
 First, generate your uncompressed production bundle with the following command:
 
-<Terminal
-  cmd={[
-    '$ npx expo export'
-  ]}
-  cmdCopy="npx expo export"
-/>
+<Terminal cmd={['$ npx expo export']} cmdCopy="npx expo export" />
 
-Look in the **dist/_expo/static/js** directory. There will be **android** and **ios** folders with a **.hbc** file in each. The size of the **.hbc** file is the uncompressed size of your Hermes bundle. Note that Android and iOS bundles may differ in size, especially if you make use of platform-specific code files.
+Look in the **dist/\_expo/static/js** directory. There will be **android** and **ios** folders with a **.hbc** file in each. The size of the **.hbc** file is the uncompressed size of your Hermes bundle. Note that Android and iOS bundles may differ in size, especially if you make use of platform-specific code files.
 
 These files have long names that include a hash. For the sake of this exercise, rename the file you would like to analyze to **bundle.hbc**.
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -31,7 +31,20 @@ Given a bandwidth allocation, we estimate how many updates can be downloaded in 
 
 ## Measuring your actual update size
 
-To determine the actual compressed size of your Hermes bundle, run the following commands:
+First, generate your uncompressed production bundle with the following command:
+
+<Terminal
+  cmd={[
+    '$ npx expo export'
+  ]}
+  cmdCopy="npx expo export"
+/>
+
+Look in the **dist/_expo/static/js** directory. There will be **android** and **ios** folders with a **.hbc** file in each. The size of the **.hbc** file is the uncompressed size of your Hermes bundle. Note that Android and iOS bundles may differ in size, especially if you make use of platform-specific code files.
+
+These files have long names that include a hash. For the sake of this exercise, rename the file you would like to analyze to **bundle.hbc**.
+
+To determine the actual compressed size of your Hermes bundle, which is how large it will be when downloaded by users, run the following commands:
 
 <Terminal
   cmd={[

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -31,7 +31,7 @@ Given a bandwidth allocation, we estimate how many updates can be downloaded in 
 
 ## Measuring your actual update size
 
-First, generate your uncompressed production bundle with the following command:
+Start by generating your uncompressed production bundle with the following command:
 
 <Terminal cmd={['$ npx expo export']} cmdCopy="npx expo export" />
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -33,9 +33,9 @@ Given a bandwidth allocation, we estimate how many updates can be downloaded in 
 
 Start by generating your uncompressed production bundle with the following command:
 
-<Terminal cmd={['$ npx expo export']} cmdCopy="npx expo export" />
+<Terminal cmd={['$ npx expo export']} />
 
-Look in the **dist/\_expo/static/js** directory. There will be **android** and **ios** folders with a **.hbc** file in each. The size of the **.hbc** file is the uncompressed size of your Hermes bundle. Note that Android and iOS bundles may differ in size, especially if you make use of platform-specific code files.
+Then, look inside the **dist/\_expo/static/js** directory. There will be **android** and **ios** directories with a **.hbc** file in each. The size of the **.hbc** file is the uncompressed size of your Hermes bundle. Note that Android and iOS bundles may differ in size, especially if you make use of platform-specific code files.
 
 These files have long names that include a hash. For this example, rename the file you would like to analyze to **bundle.hbc**.
 


### PR DESCRIPTION
# Why

When I refer folks to this doc, often they may not know off the top of their heads how to get the bundle in the first place, so I tell them to generate the bundle, then follow this doc. Figured I'd add that first step in there.

