### PR TITLE
[ui] fix build crash with precompiled expo-modules-core

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -97,6 +97,7 @@
 - [jetpack-compose] Reuse `HorizontalAlignment` converter in `LazyColumn`. ([#44755](https://github.com/expo/expo/pull/44755) by [@kudo](https://github.com/kudo))
 - [jetpack-compose] Added `horizontalScroll` and `verticalScroll` modifiers. ([#44464](https://github.com/expo/expo/pull/44464) by [@kudo](https://github.com/kudo))
 - [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
+- [iOS] Fixed build error when using precompiled `ExpoModulesCore.xcframework`. ([#45016](https://github.com/expo/expo/pull/45016) by [@kudo](https://github.com/kudo))
 
 ## 55.0.1 — 2026-02-25
 

--- a/packages/expo-ui/ios/ExpoUIModule.swift
+++ b/packages/expo-ui/ios/ExpoUIModule.swift
@@ -1,7 +1,6 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import ExpoModulesWorklets
 
 public final class ExpoUIModule: Module {
   public func definition() -> ModuleDefinition {
@@ -17,13 +16,7 @@ public final class ExpoUIModule: Module {
 
     // MARK: - Observable State
 
-    Class(WorkletCallback.self) {
-      Constructor { (worklet: Worklet) -> WorkletCallback in
-        let callback = WorkletCallback()
-        callback.worklet = worklet
-        return callback
-      }
-    }
+    makeWorkletCallbackClass()
 
     Class(ObservableState.self) {
       Constructor { (initial: [String: Any]) -> ObservableState in

--- a/packages/expo-ui/ios/State/WorkletCallbackClassDef.swift
+++ b/packages/expo-ui/ios/State/WorkletCallbackClassDef.swift
@@ -1,0 +1,21 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+
+import ExpoModulesCore
+import ExpoModulesWorklets
+
+/**
+ Kept in a dedicated file to work around a Swift 6.3.1 compiler crash that fires
+ when `import ExpoModulesWorklets` lives in the same file as a `Class(...)` DSL
+ call while ExpoModulesCore is consumed as its precompiled xcframework. Hosting
+ this definition here — behind a function with an explicit return type — lets the
+ module-emit step skip the body and keeps ExpoUIModule.swift free of the import.
+ */
+internal func makeWorkletCallbackClass() -> ClassDefinition {
+  Class(WorkletCallback.self) {
+    Constructor { (worklet: Worklet) -> WorkletCallback in
+      let callback = WorkletCallback()
+      callback.worklet = worklet
+      return callback
+    }
+  }
+}


### PR DESCRIPTION
# Why

fixed swift compiler crash when building expo-ui with precompiled ExpoModulesCore.xcframework
supersede #44765

# How

- from the try-and-error, it turns out we cannot put two `Class` DSL in single swift file. this pr tries to split the files and have a dedicated file specific for worklet. 

# Test Plan

test with ExpoModulesCore.xcframework and `EXPO_USE_PRECOMPILED_MODULES=1` on bare-expo

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
