### PR TITLE
[expo] Add expo-widgets to bundledNativeModules

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -93,6 +93,7 @@
   "expo-video-thumbnails": "~55.0.9",
   "expo-video": "~55.0.9",
   "expo-web-browser": "~55.0.9",
+  "expo-widgets": "~55.0.1",
   "jest-expo": "~55.0.9",
   "lottie-react-native": "~7.3.4",
   "react": "19.2.3",


### PR DESCRIPTION
# Why

To verify compatible versions.

# How

Added `expo-widgets` with main version.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
