### PR TITLE
[widgets][plugin] Use relative paths in Xcode project

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Add Button children support. ([#43832](https://github.com/expo/expo/pull/43832) by [@jakex7](https://github.com/jakex7))
 - Remove unused `Compression` related code. ([#43981](https://github.com/expo/expo/pull/43981) by [@jakex7](https://github.com/jakex7))
 - [plugin] Fix "extension CFBundleVersion not synced with main app" ([#44928](https://github.com/expo/expo/pull/44928) by [@jakex7](https://github.com/jakex7))
-- [plugin] Use relative paths in Xcode project
+- [plugin] Use relative paths in Xcode project ([#45000](https://github.com/expo/expo/pull/45000) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Add Button children support. ([#43832](https://github.com/expo/expo/pull/43832) by [@jakex7](https://github.com/jakex7))
 - Remove unused `Compression` related code. ([#43981](https://github.com/expo/expo/pull/43981) by [@jakex7](https://github.com/jakex7))
 - [plugin] Fix "extension CFBundleVersion not synced with main app" ([#44928](https://github.com/expo/expo/pull/44928) by [@jakex7](https://github.com/jakex7))
+- [plugin] Use relative paths in Xcode project
 
 ### 💡 Others
 

--- a/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
+++ b/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
@@ -48,9 +48,7 @@ const withWidgetSourceFiles = (config, { widgets, targetName, onFilesGenerated, 
         if (fs.existsSync(targetDirectory)) {
             fs.rmSync(targetDirectory, { recursive: true, force: true });
         }
-        if (!fs.existsSync(targetDirectory)) {
-            fs.mkdirSync(targetDirectory, { recursive: true });
-        }
+        fs.mkdirSync(targetDirectory, { recursive: true });
         const entitlementsPath = path.join(targetDirectory, `${targetName}.entitlements`);
         const entitlementsContent = {
             'com.apple.security.application-groups': [groupIdentifier],

--- a/packages/expo-widgets/plugin/build/xcode/withTargetXcodeProject.js
+++ b/packages/expo-widgets/plugin/build/xcode/withTargetXcodeProject.js
@@ -34,6 +34,7 @@ var __importStar = (this && this.__importStar) || (function () {
 })();
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
+const path = __importStar(require("path"));
 const addBuildPhases_1 = require("./addBuildPhases");
 const addPbxGroup_1 = require("./addPbxGroup");
 const addProductFile_1 = require("./addProductFile");
@@ -41,7 +42,6 @@ const addTargetDependency_1 = require("./addTargetDependency");
 const addToPbxNativeTargetSection_1 = require("./addToPbxNativeTargetSection");
 const addToPbxProjectSection_1 = require("./addToPbxProjectSection");
 const addXCConfigurationList_1 = require("./addXCConfigurationList");
-const path = __importStar(require("path"));
 const withTargetXcodeProject = (config, { targetName, bundleIdentifier, deploymentTarget, appleTeamId, getFileUris }) => (0, config_plugins_1.withXcodeProject)(config, (config) => {
     const xcodeProject = config.modResults;
     const targetUuid = xcodeProject.generateUuid();

--- a/packages/expo-widgets/plugin/build/xcode/withTargetXcodeProject.js
+++ b/packages/expo-widgets/plugin/build/xcode/withTargetXcodeProject.js
@@ -1,4 +1,37 @@
 "use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
 Object.defineProperty(exports, "__esModule", { value: true });
 const config_plugins_1 = require("expo/config-plugins");
 const addBuildPhases_1 = require("./addBuildPhases");
@@ -8,6 +41,7 @@ const addTargetDependency_1 = require("./addTargetDependency");
 const addToPbxNativeTargetSection_1 = require("./addToPbxNativeTargetSection");
 const addToPbxProjectSection_1 = require("./addToPbxProjectSection");
 const addXCConfigurationList_1 = require("./addXCConfigurationList");
+const path = __importStar(require("path"));
 const withTargetXcodeProject = (config, { targetName, bundleIdentifier, deploymentTarget, appleTeamId, getFileUris }) => (0, config_plugins_1.withXcodeProject)(config, (config) => {
     const xcodeProject = config.modResults;
     const targetUuid = xcodeProject.generateUuid();
@@ -32,7 +66,10 @@ const withTargetXcodeProject = (config, { targetName, bundleIdentifier, deployme
     });
     (0, addToPbxProjectSection_1.addToPbxProjectSection)(xcodeProject, target);
     (0, addTargetDependency_1.addTargetDependency)(xcodeProject, target);
-    const swiftWidgetFiles = getFileUris().filter((file) => file.endsWith('.swift'));
+    const projectRoot = config.modRequest.platformProjectRoot;
+    const targetDirectory = path.join(projectRoot, targetName);
+    const relativePaths = getFileUris().map((file) => path.relative(targetDirectory, file));
+    const swiftWidgetFiles = relativePaths.filter((file) => file.endsWith('.swift'));
     (0, addBuildPhases_1.addBuildPhases)(xcodeProject, {
         targetUuid,
         groupName,
@@ -41,7 +78,7 @@ const withTargetXcodeProject = (config, { targetName, bundleIdentifier, deployme
     });
     (0, addPbxGroup_1.addPbxGroup)(xcodeProject, {
         targetName,
-        widgetFiles: getFileUris(),
+        widgetFiles: relativePaths,
     });
     return config;
 });

--- a/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
@@ -24,9 +24,7 @@ const withWidgetSourceFiles: ConfigPlugin<WidgetSourceFilesProps> = (
       if (fs.existsSync(targetDirectory)) {
         fs.rmSync(targetDirectory, { recursive: true, force: true });
       }
-      if (!fs.existsSync(targetDirectory)) {
-        fs.mkdirSync(targetDirectory, { recursive: true });
-      }
+      fs.mkdirSync(targetDirectory, { recursive: true });
       const entitlementsPath = path.join(targetDirectory, `${targetName}.entitlements`);
       const entitlementsContent = {
         'com.apple.security.application-groups': [groupIdentifier],

--- a/packages/expo-widgets/plugin/src/xcode/withTargetXcodeProject.ts
+++ b/packages/expo-widgets/plugin/src/xcode/withTargetXcodeProject.ts
@@ -1,4 +1,5 @@
 import { ConfigPlugin, withXcodeProject } from 'expo/config-plugins';
+import * as path from 'path';
 
 import { addBuildPhases } from './addBuildPhases';
 import { addPbxGroup } from './addPbxGroup';
@@ -7,7 +8,6 @@ import { addTargetDependency } from './addTargetDependency';
 import { addToPbxNativeTargetSection } from './addToPbxNativeTargetSection';
 import { addToPbxProjectSection } from './addToPbxProjectSection';
 import { addXCConfigurationList } from './addXCConfigurationList';
-import * as path from 'path';
 
 type TargetXcodeProjectProps = {
   targetName: string;

--- a/packages/expo-widgets/plugin/src/xcode/withTargetXcodeProject.ts
+++ b/packages/expo-widgets/plugin/src/xcode/withTargetXcodeProject.ts
@@ -7,6 +7,7 @@ import { addTargetDependency } from './addTargetDependency';
 import { addToPbxNativeTargetSection } from './addToPbxNativeTargetSection';
 import { addToPbxProjectSection } from './addToPbxProjectSection';
 import { addXCConfigurationList } from './addXCConfigurationList';
+import * as path from 'path';
 
 type TargetXcodeProjectProps = {
   targetName: string;
@@ -50,7 +51,10 @@ const withTargetXcodeProject: ConfigPlugin<TargetXcodeProjectProps> = (
 
     addTargetDependency(xcodeProject, target);
 
-    const swiftWidgetFiles = getFileUris().filter((file) => file.endsWith('.swift'));
+    const projectRoot = config.modRequest.platformProjectRoot;
+    const targetDirectory = path.join(projectRoot, targetName);
+    const relativePaths = getFileUris().map((file) => path.relative(targetDirectory, file));
+    const swiftWidgetFiles = relativePaths.filter((file) => file.endsWith('.swift'));
 
     addBuildPhases(xcodeProject, {
       targetUuid,
@@ -61,7 +65,7 @@ const withTargetXcodeProject: ConfigPlugin<TargetXcodeProjectProps> = (
 
     addPbxGroup(xcodeProject, {
       targetName,
-      widgetFiles: getFileUris(),
+      widgetFiles: relativePaths,
     });
 
     return config;


### PR DESCRIPTION
# Why

Config plugin uses absolute paths in `project.pbxproj`.

Fixes #44950

# How

Use relative paths instead of absolute.

# Test Plan

Inspect `project.pbxproj` for absolute paths like `/Users/jakubgrzywacz/Projects/expo-repro/widgets/ios/ExpoWidgetsTarget/ExpoWidgetsTarget.entitlements`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
