### PR TITLE
fix(expo-modules-core): stop staging SwiftUIVirtualView impl fragment…

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -40,7 +40,7 @@
 
 ### 💡 Others
 
-- [iOS] Fixed precompile build failing on `SwiftUIVirtualViewSharedImpl+Private.h` leaking into the public module umbrella.
+- [iOS] Fixed precompile build failing on `SwiftUIVirtualViewSharedImpl+Private.h` leaking into the public module umbrella. ([#44993](https://github.com/expo/expo/pull/44993) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Added explicit c++ linkage specifier to `ExpoModulesCore.podspec` to propagate to swift-only targets like Expo Widgets ([#44984](https://github.com/expo/expo/pull/44984) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Extracted ObjC protocols (`EXAppContextProtocol`, `EXReactDelegateProtocol`, `EXAppContextFactoryRegistry`) for cross-xcframework module boundaries. Refactored legacy module registry, Fabric view headers, JSI layer, and podspecs for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Add `ViewWrapper` protocol and `AnyContentViewProvider` for type-erased access to wrapped SwiftUI views. ([#43669](https://github.com/expo/expo/pull/43669) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ### 💡 Others
 
+- [iOS] Fixed precompile build failing on `SwiftUIVirtualViewSharedImpl+Private.h` leaking into the public module umbrella.
 - [iOS] Added explicit c++ linkage specifier to `ExpoModulesCore.podspec` to propagate to swift-only targets like Expo Widgets ([#44984](https://github.com/expo/expo/pull/44984) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Extracted ObjC protocols (`EXAppContextProtocol`, `EXReactDelegateProtocol`, `EXAppContextFactoryRegistry`) for cross-xcframework module boundaries. Refactored legacy module registry, Fabric view headers, JSI layer, and podspecs for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Add `ViewWrapper` protocol and `AnyContentViewProvider` for type-erased access to wrapped SwiftUI views. ([#43669](https://github.com/expo/expo/pull/43669) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -89,6 +89,13 @@
             "Tests/**",
             "Worklets/**"
           ],
+          "fileMapping": [
+            {
+              "from": "Core/Views/SwiftUI/SwiftUIVirtualViewSharedImpl+Private.h",
+              "to": "Core/Views/SwiftUI/{filename}",
+              "type": "source"
+            }
+          ],
           "dependencies": [
             "Hermes",
             "React",

--- a/tools/src/prebuilds/SPMGenerator.headerStaging.test.ts
+++ b/tools/src/prebuilds/SPMGenerator.headerStaging.test.ts
@@ -1,0 +1,58 @@
+import fs from 'fs-extra';
+import { glob } from 'glob';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import path from 'path';
+
+import { getExpoRepositoryRootDir } from '../Directories';
+
+describe('SPMGenerator header staging — expo-modules-core', () => {
+  it('does not stage @implementation-fragment headers into the public include dir', async () => {
+    const repoRoot = getExpoRepositoryRootDir();
+    const configPath = path.join(repoRoot, 'packages/expo-modules-core/spm.config.json');
+    const config = await fs.readJson(configPath);
+
+    const target = config.products[0].targets.find(
+      (t: any) => t.name === 'ExpoModulesCore_ios_objc'
+    );
+    assert.ok(target, 'ExpoModulesCore_ios_objc target must exist in spm.config.json');
+    assert.ok(target.headerPattern, 'ExpoModulesCore_ios_objc must declare a headerPattern');
+
+    // Mirror SPMGenerator's header staging:
+    //   1. Glob target.headerPattern with target.exclude.
+    //   2. Skip any file also listed in target.fileMapping — those are placed elsewhere
+    //      (e.g. next to the source files for local #include) and are NOT staged into
+    //      the public include/ dir. See SPMGenerator.ts:141-143 and 187-191.
+    const targetSourcePath = path.join(repoRoot, 'packages/expo-modules-core', target.path);
+    const stagedIntoInclude = await glob(target.headerPattern, {
+      cwd: targetSourcePath,
+      ignore: target.exclude ?? [],
+    });
+
+    const fileMappings: { from: string; to: string; type: string }[] = target.fileMapping ?? [];
+    const mappedPaths = new Set<string>();
+    for (const mapping of fileMappings) {
+      const matches = await glob(mapping.from, {
+        cwd: targetSourcePath,
+        ignore: target.exclude ?? [],
+      });
+      for (const m of matches) mappedPaths.add(m);
+    }
+    const effectivelyStagedIntoInclude = stagedIntoInclude.filter((p) => !mappedPaths.has(p));
+
+    // SwiftUIVirtualViewSharedImpl+Private.h is a code fragment that is #include'd inside an
+    // @implementation block in SwiftUIVirtualViewObjC.mm and SwiftUIVirtualViewObjCDev.mm.
+    // Staging it as a public header causes SPM explicit-PCM generation to fail because clang
+    // tries to parse it as a standalone module header (missing @implementation context,
+    // unresolved `react::` names, etc). See commit a51bee30b71 (PR #44118).
+    const fragmentMatches = effectivelyStagedIntoInclude.filter((p) =>
+      p.endsWith('SwiftUIVirtualViewSharedImpl+Private.h')
+    );
+    assert.deepEqual(
+      fragmentMatches,
+      [],
+      `Fragment header leaked into ExpoModulesCore_ios_objc public include dir: ${fragmentMatches.join(', ')}. ` +
+        `Add it to the target's fileMapping (type: "source") so it is staged next to the .mm files instead.`
+    );
+  });
+});


### PR DESCRIPTION
… as a public header

# Why

`et prebuild expo-modules-core` was failing at the SPM explicit-PCM step because `SwiftUIVirtualViewSharedImpl+Private.h` was leaking into the public ExpoModulesCore module umbrella. That file is not actually a standalone header — it's a code fragment that `SwiftUIVirtualViewObjC.mm` and `SwiftUIVirtualViewObjCDev.mm` `#include` inside their `@implementation` blocks (introduced in #44118 when the view was split into dev/release variants).

When clang tried to compile the fragment as a standalone submodule header during PCM generation, it hit parse errors on the top-level method definitions and `react::` types, which only make sense inside an `@implementation` context. The visible diagnostics looked like `RCTBridgeModule` warnings, but the real fatal error was the fragment parse. CocoaPods builds never tripped on this because pods don't emit an umbrella-PCM over the public header tree — that's why the regression wasn't caught at PR review time.

# How

Fix: add a `fileMapping` entry in `packages/expo-modules-core/spm.config.json` that routes the fragment into the target source tree next to its including `.mm` files. The SPM generator skips files listed in `fileMapping` when populating the public `include/` umbrella, so the fragment no longer leaks in, and the relative `#include` still resolves because the file is symlinked alongside the `.mm` sources in the staging dir. No rename, no IDE-ergonomics regression on the `.h` file.

Added a regression test at `tools/src/prebuilds/SPMGenerator.headerStaging.test.ts` that asserts no `@implementation` fragment leaks into the public include dir for the `ExpoModulesCore_ios_objc` target — would have caught this at PR time.

# Test-plan

Verified: `et prebuild expo-modules-core -f Debug --clean` now succeeds on both the ios-arm64 and ios-arm64_x86_64-simulator slices.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
