### PR TITLE
chore(jest-expo): Detach `jest-expo` deps from re-entering expo packages

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### 💡 Others
 
+- Drop expo dependencies from `jest-expo` to prevent cycles ([#45048](https://github.com/expo/expo/pull/45048) by [@kitten](https://github.com/kitten))
+
 ### ⚠️ Notices
 
 - Added support for React Native 0.84.x. ([#43018](https://github.com/expo/expo/pull/43018) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/jest-expo/config/extensions.js
+++ b/packages/jest-expo/config/extensions.js
@@ -1,0 +1,74 @@
+// NOTE(@kitten): Keep in sync with `@expo/config/src/paths/extensions.ts`
+
+import assert from 'assert';
+
+function getExtensions(
+  platforms,
+  extensions,
+  workflows,
+) {
+  // In the past we used spread operators to collect the values so now we enforce type safety on them.
+  assert(Array.isArray(platforms), 'Expected: `platforms: string[]`');
+  assert(Array.isArray(extensions), 'Expected: `extensions: string[]`');
+  assert(Array.isArray(workflows), 'Expected: `workflows: string[]`');
+
+  const fileExtensions = [];
+  // support .expo files
+  for (const workflow of [...workflows, '']) {
+    // Ensure order is correct: [platformA.js, platformB.js, js]
+    for (const platform of [...platforms, '']) {
+      // Support both TypeScript and JavaScript
+      for (const extension of extensions) {
+        fileExtensions.push([platform, workflow, extension].filter(Boolean).join('.'));
+      }
+    }
+  }
+  return fileExtensions;
+}
+
+function getLanguageExtensionsInOrder({
+  isTS,
+  isModern,
+  isReact,
+}) {
+  const addLanguage = (lang) => [lang, isReact && `${lang}x`].filter(Boolean);
+
+  // Support JavaScript
+  let extensions = addLanguage('js');
+
+  if (isModern) {
+    extensions.unshift('mjs');
+  }
+  if (isTS) {
+    extensions = [...addLanguage('ts'), ...extensions];
+  }
+
+  return extensions;
+}
+
+function _addMiscellaneousExtensions(platforms, fileExtensions) {
+  // Always add these with no platform extension
+  // In the future we may want to add platform and workspace extensions to json.
+  fileExtensions.push('json');
+  // Native doesn't currently support web assembly.
+  if (platforms.includes('web')) {
+    fileExtensions.push('wasm');
+  }
+  return fileExtensions;
+}
+
+module.exports.getBareExtensions = function getBareExtensions(
+  platforms,
+  languageOptions = { isTS: true, isModern: true, isReact: true }
+) {
+  const fileExtensions = getExtensions(
+    platforms,
+    getLanguageExtensionsInOrder(languageOptions),
+    []
+  );
+  // Always add these last
+  _addMiscellaneousExtensions(platforms, fileExtensions);
+  return fileExtensions;
+}
+
+

--- a/packages/jest-expo/config/extensions.js
+++ b/packages/jest-expo/config/extensions.js
@@ -1,6 +1,6 @@
 // NOTE(@kitten): Keep in sync with `@expo/config/src/paths/extensions.ts`
 
-import assert from 'assert';
+const assert = require('assert');
 
 function getExtensions(
   platforms,

--- a/packages/jest-expo/config/extensions.js
+++ b/packages/jest-expo/config/extensions.js
@@ -2,11 +2,7 @@
 
 const assert = require('assert');
 
-function getExtensions(
-  platforms,
-  extensions,
-  workflows,
-) {
+function getExtensions(platforms, extensions, workflows) {
   // In the past we used spread operators to collect the values so now we enforce type safety on them.
   assert(Array.isArray(platforms), 'Expected: `platforms: string[]`');
   assert(Array.isArray(extensions), 'Expected: `extensions: string[]`');
@@ -26,11 +22,7 @@ function getExtensions(
   return fileExtensions;
 }
 
-function getLanguageExtensionsInOrder({
-  isTS,
-  isModern,
-  isReact,
-}) {
+function getLanguageExtensionsInOrder({ isTS, isModern, isReact }) {
   const addLanguage = (lang) => [lang, isReact && `${lang}x`].filter(Boolean);
 
   // Support JavaScript
@@ -69,6 +61,4 @@ module.exports.getBareExtensions = function getBareExtensions(
   // Always add these last
   _addMiscellaneousExtensions(platforms, fileExtensions);
   return fileExtensions;
-}
-
-
+};

--- a/packages/jest-expo/config/getPlatformPreset.js
+++ b/packages/jest-expo/config/getPlatformPreset.js
@@ -1,6 +1,6 @@
 'use strict';
-const { getBareExtensions } = require('@expo/config/paths');
 
+const { getBareExtensions } = require('./extensions');
 const { withWatchPlugins } = require('./withWatchPlugins');
 const expoPreset = require('../jest-preset');
 

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -52,7 +52,6 @@
     "stacktrace-js": "^2.0.2"
   },
   "peerDependencies": {
-    "expo": "workspace:*",
     "react-native": "*",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -40,7 +40,6 @@
     "@jest/create-cache-key-function": "^29.2.1",
     "@jest/globals": "^29.2.1",
     "babel-jest": "^29.2.1",
-    "expo-modules-core": "workspace:~55.0.12",
     "jest-environment-jsdom": "^29.2.1",
     "jest-snapshot": "^29.2.1",
     "jest-watch-select-projects": "^2.0.0",

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -37,7 +37,6 @@
     "preset": "jest-expo/universal"
   },
   "dependencies": {
-    "@expo/config": "workspace:~55.0.8",
     "@expo/json-file": "workspace:^10.0.12",
     "@jest/create-cache-key-function": "^29.2.1",
     "@jest/globals": "^29.2.1",

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -37,7 +37,6 @@
     "preset": "jest-expo/universal"
   },
   "dependencies": {
-    "@expo/json-file": "workspace:^10.0.12",
     "@jest/create-cache-key-function": "^29.2.1",
     "@jest/globals": "^29.2.1",
     "babel-jest": "^29.2.1",

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -229,6 +229,7 @@ function attemptLookup(moduleName) {
   }
 }
 
+// TODO(@kitten): This is an invalid dependency chain
 jest.doMock('expo-modules-core', () => {
   const ExpoModulesCore = jest.requireActual('expo-modules-core');
 

--- a/packages/jest-expo/src/preset/withTypescriptMapping.js
+++ b/packages/jest-expo/src/preset/withTypescriptMapping.js
@@ -1,5 +1,5 @@
-const JSON5 = require('json5');
 const fs = require('fs');
+const JSON5 = require('json5');
 const path = require('path');
 
 const { toPosixPath } = require('../filePath');

--- a/packages/jest-expo/src/preset/withTypescriptMapping.js
+++ b/packages/jest-expo/src/preset/withTypescriptMapping.js
@@ -1,4 +1,5 @@
-const JsonFile = require('@expo/json-file');
+const JSON5 = require('json5');
+const fs = require('fs');
 const path = require('path');
 
 const { toPosixPath } = require('../filePath');
@@ -52,13 +53,12 @@ function convertTypescriptTargetToJestTarget(target, prefix = '<rootDir>') {
 }
 
 function mutateJestMappingFromConfig(jestConfig, configFile) {
-  const readJsonFile = JsonFile.default?.read || JsonFile.read;
-
   try {
     // The path to jsconfig.json or tsconfig.json is resolved relative to cwd
     // See: _createTypeScriptConfiguration() in `createJestPreset`
     const configPath = path.resolve(configFile);
-    const config = readJsonFile(configPath, { json5: true });
+    const configText = fs.readFileSync(configPath, 'utf8');
+    const config = JSON5.parse(configText);
     let pathPrefix = '<rootDir>';
 
     if (config?.compilerOptions?.baseUrl) {

--- a/packages/jest-expo/src/resolveBabelConfig.js
+++ b/packages/jest-expo/src/resolveBabelConfig.js
@@ -17,7 +17,7 @@ function resolveBabelConfig(projectRoot) {
 
   try {
     return require.resolve('expo/internal/babel-preset', {
-      paths: [projectRoot, __dirname]
+      paths: [projectRoot, __dirname],
     });
   } catch {
     try {

--- a/packages/jest-expo/src/resolveBabelConfig.js
+++ b/packages/jest-expo/src/resolveBabelConfig.js
@@ -16,7 +16,9 @@ function resolveBabelConfig(projectRoot) {
   }
 
   try {
-    return require.resolve('expo/internal/babel-preset');
+    return require.resolve('expo/internal/babel-preset', {
+      paths: [projectRoot, __dirname]
+    });
   } catch {
     try {
       // TODO(@kitten): Temporary, since our E2E tests don't use monorepo

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5699,9 +5699,6 @@ importers:
 
   packages/jest-expo:
     dependencies:
-      '@expo/config':
-        specifier: workspace:~55.0.8
-        version: link:../@expo/config
       '@expo/json-file':
         specifier: workspace:^10.0.12
         version: link:../@expo/json-file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5708,9 +5708,6 @@ importers:
       babel-jest:
         specifier: ^29.2.1
         version: 29.7.0(@babel/core@7.29.0)
-      expo:
-        specifier: workspace:*
-        version: link:../expo
       expo-modules-core:
         specifier: workspace:~55.0.12
         version: link:../expo-modules-core
@@ -18367,9 +18364,7 @@ snapshots:
       metro-runtime: 0.84.2
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5699,9 +5699,6 @@ importers:
 
   packages/jest-expo:
     dependencies:
-      '@expo/json-file':
-        specifier: workspace:^10.0.12
-        version: link:../@expo/json-file
       '@jest/create-cache-key-function':
         specifier: ^29.2.1
         version: 29.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5708,9 +5708,6 @@ importers:
       babel-jest:
         specifier: ^29.2.1
         version: 29.7.0(@babel/core@7.29.0)
-      expo-modules-core:
-        specifier: workspace:~55.0.12
-        version: link:../expo-modules-core
       jest-environment-jsdom:
         specifier: ^29.2.1
         version: 29.7.0
@@ -18364,7 +18361,9 @@ snapshots:
       metro-runtime: 0.84.2
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -67,6 +67,7 @@ const SPECIAL_DEPENDENCIES: Record<string, Record<string, IgnoreKind | void> | v
 
   'jest-expo': {
     'babel-preset-expo': 'ignore-dev', // TODO: Remove; only used as a fallback for now
+    expo: 'ignore-dev', // NOTE: Not resolvable without introducing a circular dependency
   },
 
   '@expo/metro-runtime': {


### PR DESCRIPTION
# Summary

This introduces circular dependencies, because we're not duplicating `jest-expo`'s presets for `expo-module-scripts`. This means that any dependency that re-enters the monorepo in `jest-expo` introduces a cycle.

For example:

```
@expo/config -> expo-module-scripts -> jest-expo -> @expo/config
```

The problem is that we don't necessarily want to remove the `expo` and `expo-modules-core` dependencies in `jest-expo`.

However,
- the `expo-modules-core` mock in `jest-expo` is invalid and shouldn't function in this way. It's likely already broken for isolated installations outside of `expo/expo`
- the peer on `expo` could be done or replaced if `expo-module-scripts` had its own version of `jest-expo` that's completely independent. But it doesn't, and it seems hard to do this right now 

Instead, we'll detach all monorepo deps for now. 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)