### PR TITLE
[ios][camera] Fix activity indicator after backgrounding

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4009,7 +4009,7 @@ SPEC CHECKSUMS:
   ExpoVideoThumbnails: 2340f0b7f599c9ce6ba49a885f783de919cf4dd3
   ExpoWebBrowser: b65b3921741b51c5513e2a369f59c37076987d9b
   EXStructuredHeaders: e25ac67c966d3795153dfdb40bfd3b999df18929
-  EXUpdates: a0f980531cbcf45906b2489febd4e11a5895f332
+  EXUpdates: 9fc7e72640aae00b570854868e04ed592efc664e
   EXUpdatesInterface: 5ab8c3e8018ef533a132b9327af5b2a1926dd299
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
   hermes-engine: e1ae00897676f600a9439d408b42f8c8ba5dbc24

--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4009,10 +4009,10 @@ SPEC CHECKSUMS:
   ExpoVideoThumbnails: 2340f0b7f599c9ce6ba49a885f783de919cf4dd3
   ExpoWebBrowser: b65b3921741b51c5513e2a369f59c37076987d9b
   EXStructuredHeaders: e25ac67c966d3795153dfdb40bfd3b999df18929
-  EXUpdates: 9fc7e72640aae00b570854868e04ed592efc664e
+  EXUpdates: a0f980531cbcf45906b2489febd4e11a5895f332
   EXUpdatesInterface: 5ab8c3e8018ef533a132b9327af5b2a1926dd299
   FBLazyVector: 26fd21c75314e101f280d401e97f27d54f3f7064
-  hermes-engine: e1ae00897676f600a9439d408b42f8c8ba5dbc24
+  hermes-engine: 725fd85144e1348879039099a6be950c471a4f2c
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4030,7 +4030,7 @@ SPEC CHECKSUMS:
   React: 13cf8451582adb1bb324306e1893b91d1cba28c6
   React-callinvoker: 91e6a605826b684ad2e623811253b4d0c4196bef
   React-Core: 46818de5f211b2a2759ac823b591af8a0a95c2c1
-  React-Core-prebuilt: 1e81ce373ae6d21c61a961e1be02e77633de3007
+  React-Core-prebuilt: 4016009b4cc1d669b1a2369a5d707cdb39fa12ef
   React-CoreModules: a6a37afee48d4a31ab398640b0795462647d5c67
   React-cxxreact: 2ec3e2f7a8ae9303460d4ba94cde183ea90d64cd
   React-debug: 0d21117b897ce0359c9d2c9dfe952f237476a14a
@@ -4100,7 +4100,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 22e2265d86a4e871e5e858f4e7ef1c8d01103680
   ReactCodegen: f564776e1b15423920d439de1965d2000433dbd2
   ReactCommon: a804bb8d1dcf3ecdec3a77eb8bba19b7863bbbdb
-  ReactNativeDependencies: ceedcc3a6ff166bea3c3816a22f58c478ffad807
+  ReactNativeDependencies: a24dd0e4b4318c05556b4b7bb144738f83775e22
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNCPicker: d74667bdfc08ed389a2a277d95b8faf2349290a9

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4636,7 +4636,7 @@ SPEC CHECKSUMS:
   ExpoMailComposer: edd4f46a26ea55ff0e3a83ef0192e79f647911c8
   ExpoMediaLibrary: 2fbddcb06042f43076cf5e495e8237ec2ab95726
   ExpoMeshGradient: 93cf09380e6d86cd7a525da26dfddab2620a8421
-  ExpoModulesCore: 936a4fb73792d8c8bc861d57522539c35fc36e40
+  ExpoModulesCore: 13bc5b9a2fefacfab477b20600dc57821aa4a200
   ExpoModulesJSI: 793687b04cbaa73ee8548bfdbcfba85954d1b2b5
   ExpoModulesTestCore: 62ce59e8c8162b449e65467e0421240256ba6732
   ExpoModulesWorklets: 3a4d6451e29822c01c397da92be1f962a0f870fe
@@ -4661,7 +4661,7 @@ SPEC CHECKSUMS:
   ExpoVideoThumbnails: 2340f0b7f599c9ce6ba49a885f783de919cf4dd3
   ExpoWebBrowser: b65b3921741b51c5513e2a369f59c37076987d9b
   EXStructuredHeaders: e25ac67c966d3795153dfdb40bfd3b999df18929
-  EXUpdates: 33cea909186babc6befefeed3596a82b6c1d63de
+  EXUpdates: 56ce06b32bea90efb1e4c6b28d73e4cfb472b71b
   EXUpdatesInterface: 5ab8c3e8018ef533a132b9327af5b2a1926dd299
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 4cd65993d9ef677523093deeb7d8710f39fb9ed7
@@ -4674,7 +4674,7 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 85bdce8babed7814816496bb6f082bc05b0a45e1
   FirebaseSessions: f5c6bfeb66a7202deaf33352017bb6365e395820
   fmt: 530618a01105dae0fa3a2f27c81ae11fa8f67eac
