### PR TITLE
[expo-module-template] Fix open commands closing the child process

### DIFF
--- a/packages/expo-module-template/internal/module_scripts/open-android.js
+++ b/packages/expo-module-template/internal/module_scripts/open-android.js
@@ -27,7 +27,7 @@ function openApp(command, args, options = {}) {
 
 switch (process.platform) {
   case 'darwin':
-    // On MacOS we spawn xed, which is a short running process so we can inherit stdio
+    // Open command sends an AppleEvent to launch the app and then exits immediately, so we can inherit the stdio.
     openApp('open', ['-a', 'Android Studio', projectPath], {
       detached: false,
       stdio: 'inherit',

--- a/packages/expo-module-template/internal/module_scripts/open-android.js
+++ b/packages/expo-module-template/internal/module_scripts/open-android.js
@@ -6,9 +6,32 @@ const os = require('os');
 
 const projectPath = path.join(process.cwd(), 'example', 'android');
 
+function openApp(command, args, options = {}) {
+  const detached = options.detached ?? true;
+  const child = spawn(command, args, {
+    detached,
+    stdio: options.stdio ?? 'ignore',
+  });
+
+  child.once('error', (error) => {
+    console.error(`Error: Failed to open Android Studio: ${error.message}`);
+    process.exit(1);
+  });
+
+  child.once('spawn', () => {
+    if (detached) {
+      child.unref();
+    }
+  });
+}
+
 switch (process.platform) {
   case 'darwin':
-    spawn('open', ['-a', 'Android Studio', projectPath], { stdio: 'inherit' });
+    // On MacOS we spawn xed, which is a short running process so we can inherit stdio
+    openApp('open', ['-a', 'Android Studio', projectPath], {
+      detached: false,
+      stdio: 'inherit',
+    });
     break;
   case 'linux': {
     const home = os.homedir();
@@ -72,7 +95,8 @@ switch (process.platform) {
         process.exit(1);
       }
     }
-    spawn(studioSh, [projectPath], { stdio: 'inherit' });
+    // On Linux we launch Android Studio directly (long-running process), so don't inherit stdio
+    openApp(studioSh, [projectPath]);
     break;
   }
   case 'win32': {
@@ -87,12 +111,11 @@ switch (process.platform) {
       );
       process.exit(1);
     }
-    spawn(studioExe, [projectPath], { stdio: 'inherit' });
+    // On Windows we launch Android Studio directly (long-running process), so don't inherit stdio
+    openApp(studioExe, [projectPath]);
     break;
   }
   default:
     console.error(`Error: Unsupported platform: ${process.platform}`);
     process.exit(1);
 }
-
-process.exit(0);

--- a/packages/expo-module-template/internal/module_scripts/open-ios.js
+++ b/packages/expo-module-template/internal/module_scripts/open-ios.js
@@ -10,5 +10,9 @@ if (process.platform !== 'darwin') {
 }
 
 const projectPath = path.join(process.cwd(), 'example', 'ios');
-spawn('xed', [projectPath], { stdio: 'inherit' });
-process.exit(0);
+const child = spawn('xed', [projectPath], { stdio: 'inherit' });
+
+child.once('error', (error) => {
+  console.error(`Error: Failed to open Xcode: ${error.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
# Why

Turns out our spawn-and-ignore method doesn't work on Windows. Calling `process.exit(0)` after spawning the process synchronously causes the child process to also close.

# How

Wait for the `spawn` event before closing the main process - also do not inherit `stdio` on windows and linux - those spawn the editors directly, which i a long running process - we are only interested about launch errors. On iOS we can keep inheriting since we will only inherit `stdio` from `xed` but not from Android Studio/Xcode itself. 

# Test Plan

Tested on Windows and MacOS
