### PR TITLE
chore(doctor): Add Node.js version requirement to expo-doctor

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Include `@react-navigation/native` and `@react-navigation/core` in duplicates check ([#43461](https://github.com/expo/expo/pull/43461) by [@kitten](https://github.com/kitten))
 - Include `web` platform in duplicate packages check ([#43724](https://github.com/expo/expo/pull/43724) by [@kitten](https://github.com/kitten))
 - Use independent native modules API call, instead of reusing `@expo/cli`'s implementation ([#44593](https://github.com/expo/expo/pull/44593) by [@kitten](https://github.com/kitten))
+- Add explicit Node.js version requirement and make `@expo/env` fault tolerant ([#44985](https://github.com/expo/expo/pull/44985) by [@kitten](https://github.com/kitten))
 
 ## 1.18.8 — 2026-02-25
 

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -32,6 +32,9 @@
     "watch": "pnpm run build -w",
     "prepublishOnly": "pnpm run clean && pnpm run build:prod"
   },
+  "engines": {
+    "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+  },
   "devDependencies": {
     "@expo/config": "workspace:*",
     "@expo/env": "workspace:*",

--- a/packages/expo-doctor/src/doctor.ts
+++ b/packages/expo-doctor/src/doctor.ts
@@ -123,6 +123,15 @@ export async function runChecksAsync(
   );
 }
 
+function maybeLoadEnv(projectRoot: string) {
+  try {
+    loadEnv(projectRoot);
+  } catch {
+    // NOTE(@kitten): It's unclear why we load env files here in expo-doctor, and it's likely optional, even with us loading the project config
+    // If this fails, e.g. because the Node.js version is too out of date, ignore the error
+  }
+}
+
 /**
  * Run the expo-doctor checks on the project.
  * @param projectRoot The root of the project to check.
@@ -131,7 +140,7 @@ export async function runChecksAsync(
 export async function actionAsync(projectRoot: string, showVerboseTestResults: boolean) {
   try {
     setNodeEnv('development');
-    loadEnv(projectRoot);
+    maybeLoadEnv(projectRoot);
 
     const projectConfig = await getProjectConfigAsync(projectRoot);
 

--- a/packages/expo-doctor/src/index.ts
+++ b/packages/expo-doctor/src/index.ts
@@ -7,6 +7,18 @@ import path from 'path';
 
 import { actionAsync } from './doctor';
 
+// Check Node.js version and issue a loud warning if it's too outdated
+// This is sent to stderr (console.error) so it doesn't interfere with programmatic commands
+const NODE_MIN = [20, 19, 4] as const;
+const nodeVersion = process.version?.slice(1).split('.', 3).map(Number);
+if (nodeVersion[0]! < NODE_MIN[0] || (nodeVersion[0] === NODE_MIN[0] && nodeVersion[1]! < NODE_MIN[1])) {
+  console.error(
+    chalk.red`{bold Node.js (${process.version}) is outdated and unsupported.}`
+      + chalk.red` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n`
+      + chalk.red`Go to: https://nodejs.org/en/download\n`
+  );
+}
+
 // Setup before requiring `debug`.
 if (boolish('EXPO_DEBUG', false)) {
   Debug.enable('expo:*');

--- a/packages/expo-doctor/src/index.ts
+++ b/packages/expo-doctor/src/index.ts
@@ -11,11 +11,14 @@ import { actionAsync } from './doctor';
 // This is sent to stderr (console.error) so it doesn't interfere with programmatic commands
 const NODE_MIN = [20, 19, 4] as const;
 const nodeVersion = process.version?.slice(1).split('.', 3).map(Number);
-if (nodeVersion[0]! < NODE_MIN[0] || (nodeVersion[0] === NODE_MIN[0] && nodeVersion[1]! < NODE_MIN[1])) {
+if (
+  nodeVersion[0]! < NODE_MIN[0] ||
+  (nodeVersion[0] === NODE_MIN[0] && nodeVersion[1]! < NODE_MIN[1])
+) {
   console.error(
-    chalk.red`{bold Node.js (${process.version}) is outdated and unsupported.}`
-      + chalk.red` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n`
-      + chalk.red`Go to: https://nodejs.org/en/download\n`
+    chalk.red`{bold Node.js (${process.version}) is outdated and unsupported.}` +
+      chalk.red` Please update to a newer Node.js LTS version (required: >=${NODE_MIN.join('.')})\n` +
+      chalk.red`Go to: https://nodejs.org/en/download\n`
   );
 }
 


### PR DESCRIPTION
# Why

See #44983

# How

- Mirror version check in CLI
- Make `@expo/env` fault-tolerant due to Node.js API requirement
- Add `package.json:engines` field (mirroring react-native for now)

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
