### PR TITLE
feat(precompile) add support for optionally downloading 3rd party libs

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Add support for optionally downloading external precompiled XCFramework tarballs from during `pod install`.
+- [iOS] Add support for optionally downloading external precompiled XCFramework tarballs from during `pod install`. ([#45067](https://github.com/expo/expo/pull/45067) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Resolve 3rd-party prebuilt xcframework packages via `@react-native-community/cli` autolinking output instead of guessing `node_modules/<pkg>`, fixing pnpm non-hoisted layouts, transitive native deps, yarn resolutions/PnP, and aliased specifiers ([#45004](https://github.com/expo/expo/pull/45004) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed precompiled modules use_frameworks! override running when only prebuilt React Native is active. ([#44554](https://github.com/expo/expo/pull/44554) by [@chrfalch](https://github.com/chrfalch))
 - Fix regression that caused `pod install` to fail with `no implicit conversion of nil into String` due to an off-by-one in the depth limit check. ([#43731](https://github.com/expo/expo/pull/43731) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Add support for optionally downloading external precompiled XCFramework tarballs from during `pod install`.
 - [iOS] Resolve 3rd-party prebuilt xcframework packages via `@react-native-community/cli` autolinking output instead of guessing `node_modules/<pkg>`, fixing pnpm non-hoisted layouts, transitive native deps, yarn resolutions/PnP, and aliased specifiers ([#45004](https://github.com/expo/expo/pull/45004) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed precompiled modules use_frameworks! override running when only prebuilt React Native is active. ([#44554](https://github.com/expo/expo/pull/44554) by [@chrfalch](https://github.com/chrfalch))
 - Fix regression that caused `pod install` to fail with `no implicit conversion of nil into String` due to an off-by-one in the depth limit check. ([#43731](https://github.com/expo/expo/pull/43731) by [@zoontek](https://github.com/zoontek))

--- a/packages/expo-modules-autolinking/external-configs/ios/README.md
+++ b/packages/expo-modules-autolinking/external-configs/ios/README.md
@@ -36,13 +36,13 @@ Configs live in `packages/expo-modules-autolinking/external-configs/ios/<package
 - **Config location**: `packages/expo-modules-autolinking/external-configs/ios/<package-name>/spm.config.json`
 - **Source location**: `node_modules/<package-name>/` (resolved at build time)
 - **Output location**: `packages/precompile/.build/<package-name>/output/<flavor>/xcframeworks/`
-- **Remote fallback**: external package prebuilds can download missing tarballs from a bucket when `EXPO_PRECOMPILED_EXTERNAL_MODULES_URL` is set.
+- **Remote fallback**: external package prebuilds can download missing tarballs from a remote host when `EXPO_PRECOMPILED_MODULES_BASE_URL` is set.
 
 ### Remote Artifact Downloads
 
-Remote downloads are opt-in via `EXPO_PRECOMPILED_EXTERNAL_MODULES_URL`.
+Remote downloads are opt-in via `EXPO_PRECOMPILED_MODULES_BASE_URL`.
 
-- Supports `gs://<bucket-name>` and HTTPS URLs. `gs://` is translated to `https://storage.googleapis.com/<bucket-name>` at download time.
+- Supports `http://` and `https://` URLs.
 - Final download path: `<baseUrl>/<npm-package>/output/<packageVersion>/<reactNativeVersion>/<hermesVersion>/<flavor>/xcframeworks/<Product>.tar.gz` when versions are known, otherwise `<baseUrl>/<npm-package>/output/<flavor>/xcframeworks/<Product>.tar.gz`
 
 ### The SPMPackageSource Interface

--- a/packages/expo-modules-autolinking/external-configs/ios/README.md
+++ b/packages/expo-modules-autolinking/external-configs/ios/README.md
@@ -36,6 +36,14 @@ Configs live in `packages/expo-modules-autolinking/external-configs/ios/<package
 - **Config location**: `packages/expo-modules-autolinking/external-configs/ios/<package-name>/spm.config.json`
 - **Source location**: `node_modules/<package-name>/` (resolved at build time)
 - **Output location**: `packages/precompile/.build/<package-name>/output/<flavor>/xcframeworks/`
+- **Remote fallback**: external package prebuilds can download missing tarballs from a bucket when `EXPO_PRECOMPILED_EXTERNAL_MODULES_URL` is set.
+
+### Remote Artifact Downloads
+
+Remote downloads are opt-in via `EXPO_PRECOMPILED_EXTERNAL_MODULES_URL`.
+
+- Supports `gs://<bucket-name>` and HTTPS URLs. `gs://` is translated to `https://storage.googleapis.com/<bucket-name>` at download time.
+- Final download path: `<baseUrl>/<npm-package>/output/<packageVersion>/<reactNativeVersion>/<hermesVersion>/<flavor>/xcframeworks/<Product>.tar.gz` when versions are known, otherwise `<baseUrl>/<npm-package>/output/<flavor>/xcframeworks/<Product>.tar.gz`
 
 ### The SPMPackageSource Interface
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -43,7 +43,7 @@ module Expo
     MODULES_PATH_ENV_VAR = 'EXPO_PRECOMPILED_MODULES_PATH'.freeze
 
     # Environment variable for a shared remote base URL used by external prebuilt packages.
-    EXTERNAL_MODULES_BASE_URL_ENV_VAR = 'EXPO_PRECOMPILED_EXTERNAL_MODULES_URL'.freeze
+    EXTERNAL_MODULES_BASE_URL_ENV_VAR = 'EXPO_PRECOMPILED_MODULES_BASE_URL'.freeze
 
     # Subdirectory within each pod dir for tarballs and build state
     ARTIFACTS_DIR_NAME = 'artifacts'.freeze
@@ -1725,17 +1725,9 @@ module Expo
           'xcframeworks',
           "#{product_name}.tar.gz"
         ].join('/')
-        remote_url = "#{normalize_remote_base_url(base_url)}/#{relative_path}"
-        return nil unless remote_url
+        remote_url = "#{base_url.chomp('/')}/#{relative_path}"
 
         download_remote_tarball(remote_url, tarball, pod_name || product_name, flavor)
-      end
-
-      def normalize_remote_base_url(base_url)
-        return base_url.chomp('/') unless base_url.start_with?('gs://')
-
-        bucket_and_prefix = base_url.delete_prefix('gs://').sub(%r{/+\z}, '')
-        "https://storage.googleapis.com/#{bucket_and_prefix}"
       end
 
       def download_remote_tarball(remote_url, destination_path, pod_name, flavor)
@@ -1756,10 +1748,9 @@ module Expo
       def download_to_file(url, destination_path, limit = 5)
         raise 'Too many HTTP redirects' if limit <= 0
 
-        uri = URI.parse(normalize_remote_base_url(url))
-        raise "Only HTTPS artifact URLs are supported: #{url}" unless uri.is_a?(URI::HTTPS)
+        uri = URI.parse(url)
 
-        Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 10, read_timeout: 120) do |http|
+        Net::HTTP.start(uri.host, uri.port, use_ssl: uri.is_a?(URI::HTTPS), open_timeout: 10, read_timeout: 120) do |http|
           request = Net::HTTP::Get.new(uri.request_uri)
 
           http.request(request) do |response|

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -28,6 +28,7 @@
 
 require 'fileutils'
 require 'json'
+require 'net/http'
 require 'uri'
 
 module Expo
@@ -40,6 +41,9 @@ module Expo
 
     # Environment variable for custom precompiled modules base path
     MODULES_PATH_ENV_VAR = 'EXPO_PRECOMPILED_MODULES_PATH'.freeze
+
+    # Environment variable for a shared remote base URL used by external prebuilt packages.
+    EXTERNAL_MODULES_BASE_URL_ENV_VAR = 'EXPO_PRECOMPILED_EXTERNAL_MODULES_URL'.freeze
 
     # Subdirectory within each pod dir for tarballs and build state
     ARTIFACTS_DIR_NAME = 'artifacts'.freeze
@@ -79,6 +83,11 @@ module Expo
       #   <npm_package>/output/<flavor>/xcframeworks/<Product>.tar.gz
       def custom_modules_path
         ENV[MODULES_PATH_ENV_VAR]
+      end
+
+      # Returns the shared base URL for remote external prebuilt artifacts, if set.
+      def external_modules_base_url
+        ENV[EXTERNAL_MODULES_BASE_URL_ENV_VAR]
       end
 
       # Returns true if precompiled modules are enabled via environment variable
@@ -637,7 +646,7 @@ module Expo
 
           # Copy both flavor tarballs
           ['debug', 'release'].each do |flavor|
-            src = File.join(build_output_dir, flavor, 'xcframeworks', "#{product_name}.tar.gz")
+            src = resolve_prebuilt_tarball(info, product_name, flavor, pod_name)
             dst = File.join(artifacts_dir, "#{product_name}-#{flavor}.tar.gz")
             FileUtils.cp(src, dst) if File.exist?(src) && !File.exist?(dst)
           end
@@ -649,7 +658,7 @@ module Expo
           # Self-healing: extract xcframework if missing (CocoaPods cache issue)
           xcframework_dir = File.join(pod_dir, "#{product_name}.xcframework")
           unless File.directory?(xcframework_dir)
-            tarball = File.join(build_output_dir, build_flavor, 'xcframeworks', "#{product_name}.tar.gz")
+            tarball = resolve_prebuilt_tarball(info, product_name, build_flavor, pod_name)
             if File.exist?(tarball)
               Pod::UI.info "#{'[Expo-precompiled] '.blue}Extracting #{product_name}.xcframework (cache miss)"
               system("tar", "xzf", tarball, "-C", pod_dir)
@@ -1695,10 +1704,78 @@ module Expo
         return nil unless pod_info
 
         product_name = pod_info[:product_name] || pod_name
-        tarball = File.join(pod_info[:build_output_dir], build_flavor, 'xcframeworks', "#{product_name}.tar.gz")
+        tarball = resolve_prebuilt_tarball(pod_info, product_name, build_flavor, pod_name)
         return nil unless File.exist?(tarball)
 
         [pod_info, product_name, tarball]
+      end
+
+      def resolve_prebuilt_tarball(pod_info, product_name, flavor, pod_name = nil)
+        tarball = File.join(pod_info[:build_output_dir], flavor, 'xcframeworks', "#{product_name}.tar.gz")
+        return tarball if File.exist?(tarball)
+
+        base_url = external_modules_base_url
+        return tarball unless pod_info[:type] == :external && base_url
+
+        output_prefix = File.join(pod_info[:npm_package], 'output')
+        idx = pod_info[:build_output_dir].rindex(output_prefix)
+        relative_path = [
+          (idx ? pod_info[:build_output_dir][idx..] : output_prefix),
+          flavor,
+          'xcframeworks',
+          "#{product_name}.tar.gz"
+        ].join('/')
+        remote_url = "#{normalize_remote_base_url(base_url)}/#{relative_path}"
+        return nil unless remote_url
+
+        download_remote_tarball(remote_url, tarball, pod_name || product_name, flavor)
+      end
+
+      def normalize_remote_base_url(base_url)
+        return base_url.chomp('/') unless base_url.start_with?('gs://')
+
+        bucket_and_prefix = base_url.delete_prefix('gs://').sub(%r{/+\z}, '')
+        "https://storage.googleapis.com/#{bucket_and_prefix}"
+      end
+
+      def download_remote_tarball(remote_url, destination_path, pod_name, flavor)
+        FileUtils.mkdir_p(File.dirname(destination_path))
+        tmp_path = "#{destination_path}.download-#{Process.pid}"
+
+        Pod::UI.info "#{'[Expo-precompiled] '.blue}#{pod_name}: downloading #{flavor} artifact from #{remote_url}"
+
+        download_to_file(remote_url, tmp_path)
+        FileUtils.mv(tmp_path, destination_path)
+        destination_path
+      rescue => e
+        FileUtils.rm_f(tmp_path) if tmp_path && File.exist?(tmp_path)
+        Pod::UI.warn "[Expo-precompiled] #{pod_name}: failed to download #{flavor} artifact from #{remote_url}: #{e.message}"
+        nil
+      end
+
+      def download_to_file(url, destination_path, limit = 5)
+        raise 'Too many HTTP redirects' if limit <= 0
+
+        uri = URI.parse(normalize_remote_base_url(url))
+        raise "Only HTTPS artifact URLs are supported: #{url}" unless uri.is_a?(URI::HTTPS)
+
+        Net::HTTP.start(uri.host, uri.port, use_ssl: true, open_timeout: 10, read_timeout: 120) do |http|
+          request = Net::HTTP::Get.new(uri.request_uri)
+
+          http.request(request) do |response|
+            case response
+            when Net::HTTPSuccess
+              File.open(destination_path, 'wb') do |file|
+                response.read_body { |chunk| file.write(chunk) }
+              end
+            when Net::HTTPRedirection
+              redirect_url = URI.join(uri.to_s, response['location']).to_s
+              return download_to_file(redirect_url, destination_path, limit - 1)
+            else
+              raise "HTTP #{response.code}"
+            end
+          end
+        end
       end
 
       # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# Why

We want to be able to use prebuilt 3rd party frameworks in eas build. These are produced and uploaded to a google bucket that we can use.

# How

If we provide the following environment variable:
`EXPO_PRECOMPILED_EXTERNAL_MODULES_URL=gs://eas-build-precompiled-modules` - pod install will look for missing 3rd party xcframeworks using the version folder structure in the google bucket/in the precompile system.

# Test-plan

Run with `EXPO_PRECOMPILED_EXTERNAL_MODULES_URL=gs://eas-build-precompiled-modules` in EAS build.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).