### PR TITLE
fix(expo-modules-core) added explicit c++ linkage to e-m-c

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ### 💡 Others
 
-- [iOS] Added explicit c++ linkage specifier to `ExpoModulesCore.podspec` to propagate to swift-only targets like Expo Widgets
+- [iOS] Added explicit c++ linkage specifier to `ExpoModulesCore.podspec` to propagate to swift-only targets like Expo Widgets ([#44984](https://github.com/expo/expo/pull/44984) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Extracted ObjC protocols (`EXAppContextProtocol`, `EXReactDelegateProtocol`, `EXAppContextFactoryRegistry`) for cross-xcframework module boundaries. Refactored legacy module registry, Fabric view headers, JSI layer, and podspecs for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Add `ViewWrapper` protocol and `AnyContentViewProvider` for type-erased access to wrapped SwiftUI views. ([#43669](https://github.com/expo/expo/pull/43669) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Decoupled Worklets integration into separate podspec. ([#42971](https://github.com/expo/expo/pull/42971) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### 💡 Others
 
+- [iOS] Added explicit c++ linkage specifier to `ExpoModulesCore.podspec` to propagate to swift-only targets like Expo Widgets
 - [iOS] Extracted ObjC protocols (`EXAppContextProtocol`, `EXReactDelegateProtocol`, `EXAppContextFactoryRegistry`) for cross-xcframework module boundaries. Refactored legacy module registry, Fabric view headers, JSI layer, and podspecs for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Add `ViewWrapper` protocol and `AnyContentViewProvider` for type-erased access to wrapped SwiftUI views. ([#43669](https://github.com/expo/expo/pull/43669) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Decoupled Worklets integration into separate podspec. ([#42971](https://github.com/expo/expo/pull/42971) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -94,6 +94,7 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => [
       '"${PODS_CONFIGURATION_BUILD_DIR}/ExpoModulesCore/Swift Compatibility Header"',
       '"$(PODS_ROOT)/Headers/Private/Yoga"', # Expo.h -> ExpoModulesCore-umbrella.h -> Fabric ViewProps.h -> Private Yoga headers
+      'OTHER_LDFLAGS' => '$(inherited) -lc++' # C++ standard library - will propagate to dependant targets
     ],
   }
 


### PR DESCRIPTION
# Why

ExpoWidgetsTarget is a Swift-only app extension. It transitively links libExpoModulesCore.a and libExpoModulesJSI.a, both of which compile C++ (common/cpp/**/*.cpp, ios/JSI/**/*.{cpp,mm}) and therefore reference std::*, __cxa_*, and the C++ EH personality __gxx_personality_v0. Because the widget target itself contains zero C++/Obj-C++ sources, Xcode picks clang as the link driver rather than clang++, and libc++ / the C++ ABI are never implicitly linked → every C++ runtime symbol is undefined.

# How

Adding -lc++ to ExpoModulesCore.podspec fixes this.

user_target_xcconfig = { 'OTHER_LDFLAGS' => '$(inherited) -lc++' } instructs CocoaPods to merge -lc++ into the OTHER_LDFLAGS of every aggregate xcconfig that consumes ExpoModulesCore — including Pods-ExpoWidgetsTarget.{debug,release}.xcconfig.

# Test-plan

Build test-widgets project in both xcframework and source - now works.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
