### PR TITLE
[gha] Publish prebuilt XCFramework tarballs to GCS by scope

### DIFF
--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -124,7 +124,7 @@ jobs:
           # Stage only XCFramework tarballs into a clean tree that mirrors the
           # package-relative output layout we want to publish to GCS.
           rsync \
-            --archive \
+            --recursive \
             --verbose \
             --prune-empty-dirs \
             --include='*/' \

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -16,11 +16,6 @@ on:
         required: false
         type: boolean
         default: false
-      scope:
-        description: 'Top-level GCS prefix, e.g. sdk-55'
-        required: false
-        default: ''
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -42,16 +37,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Validate inputs
-        env:
-          INPUT_PUBLISH: ${{ github.event.inputs.publish }}
-          INPUT_SCOPE: ${{ github.event.inputs.scope }}
-        run: |
-          if [[ "$INPUT_PUBLISH" == "true" ]] && [[ -z "$INPUT_SCOPE" ]]; then
-            echo "scope input must be set when publish=true"
-            exit 1
-          fi
 
       - name: Switch to Xcode 26.2
         run: sudo xcode-select --switch /Applications/Xcode_26.2.app
@@ -139,8 +124,8 @@ jobs:
           fi
 
           # Sync the staged tree as-is so objects land under:
-          #   gs://eas-build-precompiled-modules/<scope>/<pkg>/output/.../xcframeworks/*.tar.gz
+          #   gs://eas-build-precompiled-modules/<pkg>/output/.../xcframeworks/*.tar.gz
           gcloud storage rsync \
             "$SYNC_ROOT" \
-            "gs://eas-build-precompiled-modules/${{ github.event.inputs.scope }}" \
+            "gs://eas-build-precompiled-modules" \
             --recursive

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -123,9 +123,15 @@ jobs:
             exit 0
           fi
 
-          # Sync the staged tree as-is so objects land under:
+          # Sync each top-level package directory separately so objects still land under:
           #   gs://eas-build-precompiled-modules/<pkg>/output/.../xcframeworks/*.tar.gz
