### PR TITLE
[cli] Support resolving entry points to Metro watchFolders path

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### 🐛 Bug fixes
 
+- Resolve entry points that fall outside the Metro server root by matching against configured `watchFolders`. ([#45010](https://github.com/expo/expo/pull/45010) by [@huntie](https://github.com/huntie))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -5,13 +5,15 @@ import {
   PackageJSONConfig,
   ProjectConfig,
 } from '@expo/config';
-import { resolveRelativeEntryPoint } from '@expo/config/paths';
+import { resolveEntryPoint, resolveRelativeEntryPoint } from '@expo/config/paths';
+import path from 'path';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { resolve } from 'url';
 
 import { ExpoMiddleware } from './ExpoMiddleware';
 import {
+  convertPathToModuleSpecifier,
   createBundleUrlPath,
   getBaseUrlFromExpoConfig,
   getAsyncRoutesFromExpoConfig,
@@ -30,6 +32,23 @@ import { getPlatformBundlers, PlatformBundlers } from '../platformBundlers';
 import { createTemplateHtmlFromExpoConfigAsync } from '../webTemplate';
 
 const debug = require('debug')('expo:start:server:middleware:manifest') as typeof console.log;
+
+const watchFoldersCache = new Map<string, string[]>();
+
+function getWatchFoldersForProject(projectRoot: string): string[] {
+  const cached = watchFoldersCache.get(projectRoot);
+  if (cached) return cached;
+
+  let watchFolders: string[] = [];
+  try {
+    const configPath = path.join(projectRoot, 'metro.config.js');
+    const config = require(configPath);
+    watchFolders = (config.watchFolders ?? []).map((f: string) => path.resolve(f));
+  } catch {}
+
+  watchFoldersCache.set(projectRoot, watchFolders);
+  return watchFolders;
+}
 
 /** Info about the computer hosting the dev server. */
 export interface HostInfo {
@@ -162,6 +181,21 @@ export abstract class ManifestMiddleware<
 
     const entry = resolveRelativeEntryPoint(this.projectRoot, props);
     debug(`Resolved entry point: ${entry} (project root: ${this.projectRoot})`);
+
+    if (!entry.startsWith('..')) {
+      return entry;
+    }
+
+    const entryPoint = resolveEntryPoint(this.projectRoot, props);
+    const watchFolders = getWatchFoldersForProject(this.projectRoot);
+    for (let i = 0; i < watchFolders.length; i++) {
+      const watchFolder = watchFolders[i];
+      if (entryPoint.startsWith(watchFolder + path.sep) || entryPoint === watchFolder) {
+        const relativeToWatch = entryPoint.slice(watchFolder.length + 1);
+        return convertPathToModuleSpecifier('[metro-watchFolders]/' + i + '/' + relativeToWatch);
+      }
+    }
+
     return entry;
   }
 

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '@expo/config';
+import { resolveEntryPoint, resolveRelativeEntryPoint } from '@expo/config/paths';
 import http from 'http';
 import { vol } from 'memfs';
 import { PassThrough } from 'stream';
@@ -34,7 +35,8 @@ jest.mock('../resolveAssets', () => ({
 }));
 jest.mock('@expo/config/paths', () => ({
   ...jest.requireActual('@expo/config/paths'),
-  resolveRelativeEntryPoint: () => 'index',
+  resolveRelativeEntryPoint: jest.fn(() => 'index'),
+  resolveEntryPoint: jest.fn(() => '/index.js'),
 }));
 jest.mock('@expo/config', () => ({
   getNameFromConfig: jest.fn(jest.requireActual('@expo/config').getNameFromConfig),
@@ -236,6 +238,25 @@ describe('_resolveProjectSettingsAsync', () => {
     // Limit this to a single call since it can get expensive.
     expect(getConfig).toHaveBeenCalledTimes(1);
   });
+  it(`passes through entry points outside the server root when no watchFolders match`, async () => {
+    jest.mocked(resolveRelativeEntryPoint).mockReturnValueOnce('../shared/index');
+    jest.mocked(resolveEntryPoint).mockReturnValueOnce('/shared/index.js');
+
+    const middleware = new MockManifestMiddleware('/', {
+      constructUrl: jest.fn(() => 'http://fake.mock'),
+      mode: 'development',
+    });
+
+    middleware._getBundleUrl = jest.fn(() => 'http://fake.mock/index.bundle');
+
+    const result = await middleware._resolveProjectSettingsAsync({
+      hostname: 'localhost',
+      platform: 'android',
+    } as any);
+
+    expect(result.expoGoConfig.mainModuleName).toBe('../shared/index');
+  });
+
   it(`returns the project settings for Webpack dev servers`, async () => {
     const middleware = new MockManifestMiddleware('/', {
       isNativeWebpack: true,


### PR DESCRIPTION
> [!Note]
> **Depends on https://github.com/facebook/metro/pull/1695**. PR is in draft until we can bump this in Expo.

#Why

When the project entry point resolves to a path outside the Metro server root (e.g. due to symlink resolution to a shared store), `resolveMainModuleName` will return a `../`-prefixed relative path that Metro cannot resolve.

To address this, here we add new support for `[watchFolders]`-relative paths as an input to Metro.

# How

Expo CLI now:

- Reads and caches `watchFolders` from the project's `metro.config.js` up front.
- If the entry point path is `../`-prefixed (outside the root dir), attempts to map this to a `[metro-watchFolders]/<index>/<relative-path>` specifier that Metro can resolve.

# Test Plan

Tested end-to-end internally (SDK 55) with the corresponding Metro change via `patch-package`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