-  glog: e56ede4028c4b7418e6b1195a36b1656bb35e225
+  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
@@ -4690,7 +4690,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 36c4f904fb6cd0219dcb76b94e9502d2a72fab0b
+  RCT-Folly: 121436bcc4611f6bde5c09bf35f0a7a82cef1969
   RCTDeprecation: 5c945c659e2d68c1428f4a732c83198a4ad6a659
   RCTRequired: c98eb09689f6a2a2c75f6fd419fa94fe71a672c9
   RCTSwiftUI: 88767b796e06cd4af8dca2f7a3f97fccf1d723e0

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [iOS] Use runtime camera availability checks in Simulator so camera code paths can run when a runtime video device is present while preserving fallback behavior when no device is available. (by [@kmagiera](https://github.com/kmagiera)) ([#44159](https://github.com/expo/expo/pull/44159) by [@kmagiera](https://github.com/kmagiera))
 - [iOS] Fix orientation issue caused by upstream changes. ([#44171](https://github.com/expo/expo/pull/44171) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix inconsistent barcode `type` value returned by ZXing fallback scanner (code39, pdf417, codabar) — it now returns the same format as the AVFoundation scanner (e.g. `"code39"` instead of `"org.iso.Code39"`). ([#44726](https://github.com/expo/expo/pull/44726) by [@jensdev](https://github.com/jensdev))
-- [iOS] Fix camera activity indicator remaining active after `CameraView.launchScanner` is interactively dismissed and the app is backgrounded/foregrounded.
+- [iOS] Fix camera activity indicator remaining active after `CameraView.launchScanner` is interactively dismissed and the app is backgrounded/foregrounded. ([#45063](https://github.com/expo/expo/pull/45063) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [iOS] Use runtime camera availability checks in Simulator so camera code paths can run when a runtime video device is present while preserving fallback behavior when no device is available. (by [@kmagiera](https://github.com/kmagiera)) ([#44159](https://github.com/expo/expo/pull/44159) by [@kmagiera](https://github.com/kmagiera))
 - [iOS] Fix orientation issue caused by upstream changes. ([#44171](https://github.com/expo/expo/pull/44171) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix inconsistent barcode `type` value returned by ZXing fallback scanner (code39, pdf417, codabar) — it now returns the same format as the AVFoundation scanner (e.g. `"code39"` instead of `"org.iso.Code39"`). ([#44726](https://github.com/expo/expo/pull/44726) by [@jensdev](https://github.com/jensdev))
-
+- [iOS] Fix camera activity indicator remaining active after `CameraView.launchScanner` is interactively dismissed and the app is backgrounded/foregrounded.
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -405,7 +405,10 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       controller.delegate = delegate
     }
 
-    appContext?.utilities?.currentViewController()?.present(controller, animated: true) {
+    appContext?.utilities?.currentViewController()?.present(controller, animated: true) { [weak self] in
+      if let delegate = self?.scannerContext?.delegate as? VisionScannerDelegate {
+        controller.presentationController?.delegate = delegate
+      }
       try? controller.startScanning()
     }
   }
@@ -416,12 +419,23 @@ public final class CameraViewModule: Module, ScannerResultHandler {
     guard let controller = scannerContext?.controller as? DataScannerViewController else {
       return
     }
-    controller.stopScanning()
-    controller.dismiss(animated: true)
+    controller.dismiss(animated: true) { [weak self] in
+      self?.onScannerDismissed()
+    }
   }
 
   func onItemScanned(result: [String: Any]) {
     sendEvent("onModernBarcodeScanned", result)
+  }
+
+  @MainActor
+  func onScannerDismissed() {
+    if #available(iOS 16.0, *) {
+      if let controller = scannerContext?.controller as? DataScannerViewController {
+        controller.stopScanning()
+      }
+    }
+    scannerContext = nil
   }
 
   private func getAvailableVideoCodecs() -> [String] {

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -18,12 +18,9 @@ class BarcodeScannerUtils {
       "aztec": AVMetadataObject.ObjectType.aztec,
       "interleaved2of5": AVMetadataObject.ObjectType.interleaved2of5,
       "itf14": AVMetadataObject.ObjectType.itf14,
-      "datamatrix": AVMetadataObject.ObjectType.dataMatrix
+      "datamatrix": AVMetadataObject.ObjectType.dataMatrix,
+      "codabar": AVMetadataObject.ObjectType.codabar
     ]
-
-    if #available(iOS 15.4, *) {
-      validTypes["codabar"] = AVMetadataObject.ObjectType.codabar
-    }
 
     return [BARCODE_TYPES_KEY: Array(validTypes.values)]
   }

--- a/packages/expo-camera/ios/Current/VisionScannerDelegate.swift
+++ b/packages/expo-camera/ios/Current/VisionScannerDelegate.swift
@@ -3,10 +3,11 @@ import ExpoModulesCore
 
 protocol ScannerResultHandler {
   func onItemScanned(result: [String: Any])
+  @MainActor func onScannerDismissed()
 }
 
 @available(iOS 16.0, *)
-class VisionScannerDelegate: NSObject, DataScannerViewControllerDelegate {
+class VisionScannerDelegate: NSObject, DataScannerViewControllerDelegate, UIAdaptivePresentationControllerDelegate {
   private let handler: ScannerResultHandler
 
   init(handler: ScannerResultHandler) {
@@ -25,5 +26,9 @@ class VisionScannerDelegate: NSObject, DataScannerViewControllerDelegate {
         return
       }
     }
+  }
+
+  func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+    handler.onScannerDismissed()
   }
 }


### PR DESCRIPTION
# Why
Closes #44945
On iOS, the camera activity indicator stays active after `CameraView.launchScanner` is dismissed and the app is backgrounded and foregrounded. Only a force-close clears it.

The module's `scannerContext` retained the `DataScannerViewController` indefinitely, `dismissScanner()` didn't clear it, and drag-down dismissal wasn't observed at all.

# How
- Made `VisionScannerDelegate` also conform to `UIAdaptivePresentationControllerDelegate` and implement `presentationControllerDidDismiss` so drag-down dismissal now notifies the module.
- Added a `onScannerDismissed()` cleanup method on `CameraViewModule` that calls `stopScanning()` and clears `scannerContext`. 


# Test Plan
In the provided repro and bare expo
