### PR TITLE
[file-system] Add behavioral Jest mocks for class-based File/Directory/Paths API

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 ### 💡 Others
 
-- Add behavioral Jest mocks for the class-based `File` / `Directory` / `Paths` API, backed by an in-memory filesystem so tests can exercise create/write/read/move/copy/delete roundtrips without hand-rolling a `jest.mock`. ([@radko93](https://github.com/radko93))
+- Add behavioral Jest mocks for the class-based `File` / `Directory` / `Paths` API, backed by an in-memory filesystem so tests can exercise create/write/read/move/copy/delete roundtrips without hand-rolling a `jest.mock`. ([#45027](https://github.com/expo/expo/pull/45027) by [@radko93](https://github.com/radko93))
 - Deprecate `modificationTime` in favor of new `lastModified`, compatible with web `File` interface. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - Deprecate `File.pickFileAsync(arg1, arg2)` in favour of new `File.pickFileAsync(options)`. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Optimized performance of copy and move operations. ([#44357](https://github.com/expo/expo/pull/44357), [#44358](https://github.com/expo/expo/pull/44358) by [@barthap](https://github.com/barthap))

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### 💡 Others
 
+- Add behavioral Jest mocks for the class-based `File` / `Directory` / `Paths` API, backed by an in-memory filesystem so tests can exercise create/write/read/move/copy/delete roundtrips without hand-rolling a `jest.mock`. ([@radko93](https://github.com/radko93))
 - Deprecate `modificationTime` in favor of new `lastModified`, compatible with web `File` interface. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - Deprecate `File.pickFileAsync(arg1, arg2)` in favour of new `File.pickFileAsync(options)`. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Optimized performance of copy and move operations. ([#44357](https://github.com/expo/expo/pull/44357), [#44358](https://github.com/expo/expo/pull/44358) by [@barthap](https://github.com/barthap))

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -64,6 +64,7 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
+- Add behavioral Jest mocks for the class-based `File` / `Directory` / `Paths` API, backed by an in-memory filesystem so tests can exercise create/write/read/move/copy/delete roundtrips without hand-rolling a `jest.mock`. ([@radko93](https://github.com/radko93))
 - Deprecate `modificationTime` in favor of new `lastModified`, compatible with web `File` interface. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - Deprecate `File.pickFileAsync(arg1, arg2)` in favour of new `File.pickFileAsync(options)`. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Optimized performance of copy and move operations. ([#44357](https://github.com/expo/expo/pull/44357), [#44358](https://github.com/expo/expo/pull/44358) by [@barthap](https://github.com/barthap))

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -64,7 +64,7 @@ _This version does not introduce any user-facing changes._
 
 ### 💡 Others
 
-- Add behavioral Jest mocks for the class-based `File` / `Directory` / `Paths` API, backed by an in-memory filesystem so tests can exercise create/write/read/move/copy/delete roundtrips without hand-rolling a `jest.mock`. ([@radko93](https://github.com/radko93))
+- Add behavioral Jest mocks for the class-based `File` / `Directory` / `Paths` API, backed by an in-memory filesystem so tests can exercise create/write/read/move/copy/delete roundtrips without hand-rolling a `jest.mock`. ([#45027](https://github.com/expo/expo/pull/45027) by [@radko93](https://github.com/radko93))
 - Deprecate `modificationTime` in favor of new `lastModified`, compatible with web `File` interface. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - Deprecate `File.pickFileAsync(arg1, arg2)` in favour of new `File.pickFileAsync(options)`. ([#43411](https://github.com/expo/expo/pull/43411) by [@HubertBer](https://github.com/HubertBer))
 - [Android] Optimized performance of copy and move operations. ([#44357](https://github.com/expo/expo/pull/44357), [#44358](https://github.com/expo/expo/pull/44358) by [@barthap](https://github.com/barthap))

--- a/packages/expo-file-system/mocks/FileSystem.ts
+++ b/packages/expo-file-system/mocks/FileSystem.ts
@@ -1,82 +1,676 @@
+/**
+ * Hand-maintained mock for the FileSystem native module.
+ *
+ * Backs the class-based API (`File`, `Directory`, `Paths` from
+ * `expo-file-system`) with a small in-memory filesystem so tests can exercise
+ * create/write/read/move/copy/delete end-to-end. This module is what
+ * `jest-expo`'s preset feeds to `requireNativeModule('FileSystem')`.
+ *
+ * DO NOT regenerate this file with `expo-modules-test-core` — the generator
+ * emits a bare stub and will overwrite the behavior here. Same pattern as
+ * `packages/expo-crypto/mocks/ExpoCryptoAES.ts`.
+ */
+
 export type URL = string;
-
 export type FileSystemPath = any;
-
 export type DownloadOptions = any;
-
 export type InfoOptions = any;
-
 export type TypedArray = any;
-
 export type CreateOptions = any;
 
 export const documentDirectory = 'file:///mock/document/';
 export const cacheDirectory = 'file:///mock/cache/';
 export const bundleDirectory = 'file:///mock/bundle/';
-export const totalDiskSpace = 1000000000;
-export const availableDiskSpace = 500000000;
+export const appleSharedContainers: Record<string, string> = {};
+export const totalDiskSpace = 1_000_000_000;
+export const availableDiskSpace = 500_000_000;
 
-export function info(url: URL): any {}
+type Entry = {
+  kind: 'file' | 'dir';
+  bytes?: Uint8Array;
+  type?: string | null;
+  exists: boolean;
+};
 
-export async function downloadFileAsync(
-  url: URL,
-  to: FileSystemPath,
-  options: DownloadOptions | undefined,
-  uuid: string | undefined
-): Promise<any> {}
+const store = new Map<string, Entry>();
 
-export async function pickDirectoryAsync(initialUri?: string): Promise<any> {}
+const SEED_DIRS = [documentDirectory, cacheDirectory, bundleDirectory];
 
-export async function pickFileAsync(initialUri?: string, mimeType?: string): Promise<any> {}
+function seed() {
+  for (const uri of SEED_DIRS) {
+    store.set(normalizeKey(uri), { kind: 'dir', exists: true });
+  }
+}
 
-export function cancelDownloadAsync(uuid: string): void {}
+/**
+ * Test-only helper: reset the in-memory filesystem to a clean state with only
+ * the canonical `document`, `cache`, and `bundle` directories seeded.
+ * Call from a `beforeEach` to keep tests isolated.
+ */
+export function __resetMockFileSystem() {
+  store.clear();
+  listeners.clear();
+  cancelled.clear();
+  seed();
+}
+
+seed();
+
+function normalizeKey(uri: string): string {
+  return uri.endsWith('/') ? uri.slice(0, -1) : uri;
+}
+
+function basename(uri: string): string {
+  const key = normalizeKey(uri);
+  const i = key.lastIndexOf('/');
+  return i === -1 ? key : key.slice(i + 1);
+}
+
+function parentOf(uri: string): string {
+  const key = normalizeKey(uri);
+  const i = key.lastIndexOf('/');
+  return i === -1 ? '' : key.slice(0, i);
+}
+
+function joinUri(dir: string, name: string): string {
+  const base = normalizeKey(dir);
+  return `${base}/${name}`;
+}
+
+function utf8Encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function utf8Decode(b: Uint8Array): string {
+  return new TextDecoder('utf-8').decode(b);
+}
+
+function base64Encode(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+function base64Decode(str: string): Uint8Array {
+  return new Uint8Array(Buffer.from(str, 'base64'));
+}
+
+function fakeMd5(uri: string, size: number): string {
+  let h = 0x811c9dc5;
+  const src = `${uri}:${size}`;
+  for (let i = 0; i < src.length; i++) {
+    h = Math.imul(h ^ src.charCodeAt(i), 0x01000193);
+  }
+  const hex = (h >>> 0).toString(16).padStart(8, '0');
+  return hex.repeat(4).slice(0, 32);
+}
+
+const listeners = new Map<string, Set<(event: any) => void>>();
+const cancelled = new Set<string>();
+
+function emit(event: string, data: any) {
+  const set = listeners.get(event);
+  if (!set) return;
+  for (const fn of set) {
+    try {
+      fn(data);
+    } catch {
+      /* ignore listener errors in the mock */
+    }
+  }
+}
+
+export function addListener(event: string, handler: (data: any) => void) {
+  let set = listeners.get(event);
+  if (!set) {
+    set = new Set();
+    listeners.set(event, set);
+  }
+  set.add(handler);
+  return {
+    remove: () => {
+      set!.delete(handler);
+    },
+  };
+}
+
+export function info(uri: string): { exists: boolean; isDirectory: boolean | null } {
+  const entry = store.get(normalizeKey(uri));
+  if (!entry || !entry.exists) return { exists: false, isDirectory: null };
+  return { exists: true, isDirectory: entry.kind === 'dir' };
+}
+
+function assertParent(uri: string, allowMissing: boolean) {
+  const parent = normalizeKey(parentOf(uri));
+  if (!parent) return;
+  const entry = store.get(parent);
+  if (entry?.exists) return;
+  if (!allowMissing) {
+    throw new Error('Parent directory does not exist');
+  }
+  const missing: string[] = [];
+  let cursor = parent;
+  // Stop walking once we've peeled back to the scheme (e.g. "file://") so we
+  // don't seed nonsense keys above the root.
+  while (cursor && cursor.length >= 8 && !store.get(cursor)?.exists) {
+    missing.unshift(cursor);
+    const next = normalizeKey(parentOf(cursor));
+    if (next === cursor) break;
+    cursor = next;
+  }
+  for (const dirKey of missing) {
+    store.set(dirKey, { kind: 'dir', exists: true });
+  }
+}
+
 export class FileSystemFile {
   uri: string;
-  exists: boolean = false;
+
   constructor(uri: string) {
     this.uri = uri;
   }
-  validatePath(): any {}
-  textSync(): any {}
-  base64Sync(): any {}
-  bytesSync(): any {}
-  open(): any {}
-  info(options: InfoOptions | undefined): any {}
-  write(content: string | TypedArray): any {}
-  delete(): any {}
-  create(options: CreateOptions | undefined): any {}
-  async copy(to: FileSystemPath): Promise<any> {}
-  copySync(to: FileSystemPath): any {}
-  async move(to: FileSystemPath): Promise<any> {}
-  moveSync(to: FileSystemPath): any {}
-  rename(newName: string): any {}
-  async text(): Promise<any> {}
-  async base64(): Promise<any> {}
-  async bytes(): Promise<any> {}
+
+  validatePath(): void {}
+
+  get exists(): boolean {
+    const entry = store.get(normalizeKey(this.uri));
+    return !!(entry && entry.kind === 'file' && entry.exists);
+  }
+
+  get size(): number | null {
+    const entry = store.get(normalizeKey(this.uri));
+    return entry && entry.kind === 'file' && entry.exists ? (entry.bytes?.length ?? 0) : null;
+  }
+
+  get type(): string | null {
+    const entry = store.get(normalizeKey(this.uri));
+    return entry?.type ?? null;
+  }
+
+  get md5(): string | null {
+    return this.exists ? fakeMd5(this.uri, this.size ?? 0) : null;
+  }
+
+  create(options: { intermediates?: boolean; overwrite?: boolean } = {}): void {
+    const key = normalizeKey(this.uri);
+    const existing = store.get(key);
+    if (existing?.exists) {
+      if (!options.overwrite) {
+        throw new Error('File already exists');
+      }
+    }
+    assertParent(this.uri, !!options.intermediates);
+    store.set(key, { kind: 'file', bytes: new Uint8Array(0), exists: true });
+  }
+
+  write(
+    content: string | Uint8Array,
+    options: { append?: boolean; encoding?: 'utf8' | 'base64' } = {}
+  ): void {
+    assertParent(this.uri, false);
+    let bytes: Uint8Array;
+    if (typeof content === 'string') {
+      bytes = options.encoding === 'base64' ? base64Decode(content) : utf8Encode(content);
+    } else {
+      bytes = new Uint8Array(content);
+    }
+    const key = normalizeKey(this.uri);
+    if (options.append) {
+      const existing = store.get(key);
+      const prior = existing?.bytes ?? new Uint8Array(0);
+      const merged = new Uint8Array(prior.length + bytes.length);
+      merged.set(prior, 0);
+      merged.set(bytes, prior.length);
+      store.set(key, { kind: 'file', bytes: merged, exists: true });
+    } else {
+      store.set(key, { kind: 'file', bytes, exists: true });
+    }
+  }
+
+  private readBytesOrThrow(): Uint8Array {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'file' || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    return entry.bytes ?? new Uint8Array(0);
+  }
+
+  textSync(): string {
+    return utf8Decode(this.readBytesOrThrow());
+  }
+
+  base64Sync(): string {
+    return base64Encode(this.readBytesOrThrow());
+  }
+
+  bytesSync(): Uint8Array {
+    return new Uint8Array(this.readBytesOrThrow());
+  }
+
+  async text(): Promise<string> {
+    return this.textSync();
+  }
+
+  async base64(): Promise<string> {
+    return this.base64Sync();
+  }
+
+  async bytes(): Promise<Uint8Array> {
+    return this.bytesSync();
+  }
+
+  info(options: { md5?: boolean } = {}): any {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'file' || !entry.exists) {
+      return { exists: false, uri: this.uri };
+    }
+    const size = entry.bytes?.length ?? 0;
+    return {
+      exists: true,
+      uri: this.uri,
+      size,
+      ...(options.md5 ? { md5: fakeMd5(this.uri, size) } : {}),
+    };
+  }
+
+  open(mode: number | string = 0): FileSystemFileHandle {
+    const key = normalizeKey(this.uri);
+    const entry = store.get(key);
+    if (!entry || entry.kind !== 'file' || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    return new FileSystemFileHandle(key, mode);
+  }
+
+  delete(): void {
+    const key = normalizeKey(this.uri);
+    const entry = store.get(key);
+    if (!entry || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    store.delete(key);
+  }
+
+  private resolveDestination(destination: FileSystemFile | FileSystemDirectory): string {
+    if (destination instanceof FileSystemDirectory) {
+      return joinUri(destination.uri, basename(this.uri));
+    }
+    return normalizeKey(destination.uri);
+  }
+
+  copySync(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): void {
+    const srcKey = normalizeKey(this.uri);
+    const entry = store.get(srcKey);
+    if (!entry || entry.kind !== 'file' || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    const destKey = this.resolveDestination(destination);
+    const destExisting = store.get(destKey);
+    if (destExisting?.exists && !options.overwrite) {
+      throw new Error('Destination already exists');
+    }
+    assertParent(destKey, false);
+    store.set(destKey, {
+      kind: 'file',
+      bytes: new Uint8Array(entry.bytes ?? new Uint8Array(0)),
+      type: entry.type ?? null,
+      exists: true,
+    });
+  }
+
+  async copy(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): Promise<void> {
+    this.copySync(destination, options);
+  }
+
+  moveSync(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): void {
+    const srcKey = normalizeKey(this.uri);
+    this.copySync(destination, options);
+    const destKey = this.resolveDestination(destination);
+    if (destKey !== srcKey) {
+      store.delete(srcKey);
+    }
+    this.uri = destKey;
+  }
+
+  async move(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): Promise<void> {
+    this.moveSync(destination, options);
+  }
+
+  rename(newName: string): void {
+    const srcKey = normalizeKey(this.uri);
+    const entry = store.get(srcKey);
+    if (!entry || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    const destKey = joinUri(parentOf(this.uri), newName);
+    store.set(destKey, entry);
+    store.delete(srcKey);
+    this.uri = destKey;
+  }
 }
 
 export class FileSystemFileHandle {
-  readBytes(bytes: number): any {}
-  writeBytes(bytes: TypedArray): any {}
-  close(): any {}
+  private readonly key: string;
+  private readonly readOnly: boolean;
+  private readonly writeOnly: boolean;
+  private cursor: number;
+  private closed = false;
+
+  constructor(key: string, mode: number | string) {
+    this.key = key;
+    const modeStr = typeof mode === 'string' ? mode : MODE_NAMES[mode] ?? 'readwrite';
+    this.readOnly = modeStr === 'read';
+    this.writeOnly = modeStr === 'write';
+    const entry = store.get(key);
+    if (modeStr === 'truncate') {
+      store.set(key, { kind: 'file', bytes: new Uint8Array(0), exists: true });
+      this.cursor = 0;
+    } else if (modeStr === 'append') {
+      this.cursor = entry?.bytes?.length ?? 0;
+    } else {
+      this.cursor = 0;
+    }
+  }
+
+  private ensureOpen() {
+    if (this.closed) throw new Error('File handle is closed');
+  }
+
+  readBytes(count: number): Uint8Array {
+    this.ensureOpen();
+    if (this.writeOnly) throw new Error('File handle is write-only');
+    const entry = store.get(this.key);
+    const bytes = entry?.bytes ?? new Uint8Array(0);
+    const slice = bytes.slice(this.cursor, this.cursor + count);
+    this.cursor += slice.length;
+    return slice;
+  }
+
+  writeBytes(buffer: Uint8Array): void {
+    this.ensureOpen();
+    if (this.readOnly) throw new Error('File handle is read-only');
+    const entry = store.get(this.key) ?? { kind: 'file' as const, bytes: new Uint8Array(0), exists: true };
+    const prior = entry.bytes ?? new Uint8Array(0);
+    const newLength = Math.max(prior.length, this.cursor + buffer.length);
+    const merged = new Uint8Array(newLength);
+    merged.set(prior, 0);
+    merged.set(buffer, this.cursor);
+    store.set(this.key, { ...entry, kind: 'file', bytes: merged, exists: true });
+    this.cursor += buffer.length;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
 }
+
+// FileMode enum values from src/ExpoFileSystem.types.ts — keep as numbers but
+// map by name so callers using either work.
+const MODE_NAMES: Record<number, string> = {
+  0: 'readwrite',
+  1: 'read',
+  2: 'write',
+  3: 'append',
+  4: 'truncate',
+};
 
 export class FileSystemDirectory {
   uri: string;
-  exists: boolean = false;
+
   constructor(uri: string) {
     this.uri = uri;
   }
-  info(): any {}
-  validatePath(): any {}
-  delete(): any {}
-  create(options: CreateOptions | undefined): any {}
-  async copy(to: FileSystemPath): Promise<any> {}
-  copySync(to: FileSystemPath): any {}
-  async move(to: FileSystemPath): Promise<any> {}
-  moveSync(to: FileSystemPath): any {}
-  rename(newName: string): any {}
-  listAsRecords(): any {}
-  createFile(name: string, mimeType: string | null): any {}
-  createDirectory(name: string): any {}
+
+  validatePath(): void {}
+
+  get exists(): boolean {
+    const entry = store.get(normalizeKey(this.uri));
+    return !!(entry && entry.kind === 'dir' && entry.exists);
+  }
+
+  info(): any {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'dir' || !entry.exists) {
+      return { exists: false, uri: this.uri };
+    }
+    return {
+      exists: true,
+      uri: this.uri,
+      files: directChildren(this.uri).map((child) => child.uri),
+    };
+  }
+
+  create(
+    options: { intermediates?: boolean; idempotent?: boolean; overwrite?: boolean } = {}
+  ): void {
+    const key = normalizeKey(this.uri);
+    const existing = store.get(key);
+    if (existing?.exists) {
+      if (options.idempotent) return;
+      if (!options.overwrite) {
+        throw new Error('Directory already exists');
+      }
+      deleteSubtree(key);
+    }
+    assertParent(this.uri, !!options.intermediates);
+    store.set(key, { kind: 'dir', exists: true });
+  }
+
+  delete(): void {
+    const key = normalizeKey(this.uri);
+    const entry = store.get(key);
+    if (!entry || !entry.exists) {
+      throw new Error('Directory does not exist');
+    }
+    deleteSubtree(key);
+  }
+
+  listAsRecords(): { isDirectory: boolean; uri: string }[] {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'dir' || !entry.exists) {
+      throw new Error('Directory does not exist');
+    }
+    return directChildren(this.uri).map(({ uri, kind }) => ({
+      isDirectory: kind === 'dir',
+      uri,
+    }));
+  }
+
+  createFile(name: string, mimeType: string | null): FileSystemFile {
+    const parentKey = normalizeKey(this.uri);
+    const parent = store.get(parentKey);
+    if (!parent || parent.kind !== 'dir' || !parent.exists) {
+      throw new Error('Parent directory does not exist');
+    }
+    const childKey = joinUri(this.uri, name);
+    if (store.get(childKey)?.exists) {
+      throw new Error('File already exists');
+    }
+    store.set(childKey, {
+      kind: 'file',
+      bytes: new Uint8Array(0),
+      type: mimeType ?? null,
+      exists: true,
+    });
+    return new FileSystemFile(childKey);
+  }
+
+  createDirectory(name: string): FileSystemDirectory {
+    const parentKey = normalizeKey(this.uri);
+    const parent = store.get(parentKey);
+    if (!parent || parent.kind !== 'dir' || !parent.exists) {
+      throw new Error('Parent directory does not exist');
+    }
+    const childKey = joinUri(this.uri, name);
+    if (store.get(childKey)?.exists) {
+      throw new Error('Directory already exists');
+    }
+    store.set(childKey, { kind: 'dir', exists: true });
+    return new FileSystemDirectory(childKey);
+  }
+
+  private resolveDestination(destination: FileSystemFile | FileSystemDirectory): string {
+    if (destination instanceof FileSystemDirectory) {
+      return joinUri(destination.uri, basename(this.uri));
+    }
+    return normalizeKey(destination.uri);
+  }
+
+  copySync(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): void {
+    const srcKey = normalizeKey(this.uri);
+    const entry = store.get(srcKey);
+    if (!entry || entry.kind !== 'dir' || !entry.exists) {
+      throw new Error('Directory does not exist');
+    }
+    const destKey = this.resolveDestination(destination);
+    const destExisting = store.get(destKey);
+    if (destExisting?.exists && !options.overwrite) {
+      throw new Error('Destination already exists');
+    }
+    assertParent(destKey, false);
+    copySubtree(srcKey, destKey);
+  }
+
+  async copy(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): Promise<void> {
+    this.copySync(destination, options);
+  }
+
+  moveSync(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): void {
+    const srcKey = normalizeKey(this.uri);
+    this.copySync(destination, options);
+    const destKey = this.resolveDestination(destination);
+    if (destKey !== srcKey) {
+      deleteSubtree(srcKey);
+    }
+    this.uri = destKey;
+  }
+
+  async move(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): Promise<void> {
+    this.moveSync(destination, options);
+  }
+
+  rename(newName: string): void {
+    const srcKey = normalizeKey(this.uri);
+    const entry = store.get(srcKey);
+    if (!entry || !entry.exists) {
+      throw new Error('Directory does not exist');
+    }
+    const destKey = joinUri(parentOf(this.uri), newName);
+    copySubtree(srcKey, destKey);
+    deleteSubtree(srcKey);
+    this.uri = destKey;
+  }
+}
+
+function directChildren(dirUri: string): { uri: string; kind: 'file' | 'dir' }[] {
+  const prefix = `${normalizeKey(dirUri)}/`;
+  const result: { uri: string; kind: 'file' | 'dir' }[] = [];
+  for (const [key, entry] of store) {
+    if (!entry.exists || !key.startsWith(prefix)) continue;
+    const tail = key.slice(prefix.length);
+    if (tail.length === 0 || tail.includes('/')) continue;
+    result.push({ uri: key, kind: entry.kind });
+  }
+  return result;
+}
+
+function deleteSubtree(rootKey: string) {
+  const prefix = `${rootKey}/`;
+  const keys: string[] = [rootKey];
+  for (const key of store.keys()) {
+    if (key.startsWith(prefix)) keys.push(key);
+  }
+  for (const key of keys) store.delete(key);
+}
+
+function copySubtree(srcKey: string, destKey: string) {
+  const srcEntry = store.get(srcKey);
+  if (!srcEntry) return;
+  store.set(destKey, cloneEntry(srcEntry));
+  const prefix = `${srcKey}/`;
+  for (const [key, entry] of store) {
+    if (!key.startsWith(prefix)) continue;
+    const rewritten = destKey + key.slice(srcKey.length);
+    store.set(rewritten, cloneEntry(entry));
+  }
+}
+
+function cloneEntry(entry: Entry): Entry {
+  return {
+    kind: entry.kind,
+    exists: entry.exists,
+    type: entry.type ?? null,
+    bytes: entry.bytes ? new Uint8Array(entry.bytes) : undefined,
+  };
+}
+
+export async function downloadFileAsync(
+  url: URL,
+  to: { uri: string } | undefined,
+  options: any,
+  uuid: string | undefined
+): Promise<string> {
+  if (options?.signal?.aborted) {
+    const err = new Error(options.signal.reason ?? 'The operation was aborted.');
+    err.name = 'AbortError';
+    throw err;
+  }
+  const bytes = utf8Encode(`mock:${url}`);
+  const toUri = to?.uri ?? joinUri(cacheDirectory, basename(url));
+  const toEntry = store.get(normalizeKey(toUri));
+  const destKey = toEntry?.kind === 'dir' ? joinUri(toUri, basename(url)) : normalizeKey(toUri);
+
+  if (uuid) {
+    emit('downloadProgress', {
+      uuid,
+      data: { bytesWritten: bytes.length, totalBytes: bytes.length },
+    });
+  }
+
+  if (uuid && cancelled.has(uuid)) {
+    cancelled.delete(uuid);
+    const err = new Error('Download was cancelled.');
+    err.name = 'AbortError';
+    throw err;
+  }
+
+  store.set(destKey, { kind: 'file', bytes, exists: true });
+  return destKey;
+}
+
+export function cancelDownloadAsync(uuid: string): void {
+  cancelled.add(uuid);
+}
+
+export async function pickDirectoryAsync(_initialUri?: string): Promise<{ uri: string }> {
+  return { uri: 'file:///mock/picked/directory' };
+}
+
+export async function pickFileAsync(options?: any): Promise<any> {
+  if (options?.multipleFiles) {
+    return [{ uri: 'file:///mock/picked/file1.txt' }, { uri: 'file:///mock/picked/file2.txt' }];
+  }
+  return { uri: 'file:///mock/picked/file.txt' };
 }

--- a/packages/expo-file-system/mocks/FileSystem.ts
+++ b/packages/expo-file-system/mocks/FileSystem.ts
@@ -1,87 +1,592 @@
+/**
+ * Hand-maintained mock for the FileSystem native module.
+ *
+ * Backs the class-based API (`File`, `Directory`, `Paths` from
+ * `expo-file-system`) with a small in-memory filesystem so tests can exercise
+ * create/write/read/move/copy/delete end-to-end. This module is what
+ * `jest-expo`'s preset feeds to `requireNativeModule('FileSystem')`.
+ *
+ * DO NOT regenerate this file with `expo-modules-test-core` — the generator
+ * emits a bare stub and will overwrite the behavior here. Same pattern as
+ * `packages/expo-crypto/mocks/ExpoCryptoAES.ts`.
+ */
+
 export type URL = string;
-
 export type FileSystemPath = any;
-
 export type DownloadOptions = any;
-
 export type InfoOptions = any;
-
 export type TypedArray = any;
-
 export type CreateOptions = any;
 
 export const documentDirectory = 'file:///mock/document/';
 export const cacheDirectory = 'file:///mock/cache/';
 export const bundleDirectory = 'file:///mock/bundle/';
-export const totalDiskSpace = 1000000000;
-export const availableDiskSpace = 500000000;
+export const appleSharedContainers: Record<string, string> = {};
+export const totalDiskSpace = 1_000_000_000;
+export const availableDiskSpace = 500_000_000;
 
-export function info(url: URL): any {}
+type Entry = {
+  kind: 'file' | 'dir';
+  bytes?: Uint8Array;
+  type?: string | null;
+  exists: boolean;
+};
 
-export async function downloadFileAsync(
-  url: URL,
-  to: FileSystemPath,
-  options: DownloadOptions | undefined,
-  uuid: string | undefined
-): Promise<any> {}
+const store = new Map<string, Entry>();
 
-export async function pickDirectoryAsync(initialUri?: string): Promise<any> {}
+const SEED_DIRS = [documentDirectory, cacheDirectory, bundleDirectory];
 
-export async function pickFileAsync(initialUri?: string, mimeType?: string): Promise<any> {}
+function seed() {
+  for (const uri of SEED_DIRS) {
+    store.set(normalizeKey(uri), { kind: 'dir', exists: true });
+  }
+}
 
-export function cancelDownloadAsync(uuid: string): void {}
+/**
+ * Test-only helper: reset the in-memory filesystem to a clean state with only
+ * the canonical `document`, `cache`, and `bundle` directories seeded.
+ * Call from a `beforeEach` to keep tests isolated.
+ */
+export function __resetMockFileSystem() {
+  store.clear();
+  listeners.clear();
+  cancelled.clear();
+  seed();
+}
+
+seed();
+
+function normalizeKey(uri: string): string {
+  return uri.endsWith('/') ? uri.slice(0, -1) : uri;
+}
+
+function basename(uri: string): string {
+  const key = normalizeKey(uri);
+  const i = key.lastIndexOf('/');
+  return i === -1 ? key : key.slice(i + 1);
+}
+
+function parentOf(uri: string): string {
+  const key = normalizeKey(uri);
+  const i = key.lastIndexOf('/');
+  return i === -1 ? '' : key.slice(0, i);
+}
+
+function joinUri(dir: string, name: string): string {
+  const base = normalizeKey(dir);
+  return `${base}/${name}`;
+}
+
+function utf8Encode(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function utf8Decode(b: Uint8Array): string {
+  return new TextDecoder('utf-8').decode(b);
+}
+
+function base64Encode(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+function base64Decode(str: string): Uint8Array {
+  return new Uint8Array(Buffer.from(str, 'base64'));
+}
+
+function fakeMd5(uri: string, size: number): string {
+  let h = 0x811c9dc5;
+  const src = `${uri}:${size}`;
+  for (let i = 0; i < src.length; i++) {
+    h = Math.imul(h ^ src.charCodeAt(i), 0x01000193);
+  }
+  const hex = (h >>> 0).toString(16).padStart(8, '0');
+  return hex.repeat(4).slice(0, 32);
+}
+
+const listeners = new Map<string, Set<(event: any) => void>>();
+const cancelled = new Set<string>();
+
+function emit(event: string, data: any) {
+  const set = listeners.get(event);
+  if (!set) return;
+  for (const fn of set) {
+    try {
+      fn(data);
+    } catch {
+      /* ignore listener errors in the mock */
+    }
+  }
+}
+
+export function addListener(event: string, handler: (data: any) => void) {
+  let set = listeners.get(event);
+  if (!set) {
+    set = new Set();
+    listeners.set(event, set);
+  }
+  set.add(handler);
+  return {
+    remove: () => {
+      set!.delete(handler);
+    },
+  };
+}
+
+export function info(uri: string): { exists: boolean; isDirectory: boolean | null } {
+  const entry = store.get(normalizeKey(uri));
+  if (!entry || !entry.exists) return { exists: false, isDirectory: null };
+  return { exists: true, isDirectory: entry.kind === 'dir' };
+}
+
+function assertParent(uri: string, allowMissing: boolean) {
+  const parent = normalizeKey(parentOf(uri));
+  if (!parent) return;
+  const entry = store.get(parent);
+  if (entry?.exists) return;
+  if (!allowMissing) {
+    throw new Error('Parent directory does not exist');
+  }
+  const missing: string[] = [];
+  let cursor = parent;
+  // Stop walking once we've peeled back to the scheme (e.g. "file://") so we
+  // don't seed nonsense keys above the root.
+  while (cursor && cursor.length >= 8 && !store.get(cursor)?.exists) {
+    missing.unshift(cursor);
+    const next = normalizeKey(parentOf(cursor));
+    if (next === cursor) break;
+    cursor = next;
+  }
+  for (const dirKey of missing) {
+    store.set(dirKey, { kind: 'dir', exists: true });
+  }
+}
+
 export class FileSystemFile {
   uri: string;
-  exists: boolean = false;
+
   constructor(uri: string) {
     this.uri = uri;
   }
-  validatePath(): any {}
-  textSync(): any {}
-  base64Sync(): any {}
-  bytesSync(): any {}
-  open(): any {}
-  info(options: InfoOptions | undefined): any {}
-  write(content: string | TypedArray): any {}
-  delete(): any {}
-  create(options: CreateOptions | undefined): any {}
-  async copy(to: FileSystemPath): Promise<any> {}
-  copySync(to: FileSystemPath): any {}
-  async move(to: FileSystemPath): Promise<any> {}
-  moveSync(to: FileSystemPath): any {}
-  rename(newName: string): any {}
-  async text(): Promise<any> {}
-  async base64(): Promise<any> {}
-  async bytes(): Promise<any> {}
+
+  validatePath(): void {}
+
+  get exists(): boolean {
+    const entry = store.get(normalizeKey(this.uri));
+    return !!(entry && entry.kind === 'file' && entry.exists);
+  }
+
+  get size(): number | null {
+    const entry = store.get(normalizeKey(this.uri));
+    return entry && entry.kind === 'file' && entry.exists ? (entry.bytes?.length ?? 0) : null;
+  }
+
+  get type(): string | null {
+    const entry = store.get(normalizeKey(this.uri));
+    return entry?.type ?? null;
+  }
+
+  get md5(): string | null {
+    return this.exists ? fakeMd5(this.uri, this.size ?? 0) : null;
+  }
+
+  create(options: { intermediates?: boolean; overwrite?: boolean } = {}): void {
+    const key = normalizeKey(this.uri);
+    const existing = store.get(key);
+    if (existing?.exists) {
+      if (!options.overwrite) {
+        throw new Error('File already exists');
+      }
+    }
+    assertParent(this.uri, !!options.intermediates);
+    store.set(key, { kind: 'file', bytes: new Uint8Array(0), exists: true });
+  }
+
+  write(
+    content: string | Uint8Array,
+    options: { append?: boolean; encoding?: 'utf8' | 'base64' } = {}
+  ): void {
+    assertParent(this.uri, false);
+    let bytes: Uint8Array;
+    if (typeof content === 'string') {
+      bytes = options.encoding === 'base64' ? base64Decode(content) : utf8Encode(content);
+    } else {
+      bytes = new Uint8Array(content);
+    }
+    const key = normalizeKey(this.uri);
+    if (options.append) {
+      const existing = store.get(key);
+      const prior = existing?.bytes ?? new Uint8Array(0);
+      const merged = new Uint8Array(prior.length + bytes.length);
+      merged.set(prior, 0);
+      merged.set(bytes, prior.length);
+      store.set(key, { kind: 'file', bytes: merged, exists: true });
+    } else {
+      store.set(key, { kind: 'file', bytes, exists: true });
+    }
+  }
+
+  private readBytesOrThrow(): Uint8Array {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'file' || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    return entry.bytes ?? new Uint8Array(0);
+  }
+
+  textSync(): string {
+    return utf8Decode(this.readBytesOrThrow());
+  }
+
+  base64Sync(): string {
+    return base64Encode(this.readBytesOrThrow());
+  }
+
+  bytesSync(): Uint8Array {
+    return new Uint8Array(this.readBytesOrThrow());
+  }
+
+  async text(): Promise<string> {
+    return this.textSync();
+  }
+
+  async base64(): Promise<string> {
+    return this.base64Sync();
+  }
+
+  async bytes(): Promise<Uint8Array> {
+    return this.bytesSync();
+  }
+
+  info(options: { md5?: boolean } = {}): any {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'file' || !entry.exists) {
+      return { exists: false, uri: this.uri };
+    }
+    const size = entry.bytes?.length ?? 0;
+    return {
+      exists: true,
+      uri: this.uri,
+      size,
+      ...(options.md5 ? { md5: fakeMd5(this.uri, size) } : {}),
+    };
+  }
+
+  open(mode: number | string = 0): FileSystemFileHandle {
+    const key = normalizeKey(this.uri);
+    const entry = store.get(key);
+    if (!entry || entry.kind !== 'file' || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    return new FileSystemFileHandle(key, mode);
+  }
+
+  delete(): void {
+    const key = normalizeKey(this.uri);
+    const entry = store.get(key);
+    if (!entry || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    store.delete(key);
+  }
+
+  private resolveDestination(destination: FileSystemFile | FileSystemDirectory): string {
+    if (destination instanceof FileSystemDirectory) {
+      return joinUri(destination.uri, basename(this.uri));
+    }
+    return normalizeKey(destination.uri);
+  }
+
+  copySync(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): void {
+    const srcKey = normalizeKey(this.uri);
+    const entry = store.get(srcKey);
+    if (!entry || entry.kind !== 'file' || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    const destKey = this.resolveDestination(destination);
+    const destExisting = store.get(destKey);
+    if (destExisting?.exists && !options.overwrite) {
+      throw new Error('Destination already exists');
+    }
+    assertParent(destKey, false);
+    store.set(destKey, {
+      kind: 'file',
+      bytes: new Uint8Array(entry.bytes ?? new Uint8Array(0)),
+      type: entry.type ?? null,
+      exists: true,
+    });
+  }
+
+  async copy(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): Promise<void> {
+    this.copySync(destination, options);
+  }
+
+  moveSync(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): void {
+    const srcKey = normalizeKey(this.uri);
+    this.copySync(destination, options);
+    const destKey = this.resolveDestination(destination);
+    if (destKey !== srcKey) {
+      store.delete(srcKey);
+    }
+    this.uri = destKey;
+  }
+
+  async move(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): Promise<void> {
+    this.moveSync(destination, options);
+  }
+
+  rename(newName: string): void {
+    const srcKey = normalizeKey(this.uri);
+    const entry = store.get(srcKey);
+    if (!entry || !entry.exists) {
+      throw new Error('File does not exist');
+    }
+    const destKey = joinUri(parentOf(this.uri), newName);
+    store.set(destKey, entry);
+    store.delete(srcKey);
+    this.uri = destKey;
+  }
+
   watch(_callback: any, _options?: any): { remove: () => void } {
     return { remove: () => {} };
   }
 }
 
 export class FileSystemFileHandle {
-  readBytes(bytes: number): any {}
-  writeBytes(bytes: TypedArray): any {}
-  close(): any {}
+  private readonly key: string;
+  private readonly readOnly: boolean;
+  private readonly writeOnly: boolean;
+  private cursor: number;
+  private closed = false;
+
+  constructor(key: string, mode: number | string) {
+    this.key = key;
+    const modeStr = typeof mode === 'string' ? mode : MODE_NAMES[mode] ?? 'readwrite';
+    this.readOnly = modeStr === 'read';
+    this.writeOnly = modeStr === 'write';
+    const entry = store.get(key);
+    if (modeStr === 'truncate') {
+      store.set(key, { kind: 'file', bytes: new Uint8Array(0), exists: true });
+      this.cursor = 0;
+    } else if (modeStr === 'append') {
+      this.cursor = entry?.bytes?.length ?? 0;
+    } else {
+      this.cursor = 0;
+    }
+  }
+
+  private ensureOpen() {
+    if (this.closed) throw new Error('File handle is closed');
+  }
+
+  readBytes(count: number): Uint8Array {
+    this.ensureOpen();
+    if (this.writeOnly) throw new Error('File handle is write-only');
+    const entry = store.get(this.key);
+    const bytes = entry?.bytes ?? new Uint8Array(0);
+    const slice = bytes.slice(this.cursor, this.cursor + count);
+    this.cursor += slice.length;
+    return slice;
+  }
+
+  writeBytes(buffer: Uint8Array): void {
+    this.ensureOpen();
+    if (this.readOnly) throw new Error('File handle is read-only');
+    const entry = store.get(this.key) ?? { kind: 'file' as const, bytes: new Uint8Array(0), exists: true };
+    const prior = entry.bytes ?? new Uint8Array(0);
+    const newLength = Math.max(prior.length, this.cursor + buffer.length);
+    const merged = new Uint8Array(newLength);
+    merged.set(prior, 0);
+    merged.set(buffer, this.cursor);
+    store.set(this.key, { ...entry, kind: 'file', bytes: merged, exists: true });
+    this.cursor += buffer.length;
+  }
+
+  close(): void {
+    this.closed = true;
+  }
 }
+
+// FileMode enum values from src/ExpoFileSystem.types.ts — keep as numbers but
+// map by name so callers using either work.
+const MODE_NAMES: Record<number, string> = {
+  0: 'readwrite',
+  1: 'read',
+  2: 'write',
+  3: 'append',
+  4: 'truncate',
+};
 
 export class FileSystemDirectory {
   uri: string;
-  exists: boolean = false;
+
   constructor(uri: string) {
     this.uri = uri;
   }
-  info(): any {}
-  validatePath(): any {}
-  delete(): any {}
-  create(options: CreateOptions | undefined): any {}
-  async copy(to: FileSystemPath): Promise<any> {}
-  copySync(to: FileSystemPath): any {}
-  async move(to: FileSystemPath): Promise<any> {}
-  moveSync(to: FileSystemPath): any {}
-  rename(newName: string): any {}
-  listAsRecords(): any {}
-  createFile(name: string, mimeType: string | null): any {}
-  createDirectory(name: string): any {}
+
+  validatePath(): void {}
+
+  get exists(): boolean {
+    const entry = store.get(normalizeKey(this.uri));
+    return !!(entry && entry.kind === 'dir' && entry.exists);
+  }
+
+  info(): any {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'dir' || !entry.exists) {
+      return { exists: false, uri: this.uri };
+    }
+    return {
+      exists: true,
+      uri: this.uri,
+      files: directChildren(this.uri).map((child) => child.uri),
+    };
+  }
+
+  create(
+    options: { intermediates?: boolean; idempotent?: boolean; overwrite?: boolean } = {}
+  ): void {
+    const key = normalizeKey(this.uri);
+    const existing = store.get(key);
+    if (existing?.exists) {
+      if (options.idempotent) return;
+      if (!options.overwrite) {
+        throw new Error('Directory already exists');
+      }
+      deleteSubtree(key);
+    }
+    assertParent(this.uri, !!options.intermediates);
+    store.set(key, { kind: 'dir', exists: true });
+  }
+
+  delete(): void {
+    const key = normalizeKey(this.uri);
+    const entry = store.get(key);
+    if (!entry || !entry.exists) {
+      throw new Error('Directory does not exist');
+    }
+    deleteSubtree(key);
+  }
+
+  listAsRecords(): { isDirectory: boolean; uri: string }[] {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'dir' || !entry.exists) {
+      throw new Error('Directory does not exist');
+    }
+    return directChildren(this.uri).map(({ uri, kind }) => ({
+      isDirectory: kind === 'dir',
+      uri,
+    }));
+  }
+
+  createFile(name: string, mimeType: string | null): FileSystemFile {
+    const parentKey = normalizeKey(this.uri);
+    const parent = store.get(parentKey);
+    if (!parent || parent.kind !== 'dir' || !parent.exists) {
+      throw new Error('Parent directory does not exist');
+    }
+    const childKey = joinUri(this.uri, name);
+    if (store.get(childKey)?.exists) {
+      throw new Error('File already exists');
+    }
+    store.set(childKey, {
+      kind: 'file',
+      bytes: new Uint8Array(0),
+      type: mimeType ?? null,
+      exists: true,
+    });
+    return new FileSystemFile(childKey);
+  }
+
+  createDirectory(name: string): FileSystemDirectory {
+    const parentKey = normalizeKey(this.uri);
+    const parent = store.get(parentKey);
+    if (!parent || parent.kind !== 'dir' || !parent.exists) {
+      throw new Error('Parent directory does not exist');
+    }
+    const childKey = joinUri(this.uri, name);
+    if (store.get(childKey)?.exists) {
+      throw new Error('Directory already exists');
+    }
+    store.set(childKey, { kind: 'dir', exists: true });
+    return new FileSystemDirectory(childKey);
+  }
+
+  private resolveDestination(destination: FileSystemFile | FileSystemDirectory): string {
+    if (destination instanceof FileSystemDirectory) {
+      return joinUri(destination.uri, basename(this.uri));
+    }
+    return normalizeKey(destination.uri);
+  }
+
+  copySync(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): void {
+    const srcKey = normalizeKey(this.uri);
+    const entry = store.get(srcKey);
+    if (!entry || entry.kind !== 'dir' || !entry.exists) {
+      throw new Error('Directory does not exist');
+    }
+    const destKey = this.resolveDestination(destination);
+    const destExisting = store.get(destKey);
+    if (destExisting?.exists && !options.overwrite) {
+      throw new Error('Destination already exists');
+    }
+    assertParent(destKey, false);
+    copySubtree(srcKey, destKey);
+  }
+
+  async copy(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): Promise<void> {
+    this.copySync(destination, options);
+  }
+
+  moveSync(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): void {
+    const srcKey = normalizeKey(this.uri);
+    this.copySync(destination, options);
+    const destKey = this.resolveDestination(destination);
+    if (destKey !== srcKey) {
+      deleteSubtree(srcKey);
+    }
+    this.uri = destKey;
+  }
+
+  async move(
+    destination: FileSystemFile | FileSystemDirectory,
+    options: { overwrite?: boolean } = {}
+  ): Promise<void> {
+    this.moveSync(destination, options);
+  }
+
+  rename(newName: string): void {
+    const srcKey = normalizeKey(this.uri);
+    const entry = store.get(srcKey);
+    if (!entry || !entry.exists) {
+      throw new Error('Directory does not exist');
+    }
+    const destKey = joinUri(parentOf(this.uri), newName);
+    copySubtree(srcKey, destKey);
+    deleteSubtree(srcKey);
+    this.uri = destKey;
+  }
+
   watch(_callback: any, _options?: any): { remove: () => void } {
     return { remove: () => {} };
   }
@@ -134,4 +639,95 @@ export class FileSystemDownloadTask extends SharedObject {
     super.release();
   }
   cancel(): void {}
+}
+
+function directChildren(dirUri: string): { uri: string; kind: 'file' | 'dir' }[] {
+  const prefix = `${normalizeKey(dirUri)}/`;
+  const result: { uri: string; kind: 'file' | 'dir' }[] = [];
+  for (const [key, entry] of store) {
+    if (!entry.exists || !key.startsWith(prefix)) continue;
+    const tail = key.slice(prefix.length);
+    if (tail.length === 0 || tail.includes('/')) continue;
+    result.push({ uri: key, kind: entry.kind });
+  }
+  return result;
+}
+
+function deleteSubtree(rootKey: string) {
+  const prefix = `${rootKey}/`;
+  const keys: string[] = [rootKey];
+  for (const key of store.keys()) {
+    if (key.startsWith(prefix)) keys.push(key);
+  }
+  for (const key of keys) store.delete(key);
+}
+
+function copySubtree(srcKey: string, destKey: string) {
+  const srcEntry = store.get(srcKey);
+  if (!srcEntry) return;
+  store.set(destKey, cloneEntry(srcEntry));
+  const prefix = `${srcKey}/`;
+  for (const [key, entry] of store) {
+    if (!key.startsWith(prefix)) continue;
+    const rewritten = destKey + key.slice(srcKey.length);
+    store.set(rewritten, cloneEntry(entry));
+  }
+}
+
+function cloneEntry(entry: Entry): Entry {
+  return {
+    kind: entry.kind,
+    exists: entry.exists,
+    type: entry.type ?? null,
+    bytes: entry.bytes ? new Uint8Array(entry.bytes) : undefined,
+  };
+}
+
+export async function downloadFileAsync(
+  url: URL,
+  to: { uri: string } | undefined,
+  options: any,
+  uuid: string | undefined
+): Promise<string> {
+  if (options?.signal?.aborted) {
+    const err = new Error(options.signal.reason ?? 'The operation was aborted.');
+    err.name = 'AbortError';
+    throw err;
+  }
+  const bytes = utf8Encode(`mock:${url}`);
+  const toUri = to?.uri ?? joinUri(cacheDirectory, basename(url));
+  const toEntry = store.get(normalizeKey(toUri));
+  const destKey = toEntry?.kind === 'dir' ? joinUri(toUri, basename(url)) : normalizeKey(toUri);
+
+  if (uuid) {
+    emit('downloadProgress', {
+      uuid,
+      data: { bytesWritten: bytes.length, totalBytes: bytes.length },
+    });
+  }
+
+  if (uuid && cancelled.has(uuid)) {
+    cancelled.delete(uuid);
+    const err = new Error('Download was cancelled.');
+    err.name = 'AbortError';
+    throw err;
+  }
+
+  store.set(destKey, { kind: 'file', bytes, exists: true });
+  return destKey;
+}
+
+export function cancelDownloadAsync(uuid: string): void {
+  cancelled.add(uuid);
+}
+
+export async function pickDirectoryAsync(_initialUri?: string): Promise<{ uri: string }> {
+  return { uri: 'file:///mock/picked/directory' };
+}
+
+export async function pickFileAsync(options?: any): Promise<any> {
+  if (options?.multipleFiles) {
+    return [{ uri: 'file:///mock/picked/file1.txt' }, { uri: 'file:///mock/picked/file2.txt' }];
+  }
+  return { uri: 'file:///mock/picked/file.txt' };
 }

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -1,4 +1,9 @@
 import { File, Directory, Paths } from '../..';
+import { __resetMockFileSystem } from '../../mocks/FileSystem';
+
+beforeEach(() => {
+  __resetMockFileSystem();
+});
 
 describe('expo-file-system new API', () => {
   it('exports File, Directory, and Paths classes', () => {
@@ -66,20 +71,23 @@ describe('expo-file-system new API', () => {
     expect(typeof dir.moveSync).toBe('function');
   });
 
-  it('File copy and move return promises', () => {
+  it('File copy and move return promises', async () => {
     const file = new File(Paths.cache, 'test.txt');
+    file.create();
     const destination = new File(Paths.cache, 'destination.txt');
 
-    expect(file.copy(destination)).toBeInstanceOf(Promise);
-    expect(file.move(destination)).toBeInstanceOf(Promise);
+    await expect(file.copy(destination)).resolves.toBeUndefined();
+    await expect(file.move(destination, { overwrite: true })).resolves.toBeUndefined();
   });
 
-  it('Directory copy and move return promises', () => {
+  it('Directory copy and move return promises', async () => {
     const dir = new Directory(Paths.document, 'subdir');
+    dir.create();
     const destination = new Directory(Paths.document, 'destination');
+    destination.create();
 
-    expect(dir.copy(destination)).toBeInstanceOf(Promise);
-    expect(dir.move(destination)).toBeInstanceOf(Promise);
+    await expect(dir.copy(destination)).resolves.toBeUndefined();
+    await expect(dir.move(destination, { overwrite: true })).resolves.toBeUndefined();
   });
 
   it('File.parentDirectory returns a Directory', () => {
@@ -93,6 +101,168 @@ describe('expo-file-system new API', () => {
     const file = new File(Paths.cache, 'test.txt');
     expect(file.name).toBe('test.txt');
     expect(file.extension).toBe('.txt');
+  });
+});
+
+describe('expo-file-system behavioral mock', () => {
+  it('seeds canonical directories so Paths.*.exists is true', () => {
+    expect(Paths.cache.exists).toBe(true);
+    expect(Paths.document.exists).toBe(true);
+    expect(Paths.bundle.exists).toBe(true);
+  });
+
+  it('Directory.create flips exists from false to true', () => {
+    const dir = new Directory(Paths.cache, 'new-dir');
+    expect(dir.exists).toBe(false);
+    dir.create();
+    expect(dir.exists).toBe(true);
+  });
+
+  it('Directory.create throws when the directory already exists', () => {
+    const dir = new Directory(Paths.cache, 'already-there');
+    dir.create();
+    expect(() => dir.create()).toThrow();
+    expect(() => dir.create({ idempotent: true })).not.toThrow();
+  });
+
+  it('Directory.create({ intermediates }) creates missing ancestors', () => {
+    const nested = new Directory(Paths.cache, 'a', 'b', 'c');
+    expect(() => nested.create()).toThrow();
+    nested.create({ intermediates: true });
+    expect(nested.exists).toBe(true);
+    expect(new Directory(Paths.cache, 'a').exists).toBe(true);
+    expect(new Directory(Paths.cache, 'a', 'b').exists).toBe(true);
+  });
+
+  it('Directory.createFile returns a File that appears in list()', () => {
+    const dir = new Directory(Paths.cache, 'listing');
+    dir.create();
+    const file = dir.createFile('hello.txt', null);
+    expect(file).toBeInstanceOf(File);
+    expect(file.exists).toBe(true);
+
+    const children = dir.list();
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBeInstanceOf(File);
+    expect(children[0].uri).toBe(file.uri);
+  });
+
+  it('File.write(string) and File.text() roundtrip utf-8', async () => {
+    const file = new File(Paths.cache, 'hello.txt');
+    file.write('hello world');
+    expect(file.textSync()).toBe('hello world');
+    await expect(file.text()).resolves.toBe('hello world');
+  });
+
+  it('File.write(Uint8Array) and File.bytes() roundtrip byte-for-byte', async () => {
+    const file = new File(Paths.cache, 'bin.dat');
+    const payload = new Uint8Array([1, 2, 3, 4, 5]);
+    file.write(payload);
+    expect(Array.from(file.bytesSync())).toEqual([1, 2, 3, 4, 5]);
+    await expect(file.bytes()).resolves.toEqual(payload);
+  });
+
+  it('File.write with append option appends to existing bytes', () => {
+    const file = new File(Paths.cache, 'log.txt');
+    file.write('a');
+    file.write('b', { append: true });
+    file.write('c', { append: true });
+    expect(file.textSync()).toBe('abc');
+  });
+
+  it('File.write with base64 encoding decodes before storing', () => {
+    const file = new File(Paths.cache, 'encoded.txt');
+    file.write(Buffer.from('hello').toString('base64'), { encoding: 'base64' });
+    expect(file.textSync()).toBe('hello');
+  });
+
+  it('File.move updates this.uri and removes the source', async () => {
+    const source = new File(Paths.cache, 'source.txt');
+    source.write('payload');
+    const originalUri = source.uri;
+
+    const destDir = new Directory(Paths.cache, 'moved');
+    destDir.create();
+
+    await source.move(destDir);
+
+    expect(source.uri).not.toBe(originalUri);
+    expect(source.uri).toContain('moved/source.txt');
+    expect(source.exists).toBe(true);
+    expect(source.textSync()).toBe('payload');
+
+    const oldRef = new File(originalUri);
+    expect(oldRef.exists).toBe(false);
+  });
+
+  it('File.copy leaves the source intact and copies contents', async () => {
+    const source = new File(Paths.cache, 'copy-src.txt');
+    source.write('original');
+
+    const dest = new File(Paths.cache, 'copy-dest.txt');
+    await source.copy(dest);
+
+    expect(source.exists).toBe(true);
+    expect(dest.exists).toBe(true);
+    expect(dest.textSync()).toBe('original');
+
+    // Writing to the copy must not mutate the source.
+    dest.write('mutated');
+    expect(source.textSync()).toBe('original');
+    expect(dest.textSync()).toBe('mutated');
+  });
+
+  it('Directory.delete removes the directory and all descendants', () => {
+    const dir = new Directory(Paths.cache, 'doomed');
+    dir.create();
+    dir.createFile('a.txt', null).write('a');
+    const inner = dir.createDirectory('inner');
+    inner.createFile('b.txt', null).write('b');
+
+    dir.delete();
+
+    expect(dir.exists).toBe(false);
+    expect(new File(Paths.cache, 'doomed', 'a.txt').exists).toBe(false);
+    expect(new Directory(Paths.cache, 'doomed', 'inner').exists).toBe(false);
+    expect(new File(Paths.cache, 'doomed', 'inner', 'b.txt').exists).toBe(false);
+  });
+
+  it('File.delete throws when the file does not exist', () => {
+    const file = new File(Paths.cache, 'missing.txt');
+    expect(() => file.delete()).toThrow();
+  });
+
+  it('File.text throws when the file does not exist', async () => {
+    const file = new File(Paths.cache, 'nope.txt');
+    expect(() => file.textSync()).toThrow();
+    await expect(file.text()).rejects.toBeInstanceOf(Error);
+  });
+
+  it('two File instances at the same URI share state via the live getter', () => {
+    const a = new File(Paths.cache, 'shared.txt');
+    const b = new File(Paths.cache, 'shared.txt');
+    expect(a.exists).toBe(false);
+    expect(b.exists).toBe(false);
+
+    a.create();
+    expect(a.exists).toBe(true);
+    expect(b.exists).toBe(true);
+
+    b.delete();
+    expect(a.exists).toBe(false);
+    expect(b.exists).toBe(false);
+  });
+
+  it('File.downloadFileAsync writes bytes to the destination', async () => {
+    const destDir = new Directory(Paths.cache, 'downloads');
+    destDir.create();
+    const dest = new File(destDir, 'out.bin');
+
+    const result = await File.downloadFileAsync('https://example.com/foo.bin', dest);
+    expect(result).toBeInstanceOf(File);
+    expect(result.uri).toContain('downloads/out.bin');
+    expect(result.exists).toBe(true);
+    expect(result.textSync()).toBe('mock:https://example.com/foo.bin');
   });
 });
 

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -1,4 +1,9 @@
 import { DownloadTask, File, Directory, Paths, UploadTask } from '../..';
+import { __resetMockFileSystem } from '../../mocks/FileSystem';
+
+beforeEach(() => {
+  __resetMockFileSystem();
+});
 
 describe('expo-file-system new API', () => {
   it('exports File, Directory, Paths, and network task classes', () => {
@@ -68,20 +73,23 @@ describe('expo-file-system new API', () => {
     expect(typeof dir.moveSync).toBe('function');
   });
 
-  it('File copy and move return promises', () => {
+  it('File copy and move return promises', async () => {
     const file = new File(Paths.cache, 'test.txt');
+    file.create();
     const destination = new File(Paths.cache, 'destination.txt');
 
-    expect(file.copy(destination)).toBeInstanceOf(Promise);
-    expect(file.move(destination)).toBeInstanceOf(Promise);
+    await expect(file.copy(destination)).resolves.toBeUndefined();
+    await expect(file.move(destination, { overwrite: true })).resolves.toBeUndefined();
   });
 
-  it('Directory copy and move return promises', () => {
+  it('Directory copy and move return promises', async () => {
     const dir = new Directory(Paths.document, 'subdir');
+    dir.create();
     const destination = new Directory(Paths.document, 'destination');
+    destination.create();
 
-    expect(dir.copy(destination)).toBeInstanceOf(Promise);
-    expect(dir.move(destination)).toBeInstanceOf(Promise);
+    await expect(dir.copy(destination)).resolves.toBeUndefined();
+    await expect(dir.move(destination, { overwrite: true })).resolves.toBeUndefined();
   });
 
   it('File.parentDirectory returns a Directory', () => {
@@ -95,6 +103,168 @@ describe('expo-file-system new API', () => {
     const file = new File(Paths.cache, 'test.txt');
     expect(file.name).toBe('test.txt');
     expect(file.extension).toBe('.txt');
+  });
+});
+
+describe('expo-file-system behavioral mock', () => {
+  it('seeds canonical directories so Paths.*.exists is true', () => {
+    expect(Paths.cache.exists).toBe(true);
+    expect(Paths.document.exists).toBe(true);
+    expect(Paths.bundle.exists).toBe(true);
+  });
+
+  it('Directory.create flips exists from false to true', () => {
+    const dir = new Directory(Paths.cache, 'new-dir');
+    expect(dir.exists).toBe(false);
+    dir.create();
+    expect(dir.exists).toBe(true);
+  });
+
+  it('Directory.create throws when the directory already exists', () => {
+    const dir = new Directory(Paths.cache, 'already-there');
+    dir.create();
+    expect(() => dir.create()).toThrow();
+    expect(() => dir.create({ idempotent: true })).not.toThrow();
+  });
+
+  it('Directory.create({ intermediates }) creates missing ancestors', () => {
+    const nested = new Directory(Paths.cache, 'a', 'b', 'c');
+    expect(() => nested.create()).toThrow();
+    nested.create({ intermediates: true });
+    expect(nested.exists).toBe(true);
+    expect(new Directory(Paths.cache, 'a').exists).toBe(true);
+    expect(new Directory(Paths.cache, 'a', 'b').exists).toBe(true);
+  });
+
+  it('Directory.createFile returns a File that appears in list()', () => {
+    const dir = new Directory(Paths.cache, 'listing');
+    dir.create();
+    const file = dir.createFile('hello.txt', null);
+    expect(file).toBeInstanceOf(File);
+    expect(file.exists).toBe(true);
+
+    const children = dir.list();
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBeInstanceOf(File);
+    expect(children[0].uri).toBe(file.uri);
+  });
+
+  it('File.write(string) and File.text() roundtrip utf-8', async () => {
+    const file = new File(Paths.cache, 'hello.txt');
+    file.write('hello world');
+    expect(file.textSync()).toBe('hello world');
+    await expect(file.text()).resolves.toBe('hello world');
+  });
+
+  it('File.write(Uint8Array) and File.bytes() roundtrip byte-for-byte', async () => {
+    const file = new File(Paths.cache, 'bin.dat');
+    const payload = new Uint8Array([1, 2, 3, 4, 5]);
+    file.write(payload);
+    expect(Array.from(file.bytesSync())).toEqual([1, 2, 3, 4, 5]);
+    await expect(file.bytes()).resolves.toEqual(payload);
+  });
+
+  it('File.write with append option appends to existing bytes', () => {
+    const file = new File(Paths.cache, 'log.txt');
+    file.write('a');
+    file.write('b', { append: true });
+    file.write('c', { append: true });
+    expect(file.textSync()).toBe('abc');
+  });
+
+  it('File.write with base64 encoding decodes before storing', () => {
+    const file = new File(Paths.cache, 'encoded.txt');
+    file.write(Buffer.from('hello').toString('base64'), { encoding: 'base64' });
+    expect(file.textSync()).toBe('hello');
+  });
+
+  it('File.move updates this.uri and removes the source', async () => {
+    const source = new File(Paths.cache, 'source.txt');
+    source.write('payload');
+    const originalUri = source.uri;
+
+    const destDir = new Directory(Paths.cache, 'moved');
+    destDir.create();
+
+    await source.move(destDir);
+
+    expect(source.uri).not.toBe(originalUri);
+    expect(source.uri).toContain('moved/source.txt');
+    expect(source.exists).toBe(true);
+    expect(source.textSync()).toBe('payload');
+
+    const oldRef = new File(originalUri);
+    expect(oldRef.exists).toBe(false);
+  });
+
+  it('File.copy leaves the source intact and copies contents', async () => {
+    const source = new File(Paths.cache, 'copy-src.txt');
+    source.write('original');
+
+    const dest = new File(Paths.cache, 'copy-dest.txt');
+    await source.copy(dest);
+
+    expect(source.exists).toBe(true);
+    expect(dest.exists).toBe(true);
+    expect(dest.textSync()).toBe('original');
+
+    // Writing to the copy must not mutate the source.
+    dest.write('mutated');
+    expect(source.textSync()).toBe('original');
+    expect(dest.textSync()).toBe('mutated');
+  });
+
+  it('Directory.delete removes the directory and all descendants', () => {
+    const dir = new Directory(Paths.cache, 'doomed');
+    dir.create();
+    dir.createFile('a.txt', null).write('a');
+    const inner = dir.createDirectory('inner');
+    inner.createFile('b.txt', null).write('b');
+
+    dir.delete();
+
+    expect(dir.exists).toBe(false);
+    expect(new File(Paths.cache, 'doomed', 'a.txt').exists).toBe(false);
+    expect(new Directory(Paths.cache, 'doomed', 'inner').exists).toBe(false);
+    expect(new File(Paths.cache, 'doomed', 'inner', 'b.txt').exists).toBe(false);
+  });
+
+  it('File.delete throws when the file does not exist', () => {
+    const file = new File(Paths.cache, 'missing.txt');
+    expect(() => file.delete()).toThrow();
+  });
+
+  it('File.text throws when the file does not exist', async () => {
+    const file = new File(Paths.cache, 'nope.txt');
+    expect(() => file.textSync()).toThrow();
+    await expect(file.text()).rejects.toBeInstanceOf(Error);
+  });
+
+  it('two File instances at the same URI share state via the live getter', () => {
+    const a = new File(Paths.cache, 'shared.txt');
+    const b = new File(Paths.cache, 'shared.txt');
+    expect(a.exists).toBe(false);
+    expect(b.exists).toBe(false);
+
+    a.create();
+    expect(a.exists).toBe(true);
+    expect(b.exists).toBe(true);
+
+    b.delete();
+    expect(a.exists).toBe(false);
+    expect(b.exists).toBe(false);
+  });
+
+  it('File.downloadFileAsync writes bytes to the destination', async () => {
+    const destDir = new Directory(Paths.cache, 'downloads');
+    destDir.create();
+    const dest = new File(destDir, 'out.bin');
+
+    const result = await File.downloadFileAsync('https://example.com/foo.bin', dest);
+    expect(result).toBeInstanceOf(File);
+    expect(result.uri).toContain('downloads/out.bin');
+    expect(result.exists).toBe(true);
+    expect(result.textSync()).toBe('mock:https://example.com/foo.bin');
   });
 });
 


### PR DESCRIPTION
# Why

`packages/expo-file-system/mocks/FileSystem.ts` is what the `jest-expo` preset feeds to `requireNativeModule('FileSystem')` at test time. Today it exposes the correct surface — `FileSystemFile`, `FileSystemDirectory`, `FileSystemFileHandle`, the directory constants — but every method body is an empty stub returning `any`. That keeps consumer test files from crashing on *import*, but code that actually exercises `file.write(...)` / `file.text()` / `dir.list()` / copy / move / delete gets no behavior back.

Downstream RN projects using the class-based API (`new File(...)`, `new Directory(...)`, `Paths.cache`) from [`packages/expo-file-system/src/FileSystem.ts`](https://github.com/expo/expo/blob/main/packages/expo-file-system/src/FileSystem.ts) therefore can't unit-test anything non-trivial against `expo-file-system` without hand-rolling a `jest.mock` — and those hand-rolls drift out of sync with the real class shape each SDK.

The legacy procedural API already enjoys behavioral mocking via `jest-expo/src/preset/setup.js` (e.g. `downloadAsync` → `{md5:'md5', uri:'uri'}`). This brings the class-based API up to the same fidelity bar.

# How

Behavioral rewrite of `mocks/FileSystem.ts`, backed by an in-memory `Map<string, Entry>`:

- **`FileSystemFile`** / **`FileSystemDirectory`** — live `exists` / `size` / `type` getters reading from the store, so two instances at the same URI stay consistent after one creates or deletes. Error semantics match native (`create` throws on existing without `overwrite`, `Directory.create` honors `idempotent`, `copy`/`move` throw on existing destination, missing parent throws without `intermediates`).
- **`write(content, options?)`** supports `append`, `encoding: 'base64'`, and both `string` and `Uint8Array` payloads. `text()` / `base64()` / `bytes()` roundtrip.
- **`move`** updates `this.uri` in place so the caller's reference still points at the file at its new location.
- **`FileSystemFileHandle`** is a cursor over the stored bytes; honors the `FileMode` variants (`ReadOnly`, `WriteOnly`, `ReadWrite`, `Append`, `Truncate`).
- **`addListener`** is a tiny emitter so the real `File.downloadFileAsync` wrapper at `src/FileSystem.ts:172` doesn't blow up subscribing to `downloadProgress`.
- **`__resetMockFileSystem()`** — test-only helper that clears the store *and re-seeds* the canonical `cache` / `document` / `bundle` directories. Tests call this from `beforeEach`.

Follows the manually-maintained-mock pattern from [`packages/expo-crypto/mocks/ExpoCryptoAES.ts`](https://github.com/expo/expo/blob/main/packages/expo-crypto/mocks/ExpoCryptoAES.ts), with a banner warning not to regenerate the file via `expo-modules-test-core` (which would emit a bare stub and overwrite the behavior).

No `src/` changes. No `package.json` changes — `jest-expo`'s preset already auto-resolves `mocks/FileSystem.ts` via `requireNativeModule('FileSystem')` stack-walking, so consumers using the preset pick up the improved mock automatically with zero wiring.

# Test Plan

Extended `packages/expo-file-system/src/__tests__/FileSystem-test.native.ts` with a `behavioral mock` describe block covering:

- Canonical `Paths.{cache,document,bundle}.exists === true` after init and after `__resetMockFileSystem()`.
- `Directory.create` flips `exists`, throws on duplicate, idempotent + intermediates variants.
- `Directory.createFile` returns a `File` visible in `list()`.
- `File.write(string)` ↔ `text()` utf-8 roundtrip.
- `File.write(Uint8Array)` ↔ `bytes()` byte-for-byte roundtrip.
- `write({ append })` appends, `write(..., { encoding: 'base64' })` decodes.
- `File.move(dir)` updates `this.uri`, old URI reports `exists: false`.
- `File.copy` leaves source intact; writes to the copy don't mutate the source.
- `Directory.delete` removes the directory and every descendant recursively.
- `File.delete` / `File.text` throw on missing files.
- Two `File` instances at the same URI share state via the live getter.
- `File.downloadFileAsync` writes placeholder bytes to the destination and resolves to a `File`.

```
$ yarn test
Test Suites: 4 passed, 4 total
Tests:       70 passed, 70 total

$ yarn lint
(clean)

$ yarn build
(clean)
```

Also verified no regression in downstream consumers that pull `expo-file-system` through the preset:

- `packages/expo-asset`: 178 passed
- `packages/expo winter/fetch convertFormData`: 14 passed
- `packages/jest-expo`: 67 passed

# Checklist

- [x] I added a \`changelog.md\` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for \`npx expo prebuild\` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)