### PR TITLE
[CI] Fix check-packages-windows failure              

### DIFF
--- a/packages/expo-splash-screen/plugin/src/__tests__/withIosSplashScreen-test.ts
+++ b/packages/expo-splash-screen/plugin/src/__tests__/withIosSplashScreen-test.ts
@@ -93,7 +93,7 @@ describe(withIosSplashScreen, () => {
     const infoPlist = await readPlistAsync('/app/ios/HelloWorld/Info.plist');
     expect(infoPlist.UILaunchStoryboardName).toBe('SplashScreen');
 
-    const after = getDirFromFS(vol.toJSON(), path.join(projectRoot, 'ios'));
+    const after = getDirFromFS(vol.toJSON(), path.posix.join(projectRoot, 'ios'));
 
     // Image is not defined
     expect(
@@ -130,7 +130,7 @@ describe(withIosSplashScreen, () => {
     const infoPlist = await readPlistAsync('/app/ios/HelloWorld/Info.plist');
     expect(infoPlist.UILaunchStoryboardName).toBe('SplashScreen');
 
-    const after = getDirFromFS(vol.toJSON(), path.join(projectRoot, 'ios'));
+    const after = getDirFromFS(vol.toJSON(), path.posix.join(projectRoot, 'ios'));
 
     // Image is defined
     expect(after['HelloWorld/Images.xcassets/SplashScreenLogo.imageset/image.png']).toBeDefined();

--- a/packages/expo-sqlite/dev-plugin-webui/package.json
+++ b/packages/expo-sqlite/dev-plugin-webui/package.json
@@ -3,7 +3,7 @@
   "main": "expo-router/entry",
   "version": "0.0.1",
   "scripts": {
-    "build": "bun install && ./node_modules/.bin/expo export -p web --output-dir dist",
+    "build": "bun install && expo export -p web --output-dir dist",
     "start": "expo start --web",
     "lint": "expo lint",
     "test": "jest",


### PR DESCRIPTION
# Why

Fixes check-packages-windows CI step failure - https://github.com/expo/expo/actions/runs/24672582143/job/72147295579

```
🏁 124 packages passed, 2 packages failed: expo-splash-screen, sqlite-inspector-webui
```

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Replaced `path.join` with `path.posix.join`
- Dropped `./node_modules/.bin/`  prefix from build script.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

https://github.com/expo/expo/actions/runs/24710449879/job/72273556983 - CI passed ✅

 
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
