### PR TITLE
[expo-observe] Use default value for dispatchingEnabled when not specified in configure

### DIFF
--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -85,7 +85,8 @@ class BaseObservabilityManager(
     }
 
     // When disabled, mark pending metrics as sent without dispatching
-    if (!ObservePreferences.getDispatchingEnabled(context)) {
+    val dispatchingEnabled = ObservePreferences.getConfig(context)?.dispatchingEnabled ?: true
+    if (!dispatchingEnabled) {
       pendingMetricsManager.removePendingMetrics(pendingIds)
       return
     }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
@@ -45,7 +45,10 @@ class ObserveModule : Module() {
       AsyncFunction("dispatchEvents") Coroutine { -> observabilityManager.dispatchUnsentMetrics() }
 
       Function("configure") { config: Config ->
-        config.dispatchingEnabled?.let { ObservePreferences.setDispatchingEnabled(context, it) }
+        ObservePreferences.setConfig(
+          context,
+          PersistedConfig(dispatchingEnabled = config.dispatchingEnabled)
+        )
         config.environment?.let { appMetricsModule.setEnvironment(it) }
       }
     }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservePreferences.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservePreferences.kt
@@ -2,21 +2,31 @@ package expo.modules.observe
 
 import android.content.Context
 import androidx.core.content.edit
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 private const val PREFS_NAME = "dev.expo.observe"
-private const val KEY_DISPATCHING_ENABLED = "dispatchingEnabled"
+private const val KEY_CONFIG = "config"
+
+/**
+ * Snapshot of the last `configure(...)` payload
+ */
+@Serializable
+data class PersistedConfig(
+  val dispatchingEnabled: Boolean? = null
+)
 
 object ObservePreferences {
-  fun getDispatchingEnabled(context: Context): Boolean {
+  fun getConfig(context: Context): PersistedConfig? {
     val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    return prefs.getBoolean(KEY_DISPATCHING_ENABLED, true)
+    val json = prefs.getString(KEY_CONFIG, null) ?: return null
+    return runCatching { Json.decodeFromString<PersistedConfig>(json) }.getOrNull()
   }
 
-  fun setDispatchingEnabled(
-    context: Context,
-    enabled: Boolean
-  ) {
+  fun setConfig(context: Context, config: PersistedConfig) {
     val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-    prefs.edit(commit = true) { putBoolean(KEY_DISPATCHING_ENABLED, enabled) }
+    prefs.edit(commit = true) {
+      putString(KEY_CONFIG, Json.encodeToString(config))
+    }
   }
 }

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -38,7 +38,7 @@ class BaseObservabilityManagerTest {
 
     // Default to enabled so existing tests aren't short-circuited
     mockkObject(ObservePreferences)
-    every { ObservePreferences.getDispatchingEnabled(any()) } returns true
+    every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchingEnabled = true)
   }
 
   @After
@@ -226,7 +226,7 @@ class BaseObservabilityManagerTest {
   fun `when enabled is false, pending metrics are removed without dispatching`() =
     runTest {
       // Arrange
-      every { ObservePreferences.getDispatchingEnabled(any()) } returns false
+      every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchingEnabled = false)
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1", "id2")
 
       val removedIds = mutableListOf<String>()
@@ -255,7 +255,7 @@ class BaseObservabilityManagerTest {
   fun `when enabled is false, enableInDebug has no effect`() =
     runTest {
       // Arrange — enabled=false takes precedence over enableInDebug=true
-      every { ObservePreferences.getDispatchingEnabled(any()) } returns false
+      every { ObservePreferences.getConfig(any()) } returns PersistedConfig(dispatchingEnabled = false)
       coEvery { mockPendingMetricsManager.getAllPendingMetricIds() } returns listOf("id1")
 
       coEvery { mockPendingMetricsManager.removePendingMetrics(any()) } just runs

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/ObservePreferencesTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/ObservePreferencesTest.kt
@@ -26,22 +26,30 @@ class ObservePreferencesTest {
   }
 
   @Test
-  fun `getEnabled returns true by default`() {
-    assertTrue(ObservePreferences.getDispatchingEnabled(context))
+  fun `getConfig returns null by default`() {
+    assertNull(ObservePreferences.getConfig(context))
   }
 
   @Test
-  fun `setDispatchingEnabled false persists`() {
-    ObservePreferences.setDispatchingEnabled(context, false)
-    assertFalse(ObservePreferences.getDispatchingEnabled(context))
+  fun `setConfig with dispatchingEnabled false persists false`() {
+    ObservePreferences.setConfig(context, PersistedConfig(dispatchingEnabled = false))
+    assertEquals(false, ObservePreferences.getConfig(context)?.dispatchingEnabled)
   }
 
   @Test
-  fun `setDispatchingEnabled true after false persists`() {
-    ObservePreferences.setDispatchingEnabled(context, false)
-    assertFalse(ObservePreferences.getDispatchingEnabled(context))
-    ObservePreferences.setDispatchingEnabled(context, true)
-    assertTrue(ObservePreferences.getDispatchingEnabled(context))
+  fun `setConfig overwrites previous value`() {
+    ObservePreferences.setConfig(context, PersistedConfig(dispatchingEnabled = false))
+    assertEquals(false, ObservePreferences.getConfig(context)?.dispatchingEnabled)
+    ObservePreferences.setConfig(context, PersistedConfig(dispatchingEnabled = true))
+    assertEquals(true, ObservePreferences.getConfig(context)?.dispatchingEnabled)
   }
 
+  @Test
+  fun `setConfig with null field clears previously set value`() {
+    ObservePreferences.setConfig(context, PersistedConfig(dispatchingEnabled = false))
+    assertEquals(false, ObservePreferences.getConfig(context)?.dispatchingEnabled)
+    ObservePreferences.setConfig(context, PersistedConfig(dispatchingEnabled = null))
+    assertNotNull(ObservePreferences.getConfig(context))
+    assertNull(ObservePreferences.getConfig(context)?.dispatchingEnabled)
+  }
 }

--- a/packages/expo-observe/ios/Observability.swift
+++ b/packages/expo-observe/ios/Observability.swift
@@ -50,7 +50,8 @@ internal struct ObservabilityManager {
           environment: entry.environment)
       }
 
-      if events.isEmpty || !ObserveUserDefaults.dispatchingEnabled {
+      let dispatchingEnabled = ObserveUserDefaults.config?.dispatchingEnabled ?? true
+      if events.isEmpty || !dispatchingEnabled {
         // All entries were filtered out or dispatching is disabled — mark as dispatched
         ObserveUserDefaults.lastDispatchedEntryId = entries.first?.id ?? -1
         return

--- a/packages/expo-observe/ios/ObserveModule.swift
+++ b/packages/expo-observe/ios/ObserveModule.swift
@@ -34,9 +34,8 @@ public final class ObserveModule: Module {
 
     Function("configure") { (config: Config) in
       AppMetricsActor.isolated {
-        if let enabled = config.dispatchingEnabled {
-          ObserveUserDefaults.dispatchingEnabled = enabled
-        }
+        // Each call to `configure(...)` is a full replacement: absent fields reset prior values.
+        ObserveUserDefaults.setConfig(PersistedConfig(dispatchingEnabled: config.dispatchingEnabled))
         if let environment = config.environment {
           AppMetrics.setEnvironment(environment)
         }

--- a/packages/expo-observe/ios/ObserveUserDefaults.swift
+++ b/packages/expo-observe/ios/ObserveUserDefaults.swift
@@ -3,7 +3,14 @@
 import ExpoAppMetrics
 
 /**
- Class that manages a custom `UserDefaults` database with `"dev.expo.eas.observe"` suite name.
+ Snapshot of the last `configure(...)` payload. 
+ */
+internal struct PersistedConfig: Codable {
+  var dispatchingEnabled: Bool?
+}
+
+/**
+ Class that manages a custom `UserDefaults` database with `"dev.expo.observe"` suite name.
  */
 @AppMetricsActor
 internal final class ObserveUserDefaults: UserDefaults {
@@ -18,7 +25,7 @@ internal final class ObserveUserDefaults: UserDefaults {
   private enum Keys: String {
     case lastDispatchedEntryId
     case lastDispatchDate
-    case dispatchingEnabled
+    case config
   }
 
   private init() {
@@ -55,21 +62,13 @@ internal final class ObserveUserDefaults: UserDefaults {
       defaults.set(newValue, forKey: Keys.lastDispatchedEntryId.rawValue)
     }
   }
-
-  /**
-   Whether observability dispatching is enabled. Defaults to `true`.
-   */
-  static var dispatchingEnabled: Bool {
-    get {
-      // UserDefaults returns false for unset bools, so we check for existence
-      if defaults.object(forKey: Keys.dispatchingEnabled.rawValue) == nil {
-        return true
-      }
-      return defaults.bool(forKey: Keys.dispatchingEnabled.rawValue)
-    }
-    set {
-      defaults.set(newValue, forKey: Keys.dispatchingEnabled.rawValue)
-    }
+  static var config: PersistedConfig? {
+    guard let data = defaults.data(forKey: Keys.config.rawValue) else { return nil }
+    return try? JSONDecoder().decode(PersistedConfig.self, from: data)
   }
 
+  static func setConfig(_ newValue: PersistedConfig) {
+    guard let data = try? JSONEncoder().encode(newValue) else { return }
+    defaults.set(data, forKey: Keys.config.rawValue)
+  }
 }

--- a/packages/expo-observe/ios/Tests/ObserveUserDefaultsTests.swift
+++ b/packages/expo-observe/ios/Tests/ObserveUserDefaultsTests.swift
@@ -7,30 +7,35 @@ import ExpoAppMetrics
 @Suite("ObserveUserDefaults")
 struct ObserveUserDefaultsTests {
   init() {
-    // Reset by explicitly clearing the key via the property itself,
-    // ensuring the singleton's in-memory cache is also cleared.
-    ObserveUserDefaults.dispatchingEnabled = true
+    // Remove the persistent domain to simulate a fresh install between tests.
+    UserDefaults.standard.removePersistentDomain(forName: "dev.expo.observe")
   }
 
   @Test
-  func `enabled defaults to true`() {
-    // Remove the persistent domain to simulate a fresh install
-    UserDefaults.standard.removePersistentDomain(forName: "dev.expo.eas.observe")
-    #expect(ObserveUserDefaults.dispatchingEnabled == true)
+  func `config defaults to nil`() {
+    #expect(ObserveUserDefaults.config == nil)
   }
 
   @Test
-  func `setDispatchingEnabled false persists false`() {
-    ObserveUserDefaults.dispatchingEnabled = false
-    #expect(ObserveUserDefaults.dispatchingEnabled == false)
+  func `setConfig with dispatchingEnabled false persists false`() {
+    ObserveUserDefaults.setConfig(PersistedConfig(dispatchingEnabled: false))
+    #expect(ObserveUserDefaults.config?.dispatchingEnabled == false)
   }
 
   @Test
-  func `setDispatchingEnabled true persists true`() {
-    ObserveUserDefaults.dispatchingEnabled = false
-    #expect(ObserveUserDefaults.dispatchingEnabled == false)
-    ObserveUserDefaults.dispatchingEnabled = true
-    #expect(ObserveUserDefaults.dispatchingEnabled == true)
+  func `setConfig overwrites previous value`() {
+    ObserveUserDefaults.setConfig(PersistedConfig(dispatchingEnabled: false))
+    #expect(ObserveUserDefaults.config?.dispatchingEnabled == false)
+    ObserveUserDefaults.setConfig(PersistedConfig(dispatchingEnabled: true))
+    #expect(ObserveUserDefaults.config?.dispatchingEnabled == true)
   }
 
+  @Test
+  func `setConfig with nil field clears previously set value`() {
+    ObserveUserDefaults.setConfig(PersistedConfig(dispatchingEnabled: false))
+    #expect(ObserveUserDefaults.config?.dispatchingEnabled == false)
+    ObserveUserDefaults.setConfig(PersistedConfig(dispatchingEnabled: nil))
+    #expect(ObserveUserDefaults.config != nil)
+    #expect(ObserveUserDefaults.config?.dispatchingEnabled == nil)
+  }
 }


### PR DESCRIPTION
# Why

At the moment when no value is passed to `Observe.configure` for `dispatchingEnabled`, then the previous value is used instead of the default one

# How

Remove saved value, when `dispatchingEnabled` is `null`

# Test Plan

Unit tests

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
