### PR TITLE
[core][Android] Bump pika to `0.1.7`

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation workletsProject
   }
 
-  implementation("io.github.lukmccall.pika:pika-api:0.1.5-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-api:0.1.7-2.1.20")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-  implementation("io.github.lukmccall.pika:pika-gradle:0.1.5-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.1.7-2.1.20")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")


### PR DESCRIPTION
# Why

Bumps pika to `0.1.7`.
This version of the compiler plugin is slightly slower than the previous one. However, I've spent some time optimizing the memory footprint of the generated type descriptors, which seems to be beneficial in our use case

# Test Plan

- bare-expo ✅ 
 