### PR TITLE
[docs] Strip YAML quote wrappers when syncing Expo Skills

### DIFF
--- a/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
+++ b/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
@@ -2,7 +2,7 @@
   "source": {
     "repo": "expo/skills",
     "url": "https://api.github.com/repos/expo/skills/contents/plugins/expo/skills",
-    "fetchedAt": "2026-04-23T15:32:02.799Z"
+    "fetchedAt": "2026-04-23T16:26:03.579Z"
   },
   "totalSkills": 13,
   "skills": [
@@ -13,7 +13,7 @@
     },
     {
       "name": "eas-update-insights",
-      "description": "\"Check the health of published EAS Updates: crash rates, install/launch counts, unique users, payload size, and the split between embedded and OTA users per channel. Use when the user asks how an update is performing, whether a rollout is healthy, how many users are on the embedded build vs OTA, or wants to gate CI on update health.\".",
+      "description": "Check the health of published EAS Updates: crash rates, install/launch counts, unique users, payload size, and the split between embedded and OTA users per channel. Use when the user asks how an update is performing, whether a rollout is healthy, how many users are on the embedded build vs OTA, or wants to gate CI on update health.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/eas-update-insights/SKILL.md"
     },
     {
@@ -48,12 +48,12 @@
     },
     {
       "name": "expo-ui-jetpack-compose",
-      "description": "\"`@expo/ui/jetpack-compose` package lets you use Jetpack Compose Views and modifiers in your app.\".",
+      "description": "`@expo/ui/jetpack-compose` package lets you use Jetpack Compose Views and modifiers in your app.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-ui-jetpack-compose/SKILL.md"
     },
     {
       "name": "expo-ui-swift-ui",
-      "description": "\"`@expo/ui/swift-ui` package lets you use SwiftUI Views and modifiers in your app.\".",
+      "description": "`@expo/ui/swift-ui` package lets you use SwiftUI Views and modifiers in your app.",
       "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/expo-ui-swift-ui/SKILL.md"
     },
     {

--- a/docs/ui/components/ExpoSkillsTable/sync-expo-skills.js
+++ b/docs/ui/components/ExpoSkillsTable/sync-expo-skills.js
@@ -42,7 +42,13 @@ function parseFrontmatter(content) {
       continue;
     }
     const key = line.slice(0, colonIndex).trim();
-    const value = line.slice(colonIndex + 1).trim();
+    let value = line.slice(colonIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
     frontmatter[key] = value;
   }
   return frontmatter;


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Some skill descriptions on `/skills` rendered with stray quotes (for example, `"Check the health of published EAS Updates: ...health.".`). Upstream `SKILL.md` frontmatter wraps descriptions in double quotes, but the sync script's frontmatter parser kept those quotes literally.

<img width="2450" height="2090" alt="CleanShot 2026-04-23 at 21 56 40@2x" src="https://github.com/user-attachments/assets/6084369c-edd3-4309-ba4c-ca6937a66fff" />

# How

- Update `parseFrontmatter` in `sync-expo-skills.js` to strip a matching pair of surrounding single or double quotes from each value before storing it.
- Re-run the script using `pnpm expo-skills-sync`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
<img width="2364" height="2134" alt="CleanShot 2026-04-23 at 21 56 29@2x" src="https://github.com/user-attachments/assets/bf6f4aa2-f6ff-4e05-a2da-a1440b75a3db" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
