### PR TITLE
refactor(expo-modules-core): route AppContext uiRuntimeFactory through ObjC protocol

### DIFF
--- a/apps/bare-expo/modules/worklets-tester/ios/WorkletsTesterModule.swift
+++ b/apps/bare-expo/modules/worklets-tester/ios/WorkletsTesterModule.swift
@@ -2,32 +2,38 @@ import ExpoModulesCore
 import ExpoModulesWorklets
 
 public final class WorkletsTesterModule: Module {
+  // `_uiRuntime` is reached through `EXAppContextProtocol` — see
+  // `EXWorkletsUIRuntimeFactory.h` for the reason.
+  private var uiWorkletRuntime: WorkletRuntime? {
+    (appContext as? any EXAppContextProtocol)?._uiRuntime as? WorkletRuntime
+  }
+
   public func definition() -> ModuleDefinition {
     Name("WorkletsTesterModule")
 
     Function("executeWorklet") { (worklet: Worklet) in
-      guard let uiRuntime = try appContext?.uiRuntime as? WorkletRuntime else {
+      guard let uiRuntime = uiWorkletRuntime else {
         throw Exceptions.RuntimeLost()
       }
       worklet.execute(on: uiRuntime)
     }
 
     Function("scheduleWorklet") { (worklet: Worklet) in
-      guard let uiRuntime = try appContext?.uiRuntime as? WorkletRuntime else {
+      guard let uiRuntime = uiWorkletRuntime else {
         throw Exceptions.RuntimeLost()
       }
       worklet.schedule(on: uiRuntime)
     }
 
     Function("executeWorkletWithArgs") { (worklet: Worklet) in
-      guard let uiRuntime = try appContext?.uiRuntime as? WorkletRuntime else {
+      guard let uiRuntime = uiWorkletRuntime else {
         throw Exceptions.RuntimeLost()
       }
       worklet.execute(on: uiRuntime, arguments: [2026, "worklet", true])
     }
 
     Function("scheduleWorkletWithArgs") { (worklet: Worklet) in
-      guard let uiRuntime = try appContext?.uiRuntime as? WorkletRuntime else {
+      guard let uiRuntime = uiWorkletRuntime else {
         throw Exceptions.RuntimeLost()
       }
       worklet.schedule(on: uiRuntime, arguments: [2026, "worklet", true])

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🛠 Breaking changes
 
 - Bumped minimum iOS/tvOS version to 16.4, macOS to 13.4. ([#43296](https://github.com/expo/expo/pull/43296) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] `AppContext.uiRuntimeFactory` is now a `WorkletsUIRuntimeFactory` ObjC-protocol existential instead of a Swift closure. Callers that previously assigned a closure should now assign an instance of a class conforming to `WorkletsUIRuntimeFactory` (declared in `EXWorkletsUIRuntimeFactory.h`). Works around a Swift 6.3 bug that silently drops `AppContext` members with closure types referencing `NS_SWIFT_NAME`-bridged JSI types from the precompiled `.swiftinterface`. (by [@chrfalch](https://github.com/chrfalch))
+- [iOS] `AppContext.uiRuntimeFactory` is now a `WorkletsUIRuntimeFactory` ObjC-protocol existential instead of a Swift closure. Callers that previously assigned a closure should now assign an instance of a class conforming to `WorkletsUIRuntimeFactory` (declared in `EXWorkletsUIRuntimeFactory.h`). Works around a Swift 6.3 bug that silently drops `AppContext` members with closure types referencing `NS_SWIFT_NAME`-bridged JSI types from the precompiled `.swiftinterface`. (by [@chrfalch](https://github.com/chrfalch)) ([#45032](https://github.com/expo/expo/pull/45032) by [@chrfalch](https://github.com/chrfalch))
 
 ### 🎉 New features
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🛠 Breaking changes
 
 - Bumped minimum iOS/tvOS version to 16.4, macOS to 13.4. ([#43296](https://github.com/expo/expo/pull/43296) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] `AppContext.uiRuntimeFactory` is now a `WorkletsUIRuntimeFactory` ObjC-protocol existential instead of a Swift closure. Callers that previously assigned a closure should now assign an instance of a class conforming to `WorkletsUIRuntimeFactory` (declared in `EXWorkletsUIRuntimeFactory.h`). Works around a Swift 6.3 bug that silently drops `AppContext` members with closure types referencing `NS_SWIFT_NAME`-bridged JSI types from the precompiled `.swiftinterface`. (by [@chrfalch](https://github.com/chrfalch))
 
 ### 🎉 New features
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -92,11 +92,14 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
     }
   }
 
-  /** 
-   Hook for ExpoModulesWorklets to register the UI runtime installer.
-   When set, the `installOnUIRuntime` function in CoreModule will use this to create the worklet runtime.
+  /**
+   Hook for registering a UI-runtime factory (typically provided by
+   `ExpoModulesWorklets` when `react-native-worklets` is installed).
+   When set, `installOnUIRuntime` in `CoreModule` uses it to create
+   the worklet runtime. See `EXWorkletsUIRuntimeFactory.h` for why the
+   hook is an ObjC protocol existential instead of a Swift closure.
   */
-  nonisolated(unsafe) public static var uiRuntimeFactory: ((_ appContext: AppContext, _ pointerValue: JavaScriptValue, _ runtime: JavaScriptRuntime) throws -> JavaScriptRuntime)?
+  nonisolated(unsafe) public static var uiRuntimeFactory: (any WorkletsUIRuntimeFactory)?
 
   @objc
   public var _uiRuntime: JavaScriptRuntime? {

--- a/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/CoreModule.swift
@@ -60,7 +60,10 @@ internal final class CoreModule: Module {
 
       let block = {
         do {
-          let uiRuntime = try factory(appContext, pointerHolder, runtime)
+          let uiRuntime = try factory.createUIRuntime(
+            pointerValue: pointerHolder,
+            runtime: runtime
+          )
           appContext._uiRuntime = uiRuntime
         } catch {
           errorHolder.error = error

--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -13,6 +13,7 @@
 #import <ExpoModulesCore/ExpoFabricViewObjC.h>
 #import <ExpoModulesCore/EXAppContextProtocol.h>
 #import <ExpoModulesCore/EXReactDelegateProtocol.h>
+#import <ExpoModulesCore/EXWorkletsUIRuntimeFactory.h>
 #import <ExpoModulesCore/EXCameraInterface.h>
 #import <ExpoModulesCore/EXConstantsInterface.h>
 #import <ExpoModulesCore/EXFaceDetectorManagerInterface.h>

--- a/packages/expo-modules-core/ios/Protocols/EXAppContextProtocol.h
+++ b/packages/expo-modules-core/ios/Protocols/EXAppContextProtocol.h
@@ -3,6 +3,7 @@
 #import <Foundation/Foundation.h>
 
 @class EXJavaScriptObject;
+@class EXJavaScriptRuntime;
 @class EXModuleRegistry;
 @class EXModulesProxyConfig;
 @class EXRuntime;
@@ -29,6 +30,15 @@ typedef void (NS_SWIFT_SENDABLE ^EXPromiseRejectBlock)(NSString * _Nullable code
  Underlying JSI runtime of the running app.
  */
 @property(nonatomic, strong, nullable) EXRuntime *_runtime;
+
+/**
+ Secondary JavaScript runtime (typically the Worklets UI runtime) installed
+ via `AppContext.uiRuntimeFactory`. Exposed on the ObjC protocol so
+ precompiled-xcframework consumers can reach it — see
+ `EXWorkletsUIRuntimeFactory.h`. `readonly` because writes must go through
+ the Swift setter to fire its `didSet` hook.
+ */
+@property(nonatomic, strong, readonly, nullable) EXJavaScriptRuntime *_uiRuntime;
 
 /**
  The application identifier used to distinguish between different RCTHost.

--- a/packages/expo-modules-core/ios/Protocols/EXWorkletsUIRuntimeFactory.h
+++ b/packages/expo-modules-core/ios/Protocols/EXWorkletsUIRuntimeFactory.h
@@ -1,0 +1,46 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+@class EXJavaScriptValue;
+@class EXJavaScriptRuntime;
+
+/**
+ Protocol for installing a secondary JavaScript runtime (typically the
+ Worklets UI runtime) into an `AppContext`. Register a conforming
+ instance via `AppContext.uiRuntimeFactory`. `ExpoModulesWorklets`
+ provides one automatically when `react-native-worklets` is installed.
+
+ ## Why this is declared in Objective-C
+
+ When `ExpoModulesCore` ships as a precompiled xcframework, its Swift
+ module is published as a `.swiftinterface` file that consumers re-parse
+ to rebuild the `AppContext` member table. Swift 6.3 has a race in that
+ rebuild: members whose signature mentions `NS_SWIFT_NAME`-bridged ObjC
+ types (`JavaScriptValue`, `JavaScriptRuntime`, etc. from the
+ `ExpoModulesCore.ExpoModulesJSI` submodule) may be walked before the
+ submodule has materialized those aliases. When the type lookup fails,
+ **the whole member is dropped silently** — the consumer then sees
+ "type 'AppContext' has no member 'uiRuntimeFactory'" even though the
+ declaration is right there in the interface file.
+
+ Routing the hook through an `@objc` protocol declared in an ObjC
+ header sidesteps the bug: clang's module bridge resolves the protocol
+ before Swift walks `AppContext`'s member table, the stored-property
+ type (`(any WorkletsUIRuntimeFactory)?`) doesn't itself mention any
+ `NS_SWIFT_NAME`-bridged type, and the JSI types only appear inside the
+ protocol's method signature (which isn't part of the `AppContext`
+ member-table lookup).
+
+ This is the canonical explanation of the workaround. Other references
+ to it (see `EXAppContextProtocol.h`, `AppContext.swift`) point here.
+ */
+NS_SWIFT_NAME(WorkletsUIRuntimeFactory)
+@protocol EXWorkletsUIRuntimeFactory <NSObject>
+
+- (nullable EXJavaScriptRuntime *)createUIRuntimeWithPointerValue:(nonnull EXJavaScriptValue *)pointerValue
+                                                          runtime:(nonnull EXJavaScriptRuntime *)runtime
+                                                            error:(NSError * _Nullable * _Nullable)error
+    NS_SWIFT_NAME(createUIRuntime(pointerValue:runtime:));
+
+@end

--- a/packages/expo-modules-core/ios/Worklets/Core/WorkletIntegration.swift
+++ b/packages/expo-modules-core/ios/Worklets/Core/WorkletIntegration.swift
@@ -7,12 +7,19 @@ import ExpoModulesCore
 @objc(EXWorkletIntegration)
 public final class WorkletIntegration: NSObject {
   @objc public static func register() {
-    AppContext.uiRuntimeFactory = { _, pointerValue, runtime in
-      guard let pointer = WorkletRuntimeFactory.extractRuntimePointer(pointerValue, runtime: runtime) else {
-        throw WorkletRuntimePointerExtractionException()
-      }
-      return WorkletRuntimeFactory.createWorkletRuntime(fromPointer: pointer)
+    AppContext.uiRuntimeFactory = DefaultWorkletsUIRuntimeFactory()
+  }
+}
+
+internal final class DefaultWorkletsUIRuntimeFactory: NSObject, WorkletsUIRuntimeFactory {
+  func createUIRuntime(
+    pointerValue: JavaScriptValue,
+    runtime: JavaScriptRuntime
+  ) throws -> JavaScriptRuntime {
+    guard let pointer = WorkletRuntimeFactory.extractRuntimePointer(pointerValue, runtime: runtime) else {
+      throw WorkletRuntimePointerExtractionException()
     }
+    return WorkletRuntimeFactory.createWorkletRuntime(fromPointer: pointer)
   }
 }
 

--- a/packages/expo-ui/ios/State/WorkletCallback.swift
+++ b/packages/expo-ui/ios/State/WorkletCallback.swift
@@ -18,7 +18,7 @@ internal final class WorkletCallback: SharedObject {
       #endif
       return
     }
-    guard let runtime = appContext?._uiRuntime as? WorkletRuntime else {
+    guard let runtime = (appContext as? any EXAppContextProtocol)?._uiRuntime as? WorkletRuntime else {
       #if DEBUG
       log.warn("WorkletCallback.invoke: UI worklet runtime is not available, the callback will not run.")
       #endif

--- a/packages/expo-ui/spm.config.json
+++ b/packages/expo-ui/spm.config.json
@@ -11,7 +11,8 @@
         "ReactNativeDependencies",
         "React",
         "Hermes",
-        "expo-modules-core/ExpoModulesCore"
+        "expo-modules-core/ExpoModulesCore",
+        "expo-modules-core/ExpoModulesWorklets"
       ],
       "targets": [
         {
@@ -43,6 +44,7 @@
             "React",
             "ReactNativeDependencies",
             "expo-modules-core/ExpoModulesCore",
+            "expo-modules-core/ExpoModulesWorklets",
             "ExpoUI_ios_objc"
           ],
           "linkedFrameworks": [


### PR DESCRIPTION
# Why

With Swift 6.3, when ExpoModulesCore is consumed from a precompiled xcframework, AppContext members that reference NS_SWIFT_NAME-bridged JSI types can be dropped from the generated member table. This caused uiRuntimeFactory to disappear for some consumers. AppContext.uiRuntimeFactory was a Swift closure.

This PR is a pre-requisite for making `expo-ui` build with XCFrameworks. To fully support this we need to refactor ExpoModulesWorklets to stop using conditional defines - this will be fixed in a followup-pr.

# How

To avoid that, this PR routes the hook through an ObjC protocol type instead of a Swift closure.

Declaring the hook as an `@objc` protocol in `EXWorkletsUIRuntimeFactory.h` resolves it through the clang module bridge instead.

- New `EXWorkletsUIRuntimeFactory.h` ObjC protocol with the canonical explanation of the workaround.
- Expose `_uiRuntime` on `EXAppContextProtocol` so xcframework consumers can reach it through the ObjC bridge.
- `WorkletIntegration` registers a `WorkletsUIRuntimeFactory`-conforming adapter that still dispatches to the existing `WorkletRuntimeFactory` implementation — behavior unchanged.
- Update `WorkletCallback` / `WorkletsTesterModule` to read `_uiRuntime` via `EXAppContextProtocol` rather than the Swift `AppContext` surface.

# Test Plan

✅ Build Bare-Expo with/without precompiled XCFrameworks
✅ Run pod-install on native-tester with/without precompiled
✅ Run pod-install on minimal-tester with/without precompiled

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
