### PR TITLE
[core][Android] Add a way to disable the compile-time optimization

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation workletsProject
   }
 
-  implementation("io.github.lukmccall.pika:pika-api:0.1.4-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-api:0.1.5-2.1.20")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/typeDescriptorOf.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/typeDescriptorOf.kt
@@ -1,6 +1,5 @@
 package expo.modules.kotlin.types.descriptors
 
-import android.util.Log
 import io.github.lukmccall.pika.PTypeDescriptor
 import kotlin.reflect.typeOf
 import io.github.lukmccall.pika.typeDescriptorOf as pikaTypeDescriptorOf
@@ -42,9 +41,6 @@ internal inline fun <reified T> ctTypeDescriptorOf(): TypeDescriptor {
 
 inline fun <reified T> typeDescriptorOf(): TypeDescriptor {
   val typeDescriptor = runCatching { ctTypeDescriptorOf<T>() }
-    .onFailure {
-      Log.e("ExpoModulesCore", "Failed to get type info for ${T::class.java.name}", it)
-    }
     .getOrNull()
 
   if (typeDescriptor != null) {

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-  implementation("io.github.lukmccall.pika:pika-gradle:0.1.4-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.1.5-2.1.20")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
@@ -22,12 +22,13 @@ abstract class ExpoModulesGradlePlugin : Plugin<Project> {
     with(project) {
       applyDefaultPlugins()
       applyPikaPlugin()
-
       applyKotlin(kotlinVersion, kspVersion)
       applyDefaultDependencies()
       applyDefaultAndroidSdkVersions()
 
       extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl {
+        configurePika(shouldBeEnabled = expoModuleExtension.enableCompileTimeOptimization)
+
         applyPublishing(expoModuleExtension)
       }
     }

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -40,6 +40,11 @@ internal fun Project.applyPikaPlugin() {
   pika.introspectableAnnotation("expo.modules.kotlin.types.OptimizedRecord")
 }
 
+internal fun Project.configurePika(shouldBeEnabled: Boolean = true) {
+  val pika = extensions.getByType(PikaGradleExtension::class.java)
+  pika.enabled = shouldBeEnabled
+}
+
 internal fun Project.applyKotlin(kotlinVersion: String, kspVersion: String) {
   extra.set("kotlinVersion", kotlinVersion)
   extra.set("kspVersion", kspVersion)

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
@@ -44,9 +44,20 @@ open class ExpoModuleExtension(val project: Project) {
 
   var canBePublished: Boolean = true
 
+  var enableCompileTimeOptimization: Boolean =
+    findBoolProperty("expo.enableCompileTimeOptimization", default = true)
+
   internal var pomConfigurator: POMConfigurator? = null
 
   fun pom(configurator: POMConfigurator) {
     pomConfigurator = configurator
+  }
+
+  private fun findBoolProperty(name: String, default: Boolean): Boolean {
+    val propertyValue = project.findProperty(name)?.toString() ?: return default
+    if (!propertyValue.equals("true", ignoreCase = true) && !propertyValue.equals("false", ignoreCase = true)) {
+      error("Property '$name' must be either 'true' or 'false', but found '$propertyValue'.")
+    }
+    return propertyValue.toBoolean()
   }
 }


### PR DESCRIPTION
# Why

Adds a way to disable the compile-time optimization.
It can be disabled by the project using `expoModuleExtension` or globally using gradle property 

# Test Plan

- bare-expo ✅ 