### PR TITLE
[expo-task-manager][Android] Flush orphaned task callbacks when HeadlessJsTask finishes (fixes cold-start background task hang)

### DIFF
--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Fixed background task execution failing with "Could not find TaskService module" due to broken `ModuleRegistryProvider.singletonModules()` lookup after `EXTaskService` was migrated from `EXSingletonModule` to `NSObject`. ([#44646](https://github.com/expo/expo/pull/44646) by [@xTMNTxRaphaelx](https://github.com/xTMNTxRaphaelx))
 - [Android] Preserve WorkManager cancellation semantics when a background task worker is cancelled. ([#44667](https://github.com/expo/expo/pull/44667) by [@chrfalch](https://github.com/chrfalch))- [Android] Prevent background task registration from replacing an already scheduled or running worker. ([#44663](https://github.com/expo/expo/pull/44663) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed a race when rescheduling background tasks concurrently. ([#44666](https://github.com/expo/expo/pull/44666) by [@chrfalch](https://github.com/chrfalch))
+- [Android] Complete the per-consumer `CompletableDeferred` when `executeTask` throws synchronously, so one failing consumer doesn't stall `awaitAll()`. ([#45029](https://github.com/expo/expo/pull/45029) by [@chocky335](https://github.com/chocky335))
 
 ### 💡 Others
 

--- a/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
+++ b/packages/expo-background-task/android/src/main/java/expo/modules/backgroundtask/BackgroundTaskScheduler.kt
@@ -240,6 +240,8 @@ object BackgroundTaskScheduler {
           }
         } catch (e: Exception) {
           Log.e(TAG, "Task failed: ${e.message}")
+          // Ensure awaitAll() doesn't stall on a consumer that threw before registering its callback.
+          taskCompletion.complete(Unit)
         }
         taskCompletion
       }

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Fixed JS timers hanging during background task execution on Android by registering with `HeadlessJsTaskContext`. ([#43821](https://github.com/expo/expo/pull/43821) by [@janicduplessis](https://github.com/janicduplessis))
+- [Android] Prevent background task hang when JS has no `AppRegistry` handler for `expo-task-manager` (e.g. the module is only imported from a lazy-loaded route). Bound the backing `HeadlessJsTask` to 2 minutes and flush any undelivered `TaskExecutionCallback`s on task finish, so native awaiters unblock instead of hanging until the OS kills the worker. ([#45029](https://github.com/expo/expo/pull/45029) by [@chocky335](https://github.com/chocky335))
 
 ### 💡 Others
 

--- a/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
+++ b/packages/expo-task-manager/android/src/main/java/expo/modules/taskManager/TaskService.java
@@ -31,6 +31,7 @@ import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.jstasks.HeadlessJsTaskConfig;
 import com.facebook.react.jstasks.HeadlessJsTaskContext;
+import com.facebook.react.jstasks.HeadlessJsTaskEventListener;
 import expo.modules.apploader.AppLoaderProvider;
 import expo.modules.apploader.HeadlessAppLoader;
 import expo.modules.core.interfaces.SingletonModule;
@@ -647,12 +648,17 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
     }
   }
 
+  // Bounds how long the HeadlessJsTask keeps JS alive. Finite so the worker
+  // can reschedule before the ~10-minute OS kill, and so a missing JS
+  // AppRegistry handler doesn't strand the task forever.
+  private static final long HEADLESS_TASK_TIMEOUT_MS = 2L * 60L * 1000L;
+
   private void invokeStartHeadlessTask(ReactContext reactContext, String appScopeKey) {
     HeadlessJsTaskContext headlessContext = HeadlessJsTaskContext.getInstance(reactContext);
     HeadlessJsTaskConfig taskConfig = new HeadlessJsTaskConfig(
       "expo-task-manager",
       new WritableNativeMap(),
-      0, // no timeout, managed by the task consumer
+      HEADLESS_TASK_TIMEOUT_MS,
       true // allow in foreground to avoid exceptions if app returns
     );
 
@@ -661,10 +667,49 @@ public class TaskService implements SingletonModule, TaskServiceInterface {
         int taskId = headlessContext.startTask(taskConfig);
         sHeadlessTaskIds.put(appScopeKey, taskId);
         Log.i(TAG, "Started headless task " + taskId + " to keep JS timers alive for '" + appScopeKey + "'");
+
+        headlessContext.addTaskEventListener(new HeadlessJsTaskEventListener() {
+          @Override
+          public void onHeadlessJsTaskStart(int id) {}
+
+          @Override
+          public void onHeadlessJsTaskFinish(int id) {
+            if (id != taskId) {
+              return;
+            }
+            headlessContext.removeTaskEventListener(this);
+            flushOrphanedTaskCallbacks(appScopeKey);
+          }
+        });
       } catch (Exception e) {
         Log.w(TAG, "Failed to start headless task: " + e.getMessage());
       }
     });
+  }
+
+  // Fails any TaskExecutionCallbacks whose events were never delivered to JS
+  // (e.g. AppRegistry had no handler for "expo-task-manager", or the headless
+  // task timed out). `sEvents[appScopeKey]` only retains undelivered events —
+  // `notifyTaskFinished` removes them on delivery.
+  private void flushOrphanedTaskCallbacks(String appScopeKey) {
+    List<String> pendingEvents = sEvents.get(appScopeKey);
+    if (pendingEvents == null || pendingEvents.isEmpty()) {
+      return;
+    }
+
+    // Copy because callback.onFinished may mutate sEvents through notifyTaskFinished.
+    List<String> snapshot = new ArrayList<>(pendingEvents);
+    for (String eventId : snapshot) {
+      TaskExecutionCallback callback = sTaskCallbacks.remove(eventId);
+      if (callback == null) {
+        continue;
+      }
+      Log.w(TAG, "Headless task finished without JS delivering event '" + eventId
+        + "' for '" + appScopeKey + "'. Check that expo-task-manager is imported at bundle entry.");
+      callback.onFinished(null);
+    }
+    sEvents.remove(appScopeKey);
+    mTasksAndEventsRepository.removeEvents(appScopeKey);
   }
 
   private void waitForReactContextAndStartTask(Context context, String appScopeKey) {


### PR DESCRIPTION
Fixes [#44882](https://github.com/expo/expo/issues/44882).

## Bug

On Android, `expo-background-task` hangs for ~10 min on a cold-start wake-up (until OOM-kill) and the next periodic run never fires.

Traced on a Pixel 9a API 36 emulator / New Architecture, `expo-task-manager@55.0.15` + `expo-background-task@55.0.17`:

```
BackgroundTaskConsumer: Executing task 'expo-background-refresh'
TaskService: Started headless task 1 to keep JS timers alive for '...'
ReactNativeJS: No task registered for key expo-task-manager    ← handler missing
[10 min silence, then OOM]
```

`AppRegistry.registerHeadlessTask("expo-task-manager", ...)` is module-level in `expo-task-manager` JS, so it only runs when the module is imported at bundle evaluation. `expo-router` apps that only call `defineTask` from a lazy route file don't import it in headless mode, so there's no handler. `runHeadlessTask` then logs the warning and (on Bridgeless) skips `NativeHeadlessJsTaskSupport.notifyTaskFinished`. `HeadlessJsTaskConfig` is built with `timeout=0` so the task never ends, and any native caller waiting on the per-event `TaskExecutionCallback` in `sTaskCallbacks` blocks until the OS kills the worker.

## Fix

In `TaskService.invokeStartHeadlessTask`:

- Set `HeadlessJsTaskConfig` timeout to 2 minutes (from infinite). Long enough for normal work, well under the OS's ~10-min kill so the worker can still reschedule.
- Attach a `HeadlessJsTaskEventListener`; on finish, `flushOrphanedTaskCallbacks(appScopeKey)` invokes and drops any `TaskExecutionCallback`s whose events are still in `sEvents[appScopeKey]` (undelivered). Native awaiters unblock.

Plus a small adjacent fix in `BackgroundTaskScheduler.runTasks`: complete the per-consumer `CompletableDeferred` when `executeTask` throws synchronously, so one failing consumer doesn't stall `awaitAll()`.

No iOS changes. +50 lines across 2 source files + 2 CHANGELOGs.

## Verified on-device

Pixel 9a API 36. Patched `expo-task-manager` and `expo-background-task` built from source via `expo.autolinking.buildFromSource`. Reproduction from #44882 repro app.

```
doWork: Running worker
runTasks: executing tasks for consumer of type expo-background-task
Started headless task 1 to keep JS timers alive for '...'
ReactNativeJS: No task registered for key expo-task-manager                    ← bug path hit
Headless task finished without JS delivering event '...' for '...'.            ← flush fires
BackgroundTaskScheduler: Task successfully finished
Enqueuing worker with identifier EXPO_BACKGROUND_WORKER and '15' minutes delay ← next run scheduled
WM-WorkerWrapper: Worker result SUCCESS
```

## Checklist

- [x] Behavior change, no public API. Docs n/a.
- [x] CHANGELOG updated for both packages.