### PR TITLE
[tools] Add --skip-ios-prebuilds option to publish command

### DIFF
--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -1,7 +1,12 @@
 name: Publish Canaries
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+      inputs:
+        skip-ios-prebuilds:
+          description: Skip bundling iOS xcframeworks
+          type: boolean
+          default: false
   pull_request:
     paths:
       - .github/workflows/publish-canaries.yml
@@ -45,7 +50,7 @@ jobs:
       - name: 📦 Install dependencies
         run: pnpm install --frozen-lockfile
       - name: 📦 Publish canaries
-        run: pnpm expotools publish-packages --canary ${{ github.event_name != 'workflow_dispatch' && '--dry' || '' }}
+        run: pnpm expotools publish-packages --canary ${{ github.event_name != 'workflow_dispatch' && '--dry' || '' }} ${{ inputs.skip-ios-prebuilds && '--skip-ios-prebuilds' || '' }}
         env:
           FORCE_COLOR: '2'
       - name: 🔔 Notify on Slack

--- a/tools/src/commands/PublishPackages.ts
+++ b/tools/src/commands/PublishPackages.ts
@@ -92,6 +92,7 @@ export default (program: Command) => {
       'Whether to build and publish Android artifacts to the local NPM registry.',
       false
     )
+    .option('--skip-ios-prebuilds', 'Skips bundling iOS xcframeworks.', false)
     .option(
       '--auto-select-unpublished',
       'When retrying after a failed publish, auto-select all packages whose current version is not published yet and allow deselecting in a multi-select prompt.',

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -7,7 +7,7 @@ import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { runPrebuildPackagesAsync } from '../../commands/PrebuildPackages';
-import { Parcel, TaskArgs } from '../types';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
 
 /**
  * Packages whose iOS prebuilt xcframeworks should be bundled into the npm tarball.
@@ -43,7 +43,12 @@ export const bundleIOSPrebuilds = new Task<TaskArgs>(
     name: 'bundleIOSPrebuilds',
     dependsOn: [loadRequestedParcels],
   },
-  async (parcels: Parcel[]) => {
+  async (parcels: Parcel[], options: CommandOptions) => {
+    if (options.skipIosPrebuilds) {
+      logger.debug('\n📱 Skipping iOS prebuilds due to --skip-ios-prebuilds flag.');
+      return;
+    }
+
     logger.log('\n📱 Building iOS prebuilds...');
 
     const relevantParcels = IOS_PREBUILD_PACKAGES.filter((name) =>

--- a/tools/src/publish-packages/types.ts
+++ b/tools/src/publish-packages/types.ts
@@ -26,6 +26,7 @@ export type CommandOptions = {
   /** Bypass the non-cascading package filter and cascade dependents for all packages */
   cascadeAll: boolean;
   skipAndroidArtifacts: boolean;
+  skipIosPrebuilds: boolean;
   /**
    * When true, automatically selects packages whose current package.json version
    * has already been bumped locally but that version has not been published yet.


### PR DESCRIPTION
## Summary
- Adds `--skip-ios-prebuilds` CLI option to the `publish-packages` command to skip bundling iOS xcframeworks.
- Adds a `skip-ios-prebuilds` boolean input to the `publish-canaries` workflow so it can be toggled from the GitHub UI.

## Test plan
- [x] Run `et publish --canary --skip-ios-prebuilds --dry` and verify iOS prebuilds are skipped.
- [x] Trigger the `publish-canaries` workflow with the input checked.