### PR TITLE
[JSI] Ensure stub xcframework is created on every pod install

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3980,8 +3980,8 @@ SPEC CHECKSUMS:
   ExpoMaps: 94294944cff46ad1170ce4f92800adecbcdd04ac
   ExpoMediaLibrary: 2fbddcb06042f43076cf5e495e8237ec2ab95726
   ExpoMeshGradient: 93cf09380e6d86cd7a525da26dfddab2620a8421
-  ExpoModulesCore: 110aff3e8bff75926b963c45ef9caf89e4132c5c
-  ExpoModulesJSI: 71ee2c91700fbad70c35aff1dcea87d3a6e071bb
+  ExpoModulesCore: e25604088a83936db2694ace1ca680fecf34817d
+  ExpoModulesJSI: 16f789b94db843249981e5f550e050cc321fe554
   ExpoModulesTestCore: 62ce59e8c8162b449e65467e0421240256ba6732
   ExpoModulesWorklets: 3a4d6451e29822c01c397da92be1f962a0f870fe
   ExpoNetwork: 15d026c5c28251e0810849c8c01ebc9bc73ad007

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -56,6 +56,11 @@ module Pod
       # Call original implementation first
       _original_run_podfile_pre_install_hooks.bind(self).()
 
+      # ExpoModulesJSI needs a stub xcframework so CocoaPods generates the
+      # "[CP] Copy XCFrameworks" build phase. The stub is gitignored and may be
+      # absent after a fresh checkout or when CI restores a stale Pods/ cache.
+      ensure_expo_modules_jsi_stub_xcframework()
+
       # Disable use_frameworks! for pods that can't be built as frameworks
       Expo::PrecompiledModules.perform_pre_install(self)
 
@@ -78,6 +83,23 @@ module Pod
     end
 
     private
+
+    # Creates the stub xcframework for ExpoModulesJSI if it doesn't exist.
+    # CocoaPods only runs prepare_command when a pod is freshly downloaded or
+    # its podspec changes, so CI cache hits skip it. This method runs on every
+    # pod install to guarantee the stub is always present.
+    def ensure_expo_modules_jsi_stub_xcframework
+      jsi_target = self.pod_targets.find { |t| t.name == 'ExpoModulesJSI' }
+      return if jsi_target.nil?
+
+      pod_dir = jsi_target.sandbox.pod_dir('ExpoModulesJSI')
+      return unless File.directory?(pod_dir)
+
+      xcframework_path = File.join(pod_dir, 'Products', 'ExpoModulesJSI.xcframework')
+      return if File.directory?(xcframework_path)
+
+      system('./scripts/create-stub-xcframework.sh', chdir: pod_dir.to_s)
+    end
 
     # We should only disable USE_FRAMEWORKS for specific pods when:
     # - RCT_USE_PREBUILT_RNCORE is not '1'

--- a/packages/expo-modules-jsi/apple/ExpoModulesJSI.podspec
+++ b/packages/expo-modules-jsi/apple/ExpoModulesJSI.podspec
@@ -55,6 +55,9 @@ Pod::Spec.new do |s|
 
   # Create a stub xcframework if needed, so CocoaPods generates the
   # "[CP] Copy XCFrameworks" and "[CP] Embed Pods Frameworks" build phases.
+  # This is only a fallback — CocoaPods skips prepare_command when the podspec
+  # hasn't changed (e.g. CI cache hit). The primary path is
+  # ensure_expo_modules_jsi_stub_xcframework in expo-modules-autolinking.
   s.prepare_command = './scripts/create-stub-xcframework.sh'
 
   s.vendored_frameworks = ["Products/#{s.name}.xcframework"]

--- a/packages/expo-modules-jsi/apple/scripts/create-stub-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/create-stub-xcframework.sh
@@ -11,6 +11,14 @@ PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PACKAGE_NAME="ExpoModulesJSI"
 XCFRAMEWORK_PATH="${PACKAGE_DIR}/Products/${PACKAGE_NAME}.xcframework"
 
+# Use colors only when run in the terminal
+BLUE=""; RESET=""
+if [ -t 1 ]; then
+  BLUE="\033[34m"
+  RESET="\033[0m"
+fi
+echo -e "${BLUE}[Expo]${RESET} Creating stub xcframework for ${PACKAGE_NAME}"
+
 # Platform slices the podspec supports. CocoaPods reads Info.plist at
 # `pod install` time to generate per-slice cases in its xcframework copy
 # script, so every SDK we want to build for must appear here.


### PR DESCRIPTION
## Summary
- CocoaPods skips `prepare_command` when the podspec hasn't changed (e.g. CI cache hit), so the stub xcframework that ExpoModulesJSI needs for the "[CP] Copy XCFrameworks" build phase may be missing.
- Added `ensure_expo_modules_jsi_stub_xcframework` hook in `expo-modules-autolinking`'s `pre_install` that runs on every `pod install` to guarantee the stub exists.
- The podspec's `prepare_command` is kept as a fallback for standalone usage.

## Test plan
- Delete `packages/expo-modules-jsi/apple/Products/` and run `pod install` in bare-expo — the hook creates the stub and logs `[Expo] Creating stub xcframework for ExpoModulesJSI`.

<!-- disable:changelog-checks -->