### PR TITLE
fix(precompiled) skip on dependency failure

### DIFF
--- a/tools/src/prebuilds/pipeline/ErrorPolicy.test.ts
+++ b/tools/src/prebuilds/pipeline/ErrorPolicy.test.ts
@@ -480,5 +480,4 @@ describe('synthesizeSkippedResult', () => {
     assert.equal(result.statuses[0].productName, 'ProdTwo');
     assert.equal(result.errors.length, 1);
   });
-
 });

--- a/tools/src/prebuilds/pipeline/ErrorPolicy.test.ts
+++ b/tools/src/prebuilds/pipeline/ErrorPolicy.test.ts
@@ -6,9 +6,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
+import type { SPMPackageSource } from '../ExternalPackage';
 import { createRequest, createContext } from './Context';
 import type { PrebuildContext, PrebuildCliOptions } from './Context';
-import { executeStep, runPrebuildPipeline } from './Executor';
+import { executeStep, runPrebuildPipeline, synthesizeSkippedResult } from './Executor';
 import type { PipelineSteps } from './Executor';
 import type { Step } from './Types';
 
@@ -424,4 +425,60 @@ describe('runPrebuildPipeline', () => {
     assert.equal(result.exitCode, 0);
     assert.deepEqual(ran, ['run']);
   });
+});
+
+// ---------------------------------------------------------------------------
+// synthesizeSkippedResult tests
+// ---------------------------------------------------------------------------
+
+function makePkgWithProducts(name: string, productNames: string[]): SPMPackageSource {
+  return {
+    path: `/repo/packages/${name}`,
+    buildPath: `/repo/packages/precompile/.build/${name}`,
+    packageName: name,
+    packageVersion: '1.0.0',
+    getSwiftPMConfiguration: () => ({
+      products: productNames.map((n) => ({ name: n })),
+    }),
+  } as unknown as SPMPackageSource;
+}
+
+describe('synthesizeSkippedResult', () => {
+  it('produces one UnitStatus + UnitError per product × flavor, all stages skipped with skipReason', () => {
+    const pkg = makePkgWithProducts('pkg-a', ['ProdOne', 'ProdTwo']);
+    const result = synthesizeSkippedResult(pkg, ['dep-x'], ['Debug', 'Release']);
+
+    assert.equal(result.packageName, 'pkg-a');
+    assert.equal(result.stopRun, false);
+    assert.equal(result.statuses.length, 4, 'two products × two flavors = 4 units');
+    assert.equal(result.errors.length, 4);
+
+    for (const status of result.statuses) {
+      // Every stage should be 'skipped' — the whole unit was skipped, not a
+      // genuine generate failure. skipReason is what flips the summary into
+      // the failed bucket.
+      assert.equal(status.stages.generate, 'skipped');
+      assert.equal(status.stages.build, 'skipped');
+      assert.equal(status.stages.compose, 'skipped');
+      assert.equal(status.stages.verify, 'skipped');
+      assert.ok(status.skipReason, 'skipReason must be set');
+      assert.match(status.skipReason!, /dep-x/);
+    }
+
+    for (const err of result.errors) {
+      assert.equal(err.stage, 'prepare');
+      assert.match(err.error.message, /dep-x/);
+      assert.match(err.error.message, /Skipped/);
+    }
+  });
+
+  it('respects productFilter', () => {
+    const pkg = makePkgWithProducts('pkg-a', ['ProdOne', 'ProdTwo']);
+    const result = synthesizeSkippedResult(pkg, ['dep-x'], ['Release'], 'ProdTwo');
+
+    assert.equal(result.statuses.length, 1);
+    assert.equal(result.statuses[0].productName, 'ProdTwo');
+    assert.equal(result.errors.length, 1);
+  });
+
 });

--- a/tools/src/prebuilds/pipeline/Executor.ts
+++ b/tools/src/prebuilds/pipeline/Executor.ts
@@ -12,6 +12,7 @@ import { PACKAGES_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Dependencies } from '../Dependencies';
 import type { SPMPackageSource } from '../ExternalPackage';
