### PR TITLE
[ios][dev-launcher] Fix settings screen insets

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
 - [macOS] Fix LocalNetworkPermissionView max height ([#44745](https://github.com/expo/expo/pull/44745) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use `OkHttpClientProvider` instead of bare `OkHttpClient` so custom interceptors are applied. ([#44798](https://github.com/expo/expo/pull/44798) by [@fabriziocucci](https://github.com/fabriziocucci))
+- [iOS] Fix safe area insets not being applied on settings screen.
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -28,7 +28,7 @@
 - [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
 - [macOS] Fix LocalNetworkPermissionView max height ([#44745](https://github.com/expo/expo/pull/44745) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Use `OkHttpClientProvider` instead of bare `OkHttpClient` so custom interceptors are applied. ([#44798](https://github.com/expo/expo/pull/44798) by [@fabriziocucci](https://github.com/fabriziocucci))
-- [iOS] Fix safe area insets not being applied on settings screen.
+- [iOS] Fix safe area insets not being applied on settings screen. ([#45074](https://github.com/expo/expo/pull/45074) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/Navigation/Navigation.swift
@@ -2,7 +2,7 @@
 import SwiftUI
 import ExpoModulesCore
 
-private struct SafeAreaTopPadding: View {
+struct SafeAreaTopPadding: View {
   let manualInset: CGFloat
 
   var body: some View {

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -31,6 +31,11 @@ struct SettingsTabView: View {
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 24) {
+        if viewModel.topSafeAreaInset > 0 {
+          Color.expoSystemBackground
+            .frame(height: viewModel.topSafeAreaInset)
+        }
+
         titleSection
         showMenuAtLaunch
         gestures

--- a/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/SettingsTabView.swift
@@ -31,11 +31,7 @@ struct SettingsTabView: View {
   var body: some View {
     ScrollView {
       VStack(alignment: .leading, spacing: 24) {
-        if viewModel.topSafeAreaInset > 0 {
-          Color.expoSystemBackground
-            .frame(height: viewModel.topSafeAreaInset)
-        }
-
+        SafeAreaTopPadding(manualInset: viewModel.topSafeAreaInset)
         titleSection
         showMenuAtLaunch
         gestures


### PR DESCRIPTION
# Why
Fixes missing insets on the settings screen

# How
The settings screen doesn't use the `DevLauncherNavigationHeader`. Because of this is doesn't receive the safe area insets fallback from `viewModel.topSafeAreaInset`. Added the `SafeAreaTopPadding` view on that screen

# Test Plan
sandbox app on a physical device
