### PR TITLE
[ui][mesh][maps][Android] Improve app startup by replacing reflection with compile-time introspection for compose props

### DIFF
--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### 💡 Others
 
 - [iOS] Added explicit `import React` for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
-- [Android] Improved application startup performance by reducing reflection.
+- [Android] Improved application startup performance by reducing reflection. ([#45021](https://github.com/expo/expo/pull/45021) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### 💡 Others
 
 - [iOS] Added explicit `import React` for xcframework compatibility. ([#44248](https://github.com/expo/expo/pull/44248) by [@chrfalch](https://github.com/chrfalch))
+- [Android] Improved application startup performance by reducing reflection.
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleMapsView.kt
@@ -44,7 +44,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.dp
 import com.google.android.gms.maps.GoogleMapOptions
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class GoogleMapsViewProps(
   val userLocation: MutableState<UserLocationRecord> = mutableStateOf(UserLocationRecord()),
   val cameraPosition: MutableState<CameraPositionRecord> = mutableStateOf(CameraPositionRecord()),

--- a/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleStreetView.kt
+++ b/packages/expo-maps/android/src/main/java/expo/modules/maps/GoogleStreetView.kt
@@ -13,7 +13,9 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
 import expo.modules.kotlin.views.ComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class GoogleStreetViewProps(
   val position: MutableState<CameraPositionStreetViewRecord> = mutableStateOf(CameraPositionStreetViewRecord()),
   val isPanningGesturesEnabled: MutableState<Boolean> = mutableStateOf(true),

--- a/packages/expo-mesh-gradient/CHANGELOG.md
+++ b/packages/expo-mesh-gradient/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [Android] Improved application startup performance by reducing reflection.
+
 ## 55.0.8 — 2026-02-25
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-mesh-gradient/CHANGELOG.md
+++ b/packages/expo-mesh-gradient/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 💡 Others
 
-- [Android] Improved application startup performance by reducing reflection.
+- [Android] Improved application startup performance by reducing reflection. ([#45021](https://github.com/expo/expo/pull/45021) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.8 — 2026-02-25
 

--- a/packages/expo-mesh-gradient/android/src/main/java/expo/modules/meshgradient/MeshGradientView.kt
+++ b/packages/expo-mesh-gradient/android/src/main/java/expo/modules/meshgradient/MeshGradientView.kt
@@ -28,6 +28,7 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class Resolution(
@@ -38,6 +39,7 @@ data class Resolution(
   val y: Int = 8
 ) : Record
 
+@OptimizedComposeProps
 data class MeshGradientViewProps(
   val columns: MutableState<Int> = mutableIntStateOf(0),
   val rows: MutableState<Int> = mutableIntStateOf(0),

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [iOS] Add `nativeModule` look up function and `bundleURL` to AppContext. ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions. ([#44122](https://github.com/expo/expo/pull/44122) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Exposed a shared OkHttpClient instance through AppContext with new coroutine-friendly extensions. ([#44854](https://github.com/expo/expo/pull/44854) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Allow compile-time optimization of compose view props when the property class is annotated with `@OptimizedComposeProps`.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -17,7 +17,7 @@
 - [iOS] Add `nativeModule` look up function and `bundleURL` to AppContext. ([#43661](https://github.com/expo/expo/pull/43661) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions. ([#44122](https://github.com/expo/expo/pull/44122) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Exposed a shared OkHttpClient instance through AppContext with new coroutine-friendly extensions. ([#44854](https://github.com/expo/expo/pull/44854) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Allow compile-time optimization of compose view props when the property class is annotated with `@OptimizedComposeProps`.
+- [Android] Allow compile-time optimization of compose view props when the property class is annotated with `@OptimizedComposeProps`. ([#45021](https://github.com/expo/expo/pull/45021) by [@lukmccall](https://github.com/lukmccall))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
@@ -8,14 +8,13 @@ import expo.modules.kotlin.exception.PropSetException
 import expo.modules.kotlin.exception.exceptionDecorator
 import expo.modules.kotlin.logger
 import expo.modules.kotlin.types.AnyType
-import kotlin.reflect.KProperty1
 import kotlin.reflect.full.instanceParameter
 import kotlin.reflect.full.memberFunctions
 
 class ComposeViewProp(
   name: String,
   anyType: AnyType,
-  val property: KProperty1<*, *>
+  val propertyGetter: (Any) -> Any?
 ) : AnyViewProp(name, anyType) {
   private var _isStateProp = false
 
@@ -38,6 +37,7 @@ class ComposeViewProp(
       if (onView is ComposeFunctionHolder<*>) {
         // Use current props state, not the initial props instance
         val currentProps = onView.propsMutableState.value
+        // TODO(@lukmccall): We should remove the copy call
         val copy = currentProps::class.memberFunctions.firstOrNull { it.name == "copy" }
         if (copy == null) {
           logger.warn("⚠️ Props are not a data class with default values for all properties, cannot set prop $name dynamically.")
@@ -51,7 +51,7 @@ class ComposeViewProp(
         return@exceptionDecorator
       }
 
-      val mutableState = property.getter.call(props)
+      val mutableState = propertyGetter(props)
       if (mutableState is MutableState<*>) {
         (mutableState as MutableState<Any?>).value = type.convert(prop, appContext)
       } else {

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ModuleDefinitionBuilderComposeExtension.kt
@@ -9,15 +9,12 @@ import expo.modules.kotlin.modules.DefinitionMarker
 import expo.modules.kotlin.modules.InternalModuleDefinitionBuilder
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.types.AnyType
-import expo.modules.kotlin.types.descriptors.toTypeDescriptor
 import expo.modules.kotlin.types.descriptors.typeDescriptorOf
 import expo.modules.kotlin.types.toArgsArray
 import expo.modules.kotlin.viewevent.CoalescingKey
 import expo.modules.kotlin.views.decorators.UseCSSProps
 import kotlin.properties.PropertyDelegateProvider
 import kotlin.reflect.KClass
-import kotlin.reflect.full.createInstance
-import kotlin.reflect.full.memberProperties
 
 /**
  * The name for the global event dispatcher
@@ -34,11 +31,10 @@ open class ModuleDefinitionBuilderWithCompose(
   @JvmName("ComposeView")
   inline fun <reified T : ExpoComposeView<P>, reified P : ComposeProps> View(viewClass: KClass<T>, body: ViewDefinitionBuilder<T>.() -> Unit = {}) {
     val viewDefinitionBuilder = ViewDefinitionBuilder(viewClass, typeDescriptorOf<T>())
-    P::class.memberProperties.forEach { prop ->
-      val kType = prop.returnType.arguments.first().type
-      if (kType != null && viewDefinitionBuilder.props[prop.name] == null) {
-        viewDefinitionBuilder.props[prop.name] = ComposeViewProp(prop.name, AnyType(kType.toTypeDescriptor()), prop)
-      }
+
+    val propsParsingStrategy = toPropsParsingStrategy<P>()
+    for (prop in propsParsingStrategy.unwrappedProps().values) {
+      viewDefinitionBuilder.props[prop.name] = prop
     }
 
     viewDefinitionBuilder.UseCSSProps()
@@ -58,7 +54,10 @@ open class ModuleDefinitionBuilderWithCompose(
     name: String,
     block: ComposeViewBuilderScope<Props>.() -> Unit
   ) {
-    val scope = ComposeViewBuilderScope<Props>(name, Props::class).apply(block)
+    val scope = ComposeViewBuilderScope(
+      name,
+      toPropsParsingStrategy<Props>()
+    ).apply(block)
     registerViewDefinition(scope.build())
   }
 
@@ -80,7 +79,12 @@ open class ModuleDefinitionBuilderWithCompose(
   ) {
     val eventBuilder = ComposeViewEventDefinitionBuilder()
     events.invoke(eventBuilder)
-    val functionBuilder = ComposeViewFunctionDefinitionBuilder(name, Props::class, viewFunction, eventBuilder)
+    val functionBuilder = ComposeViewFunctionDefinitionBuilder(
+      name,
+      toPropsParsingStrategy<Props>(),
+      viewFunction,
+      eventBuilder
+    )
     registerViewDefinition(functionBuilder.build())
   }
 }
@@ -112,7 +116,7 @@ class ComposeViewEventDefinitionBuilder {
 @DefinitionMarker
 class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps> @PublishedApi internal constructor(
   val name: String,
-  val propsClass: KClass<Props>,
+  val propsParsingStrategy: PropsParsingStrategy<Props>,
   val viewFunction: @Composable FunctionalComposableScope.(props: Props) -> Unit,
   private val eventBuilder: ComposeViewEventDefinitionBuilder = ComposeViewEventDefinitionBuilder()
 ) {
@@ -135,7 +139,7 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps> @PublishedApi i
       name = name,
       viewFactory = { context, appContext ->
         val instance: Props = try {
-          propsClass.createInstance()
+          propsParsingStrategy.createNewInstance()
         } catch (e: Exception) {
           throw IllegalStateException("Could not instantiate props instance of $name compose component.", e)
         }
@@ -143,10 +147,7 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps> @PublishedApi i
       },
       callbacksDefinition = eventBuilder.callbacksDefinition,
       viewType = ComposeFunctionHolder::class.java,
-      props = propsClass.memberProperties.associate { prop ->
-        val kType = prop.returnType
-        prop.name to ComposeViewProp(prop.name, AnyType(kType.toTypeDescriptor()), prop)
-      },
+      props = propsParsingStrategy.props(),
       asyncFunctions = allFunctions.values.toList()
     )
   }
@@ -174,7 +175,7 @@ class ComposeViewFunctionDefinitionBuilder<Props : ComposeProps> @PublishedApi i
 @DefinitionMarker
 class ComposeViewBuilderScope<Props : ComposeProps> @PublishedApi internal constructor(
   @PublishedApi internal val name: String,
-  @PublishedApi internal val propsClass: KClass<Props>
+  @PublishedApi internal val propsParsingStrategy: PropsParsingStrategy<Props>
 ) {
   @PublishedApi
   internal val viewType = typeDescriptorOf<ComposeFunctionHolder<ComposeProps>>()
@@ -360,7 +361,7 @@ class ComposeViewBuilderScope<Props : ComposeProps> @PublishedApi internal const
     if (eventNames.isNotEmpty()) {
       eventBuilder.Events(*eventNames.toTypedArray())
     }
-    val functionBuilder = ComposeViewFunctionDefinitionBuilder(name, propsClass, content, eventBuilder)
+    val functionBuilder = ComposeViewFunctionDefinitionBuilder(name, propsParsingStrategy, content, eventBuilder)
     asyncFunctions.forEach { (fnName, component) ->
       functionBuilder.deferredFunctions[fnName] = component
     }

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/OptimizedComposeProps.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/OptimizedComposeProps.kt
@@ -1,0 +1,6 @@
+package expo.modules.kotlin.views
+
+// Keep in sync with `expo-modules-gradle-plugin`.
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class OptimizedComposeProps

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/PropsParsingStrategy.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/PropsParsingStrategy.kt
@@ -1,0 +1,117 @@
+package expo.modules.kotlin.views
+
+import expo.modules.kotlin.types.AnyType
+import expo.modules.kotlin.types.descriptors.TypeDescriptor
+import expo.modules.kotlin.types.descriptors.toRawTypeDescriptor
+import expo.modules.kotlin.types.descriptors.toTypeDescriptor
+import io.github.lukmccall.pika.PIntrospectionData
+import io.github.lukmccall.pika.PTypeDescriptor
+import io.github.lukmccall.pika.introspectionOf
+import io.github.lukmccall.pika.isIntrospectable
+import kotlin.reflect.KClass
+import kotlin.reflect.full.memberProperties
+
+@PublishedApi
+internal inline fun <reified Props : ComposeProps> toPropsParsingStrategy(): PropsParsingStrategy<Props> {
+  return if (isIntrospectable<Props>()) {
+    PropsParsingStrategy.Introspection(introspectionOf<Props>())
+  } else {
+    PropsParsingStrategy.Reflection(Props::class)
+  }
+}
+
+/**
+ * Defines a strategy for parsing data class to props. We have two implementations:
+ * 1. Introspection - uses Pika to introspect the properties of the props class
+ * 2. Reflection - uses Kotlin reflection to get the properties of the props class
+ */
+sealed interface PropsParsingStrategy<Props : ComposeProps> {
+  fun createNewInstance(): Props
+  fun props(): Map<String, ComposeViewProp>
+
+  // Used with props that are represented as MutableState<T> - in this case, we need to unwrap the type to get T
+  fun unwrappedProps(): Map<String, ComposeViewProp>
+
+  @JvmInline
+  value class Introspection<Props : ComposeProps>(
+    private val introspectableData: PIntrospectionData<Props>
+  ) : PropsParsingStrategy<Props> {
+    override fun createNewInstance(): Props {
+      @Suppress("UNCHECKED_CAST")
+      return introspectableData.jClass.getDeclaredConstructor().newInstance() as Props
+    }
+
+    override fun props(): Map<String, ComposeViewProp> {
+      return introspectableData.properties.associate { prop ->
+        val propType = TypeDescriptor(
+          typeInfo = prop.type.toRawTypeDescriptor(),
+          kTypeProvider = { error("KType is not available for introspected properties, should not be accessed") }
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        prop.name to ComposeViewProp(
+          prop.name,
+          AnyType(propType),
+          prop.getter as (Any) -> Any?
+        )
+      }
+    }
+
+    override fun unwrappedProps(): Map<String, ComposeViewProp> {
+      return introspectableData.properties.associate { prop ->
+        val mutableStateType = (prop.type as? PTypeDescriptor.Concrete.Parameterized)
+        requireNotNull(mutableStateType) {
+          "Wrapped props must be of type MutableState<T>. Property ${prop.name} is not a valid wrapped prop because its return type is not parameterized."
+        }
+        val propTypeDescriptor = requireNotNull(mutableStateType.parameters.firstOrNull()) { "Can't unwrap prop type" }
+
+        val propType = TypeDescriptor(
+          typeInfo = propTypeDescriptor.toRawTypeDescriptor(),
+          kTypeProvider = { error("KType is not available for introspected properties, should not be accessed") }
+        )
+
+        @Suppress("UNCHECKED_CAST")
+        prop.name to ComposeViewProp(
+          prop.name,
+          AnyType(propType),
+          prop.getter as (Any) -> Any?
+        )
+      }
+    }
+  }
+
+  @JvmInline
+  value class Reflection<Props : ComposeProps>(
+    private val propsClass: KClass<*>
+  ) : PropsParsingStrategy<Props> {
+    override fun createNewInstance(): Props {
+      @Suppress("UNCHECKED_CAST")
+      return propsClass.java.getDeclaredConstructor().newInstance() as Props
+    }
+
+    override fun props(): Map<String, ComposeViewProp> {
+      return propsClass.memberProperties.associate { prop ->
+        val kType = prop.returnType
+        prop.name to ComposeViewProp(
+          prop.name,
+          AnyType(kType.toTypeDescriptor()),
+          propertyGetter = { self -> prop.getter.call(self) }
+        )
+      }
+    }
+
+    override fun unwrappedProps(): Map<String, ComposeViewProp> {
+      return propsClass.memberProperties.associate { prop ->
+        val kType = prop.returnType.arguments.first().type
+        requireNotNull(kType) {
+          "Wrapped props must be of type MutableState<T>. Property ${prop.name} is not a valid wrapped prop because its return type is not parameterized."
+        }
+        prop.name to ComposeViewProp(
+          prop.name,
+          AnyType(kType.toTypeDescriptor()),
+          propertyGetter = { self -> prop.getter.call(self) }
+        )
+      }
+    }
+  }
+}

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/PropsParsingStrategy.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/PropsParsingStrategy.kt
@@ -1,5 +1,6 @@
 package expo.modules.kotlin.views
 
+import android.util.Log
 import expo.modules.kotlin.types.AnyType
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
 import expo.modules.kotlin.types.descriptors.toRawTypeDescriptor
@@ -16,6 +17,7 @@ internal inline fun <reified Props : ComposeProps> toPropsParsingStrategy(): Pro
   return if (isIntrospectable<Props>()) {
     PropsParsingStrategy.Introspection(introspectionOf<Props>())
   } else {
+    Log.w("ExpoModulesCore", "Props class ${Props::class.java} is not introspectable. Falling back to reflection-based props parsing, which may have performance implications. To fix this, annotate the props class with @OptimizedComposeProps.")
     PropsParsingStrategy.Reflection(Props::class)
   }
 }

--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
@@ -38,6 +38,7 @@ internal fun Project.applyPikaPlugin() {
 
   val pika = extensions.getByType(PikaGradleExtension::class.java)
   pika.introspectableAnnotation("expo.modules.kotlin.types.OptimizedRecord")
+  pika.introspectableAnnotation("expo.modules.kotlin.views.OptimizedComposeProps")
 }
 
 internal fun Project.configurePika(shouldBeEnabled: Boolean = true) {

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -100,6 +100,7 @@
 - [jetpack-compose] Added `horizontalScroll` and `verticalScroll` modifiers. ([#44464](https://github.com/expo/expo/pull/44464) by [@kudo](https://github.com/kudo))
 - [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
 - [iOS] Fixed build error when using precompiled `ExpoModulesCore.xcframework`. ([#45016](https://github.com/expo/expo/pull/45016) by [@kudo](https://github.com/kudo))
+- [Android] Improved application startup performance by reducing reflection. ([#45021](https://github.com/expo/expo/pull/45021) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.1 — 2026-02-25
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/AlertDialogView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/AlertDialogView.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class AlertDialogColors(
@@ -28,6 +29,7 @@ data class ExpoDialogProperties(
   @Field val decorFitsSystemWindows: Boolean = true
 ) : Record
 
+@OptimizedComposeProps
 data class AlertDialogProps(
   val colors: AlertDialogColors = AlertDialogColors(),
   val tonalElevation: Double? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/AnimatedVisibilityView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/AnimatedVisibilityView.kt
@@ -24,6 +24,7 @@ import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 // region Transition types
 
@@ -108,6 +109,7 @@ private fun List<ExitTransitionRecord>.toComposedExitTransition(): ExitTransitio
 
 // endregion
 
+@OptimizedComposeProps
 data class AnimatedVisibilityProps(
   val visible: Boolean = true,
   val enterTransition: List<EnterTransitionRecord>? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BadgeView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BadgeView.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.size
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class BadgeProps(
   val containerColor: Color? = null,
   val contentColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BadgedBoxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BadgedBoxView.kt
@@ -5,7 +5,9 @@ import androidx.compose.material3.BadgedBox
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class BadgedBoxProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BasicAlertDialogView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BasicAlertDialogView.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.window.DialogProperties
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class BasicAlertDialogProps(
   val properties: ExpoDialogProperties = ExpoDialogProperties(),
   val modifiers: ModifierList = emptyList()

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/BottomSheetView.kt
@@ -11,14 +11,15 @@ import androidx.compose.material3.contentColorFor
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
-import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.withContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.views.ComposeProps
-import expo.modules.kotlin.views.AsyncFunctionHandle
-import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.AsyncFunctionHandle
+import expo.modules.kotlin.views.ComposeProps
+import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
 
 @OptimizedRecord
 data class ModalBottomSheetPropertiesRecord(
@@ -26,6 +27,7 @@ data class ModalBottomSheetPropertiesRecord(
   @Field val shouldDismissOnClickOutside: Boolean = true
 ) : Record
 
+@OptimizedComposeProps
 data class ModalBottomSheetViewProps(
   val skipPartiallyExpanded: Boolean = false,
   val containerColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CardView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CardView.kt
@@ -14,6 +14,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class CardColors(
@@ -29,6 +30,7 @@ data class CardBorder(
 
 // region Card
 
+@OptimizedComposeProps
 data class CardProps(
   val colors: CardColors = CardColors(),
   val elevation: Float? = null,
@@ -83,6 +85,7 @@ fun FunctionalComposableScope.CardContent(props: CardProps) {
 
 // region ElevatedCard
 
+@OptimizedComposeProps
 data class ElevatedCardProps(
   val colors: CardColors = CardColors(),
   val elevation: Float? = null,
@@ -124,6 +127,7 @@ fun FunctionalComposableScope.ElevatedCardContent(props: ElevatedCardProps) {
 
 // region OutlinedCard
 
+@OptimizedComposeProps
 data class OutlinedCardProps(
   val colors: CardColors = CardColors(),
   val elevation: Float? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CarouselView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CarouselView.kt
@@ -19,6 +19,7 @@ import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 enum class FlingBehaviorType(val value: String) : Enumerable {
   SINGLE_ADVANCE("singleAdvance"),
@@ -54,6 +55,7 @@ fun paddingValuesFromEither(either: Either<Float, PaddingValuesRecord>?): Paddin
   }
 }
 
+@OptimizedComposeProps
 data class HorizontalCenteredHeroCarouselProps(
   val maxItemWidth: Float? = null,
   val itemSpacing: Float? = null,
@@ -93,6 +95,7 @@ fun FunctionalComposableScope.HorizontalCenteredHeroCarouselContent(props: Horiz
   }
 }
 
+@OptimizedComposeProps
 data class HorizontalMultiBrowseCarouselProps(
   val preferredItemWidth: Float = 200f,
   val itemSpacing: Float? = null,
@@ -132,6 +135,7 @@ fun FunctionalComposableScope.HorizontalMultiBrowseCarouselContent(props: Horizo
   }
 }
 
+@OptimizedComposeProps
 data class HorizontalUncontainedCarouselProps(
   val itemWidth: Float = 200f,
   val itemSpacing: Float? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/CheckboxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/CheckboxView.kt
@@ -12,6 +12,7 @@ import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class CheckboxColors(
@@ -23,6 +24,7 @@ data class CheckboxColors(
   @Field val disabledIndeterminateColor: Color? = null
 ) : Record
 
+@OptimizedComposeProps
 data class CheckboxProps(
   val value: Boolean = false,
   val enabled: Boolean = true,
@@ -62,6 +64,7 @@ enum class ToggleableStateValue(val value: String) : Enumerable {
   INDETERMINATE("indeterminate")
 }
 
+@OptimizedComposeProps
 data class TriStateCheckboxProps(
   val state: ToggleableStateValue = ToggleableStateValue.OFF,
   val enabled: Boolean = true,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ChipView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ChipView.kt
@@ -20,6 +20,7 @@ import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 open class ChipPressedEvent : Record, Serializable
@@ -82,6 +83,7 @@ private fun FunctionalComposableScope.slotContent(slotName: String): (@Composabl
 
 // region AssistChip
 
+@OptimizedComposeProps
 data class AssistChipProps(
   val enabled: Boolean = true,
   val colors: AssistChipColors = AssistChipColors(),
@@ -138,6 +140,7 @@ fun FunctionalComposableScope.AssistChipContent(
 
 // region FilterChip
 
+@OptimizedComposeProps
 data class FilterChipProps(
   val selected: Boolean = false,
   val enabled: Boolean = true,
@@ -199,6 +202,7 @@ fun FunctionalComposableScope.FilterChipContent(
 
 // region InputChip
 
+@OptimizedComposeProps
 data class InputChipProps(
   val enabled: Boolean = true,
   val selected: Boolean = false,
@@ -262,6 +266,7 @@ fun FunctionalComposableScope.InputChipContent(
 
 // region SuggestionChip
 
+@OptimizedComposeProps
 data class SuggestionChipProps(
   val enabled: Boolean = true,
   val colors: SuggestionChipColors = SuggestionChipColors(),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ComposeViews.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ComposeViews.kt
@@ -24,6 +24,7 @@ import expo.modules.ui.convertibles.VerticalAlignment
 import expo.modules.ui.convertibles.ContentAlignment
 import expo.modules.ui.convertibles.VerticalArrangement
 import expo.modules.ui.convertibles.toComposeArrangement
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 enum class FloatingToolbarExitAlwaysScrollBehavior(val value: String) : Enumerable {
   TOP("top"),
@@ -41,6 +42,7 @@ enum class FloatingToolbarExitAlwaysScrollBehavior(val value: String) : Enumerab
   }
 }
 
+@OptimizedComposeProps
 data class LayoutProps(
   val horizontalArrangement: HorizontalArrangement? = null,
   val verticalArrangement: VerticalArrangement? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DatePickerView.kt
@@ -29,6 +29,7 @@ import java.util.Calendar
 import java.util.Date
 import android.graphics.Color as AndroidColor
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class DatePickerResult(
@@ -106,6 +107,7 @@ class SelectableDatesRecord : Record {
   @Field val end: Long? = null
 }
 
+@OptimizedComposeProps
 data class DateTimePickerProps(
   val initialDate: Long? = null,
   val variant: Variant = Variant.PICKER,
@@ -118,6 +120,7 @@ data class DateTimePickerProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps
 
+@OptimizedComposeProps
 data class DatePickerDialogProps(
   val initialDate: Long? = null,
   val variant: Variant = Variant.PICKER,
@@ -129,6 +132,7 @@ data class DatePickerDialogProps(
   val selectableDates: SelectableDatesRecord? = null,
 ) : ComposeProps
 
+@OptimizedComposeProps
 data class TimePickerDialogProps(
   val initialDate: Long? = null,
   val is24Hour: Boolean = true,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DividerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DividerView.kt
@@ -8,7 +8,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.dp
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class DividerProps(
   val thickness: Float? = null,
   val color: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/DockedSearchBarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/DockedSearchBarView.kt
@@ -13,7 +13,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.snapshotFlow
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class DockedSearchBarProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HorizontalFloatingToolbarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HorizontalFloatingToolbarView.kt
@@ -10,12 +10,14 @@ import androidx.compose.runtime.Composable
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 enum class HorizontalFloatingToolbarVariant(val value: String) : Enumerable {
   STANDARD("standard"),
   VIBRANT("vibrant")
 }
 
+@OptimizedComposeProps
 data class HorizontalFloatingToolbarProps(
   val variant: HorizontalFloatingToolbarVariant? =
     HorizontalFloatingToolbarVariant.STANDARD,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
@@ -38,13 +38,12 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.types.Enumerable
+import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
-import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.views.OptimizedComposeProps
-import io.github.lukmccall.pika.Introspectable
 
 internal enum class ExpoLayoutDirection(val value: String) : Enumerable {
   LeftToRight("leftToRight"),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
@@ -43,6 +43,8 @@ import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
+import io.github.lukmccall.pika.Introspectable
 
 internal enum class ExpoLayoutDirection(val value: String) : Enumerable {
   LeftToRight("leftToRight"),
@@ -56,6 +58,7 @@ internal enum class ExpoLayoutDirection(val value: String) : Enumerable {
   }
 }
 
+@OptimizedComposeProps
 internal data class HostProps(
   val colorScheme: MutableState<ExpoColorScheme?> = mutableStateOf(null),
   val layoutDirection: MutableState<ExpoLayoutDirection> = mutableStateOf(ExpoLayoutDirection.LeftToRight),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyColumnView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyColumnView.kt
@@ -24,6 +24,7 @@ import expo.modules.ui.convertibles.HorizontalAlignment
 import expo.modules.ui.convertibles.VerticalArrangement
 import expo.modules.ui.convertibles.toComposeArrangement
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class ContentPadding(
@@ -33,6 +34,7 @@ data class ContentPadding(
   @Field val bottom: Int = 0
 ) : Record
 
+@OptimizedComposeProps
 data class LazyColumnProps(
   val verticalArrangement: MutableState<VerticalArrangement?> = mutableStateOf(null),
   val horizontalAlignment: MutableState<HorizontalAlignment?> = mutableStateOf(null),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyRowView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/LazyRowView.kt
@@ -21,7 +21,9 @@ import expo.modules.kotlin.views.ExpoComposeView
 import expo.modules.ui.convertibles.HorizontalArrangement
 import expo.modules.ui.convertibles.VerticalAlignment
 import expo.modules.ui.convertibles.toComposeArrangement
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class LazyRowProps(
   val horizontalArrangement: MutableState<HorizontalArrangement?> = mutableStateOf(null),
   val verticalAlignment: MutableState<VerticalAlignment?> = mutableStateOf(null),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ListItemView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ListItemView.kt
@@ -10,6 +10,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class ListItemColors(
@@ -21,6 +22,7 @@ data class ListItemColors(
   @Field val overlineContentColor: Color? = null
 ) : Record
 
+@OptimizedComposeProps
 data class ListItemProps(
   val tonalElevation: Float? = null,
   val shadowElevation: Float? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ProgressView.kt
@@ -19,6 +19,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 // region LinearProgressIndicator
 
@@ -29,6 +30,7 @@ class DrawStopIndicatorConfig : Record {
   @Field val stopSize: Float? = null
 }
 
+@OptimizedComposeProps
 data class LinearProgressIndicatorProps(
   val progress: Float? = null,
   val color: Color? = null,
@@ -91,6 +93,7 @@ fun FunctionalComposableScope.LinearProgressIndicatorContent(props: LinearProgre
 
 // region CircularProgressIndicator
 
+@OptimizedComposeProps
 data class CircularProgressIndicatorProps(
   val progress: Float? = null,
   val color: Color? = null,
@@ -139,6 +142,7 @@ fun FunctionalComposableScope.CircularProgressIndicatorContent(props: CircularPr
 
 // region LinearWavyProgressIndicator
 
+@OptimizedComposeProps
 data class LinearWavyProgressIndicatorProps(
   val progress: Float? = null,
   val color: Color? = null,
@@ -175,6 +179,7 @@ fun FunctionalComposableScope.LinearWavyProgressIndicatorContent(props: LinearWa
 
 // region CircularWavyProgressIndicator
 
+@OptimizedComposeProps
 data class CircularWavyProgressIndicatorProps(
   val progress: Float? = null,
   val color: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/PullToRefreshBoxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/PullToRefreshBoxView.kt
@@ -16,6 +16,7 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.ui.convertibles.ContentAlignment
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class PullToRefreshIndicatorProps(
@@ -24,6 +25,7 @@ data class PullToRefreshIndicatorProps(
   @Field val modifiers: ModifierList = emptyList()
 ) : Record
 
+@OptimizedComposeProps
 data class PullToRefreshBoxProps(
   val isRefreshing: Boolean = false,
   val contentAlignment: ContentAlignment? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
@@ -33,7 +33,9 @@ import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
 import expo.modules.kotlin.views.RNHostViewInterface
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 internal data class RNHostViewProps(
   val matchContents: MutableState<Boolean?> = mutableStateOf(null)
 ) : ComposeProps

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RadioButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RadioButtonView.kt
@@ -4,7 +4,9 @@ import androidx.compose.material3.RadioButton
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class RadioButtonProps(
   val selected: Boolean = false,
   val clickable: Boolean = true,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SearchBarView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SearchBarView.kt
@@ -11,7 +11,9 @@ import androidx.compose.material3.rememberSearchBarState
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class SearchBarProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedButtonView.kt
@@ -14,6 +14,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class SegmentedButtonColors(
@@ -31,6 +32,7 @@ data class SegmentedButtonColors(
   @Field val disabledInactiveContainerColor: Color? = null
 ) : Record
 
+@OptimizedComposeProps
 data class SegmentedButtonProps(
   val selected: Boolean = false,
   val checked: Boolean = false,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedControlView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SegmentedControlView.kt
@@ -5,7 +5,9 @@ import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class SingleChoiceSegmentedButtonRowProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps
@@ -19,6 +21,7 @@ fun FunctionalComposableScope.SingleChoiceSegmentedButtonRowContent(props: Singl
   }
 }
 
+@OptimizedComposeProps
 data class MultiChoiceSegmentedButtonRowProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ShapeView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ShapeView.kt
@@ -29,6 +29,7 @@ import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import android.graphics.Color as GraphicsColor
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 enum class ShapeType(val value: String) : Enumerable {
   STAR("star"),
@@ -48,6 +49,7 @@ data class CornerRadii(
   @Field val bottomEnd: Float = 0f
 ) : Record
 
+@OptimizedComposeProps
 data class ShapeProps(
   val cornerRounding: Float = 0.0f,
   val smoothing: Float = 0.0f,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SliderView.kt
@@ -17,6 +17,7 @@ import expo.modules.kotlin.viewevent.getValue
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 class SliderColors : Record {
@@ -36,6 +37,7 @@ class SliderColors : Record {
   val inactiveTickColor: Color? = null
 }
 
+@OptimizedComposeProps
 data class SliderProps(
   val value: Float = 0.0f,
   val min: Float = 0.0f,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SlotView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SlotView.kt
@@ -12,7 +12,9 @@ import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ComposableScope
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.ExpoComposeView
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class SlotProps(
   val slotName: MutableState<String> = mutableStateOf("")
 ) : ComposeProps

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SpacerView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SpacerView.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.runtime.Composable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class SpacerProps(
   val modifiers: ModifierList = emptyList()
 ) : ComposeProps

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SurfaceView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SurfaceView.kt
@@ -13,6 +13,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 
 @OptimizedRecord
@@ -21,6 +22,7 @@ data class SurfaceBorder(
   @Field val color: Color? = null
 ) : Record
 
+@OptimizedComposeProps
 data class SurfaceProps(
   val color: Color? = null,
   val contentColor: Color? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SurfaceView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SurfaceView.kt
@@ -15,7 +15,6 @@ import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
 import expo.modules.kotlin.views.OptimizedComposeProps
 
-
 @OptimizedRecord
 data class SurfaceBorder(
   @Field val width: Float = 1f,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SwitchView.kt
@@ -10,6 +10,7 @@ import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import java.io.Serializable
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 open class CheckedChangeEvent(
@@ -36,6 +37,7 @@ data class SwitchColors(
   @Field val disabledUncheckedIconColor: Color? = null
 ) : Record
 
+@OptimizedComposeProps
 data class SwitchProps(
   val value: Boolean = false,
   val enabled: Boolean = true,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/SyncSwitchView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/SyncSwitchView.kt
@@ -6,7 +6,9 @@ import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.state.ObservableState
 import expo.modules.ui.state.WorkletCallback
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class SyncSwitchProps(
   val isOn: ObservableState? = null,
   val onCheckedChangeSync: WorkletCallback? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextFieldView.kt
@@ -26,6 +26,7 @@ import expo.modules.kotlin.views.AsyncFunctionHandle
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 // region Records
 
@@ -162,6 +163,7 @@ fun TextFieldColorsRecord.toColors(isOutlined: Boolean): TextFieldColors {
 
 // region Props
 
+@OptimizedComposeProps
 data class TextFieldProps(
   val defaultValue: String = "",
   val autoFocus: Boolean = false,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
@@ -27,6 +27,7 @@ import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 enum class TextFontWeight(val value: String) : Enumerable {
   NORMAL("normal"),
@@ -221,7 +222,8 @@ interface TextSpanStyle {
   val shadow: TextShadowRecord?
 }
 
-@OptimizedRecord
+// TODO(@lukmccall): Figure out why it's crashing with `Attempt to invoke virtual method 'io.github.lukmccall.pika.PIntrospectionData expo.modules.ui.TextSpanRecord$Companion.__PIntrospectionData()' on a null object reference`
+//@OptimizedRecord
 data class TextSpanRecord(
   @Field override val text: String = "",
   @Field val children: List<TextSpanRecord>? = null,
@@ -236,6 +238,7 @@ data class TextSpanRecord(
   @Field override val shadow: TextShadowRecord? = null
 ) : Record, TextSpanStyle
 
+@OptimizedComposeProps
 data class TextProps(
   override val text: String = "",
   val spans: List<TextSpanRecord>? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
@@ -223,7 +223,7 @@ interface TextSpanStyle {
 }
 
 // TODO(@lukmccall): Figure out why it's crashing with `Attempt to invoke virtual method 'io.github.lukmccall.pika.PIntrospectionData expo.modules.ui.TextSpanRecord$Companion.__PIntrospectionData()' on a null object reference`
-//@OptimizedRecord
+// @OptimizedRecord
 data class TextSpanRecord(
   @Field override val text: String = "",
   @Field val children: List<TextSpanRecord>? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ToggleButtonView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ToggleButtonView.kt
@@ -16,6 +16,7 @@ import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class ToggleButtonColors(
@@ -27,6 +28,7 @@ data class ToggleButtonColors(
   @Field val disabledContentColor: Color? = null
 ) : Record
 
+@OptimizedComposeProps
 data class ToggleButtonProps(
   val checked: Boolean = false,
   val enabled: Boolean = true,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TooltipView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TooltipView.kt
@@ -23,9 +23,11 @@ import expo.modules.kotlin.views.ExpoComposeView
 import expo.modules.kotlin.views.FunctionalComposableScope
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 // --- PlainTooltipView ---
 
+@OptimizedComposeProps
 data class PlainTooltipViewProps(
   val containerColor: MutableState<Color?> = mutableStateOf(null),
   val contentColor: MutableState<Color?> = mutableStateOf(null),
@@ -45,6 +47,7 @@ class PlainTooltipView(context: Context, appContext: AppContext) :
 
 // --- RichTooltipView ---
 
+@OptimizedComposeProps
 data class RichTooltipViewProps(
   val containerColor: MutableState<Color?> = mutableStateOf(null),
   val contentColor: MutableState<Color?> = mutableStateOf(null),
@@ -66,6 +69,7 @@ class RichTooltipView(context: Context, appContext: AppContext) :
 
 // --- TooltipBoxView ---
 
+@OptimizedComposeProps
 data class TooltipBoxViewProps(
   val isPersistent: Boolean = false,
   val hasAction: Boolean? = null,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/Utils.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/Utils.kt
@@ -43,7 +43,7 @@ fun getImageVector(icon: String?): ImageVector? {
 }
 
 // TODO(@lukmccall): Make it work with introspectable
-//@Introspectable
+// @Introspectable
 data class GenericEventPayload1<T>(
   @Field val value: T
 ) : Record

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/Button.kt
@@ -21,6 +21,7 @@ import expo.modules.ui.compose
 import expo.modules.ui.shapeFromShapeRecord
 import java.io.Serializable
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 open class ButtonPressedEvent() : Record, Serializable
@@ -49,6 +50,7 @@ fun ContentPaddingRecord.toPaddingValues(): PaddingValues =
     bottom = bottom?.dp ?: ButtonDefaults.ContentPadding.calculateBottomPadding()
   )
 
+@OptimizedComposeProps
 data class ButtonProps(
   val colors: ButtonColors = ButtonColors(),
   val enabled: Boolean = true,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/button/FloatingActionButton.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/button/FloatingActionButton.kt
@@ -15,6 +15,7 @@ import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.compose
 import expo.modules.ui.findChildSlotView
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 enum class FloatingActionButtonVariant(val value: String) : Enumerable {
   SMALL("small"),
@@ -23,6 +24,7 @@ enum class FloatingActionButtonVariant(val value: String) : Enumerable {
   EXTENDED("extended")
 }
 
+@OptimizedComposeProps
 data class FloatingActionButtonProps(
   val variant: FloatingActionButtonVariant = FloatingActionButtonVariant.MEDIUM,
   val expanded: Boolean = true,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/icon/IconView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/icon/IconView.kt
@@ -36,6 +36,7 @@ import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.compose
 import expo.modules.kotlin.types.OptimizedRecord
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 data class Source(
@@ -45,6 +46,7 @@ data class Source(
   @Field val scale: Double = 1.0
 ) : Record
 
+@OptimizedComposeProps
 data class IconProps(
   val source: MutableState<Source?> = mutableStateOf(null),
   val tint: MutableState<Color?> = mutableStateOf(null),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuItem.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuItem.kt
@@ -14,6 +14,7 @@ import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.composeOrNull
 import expo.modules.ui.findChildSlotView
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 @OptimizedRecord
 class DropdownMenuItemColors : Record {
@@ -25,6 +26,7 @@ class DropdownMenuItemColors : Record {
   @Field val disabledTrailingIconColor: Color? = null
 }
 
+@OptimizedComposeProps
 data class DropdownMenuItemProps(
   val enabled: Boolean = true,
   val elementColors: DropdownMenuItemColors = DropdownMenuItemColors(),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuRecords.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/DropdownMenuRecords.kt
@@ -4,12 +4,14 @@ import android.graphics.Color
 import expo.modules.kotlin.types.Enumerable
 import expo.modules.kotlin.views.ComposeProps
 import expo.modules.ui.ModifierList
+import expo.modules.kotlin.views.OptimizedComposeProps
 
 enum class ActivationMethod(val value: String) : Enumerable {
   SINGLE_PRESS("singlePress"),
   LONG_PRESS("longPress")
 }
 
+@OptimizedComposeProps
 data class DropdownMenuProps(
   val activationMethod: ActivationMethod = ActivationMethod.SINGLE_PRESS,
   val expanded: Boolean = false,

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ExposedDropdownMenuBoxView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ExposedDropdownMenuBoxView.kt
@@ -8,7 +8,9 @@ import expo.modules.kotlin.views.FunctionalComposableScope
 import expo.modules.ui.ModifierList
 import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.ExposedDropdownMenuBoxComposableScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class ExposedDropdownMenuBoxProps(
   val expanded: Boolean = false,
   val modifiers: ModifierList = emptyList()

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ExposedDropdownMenuView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/menu/ExposedDropdownMenuView.kt
@@ -11,7 +11,9 @@ import expo.modules.ui.ModifierRegistry
 import expo.modules.ui.UIComposableScope
 import expo.modules.ui.composeOrNull
 import expo.modules.ui.exposedDropdownMenuBoxScope
+import expo.modules.kotlin.views.OptimizedComposeProps
 
+@OptimizedComposeProps
 data class ExposedDropdownMenuProps(
   val expanded: Boolean = false,
   val containerColor: Color? = null,


### PR DESCRIPTION
# Why

Improves the app startup by replacing reflection with compile-time introspection for compose props.

# How

- Introduces `@OptimizedComposeProps` annotation and a new `PropsParsingStrategy` sealed interface that chooses between compile-time introspection (via Pika) and Kotlin reflection for parsing Compose view
props
- Annotates all `ComposeProps` data classes across `expo-ui`, `expo-maps`, and `expo-mesh-gradient` with `@OptimizedComposeProps` so Pika generates introspection data at build time
- Replaces runtime `KClass.memberProperties` reflection with `PropsParsingStrategy`, which prefers Pika introspection when available and falls back to reflection otherwise
- Registers the new annotation in the Gradle plugin so Pika processes it alongside `@OptimizedRecord`. I've decided to register a new annotation, which basically does the same thing, but I think it's easier to understand for end users.

> Note: optimization of  `TextSpanRecord` is temporarily disabled due to a crash with Pika introspection on that class (see TODO in `TextView.kt`).

# Test Plan

expo-ui registration time:
Before (1s 600ms):
<img width="2052" height="368" alt="image" src="https://github.com/user-attachments/assets/d7381429-b407-46c5-944c-412dc5bf494d" />

After (169ms):
<img width="1644" height="460" alt="image" src="https://github.com/user-attachments/assets/e834a9c8-719c-425d-b7d5-aa08bf03f4f9" />

> Note: those times were measured in the debug build with traces. The release version of the app is working faster, but the ratio is very similar.   