### PR TITLE
[expo-cli] Rewrite @react-navigation/core to expo-router for library compatibility

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Show Xcode build progress bar in interactive terminals with retry logic for concurrent build DB lock failures. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))
 - Enable parallel CocoaPods code signing to speed up device builds. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))
 - Prompt before clearing native folders when we detect project as a native module ([#44458](https://github.com/expo/expo/pull/44458) by [@kitten](https://github.com/kitten))
+- Rewrite @react-navigation/core to expo-router for library compatibility ([#45039](https://github.com/expo/expo/pull/45039) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -198,6 +198,8 @@ export function withExtendedResolver(
     },
   };
 
+  const isExpoRouterResolvable = !!resolveFrom.silent(config.projectRoot, 'expo-router');
+
   let _universalAliases: [RegExp, string][] | null;
 
   function getUniversalAliases() {
@@ -678,6 +680,21 @@ export function withExtendedResolver(
         if (webModalModule) {
           debug('Using `_unstable-web-modal` implementation.');
           return webModalModule;
+        }
+      }
+
+      // TODO(@ubax): Remove this rewrite once we published migration guide for library authors
+      if (moduleName.startsWith('@react-navigation/') && isExpoRouterResolvable) {
+        const filePath = context.originModulePath;
+        if (!filePath.includes('node_modules')) {
+          // TODO(@ubax): Add link to migration guide, once it is published
+          throw new Error(
+            'As of SDK 56, expo-router is no longer compatible with react-navigation. For more information, see [MIGRATION_GUIDE_URL].'
+          );
+        }
+        if (moduleName === '@react-navigation/core') {
+          // We already checked if expo-router resolves
+          return doResolve('expo-router');
         }
       }
 


### PR DESCRIPTION
# Why

To make the migration to SDK 56 smoother, we want to avoid requiring changes in libraries that use `react-navigation`. For this reason, I’d like to add a rewrite from `@react-navigation/core` to `expo-router`.

For v56, all our exports will be compatible with `@react-navigation/core`, so this approach will be safe.

Once the migration guide is published, I’ll replace the placeholder with the actual link:
https://linear.app/expo/issue/ENG-20759/add-a-link-to-migration-guide-to-metro-error

# How

1. Detect if the imported module is `@react-navigation/core`
2. Check whether `expo-router` can be resolved
3. If the import originates from a library (`node_modules`), rewrite it to expo-router
4. Otherwise, throw an error to force the user to migrate their code

# Test Plan

Using the CLI in separate project

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