+import { BuildFlavor } from '../Prebuilder.types';
 import { runWithLogPrefix } from '../Utils';
 import { ArtifactLock } from './ArtifactLock';
 import type { PrebuildContext } from './Context';
@@ -21,7 +22,7 @@ import { logPackageBanner, printPrebuildSummary, writeErrorLog } from './Reporte
 import { runSteps, resolveFlavorTemplatedPath } from './RunSteps';
 import type { PackageResult } from './Scheduler';
 import { runPackagesInParallel } from './Scheduler';
-import type { PrebuildRunResult, Step, UnitStatus, ProductStage } from './Types';
+import type { PrebuildRunResult, Step, UnitStatus, UnitError, ProductStage } from './Types';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -145,6 +146,41 @@ const defaultSteps: PipelineSteps = {
 // ---------------------------------------------------------------------------
 
 /**
+ * PackageResult for a package being skipped because an upstream DAG dep failed.
+ * One UnitStatus (all stages `'skipped'`, `skipReason` set) + one UnitError
+ * per product×flavor — never touches disk.
+ */
+export function synthesizeSkippedResult(
+  pkg: SPMPackageSource,
+  failedDeps: string[],
+  buildFlavors: BuildFlavor[],
+  productFilter?: string
+): PackageResult {
+  const reason = `dependency ${failedDeps.join(', ')} failed`;
+  const statuses: UnitStatus[] = [];
+  const errors: UnitError[] = [];
+
+  for (const product of pkg.getSwiftPMConfiguration().products) {
+    if (productFilter && productFilter !== product.name) continue;
+    for (const flavor of buildFlavors) {
+      const status = createUnitStatus(pkg.packageName, product.name, flavor);
+      status.skipReason = reason;
+      statuses.push(status);
+      errors.push({
+        packageName: pkg.packageName,
+        productName: product.name,
+        flavor,
+        unitId: status.unitId,
+        stage: 'prepare',
+        error: new Error(`Skipped: ${reason} — no build attempted`),
+      });
+    }
+  }
+
+  return { packageName: pkg.packageName, statuses, errors, stopRun: false };
+}
+
+/**
  * Executes all build steps for a single package (package-scope + flavor/product loops).
  * Uses its own per-package context clone so parallel packages don't share mutable state.
  */
@@ -174,6 +210,7 @@ async function executePackageStepsInner(
   artifactLock: ArtifactLock,
   signal: AbortSignal
 ): Promise<PackageResult> {
+
   // Create a per-package context that shares immutable/shared state by reference
   // but has its own iteration pointers, statuses, and errors.
   const ctx: PrebuildContext = {
@@ -341,8 +378,21 @@ export async function runPrebuildPipeline(
       ctx.dependsOn,
       concurrency,
       ctx.abortController,
-      (pkg, signal) =>
-        executePackageSteps(
+      (pkg, signal, failedDeps) => {
+        if (failedDeps && failedDeps.length > 0) {
+          logger.info(
+            `⏭️  Skipping ${chalk.yellow(pkg.packageName)} — dependency failed: ${chalk.yellow(failedDeps.join(', '))}`
+          );
+          return Promise.resolve(
+            synthesizeSkippedResult(
+              pkg,
+              failedDeps,
+              ctx.request.buildFlavors,
+              ctx.request.productFilter
+            )
+          );
+        }
+        return executePackageSteps(
           pkg,
           packageIndices.get(pkg.packageName) ?? 0,
           packages.length,
@@ -350,7 +400,8 @@ export async function runPrebuildPipeline(
           steps,
           artifactLock,
           signal
-        )
+        );
+      }
     );
 
     // Merge results into root context

--- a/tools/src/prebuilds/pipeline/Executor.ts
+++ b/tools/src/prebuilds/pipeline/Executor.ts
@@ -210,7 +210,6 @@ async function executePackageStepsInner(
   artifactLock: ArtifactLock,
   signal: AbortSignal
 ): Promise<PackageResult> {
-
   // Create a per-package context that shares immutable/shared state by reference
   // but has its own iteration pointers, statuses, and errors.
   const ctx: PrebuildContext = {

--- a/tools/src/prebuilds/pipeline/Reporter.test.ts
+++ b/tools/src/prebuilds/pipeline/Reporter.test.ts
@@ -10,7 +10,8 @@ import { describe, it } from 'node:test';
 
 import type { SPMPackageSource } from '../ExternalPackage';
 import type { BuildFlavor } from '../Prebuilder.types';
-import { logPackageBanner } from './Reporter';
+import { computeSummaryCounts, logPackageBanner } from './Reporter';
+import type { UnitStatus } from './Types';
 
 // ---------------------------------------------------------------------------
 // Stub helpers
@@ -78,5 +79,66 @@ describe('logPackageBanner', () => {
         '/repo/packages/precompile/.cache'
       );
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeSummaryCounts
+// ---------------------------------------------------------------------------
+
+function makeUnit(overrides: Partial<UnitStatus> = {}): UnitStatus {
+  return {
+    packageName: 'pkg',
+    productName: 'prod',
+    flavor: 'Release',
+    unitId: 'pkg/prod[Release]',
+    stages: {
+      generate: 'success',
+      build: 'success',
+      compose: 'success',
+      verify: 'success',
+    },
+    elapsedMs: 0,
+    ...overrides,
+  };
+}
+
+describe('computeSummaryCounts', () => {
+  it('counts a fully successful unit as successful', () => {
+    const counts = computeSummaryCounts([makeUnit()]);
+    assert.equal(counts.successful, 1);
+    assert.equal(counts.failed, 0);
+  });
+
+  it('counts a unit with a failed stage as failed', () => {
+    const counts = computeSummaryCounts([
+      makeUnit({ stages: { generate: 'failed', build: 'skipped', compose: 'skipped', verify: 'skipped' } }),
+    ]);
+    assert.equal(counts.successful, 0);
+    assert.equal(counts.failed, 1);
+  });
+
+  it('counts a unit with a verify warning as successful-with-warning', () => {
+    const counts = computeSummaryCounts([
+      makeUnit({ stages: { generate: 'success', build: 'success', compose: 'success', verify: 'warning' } }),
+    ]);
+    assert.equal(counts.successful, 1);
+    assert.equal(counts.warnings, 1);
+    assert.equal(counts.failed, 0);
+  });
+
+  it('counts a unit with skipReason as failed even when all stages are skipped', () => {
+    // This is the core behavior for "skipped due to upstream failure": every
+    // stage is `'skipped'` (which normally counts as success), but the presence
+    // of skipReason flips the unit into the failed bucket so counts + exit
+    // code remain accurate.
+    const counts = computeSummaryCounts([
+      makeUnit({
+        stages: { generate: 'skipped', build: 'skipped', compose: 'skipped', verify: 'skipped' },
+        skipReason: 'dependency foo failed',
+      }),
+    ]);
+    assert.equal(counts.successful, 0);
+    assert.equal(counts.failed, 1);
   });
 });

--- a/tools/src/prebuilds/pipeline/Reporter.test.ts
+++ b/tools/src/prebuilds/pipeline/Reporter.test.ts
@@ -112,7 +112,9 @@ describe('computeSummaryCounts', () => {
 
   it('counts a unit with a failed stage as failed', () => {
     const counts = computeSummaryCounts([
-      makeUnit({ stages: { generate: 'failed', build: 'skipped', compose: 'skipped', verify: 'skipped' } }),
+      makeUnit({
+        stages: { generate: 'failed', build: 'skipped', compose: 'skipped', verify: 'skipped' },
+      }),
     ]);
     assert.equal(counts.successful, 0);
     assert.equal(counts.failed, 1);
@@ -120,7 +122,9 @@ describe('computeSummaryCounts', () => {
 
   it('counts a unit with a verify warning as successful-with-warning', () => {
     const counts = computeSummaryCounts([
-      makeUnit({ stages: { generate: 'success', build: 'success', compose: 'success', verify: 'warning' } }),
+      makeUnit({
+        stages: { generate: 'success', build: 'success', compose: 'success', verify: 'warning' },
+      }),
     ]);
     assert.equal(counts.successful, 1);
     assert.equal(counts.warnings, 1);

--- a/tools/src/prebuilds/pipeline/Reporter.ts
+++ b/tools/src/prebuilds/pipeline/Reporter.ts
@@ -79,6 +79,29 @@ function stageIcon(status: StageStatus): string {
   }
 }
 
+export interface SummaryCounts {
+  successful: number;
+  warnings: number;
+  failed: number;
+}
+
+export function computeSummaryCounts(statuses: UnitStatus[]): SummaryCounts {
+  // A unit with skipReason is never successful, regardless of stage values
+  // (all 'skipped' by construction) — that's what flips skipped-due-to-dep
+  // into the failed bucket.
+  const isOk = (st: StageStatus) => st === 'success' || st === 'skipped';
+  const successful = statuses.filter(
+    (s) =>
+      !s.skipReason &&
+      isOk(s.stages.generate) &&
+      isOk(s.stages.build) &&
+      isOk(s.stages.compose) &&
+      (isOk(s.stages.verify) || s.stages.verify === 'warning')
+  ).length;
+  const warnings = statuses.filter((s) => !s.skipReason && s.stages.verify === 'warning').length;
+  return { successful, warnings, failed: statuses.length - successful };
+}
+
 export function printPrebuildSummary(statuses: UnitStatus[], elapsedMs: number): void {
   if (statuses.length === 0) {
     return;
@@ -93,22 +116,17 @@ export function printPrebuildSummary(statuses: UnitStatus[], elapsedMs: number):
         ? chalk.cyan(status.packageName)
         : `${chalk.cyan(status.packageName)}/${chalk.yellow(`${status.productName} [${status.flavor}]`)}`;
 
+    if (status.skipReason) {
+      logger.info(`${productDisplay}: ${chalk.red('⛔ Skipped')} (${status.skipReason})`);
+      continue;
+    }
+
     logger.info(
       `${productDisplay}: Gen ${stageIcon(status.stages.generate)} | Build ${stageIcon(status.stages.build)} | Compose ${stageIcon(status.stages.compose)} | Verify ${stageIcon(status.stages.verify)}`
     );
   }
 
-  const successful = statuses.filter(
-    (s) =>
-      (s.stages.generate === 'success' || s.stages.generate === 'skipped') &&
-      (s.stages.build === 'success' || s.stages.build === 'skipped') &&
-      (s.stages.compose === 'success' || s.stages.compose === 'skipped') &&
-      (s.stages.verify === 'success' ||
-        s.stages.verify === 'skipped' ||
-        s.stages.verify === 'warning')
-  ).length;
-  const warnings = statuses.filter((s) => s.stages.verify === 'warning').length;
-  const failed = statuses.length - successful;
+  const { successful, warnings, failed } = computeSummaryCounts(statuses);
 
   logger.info('─'.repeat(80));
   const warningText = warnings > 0 ? ` | ${chalk.yellow(`⚠️  ${warnings} with warnings`)}` : '';

--- a/tools/src/prebuilds/pipeline/Scheduler.test.ts
+++ b/tools/src/prebuilds/pipeline/Scheduler.test.ts
@@ -30,6 +30,24 @@ function stopRunResult(name: string): PackageResult {
   return { packageName: name, statuses: [], errors: [], stopRun: true };
 }
 
+function failedResult(name: string): PackageResult {
+  return {
+    packageName: name,
+    statuses: [],
+    errors: [
+      {
+        packageName: name,
+        productName: 'p',
+        flavor: 'Release',
+        unitId: `${name}/p[Release]`,
+        stage: 'build',
+        error: new Error(`${name} failed`),
+      },
+    ],
+    stopRun: false,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -246,5 +264,99 @@ describe('runPackagesInParallel', () => {
     // d must start after both b and c finish
     assert.ok(bEnd < dStart, 'b must finish before d starts');
     assert.ok(cEnd < dStart, 'c must finish before d starts');
+  });
+
+  it('skips downstream packages when a dependency fails (transitive diamond)', async () => {
+    const a = makePkg('a');
+    const b = makePkg('b');
+    const c = makePkg('c');
+    const d = makePkg('d');
+
+    // b → a, c → a, d → b, c
+    const dependsOn = new Map<string, Set<string>>([
+      ['a', new Set()],
+      ['b', new Set(['a'])],
+      ['c', new Set(['a'])],
+      ['d', new Set(['b', 'c'])],
+    ]);
+
+    const failedDepsReceived: Record<string, string[] | undefined> = {};
+    const realExecutions: string[] = [];
+
+    const results = await runPackagesInParallel(
+      [a, b, c, d],
+      dependsOn,
+      4,
+      new AbortController(),
+      async (pkg, _signal, failedDeps) => {
+        failedDepsReceived[pkg.packageName] = failedDeps;
+        if (failedDeps && failedDeps.length > 0) {
+          // Caller signals this package should be skipped; return a fake result.
+          return failedResult(pkg.packageName);
+        }
+        realExecutions.push(pkg.packageName);
+        if (pkg.packageName === 'a') {
+          return failedResult('a');
+        }
+        return successResult(pkg.packageName);
+      }
+    );
+
+    // a runs for real (and fails)
+    assert.ok(realExecutions.includes('a'), 'a should run for real');
+    // b, c, d must NOT run for real — they are skipped due to upstream failure
+    assert.ok(!realExecutions.includes('b'), 'b should be skipped because a failed');
+    assert.ok(!realExecutions.includes('c'), 'c should be skipped because a failed');
+    assert.ok(!realExecutions.includes('d'), 'd should be skipped transitively');
+
+    // Executor should be called for every package so it can synthesize statuses,
+    // but dependents should receive non-empty failedDeps.
+    assert.equal(failedDepsReceived.a, undefined, 'a has no failed upstream deps');
+    assert.deepEqual(failedDepsReceived.b, ['a']);
+    assert.deepEqual(failedDepsReceived.c, ['a']);
+    assert.ok(
+      failedDepsReceived.d && failedDepsReceived.d.length > 0,
+      'd must be told its deps failed (transitively)'
+    );
+
+    assert.equal(results.length, 4, 'all four packages must appear in results');
+  });
+
+  it('does not skip independent packages when an unrelated package fails', async () => {
+    const a = makePkg('a');
+    const b = makePkg('b');
+
+    // a and b are independent
+    const dependsOn = new Map<string, Set<string>>([
+      ['a', new Set()],
+      ['b', new Set()],
+    ]);
+
+    let bFailedDeps: string[] | undefined = ['sentinel'];
+    const realExecutions: string[] = [];
+
+    await runPackagesInParallel(
+      [a, b],
+      dependsOn,
+      2,
+      new AbortController(),
+      async (pkg, _signal, failedDeps) => {
+        realExecutions.push(pkg.packageName);
+        if (pkg.packageName === 'b') {
+          bFailedDeps = failedDeps;
+        }
+        if (pkg.packageName === 'a') {
+          return failedResult('a');
+        }
+        return successResult(pkg.packageName);
+      }
+    );
+
+    assert.ok(realExecutions.includes('a'));
+    assert.ok(realExecutions.includes('b'), 'b is independent and should run');
+    assert.ok(
+      bFailedDeps === undefined || bFailedDeps.length === 0,
+      `b should have no failed deps, got ${JSON.stringify(bFailedDeps)}`
+    );
   });
 });

--- a/tools/src/prebuilds/pipeline/Scheduler.ts
+++ b/tools/src/prebuilds/pipeline/Scheduler.ts
@@ -16,7 +16,16 @@ export interface PackageResult {
   stopRun: boolean;
 }
 
-type ExecutePackageFn = (pkg: SPMPackageSource, signal: AbortSignal) => Promise<PackageResult>;
+type ExecutePackageFn = (
+  pkg: SPMPackageSource,
+  signal: AbortSignal,
+  /**
+   * Names of upstream DAG dependencies that failed or were themselves skipped.
+   * When non-empty, the executor should short-circuit without running build
+   * steps and synthesize a "skipped due to failed dependency" result.
+   */
+  failedDeps?: string[]
+) => Promise<PackageResult>;
 
 /**
  * Runs packages in parallel, respecting the dependency DAG and concurrency limit.
@@ -39,6 +48,9 @@ export async function runPackagesInParallel(
 
   const results: PackageResult[] = [];
   const completed = new Set<string>();
+  // Transitively poisoned — failed packages + packages skipped because of an
+  // upstream failure. Used to short-circuit dependents.
+  const failedOrDoomed = new Set<string>();
 
   // Build in-degree map (count of unfinished dependencies)
   const inDegree = new Map<string, number>();
@@ -81,10 +93,14 @@ export async function runPackagesInParallel(
     // Launch ready packages up to concurrency limit (unless aborted)
     while (readyQueue.length > 0 && running.size < concurrency && !abortController.signal.aborted) {
       const pkg = readyQueue.shift()!;
-      const promise = executePackage(pkg, abortController.signal).then((result) => ({
-        name: pkg.packageName,
-        result,
-      }));
+      const failedDeps = [...(dependsOn.get(pkg.packageName) ?? [])].filter((d) =>
+        failedOrDoomed.has(d)
+      );
+      const promise = executePackage(
+        pkg,
+        abortController.signal,
+        failedDeps.length > 0 ? failedDeps : undefined
+      ).then((result) => ({ name: pkg.packageName, result }));
       running.set(pkg.packageName, promise);
     }
 
@@ -97,6 +113,9 @@ export async function runPackagesInParallel(
     running.delete(name);
     results.push(result);
     completed.add(name);
+    if (result.errors.length > 0) {
+      failedOrDoomed.add(name);
+    }
 
     // If stop-run, abort and drain remaining
     if (result.stopRun) {

--- a/tools/src/prebuilds/pipeline/Types.ts
+++ b/tools/src/prebuilds/pipeline/Types.ts
@@ -59,6 +59,13 @@ export interface UnitStatus {
   unitId: string;
   stages: Record<ProductStage, StageStatus>;
   elapsedMs: number;
+  /**
+   * Set when a unit was skipped because of an upstream DAG failure. The value
+   * is a human-readable reason (e.g., `"dependency react-native-worklets failed"`).
+   * When present, the unit is rendered as a single-line skip in the summary
+   * and counted as a failure, independent of its per-stage statuses.
+   */
+  skipReason?: string;
 }
 
 export interface UnitError {


### PR DESCRIPTION
# Why

The scheduler unblocked dependents as soon as a dependency finished, without checking whether it actually succeeded. 

So when react-native-worklets fails, react-native-reanimated (which depends on RNWorklets) will still be launched — and either cascaded a misleading "xcframework not found, please build worklets first" error that buried the real root cause, or, on machines with a stale RNWorklets.xcframework left over from a previous good build, silently built against the stale artifact — which is where the non-deterministic failures came from. 

The fix tracks failed packages in the scheduler and short-circuits dependents before they run, so a failed upstream always prevents a downstream build instead of racing with the filesystem.

# How

Scheduler.ts:
- Added a failedOrDoomed: Set<string> next to the existing completed set.
- When a package returns with result.errors.length > 0, it goes into that set.
- Before launching any package, compute failedDeps = package.deps ∩ failedOrDoomed. If non-empty, pass that list through to the executor as a third argument.
- Because synthesized skip-results also carry errors, the poison propagates transitively through the DAG without any extra logic — a dependent that's skipped becomes "failed" itself and poisons its dependents.

Executor.ts:
- In the scheduler callback, if failedDeps is non-empty: log ⏭️  Skipping <pkg> — dependency failed: <deps> and return a synthesizeSkippedResult(...) instead of actually running.
- synthesizeSkippedResult produces one UnitStatus (all stages 'skipped', with a skipReason string) + one UnitError per product × flavor, so the summary, error log, and exit code all reflect the skip without touching disk.

Reporter.ts:
  - A unit with skipReason is rendered as a single-line ⛔ Skipped (dependency X failed) and counted as failed — so the summary is visually distinct from a real generate failure and the ❌ N failed total stays honest. Net effect: a failed upstream deterministically prevents its downstream from running, regardless of what leftover artifacts happen to be on disk.

