### PR TITLE
internal(tools): Add "lpd" / "list-package-dependencies" tool

### DIFF
--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -1,8 +1,12 @@
-import { glob } from 'glob';
-import { isBuiltin } from 'node:module';
 import path from 'node:path';
-import ts from 'typescript';
 
+import {
+  getPackageName,
+  getSourceFileImports,
+  getSourceFilesAsync,
+  isNCCBuilt,
+  type SourceFileImportRef,
+} from './scanDependenciesAsync';
 import type { ActionOptions } from './types';
 import Logger from '../Logger';
 import { DependencyKind, type PackageDependency, type Package } from '../Packages';
@@ -19,19 +23,6 @@ type PackageCheckType = ActionOptions['checkPackageType'];
  * dependency chains in user projects!
  */
 type IgnoreKind = 'types-only' | 'ignore' | 'ignore-dev';
-
-type SourceFile = {
-  path: string;
-  type: 'source' | 'test';
-};
-
-type SourceFileImportRef = {
-  type: 'builtIn' | 'internal' | 'external';
-  importValue: string;
-  packageName: string;
-  packagePath?: string;
-  isTypeOnly?: boolean;
-};
 
 const IGNORED_PACKAGES: string[] = [
   'sqlite-inspector-webui', // This is prebuilt devtools plugin webui. It's not a user depended package.
@@ -100,7 +91,6 @@ const IGNORED_IMPORTS: Record<string, IgnoreKind | void> = {
   '@react-native/assets-registry/registry': 'ignore-dev',
 };
 
-const REGEXP_REPLACE_SLASHES = /\\/g;
 const WORKSPACE_SPECIFIER = 'workspace:';
 
 /**
@@ -128,7 +118,7 @@ export async function checkDependenciesAsync(pkg: Package, type: PackageCheckTyp
 
   const validator = createExternalImportValidator(pkg);
   let invalidImports: {
-    file: SourceFile;
+    file: { path: string };
     importRef: SourceFileImportRef;
     kind: DependencyKind | undefined;
   }[] = [];
@@ -209,11 +199,6 @@ export async function checkDependenciesAsync(pkg: Package, type: PackageCheckTyp
   }
 }
 
-function isNCCBuilt(pkg: Package): boolean {
-  const { build: buildScript } = pkg.packageJson.scripts;
-  return !!pkg.packageJson.bin && !!buildScript?.includes('ncc');
-}
-
 function isDisallowedImport(ref: SourceFileImportRef): boolean {
   const packageName = getPackageName(ref.packageName);
   return packageName === 'metro' || packageName.startsWith('metro-');
@@ -282,169 +267,4 @@ function createExternalImportValidator(pkg: Package) {
       return null;
     },
   };
-}
-
-/** Get a list of all source files to validate for dependency chains */
-async function getSourceFilesAsync(pkg: Package, type: PackageCheckType): Promise<SourceFile[]> {
-  const files = await glob('src/**/*.{ts,tsx,js,jsx}', {
-    cwd: getSourceFilePaths(pkg, type),
-    absolute: true,
-    nodir: true,
-  });
-
-  return files
-    .filter((filePath) => !filePath.endsWith('.d.ts'))
-    .map((filePath) => toPosixPath(filePath))
-    .map((filePath) =>
-      filePath.includes('/__tests__/') || filePath.includes('/__mocks__/')
-        ? { path: filePath, type: 'test' }
-        : { path: filePath, type: 'source' }
-    );
-}
-
-function getPackageName(name: string): string {
-  let idx: number;
-  if (name[0] === '@') {
-    idx = name.indexOf('/');
-    return idx > -1 ? name.slice(0, name.indexOf('/', idx + 1)) : name;
-  } else {
-    idx = name.indexOf('/');
-    return idx > -1 ? name.slice(0, idx) : name;
-  }
-}
-
-/** Get the path of source files based on the package, and the type of check currently running */
-function getSourceFilePaths(pkg: Package, type: PackageCheckType): string {
-  switch (type) {
-    case 'package':
-      return pkg.path;
-
-    case 'plugin':
-    case 'cli':
-    case 'utils':
-      return path.join(pkg.path, type);
-
-    default:
-      throw new Error(`Unexpected package type received: ${type}`);
-  }
-}
-
-/** Parse and return all imports from a single source file, usign TypeScript AST parsing */
-function getSourceFileImports(sourceFile: SourceFile): SourceFileImportRef[] {
-  const importRefs: SourceFileImportRef[] = [];
-  const compiler = createTypescriptCompiler();
-  const source = compiler.getSourceFile(sourceFile.path, ts.ScriptTarget.Latest, (message) => {
-    throw new Error(`Failed to parse ${sourceFile.path}: ${message}`);
-  });
-
-  if (source) {
-    return collectTypescriptImports(source, importRefs);
-  }
-
-  return importRefs;
-}
-
-/** Iterate the parsed TypeScript AST and collect all imports or require statements */
-function collectTypescriptImports(node: ts.Node | ts.SourceFile, imports: SourceFileImportRef[]) {
-  if (ts.isImportDeclaration(node)) {
-    let isTypeOnly = false;
-    if (node.importClause?.namedBindings) {
-      isTypeOnly =
-        node.importClause.isTypeOnly ||
-        (ts.isNamedImports(node.importClause.namedBindings) &&
-          node.importClause.namedBindings.elements.every((binding) => binding.isTypeOnly));
-    } else {
-      isTypeOnly = !!node.importClause?.isTypeOnly;
-    }
-    // Collect `import` statements
-    imports.push(createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly));
-  } else if (
-    ts.isCallExpression(node) &&
-    node.expression.getText() === 'require' &&
-    node.arguments.every((arg) => ts.isStringLiteral(arg)) // Filter `require(requireFrom(...))
-  ) {
-    // Collect `require` statement
-    imports.push(createTypescriptImportRef(node.arguments[0].getText()));
-  } else if (
-    ts.isCallExpression(node) &&
-    node.expression.getText() === 'require.resolve' &&
-    node.arguments.length === 1 && // Filter out `require.resolve('', { paths: ... })`
-    ts.isStringLiteral(node.arguments[0]) // Filter `require(requireFrom(...))
-  ) {
-    // Collect `require.resolve` statement
-    imports.push(createTypescriptImportRef(node.arguments[0].getText()));
-  } else {
-    ts.forEachChild(node, (child) => {
-      collectTypescriptImports(child, imports);
-    });
-  }
-
-  return imports;
-}
-
-/** Analyze the import and return the import ref object */
-function createTypescriptImportRef(
-  importText: string,
-  importTypeOnly = false
-): SourceFileImportRef {
-  const importValue = importText.replace(/['"]/g, '').trim();
-
-  if (isBuiltin(importValue)) {
-    return { type: 'builtIn', importValue, packageName: importValue, isTypeOnly: importTypeOnly };
-  }
-
-  if (importValue.startsWith('.')) {
-    return { type: 'internal', importValue, packageName: importValue, isTypeOnly: importTypeOnly };
-  }
-
-  if (importValue.startsWith('@')) {
-    const [packageScope, packageName, ...packagePath] = importValue.split('/');
-    return {
-      type: 'external',
-      importValue,
-      packageName: `${packageScope}/${packageName}`,
-      packagePath: packagePath.join('/'),
-      isTypeOnly: importTypeOnly,
-    };
-  }
-
-  const [packageName, ...packagePath] = importValue.split('/');
-  return {
-    type: 'external',
-    importValue,
-    packageName,
-    packagePath: packagePath.join(','),
-    isTypeOnly: importTypeOnly,
-  };
-}
-
-/** The shared but lazily initialized TypeScript compiler instance */
-let compiler: ts.CompilerHost | null = null;
-
-/** Get or create the TypeScript compiler used to analyze imports for all source files */
-function createTypescriptCompiler() {
-  if (!compiler) {
-    compiler = ts.createCompilerHost(
-      {
-        allowJs: true,
-        noEmit: true,
-        isolatedModules: true,
-        resolveJsonModule: false,
-        moduleResolution: ts.ModuleResolutionKind.Classic, // we don't want node_modules
-        incremental: true,
-        noLib: true,
-        noResolve: true,
-      },
-      true
-    );
-  }
-
-  return compiler;
-}
-
-/**
- * Convert any platform-specific path to a POSIX path.
- */
-function toPosixPath(filePath: string): string {
-  return filePath.replace(REGEXP_REPLACE_SLASHES, '/');
 }

--- a/tools/src/check-packages/scanDependenciesAsync.ts
+++ b/tools/src/check-packages/scanDependenciesAsync.ts
@@ -208,6 +208,10 @@ function collectTypescriptImports(
     const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
     // Collect `require.resolve` statement
     imports.push(createTypescriptImportRef(node.arguments[0].getText(), false, false, line));
+  } else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument) && ts.isStringLiteral(node.argument.literal)) {
+    const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
+    // Collect `typeof import('...')` and `import('...')` in type positions
+    imports.push(createTypescriptImportRef(node.argument.literal.getText(), true, false, line));
   } else {
     ts.forEachChild(node, (child) => {
       collectTypescriptImports(child, sourceFile, imports);

--- a/tools/src/check-packages/scanDependenciesAsync.ts
+++ b/tools/src/check-packages/scanDependenciesAsync.ts
@@ -18,6 +18,7 @@ export type SourceFileImportRef = {
   packageName: string;
   packagePath?: string;
   isTypeOnly?: boolean;
+  isSideEffect?: boolean;
   /** 1-based line number in the source file where this import appears */
   line?: number;
 };
@@ -32,6 +33,7 @@ export type FileRef = {
 export type ScannedDependency = {
   packageName: string;
   isTypeOnly: boolean;
+  isSideEffect: boolean;
   /** The dependency kind from package.json, or undefined if undeclared */
   kind: DependencyKind | undefined;
   /** One entry per file, deduplicated, showing the first import line */
@@ -67,7 +69,7 @@ export async function scanDependenciesAsync(
   // Aggregate imports by package name, tracking one line per file (the earliest)
   const aggregated = new Map<
     string,
-    { isTypeOnly: boolean; fileLines: Map<string, number> }
+    { isTypeOnly: boolean; isSideEffect: boolean; fileLines: Map<string, number> }
   >();
 
   for (const source of sources) {
@@ -78,7 +80,7 @@ export async function scanDependenciesAsync(
 
       let entry = aggregated.get(ref.packageName);
       if (!entry) {
-        entry = { isTypeOnly: true, fileLines: new Map() };
+        entry = { isTypeOnly: true, isSideEffect: true, fileLines: new Map() };
         aggregated.set(ref.packageName, entry);
       }
 
@@ -90,6 +92,9 @@ export async function scanDependenciesAsync(
       if (!ref.isTypeOnly) {
         entry.isTypeOnly = false;
       }
+      if (!ref.isSideEffect) {
+        entry.isSideEffect = false;
+      }
     }
   }
 
@@ -98,6 +103,7 @@ export async function scanDependenciesAsync(
     results.push({
       packageName,
       isTypeOnly: entry.isTypeOnly,
+      isSideEffect: entry.isSideEffect,
       kind: dependencyMap.get(packageName)?.kind,
       files: [...entry.fileLines.entries()]
         .sort(([a], [b]) => a.localeCompare(b))
@@ -171,6 +177,7 @@ function collectTypescriptImports(
   imports: SourceFileImportRef[]
 ) {
   if (ts.isImportDeclaration(node)) {
+    const isSideEffect = !node.importClause;
     let isTypeOnly = false;
     if (node.importClause?.namedBindings) {
       isTypeOnly =
@@ -182,15 +189,16 @@ function collectTypescriptImports(
     }
     const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
     // Collect `import` statements
-    imports.push(createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly, line));
+    imports.push(createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly, isSideEffect, line));
   } else if (
     ts.isCallExpression(node) &&
     node.expression.getText() === 'require' &&
     node.arguments.every((arg) => ts.isStringLiteral(arg)) // Filter `require(requireFrom(...))
   ) {
+    const isSideEffect = ts.isExpressionStatement(node.parent);
     const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
     // Collect `require` statement
-    imports.push(createTypescriptImportRef(node.arguments[0].getText(), false, line));
+    imports.push(createTypescriptImportRef(node.arguments[0].getText(), false, isSideEffect, line));
   } else if (
     ts.isCallExpression(node) &&
     node.expression.getText() === 'require.resolve' &&
@@ -199,7 +207,7 @@ function collectTypescriptImports(
   ) {
     const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
     // Collect `require.resolve` statement
-    imports.push(createTypescriptImportRef(node.arguments[0].getText(), false, line));
+    imports.push(createTypescriptImportRef(node.arguments[0].getText(), false, false, line));
   } else {
     ts.forEachChild(node, (child) => {
       collectTypescriptImports(child, sourceFile, imports);
@@ -213,16 +221,17 @@ function collectTypescriptImports(
 function createTypescriptImportRef(
   importText: string,
   importTypeOnly = false,
+  importSideEffect = false,
   line?: number
 ): SourceFileImportRef {
   const importValue = importText.replace(/['"]/g, '').trim();
 
   if (isBuiltin(importValue)) {
-    return { type: 'builtIn', importValue, packageName: importValue, isTypeOnly: importTypeOnly, line };
+    return { type: 'builtIn', importValue, packageName: importValue, isTypeOnly: importTypeOnly, isSideEffect: importSideEffect, line };
   }
 
   if (importValue.startsWith('.')) {
-    return { type: 'internal', importValue, packageName: importValue, isTypeOnly: importTypeOnly, line };
+    return { type: 'internal', importValue, packageName: importValue, isTypeOnly: importTypeOnly, isSideEffect: importSideEffect, line };
   }
 
   if (importValue.startsWith('@')) {
@@ -233,6 +242,7 @@ function createTypescriptImportRef(
       packageName: `${packageScope}/${packageName}`,
       packagePath: packagePath.join('/'),
       isTypeOnly: importTypeOnly,
+      isSideEffect: importSideEffect,
       line,
     };
   }
@@ -244,6 +254,7 @@ function createTypescriptImportRef(
     packageName,
     packagePath: packagePath.join(','),
     isTypeOnly: importTypeOnly,
+    isSideEffect: importSideEffect,
     line,
   };
 }

--- a/tools/src/check-packages/scanDependenciesAsync.ts
+++ b/tools/src/check-packages/scanDependenciesAsync.ts
@@ -189,7 +189,9 @@ function collectTypescriptImports(
     }
     const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
     // Collect `import` statements
-    imports.push(createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly, isSideEffect, line));
+    imports.push(
+      createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly, isSideEffect, line)
+    );
   } else if (
     ts.isCallExpression(node) &&
     node.expression.getText() === 'require' &&
@@ -208,7 +210,11 @@ function collectTypescriptImports(
     const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
     // Collect `require.resolve` statement
     imports.push(createTypescriptImportRef(node.arguments[0].getText(), false, false, line));
-  } else if (ts.isImportTypeNode(node) && ts.isLiteralTypeNode(node.argument) && ts.isStringLiteral(node.argument.literal)) {
+  } else if (
+    ts.isImportTypeNode(node) &&
+    ts.isLiteralTypeNode(node.argument) &&
+    ts.isStringLiteral(node.argument.literal)
+  ) {
     const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
     // Collect `typeof import('...')` and `import('...')` in type positions
     imports.push(createTypescriptImportRef(node.argument.literal.getText(), true, false, line));
@@ -231,11 +237,25 @@ function createTypescriptImportRef(
   const importValue = importText.replace(/['"]/g, '').trim();
 
   if (isBuiltin(importValue)) {
-    return { type: 'builtIn', importValue, packageName: importValue, isTypeOnly: importTypeOnly, isSideEffect: importSideEffect, line };
+    return {
+      type: 'builtIn',
+      importValue,
+      packageName: importValue,
+      isTypeOnly: importTypeOnly,
+      isSideEffect: importSideEffect,
+      line,
+    };
   }
 
   if (importValue.startsWith('.')) {
-    return { type: 'internal', importValue, packageName: importValue, isTypeOnly: importTypeOnly, isSideEffect: importSideEffect, line };
+    return {
+      type: 'internal',
+      importValue,
+      packageName: importValue,
+      isTypeOnly: importTypeOnly,
+      isSideEffect: importSideEffect,
+      line,
+    };
   }
 
   if (importValue.startsWith('@')) {

--- a/tools/src/check-packages/scanDependenciesAsync.ts
+++ b/tools/src/check-packages/scanDependenciesAsync.ts
@@ -1,0 +1,299 @@
+import { glob } from 'glob';
+import { isBuiltin } from 'node:module';
+import path from 'node:path';
+import ts from 'typescript';
+
+import { DependencyKind, type PackageDependency, type Package } from '../Packages';
+
+type PackageCheckType = 'package' | 'plugin' | 'cli' | 'utils';
+
+export type SourceFile = {
+  path: string;
+  type: 'source' | 'test';
+};
+
+export type SourceFileImportRef = {
+  type: 'builtIn' | 'internal' | 'external';
+  importValue: string;
+  packageName: string;
+  packagePath?: string;
+  isTypeOnly?: boolean;
+  /** 1-based line number in the source file where this import appears */
+  line?: number;
+};
+
+export type FileRef = {
+  /** Path relative to the package root */
+  relativePath: string;
+  /** 1-based line number of the first import of this dependency in the file */
+  line: number;
+};
+
+export type ScannedDependency = {
+  packageName: string;
+  isTypeOnly: boolean;
+  /** The dependency kind from package.json, or undefined if undeclared */
+  kind: DependencyKind | undefined;
+  /** One entry per file, deduplicated, showing the first import line */
+  files: FileRef[];
+};
+
+const REGEXP_REPLACE_SLASHES = /\\/g;
+
+/**
+ * Scans source files of a package and returns all external dependencies found via imports.
+ * This resolves each import against the package's declared dependencies.
+ */
+export async function scanDependenciesAsync(
+  pkg: Package,
+  type: PackageCheckType = 'package'
+): Promise<ScannedDependency[]> {
+  const sources = (await getSourceFilesAsync(pkg, type))
+    .filter((file) => file.type === 'source')
+    .map((file) => ({ file, importRefs: getSourceFileImports(file) }));
+
+  if (!sources.length) {
+    return [];
+  }
+
+  const dependencies = pkg.getDependencies([
+    DependencyKind.Normal,
+    DependencyKind.Dev,
+    DependencyKind.Peer,
+  ]);
+  const dependencyMap = new Map<string, PackageDependency>();
+  dependencies.forEach((dep) => dependencyMap.set(dep.name, dep));
+
+  // Aggregate imports by package name, tracking one line per file (the earliest)
+  const aggregated = new Map<
+    string,
+    { isTypeOnly: boolean; fileLines: Map<string, number> }
+  >();
+
+  for (const source of sources) {
+    for (const ref of source.importRefs) {
+      if (ref.type !== 'external' || pkg.packageName === ref.packageName) {
+        continue;
+      }
+
+      let entry = aggregated.get(ref.packageName);
+      if (!entry) {
+        entry = { isTypeOnly: true, fileLines: new Map() };
+        aggregated.set(ref.packageName, entry);
+      }
+
+      const refLine = ref.line ?? 1;
+      const existing = entry.fileLines.get(source.file.path);
+      if (existing === undefined || refLine < existing) {
+        entry.fileLines.set(source.file.path, refLine);
+      }
+      if (!ref.isTypeOnly) {
+        entry.isTypeOnly = false;
+      }
+    }
+  }
+
+  const results: ScannedDependency[] = [];
+  for (const [packageName, entry] of aggregated) {
+    results.push({
+      packageName,
+      isTypeOnly: entry.isTypeOnly,
+      kind: dependencyMap.get(packageName)?.kind,
+      files: [...entry.fileLines.entries()]
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([filePath, line]) => ({
+          relativePath: path.relative(pkg.path, filePath),
+          line,
+        })),
+    });
+  }
+
+  results.sort((a, b) => a.packageName.localeCompare(b.packageName));
+  return results;
+}
+
+/** Get a list of all source files to validate for dependency chains */
+export async function getSourceFilesAsync(
+  pkg: Package,
+  type: PackageCheckType
+): Promise<SourceFile[]> {
+  const files = await glob('src/**/*.{ts,tsx,js,jsx}', {
+    cwd: getSourceFilePaths(pkg, type),
+    absolute: true,
+    nodir: true,
+  });
+
+  return files
+    .filter((filePath) => !filePath.endsWith('.d.ts'))
+    .map((filePath) => toPosixPath(filePath))
+    .map((filePath) =>
+      filePath.includes('/__tests__/') || filePath.includes('/__mocks__/')
+        ? { path: filePath, type: 'test' }
+        : { path: filePath, type: 'source' }
+    );
+}
+
+/** Get the path of source files based on the package, and the type of check currently running */
+function getSourceFilePaths(pkg: Package, type: PackageCheckType): string {
+  switch (type) {
+    case 'package':
+      return pkg.path;
+
+    case 'plugin':
+    case 'cli':
+    case 'utils':
+      return path.join(pkg.path, type);
+
+    default:
+      throw new Error(`Unexpected package type received: ${type}`);
+  }
+}
+
+/** Parse and return all imports from a single source file, using TypeScript AST parsing */
+export function getSourceFileImports(sourceFile: SourceFile): SourceFileImportRef[] {
+  const importRefs: SourceFileImportRef[] = [];
+  const compiler = createTypescriptCompiler();
+  const source = compiler.getSourceFile(sourceFile.path, ts.ScriptTarget.Latest, (message) => {
+    throw new Error(`Failed to parse ${sourceFile.path}: ${message}`);
+  });
+
+  if (source) {
+    return collectTypescriptImports(source, source, importRefs);
+  }
+
+  return importRefs;
+}
+
+/** Iterate the parsed TypeScript AST and collect all imports or require statements */
+function collectTypescriptImports(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  imports: SourceFileImportRef[]
+) {
+  if (ts.isImportDeclaration(node)) {
+    let isTypeOnly = false;
+    if (node.importClause?.namedBindings) {
+      isTypeOnly =
+        node.importClause.isTypeOnly ||
+        (ts.isNamedImports(node.importClause.namedBindings) &&
+          node.importClause.namedBindings.elements.every((binding) => binding.isTypeOnly));
+    } else {
+      isTypeOnly = !!node.importClause?.isTypeOnly;
+    }
+    const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
+    // Collect `import` statements
+    imports.push(createTypescriptImportRef(node.moduleSpecifier.getText(), isTypeOnly, line));
+  } else if (
+    ts.isCallExpression(node) &&
+    node.expression.getText() === 'require' &&
+    node.arguments.every((arg) => ts.isStringLiteral(arg)) // Filter `require(requireFrom(...))
+  ) {
+    const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
+    // Collect `require` statement
+    imports.push(createTypescriptImportRef(node.arguments[0].getText(), false, line));
+  } else if (
+    ts.isCallExpression(node) &&
+    node.expression.getText() === 'require.resolve' &&
+    node.arguments.length === 1 && // Filter out `require.resolve('', { paths: ... })`
+    ts.isStringLiteral(node.arguments[0]) // Filter `require(requireFrom(...))
+  ) {
+    const line = ts.getLineAndCharacterOfPosition(sourceFile, node.getStart(sourceFile)).line + 1;
+    // Collect `require.resolve` statement
+    imports.push(createTypescriptImportRef(node.arguments[0].getText(), false, line));
+  } else {
+    ts.forEachChild(node, (child) => {
+      collectTypescriptImports(child, sourceFile, imports);
+    });
+  }
+
+  return imports;
+}
+
+/** Analyze the import and return the import ref object */
+function createTypescriptImportRef(
+  importText: string,
+  importTypeOnly = false,
+  line?: number
+): SourceFileImportRef {
+  const importValue = importText.replace(/['"]/g, '').trim();
+
+  if (isBuiltin(importValue)) {
+    return { type: 'builtIn', importValue, packageName: importValue, isTypeOnly: importTypeOnly, line };
+  }
+
+  if (importValue.startsWith('.')) {
+    return { type: 'internal', importValue, packageName: importValue, isTypeOnly: importTypeOnly, line };
+  }
+
+  if (importValue.startsWith('@')) {
+    const [packageScope, packageName, ...packagePath] = importValue.split('/');
+    return {
+      type: 'external',
+      importValue,
+      packageName: `${packageScope}/${packageName}`,
+      packagePath: packagePath.join('/'),
+      isTypeOnly: importTypeOnly,
+      line,
+    };
+  }
+
+  const [packageName, ...packagePath] = importValue.split('/');
+  return {
+    type: 'external',
+    importValue,
+    packageName,
+    packagePath: packagePath.join(','),
+    isTypeOnly: importTypeOnly,
+    line,
+  };
+}
+
+export function getPackageName(name: string): string {
+  let idx: number;
+  if (name[0] === '@') {
+    idx = name.indexOf('/');
+    return idx > -1 ? name.slice(0, name.indexOf('/', idx + 1)) : name;
+  } else {
+    idx = name.indexOf('/');
+    return idx > -1 ? name.slice(0, idx) : name;
+  }
+}
+
+/** The shared but lazily initialized TypeScript compiler instance */
+let compiler: ts.CompilerHost | null = null;
+
+/** Get or create the TypeScript compiler used to analyze imports for all source files */
+function createTypescriptCompiler() {
+  if (!compiler) {
+    compiler = ts.createCompilerHost(
+      {
+        allowJs: true,
+        noEmit: true,
+        isolatedModules: true,
+        resolveJsonModule: false,
+        moduleResolution: ts.ModuleResolutionKind.Classic, // we don't want node_modules
+        incremental: true,
+        noLib: true,
+        noResolve: true,
+      },
+      true
+    );
+  }
+
+  return compiler;
+}
+
+/**
+ * Convert any platform-specific path to a POSIX path.
+ */
+function toPosixPath(filePath: string): string {
+  return filePath.replace(REGEXP_REPLACE_SLASHES, '/');
+}
+
+/**
+ * Check whether a package is built with ncc (bundled), meaning imports are inlined.
+ */
+export function isNCCBuilt(pkg: Package): boolean {
+  const { build: buildScript } = pkg.packageJson.scripts;
+  return !!pkg.packageJson.bin && !!buildScript?.includes('ncc');
+}

--- a/tools/src/commands/ListPackageDependencies.ts
+++ b/tools/src/commands/ListPackageDependencies.ts
@@ -1,13 +1,13 @@
 import { Command } from '@expo/commander';
 import chalk from 'chalk';
 
+import logger from '../Logger';
+import { DependencyKind, getListOfPackagesAsync } from '../Packages';
 import {
   isNCCBuilt,
   scanDependenciesAsync,
   type ScannedDependency,
 } from '../check-packages/scanDependenciesAsync';
-import logger from '../Logger';
-import { DependencyKind, getListOfPackagesAsync } from '../Packages';
 
 const { green, yellow, red, cyan, gray, bold } = chalk;
 
@@ -83,8 +83,7 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
         continue;
       }
 
-      const label =
-        checkType === 'package' ? pkg.packageName : `${pkg.packageName} (${checkType})`;
+      const label = checkType === 'package' ? pkg.packageName : `${pkg.packageName} (${checkType})`;
 
       if (options.json) {
         jsonOutput[label] = filtered.map((d) => ({

--- a/tools/src/commands/ListPackageDependencies.ts
+++ b/tools/src/commands/ListPackageDependencies.ts
@@ -7,12 +7,11 @@ import {
   type ScannedDependency,
 } from '../check-packages/scanDependenciesAsync';
 import logger from '../Logger';
-import { DependencyKind, getListOfPackagesAsync, type Package } from '../Packages';
+import { DependencyKind, getListOfPackagesAsync } from '../Packages';
 
 const { green, yellow, red, cyan, gray, bold } = chalk;
 
 type ActionOptions = {
-  all: boolean;
   json: boolean;
   undeclared: boolean;
   devOnly: boolean;
@@ -22,9 +21,8 @@ type PackageCheckType = 'package' | 'plugin' | 'cli' | 'utils';
 
 export default (program: Command) => {
   program
-    .command('list-package-dependencies [packageNames...]')
+    .command('list-package-dependencies <packageNames...>')
     .alias('lpd')
-    .option('-a, --all', 'List dependencies for all packages.', false)
     .option('--json', 'Output as JSON.', false)
     .option(
       '--undeclared',
@@ -39,20 +37,17 @@ export default (program: Command) => {
 async function main(packageNames: string[], options: ActionOptions): Promise<void> {
   const allPackages = await getListOfPackagesAsync();
 
-  let packages: Package[];
-  if (options.all) {
-    packages = allPackages;
-  } else if (packageNames.length > 0) {
-    packages = allPackages.filter((pkg) => packageNames.includes(pkg.packageName));
-    const found = new Set(packages.map((p) => p.packageName));
-    for (const name of packageNames) {
-      if (!found.has(name)) {
-        logger.warn(`Package ${yellow(name)} not found in monorepo.`);
-      }
-    }
-  } else {
-    logger.error('Specify package names or use --all to scan all packages.');
+  if (!packageNames.length) {
+    logger.error('Specify at least one package name.');
     process.exit(1);
+  }
+
+  const packages = allPackages.filter((pkg) => packageNames.includes(pkg.packageName));
+  const found = new Set(packages.map((p) => p.packageName));
+  for (const name of packageNames) {
+    if (!found.has(name)) {
+      logger.warn(`Package ${yellow(name)} not found in monorepo.`);
+    }
   }
 
   if (!packages.length) {

--- a/tools/src/commands/ListPackageDependencies.ts
+++ b/tools/src/commands/ListPackageDependencies.ts
@@ -95,6 +95,7 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
           packageName: d.packageName,
           kind: d.kind ?? null,
           isTypeOnly: d.isTypeOnly,
+          isSideEffect: d.isSideEffect,
           files: d.files.map((f) => ({ path: f.relativePath, line: f.line })),
         }));
       } else {
@@ -163,6 +164,9 @@ function buildHints(dep: ScannedDependency): string {
   const parts: string[] = [];
   if (dep.isTypeOnly) {
     parts.push('types only');
+  }
+  if (dep.isSideEffect) {
+    parts.push('side-effect');
   }
   return parts.join(', ');
 }

--- a/tools/src/commands/ListPackageDependencies.ts
+++ b/tools/src/commands/ListPackageDependencies.ts
@@ -36,6 +36,7 @@ export default (program: Command) => {
 
 async function main(packageNames: string[], options: ActionOptions): Promise<void> {
   const allPackages = await getListOfPackagesAsync();
+  const monorepoPackageNames = new Set(allPackages.map((p) => p.packageName));
 
   if (!packageNames.length) {
     logger.error('Specify at least one package name.');
@@ -95,7 +96,7 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
         }));
       } else {
         logger.log(`\n${green.bold(label)}`);
-        printTable(filtered);
+        printTable(filtered, monorepoPackageNames);
       }
     }
   }
@@ -105,13 +106,23 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
   }
 }
 
-function printTable(deps: ScannedDependency[]) {
-  const rows = deps.map((d) => ({
-    dep: d.packageName,
-    kind: kindLabel(d.kind),
-    hints: buildHints(d),
-    refs: d.files.map((f) => `${f.relativePath}:${f.line}`),
-  }));
+function printTable(deps: ScannedDependency[], monorepoPackageNames: Set<string>) {
+  const rows = deps.map((d) => {
+    const isInternal = monorepoPackageNames.has(d.packageName);
+    return {
+      dep: isInternal ? `${d.packageName}*` : d.packageName,
+      isInternal,
+      kind: kindLabel(d.kind),
+      hints: buildHints(d),
+      refs: d.files.map((f) => `${f.relativePath}:${f.line}`),
+    };
+  });
+
+  // Sort internal dependencies first, then alphabetically
+  rows.sort((a, b) => {
+    if (a.isInternal !== b.isInternal) return a.isInternal ? -1 : 1;
+    return a.dep.localeCompare(b.dep);
+  });
 
   const GAP = 2;
   const depW = Math.max('Dependency'.length, ...rows.map((r) => r.dep.length)) + GAP;
@@ -143,7 +154,7 @@ function printTable(deps: ScannedDependency[]) {
     const firstRef = row.refs[0] ?? '';
     logger.log(
       indent +
-        row.dep.padEnd(depW) +
+        depCell(row.dep, row.isInternal, depW) +
         coloredCell(row.kind, kindW) +
         hintCell(row.hints, hintsW) +
         gray(firstRef)
@@ -179,6 +190,11 @@ function kindLabel(kind: DependencyKind | undefined): string {
     default:
       return kind;
   }
+}
+
+function depCell(text: string, isInternal: boolean, width: number): string {
+  const colored = isInternal ? green(text) : text;
+  return colored + ' '.repeat(Math.max(0, width - text.length));
 }
 
 /** Render a kind cell: colored text + plain padding to fill the column width */

--- a/tools/src/commands/ListPackageDependencies.ts
+++ b/tools/src/commands/ListPackageDependencies.ts
@@ -1,0 +1,210 @@
+import { Command } from '@expo/commander';
+import chalk from 'chalk';
+
+import {
+  isNCCBuilt,
+  scanDependenciesAsync,
+  type ScannedDependency,
+} from '../check-packages/scanDependenciesAsync';
+import logger from '../Logger';
+import { DependencyKind, getListOfPackagesAsync, type Package } from '../Packages';
+
+const { green, yellow, red, cyan, gray, bold } = chalk;
+
+type ActionOptions = {
+  all: boolean;
+  json: boolean;
+  undeclared: boolean;
+  devOnly: boolean;
+};
+
+type PackageCheckType = 'package' | 'plugin' | 'cli' | 'utils';
+
+export default (program: Command) => {
+  program
+    .command('list-package-dependencies [packageNames...]')
+    .alias('lpd')
+    .option('-a, --all', 'List dependencies for all packages.', false)
+    .option('--json', 'Output as JSON.', false)
+    .option(
+      '--undeclared',
+      'Only show imports that have no matching dependency in package.json.',
+      false
+    )
+    .option('--dev-only', 'Only show imports that resolve to devDependencies.', false)
+    .description('Lists external dependencies found in source code for each package.')
+    .asyncAction(main);
+};
+
+async function main(packageNames: string[], options: ActionOptions): Promise<void> {
+  const allPackages = await getListOfPackagesAsync();
+
+  let packages: Package[];
+  if (options.all) {
+    packages = allPackages;
+  } else if (packageNames.length > 0) {
+    packages = allPackages.filter((pkg) => packageNames.includes(pkg.packageName));
+    const found = new Set(packages.map((p) => p.packageName));
+    for (const name of packageNames) {
+      if (!found.has(name)) {
+        logger.warn(`Package ${yellow(name)} not found in monorepo.`);
+      }
+    }
+  } else {
+    logger.error('Specify package names or use --all to scan all packages.');
+    process.exit(1);
+  }
+
+  if (!packages.length) {
+    logger.error('No packages matched.');
+    process.exit(1);
+  }
+
+  const jsonOutput: Record<string, object[]> = {};
+
+  for (const pkg of packages) {
+    if (isNCCBuilt(pkg)) {
+      continue;
+    }
+
+    const checkTypes: PackageCheckType[] = ['package'];
+    if (pkg.hasPlugin) checkTypes.push('plugin');
+    if (pkg.hasCli) checkTypes.push('cli');
+    if (pkg.hasUtils) checkTypes.push('utils');
+
+    for (const checkType of checkTypes) {
+      const deps = await scanDependenciesAsync(pkg, checkType);
+
+      let filtered = deps;
+      if (options.undeclared) {
+        filtered = filtered.filter((d) => d.kind === undefined);
+      }
+      if (options.devOnly) {
+        filtered = filtered.filter((d) => d.kind === DependencyKind.Dev);
+      }
+
+      if (!filtered.length) {
+        continue;
+      }
+
+      const label =
+        checkType === 'package' ? pkg.packageName : `${pkg.packageName} (${checkType})`;
+
+      if (options.json) {
+        jsonOutput[label] = filtered.map((d) => ({
+          packageName: d.packageName,
+          kind: d.kind ?? null,
+          isTypeOnly: d.isTypeOnly,
+          files: d.files.map((f) => ({ path: f.relativePath, line: f.line })),
+        }));
+      } else {
+        logger.log(`\n${green.bold(label)}`);
+        printTable(filtered);
+      }
+    }
+  }
+
+  if (options.json) {
+    logger.log(JSON.stringify(jsonOutput, null, 2));
+  }
+}
+
+function printTable(deps: ScannedDependency[]) {
+  const rows = deps.map((d) => ({
+    dep: d.packageName,
+    kind: kindLabel(d.kind),
+    hints: buildHints(d),
+    refs: d.files.map((f) => `${f.relativePath}:${f.line}`),
+  }));
+
+  const GAP = 2;
+  const depW = Math.max('Dependency'.length, ...rows.map((r) => r.dep.length)) + GAP;
+  const kindW = Math.max('Kind'.length, ...rows.map((r) => r.kind.length)) + GAP;
+  const hintsW = Math.max('Hints'.length, ...rows.map((r) => r.hints.length)) + GAP;
+
+  const indent = '  ';
+
+  // Header
+  logger.log(
+    indent +
+      bold('Dependency'.padEnd(depW) + 'Kind'.padEnd(kindW) + 'Hints'.padEnd(hintsW) + 'References')
+  );
+
+  // Separator
+  logger.log(
+    indent +
+      gray(
+        '─'.repeat(depW - GAP).padEnd(depW) +
+          '─'.repeat(kindW - GAP).padEnd(kindW) +
+          '─'.repeat(hintsW - GAP).padEnd(hintsW) +
+          '─'.repeat(10)
+      )
+  );
+
+  const emptyPrefix = indent + ' '.repeat(depW + kindW + hintsW);
+
+  for (const row of rows) {
+    const firstRef = row.refs[0] ?? '';
+    logger.log(
+      indent +
+        row.dep.padEnd(depW) +
+        coloredCell(row.kind, kindW) +
+        hintCell(row.hints, hintsW) +
+        gray(firstRef)
+    );
+
+    for (let i = 1; i < row.refs.length; i++) {
+      logger.log(emptyPrefix + gray(row.refs[i]));
+    }
+  }
+}
+
+function buildHints(dep: ScannedDependency): string {
+  const parts: string[] = [];
+  if (dep.isTypeOnly) {
+    parts.push('types only');
+  }
+  return parts.join(', ');
+}
+
+function kindLabel(kind: DependencyKind | undefined): string {
+  switch (kind) {
+    case DependencyKind.Normal:
+      return 'dependency';
+    case DependencyKind.Dev:
+      return 'devDependency';
+    case DependencyKind.Peer:
+      return 'peerDependency';
+    case undefined:
+      return 'undeclared';
+    default:
+      return kind;
+  }
+}
+
+/** Render a kind cell: colored text + plain padding to fill the column width */
+function coloredCell(text: string, width: number): string {
+  const colorFn = kindColorFn(text);
+  return colorFn(text) + ' '.repeat(Math.max(0, width - text.length));
+}
+
+function kindColorFn(kind: string): (s: string) => string {
+  switch (kind) {
+    case 'dependency':
+    case 'peerDependency':
+      return cyan;
+    case 'devDependency':
+      return yellow;
+    case 'undeclared':
+      return red;
+    default:
+      return (s: string) => s;
+  }
+}
+
+function hintCell(text: string, width: number): string {
+  if (!text) {
+    return ' '.repeat(width);
+  }
+  return yellow(text) + ' '.repeat(Math.max(0, width - text.length));
+}


### PR DESCRIPTION
# Why

> [!NOTE]
> Largely LLM-generated, since this is a trivial task of moving around existing code and adding a new way to present the data that `checkDependenciesAsync` already generated

This adds a new `et lpd` tool to our dependencies. As part of testing out Turborepo, where some packages may need a manual `build.dependsOn` task definition, it'd be useful to verify actual TypeScript dependencies manually, with the existing tool we already have for this as part of the checks.

# How

- Move classification code to `scanDependenciesAsync.ts`
- Use classification code in `checkDependenciesAsync.ts`
- Add `commands/ListPackageDependencies.ts`
- Detect `typeof import` (**NOTE:** This was missing before)

# Test Plan

- Existing `check-packages` CI task should pass unchanged
- Ran `et check-packages --no-lint --no-test --no-uniformity-check --no-build -a` manually, and no new issues are reported

<img width="846" height="793" alt="image" src="https://github.com/user-attachments/assets/3b5954a5-2d2c-4af4-a660-9b9af18e6a9b" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
