### PR TITLE
chore: remove `workspaces` property from root `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,6 @@
     "lint": "eslint .",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1"
   },
-  "workspaces": {
-    "packages": [
-      "apps/*",
-      "apps/brownfield-tester/*",
-      "packages/*",
-      "packages/@expo/*"
-    ]
-  },
   "resolutions": {
     "react": "19.2.3",
     "react-dom": "19.2.3",


### PR DESCRIPTION
# Why

The `workspaces` property was used by Yarn; since we're now using pnpm, we now configure workspaces in `pnpm-workspace.yaml` instead.

# How

Removed `workspaces` from the root `package.json`.

# Test Plan

- CI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
