### PR TITLE
[core] Fix explicit c++ linkage to e-m-c

### DIFF
--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -94,8 +94,8 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => [
       '"${PODS_CONFIGURATION_BUILD_DIR}/ExpoModulesCore/Swift Compatibility Header"',
       '"$(PODS_ROOT)/Headers/Private/Yoga"', # Expo.h -> ExpoModulesCore-umbrella.h -> Fabric ViewProps.h -> Private Yoga headers
-      'OTHER_LDFLAGS' => '$(inherited) -lc++' # C++ standard library - will propagate to dependant targets
     ],
+    'OTHER_LDFLAGS' => '$(inherited) -lc++', # C++ standard library - will propagate to dependant targets
   }
 
   if use_hermes


### PR DESCRIPTION
# Why

https://github.com/expo/expo/pull/44984 was a correct fix but was mistakenly added in the wrong line - to `HEADER_SEARCH_PATHS`.

# How

Move `OTHER_LDFLAGS` to correct place. 

# Test Plan

Build test-widgets project - now works.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
