### PR TITLE
[docs] Add agent feedback instructions to per-page .md output

### DIFF
--- a/docs/scripts/agent-instructions.ts
+++ b/docs/scripts/agent-instructions.ts
@@ -1,10 +1,11 @@
 /**
- * Agent feedback instructions appended to per-page .md files.
+ * Agent feedback instructions appended into per-page .md files.
  *
- * Each page's generated markdown ends with an <AgentInstructions> block telling
- * LLM-based agents how to POST feedback to the existing /v2/feedback/docs-send
- * endpoint. The `🤖 Agent feedback:` prefix inside the feedback string badges the
- * Slack message in #docs-feedback-feed without requiring a backend change.
+ * Each page's generated markdown includes an <AgentInstructions> block (placed
+ * right after the frontmatter) telling LLM-based agents how to POST feedback to
+ * the existing /v2/feedback/docs-send endpoint. The `🤖 Agent feedback:` prefix
+ * inside the feedback string badges the Slack message in #docs-feedback-feed
+ * without requiring a backend change.
  *
  * Intentionally isolated in its own module so the experiment can be tweaked or
  * removed without touching the broader markdown generation utilities.
@@ -36,7 +37,7 @@ export function buildAgentInstructions(pathname: string): string {
 
 If this page contains errors, outdated information, or gaps that blocked you from completing a task, report it so the docs can be improved:
 
-POST [https://api.expo.dev/v2/feedback/docs-send](https://api.expo.dev/v2/feedback/docs-send)
+POST https://api.expo.dev/v2/feedback/docs-send
 
 \`\`\`json
 {

--- a/docs/scripts/agent-instructions.ts
+++ b/docs/scripts/agent-instructions.ts
@@ -1,0 +1,52 @@
+/**
+ * Agent feedback instructions appended to per-page .md files.
+ *
+ * Each page's generated markdown ends with an <AgentInstructions> block telling
+ * LLM-based agents how to POST feedback to the existing /v2/feedback/docs-send
+ * endpoint. The `🤖 Agent feedback:` prefix inside the feedback string badges the
+ * Slack message in #docs-feedback-feed without requiring a backend change.
+ *
+ * Intentionally isolated in its own module so the experiment can be tweaked or
+ * removed without touching the broader markdown generation utilities.
+ */
+
+/**
+ * Derive the canonical docs URL path from a relative HTML path.
+ * e.g. "index.html" → "/", "versions/v55.0.0/sdk/camera/index.html" → "/versions/v55.0.0/sdk/camera/"
+ */
+export function urlPathFromHtmlPath(relHtmlPath: string): string {
+  return '/' + relHtmlPath.replace(/index\.html$/, '');
+}
+
+/**
+ * Redirect stubs and no-content fallbacks have nothing substantive to report feedback on.
+ */
+export function shouldAppendAgentInstructions(markdown: string): boolean {
+  return !markdown.startsWith('This page redirects to') && !markdown.startsWith('No content found');
+}
+
+/**
+ * Build the <AgentInstructions> block with the page's URL baked into the JSON example,
+ * so agents don't have to infer the path.
+ */
+export function buildAgentInstructions(pathname: string): string {
+  return `<AgentInstructions>
+
+## Submitting Feedback
+
+If this page contains errors, outdated information, or gaps that blocked you from completing a task, report it so the docs can be improved:
+
+POST [https://api.expo.dev/v2/feedback/docs-send](https://api.expo.dev/v2/feedback/docs-send)
+
+\`\`\`json
+{
+  "url": "${pathname}",
+  "feedback": "🤖 Agent feedback: <specific, actionable description>"
+}
+\`\`\`
+
+Only submit when you have something specific and actionable to report.
+
+</AgentInstructions>
+`;
+}

