### PR TITLE
[audio][Android] Fix pixelated lock screen artwork on Android 13+

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [iOS] Improve looping support. ([#43600](https://github.com/expo/expo/pull/43600) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Prevent stale lock screen artwork updates from crashing or overwriting newer metadata. ([#44498](https://github.com/expo/expo/pull/44498) by [@kotadd](https://github.com/kotadd))
 - [Android] Fix lock screen controls on android 12 and earlier. ([#44754](https://github.com/expo/expo/pull/44754) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix pixelated lock screen artwork on Android 13+ by setting `artworkUri` on the session's `MediaMetadata`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@radko93](https://github.com/radko93))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -19,7 +19,7 @@
 - [iOS] Improve looping support. ([#43600](https://github.com/expo/expo/pull/43600) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Prevent stale lock screen artwork updates from crashing or overwriting newer metadata. ([#44498](https://github.com/expo/expo/pull/44498) by [@kotadd](https://github.com/kotadd))
 - [Android] Fix lock screen controls on android 12 and earlier. ([#44754](https://github.com/expo/expo/pull/44754) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix pixelated lock screen artwork on Android 13+ by setting `artworkUri` on the session's `MediaMetadata`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@radko93](https://github.com/radko93))
+- [Android] Fix pixelated lock screen artwork on Android 13+ by setting `artworkUri` on the session's `MediaMetadata`. ([#44953](https://github.com/expo/expo/pull/44953) by [@radko93](https://github.com/radko93))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -52,6 +52,7 @@ _This version does not introduce any user-facing changes._
 - [iOS] Prevent stale lock screen artwork updates from crashing or overwriting newer metadata. ([#44498](https://github.com/expo/expo/pull/44498) by [@kotadd](https://github.com/kotadd))
 - [iOS] Fix playback progress continuing after pause by setting correct playback rate in now playing info. ([#44974](https://github.com/expo/expo/pull/44974) by [@JstUsername](https://github.com/JstUsername))
 - [Android] Remove `RECORD_AUDIO` from the manifest so `recordAudioAndroid` depends on the plugin. ([#45131](https://github.com/expo/expo/pull/45131) by [@alanjhughes](https://github.com/alanjhughes))
+- [Android] Fix pixelated lock screen artwork on Android 13+ by setting `artworkUri` on the session's `MediaMetadata`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@radko93](https://github.com/radko93))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -52,7 +52,7 @@ _This version does not introduce any user-facing changes._
 - [iOS] Prevent stale lock screen artwork updates from crashing or overwriting newer metadata. ([#44498](https://github.com/expo/expo/pull/44498) by [@kotadd](https://github.com/kotadd))
 - [iOS] Fix playback progress continuing after pause by setting correct playback rate in now playing info. ([#44974](https://github.com/expo/expo/pull/44974) by [@JstUsername](https://github.com/JstUsername))
 - [Android] Remove `RECORD_AUDIO` from the manifest so `recordAudioAndroid` depends on the plugin. ([#45131](https://github.com/expo/expo/pull/45131) by [@alanjhughes](https://github.com/alanjhughes))
-- [Android] Fix pixelated lock screen artwork on Android 13+ by setting `artworkUri` on the session's `MediaMetadata`. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@radko93](https://github.com/radko93))
+- [Android] Fix pixelated lock screen artwork on Android 13+ by setting `artworkUri` on the session's `MediaMetadata`. ([#44953](https://github.com/expo/expo/pull/44953) by [@radko93](https://github.com/radko93))
 
 ### 💡 Others
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -10,6 +10,7 @@ import android.media.AudioManager
 import android.content.pm.ServiceInfo
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
@@ -344,12 +345,35 @@ class AudioControlsService : MediaSessionService() {
 
         addPlayerListener(player)
 
+        // Set artwork URI on MediaMetadata so Android 13+ lock screen uses the
+        // full-resolution bitmap via the session's BitmapLoader instead of
+        // falling back to the notification largeIcon (which gets downsampled).
+        applyArtworkUriToSession()
+
         // Initial update now that session exists
         postOrStartForegroundNotification(startInForeground = false)
       }
     } else {
       clearSessionInternal()
     }
+  }
+
+  private fun applyArtworkUriToSession() {
+    val url = currentArtworkUrl ?: return
+    val player = currentPlayer?.ref ?: return
+    val index = player.currentMediaItemIndex
+    if (index < 0 || index >= player.mediaItemCount) return
+    val currentItem = player.getMediaItemAt(index)
+    val newMetadata = currentItem.mediaMetadata.buildUpon().apply {
+      setTitle(currentMetadata?.title)
+      setArtist(currentMetadata?.artist)
+      setAlbumTitle(currentMetadata?.albumTitle)
+      setArtworkUri(Uri.parse(url.toString()))
+    }.build()
+    player.replaceMediaItem(
+      index,
+      currentItem.buildUpon().setMediaMetadata(newMetadata).build()
+    )
   }
 
   private fun updateMetadataInternal(player: AudioPlayer, metadata: Metadata?) {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -10,7 +10,6 @@ import android.media.AudioManager
 import android.content.pm.ServiceInfo
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
@@ -43,6 +42,7 @@ class AudioControlsService : MediaSessionService() {
   private lateinit var audioManager: AudioManager
   private val binder = AudioPlaybackServiceBinder(this)
   private var mediaSession: MediaSession? = null
+  private var sessionMetadataPlayer: MetadataInjectingPlayer? = null
   private var currentMetadata: Metadata? = null
   private var currentPlayer: AudioPlayer? = null
   private var currentOptions: AudioLockScreenOptions? = null
@@ -324,10 +324,13 @@ class AudioControlsService : MediaSessionService() {
 
     if (player != null) {
       mediaSession?.release()
+      sessionMetadataPlayer = null
 
       appContext?.mainQueue?.launch {
         val context = appContext?.reactContext ?: return@launch
-        val sessionPlayer = resolveSessionPlayer(player, options)
+        val sessionPlayer = MetadataInjectingPlayer(resolveSessionPlayer(player, options)).apply {
+          updateMetadata(metadata)
+        }
         val session = MediaSession.Builder(context, sessionPlayer)
           .setCallback(AudioMediaSessionCallback())
           .build()
@@ -338,17 +341,13 @@ class AudioControlsService : MediaSessionService() {
 
         addSession(session)
         mediaSession = session
+        sessionMetadataPlayer = sessionPlayer
 
         updateSessionCustomLayout(player.ref.isPlaying)
 
         postOrStartForegroundNotification(startInForeground = true)
 
         addPlayerListener(player)
-
-        // Set artwork URI on MediaMetadata so Android 13+ lock screen uses the
-        // full-resolution bitmap via the session's BitmapLoader instead of
-        // falling back to the notification largeIcon (which gets downsampled).
-        applyArtworkUriToSession()
 
         // Initial update now that session exists
         postOrStartForegroundNotification(startInForeground = false)
@@ -358,29 +357,12 @@ class AudioControlsService : MediaSessionService() {
     }
   }
 
-  private fun applyArtworkUriToSession() {
-    val url = currentArtworkUrl ?: return
-    val player = currentPlayer?.ref ?: return
-    val index = player.currentMediaItemIndex
-    if (index < 0 || index >= player.mediaItemCount) return
-    val currentItem = player.getMediaItemAt(index)
-    val newMetadata = currentItem.mediaMetadata.buildUpon().apply {
-      setTitle(currentMetadata?.title)
-      setArtist(currentMetadata?.artist)
-      setAlbumTitle(currentMetadata?.albumTitle)
-      setArtworkUri(Uri.parse(url.toString()))
-    }.build()
-    player.replaceMediaItem(
-      index,
-      currentItem.buildUpon().setMediaMetadata(newMetadata).build()
-    )
-  }
-
   private fun updateMetadataInternal(player: AudioPlayer, metadata: Metadata?) {
     if (player != currentPlayer || metadata == currentMetadata) {
       return
     }
     currentMetadata = metadata
+    sessionMetadataPlayer?.updateMetadata(metadata)
     currentMetadata?.artworkUrl?.let {
       loadArtworkFromUrl(it) { bitmap ->
         currentArtwork = bitmap
@@ -396,6 +378,7 @@ class AudioControlsService : MediaSessionService() {
     currentMetadata = null
     mediaSession?.release()
     mediaSession = null
+    sessionMetadataPlayer = null
     currentPlayer?.assignBasicMediaSession()
     stopForeground(STOP_FOREGROUND_REMOVE)
   }
@@ -423,9 +406,12 @@ class AudioControlsService : MediaSessionService() {
       currentOptions = options
 
       mediaSession?.release()
+      sessionMetadataPlayer = null
       appContext?.mainQueue?.launch {
         val context = appContext?.reactContext ?: return@launch
-        val sessionPlayer = resolveSessionPlayer(player, options)
+        val sessionPlayer = MetadataInjectingPlayer(resolveSessionPlayer(player, options)).apply {
+          updateMetadata(metadata)
+        }
         val session = MediaSession.Builder(context, sessionPlayer)
           .setCallback(AudioMediaSessionCallback())
           .build()
@@ -435,6 +421,7 @@ class AudioControlsService : MediaSessionService() {
 
         addSession(session)
         mediaSession = session
+        sessionMetadataPlayer = sessionPlayer
 
         updateSessionCustomLayout(player.ref.isPlaying)
         postOrStartForegroundNotification(startInForeground = false)
@@ -492,6 +479,7 @@ class AudioControlsService : MediaSessionService() {
     scope.cancel()
     mediaSession?.release()
     mediaSession = null
+    sessionMetadataPlayer = null
     currentPlayer = null
     currentMetadata = null
     currentOptions = null

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/MetadataInjectingPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/MetadataInjectingPlayer.kt
@@ -1,0 +1,93 @@
+package expo.modules.audio.service
+
+import android.os.Handler
+import android.os.Looper
+import androidx.core.net.toUri
+import androidx.media3.common.FlagSet
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import expo.modules.audio.Metadata
+import java.util.IdentityHashMap
+
+// MediaSession reads artwork from Player.mediaMetadata, but expo-audio lock-screen metadata can
+// change independently of the underlying MediaItem. This wrapper lets the session observe those
+// metadata updates without replacing the active media item on the real ExoPlayer instance.
+@UnstableApi
+internal class MetadataInjectingPlayer(
+  player: Player
+) : ForwardingPlayer(player) {
+  private val handler = Handler(applicationLooper)
+  private val listeners = IdentityHashMap<Player.Listener, Player.Listener>()
+  private var injectedMetadata: Metadata? = null
+
+  override fun addListener(listener: Player.Listener) {
+    val forwardingListener = synchronized(listeners) {
+      listeners.getOrPut(listener) { MetadataForwardingListener(listener) }
+    }
+    super.addListener(forwardingListener)
+  }
+
+  override fun removeListener(listener: Player.Listener) {
+    val forwardingListener = synchronized(listeners) {
+      listeners.remove(listener)
+    }
+    super.removeListener(forwardingListener ?: listener)
+  }
+
+  override fun getMediaMetadata(): MediaMetadata {
+    val metadata = injectedMetadata
+    return super.getMediaMetadata()
+      .buildUpon()
+      .setTitle(metadata?.title)
+      .setArtist(metadata?.artist)
+      .setAlbumTitle(metadata?.albumTitle)
+      .setArtworkUri(metadata?.artworkUrl?.toString()?.toUri())
+      .setArtworkData(null, null)
+      .build()
+  }
+
+  fun updateMetadata(metadata: Metadata?) {
+    if (Looper.myLooper() != applicationLooper) {
+      handler.post { updateMetadata(metadata) }
+      return
+    }
+
+    val previousMetadata = mediaMetadata
+    injectedMetadata = metadata
+    val newMetadata = mediaMetadata
+
+    if (previousMetadata == newMetadata) {
+      return
+    }
+
+    val events = Player.Events(
+      FlagSet.Builder()
+        .add(Player.EVENT_MEDIA_METADATA_CHANGED)
+        .build()
+    )
+    val currentListeners = synchronized(listeners) {
+      listeners.keys.toList()
+    }
+
+    currentListeners.forEach {
+      it.onMediaMetadataChanged(newMetadata)
+    }
+    currentListeners.forEach {
+      it.onEvents(this, events)
+    }
+  }
+
+  private inner class MetadataForwardingListener(
+    private val listener: Player.Listener
+  ) : Player.Listener by listener {
+    override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+      listener.onMediaMetadataChanged(this@MetadataInjectingPlayer.mediaMetadata)
+    }
+
+    override fun onEvents(player: Player, events: Player.Events) {
+      listener.onEvents(this@MetadataInjectingPlayer, events)
+    }
+  }
+}


### PR DESCRIPTION
# Why

On Android 13+, the lock screen's blurred background falls back to the notification's `largeIcon` — the bitmap we set via `NotificationCompat.Builder.setLargeIcon(currentArtwork)` in `buildNotification()` — when the `MediaSession`'s `MediaMetadata.artworkUri` is not set. Android then upscales that bitmap to fill the background, which is visibly pixelated.

`AudioControlsService` today downloads the artwork bitmap into `currentArtwork` and hands it to the notification, but never publishes the original URL to the session's `MediaMetadata`, so the session has nothing to load the full-resolution artwork from.

# How

Set `artworkUri` on the current `MediaItem`'s `MediaMetadata` inside `setActivePlayerInternal`, right after the `MediaSession` is created. Media3's default `BitmapLoader` can then fetch the full-resolution image from that URI, so the lock screen no longer needs to upscale the notification's small `largeIcon`.

Extracted into a small helper `applyArtworkUriToSession()` that:

- no-ops if there is no artwork URL or no active player;
- guards `currentMediaItemIndex` against `C.INDEX_UNSET` / out-of-range;
- preserves existing `MediaMetadata` fields via `buildUpon()` and mirrors `title` / `artist` / `albumTitle` from the `Metadata` the app already passes in — matching what `buildNotification()` already puts on the notification.

The call site is inside the existing `appContext?.mainQueue?.launch { ... }` block. `mainQueue` is `CoroutineScope(Dispatchers.Main)` (`AppContext.kt:94`), so `replaceMediaItem` runs on the application thread as Media3 requires.

No behavior change on Android ≤ 12: the notification `largeIcon` path already drives the lock screen there, and this patch doesn't touch that path.

Scope note: this only fires at initial session setup (`setActivePlayerInternal`). `setPlayerMetadata` / same-player `setPlayerOptions` still update `currentMetadata` without re-publishing it to the session — same as before this change. Happy to broaden the helper call sites in a follow-up if reviewers prefer.

# Test Plan

The equivalent change has been running in a production app via a yarn patch on `expo-audio@55.0.13`, resolving the pixelated lock-screen background on Android 13+ with no observed regressions.

- **Before:** lock screen blurred background is visibly pixelated.
- **After:** lock screen blurred background renders at full resolution; the small artwork thumbnail inside the media controls is unchanged.


Local build for this PR: `:expo-audio:compileDebugKotlin` and `:expo-audio:spotlessCheck` pass from `apps/bare-expo/android`.

<img width="1070" height="619" alt="Untitled" src="https://github.com/user-attachments/assets/e5d32971-2d84-4a98-91da-449cdd5de0d8" />
<img width="566" height="296" alt="2" src="https://github.com/user-attachments/assets/aa3501bb-a68e-429f-b4bf-f002cc59b994" />


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)