### PR TITLE
fix(workflow): handle empty package list in prebuild smoke test

### DIFF
--- a/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
@@ -34,11 +34,11 @@ jobs:
             "${{ github.event.repository.full_name }}" \
             "${{ github.event.pull_request.number }}" \
             "${{ github.event.inputs.packages }}"
-      - if: ${{ steps.detect.outputs.packages != '' }}
+      - if: ${{ steps.detect.outputs.packages != 'none' }}
         uses: eas/use_npm_token
-      - if: ${{ steps.detect.outputs.packages != '' }}
+      - if: ${{ steps.detect.outputs.packages != 'none' }}
         uses: eas/install_node_modules
-      - if: ${{ steps.detect.outputs.packages != '' }}
+      - if: ${{ steps.detect.outputs.packages != 'none' }}
         name: Prebuild XCFrameworks
         working_directory: ../..
         run: |

--- a/apps/expo-workflow-testing/scripts/detect-prebuild-packages.sh
+++ b/apps/expo-workflow-testing/scripts/detect-prebuild-packages.sh
@@ -98,4 +98,6 @@ else
 fi
 
 echo "Resolved packages: ${PKGS:-<none — skipping smoke test>}"
-set-output packages "$PKGS"
+# set-output rejects an empty VALUE (exit 2), so emit a sentinel the
+# workflow can compare against in its `if:` conditions.
+set-output packages "${PKGS:-none}"


### PR DESCRIPTION
## Why

The `detect` step of the iOS XCFramework prebuild smoke test was failing on PRs that touched no eligible packages. EAS's `set-output` helper rejects an empty VALUE and exits 2:

```
Resolved packages: <none — skipping smoke test>
Usage: set-output NAME VALUE
... exited with non-zero code: 2
```

That turned the intended "nothing to smoke-test → skip" path into a hard failure for every PR matching the workflow's `paths:` filters without resolving packages.

## How

- `scripts/detect-prebuild-packages.sh`: when `$PKGS` is empty, emit the sentinel `none` via `set-output packages "${PKGS:-none}"` instead of an empty string.
- `.eas/workflows/ios-prebuild-xcframeworks-smoke.yml`: switch the three gated steps from `packages != ''` to `packages != 'none'` so they still skip in the no-packages case.

Net result: the job reports success with the three real-work steps skipped (visible in the EAS UI), matching the comment at the top of the script.

## Test plan

- [ ] This PR itself touches the script + workflow, so the `detect` step should resolve to `expo-modules-core` (via the tools/workflow-changed branch) and run the smoke test end-to-end.
- [ ] Confirm on a separate PR that touches no eligible packages, the job goes green with `use_npm_token`, `install_node_modules`, and `Prebuild XCFrameworks` marked skipped.