### PR TITLE
[core][Android] Improve performance of `PersistentFileLog`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -62,6 +62,7 @@
 - Throwing error when converting invalid color array. ([#44734](https://github.com/expo/expo/pull/44734) by [@kudo](https://github.com/kudo))
 - [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
 - Fixed `ExpoModulesMacros` precompiling. ([#44863](https://github.com/expo/expo/pull/44863) by [@kudo](https://github.com/kudo))
+- [Android] Improve performance of `PersistentFileLog`.
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -62,7 +62,7 @@
 - Throwing error when converting invalid color array. ([#44734](https://github.com/expo/expo/pull/44734) by [@kudo](https://github.com/kudo))
 - [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
 - Fixed `ExpoModulesMacros` precompiling. ([#44863](https://github.com/expo/expo/pull/44863) by [@kudo](https://github.com/kudo))
-- [Android] Improve performance of `PersistentFileLog`.
+- [Android] Improve performance of `PersistentFileLog`. ([#45058](https://github.com/expo/expo/pull/45058) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLog.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLog.kt
@@ -2,6 +2,7 @@ package expo.modules.core.logging
 
 import java.io.File
 import java.io.IOException
+import java.io.PrintWriter
 import java.nio.charset.Charset
 
 /**
@@ -25,6 +26,9 @@ class PersistentFileLog(
   category: String,
   filesDirectory: File
 ) {
+  init {
+    ensureFileExists()
+  }
 
   /**
    * Read entries from log file
@@ -43,7 +47,6 @@ class PersistentFileLog(
   fun appendEntry(entry: String, completionHandler: ((_: Error?) -> Unit) = { }) {
     queue.add {
       try {
-        this.ensureFileExists()
         val text = when (this.getFileSize()) {
           0L -> entry
           else -> {
@@ -66,7 +69,6 @@ class PersistentFileLog(
   fun purgeEntriesNotMatchingFilter(filter: (_: String) -> Boolean, completionHandler: (_: Exception?) -> Unit) {
     queue.add {
       try {
-        this.ensureFileExists()
         val contents = this.readFileLinesSync()
         val reducedContents = contents.filter(filter)
         this.writeFileLinesSync(reducedContents)
@@ -83,7 +85,10 @@ class PersistentFileLog(
   fun clearEntries(completionHandler: (_: Error?) -> Unit) {
     queue.add {
       try {
-        this.deleteFileSync()
+        // Clearing the file can be done by writing an empty string to it
+        PrintWriter(File(filePath)).use { writer ->
+          writer.print("")
+        }
         completionHandler.invoke(null)
       } catch (e: Error) {
         completionHandler.invoke(e)
@@ -110,12 +115,10 @@ class PersistentFileLog(
     if (!file.exists()) {
       return 0L
     }
-    return try {
-      file.inputStream().use { it.channel.size() }
-    } catch (e: IOException) {
-      // File does not exist or is inaccessible
-      0L
-    }
+
+    return runCatching {
+      file.length()
+    }.getOrDefault(0L)
   }
 
   private fun appendTextToFile(text: String) {
@@ -128,13 +131,6 @@ class PersistentFileLog(
 
   private fun writeFileLinesSync(entries: List<String>) {
     File(filePath).writeText(entries.joinToString("\n"), Charset.defaultCharset())
-  }
-
-  private fun deleteFileSync() {
-    val fd = File(filePath)
-    if (fd.exists()) {
-      fd.delete()
-    }
   }
 
   companion object {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLog.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLog.kt
@@ -26,6 +26,8 @@ class PersistentFileLog(
   category: String,
   filesDirectory: File
 ) {
+  private val filePath = "${filesDirectory.path}/$FILE_NAME_PREFIX.$category"
+
   init {
     ensureFileExists()
   }
@@ -97,8 +99,6 @@ class PersistentFileLog(
   }
 
   // Private functions
-
-  private val filePath = "${filesDirectory.path}/$FILE_NAME_PREFIX.$category"
 
   private fun ensureFileExists() {
     val fd = File(filePath)

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLogSerialDispatchQueue.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/core/logging/PersistentFileLogSerialDispatchQueue.kt
@@ -1,27 +1,15 @@
 package expo.modules.core.logging
 
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
+import java.util.concurrent.Executors
 
 internal typealias PersistentFileLogSerialDispatchQueueBlock = () -> Unit
 
 internal class PersistentFileLogSerialDispatchQueue {
-  private val channel = Channel<PersistentFileLogSerialDispatchQueueBlock>(Channel.BUFFERED)
+  fun add(block: PersistentFileLogSerialDispatchQueueBlock) {
+    executor.execute(block)
+  }
 
-  // Queue a block in the channel
-  fun add(block: PersistentFileLogSerialDispatchQueueBlock) = runBlocking { channel.send(block) }
-
-  fun stop() = queueRunner.cancel()
-
-  // On creation, this starts and runs for the lifetime of the app, pulling blocks off the channel
-  // and running them as needed
-  @OptIn(DelicateCoroutinesApi::class)
-  private val queueRunner = GlobalScope.launch {
-    while (true) {
-      channel.receive()()
-    }
+  companion object {
+    private val executor = Executors.newSingleThreadExecutor()
   }
 }


### PR DESCRIPTION
# Why

Improves the performance of `PersistentFileLog` by making it non-blocking, reducing the number of times we check if the file exists, and using a dedicated function to get the file size.

> It's not 100% correct way of making it faster, it's just a starting point.

# Test Plan

- bare-expo ✅ 