### PR TITLE
chore(expo-router): remove unused React imports in tests

### DIFF
--- a/packages/expo-router/src/__tests__/+native-intent.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/+native-intent.test.ios.tsx
@@ -1,5 +1,4 @@
 import { screen, act } from '@testing-library/react-native';
-import React from 'react';
 import { View } from 'react-native';
 
 import { renderRouter } from '../testing-library';

--- a/packages/expo-router/src/__tests__/SuspenseFallback.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/SuspenseFallback.test.ios.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react-native';
-import React, { use } from 'react';
+import { use } from 'react';
 import { Text, View } from 'react-native';
 
 import type { SuspenseFallbackProps } from '../exports';

--- a/packages/expo-router/src/__tests__/custom-navigators.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/custom-navigators.test.ios.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react-native';
-import React from 'react';
 import { Text } from 'react-native';
 
 import { Navigator, Slot } from '../index';

--- a/packages/expo-router/src/__tests__/dismissTo.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/dismissTo.test.ios.tsx
@@ -1,5 +1,4 @@
 import { screen, act } from '@testing-library/react-native';
-import React from 'react';
 
 import { router } from '../imperative-api';
 import Stack from '../layouts/StackClient';

--- a/packages/expo-router/src/__tests__/hashs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/hashs.test.ios.tsx
@@ -1,5 +1,5 @@
 import { act, screen } from '@testing-library/react-native';
-import React, { Text } from 'react-native';
+import { Text } from 'react-native';
 
 import { router } from '../exports';
 import { store } from '../global-state/router-store';

--- a/packages/expo-router/src/__tests__/initialRouteName.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/initialRouteName.test.ios.tsx
@@ -1,5 +1,4 @@
 import { screen, act } from '@testing-library/react-native';
-import React from 'react';
 import { Text } from 'react-native';
 
 import { store } from '../global-state/router-store';

--- a/packages/expo-router/src/__tests__/modal-stack.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/modal-stack.test.ios.tsx
@@ -1,5 +1,4 @@
 import { act, screen } from '@testing-library/react-native';
-import React from 'react';
 import { Text } from 'react-native';
 
 import { router } from '../imperative-api';

--- a/packages/expo-router/src/__tests__/prefetch.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/prefetch.test.ios.tsx
@@ -1,5 +1,4 @@
 import { screen, act } from '@testing-library/react-native';
-import React from 'react';
 import { Text } from 'react-native';
 
 import { router } from '../imperative-api';

--- a/packages/expo-router/src/__tests__/protected.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/protected.test.ios.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, screen } from '@testing-library/react-native';
 import type { Dispatch, SetStateAction } from 'react';
-import React, { createContext, use, useState } from 'react';
+import { createContext, use, useState } from 'react';
 import { Text } from 'react-native';
 
 import { store } from '../global-state/router-store';

--- a/packages/expo-router/src/__tests__/push.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/push.test.ios.tsx
@@ -1,5 +1,4 @@
 import { act, screen } from '@testing-library/react-native';
-import React from 'react';
 import { Text, View } from 'react-native';
 
 import { store } from '../global-state/router-store';

--- a/packages/expo-router/src/__tests__/redirects.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/redirects.test.ios.tsx
@@ -1,5 +1,4 @@
 import { screen, act, fireEvent } from '@testing-library/react-native';
-import React from 'react';
 import { Text } from 'react-native';
 
 import type { RedirectConfig } from '../exports';

--- a/packages/expo-router/src/__tests__/stacks.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/stacks.test.ios.tsx
@@ -1,5 +1,4 @@
 import { act, screen } from '@testing-library/react-native';
-import React from 'react';
 import { Text } from 'react-native';
 import { expectAssignable } from 'tsd';
 

--- a/packages/expo-router/src/__tests__/tabs.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/tabs.test.ios.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, act, screen } from '@testing-library/react-native';
-import React from 'react';
 import { Text, View } from 'react-native';
 
 import { router } from '../exports';

--- a/packages/expo-router/src/__tests__/useFocusEffect.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/useFocusEffect.test.ios.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { Text } from 'react-native';
 
 import { router } from '../imperative-api';

--- a/packages/expo-router/src/__tests__/useNavigation.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/useNavigation.test.ios.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Stack from '../layouts/Stack';
 import type { NavigationProp } from '../react-navigation/native';
 import { renderRouter } from '../testing-library';

--- a/packages/expo-router/src/layouts/__rsc_tests__/JSStack.test.tsx
+++ b/packages/expo-router/src/layouts/__rsc_tests__/JSStack.test.tsx
@@ -1,7 +1,5 @@
 /// <reference types="jest-expo/rsc/expect" />
 
