### PR TITLE
fix(precompile) REA and RNWorklets fails precompiling

### DIFF
--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-reanimated/spm.config.json
@@ -91,7 +91,9 @@
                         { "from": "LayoutAnimations/*.h", "to": "reanimated/LayoutAnimations/{filename}", "type": "header" },
                         { "from": "NativeModules/*.h", "to": "reanimated/NativeModules/{filename}", "type": "header" },
                         { "from": "RuntimeDecorators/*.h", "to": "reanimated/RuntimeDecorators/{filename}", "type": "header" },
-                        { "from": "Tools/*.h", "to": "reanimated/Tools/{filename}", "type": "header" }
+                        { "from": "Tools/*.h", "to": "reanimated/Tools/{filename}", "type": "header" },
+                        { "from": "Compat/*.h", "to": "reanimated/Compat/{filename}", "type": "header" },
+                        { "from": "Events/*.h", "to": "reanimated/Events/{filename}", "type": "header" }
                     ]
                 },
                 {

--- a/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/react-native-worklets/spm.config.json
@@ -68,6 +68,7 @@
                         { "from": "AnimationFrameQueue/*.h", "to": "worklets/AnimationFrameQueue/{filename}", "type": "header" },
                         { "from": "NativeModules/*.h", "to": "worklets/NativeModules/{filename}", "type": "header" },
                         { "from": "Registries/*.h", "to": "worklets/Registries/{filename}", "type": "header" },
+                        { "from": "Compat/*.h", "to": "worklets/Compat/{filename}", "type": "header" },
                         { "from": "Resources/*.h", "to": "worklets/Resources/{filename}", "type": "header" },
                         { "from": "RunLoop/*.h", "to": "worklets/RunLoop/{filename}", "type": "header" },
                         { "from": "SharedItems/*.h", "to": "worklets/SharedItems/{filename}", "type": "header" },


### PR DESCRIPTION
# Why

After upgrading to REA 4.3.0 and RNWorklets 0.8.1 the prebuild failed due to missing headers

# How

Fixed by adding missing header directories to spm.config.json

# Test-plan

Run prebiuld on main:
`et prebuild -f Debug --external-only --clean`

