### PR TITLE
[ios] Add test targets for expo-task-manager and unimodules-app-loader

### DIFF
--- a/packages/expo-task-manager/ios/ExpoTaskManager.podspec
+++ b/packages/expo-task-manager/ios/ExpoTaskManager.podspec
@@ -28,4 +28,10 @@ Pod::Spec.new do |s|
     'ExpoTaskManager_privacy' => ['PrivacyInfo.xcprivacy']
   }
   s.source_files = '**/*.{h,m,mm,swift}'
+  s.exclude_files = 'Tests/'
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.dependency 'ExpoModulesTestCore'
+    test_spec.source_files = 'Tests/**/*.{m,swift}'
+  end
 end

--- a/packages/expo-task-manager/ios/Tests/EXTaskServiceSpec.swift
+++ b/packages/expo-task-manager/ios/Tests/EXTaskServiceSpec.swift
@@ -1,0 +1,13 @@
+import ExpoModulesTestCore
+
+@testable import ExpoTaskManager
+
+class EXTaskServiceSpec: ExpoSpec {
+  override class func spec() {
+    describe("EXTaskService") {
+      it("exposes a shared singleton") {
+        expect(EXTaskService.shared).notTo(beNil())
+      }
+    }
+  }
+}

--- a/packages/unimodules-app-loader/ios/Tests/UMAppLoaderProviderSpec.swift
+++ b/packages/unimodules-app-loader/ios/Tests/UMAppLoaderProviderSpec.swift
@@ -1,0 +1,13 @@
+import ExpoModulesTestCore
+
+@testable import UMAppLoader
+
+class UMAppLoaderProviderSpec: ExpoSpec {
+  override class func spec() {
+    describe("UMAppLoaderProvider") {
+      it("exposes a shared singleton") {
+        expect(UMAppLoaderProvider.sharedInstance()).notTo(beNil())
+      }
+    }
+  }
+}

--- a/packages/unimodules-app-loader/ios/UMAppLoader.podspec
+++ b/packages/unimodules-app-loader/ios/UMAppLoader.podspec
@@ -22,4 +22,9 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
   }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.dependency 'ExpoModulesTestCore'
+    test_spec.source_files = 'Tests/**/*.{m,swift}'
+  end
 end


### PR DESCRIPTION
# Why

Running `pod install` with `use_expo_modules_tests!` failed because `expo-task-manager` and `unimodules-app-loader` did not declare a `test_spec`.

# How

Added a `test_spec` to both podspecs and a minimal `ExpoSpec` that verifies the shared singleton can be resolved (`EXTaskService.shared` and `UMAppLoaderProvider.sharedInstance()`).

# Test Plan

Ran the new test targets locally via the generated Xcode workspace and confirmed both specs pass.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
