### PR TITLE
add expo-ui dep to notification-tester

### DIFF
--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@react-navigation/bottom-tabs": "^7.15.5",
     "@react-navigation/native": "^7.1.33",
+    "@expo/ui": "workspace:*",
     "expo": "workspace:*",
     "expo-font": "workspace:*",
     "expo-linking": "workspace:*",

--- a/apps/notification-tester/scripts/prebuild-android.sh
+++ b/apps/notification-tester/scripts/prebuild-android.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-RELEASE=1 MICROFOAM_GOOGLE_SERVICES_JSON=~/google-services-microfoam-vonovak.json EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p android --template expo-template-bare-minimum@55
-
+RELEASE=1 MICROFOAM_GOOGLE_SERVICES_JSON=~/google-services-microfoam-vonovak.json EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p android --template expo-template-bare-minimum@canary
 
 echo 'include(":expo-modules-test-core")' >> ./android/settings.gradle
 echo 'project(":expo-modules-test-core").projectDir = new File("../../../packages/expo-modules-test-core/android")' >> ./android/settings.gradle

--- a/apps/notification-tester/scripts/prebuild-ios.sh
+++ b/apps/notification-tester/scripts/prebuild-ios.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p ios --template expo-template-bare-minimum@55 && xed ios
+EXPO_NO_GIT_STATUS=1 EXPO_DEBUG=1 npx expo prebuild --clean -p ios --template expo-template-bare-minimum@canary && xed ios

--- a/apps/notification-tester/src/app/expo-ui.tsx
+++ b/apps/notification-tester/src/app/expo-ui.tsx
@@ -1,0 +1,4 @@
+//@ts-expect-error
+import ExpoUITestScreen from 'native-component-list/src/screens/UI/ButtonScreen';
+
+export default ExpoUITestScreen;

--- a/apps/notification-tester/src/app/index.tsx
+++ b/apps/notification-tester/src/app/index.tsx
@@ -15,6 +15,7 @@ export default function IndexPage() {
         onPress={() => router.push('/ncl-notification-screen')}
       />
       <Button title="Go to playground" onPress={() => router.push('/playground')} />
+      <Button title="See Expo ui" onPress={() => router.push('/expo-ui')} />
       <Button title="Go to test scenarios" onPress={() => router.push('/scenarios')} />
       <Button
         title="Get Notification permissions"


### PR DESCRIPTION
# Why

to be able to use expo-ui to build out the notification tester, and to be able to preview expo ui components more easily without the baggage of bare-expo

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- list expo ui as a dep, add link to NCL screen

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)