### PR TITLE
[create-expo] fix claude plugin setup

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Replace tar dependency logic with `multitars` package ([#44764](https://github.com/expo/expo/pull/44764) by [@kitten](https://github.com/kitten))
 - Update to `multitars@^1.0.0` ([#44774](https://github.com/expo/expo/pull/44774) by [@kitten](https://github.com/kitten))
+- Fixed plugin setup in `.claude/settings.json`. ([#44951](https://github.com/expo/expo/pull/44951) by [@kudo](https://github.com/kudo))
 
 ## 3.6.6 — 2026-02-25
 

--- a/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
+++ b/packages/create-expo/src/__tests__/generateAgentFiles.test.ts
@@ -59,7 +59,7 @@ describe(generateAgentFiles, () => {
     const content = JSON.parse(
       fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8')
     );
-    expect(content).toEqual({ plugins: ['expo'] });
+    expect(content).toEqual({ enabledPlugins: { 'expo@claude-plugins-official': true } });
   });
 
   it('skips files that already exist', () => {

--- a/packages/create-expo/src/generateAgentFiles.ts
+++ b/packages/create-expo/src/generateAgentFiles.ts
@@ -27,7 +27,9 @@ const CLAUDE_MD_CONTENT = `@AGENTS.md
 `;
 
 const CLAUDE_SETTINGS_CONTENT = `{
-  "plugins": ["expo"]
+  "enabledPlugins": {
+    "expo@claude-plugins-official": true
+  }
 }
 `;
 


### PR DESCRIPTION
# Why

follow up https://github.com/expo/expo/pull/44618#discussion_r3055553631

# How

fix expo plugin setup for claude

# Test Plan

install project scope plugin in a blank project and check the config in **.claude/settings.json**

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