-import React from 'react';
-
 import Stack from '../JSStack';
 
 it(`renders to RSC`, async () => {

--- a/packages/expo-router/src/layouts/__rsc_tests__/Stack.test.tsx
+++ b/packages/expo-router/src/layouts/__rsc_tests__/Stack.test.tsx
@@ -1,7 +1,5 @@
 /// <reference types="jest-expo/rsc/expect" />
 
-import React from 'react';
-
 import Stack from '../Stack';
 
 it(`renders to RSC`, async () => {

--- a/packages/expo-router/src/layouts/__rsc_tests__/TopTabs.test.tsx
+++ b/packages/expo-router/src/layouts/__rsc_tests__/TopTabs.test.tsx
@@ -1,7 +1,5 @@
 /// <reference types="jest-expo/rsc/expect" />
 
-import React from 'react';
-
 import TopTabs from '../TopTabs';
 
 it(`renders to RSC`, async () => {

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/processHeaderItemsForPlatform.test.ios.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/processHeaderItemsForPlatform.test.ios.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Text } from 'react-native';
 
 import { StackToolbarButton } from '../toolbar/StackToolbarButton';

--- a/packages/expo-router/src/link/__rsc_tests__/Link.test.tsx
+++ b/packages/expo-router/src/link/__rsc_tests__/Link.test.tsx
@@ -1,5 +1,4 @@
 /// <reference types="jest-expo/rsc/expect" />
-import * as React from 'react';
 
 import { Link } from '../Link';
 

--- a/packages/expo-router/src/link/__tests__/Link.test.web.tsx
+++ b/packages/expo-router/src/link/__tests__/Link.test.web.tsx
@@ -1,6 +1,5 @@
 /** @jest-environment jsdom */
 import { render } from '@testing-library/react';
-import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { Link } from '../Link';

--- a/packages/expo-router/src/link/preview/__tests__/HrefPreview.test.ios.tsx
+++ b/packages/expo-router/src/link/preview/__tests__/HrefPreview.test.ios.tsx
@@ -1,5 +1,5 @@
 import { screen } from '@testing-library/react-native';
-import React, { useEffect, type PropsWithChildren } from 'react';
+import { useEffect, type PropsWithChildren } from 'react';
 import { View, Text } from 'react-native';
 import { ScreenStackItem as _ScreenStackItem } from 'react-native-screens';
 

--- a/packages/expo-router/src/link/zoom/__tests__/link-apple-zoom-target.test.ios.tsx
+++ b/packages/expo-router/src/link/zoom/__tests__/link-apple-zoom-target.test.ios.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react-native';
-import * as React from 'react';
 import { Text } from 'react-native';
 
 import { LinkZoomTransitionAlignmentRectDetector } from '../../preview/native';

--- a/packages/expo-router/src/native-tabs/__rsc_tests__/tabs.test.tsx
+++ b/packages/expo-router/src/native-tabs/__rsc_tests__/tabs.test.tsx
@@ -1,5 +1,4 @@
 /// <reference types="jest-expo/rsc/expect" />
-import * as React from 'react';
 
 // Right now NativeTabs.Trigger.* components cannot be used in the server environment
 import { Badge, Icon, Label } from '../../primitives';

--- a/packages/expo-router/src/native-tabs/__tests__/listeners.test.ios.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/listeners.test.ios.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { View, type NativeSyntheticEvent } from 'react-native';
 import {
   Tabs as _Tabs,

--- a/packages/expo-router/src/native-tabs/__tests__/options.test.android.tsx
+++ b/packages/expo-router/src/native-tabs/__tests__/options.test.android.tsx
@@ -1,5 +1,4 @@
 import { screen } from '@testing-library/react-native';
-import React from 'react';
 import { View } from 'react-native';
 import { Tabs } from 'react-native-screens';
 

--- a/packages/expo-router/src/native-tabs/utils/__tests__/icon.test.tsx
+++ b/packages/expo-router/src/native-tabs/utils/__tests__/icon.test.tsx
@@ -1,5 +1,4 @@
 import { renderHook, act } from '@testing-library/react-native';
-import React from 'react';
 import type { ImageSourcePropType } from 'react-native';
 
 import { NativeTabsTriggerPromiseIcon, NativeTabsTriggerVectorIcon } from '../../common/elements';

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/index.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/index.test.ios.tsx
@@ -1,6 +1,5 @@
 import { expect, jest, test } from '@jest/globals';
 import { fireEvent, render } from '@testing-library/react-native';
-import type * as React from 'react';
 import { Button, View } from 'react-native';
 
 import { NavigationContainer } from '../../../fork/NavigationContainer';
@@ -29,7 +28,6 @@ jest.mock('react-native-pager-view', () => {
 jest.mock(
   'react-native-tab-view',
   () => {
-    const React = require('react');
     const { View, Text, Pressable } = require('react-native');
 
     return {

--- a/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.android.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.android.tsx
@@ -1,5 +1,4 @@
 import { render, renderHook, within } from '@testing-library/react-native';
-import React from 'react';
 import { View } from 'react-native';
 
 import {

--- a/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/native-stack/__tests__/useHeaderConfigProps.test.ios.tsx
@@ -1,5 +1,4 @@
 import { render, renderHook, within } from '@testing-library/react-native';
-import React from 'react';
 import { Platform, View } from 'react-native';
 
 import type { NativeStackHeaderItem } from '../types';

--- a/packages/expo-router/src/react-navigation/stack/views/Stack/__tests__/StackView.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/stack/views/Stack/__tests__/StackView.test.ios.tsx
@@ -1,7 +1,6 @@
 import 'react-native-gesture-handler/jestSetup';
 
 import { describe, expect, test } from '@jest/globals';
-import * as React from 'react';
 
 import type { ParamListBase, Route, StackNavigationState } from '../../../../native';
 import type { StackDescriptorMap } from '../../../types';

--- a/packages/expo-router/src/views/__rsc_tests__/views.test.tsx
+++ b/packages/expo-router/src/views/__rsc_tests__/views.test.tsx
@@ -1,5 +1,4 @@
 /// <reference types="jest-expo/rsc/expect" />
-import * as React from 'react';
 
 import { EmptyRoute } from '../EmptyRoute';
 import { ErrorBoundary } from '../ErrorBoundary';


### PR DESCRIPTION
# Why

Followup to https://github.com/expo/expo/pull/44959.

After we updated the base `tsconfig.json` to use `"jsx": "react-jsx"`, the tests in `expo-router` also needed their React imports stripped.

# How

Stripped the React imports from `expo-router`'s tests.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
