### PR TITLE
[updates][Android] Improve `isEntryStringLaterThanTimestamp`

### DIFF
--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
@@ -63,5 +63,10 @@ data class UpdatesLogEntry(
         null
       }
     }
+
+    fun getTimestamp(json: String): Long? {
+      return runCatching { JSONObject(json).getLong("timestamp") }
+        .getOrNull()
+    }
   }
 }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
@@ -40,8 +40,8 @@ class UpdatesLogReader(
   private val persistentLog = PersistentFileLog(EXPO_UPDATES_LOGGING_TAG, filesDirectory)
 
   private fun isEntryStringLaterThanTimestamp(entryString: String, timestamp: Long): Boolean {
-    val entry = UpdatesLogEntry.create(entryString) ?: return false
-    return entry.timestamp >= timestamp
+    val entryTimestamp = UpdatesLogEntry.getTimestamp(entryString) ?: return false
+    return entryTimestamp >= timestamp
   }
 
   private fun epochFromDateOrOneDayAgo(date: Date): Long {


### PR DESCRIPTION
# Why

Improves `isEntryStringLaterThanTimestamp` by not deserializing the whole `UpdatesLogEntry`.

# Test Plan

- bare-expo ✅ 