### PR TITLE
[ci] Upload xcresult artifact from iOS unit tests

### DIFF
--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -90,3 +90,9 @@ jobs:
           FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 30
           FASTLANE_XCODEBUILD_SETTINGS_RETRIES: 8
         run: pnpm expotools native-unit-tests --platform ios
+      - name: 📤 Upload xcresult
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-unit-tests-results
+          path: /tmp/ios-unit-tests-results

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -168,11 +168,16 @@ platform :ios do
   lane :unit_tests do |options|
     workspace = "apps/native-tests/ios/NativeTests.xcworkspace"
 
+    result_bundle_path = "/tmp/ios-unit-tests-results/results.xcresult"
+
     generated_scheme = generate_test_scheme(
       scheme_name: 'NativeTests',
       workspace_path: workspace,
       targets: options[:targets]
     )
+
+    # xcodebuild fails if the result bundle already exists at the given path.
+    FileUtils.rm_rf(result_bundle_path)
 
     run_tests(
       workspace: workspace,
@@ -186,6 +191,8 @@ platform :ios do
       skip_detect_devices: false,
       skip_package_dependencies_resolution: true,
       derived_data_path: "/tmp/ExpoUnitTestsDerivedData",
+      result_bundle: true,
+      result_bundle_path: result_bundle_path,
       xcargs: 'CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO',
     )
   end


### PR DESCRIPTION
## Summary
- Configure Fastlane to produce a result bundle at a known path (`/tmp/ios-unit-tests-results.xcresult`)
- Upload the xcresult as a GitHub Actions artifact after the iOS unit tests run

## Test plan
- [x] Verify the xcresult artifact appears in the workflow run summary