### PR TITLE
[docs] Fix sidebar scroll position reset after initial load

### DIFF
--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -34,7 +34,9 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
   const isSelected = isRouteActive(info, router?.asPath, router?.pathname);
 
   useEffect(() => {
-    if (isSelected && ref?.current && !isLinkInViewport(ref?.current)) {
+    const willRestoreSavedScroll =
+      typeof window !== 'undefined' && (window.__sidebarScroll ?? 0) > 0;
+    if (isSelected && ref?.current && !isLinkInViewport(ref?.current) && !willRestoreSavedScroll) {
       setTimeout(() => {
         if (ref?.current) {
           ref.current.scrollIntoView({ behavior: 'smooth' });

--- a/docs/ui/components/Sidebar/SidebarLink.tsx
+++ b/docs/ui/components/Sidebar/SidebarLink.tsx
@@ -34,15 +34,17 @@ export const SidebarLink = ({ info, className, children }: SidebarLinkProps) => 
   const isSelected = isRouteActive(info, router?.asPath, router?.pathname);
 
   useEffect(() => {
-    const willRestoreSavedScroll =
-      typeof window !== 'undefined' && (window.__sidebarScroll ?? 0) > 0;
-    if (isSelected && ref?.current && !isLinkInViewport(ref?.current) && !willRestoreSavedScroll) {
-      setTimeout(() => {
-        if (ref?.current) {
-          ref.current.scrollIntoView({ behavior: 'smooth' });
-        }
-      }, 50);
+    if (!isSelected || !ref?.current) {
+      return;
     }
+    const timeoutId = setTimeout(() => {
+      if (ref?.current && !isLinkInViewport(ref.current)) {
+        ref.current.scrollIntoView({ behavior: 'smooth' });
+      }
+    }, 50);
+    return () => {
+      clearTimeout(timeoutId);
+    };
   }, []);
 
   if (info.hidden) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20113

https://github.com/user-attachments/assets/57289caf-6cdc-44c6-ba2d-4b1fe7737204

# How

<!--
How did you build this feature or fix this bug and why?
-->

In `SidebarLink.tsx`, moved the `isLinkInViewport` check inside the existing 50ms `setTimeout` callback so it runs after `ScrollContainer`'s restore has applied. The active link only calls `scrollIntoView` when it is genuinely off-screen in the restored state, not based on a stale snapshot taken before restore. Also added a `clearTimeout` cleanup for the effect.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

**On desktop:** 

https://github.com/user-attachments/assets/6c643494-4643-4a6c-a87c-05867d08d73e

**On mobile, behavior does not change:**

https://github.com/user-attachments/assets/2927eb17-671b-4b43-8a99-0bd5ce951bbe

**Testing locally**

Run `yarn dev` in `docs/` and verify each case in a fresh browser tab:

 1. Navigate to a page deep in EAS (for example `/eas/build/setup`), scroll the sidebar down, click another EAS link that is visible in the current view. The sidebar should stay put.
2. From an EAS page, click the top-level Guides or Reference tab. The sidebar should repaint for the new section with the active link visible.
3. Paste a deep link like `/eas/build-reference/android-builds` into a new tab. On load, the sidebar should scroll so the active link is visible.
4. Use browser Back and Forward across the scenarios above. Same-section back and forward should not cause sidebar jumps. Cross-section back and forward should show the active link.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