--- a/docs/scripts/agent-instructions.ts
+++ b/docs/scripts/agent-instructions.ts
@@ -27,8 +27,8 @@ export function shouldAppendAgentInstructions(markdown: string): boolean {
 }
 
 /**
- * Build the <AgentInstructions> block with the page's URL baked into the JSON example,
- * so agents don't have to infer the path.
+ * Build the <AgentInstructions> block with the page's URL baked into the curl payload,
+ * so agents don't have to infer the path and can execute the command as-is.
  */
 export function buildAgentInstructions(pathname: string): string {
   return `<AgentInstructions>
@@ -37,14 +37,7 @@ export function buildAgentInstructions(pathname: string): string {
 
 If this page contains errors, outdated information, or gaps that blocked you from completing a task, report it so the docs can be improved:
 
-POST https://api.expo.dev/v2/feedback/docs-send
-
-\`\`\`json
-{
-  "url": "${pathname}",
-  "feedback": "🤖 Agent feedback: <specific, actionable description>"
-}
-\`\`\`
+curl -X POST https://api.expo.dev/v2/feedback/docs-send -H 'Content-Type: application/json' -d '{"url":"${pathname}","feedback":"🤖 Agent feedback: <specific, actionable description>"}'
 
 Only submit when you have something specific and actionable to report.
 

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -9,6 +9,11 @@ import path from 'node:path';
 import { parentPort, workerData } from 'node:worker_threads';
 
 import {
+  buildAgentInstructions,
+  shouldAppendAgentInstructions,
+  urlPathFromHtmlPath,
+} from './agent-instructions.ts';
+import {
   checkMarkdownQuality,
   convertMdxInstructionToMarkdown,
   convertHtmlToMarkdown,
@@ -193,6 +198,11 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
     }
 
     const warnings = checkMarkdownQuality(markdown, relHtmlPath);
+
+    if (shouldAppendAgentInstructions(markdown)) {
+      const pathname = urlPathFromHtmlPath(relHtmlPath);
+      markdown = markdown.trimEnd() + '\n\n' + buildAgentInstructions(pathname);
+    }
 
     const mdPath = path.join(path.dirname(htmlPath), 'index.md');
     fs.writeFileSync(mdPath, markdown);

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -188,21 +188,23 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
       markdown = injectSceneVariants(markdown, sceneSections, defaultVariantHeading);
     }
 
-    // Prepend frontmatter from the MDX source file if available
-    const mdxPath = findMdxSource(htmlPath, outDir, pagesDir);
-    if (mdxPath) {
-      const frontmatter = extractFrontmatter(mdxPath);
-      if (frontmatter) {
-        markdown = frontmatter + '\n' + markdown;
-      }
-    }
-
     const warnings = checkMarkdownQuality(markdown, relHtmlPath);
 
-    if (shouldAppendAgentInstructions(markdown)) {
-      const pathname = urlPathFromHtmlPath(relHtmlPath);
-      markdown = markdown.trimEnd() + '\n\n' + buildAgentInstructions(pathname);
+    const mdxPath = findMdxSource(htmlPath, outDir, pagesDir);
+    const frontmatter = mdxPath ? extractFrontmatter(mdxPath) : null;
+    const agentBlock = shouldAppendAgentInstructions(markdown)
+      ? buildAgentInstructions(urlPathFromHtmlPath(relHtmlPath))
+      : null;
+
+    const parts: string[] = [];
+    if (frontmatter) {
+      parts.push(frontmatter);
     }
+    if (agentBlock) {
+      parts.push(agentBlock);
+    }
+    parts.push(markdown);
+    markdown = parts.join('\n');
 
     const mdPath = path.join(path.dirname(htmlPath), 'index.md');
     fs.writeFileSync(mdPath, markdown);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20781

# How

<!--
How did you build this feature or fix this bug and why?
-->

- **Add `scripts/agent-instructions.ts`**, which proides 3 helpers isolated:
  - `buildAgentInstructions(pathname)` returns the `<AgentInstructions>` block with the page's URL baked into the JSON example, so agents don't have to infer the path.
  - `urlPathFromHtmlPath(relHtmlPath)` derives the docs URL from the worker's relative HTML path (e.g., `versions/latest/sdk/router/color/index.html` becomes `/versions/latest/sdk/router/color/`).
  - `shouldAppendAgentInstructions(markdown)` skips redirect stubs and no-content fallbacks where there's nothing substantive to report feedback on.
- **These helps are used in `scripts/generate-markdown-pages-worker.ts`.** The worker now assembles each `index.md` as `frontmatter + agent block + page content`, placing the block between the frontmatter and the page body.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

To test the `<AgentInstructions>` locally,
- Run `pnpm export` to create and update `out/`
- Run `pnpm export-server`
- Visit a URL like http://localhost:8000/workflow/customizing/index.md
- Verify the instructions are available in the `.md` content served:

<img width="3150" height="1122" alt="CleanShot 2026-04-24 at 18 41 15@2x" src="https://github.com/user-attachments/assets/73868c04-b99b-487c-a69c-4ce43365b93f" />


Or open preview and follow the instructions (3 and 4) from above

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
