### PR TITLE
Revert "chore: remove `workspaces` property from root `package.json` (#45037)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,14 @@
     "lint": "eslint .",
     "tsc": "echo 'You are trying to run \"tsc\" in the workspace root. Run it from an individual package instead.' && exit 1"
   },
+  "workspaces": {
+    "packages": [
+      "apps/*",
+      "apps/brownfield-tester/*",
+      "packages/*",
+      "packages/@expo/*"
+    ]
+  },
   "resolutions": {
     "react": "19.2.3",
     "react-dom": "19.2.3",


### PR DESCRIPTION
# Why

`et publish` still uses `yarn` to update workspace dependencies, so removing `workspaces` from the root `package.json` broke publishing, including canaries. See https://github.com/expo/expo/actions/runs/24867610484/job/72807012781