-          gcloud storage rsync \
-            "$SYNC_ROOT" \
-            "gs://eas-build-precompiled-modules" \
-            --recursive
+          # without requiring bucket-level metadata access for a root rsync target.
+          shopt -s nullglob
+          for package_dir in "$SYNC_ROOT"/*; do
+            [ -d "$package_dir" ] || continue
+            package_name="$(basename "$package_dir")"
+            gcloud storage rsync \
+              "$package_dir" \
+              "gs://eas-build-precompiled-modules/$package_name" \
+              --recursive
+          done

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -121,7 +121,12 @@ jobs:
           rm -rf "$SYNC_ROOT"
           mkdir -p "$SYNC_ROOT"
 
-          rsync -avm --prune-empty-dirs \
+          # Stage only XCFramework tarballs into a clean tree that mirrors the
+          # package-relative output layout we want to publish to GCS.
+          rsync \
+            --archive \
+            --verbose \
+            --prune-empty-dirs \
             --include='*/' \
             --include='*/xcframeworks/*.tar.gz' \
             --exclude='*' \
@@ -133,6 +138,8 @@ jobs:
             exit 0
           fi
 
+          # Sync the staged tree as-is so objects land under:
+          #   gs://eas-build-precompiled-modules/<scope>/<pkg>/output/.../xcframeworks/*.tar.gz
           gcloud storage rsync \
             "$SYNC_ROOT" \
             "gs://eas-build-precompiled-modules/${{ github.event.inputs.scope }}" \

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -12,13 +12,14 @@ on:
         required: false
         default: ''
       publish:
-        description: 'Publish XCFramework archive to GCS'
+        description: 'Publish XCFramework tarballs to GCS'
         required: false
         type: boolean
         default: false
-      sdk-version:
-        description: 'SDK version used in the GCS object path'
-        required: true
+      scope:
+        description: 'Top-level GCS prefix, e.g. sdk-55'
+        required: false
+        default: ''
         type: string
 
 concurrency:
@@ -44,11 +45,11 @@ jobs:
 
       - name: Validate inputs
         env:
-          INPUT_PACKAGES: ${{ github.event.inputs.packages }}
           INPUT_PUBLISH: ${{ github.event.inputs.publish }}
+          INPUT_SCOPE: ${{ github.event.inputs.scope }}
         run: |
-          if [[ "$INPUT_PUBLISH" == "true" ]] && [[ -n "$INPUT_PACKAGES" ]]; then
-            echo "packages input must be empty when publish=true"
+          if [[ "$INPUT_PUBLISH" == "true" ]] && [[ -z "$INPUT_SCOPE" ]]; then
+            echo "scope input must be set when publish=true"
             exit 1
           fi
 
@@ -93,7 +94,6 @@ jobs:
 
       - name: Upload XCFrameworks
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
         with:
           name: xcframeworks-${{ matrix.flavor }}
           path: packages/precompile/.build/*/output/**/${{ matrix.flavor == 'Debug' && 'debug' || 'release' }}/xcframeworks/*.tar.gz
@@ -101,43 +101,39 @@ jobs:
           retention-days: 14
           include-hidden-files: true
 
-      - name: Package XCFrameworks (${{ matrix.flavor }})
-        id: package_xcframeworks
-        if: ${{ !cancelled() }}
-        run: |
-          FLAVOR_LOWER=$(echo "${{ matrix.flavor }}" | tr '[:upper:]' '[:lower:]')
-          ARCHIVE_PATH="$RUNNER_TEMP/xcframeworks-${{ matrix.flavor }}.zip"
-          FILE_LIST="$RUNNER_TEMP/xcframeworks-${{ matrix.flavor }}.txt"
-
-          cd packages/precompile/.build
-          find . -type f -name "*.tar.gz" | grep "/${FLAVOR_LOWER}/xcframeworks/" | sort > "$FILE_LIST"
-
-          if [ ! -s "$FILE_LIST" ]; then
-            echo "::warning::No XCFramework tarballs found for flavor ${{ matrix.flavor }}; skipping zip packaging."
-            echo "archive_path=" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          rm -f "$ARCHIVE_PATH"
-          zip -q "$ARCHIVE_PATH" -@ < "$FILE_LIST"
-          echo "archive_path=$ARCHIVE_PATH" >> $GITHUB_OUTPUT
-
       - name: Authenticate to Google Cloud
-        if: ${{ success() && github.event.inputs.publish == 'true' && steps.package_xcframeworks.outputs.archive_path != '' }}
+        if: ${{ success() && github.event.inputs.publish == 'true' }}
         uses: google-github-actions/auth@v3
         with:
           project_id: exponentjs
           workload_identity_provider: projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo
 
       - name: Setup gcloud
-        if: ${{ success() && github.event.inputs.publish == 'true' && steps.package_xcframeworks.outputs.archive_path != '' }}
+        if: ${{ success() && github.event.inputs.publish == 'true' }}
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: exponentjs
 
-      - name: Upload XCFramework zip to GCS
-        if: ${{ success() && github.event.inputs.publish == 'true' && steps.package_xcframeworks.outputs.archive_path != '' }}
+      - name: Upload XCFramework directory structure to GCS
+        if: ${{ success() && github.event.inputs.publish == 'true' }}
         run: |
-          gcloud storage cp \
-            "${{ steps.package_xcframeworks.outputs.archive_path }}" \
-            "gs://eas-build-precompiled-modules/precompiled-modules/${{ github.event.inputs.sdk-version }}/xcframeworks-${{ matrix.flavor }}.zip"
+          SYNC_ROOT="$RUNNER_TEMP/precompiled-modules-upload"
+          rm -rf "$SYNC_ROOT"
+          mkdir -p "$SYNC_ROOT"
+
+          rsync -avm --prune-empty-dirs \
+            --include='*/' \
+            --include='*/xcframeworks/*.tar.gz' \
+            --exclude='*' \
+            packages/precompile/.build/ \
+            "$SYNC_ROOT/"
+
+          if ! find "$SYNC_ROOT" -type f -print -quit | grep -q .; then
+            echo "::warning::No XCFramework tarballs found to upload."
+            exit 0
+          fi
+
+          gcloud storage rsync \
+            "$SYNC_ROOT" \
+            "gs://eas-build-precompiled-modules/${{ github.event.inputs.scope }}" \
+            --recursive


### PR DESCRIPTION
## Summary
This updates the iOS external XCFramework workflow to publish individual XCFramework tarballs to GCS under a configurable scope prefix instead of packaging a single zip.

## What changed
- replace zip packaging and zip upload with individual tarball publishing
- publish to `gs://eas-build-precompiled-modules/<pkg>/output/.../xcframeworks/*.tar.gz`
- removed `sdk-version` which is not necessary anymore
- stage only XCFramework tarballs into a temporary tree before gcloud storage rsync, so the uploaded object layout matches the package-relative output structure

## Validation
- mise exec -- yarn prettier --check .github/workflows/ios-prebuild-external-xcframeworks.yml
- manual run — https://github.com/expo/expo/actions/runs/24775325089/job/72491939160

<img width="596" height="251" alt="Zrzut ekranu 2026-04-22 o 17 43 11" src="https://github.com/user-attachments/assets/0ccaa892-ea7d-4c36-a650-4490fb6cd537" />
