### PR TITLE
[updates][Android] Improve application startup performance by reducing reflection usage

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/objects/ObjectDefinitionBuilder.kt
@@ -448,6 +448,7 @@ open class ObjectDefinitionBuilder(
     eventsDefinition = EventsDefinition(events)
   }
 
+  @Deprecated("Use Events(vararg String) or Events(Array<String>) instead. This version can cause app startup performance issues.")
   inline fun <reified T> Events() where T : Enumerable, T : Enum<T> {
     val primaryConstructor = T::class.fastPrimaryConstructor
     val events = if (primaryConstructor?.parameters?.size == 1) {

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 - Remove pin on `arg` dependency ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Fixed Updates E2E tests. ([#43995](https://github.com/expo/expo/pull/43995) by [@kudo](https://github.com/kudo))
-- [Android] Improved application startup performance by reducing reflection usage.
+- [Android] Improved application startup performance by reducing reflection usage. ([#45023](https://github.com/expo/expo/pull/45023) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.11 — 2026-02-25
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Remove pin on `arg` dependency ([#43456](https://github.com/expo/expo/pull/43456) by [@kitten](https://github.com/kitten))
 - Fixed Updates E2E tests. ([#43995](https://github.com/expo/expo/pull/43995) by [@kudo](https://github.com/kudo))
+- [Android] Improved application startup performance by reducing reflection usage.
 
 ## 55.0.11 — 2026-02-25
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesModule.kt
@@ -11,7 +11,6 @@ import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.types.Enumerable
 import expo.modules.updates.events.IUpdatesEventManagerObserver
 import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogEntry
@@ -26,9 +25,7 @@ import java.lang.ref.WeakReference
 import java.util.Date
 import expo.modules.kotlin.types.OptimizedRecord
 
-enum class UpdatesJSEvent(val eventName: String) : Enumerable {
-  StateChange("Expo.nativeUpdatesStateChangeEvent")
-}
+private const val UpdatesStateChangeEvent = "Expo.nativeUpdatesStateChangeEvent"
 
 /**
  * Exported module which provides to the JS runtime information about the currently running update
@@ -45,18 +42,18 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
   override fun definition() = ModuleDefinition {
     Name("ExpoUpdates")
 
-    Events<UpdatesJSEvent>()
+    Events(UpdatesStateChangeEvent)
 
     Constants {
       UpdatesLogger(context.filesDir).info("UpdatesModule: getConstants called", UpdatesErrorCode.None)
       UpdatesController.instance.getConstantsForModule().toModuleConstantsMap()
     }
 
-    OnStartObserving(UpdatesJSEvent.StateChange) {
+    OnStartObserving(UpdatesStateChangeEvent) {
       UpdatesController.setUpdatesEventManagerObserver(WeakReference(this@UpdatesModule))
     }
 
-    OnStopObserving(UpdatesJSEvent.StateChange) {
+    OnStopObserving(UpdatesStateChangeEvent) {
       UpdatesController.removeUpdatesEventManagerObserver()
     }
 
@@ -224,7 +221,7 @@ class UpdatesModule : Module(), IUpdatesEventManagerObserver {
   }
 
   override fun onStateMachineContextEvent(context: UpdatesStateContext) {
-    sendEvent(UpdatesJSEvent.StateChange, Bundle().apply { putBundle("context", context.bundle) })
+    sendEvent(UpdatesStateChangeEvent, Bundle().apply { putBundle("context", context.bundle) })
   }
 
   @OptimizedRecord


### PR DESCRIPTION
# Why

I've removed problematic event registration from `expo-updates`, so we no longer have to parse Kotlin metadata annotations during app startup.
Also, I've decided to deprecate the `Events<Enum>` DSL component, at least for now. We can reintroduce it later once I figure out a faster way to obtain a constructor

# Test Plan

- bare-expo ✅ 