### PR TITLE
[widgets] Bump deploymentTarget to 16.4

### DIFF
--- a/packages/expo-widgets/plugin/build/withWidgets.js
+++ b/packages/expo-widgets/plugin/build/withWidgets.js
@@ -15,7 +15,7 @@ const withTargetXcodeProject_1 = __importDefault(require("./xcode/withTargetXcod
 const pkg = require('../../package.json');
 const withWidgets = (config, props) => {
     let plugins = [];
-    const deploymentTarget = '16.2';
+    const deploymentTarget = '16.4';
     const targetName = 'ExpoWidgetsTarget';
     let bundleIdentifier = props?.bundleIdentifier;
     if (!bundleIdentifier) {

--- a/packages/expo-widgets/plugin/src/withWidgets.ts
+++ b/packages/expo-widgets/plugin/src/withWidgets.ts
@@ -26,7 +26,7 @@ export type ExpoWidgetsConfigPluginProps = {
 
 const withWidgets: ConfigPlugin<ExpoWidgetsConfigPluginProps | undefined> = (config, props) => {
   let plugins: (StaticPlugin | ConfigPlugin | string)[] = [];
-  const deploymentTarget = '16.2';
+  const deploymentTarget = '16.4';
   const targetName = 'ExpoWidgetsTarget';
 
   let bundleIdentifier = props?.bundleIdentifier;


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/44068 missed this.

# How

Bump `deploymentTarget` in widget target.

# Test Plan

Build app with widgets.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
