### PR TITLE
fix(eslint-config-expo): Disable `no-useless-return` for TypeScript files

### DIFF
--- a/packages/eslint-config-expo/CHANGELOG.md
+++ b/packages/eslint-config-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Disable `no-useless-return` for TypeScript files ([#45031](https://github.com/expo/expo/pull/45031) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.0 — 2026-01-21

--- a/packages/eslint-config-expo/utils/typescript.js
+++ b/packages/eslint-config-expo/utils/typescript.js
@@ -47,6 +47,10 @@ module.exports = {
         // undefined variables, including types
         'no-undef': 'off',
 
+        // This conflicts with TypeScript's exhaustive branch checks, in case the return type allows `return;` via `undefined`
+        // "Function lacks ending return statement and ..."
+        'no-useless-return': 'off',
+
         // Prevent use of CJS `require` syntax unless importing assets to align with Metro behavior.
         '@typescript-eslint/no-require-imports': [
           'warn',


### PR DESCRIPTION
# Why

This conflicts with TypeScript's exhaustive branch check, and is a purely stylistic rule, which isn't needed in TypeScript. It guards against empty trailing `return;` statements. However, TypeScript sees implicit returns as risky and warns about it not being exhaustive.

As such, since this is the exact opposite recommendation as TypeScript's, and conflicts, we should disable this rule.

# How

- Disable `no-useless-return` for TypeScript files

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
