### PR TITLE
[router] Run iOS Swift tests on the main actor

### DIFF
--- a/packages/expo-router/ios/Tests/RNScreensTabCompatTests.swift
+++ b/packages/expo-router/ios/Tests/RNScreensTabCompatTests.swift
@@ -37,9 +37,11 @@ private class MockTabScreenWithReactVC: UIView {
 // MARK: - Unit tests
 
 @Suite("RNScreensTabCompat unit tests")
+@MainActor
 struct RNScreensTabCompatUnitTests {
 
   @Suite("isTabScreen")
+  @MainActor
   struct IsTabScreen {
     @Test
     func `detects mock tab screen`() {
@@ -61,6 +63,7 @@ struct RNScreensTabCompatUnitTests {
   }
 
   @Suite("tabKey")
+  @MainActor
   struct TabKey {
     @Test
     func `reads value`() {
@@ -84,6 +87,7 @@ struct RNScreensTabCompatUnitTests {
   }
 
   @Suite("tabBarController(fromTabHost:)")
+  @MainActor
   struct TabBarControllerFromTabHost {
     @Test
     func `returns tab bar controller`() {
@@ -121,6 +125,7 @@ struct RNScreensTabCompatUnitTests {
   }
 
   @Suite("tabBarController(fromTabScreen:)")
+  @MainActor
   struct TabBarControllerFromTabScreen {
     @Test
     func `returns tab bar controller via reactViewController`() {
@@ -178,6 +183,7 @@ struct RNScreensTabCompatUnitTests {
 // MARK: - Integration tests (RNScreens API contract)
 
 @Suite("RNScreens API contract")
+@MainActor
 struct RNScreensAPIContractTests {
 
   @Test


### PR DESCRIPTION
## Why

I'm investigating crashes in iOS unit tests on my branch and noticed some diagnostic markers that these tests are not isolated to the MainActor (in theory not using it may cause crashes, even in test environments)

## How

- Adds `@MainActor` to all Swift Testing suite structs in expo-router iOS tests
- These tests create `UIView` and `UIViewController` instances which must be accessed on the main thread
- `@MainActor` does not propagate to nested structs, so it is applied to each suite individually

## Test plan
- [x] `et native-unit-tests --packages expo-router -p ios` passes