### PR TITLE
[ios][audio] Stop playback progress when audio is paused

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [iOS] Improve looping support. ([#43600](https://github.com/expo/expo/pull/43600) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Prevent stale lock screen artwork updates from crashing or overwriting newer metadata. ([#44498](https://github.com/expo/expo/pull/44498) by [@kotadd](https://github.com/kotadd))
 - [Android] Fix lock screen controls on android 12 and earlier. ([#44754](https://github.com/expo/expo/pull/44754) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix playback progress continuing after pause by setting correct playback rate in now playing info. ([#44974](https://github.com/expo/expo/pull/44974) by [@JstUsername](https://github.com/JstUsername))
 
 ### 💡 Others
 

--- a/packages/expo-audio/ios/MediaController.swift
+++ b/packages/expo-audio/ios/MediaController.swift
@@ -83,7 +83,7 @@ class MediaController {
       info[MPMediaItemPropertyPlaybackDuration] = player.duration
       info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = player.currentTime
     }
-    info[MPNowPlayingInfoPropertyPlaybackRate] = player.isPlaying ? player.ref.rate : 1.0
+    info[MPNowPlayingInfoPropertyPlaybackRate] = player.isPlaying ? player.ref.rate : 0.0
     info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
   }
 


### PR DESCRIPTION
# Why
Closes #44973
Fixes an issue where playback progress continues updating after audio is paused on iOS 26.

When playback is paused (either programmatically or via system media controls), the elapsed time and progress bar keep updating as if playback is still active.

This is caused by `MPNowPlayingInfoPropertyPlaybackRate` being set to `1.0` even when the player is paused, which incorrectly signals an active playback state to the system.

# How

Updated the value of `MPNowPlayingInfoPropertyPlaybackRate` in `MediaController.swift`.

Previously, the playback rate was set to `1.0` when the player was not playing. This has been changed to `0.0`, which correctly represents the paused state according to Apple's media playback APIs.

This ensures that the system stops advancing the playback timeline when audio is paused.

# Test Plan

Tested on iOS 26 using a minimal Expo app with expo-audio.

Steps:
1. Start audio playback
2. Pause playback:
   - via player ref inside the app
   - via iOS Control Center / lock screen controls
3. Observe playback progress

Before fix:
- Elapsed time continues increasing after pause
- Progress bar keeps moving

After fix:
- Elapsed time stops immediately after pause
- Progress bar stops moving as expected

Tested both scenarios to confirm consistent behavior.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
