### PR TITLE
fix(expo-modules-autolinking): refactor 3rd party prebuilt  version lookup

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Resolve `react-native` and per-package versions from the app's nearest `node_modules` when looking up external prebuilt xcframeworks ([#45004](https://github.com/expo/expo/pull/45004) by [@chrfalch](https://github.com/chrfalch))
+- [iOS] Resolve 3rd-party prebuilt xcframework packages via `@react-native-community/cli` autolinking output instead of guessing `node_modules/<pkg>`, fixing pnpm non-hoisted layouts, transitive native deps, yarn resolutions/PnP, and aliased specifiers ([#45004](https://github.com/expo/expo/pull/45004) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed precompiled modules use_frameworks! override running when only prebuilt React Native is active. ([#44554](https://github.com/expo/expo/pull/44554) by [@chrfalch](https://github.com/chrfalch))
 - Fix regression that caused `pod install` to fail with `no implicit conversion of nil into String` due to an off-by-one in the depth limit check. ([#43731](https://github.com/expo/expo/pull/43731) by [@zoontek](https://github.com/zoontek))
 - Stop dependency resolution at depth limit and increase max depth limit to 9 ([#43636](https://github.com/expo/expo/pull/43636) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Resolve `react-native` and per-package versions from the app's nearest `node_modules` when looking up external prebuilt xcframeworks
 - [iOS] Fixed precompiled modules use_frameworks! override running when only prebuilt React Native is active. ([#44554](https://github.com/expo/expo/pull/44554) by [@chrfalch](https://github.com/chrfalch))
 - Fix regression that caused `pod install` to fail with `no implicit conversion of nil into String` due to an off-by-one in the depth limit check. ([#43731](https://github.com/expo/expo/pull/43731) by [@zoontek](https://github.com/zoontek))
 - Stop dependency resolution at depth limit and increase max depth limit to 9 ([#43636](https://github.com/expo/expo/pull/43636) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Resolve `react-native` and per-package versions from the app's nearest `node_modules` when looking up external prebuilt xcframeworks
+- [iOS] Resolve `react-native` and per-package versions from the app's nearest `node_modules` when looking up external prebuilt xcframeworks ([#45004](https://github.com/expo/expo/pull/45004) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed precompiled modules use_frameworks! override running when only prebuilt React Native is active. ([#44554](https://github.com/expo/expo/pull/44554) by [@chrfalch](https://github.com/chrfalch))
 - Fix regression that caused `pod install` to fail with `no implicit conversion of nil into String` due to an off-by-one in the depth limit check. ([#43731](https://github.com/expo/expo/pull/43731) by [@zoontek](https://github.com/zoontek))
 - Stop dependency resolution at depth limit and increase max depth limit to 9 ([#43636](https://github.com/expo/expo/pull/43636) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -104,6 +104,19 @@ module Expo
         }
       end
 
+      # @react-native-community/cli autolinking output (same shape as RN CLI's `config`).
+      # Used to locate 3rd-party packages via real node resolution so non-flat node_modules
+      # layouts (pnpm non-hoisted, yarn PnP, aliased specifiers) resolve correctly.
+      def react_native_config
+        @react_native_config ||= invoke_autolinking('react-native-config', platform: 'ios')
+      end
+
+      # The resolved Expo modules list. Used by scan_node_modules_configs to locate
+      # each internal package's spm.config.json via its resolved podspec dir.
+      def resolved_modules
+        @resolved_modules ||= invoke_autolinking('resolve', platform: 'apple').fetch('modules', [])
+      end
+
       # ──────────────────────────────────────────────────────────────────────
       # Facade methods — called from installer.rb / autolinking_manager.rb
       # ──────────────────────────────────────────────────────────────────────
@@ -585,8 +598,15 @@ module Expo
 
       # Returns the installed version for a pod by reading its package.json, or nil.
       def installed_version_for(pod_name)
-        pkg_json = File.join(pod_lookup_map.dig(pod_name, :package_root) || '', 'package.json')
-        JSON.parse(File.read(pkg_json))['version'] rescue nil
+        package_root = pod_lookup_map.dig(pod_name, :package_root)
+        return nil unless package_root
+
+        pkg_json = File.join(package_root, 'package.json')
+        return nil unless File.exist?(pkg_json)
+
+        JSON.parse(File.read(pkg_json))['version']
+      rescue JSON::ParserError, Errno::ENOENT
+        nil
       end
 
       # ──────────────────────────────────────────────────────────────────────
@@ -1240,23 +1260,18 @@ module Expo
         scan_external_configs(repo_root)
       end
 
-      # Scans node_modules for spm.config.json files in standalone projects.
-      # Used when EXPO_PRECOMPILED_MODULES_PATH is set but no monorepo root is found.
+      # Locates spm.config.json for internal Expo modules in standalone projects
+      # (no monorepo root). Uses resolved podspec dirs so non-flat layouts work.
       def scan_node_modules_configs(project_root)
-        node_modules = File.join(project_root, 'node_modules')
-        return unless File.directory?(node_modules)
-
-        # Internal Expo packages: node_modules/*/spm.config.json
-        Dir.glob(File.join(node_modules, '*', 'spm.config.json')).each do |config_path|
-          process_spm_config(config_path, :internal, project_root)
+        resolved_modules.each do |mod|
+          (mod['pods'] || []).each do |pod|
+            next unless pod['podspecDir']
+            # Convention: podspecDir is `<package>/ios`; spm.config.json lives at `<package>/`.
+            config_path = File.join(File.dirname(pod['podspecDir']), 'spm.config.json')
+            process_spm_config(config_path, :internal, project_root) if File.exist?(config_path)
+          end
         end
 
-        # Internal Expo scoped packages: node_modules/@scope/*/spm.config.json
-        Dir.glob(File.join(node_modules, '@*', '*', 'spm.config.json')).each do |config_path|
-          process_spm_config(config_path, :internal, project_root)
-        end
-
-        # External 3rd-party packages: bundled in external-configs/ios/
         scan_external_configs(project_root)
       end
 
@@ -1264,46 +1279,45 @@ module Expo
       # (e.g. react-native-screens, react-native-svg) that don't ship their own spm.config.json.
       # Shared by both monorepo and standalone project paths.
       #
-      # @param effective_root [String] The project or repo root used to locate node_modules
+      # @param effective_root [String] The project or repo root (used to compute the default build output dir)
       def scan_external_configs(effective_root)
         external_configs_dir = File.join(__dir__, '..', '..', 'external-configs', 'ios')
         return unless File.directory?(external_configs_dir)
 
-        # Resolve from the same node_modules as react-native so per-package
-        # versions match the RN version used in the build path.
-        node_modules = find_node_modules_dir
-
         # Non-scoped: external-configs/ios/*/spm.config.json
         Dir.glob(File.join(external_configs_dir, '*', 'spm.config.json')).each do |config_path|
           npm_package = File.basename(File.dirname(config_path))
-          process_external_config(config_path, npm_package, node_modules, effective_root)
+          process_external_config(config_path, npm_package, effective_root)
         end
 
         # Scoped: external-configs/ios/@scope/*/spm.config.json
         Dir.glob(File.join(external_configs_dir, '@*', '*', 'spm.config.json')).each do |config_path|
           rel = config_path.sub("#{external_configs_dir}/", '')
           npm_package = File.dirname(rel) # e.g. "@shopify/react-native-skia"
-          process_external_config(config_path, npm_package, node_modules, effective_root)
+          process_external_config(config_path, npm_package, effective_root)
         end
       end
 
       # Processes a single external spm.config.json for a 3rd-party package.
-      def process_external_config(config_path, npm_package, node_modules, effective_root)
+      def process_external_config(config_path, npm_package, effective_root)
         config = JSON.parse(File.read(config_path))
         products = config['products'] || []
-        package_root = File.join(node_modules, npm_package)
 
-        # Only process if the package is actually installed
-        return unless File.directory?(package_root)
+        # Resolve via rncli autolinking so we use real node resolution (handles pnpm,
+        # yarn resolutions/PnP, aliased specifiers). Skip if the package isn't installed.
+        dep = react_native_config.dig('dependencies', npm_package)
+        return unless dep
 
-        # Prefer codegenConfig.name from the installed package.json
+        package_root = dep['root']
+        pkg_version = dep.dig('platforms', 'ios', 'version')
+
+        # codegenConfig.name isn't surfaced by rncli; read it from package.json.
         installed_codegen_name = nil
-        pkg_version = nil
         pkg_json_path = File.join(package_root, 'package.json')
         if File.exist?(pkg_json_path)
           pkg_json = JSON.parse(File.read(pkg_json_path))
           installed_codegen_name = pkg_json.dig('codegenConfig', 'name')
-          pkg_version = pkg_json['version']
+          pkg_version ||= pkg_json['version']
         end
 
         base_dir = custom_modules_path || File.join(effective_root, 'packages', 'precompile', PRECOMPILE_BUILD_DIR)
@@ -1520,6 +1534,16 @@ module Expo
         nil
       end
 
+      # Invokes `expo-modules-autolinking <subcommand> --json` and parses the output.
+      # Used by `react_native_config` and `resolved_modules` above.
+      def invoke_autolinking(subcommand, platform:)
+        args = ['node', '--no-warnings', '--eval', "require('expo/bin/autolinking')",
+                'expo-modules-autolinking', subcommand, '--platform', platform, '--json']
+        JSON.parse(IO.popen(args, &:read))
+      rescue => error
+        raise "Failed to invoke `expo-modules-autolinking #{subcommand}`: #{error}"
+      end
+
       # ──────────────────────────────────────────────────────────────────────
       # Helpers: bundled frameworks
       # ──────────────────────────────────────────────────────────────────────
@@ -1601,11 +1625,15 @@ module Expo
       # Helpers: version resolution for 3rd-party prebuild versioning
       # ──────────────────────────────────────────────────────────────────────
 
-      # Returns the installed React Native version from node_modules.
+      # RN package path, as resolved by rncli (handles pnpm workspaces correctly).
+      def react_native_path
+        react_native_config['reactNativePath']
+      end
+
       def react_native_version
         @react_native_version ||= begin
-          rn_pkg = File.join(find_node_modules_dir, 'react-native', 'package.json')
-          File.exist?(rn_pkg) ? JSON.parse(File.read(rn_pkg))['version'] : nil
+          rn_pkg = react_native_path && File.join(react_native_path, 'package.json')
+          rn_pkg && File.exist?(rn_pkg) ? JSON.parse(File.read(rn_pkg))['version'] : nil
         end
       end
 
@@ -1613,49 +1641,22 @@ module Expo
       # Mirrors the TypeScript resolution logic in tools/src/prebuilds/Utils.ts.
       def hermes_version
         @hermes_version ||= begin
-          rn_path = File.join(find_node_modules_dir, 'react-native')
-          is_v1 = ENV['RCT_HERMES_V1_ENABLED'] == '1'
-          version = nil
+          rn_path = react_native_path
+          if rn_path
+            is_v1 = ENV['RCT_HERMES_V1_ENABLED'] == '1'
+            props_path = File.join(rn_path, 'sdks', 'hermes-engine', 'version.properties')
+            version = File.exist?(props_path) ?
+              parse_version_properties(props_path)[is_v1 ? 'HERMES_V1_VERSION_NAME' : 'HERMES_VERSION_NAME'] : nil
 
-          # Read from version.properties (primary source)
-          props_path = File.join(rn_path, 'sdks', 'hermes-engine', 'version.properties')
-          if File.exist?(props_path)
-            props = parse_version_properties(props_path)
-            version = is_v1 ? props['HERMES_V1_VERSION_NAME'] : props['HERMES_VERSION_NAME']
-          end
-
-          # Fallback to tag files
-          unless version
-            tag_file = is_v1 ? '.hermesv1version' : '.hermesversion'
-            tag_path = File.join(rn_path, 'sdks', tag_file)
-            version = File.read(tag_path).strip if File.exist?(tag_path)
-          end
-
-          # Normalize: strip "hermes-" prefix and "v" prefix
-          version&.gsub(/^hermes-?/i, '')&.gsub(/^v/i, '')&.strip
-        end
-      end
-
-      # Returns the node_modules directory that Node would resolve `react-native` from,
-      # walking up from the project root. Correctly handles pnpm workspaces where each
-      # app's node_modules may symlink a different RN version than the repo root.
-      def find_node_modules_dir
-        @node_modules_dir ||= begin
-          current = (Pod::Config.instance.installation_root || Dir.pwd).to_s
-          resolved = nil
-          loop do
-            candidate = File.join(current, 'node_modules')
-            if File.file?(File.join(candidate, 'react-native', 'package.json'))
-              resolved = candidate
-              break
+            # Fallback to tag files
+            unless version
+              tag_path = File.join(rn_path, 'sdks', is_v1 ? '.hermesv1version' : '.hermesversion')
+              version = File.read(tag_path).strip if File.exist?(tag_path)
             end
-            parent = File.dirname(current)
-            break if parent == current
-            current = parent
+
+            # Normalize: strip "hermes-" prefix and "v" prefix
+            version&.gsub(/^hermes-?/i, '')&.gsub(/^v/i, '')&.strip
           end
-          repo_root = find_repo_root
-          resolved || (repo_root && File.join(repo_root, 'node_modules')) ||
-            File.join(File.dirname(Dir.pwd), 'node_modules')
         end
       end
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -563,19 +563,30 @@ module Expo
         prefix = "[Expo-precompiled] ".blue
         Pod::UI.info "#{prefix}Precompiled modules:"
         @linked_pods.sort_by { |name, _| name.downcase }.each do |pod_name, info|
+          version = installed_version_for(pod_name)
+          version_suffix = version ? " #{"(#{version})".dark}" : ""
           if info[:found]
-            Pod::UI.info "#{prefix}  📦 #{pod_name.green}"
+            Pod::UI.info "#{prefix}  📦 #{pod_name.green}#{version_suffix}"
           else
-            Pod::UI.info "#{prefix}  ⚠️  #{pod_name} #{"(Build from source: framework not found #{info[:path]})".yellow}"
+            Pod::UI.info "#{prefix}  ⚠️  #{pod_name}#{version_suffix} #{"(Build from source: framework not found #{info[:path]})".yellow}"
           end
+          spm_versions = pod_lookup_map.dig(pod_name, :spm_dependency_versions) || {}
           info[:spm_deps].each do |dep_name|
-            Pod::UI.info "#{prefix}      ∟ #{dep_name}.xcframework".green
+            dep_version = spm_versions[dep_name]
+            dep_suffix = dep_version ? " #{"(#{dep_version})".dark}" : ""
+            Pod::UI.info "#{prefix}      ∟ #{"#{dep_name}.xcframework".green}#{dep_suffix}"
           end
         end
 
         if @linked_pods.none? { |_, info| info[:found] }
           Pod::UI.warn "#{prefix}⚠️  Precompiled modules enabled but no xcframeworks found. All modules will build from source."
         end
+      end
+
+      # Returns the installed version for a pod by reading its package.json, or nil.
+      def installed_version_for(pod_name)
+        pkg_json = File.join(pod_lookup_map.dig(pod_name, :package_root) || '', 'package.json')
+        JSON.parse(File.read(pkg_json))['version'] rescue nil
       end
 
       # ──────────────────────────────────────────────────────────────────────
@@ -1258,7 +1269,9 @@ module Expo
         external_configs_dir = File.join(__dir__, '..', '..', 'external-configs', 'ios')
         return unless File.directory?(external_configs_dir)
 
-        node_modules = File.join(effective_root, 'node_modules')
+        # Resolve from the same node_modules as react-native so per-package
+        # versions match the RN version used in the build path.
+        node_modules = find_node_modules_dir
 
         # Non-scoped: external-configs/ios/*/spm.config.json
         Dir.glob(File.join(external_configs_dir, '*', 'spm.config.json')).each do |config_path|
@@ -1331,6 +1344,7 @@ module Expo
             .map { |t| { name: t['name'], path: t['path'] } }
 
           spm_dependency_frameworks = (product['spmPackages'] || []).map { |pkg| pkg['productName'] }.compact
+          spm_dependency_versions = spm_package_versions(product['spmPackages'])
 
           @pod_lookup_map[pod_name] = {
             type: :external,
@@ -1342,11 +1356,20 @@ module Expo
             product_name: product_name,
             targets: targets,
             spm_dependency_frameworks: spm_dependency_frameworks,
+            spm_dependency_versions: spm_dependency_versions,
             autolink_when: product['autolinkWhen']
           }
         end
       rescue JSON::ParserError, StandardError => e
         Pod::UI.warn "[Expo-precompiled] Failed to read external config at #{config_path}: #{e.message}"
+      end
+
+      # Returns { productName => versionString } from a spm.config.json spmPackages array.
+      def spm_package_versions(spm_packages)
+        (spm_packages || []).each_with_object({}) do |pkg, h|
+          version = pkg['version'].is_a?(Hash) ? pkg['version']['exact'] : pkg['version']
+          h[pkg['productName']] = version if pkg['productName'] && version
+        end
       end
 
       # Processes a single spm.config.json file and adds entries to @pod_lookup_map.
@@ -1402,6 +1425,7 @@ module Expo
           .map { |t| { name: t['name'], path: t['path'] } }
 
         spm_dependency_frameworks = (product['spmPackages'] || []).map { |pkg| pkg['productName'] }.compact
+        spm_dependency_versions = spm_package_versions(product['spmPackages'])
 
         {
           type: type,
@@ -1413,6 +1437,7 @@ module Expo
           product_name: product_name,
           targets: targets,
           spm_dependency_frameworks: spm_dependency_frameworks,
+          spm_dependency_versions: spm_dependency_versions,
           autolink_when: product['autolinkWhen']
         }
       end
@@ -1530,7 +1555,13 @@ module Expo
         results = []
         pod_lookup_map.each do |pod_name, info|
           next unless info[:type] == :external
-          next unless has_prebuilt_xcframework?(pod_name)
+
+          unless has_prebuilt_xcframework?(pod_name)
+            product_name = info[:product_name] || pod_name
+            expected = File.join(info[:build_output_dir], build_flavor, 'xcframeworks', "#{product_name}.tar.gz")
+            Pod::UI.warn "[Expo-precompiled] #{pod_name}: prebuilt xcframework not found. Expected tarball at #{expected}"
+            next
+          end
 
           podspec_file = File.join(info[:podspec_dir], "#{pod_name}.podspec")
           next unless File.exist?(podspec_file)
@@ -1605,15 +1636,26 @@ module Expo
         end
       end
 
-      # Returns the node_modules directory for the project.
+      # Returns the node_modules directory that Node would resolve `react-native` from,
+      # walking up from the project root. Correctly handles pnpm workspaces where each
+      # app's node_modules may symlink a different RN version than the repo root.
       def find_node_modules_dir
         @node_modules_dir ||= begin
-          repo_root = find_repo_root
-          if repo_root
-            File.join(repo_root, 'node_modules')
-          else
-            File.join(File.dirname(Dir.pwd), 'node_modules')
+          current = (Pod::Config.instance.installation_root || Dir.pwd).to_s
+          resolved = nil
+          loop do
+            candidate = File.join(current, 'node_modules')
+            if File.file?(File.join(candidate, 'react-native', 'package.json'))
+              resolved = candidate
+              break
+            end
+            parent = File.dirname(current)
+            break if parent == current
+            current = parent
           end
+          repo_root = find_repo_root
+          resolved || (repo_root && File.join(repo_root, 'node_modules')) ||
+            File.join(File.dirname(Dir.pwd), 'node_modules')
         end
       end
 


### PR DESCRIPTION
# Why

External 3rd-party prebuilt xcframeworks were silently skipped in pnpm workspaces (and other non-flat node_modules layouts) because `scan_external_configs` and `process_external_config` resolved packages with `File.join(node_modules, npm_package)`. That assumption only holds for hoisted flat layouts — it breaks for pnpm with strict hoisting, transitive 3rd-party native deps, yarn `resolutions` / npm `overrides` / aliased specifiers, and yarn PnP (no `node_modules` at all). When it broke, `return unless File.directory?(package_root)` silently dropped the package with no diagnostic.

# How

Drive package resolution off data that `expo-modules-autolinking` already computes via Node's real resolver:

- **3rd-party packages** → new `AutolinkingManager#react_native_config` runs `expo-modules-autolinking react-native-config --json --platform ios` (same command the Podfile passes to `use_native_modules!`) and exposes the parsed output to `PrecompiledModules`. `process_external_config` now looks up `dependencies[npm_package].root` and `platforms.ios.version` instead of guessing node_modules paths.
- **Internal Expo modules (standalone project fallback)** → `scan_node_modules_configs` iterates `resolve_result['modules']` and derives `spm.config.json` paths from each pod's `podspecDir`, replacing the `node_modules/*/spm.config.json` glob. Non-hoisted pnpm internals now resolve correctly too.
- **React Native path** → sourced from the rncli config's `reactNativePath`, so `react_native_version` and `hermes_version` stay in sync with the RN the app actually resolves (important for pnpm workspaces where the root and app may differ).
- **Removed** `find_node_modules_dir` — all three call sites now use authoritative data.
- Kept the "tarball missing" warning for the case where the package is installed but the prebuilt artifact isn't built yet.

# Test-plan

Run `pod install` with `EXPO_USE_PRECOMPILED_MODULES=1` and verify:
- In a monorepo (expo/expo), precompiled modules summary lists pods with correct versions.
- In a pnpm app with strict hoisting (e.g. `public-hoist-pattern=[]`), 3rd-party prebuilts that used to be silently dropped are registered (or produce the "tarball missing" warning if the build hasn't been run). Tarballs can be built with `et prebuild -f Debug --external-only`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
