### PR TITLE
[docs] Migrate multiple docs pages with Prerequisites sections to use the `<Prerequisites>` component

### DIFF
--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -5,6 +5,7 @@ description: Learn how to install and configure expo-dev-client in your existing
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -24,9 +25,13 @@ To use `expo-dev-client` in a project that uses [CNG](/workflow/continuous-nativ
 
 </Collapsible>
 
-## Prerequisites
-
-**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="Install and configure the expo package">
+    If you created your project with `npx @react-native-community/cli@latest init` and do not have
+    any other Expo libraries installed, you will need to [install Expo
+    modules](/bare/installing-expo-modules) before proceeding.
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -5,6 +5,7 @@ description: Learn how to install and configure expo-updates in your existing Re
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 
 `expo-updates` is a library that enables your app to manage remote updates to your application code. It communicates with the configured remote update service to get information about available updates. This guide explains how to set up a bare React Native project for use with [EAS Update](/eas-update/introduction), a hosted remote update service that includes tools to simplify installation and configuration of the `expo-updates` library.
@@ -15,9 +16,13 @@ You may be reading the wrong guide. To use `expo-updates` in a project that uses
 
 </Collapsible>
 
-## Prerequisites
-
-**The `expo` package must be installed and configured.** If you created your project with `npx @react-native-community/cli@latest init` and do not have any other Expo libraries installed, you will need to [install Expo modules](/bare/installing-expo-modules) before proceeding.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="Install and configure the expo package">
+    If you created your project with `npx @react-native-community/cli@latest init` and do not have
+    any other Expo libraries installed, you will need to [install Expo
+    modules](/bare/installing-expo-modules) before proceeding.
+  </Requirement>
+</Prerequisites>
 
 ## Installation
 

--- a/docs/pages/bare/overview.mdx
+++ b/docs/pages/bare/overview.mdx
@@ -33,6 +33,8 @@ Below are four suggested phases of incremental adoption. These phases generally 
 
 Only the first phase &mdash; prerequisites &mdash; is required by other phases. After following its instructions, you can skip to the tools and services that are most relevant to your goals in adopting Expo.
 
+{/* Note: This "Prerequisites" heading intentionally does not use the <Prerequisites> component. It is a phase label in the "Incremental adoption steps" sequence (alongside "Quick wins", "New workflows", "New mindsets") and its body is navigational BoxLinks, not a checklist of requirements to complete before reading the page. */}
+
 ### Prerequisites
 
 These first steps are required to later adopt Expo tools and services:

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -6,6 +6,7 @@ description: A guide for adding Expo and React Native to existing native (brownf
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
@@ -17,16 +18,25 @@ This guide will walk you through the steps to add a React Native view into an ex
 
 > **info** Another popular technique is what we call the "isolated" approach, where your Expo app is packaged as a library and treated as a black box by the main existing application. See the [isolated approach guide](/brownfield/isolated-approach/) for details.
 
-## Prerequisites
-
-To integrate React Native into your existing application, you'll need to set up a JavaScript development environment. This includes installing Node.js to run Expo CLI and Yarn to manage the project's JavaScript dependencies.
-
-- [Node.js (LTS)](https://nodejs.org/en/): The runtime to execute JavaScript code and Expo CLI.
-- [Yarn](https://yarnpkg.com/): A package manager for installing and managing JavaScript dependencies.
-- <PlatformTag platform="ios" /> [CocoaPods](https://cocoapods.org/): one of the dependency
-  management system available for iOS. CocoaPods is a Ruby
-  [gem](https://en.wikipedia.org/wiki/RubyGems). You can install CocoaPods using the version of Ruby
-  that ships with the latest version of macOS.
+<Prerequisites numberOfRequirements={3}>
+  <Requirement number={1} title="Node.js (LTS)">
+    Install [Node.js](https://nodejs.org/en/) to run JavaScript code and Expo CLI.
+  </Requirement>
+  <Requirement number={2} title="Yarn">
+    Install [Yarn](https://yarnpkg.com/) as a package manager for JavaScript dependencies.
+  </Requirement>
+  <Requirement
+    number={3}
+    title={
+      <>
+        CocoaPods <PlatformTag platform="ios" />
+      </>
+    }>
+    Install [CocoaPods](https://cocoapods.org/), one of the dependency management systems for iOS.
+    CocoaPods is a Ruby [gem](https://en.wikipedia.org/wiki/RubyGems), and you can install it using
+    the version of Ruby that ships with the latest version of macOS.
+  </Requirement>
+</Prerequisites>
 
 Learn more from the [Set up environment guide](/get-started/set-up-your-environment/).
 

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -8,6 +8,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
@@ -18,12 +19,14 @@ This approach is ideal when you want to minimize the impact of React Native on y
 
 > **info** For an alternative approach where React Native is integrated directly into your native project, see the [integrated approach guide](/brownfield/integrated-approach/).
 
-## Prerequisites
-
-To integrate React Native into your existing application, you'll need to set up a JavaScript development environment. This includes installing Node.js to run Expo CLI and Yarn to manage the project's JavaScript dependencies.
-
-- [Node.js (LTS)](https://nodejs.org/en/): The runtime to execute JavaScript code and Expo CLI.
-- [Yarn](https://yarnpkg.com/): A package manager for installing and managing JavaScript dependencies.
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Node.js (LTS)">
+    Install [Node.js](https://nodejs.org/en/) to run JavaScript code and Expo CLI.
+  </Requirement>
+  <Requirement number={2} title="Yarn">
+    Install [Yarn](https://yarnpkg.com/) as a package manager for JavaScript dependencies.
+  </Requirement>
+</Prerequisites>
 
 Learn more from the [Set up environment guide](/get-started/set-up-your-environment/).
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -18,7 +18,8 @@ You can run the same build process that is typically run on the EAS Build server
 
 <Prerequisites numberOfRequirements={1}>
   <Requirement number={1} title="Authenticate with Expo">
-    Run `eas login`, or alternatively, set `EXPO_TOKEN` [using token-based authentication](/accounts/programmatic-access).
+    Run `eas login`, or alternatively, set `EXPO_TOKEN` [using token-based
+    authentication](/accounts/programmatic-access).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -7,6 +7,7 @@ description: Learn how to use EAS Build locally on your machine or a custom infr
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 
 You can run the same build process that is typically run on the EAS Build servers directly on your machine by using the `eas build --local` flag. This is a useful way to debug build failures that are happening on your cloud builds, which you may not be able to reproduce without running the same set of steps.
@@ -15,12 +16,11 @@ You can run the same build process that is typically run on the EAS Build server
   cmd={['$ eas build --platform android --local', '# or', '$ eas build --platform ios --local']}
 />
 
-## Prerequisites
-
-You need to be authenticated with Expo:
-
-- Run `eas login`
-- Alternatively, set `EXPO_TOKEN` [using token-based authentication](/accounts/programmatic-access)
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="Authenticate with Expo">
+    Run `eas login`, or alternatively, set `EXPO_TOKEN` [using token-based authentication](/accounts/programmatic-access).
+  </Requirement>
+</Prerequisites>
 
 ## Use cases for local builds
 

--- a/docs/pages/build-reference/npx-testflight.mdx
+++ b/docs/pages/build-reference/npx-testflight.mdx
@@ -5,16 +5,24 @@ description: A single command that allows you to build, sign, and submit your iO
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { CODE } from '~/ui/components/Text';
 
 [`npx testflight`](https://www.npmjs.com/package/testflight) is a CLI tool that walks you through building, signing, and submitting your iOS app to TestFlight.
 
-## Prerequisites
-
-- A React Native iOS project you want to deploy to TestFlight
-- A paid [Apple Developer Account](https://developer.apple.com/account/)
-- An [Expo](https://expo.dev/signup) account
+<Prerequisites numberOfRequirements={3}>
+  <Requirement number={1} title="A React Native iOS project">
+    A React Native iOS project you want to deploy to TestFlight.
+  </Requirement>
+  <Requirement number={2} title="Apple Developer account">
+    A paid [Apple Developer account](https://developer.apple.com/account/) is required for
+    TestFlight distribution.
+  </Requirement>
+  <Requirement number={3} title="Expo account">
+    Sign up for an [Expo](https://expo.dev/signup) account, if you haven't already.
+  </Requirement>
+</Prerequisites>
 
 ## Run `npx testflight` command
 

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -11,7 +11,7 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 To learn more about how fingerprint and repack work together to accelerate CI, see [Accelerating Continuous Integration with Fingerprint and Repack in EAS Workflows](https://expo.dev/blog/accelerating-continuous-integration-with-fingerprint-repack-in-eas-workflows) blog post.
 
-<Prerequisites numberOfRequirements={1}>
+<Prerequisites numberOfRequirements={2}>
   <Requirement number={1} title="An existing build artifact">
     A build artifact produced from your Expo project: an APK for Android, or an IPA or **.app**
     bundle for iOS.

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -13,10 +13,12 @@ To learn more about how fingerprint and repack work together to accelerate CI, s
 
 <Prerequisites numberOfRequirements={1}>
   <Requirement number={1} title="An existing build artifact">
-    A build artifact produced from your Expo project: an APK for Android, or an IPA or **.app** bundle for iOS.
+    A build artifact produced from your Expo project: an APK for Android, or an IPA or **.app**
+    bundle for iOS.
   </Requirement>
   <Requirement number={2} title="Signing credentials (optional)">
-    Required if the repacked artifact needs to be installable on a device. For more information, see [Signing](#signing).
+    Required if the repacked artifact needs to be installable on a device. For more information, see
+    [Signing](#signing).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -3,6 +3,7 @@ title: Repack app
 description: Repackage an existing APK, IPA, or .app with an updated JavaScript bundle without a full native rebuild.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -10,10 +11,14 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 To learn more about how fingerprint and repack work together to accelerate CI, see [Accelerating Continuous Integration with Fingerprint and Repack in EAS Workflows](https://expo.dev/blog/accelerating-continuous-integration-with-fingerprint-repack-in-eas-workflows) blog post.
 
-## Prerequisites
-
-- An existing build artifact produced from your Expo project: an APK for Android, or an IPA or **.app** bundle for iOS.
-- (Optional) Signing credentials if the repacked artifact needs to be installable on a device. For more information, see [Signing](#signing).
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="An existing build artifact">
+    A build artifact produced from your Expo project: an APK for Android, or an IPA or **.app** bundle for iOS.
+  </Requirement>
+  <Requirement number={2} title="Signing credentials (optional)">
+    Required if the repacked artifact needs to be installable on a device. For more information, see [Signing](#signing).
+  </Requirement>
+</Prerequisites>
 
 ## When to use repack
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -6,14 +6,17 @@ description: Learn how to install multiple variants of an app on the same device
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 When creating [development, preview, and production builds](/build/eas-json/#common-use-cases), installing these build variants simultaneously on the same device is common. This allows working in development, previewing the next version of the app, and running the production version on a device without needing to uninstall and reinstall the app.
 
 This guide provides the steps required to configure multiple (development and production) variants to install and use them on the same device.
 
-## Prerequisites
-
-To have multiple variants of an app installed on your device, each variant must have a unique [Application ID (Android)](/versions/latest/config/app/#package) or [Bundle Identifier (iOS)](/versions/latest/config/app/#bundleidentifier).
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="Unique Application ID or Bundle Identifier per variant">
+    To have multiple variants of an app installed on your device, each variant must have a unique [Application ID (Android)](/versions/latest/config/app/#package) or [Bundle Identifier (iOS)](/versions/latest/config/app/#bundleidentifier).
+  </Requirement>
+</Prerequisites>
 
 ## Configure development and production variants
 

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -14,7 +14,9 @@ This guide provides the steps required to configure multiple (development and pr
 
 <Prerequisites numberOfRequirements={1}>
   <Requirement number={1} title="Unique Application ID or Bundle Identifier per variant">
-    To have multiple variants of an app installed on your device, each variant must have a unique [Application ID (Android)](/versions/latest/config/app/#package) or [Bundle Identifier (iOS)](/versions/latest/config/app/#bundleidentifier).
+    To have multiple variants of an app installed on your device, each variant must have a unique
+    [Application ID (Android)](/versions/latest/config/app/#package) or [Bundle Identifier
+    (iOS)](/versions/latest/config/app/#bundleidentifier).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -6,16 +6,13 @@ description: Learn how to trigger builds on EAS for your app using the Expo GitH
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 This guide explains how to trigger builds directly from your GitHub repository using the Expo GitHub App.
 
-## Prerequisites
-
-### Set the `image` field in your eas.json
-
-For the build profiles you want to use with GitHub, specify an [`image`](/eas/json/#image) to use for the native platform in **eas.json**.
-
-Use the `latest` image if your project's configuration does not rely on a specific [build image](/build-reference/infrastructure/). For example:
+<Prerequisites numberOfRequirements={3}>
+  <Requirement number={1} title="Set the image field in eas.json">
+    For the build profiles you want to use with GitHub, specify an [`image`](/eas/json/#image) to use for the native platform in **eas.json**. Use the `latest` image if your project's configuration does not rely on a specific [build image](/build-reference/infrastructure/). For example:
 
 ```json eas.json
 {
@@ -33,16 +30,15 @@ Use the `latest` image if your project's configuration does not rely on a specif
 }
 ```
 
-### Run a successful build from your local machine
-
-To trigger EAS builds from a GitHub repo, you'll need to configure your project for EAS Build and successfully run a build from your computer for each platform that you'd like to support on GitHub.
-
-If you haven't successfully run `eas build -p [all|ios|android]` yet, see [Create your first build](/build/setup/) for more information. Once you have, continue with the steps in this guide.
-
-The following must also be true:
-
-- An Expo user in the organization must have a linked GitHub user with access to the target repository. Check **Account settings** > **Overview** > **User settings** > [**Connections**](https://expo.dev/settings#connections) and verify that your GitHub user account is linked.
-- You must accept the permissions requested by the [Expo GitHub app](https://github.com/settings/installations).
+  </Requirement>
+  <Requirement number={2} title="A successful build from your local machine">
+    To trigger EAS builds from a GitHub repository, you'll need to configure your project for EAS Build and successfully run a build from your computer for each platform that you'd like to support on GitHub. If you haven't successfully run `eas build -p [all|ios|android]` yet, see [Create your first build](/build/setup/) for more information.
+  </Requirement>
+  <Requirement number={3} title="Linked GitHub account and app permissions">
+    - An Expo user in the organization must have a linked GitHub user with access to the target repository. Check **Account settings** > **Overview** > **User settings** > [**Connections**](https://expo.dev/settings#connections) and verify that your GitHub user account is linked.
+    - You must accept the permissions requested by the [Expo GitHub app](https://github.com/settings/installations).
+  </Requirement>
+</Prerequisites>
 
 ## Configure your app for GitHub
 

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -4,26 +4,26 @@ description: Learn how to trigger builds on EAS for your app from a CI environme
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 
 This document outlines how to trigger builds on EAS for your app from a CI environment such as GitHub Actions, Travis CI, and more.
 
-## Prerequisites
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A successful build from your local machine">
+    To trigger EAS builds from a CI environment, your app needs to be set up to use EAS Build in non-interactive mode. Run `eas build -p [all|android|ios]` from your local terminal for each platform you want to support on CI, so the `eas build` command can prompt for any additional configuration it needs. That configuration will then be available for future non-interactive runs.
 
-### Run a successful build from your local machine
+    Running a build locally accomplishes the following critical configuration steps:
 
-To trigger EAS builds from a CI environment, your app needs to be set up to use EAS Build in non-interactive mode. To do this, go through the EAS Build initialization steps and run a successful build from your local terminal for each platform you would like to support on CI. This way, the `eas build` command can prompt for any additional configuration it needs, and then that configuration will be available for future non-interactive runs on CI.
+    - Initialize the project on EAS by generating a `projectId`.
+    - Add an **eas.json** file defining your build profiles.
+    - Populate critical app config properties for native builds, such as `android.packageName` and `ios.bundleIdentifier`.
+    - Ensure build credentials are created, including Android keystores and iOS distribution certs and provisioning profiles.
 
-Running a build locally will accomplish the following critical configuration steps:
+    If you haven't done this yet, see the [Create your first build](/build/setup/) guide and return here when you're ready.
 
-- Initialize the project on EAS by generating a `projectId`.
-- Add an **eas.json** file defining your build profiles.
-- Populates critical app config properties for native builds, such as `android.packageName` and `ios.bundleIdentifier`.
-- Ensure build credentials are created, including Android keystores and iOS distribution certs and provisioning profiles.
-
-Run `eas build -p [all|android|ios]` and verify that your builds for each platform complete successfully. Then, continue with the below steps for implementing EAS Build on CI.
-
-If you haven't done this yet, see the [Create your first build](/build/setup/) guide and return here when you're ready.
+  </Requirement>
+</Prerequisites>
 
 ## Using EAS Workflows
 

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -4,6 +4,7 @@ description: Learn how to create a build for your app with EAS Build.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
@@ -15,29 +16,24 @@ Alternatively, if you prefer to install the app directly to your Android device/
 
 For a small app, builds for Android and iOS platforms trigger within a few minutes. If you encounter any issues along the way, you can reach out on <A href="https://chat.expo.dev/" shouldLeakReferrer>Discord and Forums</A>.
 
-## Prerequisites
+> **info** EAS Build is a rapidly evolving service. Before you set out to create a build for your project we recommend consulting the [limitations](/build-reference/limitations) and the other prerequisites below.
 
-EAS Build is a rapidly evolving service. Before you set out to create a build for your project we recommend consulting the [limitations](/build-reference/limitations) page and the other prerequisites below.
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="A React Native Android or iOS project">
+    Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide:
 
-<Collapsible summary="A React Native Android and/or iOS project that you want to build">
+    <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
 
-Don't have a project yet? No problem. It's quick and easy to create a "Hello world" app that you can use with this guide.
+    EAS Build also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 
-Run the following command to create a new project:
+  </Requirement>
+  <Requirement number={2} title="An Expo account">
+    EAS Build is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan. You can sign up at [expo.dev](https://expo.dev/signup).
 
-<Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
+    Paid subscribers get quality improvements such as additional build concurrencies, priority access to minimize the time your builds spend queueing, and increased limits on build timeouts. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
 
-EAS Build also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
-
-</Collapsible>
-
-<Collapsible summary="An Expo user account">
-
-EAS Build is available to anyone with an Expo account, regardless of whether you pay for EAS or use our Free plan. You can sign up at [https://expo.dev/signup](https://expo.dev/signup).
-
-Paid subscribers get quality improvements such as additional build concurrencies, priority access to minimize the time your builds spend queueing, and increased limits on build timeouts. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
-
-</Collapsible>
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 ## Install the latest EAS CLI

--- a/docs/pages/deploy/app-stores-metadata.mdx
+++ b/docs/pages/deploy/app-stores-metadata.mdx
@@ -8,17 +8,13 @@ import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **important** **EAS Metadata** is in [beta](/more/release-statuses/#beta) and subject to breaking changes.
+> **important** **EAS Metadata** is in [beta](/more/release-statuses/#beta) and subject to breaking changes. The service currently **only supports the Apple App Store**.
 
 When submitting your app to app stores, you need to provide metadata. This process is lengthy and is often about complex topics that don't apply to your app. After the information you provide gets reviewed and if there is any issue with it, you need to restart this process.
 
 [**EAS Metadata**](/eas/metadata/) enables you to automate and maintain this information from the command line instead of going through multiple forms in the app store dashboards. It can also instantly identify well-known app store restrictions that could trigger a rejection after a lengthy review queue. This guide shows how to use EAS Metadata to automate and maintain your app store presence.
 
-## Prerequisites
-
-EAS Metadata currently **only supports the Apple App Store**.
-
-> Using VS Code? Install the [Expo Tools extension](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
+> **info** **Tip:** Using VS Code? Install the [Expo Tools extension](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
 
 ## Create a store config
 

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -4,13 +4,25 @@ sidebar_title: Deploy web apps
 description: Learn how to deploy your web app using EAS Hosting.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
+import { CODE } from '~/ui/components/Text';
 
 If you are building a universal app, you can quickly deploy your web app using [EAS Hosting](/eas/hosting/introduction/). It is a service for deploying web apps built with Expo Router and React.
 
-## Prerequisites
-
-Before you begin, in your project's **app.json** file, ensure that the [`expo.web.output`](/versions/latest/config/app/#output) property is either `static` or `server`.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement
+    number={1}
+    title={
+      <>
+        Set <CODE>expo.web.output</CODE> in app.json
+      </>
+    }>
+    In your project's **app.json**, ensure that the
+    [`expo.web.output`](/versions/latest/config/app/#output) property is either `static` or
+    `server`.
+  </Requirement>
+</Prerequisites>
 
 ## Export your web project
 

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -4,15 +4,18 @@ sidebar_title: Serve bundle diffs
 description: Enable your project to accept bundle diffs when available.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **important** Bundle diffing is in [**beta**](/more/release-statuses/#beta) and may have limitations. See [Current limitations](#current-limitations) for details.
 
 Enable bundle diffing to let EAS Update deliver a **bundle patch** when possible. When you publish a new update, EAS Update can generate a smaller file containing only the differences between the bundle currently running on the device and the new bundle. This often reduces update download size significantly.
 
-## Prerequisites
-
-Your app must use **Expo SDK 55 or later**.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="Expo SDK 55 or later">
+    Your app must be on Expo SDK 55 or later.
+  </Requirement>
+</Prerequisites>
 
 ## Enable bundle diffing
 

--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -19,10 +19,18 @@ This guide walks through the steps required to load and preview a published upda
 
 <Prerequisites numberOfRequirements={2}>
   <Requirement number={1} title="A development build installed">
-    [Create a development build and install it](/develop/development-builds/create-a-build/) on your device, Android Emulator, or iOS Simulator.
+    [Create a development build and install it](/develop/development-builds/create-a-build/) on your
+    device, Android Emulator, or iOS Simulator.
   </Requirement>
-  <Requirement number={2} title={<><CODE>expo-updates</CODE> installed</>}>
-    Make sure your development build has the [`expo-updates` library installed](/eas-update/getting-started/#configure-your-project).
+  <Requirement
+    number={2}
+    title={
+      <>
+        <CODE>expo-updates</CODE> installed
+      </>
+    }>
+    Make sure your development build has the [`expo-updates` library
+    installed](/eas-update/getting-started/#configure-your-project).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -8,6 +8,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
@@ -16,10 +17,14 @@ import { CODE } from '~/ui/components/Text';
 
 This guide walks through the steps required to load and preview a published update inside a development build using the **Extensions** tab or constructing a specific Update URL.
 
-## Prerequisites
-
-- [Create a development build and install it](/develop/development-builds/create-a-build/) on your device or Android Emulator or iOS Simulator.
-- Make sure your development build has the [`expo-updates` library installed](/eas-update/getting-started/#configure-your-project).
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="A development build installed">
+    [Create a development build and install it](/develop/development-builds/create-a-build/) on your device, Android Emulator, or iOS Simulator.
+  </Requirement>
+  <Requirement number={2} title={<><CODE>expo-updates</CODE> installed</>}>
+    Make sure your development build has the [`expo-updates` library installed](/eas-update/getting-started/#configure-your-project).
+  </Requirement>
+</Prerequisites>
 
 ## What is an Extensions tab
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -19,7 +19,7 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
 <Prerequisites numberOfRequirements={4}>
   <Requirement number={1} title="An Expo account">
-    EAS Update is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan.You can sign up at [expo.dev/signup](https://expo.dev/signup).
+    EAS Update is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan. You can sign up at [expo.dev/signup](https://expo.dev/signup).
 
     Paid subscribers can publish updates to more users and use more bandwidth and storage. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
 
@@ -57,7 +57,7 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
     <DiffBlock source="/static/diffs/expo-updates-register-root-component.diff" />
 
-    After making that change, update your [`MainActivity`](/versions/latest/sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) and [`AppDelegate`](/versions/latest//sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) to use the module name `"main"` instead of your app name.
+    After making that change, update your [`MainActivity`](/versions/latest/sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) and [`AppDelegate`](/versions/latest/sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) to use the module name `"main"` instead of your app name.
 
   </Requirement>
 </Prerequisites>

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -8,6 +8,7 @@ import { LayersTwo02Icon } from '@expo/styleguide-icons/outline/LayersTwo02Icon'
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { CODE } from '~/ui/components/Text';
@@ -16,66 +17,50 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
 > **info** If you plan to use EAS Update with EAS Build, we recommend following the [EAS Build setup guide](/build/setup/) before proceeding here. That said, [you can use EAS Update without any other EAS services](/eas-update/standalone-service/).
 
-## Prerequisites
+<Prerequisites numberOfRequirements={4}>
+  <Requirement number={1} title="An Expo account">
+    EAS Update is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan.You can sign up at [expo.dev/signup](https://expo.dev/signup).
 
-<Collapsible summary="An Expo user account">
+    Paid subscribers can publish updates to more users and use more bandwidth and storage. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
 
-EAS Update is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan. You can sign up at [expo.dev/signup](https://expo.dev/signup).
+  </Requirement>
+  <Requirement number={2} title="A React Native project">
+    Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide. Run the following command to create a new project:
 
-Paid subscribers can publish updates to more users and use more bandwidth and storage. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
+    <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
 
-</Collapsible>
+    EAS Update also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 
-<Collapsible summary="A React Native project">
+  </Requirement>
+  <Requirement number={3} title="Expo CLI and the Expo Metro Config">
+    If you already run your project with `npx expo [command]` (for example, if you created it with `npx create-expo-app`), you're all set.
 
-Don't have a project yet? No problem. It's quick and easy to create a "Hello world" app that you can use with this guide.
+    If you don't have the `expo` package in your project yet, install it by running the command below and [opt in to using Expo CLI and Metro Config](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios):
 
-Run the following command to create a new project:
+    <Terminal cmd={['$ npx install-expo-modules@latest']} />
 
-<Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
+    If the command fails, refer to the [Installing Expo modules](/bare/installing-expo-modules/#manual-installation) guide.
 
-EAS Update also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
+  </Requirement>
+  <Requirement
+    number={4}
+    title={
+      <>
+        Use <CODE>registerRootComponent</CODE> instead of <CODE>registerComponent</CODE>
+      </>
+    }>
+    If you created your project with `npx create-expo-app`, or you don't call `registerRootComponent` in your app at all (for example, it's handled by Expo Router), you are all set. The following applies to projects created with other tools, such as React Native Community CLI.
 
-</Collapsible>
+    We recommend apps using EAS Update use Expo's [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent) instead of React Native's `registerApplication`. This ensures Expo can configure React Native to load assets, such as images, that are included in updates. If you do not use `registerRootComponent`, your assets may not be available in release builds.
 
-<Collapsible summary="Your project must use Expo CLI and extend the Expo Metro Config">
+    In a simple app created with React Native Community CLI, the diff would look like this:
 
-If you already run your project with `npx expo [command]` (for example, if you created it with `npx create-expo-app`) then you're all set.
+    <DiffBlock source="/static/diffs/expo-updates-register-root-component.diff" />
 
-If you don't have the `expo` package in your project yet, then install it by running the command below and [opt in to using Expo CLI and Metro Config](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios):
+    After making that change, update your [`MainActivity`](/versions/latest/sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) and [`AppDelegate`](/versions/latest//sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) to use the module name `"main"` instead of your app name.
 
-<Terminal cmd={['$ npx install-expo-modules@latest']} />
-
-If the command fails, refer to the [Installing Expo modules](/bare/installing-expo-modules/#manual-installation) guide.
-
-</Collapsible>
-
-<Collapsible summary={<>Your project must use the <CODE>registerRootComponent</CODE> function instead of <CODE>registerComponent</CODE></>}>
-
-If you created your project with `npx create-expo-app`, or you don't call `registerRootComponent` in your app at all (for example, it's handled by Expo Router), then you are all set. The following applies to projects created with other tools, such as React Native Community CLI.
-
-We recommend that apps using EAS Update use Expo's [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent) instead of React Native's `registerApplication`. This will ensure that Expo is able to configure React Native to load assets, such as images, that are included in updates. If you do not use `registerRootComponent`, you may find that your assets will not be available in release builds.
-
-In a simple app created with React Native Community CLI, the diff would look like this:
-
-<DiffBlock
-  raw={`diff --git a/index.js b/index.js
-index 0000000..1111111 100644
---- a/index.js
-+++ b/index.js
-@@ -1,5 +1,4 @@
--import {AppRegistry} from 'react-native';
--import {name as appName} from './app.json';
-+import {registerRootComponent} from 'expo';
- import App from './App';
--
--AppRegistry.registerComponent(appName, () => App);
-+export default registerRootComponent(App);`}
-/>
-
-After making that change, update your [`MainActivity`](/versions/latest/sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) and [`AppDelegate`](/versions/latest//sdk/expo/#rootregistercomponent-setup-for-existing-react-native-projects) to use the module name `"main"` instead of your app name.
-
-</Collapsible>
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 ## Install the latest EAS CLI

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -47,7 +47,13 @@ Instructions are not available for older Expo SDK and React Native versions. Add
   <Requirement number={6} title="babel.config.js extends babel-preset-expo">
     Your **babel.config.js** [must extend `babel-preset-expo`](/versions/latest/config/babel/).
   </Requirement>
-  <Requirement number={7} title={<><CODE>npx expo export</CODE> runs successfully</>}>
+  <Requirement
+    number={7}
+    title={
+      <>
+        <CODE>npx expo export</CODE> runs successfully
+      </>
+    }>
     The command `npx expo export -p android` must run successfully in your project if it supports
     Android, and `npx expo export -p ios` if it supports iOS.
   </Requirement>

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -6,8 +6,10 @@ description: Learn how to integrate EAS Update into your existing native Android
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FAQ } from '~/ui/components/FAQ';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
+import { CODE } from '~/ui/components/Text';
 
 > **info** If your project is a **greenfield React Native app** &mdash; primarily built with React Native from the start, and the entry point of the app is React Native, then skip this guide and proceed to [Get started with EAS Update](/eas-update/getting-started/).
 
@@ -15,18 +17,41 @@ This guide explains how to integrate EAS Update in an existing native app, somet
 
 Instructions are not available for older Expo SDK and React Native versions. Additional hands-on support for integrating with older versions can only be provided for enterprise customers ([contact us](https://expo.dev/contact)).
 
-## Prerequisites
-
 > **warning** The following instructions may not work for all projects. The specifics of integrating EAS Update into existing projects depend heavily on the specifics of your app, and so you may need to adapt the instructions to your unique setup. If you encounter issues, [create an issue on GitHub](https://github.com/expo/expo/issues) or open a pull request to suggest improvements to this guide.
 
-You should have a brownfield native project with React Native installed and configured to render a root view. If you don't have this yet, follow the [Integration with Existing Apps](https://reactnative.dev/docs/integration-with-existing-apps) guide from the React Native documentation and then come back here once you have followed the steps.
-
-- Your app must be using the [latest Expo SDK version and its supported React Native version](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).
-- Remove any other update library integration from your app, such as react-native-code-push, and ensure that your app compiles and runs successfully in both debug and release on your supported platforms.
-- Support for Expo modules (through the `expo` package) must be installed and configured in your project. [Learn more](/brownfield/overview/).
-- Your **metro.config.js** [must extend `expo/metro-config`](/guides/customizing-metro/#customizing) .
-- Your **babel.config.js** [must extend `babel-preset-expo`](/versions/latest/config/babel/).
-- The command `npx expo export -p android` must run successfully in your project if it supports Android, and `npx expo export -p ios` if it supports iOS.
+<Prerequisites numberOfRequirements={7}>
+  <Requirement number={1} title="A brownfield native project with React Native">
+    You should have a brownfield native project with React Native installed and configured to render
+    a root view. If you don't have this yet, follow the [Integration with Existing
+    Apps](https://reactnative.dev/docs/integration-with-existing-apps) guide from the React Native
+    documentation and then come back here.
+  </Requirement>
+  <Requirement number={2} title="Latest Expo SDK and supported React Native">
+    Your app must be using the [latest Expo SDK version and its supported React Native
+    version](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).
+  </Requirement>
+  <Requirement number={3} title="No other update libraries">
+    Remove any other update library integration from your app, such as `react-native-code-push`, and
+    ensure that your app compiles and runs successfully in both debug and release on your supported
+    platforms.
+  </Requirement>
+  <Requirement number={4} title="Expo modules installed">
+    Support for Expo modules (through the `expo` package) must be installed and configured in your
+    project. See [Integrating Expo tools into existing native apps](/brownfield/overview/) for more
+    information.
+  </Requirement>
+  <Requirement number={5} title="metro.config.js extends expo/metro-config">
+    Your **metro.config.js** [must extend
+    `expo/metro-config`](/guides/customizing-metro/#customizing).
+  </Requirement>
+  <Requirement number={6} title="babel.config.js extends babel-preset-expo">
+    Your **babel.config.js** [must extend `babel-preset-expo`](/versions/latest/config/babel/).
+  </Requirement>
+  <Requirement number={7} title={<><CODE>npx expo export</CODE> runs successfully</>}>
+    The command `npx expo export -p android` must run successfully in your project if it supports
+    Android, and `npx expo export -p ios` if it supports iOS.
+  </Requirement>
+</Prerequisites>
 
 ## Installation and basic configuration
 

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -3,6 +3,7 @@ title: Migrate from Classic Updates
 description: A guide to help migrate from Classic Updates to EAS Update.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { A } from '~/ui/components/Text';
@@ -11,14 +12,17 @@ import { A } from '~/ui/components/Text';
 
 EAS Update is the next generation of Expo's updates service. If you're using Classic Updates, this guide will help you upgrade to EAS Update.
 
-## Prerequisites
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="Minimum versions for EAS Update">
+    EAS Update requires the following versions or greater:
 
-EAS Update requires the following versions or greater:
+    - Expo SDK 45.0.0 and later
+    - Expo CLI 5.3.0 and later
+    - EAS CLI 0.50.0 and later
+    - `expo-updates` 0.13.0 and later
 
-- Expo SDK >= 45.0.0
-- Expo CLI >= 5.3.0
-- EAS CLI >= 0.50.0
-- expo-updates >= 0.13.0
+  </Requirement>
+</Prerequisites>
 
 ## Install EAS CLI
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -9,6 +9,7 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ExpoMCPToolsTable, ExpoMCPPromptsTable } from '~/ui/components/ExpoMCPToolsTable';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
@@ -60,13 +61,17 @@ Your AI-assisted tools can autonomously write the code, capture screenshots to v
 
 The complete table of [MCP capabilities](#available-mcp-capabilities) documents the tools and prompts Expo MCP Server provides to AI-assisted tools.
 
-## Prerequisites
-
-Before using Expo MCP Server, ensure you have:
-
-- An Expo account with an EAS paid plan
-- An Expo project created either with `npx create-expo-app@latest --template default@sdk-55` or has the latest `expo` package version installed
-- AI-assisted tools with remote MCP server support (Claude Code, Cursor, VS Code, and so on)
+<Prerequisites numberOfRequirements={3}>
+  <Requirement number={1} title="Expo account with an EAS paid plan">
+    An [EAS paid plan](https://expo.dev/pricing) is required to use Expo MCP Server.
+  </Requirement>
+  <Requirement number={2} title="An Expo project on the latest SDK">
+    Create a project with `npx create-expo-app@latest --template default@sdk-55`, or ensure your existing project has the latest `expo` package installed.
+  </Requirement>
+  <Requirement number={3} title="An AI-assisted tool with remote MCP support">
+    Claude Code, Cursor, VS Code, or any other tool with remote MCP server support.
+  </Requirement>
+</Prerequisites>
 
 ## Installation and setup
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -66,7 +66,8 @@ The complete table of [MCP capabilities](#available-mcp-capabilities) documents 
     An [EAS paid plan](https://expo.dev/pricing) is required to use Expo MCP Server.
   </Requirement>
   <Requirement number={2} title="An Expo project on the latest SDK">
-    Create a project with `npx create-expo-app@latest --template default@sdk-55`, or ensure your existing project has the latest `expo` package installed.
+    Create a project with `npx create-expo-app@latest --template default@sdk-55`, or ensure your
+    existing project has the latest `expo` package installed.
   </Requirement>
   <Requirement number={3} title="An AI-assisted tool with remote MCP support">
     Claude Code, Cursor, VS Code, or any other tool with remote MCP server support.

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -15,7 +15,8 @@ Each project can have exactly one custom domain, which is assigned to the produc
 
 <Prerequisites numberOfRequirements={2}>
   <Requirement number={1} title="An EAS Hosting project with a production deployment">
-    The custom domain will always load the production deployment. To add a custom domain to your project, you need a deployment that's been promoted to production first.
+    The custom domain will always load the production deployment. To add a custom domain to your
+    project, you need a deployment that's been promoted to production first.
   </Requirement>
   <Requirement number={2} title="A domain name">
     You need to own a domain name you want to use.

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -4,7 +4,6 @@ title: Custom domain
 description: Set up a custom domain for your production deployment.
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 By default, your production deployment on EAS Hosting will look like this: `my-app.expo.app` , where `my-app` is your chosen preview subdomain name. If you own a domain, you may assign it as a custom domain to the production deployment.

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -5,6 +5,7 @@ description: Set up a custom domain for your production deployment.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 By default, your production deployment on EAS Hosting will look like this: `my-app.expo.app` , where `my-app` is your chosen preview subdomain name. If you own a domain, you may assign it as a custom domain to the production deployment.
 
@@ -12,19 +13,14 @@ Each project can have exactly one custom domain, which is assigned to the produc
 
 > **info** **Note**: Setting up a custom domain is a premium feature and isn't available on the free plan. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
 
-## Prerequisites
-
-<Collapsible summary="An EAS Hosting project with a production deployment">
-
-The custom domain will always load the production deployment. Therefore, to add a custom domain to your project, you will need a deployment that's been promoted to production first.
-
-</Collapsible>
-
-<Collapsible summary="A domain name">
-
-You will need to own a domain name you want to use.
-
-</Collapsible>
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="An EAS Hosting project with a production deployment">
+    The custom domain will always load the production deployment. To add a custom domain to your project, you need a deployment that's been promoted to production first.
+  </Requirement>
+  <Requirement number={2} title="A domain name">
+    You need to own a domain name you want to use.
+  </Requirement>
+</Prerequisites>
 
 ## Assigning a custom domain
 

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -7,6 +7,7 @@ searchRank: 9
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
@@ -21,25 +22,22 @@ This guide will walk you through the process of creating your first web deployme
   description="Set up EAS Hosting for your Expo Router web project, create your first deployment, and get a preview URL up and running."
 />
 
-## Prerequisites
+---
 
-<Collapsible summary="An Expo user account">
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="An Expo account">
+    EAS Hosting is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan. You can sign up at [expo.dev/signup](https://expo.dev/signup).
 
-EAS Hosting is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan. You can sign up at [expo.dev/signup](https://expo.dev/signup).
+    Paid subscribers can create more deployments, have more bandwidth, storage, and requests, and may set up a custom domain. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing#host).
 
-Paid subscribers can create more deployments, have more bandwidth, storage, requests, and may set up a custom domain. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing#host).
+  </Requirement>
+  <Requirement number={2} title="An Expo Router web project">
+    Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide. Run the following command to create a new project:
 
-</Collapsible>
+    <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
 
-<Collapsible summary="An Expo Router web project">
-
-Don't have a project yet? No problem. It's quick and easy to create a "Hello world" app that you can use with this guide.
-
-Run the following command to create a new project:
-
-<Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
-
-</Collapsible>
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 ## Install the latest EAS CLI

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -6,7 +6,6 @@ hasVideoLink: true
 searchRank: 9
 ---
 
-import { Collapsible } from '~/ui/components/Collapsible';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -16,7 +16,8 @@ EAS Metadata enables you to automate and maintain your app store presence from t
 
 <Prerequisites numberOfRequirements={1}>
   <Requirement number={1} title="An app on the Apple App Store">
-    EAS Metadata currently only supports the Apple App Store. You need an app registered with Apple to manage metadata for.
+    EAS Metadata currently only supports the Apple App Store. You need an app registered with Apple
+    to manage metadata for.
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -7,15 +7,18 @@ description: Learn how to automate and maintain your app store presence from the
 import { EasMetadataIcon } from '@expo/styleguide-icons/custom/EasMetadataIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 
 > **important** **EAS Metadata** is in [beta](/more/release-statuses/#beta) and subject to breaking changes.
 
 EAS Metadata enables you to automate and maintain your app store presence from the command line. It uses a [**store.config.json**](./config.mdx#static-store-config) file containing all required app information instead of going through multiple different forms. It also tries to find common pitfalls that could cause app rejections with built-in validation.
 
-## Prerequisites
-
-EAS Metadata currently **only supports the Apple App Store**.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="An app on the Apple App Store">
+    EAS Metadata currently only supports the Apple App Store. You need an app registered with Apple to manage metadata for.
+  </Requirement>
+</Prerequisites>
 
 > Using VS Code? Install the [Expo Tools extension](https://github.com/expo/vscode-expo#readme) for auto-complete, suggestions, and warnings in your **store.config.json** files.
 

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -6,6 +6,7 @@ description: Learn how to set up and use pre-packaged jobs in EAS Workflows.
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FAQ } from '~/ui/components/FAQ';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 Pre-packaged jobs are ready-to-use workflow jobs that help you automate common tasks like building, submitting, and testing your app. They provide a standardized way to handle these operations without having to write custom job configurations from scratch. This guide covers the available pre-packaged jobs and how to use them in your workflows.
 
@@ -15,9 +16,12 @@ Build your project into an Android or iOS app.
 
 Build jobs can be customized so that you can execute custom commands during the build process. See [Custom builds](/custom-builds/get-started/) for more information.
 
-### Prerequisites
-
-To successfully use the build job, you'll need to complete a build with EAS CLI using the same platform and profile as the pre-packaged job. Learn how to [create your first build](/build/setup/) to get started.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A completed build from your local machine">
+    Complete a build with EAS CLI using the same platform and profile as the pre-packaged job. Learn
+    how to [create your first build](/build/setup/) to get started.
+  </Requirement>
+</Prerequisites>
 
 ### Syntax
 
@@ -179,9 +183,12 @@ jobs:
 
 Deploy your application using [EAS Hosting](/eas/hosting/introduction).
 
-### Prerequisites
-
-To deploy your application using EAS Hosting, you'll need to set up your project. See [Get Started with EAS Hosting](/eas/hosting/get-started/#prerequisites) for more information.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A project set up for EAS Hosting">
+    See [Get started with EAS Hosting](/eas/hosting/get-started/#prerequisites) for setup
+    instructions.
+  </Requirement>
+</Prerequisites>
 
 ### Syntax
 
@@ -495,9 +502,14 @@ jobs:
 
 Submit an Android or iOS build to the app store using EAS Submit.
 
-### Prerequisites
-
-Submission jobs require additional configuration to run within a CI/CD process. See our [Apple App Store CI/CD submission guide](/submit/ios/#submitting-your-app-using-cicd-services) and [Google Play Store CI/CD submission guide](/submit/android/#submitting-your-app-using-cicd-services) for more information.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="CI/CD submission configuration">
+    Submission jobs require additional configuration to run within a CI/CD process. See the [Google
+    Play Store CI/CD submission guide](/submit/android/#submitting-your-app-using-cicd-services) and
+    [Apple App Store CI/CD submission guide](/submit/ios/#submitting-your-app-using-cicd-services)
+    for more information.
+  </Requirement>
+</Prerequisites>
 
 ### Syntax
 
@@ -590,9 +602,13 @@ jobs:
 
 Distribute iOS builds to TestFlight internal and external testing groups. This is an alternative to the iOS submit job for when you need more advanced TestFlight features. If you need to control test groups, changelog, or Beta App Review submission, use the `testflight` job instead of submit.
 
-### Prerequisites
-
-TestFlight jobs require an iOS build created with `distribution: store`. You'll need to have your Apple Developer account configured. See the [TestFlight submission guide](/submit/ios/#submitting-your-app-using-cicd-services) for more information.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="An iOS store build and Apple Developer account">
+    TestFlight jobs require an iOS build created with `distribution: store` and an Apple Developer
+    account configured. See the [TestFlight submission
+    guide](/submit/ios/#submitting-your-app-using-cicd-services) for more information.
+  </Requirement>
+</Prerequisites>
 
 ### Syntax
 
@@ -692,9 +708,13 @@ jobs:
 
 Publish an update using [EAS Update](/eas-update/introduction/).
 
-### Prerequisites
-
-To publish update previews and to send over-the-air updates, you'll need to run `npx eas-cli@latest update:configure`, then create new builds. Learn more about [configuring EAS Update](/eas-update/getting-started/#prerequisites).
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="EAS Update configured">
+    To publish update previews and to send over-the-air updates. Run `npx eas-cli@latest
+    update:configure`, then create new builds. Learn more about [configuring EAS
+    Update](/eas-update/getting-started/#prerequisites).
+  </Requirement>
+</Prerequisites>
 
 ### Syntax
 
@@ -1222,9 +1242,12 @@ jobs:
 
 Automatically post reports of your workflow's completed builds, updates, and deployments to GitHub pull requests. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, displaying EAS Hosting deployment previews, and automating deployment notifications. You can also override the comment contents by providing the `payload` parameter.
 
-### Prerequisites
-
-To use the GitHub Comment job, your project must have a GitHub repository connected. Learn how to [connect your GitHub repository](/build/building-from-github) to get started.
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A GitHub repository connected to your project">
+    To use the GitHub Comment job, your project must have a GitHub repository connected. Learn how
+    to [connect your GitHub repository](/build/building-from-github/) to get started.
+  </Requirement>
+</Prerequisites>
 
 ### Syntax
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -47,10 +47,13 @@ The necessary changes to the native Android and iOS files are minimal and can be
     Install Android Studio Iguana or later.
   </Requirement>
   <Requirement number={3} title="Android TV system image">
-    In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. For Apple silicon, choose the ARM 64 image. Otherwise, choose the Intel x86_64 image.
+    In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API
+    version 31 or later), and make sure an Android TV system image is selected for installation. For
+    Apple silicon, choose the ARM 64 image. Otherwise, choose the Intel x86_64 image.
   </Requirement>
   <Requirement number={4} title="Android TV emulator">
-    After installing the Android TV system image, create an Android TV emulator using that image (the process is the same as creating an Android phone emulator).
+    After installing the Android TV system image, create an Android TV emulator using that image
+    (the process is the same as creating an Android phone emulator).
   </Requirement>
 </Prerequisites>
 
@@ -64,7 +67,8 @@ The necessary changes to the native Android and iOS files are minimal and can be
     Install Xcode 16 or later.
   </Requirement>
   <Requirement number={3} title="tvOS SDK 17 or later">
-    tvOS SDK 17 or later is not installed automatically with Xcode. You can install it later with `xcodebuild -downloadAllPlatforms`.
+    tvOS SDK 17 or later is not installed automatically with Xcode. You can install it later with
+    `xcodebuild -downloadAllPlatforms`.
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -8,6 +8,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -17,7 +18,7 @@ React Native is supported on Android TV and Apple TV through the [React Native T
 
 Using the React Native TV library as the `react-native` dependency in an Expo project, it becomes capable of targeting both mobile (Android, iOS) and TV (Android TV, Apple TV) devices.
 
-## Prerequisites
+## Project changes required
 
 The necessary changes to the native Android and iOS files are minimal and can be automated with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv) if you use [prebuild](/more/glossary-of-terms/#prebuild). Below is a list of changes made by the config plugins, which you can alternatively apply manually:
 
@@ -38,16 +39,34 @@ The necessary changes to the native Android and iOS files are minimal and can be
 
 ### Android TV
 
-- [Node.js (LTS)](https://nodejs.org/en/) on macOS or Linux.
-- Android Studio (Iguana or later).
-- In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. (For Apple silicon, choose the ARM 64 image. Otherwise, choose the Intel x86_64 image).
-- After installing the Android TV system image, create an Android TV emulator using that image (the process is the same as creating an Android phone emulator).
+<Prerequisites numberOfRequirements={4}>
+  <Requirement number={1} title="Node.js (LTS)">
+    Install [Node.js (LTS)](https://nodejs.org/en/) on macOS or Linux.
+  </Requirement>
+  <Requirement number={2} title="Android Studio (Iguana or later)">
+    Install Android Studio Iguana or later.
+  </Requirement>
+  <Requirement number={3} title="Android TV system image">
+    In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API version 31 or later), and make sure an Android TV system image is selected for installation. For Apple silicon, choose the ARM 64 image. Otherwise, choose the Intel x86_64 image.
+  </Requirement>
+  <Requirement number={4} title="Android TV emulator">
+    After installing the Android TV system image, create an Android TV emulator using that image (the process is the same as creating an Android phone emulator).
+  </Requirement>
+</Prerequisites>
 
 ### Apple TV
 
-- [Node.js (LTS)](https://nodejs.org/en/) on macOS.
-- Xcode 16 or later.
-- tvOS SDK 17 or later. (This is not installed automatically with Xcode. You can install it later with `xcodebuild -downloadAllPlatforms`).
+<Prerequisites numberOfRequirements={3}>
+  <Requirement number={1} title="Node.js (LTS)">
+    Install [Node.js (LTS)](https://nodejs.org/en/) on macOS.
+  </Requirement>
+  <Requirement number={2} title="Xcode 16 or later">
+    Install Xcode 16 or later.
+  </Requirement>
+  <Requirement number={3} title="tvOS SDK 17 or later">
+    tvOS SDK 17 or later is not installed automatically with Xcode. You can install it later with `xcodebuild -downloadAllPlatforms`.
+  </Requirement>
+</Prerequisites>
 
 ## Quick start
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -6,6 +6,7 @@ description: Learn about rendering React DOM components in Expo native apps usin
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FAQ } from '~/ui/components/FAQ';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
@@ -13,27 +14,24 @@ Expo offers a novel approach to work with modern web code directly in a native a
 
 While the Expo native runtime generally does not support elements like `<div>` or `<img>`, there may be instances where you need to quickly incorporate web components. In such cases, DOM components provide a useful solution.
 
-## Prerequisites
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Expo CLI and the Expo Metro Config">
+    If you already run your project with `npx expo [command]` (for example, if you created it with `npx create-expo-app`), you're all set.
 
-<Collapsible summary="Your project must use Expo CLI and extend the Expo Metro Config">
+    If you don't have the `expo` package in your project yet, install it by running the command below and [opt in to using Expo CLI and Metro Config](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios):
 
-If you already run your project with `npx expo [command]` (for example, if you created it with `npx create-expo-app`), then you're all set, and you can skip this step.
+    <Terminal cmd={['$ npx install-expo-modules@latest']} />
 
-If you don't have the `expo` package in your project yet, then install it by running the command below and [opt in to using Expo CLI and Metro Config](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios):
+    If the command fails, refer to the [Installing Expo modules](/bare/installing-expo-modules/#manual-installation) guide.
 
-<Terminal cmd={['$ npx install-expo-modules@latest']} />
+  </Requirement>
+  <Requirement number={2} title="Expo Metro Runtime, React DOM, and React Native Web">
+    If you are using Expo Router and Expo Web, you can skip this step. Otherwise, install the following packages:
 
-If the command fails, refer to the [Installing Expo modules](/bare/installing-expo-modules/#manual-installation) guide.
+    <Terminal cmd={['$ npx expo install @expo/metro-runtime react-dom react-native-web']} />
 
-</Collapsible>
-
-<Collapsible summary="Expo Metro Runtime, React DOM, and React Native Web">
-
-If you are using Expo Router and Expo Web, you can skip this step. Otherwise, install the following packages:
-
-<Terminal cmd={['$ npx expo install @expo/metro-runtime react-dom react-native-web']} />
-
-</Collapsible>
+  </Requirement>
+</Prerequisites>
 
 ## Usage
 

--- a/docs/pages/guides/expo-ui-swift-ui/extending.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/extending.mdx
@@ -5,20 +5,27 @@ description: Learn how to create custom SwiftUI components and modifiers that in
 platforms: ['ios', 'tvos']
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { CODE } from '~/ui/components/Text';
 
 This guide explains how to create custom SwiftUI components and modifiers that integrate seamlessly with Expo UI.
 
-## Prerequisites
+<Prerequisites numberOfRequirements={3}>
+  <Requirement number={1} title={<><CODE>@expo/ui</CODE> installed</>}>
+    Install `@expo/ui` in your project. See [Building SwiftUI apps with Expo UI](/guides/expo-ui-swift-ui/) for more information.
 
-Before you begin, make sure you have:
+    <Terminal cmd={['$ npx expo install @expo/ui']} />
 
-- `@expo/ui` installed in your project. See [Building SwiftUI apps with Expo UI](/guides/expo-ui-swift-ui/) for more information.
-- A [development build](/develop/development-builds/introduction/) of your app (Expo UI is not available in Expo Go)
-- Basic familiarity with [Expo Modules API](/modules/overview/) and [SwiftUI](https://developer.apple.com/swiftui/)
-
-<Terminal cmd={['$ npx expo install @expo/ui']} />
+  </Requirement>
+  <Requirement number={2} title="A development build">
+    Expo UI is not available in Expo Go. Create a [development build](/develop/development-builds/introduction/) of your app.
+  </Requirement>
+  <Requirement number={3} title="Familiarity with Expo Modules API and SwiftUI">
+    Basic familiarity with [Expo Modules API](/modules/overview/) and [SwiftUI](https://developer.apple.com/swiftui/) is recommended.
+  </Requirement>
+</Prerequisites>
 
 ## Creating a custom component
 

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -13,7 +13,8 @@ This guide provides additional information on configuring the library with Expo 
 
 <Prerequisites numberOfRequirements={1}>
   <Requirement number={1} title="A development build">
-    The `react-native-fbsdk-next` library can't be used in Expo Go because it requires custom native code. Learn more about [adding custom native code to your app](/workflow/customizing/).
+    The `react-native-fbsdk-next` library can't be used in Expo Go because it requires custom native
+    code. Learn more about [adding custom native code to your app](/workflow/customizing/).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -5,14 +5,17 @@ description: A guide on using react-native-fbsdk-next library to integrate Faceb
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 The [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk-next/) library provides a wrapper around Facebook's Android and iOS SDKs. It allows integrating Facebook authentication into your Expo project and provide access to native components.
 
 This guide provides additional information on configuring the library with Expo for Android.
 
-## Prerequisites
-
-The `react-native-fbsdk-next` library can't be used in the Expo Go app because it requires custom native code. Learn more about [adding custom native code to your app](/workflow/customizing/).
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A development build">
+    The `react-native-fbsdk-next` library can't be used in Expo Go because it requires custom native code. Learn more about [adding custom native code to your app](/workflow/customizing/).
+  </Requirement>
+</Prerequisites>
 
 ## Installation
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -12,7 +12,9 @@ This guide provides information on how to configure the library for your project
 
 <Prerequisites numberOfRequirements={1}>
   <Requirement number={1} title="A development build">
-    The `@react-native-google-signin/google-signin` library can't be used in Expo Go because it requires custom native code. Learn more about [adding custom native code to your app](/workflow/customizing/).
+    The `@react-native-google-signin/google-signin` library can't be used in Expo Go because it
+    requires custom native code. Learn more about [adding custom native code to your
+    app](/workflow/customizing/).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -4,14 +4,17 @@ description: A guide on using @react-native-google-signin/google-signin library 
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 The [`@react-native-google-signin/google-signin`](https://github.com/react-native-google-signin/google-signin) library provides a way to integrate Google authentication in your Expo app. It also provides native sign-in buttons and supports authenticating the user as well as obtaining their authorization to use Google APIs. You can use the library in your project by adding the [config plugin](/config-plugins/introduction/) in the [app config](/versions/latest/config/app/).
 
 This guide provides information on how to configure the library for your project.
 
-## Prerequisites
-
-The `@react-native-google-signin/google-signin` library can't be used in the Expo Go app because it requires custom native code. Learn more about [adding custom native code to your app](/workflow/customizing/).
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A development build">
+    The `@react-native-google-signin/google-signin` library can't be used in Expo Go because it requires custom native code. Learn more about [adding custom native code to your app](/workflow/customizing/).
+  </Requirement>
+</Prerequisites>
 
 ## Installation
 

--- a/docs/pages/guides/ios-developer-mode.mdx
+++ b/docs/pages/guides/ios-developer-mode.mdx
@@ -4,6 +4,7 @@ description: Learn how to enable iOS Developer Mode setting on iOS 16 and above 
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Step } from '~/ui/components/Step';
 
 > This does not apply to builds signed using enterprise provisioning or to any builds installed on an iOS Simulator.
@@ -15,9 +16,13 @@ There are two ways you can enable Developer Mode on your device:
 - Directly on an iOS device
 - By connecting an iOS device with a Mac that has Xcode installed
 
-## Prerequisites
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A device running iOS 16 or later">
+    Developer Mode is only required on devices running iOS 16 and later.
+  </Requirement>
+</Prerequisites>
 
-The instructions specified below need to be followed once per device.
+The instructions below need to be followed only once per device.
 
 ## Enable Developer Mode
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -8,6 +8,7 @@ import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { CODE } from '~/ui/components/Text';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
@@ -121,11 +122,14 @@ export default function HomeScreen() {
 
 For more complex keyboard interactions, such as larger scrollable entry forms with several text input fields, consider using the [`react-native-keyboard-controller` (Keyboard Controller)](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
 
-### Prerequisites
-
-The following steps are described using a [development build](/develop/development-builds/introduction/) since the Keyboard Controller library is not included in Expo Go. See [Create a development build](/develop/development-builds/create-a-build/) for more information.
-
-[Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller) also requires `react-native-reanimated` to work correctly. To install it, follow these [installation instructions](/versions/latest/sdk/reanimated/#installation).
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="A development build">
+    The Keyboard Controller library is not included in Expo Go. See [Create a development build](/develop/development-builds/create-a-build/) for more information.
+  </Requirement>
+  <Requirement number={2} title={<><CODE>react-native-reanimated</CODE> installed</>}>
+    Keyboard Controller requires `react-native-reanimated` to work correctly. Follow the [installation instructions](/versions/latest/sdk/reanimated/#installation).
+  </Requirement>
+</Prerequisites>
 
 ### Install
 

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -124,10 +124,18 @@ For more complex keyboard interactions, such as larger scrollable entry forms wi
 
 <Prerequisites numberOfRequirements={2}>
   <Requirement number={1} title="A development build">
-    The Keyboard Controller library is not included in Expo Go. See [Create a development build](/develop/development-builds/create-a-build/) for more information.
+    The Keyboard Controller library is not included in Expo Go. See [Create a development
+    build](/develop/development-builds/create-a-build/) for more information.
   </Requirement>
-  <Requirement number={2} title={<><CODE>react-native-reanimated</CODE> installed</>}>
-    Keyboard Controller requires `react-native-reanimated` to work correctly. Follow the [installation instructions](/versions/latest/sdk/reanimated/#installation).
+  <Requirement
+    number={2}
+    title={
+      <>
+        <CODE>react-native-reanimated</CODE> installed
+      </>
+    }>
+    Keyboard Controller requires `react-native-reanimated` to work correctly. Follow the
+    [installation instructions](/versions/latest/sdk/reanimated/#installation).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -16,10 +16,14 @@ To build your project into an app locally using your machine, you have to manual
 
 <Prerequisites numberOfRequirements={2}>
   <Requirement number={1} title="Android Studio">
-    [Set up Android Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build) to compile and run Android projects on your local machine.
+    [Set up Android
+    Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build)
+    to compile and run Android projects on your local machine.
   </Requirement>
   <Requirement number={2} title="Xcode">
-    [Set up Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build) to compile and run iOS projects on your local machine.
+    [Set up
+    Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build)
+    to compile and run iOS projects on your local machine.
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -8,17 +8,20 @@ import { BuildIcon } from '@expo/styleguide-icons/custom/BuildIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { CODE } from '~/ui/components/Text';
 
 To build your project into an app locally using your machine, you have to manually generate native code before testing the debug build or creating a production build for it to submit to the app store. There are two ways you can build your app locally. This guide provides a brief introduction to both methods and references to other guides that are necessary to create this workflow.
 
-## Prerequisites
-
-You need to install and set up Android Studio and Xcode to compile and run Android and iOS projects on your local machine. See the following on how to set up these tools:
-
-- [Android Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build)
-- [Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build)
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Android Studio">
+    [Set up Android Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build) to compile and run Android projects on your local machine.
+  </Requirement>
+  <Requirement number={2} title="Xcode">
+    [Set up Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build) to compile and run iOS projects on your local machine.
+  </Requirement>
+</Prerequisites>
 
 ## Local app compilation
 

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -9,6 +9,7 @@ searchPosition: 1
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 You can leverage your local development environment to build your app locally by utilizing Android Studio and Xcode. This build process can be done for both debug and release builds. This page provides an overview on different ways to build your app locally using your own machine and references to other guides that might be necessary in this workflow.
 
@@ -25,12 +26,14 @@ There are different scenarios when you want to build your app on your developer 
 
 > **Note**: Building your app locally complements EAS Build. You can keep using the build service for cloud automation and fall back to local builds for development.
 
-## Prerequisites
-
-You need to install and set up Android Studio and Xcode to compile and run Android and iOS projects on your local machine. See the following guides on how to set up these tools:
-
-- [Android Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build)
-- [Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build)
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Android Studio">
+    [Set up Android Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build) to compile and run Android projects on your local machine.
+  </Requirement>
+  <Requirement number={2} title="Xcode">
+    [Set up Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build) to compile and run iOS projects on your local machine.
+  </Requirement>
+</Prerequisites>
 
 ## Creating your debug build locally
 

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -28,10 +28,14 @@ There are different scenarios when you want to build your app on your developer 
 
 <Prerequisites numberOfRequirements={2}>
   <Requirement number={1} title="Android Studio">
-    [Set up Android Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build) to compile and run Android projects on your local machine.
+    [Set up Android
+    Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build)
+    to compile and run Android projects on your local machine.
   </Requirement>
   <Requirement number={2} title="Xcode">
-    [Set up Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build) to compile and run iOS projects on your local machine.
+    [Set up
+    Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build)
+    to compile and run iOS projects on your local machine.
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -8,6 +8,7 @@ import { GoogleAppStoreIcon } from '@expo/styleguide-icons/custom/GoogleAppStore
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { DiffBlock, Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -17,10 +18,14 @@ To create your app's release build (also known as production build) locally, you
 
 Creating a release build locally for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below:
 
-### Prerequisites
-
-- [OpenJDK distribution](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local#install-watchman-and-jdk) installed to access the `keytool` command
-- **android** directory generated. If you are using [CNG](/workflow/continuous-native-generation/), then run `npx expo prebuild` to generate it.
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="OpenJDK installed">
+    Install an [OpenJDK distribution](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local#install-watchman-and-jdk) to access the `keytool` command.
+  </Requirement>
+  <Requirement number={2} title="android directory generated">
+    If you are using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/), run `npx expo prebuild` to generate it.
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 
@@ -122,11 +127,17 @@ Google Play Store requires manual app submission when submitting the **.aab** fi
 
 To create an iOS release build locally for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
 
-### Prerequisites
-
-- Paid Apple Developer membership
-- [Xcode installed](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-xcode-and-watchman) on your computer
-- **ios** directory generated. If you are using [CNG](/workflow/continuous-native-generation/), then run `npx expo prebuild` to generate it.
+<Prerequisites numberOfRequirements={3}>
+  <Requirement number={1} title="Apple Developer membership">
+    A paid Apple Developer membership is required to sign and submit iOS apps.
+  </Requirement>
+  <Requirement number={2} title="Xcode installed">
+    [Install Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-xcode-and-watchman) on your computer.
+  </Requirement>
+  <Requirement number={3} title="ios directory generated">
+    If you are using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/), run `npx expo prebuild` to generate it.
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -20,10 +20,13 @@ Creating a release build locally for Android requires signing it with an [upload
 
 <Prerequisites numberOfRequirements={2}>
   <Requirement number={1} title="OpenJDK installed">
-    Install an [OpenJDK distribution](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local#install-watchman-and-jdk) to access the `keytool` command.
+    Install an [OpenJDK
+    distribution](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local#install-watchman-and-jdk)
+    to access the `keytool` command.
   </Requirement>
   <Requirement number={2} title="android directory generated">
-    If you are using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/), run `npx expo prebuild` to generate it.
+    If you are using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/),
+    run `npx expo prebuild` to generate it.
   </Requirement>
 </Prerequisites>
 
@@ -132,10 +135,13 @@ To create an iOS release build locally for Apple App Store, you need to use Xcod
     A paid Apple Developer membership is required to sign and submit iOS apps.
   </Requirement>
   <Requirement number={2} title="Xcode installed">
-    [Install Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-xcode-and-watchman) on your computer.
+    [Install
+    Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-xcode-and-watchman)
+    on your computer.
   </Requirement>
   <Requirement number={3} title="ios directory generated">
-    If you are using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/), run `npx expo prebuild` to generate it.
+    If you are using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/),
+    run `npx expo prebuild` to generate it.
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/guides/local-https-development.mdx
+++ b/docs/pages/guides/local-https-development.mdx
@@ -12,8 +12,15 @@ import { CODE } from '~/ui/components/Text';
 When developing Expo web apps locally, you may need to use HTTPS with your local development environment for testing secure browser APIs. This guide shows you how to set up local HTTPS for Expo web apps.
 
 <Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title={<><CODE>mkcert</CODE> installed</>}>
-    `mkcert` is a tool for creating development certificates. For installation instructions, see the [`mkcert` GitHub repository](https://github.com/FiloSottile/mkcert#installation).
+  <Requirement
+    number={1}
+    title={
+      <>
+        <CODE>mkcert</CODE> installed
+      </>
+    }>
+    `mkcert` is a tool for creating development certificates. For installation instructions, see the
+    [`mkcert` GitHub repository](https://github.com/FiloSottile/mkcert#installation).
   </Requirement>
 </Prerequisites>
 

--- a/docs/pages/guides/local-https-development.mdx
+++ b/docs/pages/guides/local-https-development.mdx
@@ -4,16 +4,18 @@ sidebar_title: Local HTTPS development
 description: Learn how to set up local HTTPS for Expo web apps.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { CODE } from '~/ui/components/Text';
 
 When developing Expo web apps locally, you may need to use HTTPS with your local development environment for testing secure browser APIs. This guide shows you how to set up local HTTPS for Expo web apps.
 
-## Prerequisites
-
-This guide requires the following tool installed on your machine:
-
-- `mkcert`: A tool for creating development certificates. For installation instructions, see the [`mkcert` GitHub repository](https://github.com/FiloSottile/mkcert#installation).
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title={<><CODE>mkcert</CODE> installed</>}>
+    `mkcert` is a tool for creating development certificates. For installation instructions, see the [`mkcert` GitHub repository](https://github.com/FiloSottile/mkcert#installation).
+  </Requirement>
+</Prerequisites>
 
 ## Benefits
 

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -110,7 +110,7 @@ export async function Pokemon() {
       <Text style={{ fontWeight: 'bold', fontSize: 24 }}>{json.name}</Text>
       <Image source={{ uri: json.sprites.front_default }} style={{ width: 100, height: 100 }} />
 
-      {json.abilities.map((ability) => (
+      {json.abilities.map(ability => (
         <Text key={ability.ability.name}>- {ability.ability.name}</Text>
       ))}
     </View>
@@ -238,7 +238,7 @@ export async function renderProfile({
       // The EXPO_PUBLIC_ prefix is not required here.
       'X-Secret': process.env.SECRET,
     },
-  }).then((res) => res.json());
+  }).then(res => res.json());
 
   // Render
   return (
@@ -332,13 +332,13 @@ export async function renderTasks() {
 
 async function MediumTask() {
   // Wait one second before resolving.
-  await new Promise((resolve) => setTimeout(resolve, 1000));
+  await new Promise(resolve => setTimeout(resolve, 1000));
   return <Text>Medium task done!</Text>;
 }
 
 async function ExpensiveTask() {
   // Wait three seconds before resolving.
-  await new Promise((resolve) => setTimeout(resolve, 3000));
+  await new Promise(resolve => setTimeout(resolve, 3000));
   return <Text>Expensive task done!</Text>;
 }
 ```

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -7,6 +7,7 @@ description: Learn about rendering React components on the server in Expo.
 import { Cloud01Icon } from '@expo/styleguide-icons/outline/Cloud01Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 
 > [Experimentally](/more/release-statuses/#experimental) available in **SDK 52 and later**. This is a [beta](/more/release-statuses/#beta) release and subject to breaking changes.
@@ -20,15 +21,20 @@ React Server Components enable a number of exciting capabilities, including:
 
 Expo Router enables support for [React Server Components](https://react.dev/reference/rsc/server-components) on all platforms. This is an early [preview](/more/release-statuses/#preview) of a feature that will be enabled by default in Expo Router.
 
-## Prerequisites
-
-Your project must use Expo Router and React Native new architecture (default from SDK 52).
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="A project using Expo Router">
+    See [Expo Router installation](/router/installation/) if you don't have one yet.
+  </Requirement>
+  <Requirement number={2} title="React Native New Architecture">
+    React Native New Architecture is required, and is enabled by default from SDK 52.
+  </Requirement>
+</Prerequisites>
 
 ## Usage
 
 To use React Server Components in your Expo app, you need to:
 
-1. Install the required RSC dependency
+1. Install the required RSC dependency:
 
    <Terminal cmd={['$ npx expo install react-server-dom-webpack']} />
 
@@ -104,7 +110,7 @@ export async function Pokemon() {
       <Text style={{ fontWeight: 'bold', fontSize: 24 }}>{json.name}</Text>
       <Image source={{ uri: json.sprites.front_default }} style={{ width: 100, height: 100 }} />
 
-      {json.abilities.map(ability => (
+      {json.abilities.map((ability) => (
         <Text key={ability.ability.name}>- {ability.ability.name}</Text>
       ))}
     </View>
@@ -232,7 +238,7 @@ export async function renderProfile({
       // The EXPO_PUBLIC_ prefix is not required here.
       'X-Secret': process.env.SECRET,
     },
-  }).then(res => res.json());
+  }).then((res) => res.json());
 
   // Render
   return (
@@ -326,13 +332,13 @@ export async function renderTasks() {
 
 async function MediumTask() {
   // Wait one second before resolving.
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  await new Promise((resolve) => setTimeout(resolve, 1000));
   return <Text>Medium task done!</Text>;
 }
 
 async function ExpensiveTask() {
   // Wait three seconds before resolving.
-  await new Promise(resolve => setTimeout(resolve, 3000));
+  await new Promise((resolve) => setTimeout(resolve, 3000));
   return <Text>Expensive task done!</Text>;
 }
 ```

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -5,6 +5,7 @@ description: Learn how to configure and use Tailwind CSS in your Expo project.
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
 import { FileTree } from '~/ui/components/FileTree';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
@@ -13,25 +14,26 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 [Tailwind CSS](https://tailwindcss.com/) is a utility-first CSS framework and can be used with Metro for web projects. This guide explains how to configure your Expo project to use the framework.
 
-## Prerequisites
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A project using Metro for web">
+    Ensure your project is using Metro for web. Verify this by checking that `web.bundler` is set to `metro` in **app.json**:
+
+    ```json app.json
+    {
+      "expo": {
+        "web": {
+          "bundler": "metro"
+        }
+      }
+    }
+    ```
+
+  </Requirement>
+</Prerequisites>
 
 The following files will be modified to set the Tailwind CSS configuration:
 
 <FileTree files={['app.json', 'package.json', 'global.css', 'index.js']} />
-
-Ensure that your project is using Metro for web. You can verify this by checking the `web.bundler` field which is set to `metro` in the **app.json** file.
-
-```json app.json
-{
-  "expo": {
-    "web": {
-      /* @info The <CODE>bundler</CODE> must be set to <CODE>metro</CODE>. */
-      "bundler": "metro"
-      /* @end */
-    }
-  }
-}
-```
 
 ## Configuration
 

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -3,15 +3,20 @@ title: Using Bun
 description: A guide on using Bun with Expo and EAS.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 
 [Bun](https://bun.sh/) is a JavaScript runtime and a drop-in alternative for [Node.js](https://nodejs.org/en). In Expo projects, Bun can be used to install npm packages and run Node.js scripts. The benefits of using Bun are faster package installation than npm, pnpm, or Yarn and [at least 4x faster startup time compared to Node.js](https://bun.sh/docs#design-goals), which gives a huge boost to your local development experience.
 
-## Prerequisites
-
-> **Note:** While Bun replaces Node.js for most use cases in your project, at this time, a [Node.js LTS version](https://nodejs.org/) is still required to be installed for the `bun create expo` and `bun expo prebuild` commands. These commands use `npm pack` to download project templates.
-
-To create a new app using Bun, [install Bun on your local machine](https://bun.sh/docs/installation#installing).
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Bun installed on your machine">
+    [Install Bun](https://bun.sh/docs/installation#installing) to create a new app.
+  </Requirement>
+  <Requirement number={2} title="Node.js (LTS)">
+    A [Node.js (LTS) version](https://nodejs.org/) is still required for the `bun create expo` and
+    `bun expo prebuild` commands, which use `npm pack` to download project templates.
+  </Requirement>
+</Prerequisites>
 
 ## Start a new Expo project with Bun
 

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -6,6 +6,7 @@ description: A guide on getting started and using Firebase JS SDK and React Nati
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import RedirectNotification from '~/ui/components/RedirectNotification';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -26,9 +27,12 @@ There are two different ways you can use Firebase in your projects:
 
 React Native supports both the JS SDK and the native SDK. The following sections will guide you through when to use which SDK and all the configuration steps required to use Firebase in your Expo projects.
 
-## Prerequisites
-
-Before proceeding, make sure that you have created a new Firebase project or have an existing one using the [Firebase console](https://console.firebase.google.com/).
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A Firebase project">
+    Create a new Firebase project or use an existing one in the [Firebase
+    console](https://console.firebase.google.com/).
+  </Requirement>
+</Prerequisites>
 
 ## Using Firebase JS SDK
 

--- a/docs/pages/guides/using-resend.mdx
+++ b/docs/pages/guides/using-resend.mdx
@@ -3,6 +3,7 @@ title: Using Resend
 description: Learn how to integrate Resend in your Expo and React Native app to programmatically send emails with Expo Router's API Routes.
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
@@ -17,14 +18,23 @@ This guide demonstrates the **essential steps to integrate Resend with your Expo
   description="Integrate Resend with Expo Router API routes to send emails programmatically and deploy to EAS Hosting."
 />
 
-## Prerequisites
+---
 
-Before you get started, you need to have the following:
-
-- A project using [Expo Router](/router/installation/)
-- An [Expo account](https://expo.dev/signup) to deploy the API route using EAS Hosting
-- EAS CLI installed globally (`npm install -g eas-cli`)
-- A [Resend account](https://resend.com/)
+<Prerequisites numberOfRequirements={4}>
+  <Requirement number={1} title="A project using Expo Router">
+    See [Expo Router installation](/router/installation/) if you don't have one yet.
+  </Requirement>
+  <Requirement number={2} title="An Expo account">
+    An [Expo account](https://expo.dev/signup) is required to deploy the API route using EAS
+    Hosting.
+  </Requirement>
+  <Requirement number={3} title="EAS CLI installed globally">
+    Install [EAS CLI](/eas/cli/) with `npm install -g eas-cli`.
+  </Requirement>
+  <Requirement number={4} title="A Resend account">
+    Sign up at [resend.com](https://resend.com/).
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 

--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -4,6 +4,7 @@ description: Add a Postgres Database and user authentication to your React Nativ
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
@@ -13,18 +14,20 @@ Supabase automatically [generates a REST API](https://supabase.com/docs/guides/a
 
 Supabase provides a TypeScript client library called [`supabase-js`](https://supabase.com/docs/reference/javascript/introduction?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) to interact with the REST API. Alternatively, Supabase also exposes a [GraphQL API](https://supabase.com/docs/guides/database/extensions/pg_graphql?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) allowing you to use your favorite GraphQL client (for example, [Apollo Client](https://supabase.github.io/pg_graphql/usage_with_apollo/)) should you wish to.
 
-## Prerequisites
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="A Supabase project">
+    Head over to [database.new](https://database.new?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) to create a new Supabase project.
+  </Requirement>
+  <Requirement number={2} title="Project URL and Publishable key">
+    Get the **Project URL** from the API settings and **Publishable key** from the API Keys:
 
-Head over to [database.new](https://database.new?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) to create a new Supabase project.
+    1. Go to the [API Settings](https://supabase.com/dashboard/project/_/settings/api) page in the Dashboard.
+    2. Find your Project `URL` and `service_role` keys on this page.
+    3. Then go to the [API Keys](https://supabase.com/dashboard/project/_/settings/api-keys).
+    4. Find your Project **Publishable key** on this page under the API Keys tab.
 
-### Get the API Keys
-
-Get the **Project URL** from the API settings and **Publishable key** from the API Keys:
-
-1. Go to the [API Settings](https://supabase.com/dashboard/project/_/settings/api) page in the Dashboard.
-2. Find your Project `URL` and `service_role` keys on this page.
-3. Then go to the [API Keys](https://supabase.com/dashboard/project/_/settings/api-keys)
-4. Find your Project **Publishable key** on this page under the API Keys tab.
+  </Requirement>
+</Prerequisites>
 
 ## Using the Supabase TypeScript SDK
 

--- a/docs/pages/modules/existing-library.mdx
+++ b/docs/pages/modules/existing-library.mdx
@@ -4,17 +4,21 @@ description: Learn how to integrate Expo Modules API into an existing React Nati
 ---
 
 import { CodeBlocksTable } from '~/components/plugins/CodeBlocksTable';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Step } from '~/ui/components/Step';
 
 There are cases where you may want to integrate the Expo Modules API into an existing React Native library. For example, it might be useful to incrementally rewrite your library or to take advantage of [Android lifecycle listeners](/modules/android-lifecycle-listeners/) and [iOS AppDelegate subscribers](/modules/appdelegate-subscribers/) to automatically set up the library.
 
 This guide will help you set up your existing React Native library to access Expo Modules API.
 
-## Prerequisites
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="Create expo-module.config.json">
+    Create the [**expo-module.config.json**](/modules/module-config/) file at the root of your project and add an empty object `{}` inside it. You will update it later to enable specific features.
 
-Create the [**expo-module.config.json**](/modules/module-config/) file at the root of your project and add an empty object `{}` inside it. You will fill it in later to enable specific features.
+    This file is required for [Expo Autolinking](/modules/autolinking/) to recognize your library as an Expo module and automatically link your native code.
 
-Creating this file is necessary for [Expo Autolinking](/modules/autolinking/) to recognize your library as an Expo module and automatically link your native code.
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -6,6 +6,7 @@ hasVideoLink: true
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tab, Tabs } from '~/ui/components/Tabs';
@@ -34,11 +35,14 @@ If you need finer-grained control over your notifications, communicating directl
 
 </Collapsible>
 
-## Prerequisites
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="A physical Android or iOS device">
+    Push notifications are not supported on Android Emulators or iOS Simulators. You will need a
+    real device to test.
+  </Requirement>
+</Prerequisites>
 
-> **warning** **Important:** Push notifications are not supported on Android Emulators and iOS Simulators. A real device is required.
-
-The following steps described in this guide use [EAS Build](/build/introduction/). This is the easiest way to set up notifications since your EAS project will also contain the [notification credentials](#get-credentials-for-development-builds). However, you can use the `expo-notifications` library without EAS Build by building [your project locally](/guides/local-app-development/).
+The following steps in this guide use [EAS Build](/build/introduction/). This is the easiest way to set up notifications since your EAS project will also contain the [notification credentials](#get-credentials-for-development-builds). However, you can use the `expo-notifications` library without EAS Build by building [your project locally](/guides/local-app-development/).
 
 <Step label="1">
 

--- a/docs/pages/review/with-orbit.mdx
+++ b/docs/pages/review/with-orbit.mdx
@@ -6,6 +6,7 @@ description: Learn how to open updates with Expo Orbit as part of a review workf
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 [Expo Orbit](https://expo.dev/orbit) is a macOS and Windows app designed to speed up installing and running builds from EAS. It makes running your builds and updates as easy as pressing **Open in Orbit**.
 
@@ -17,10 +18,15 @@ If you don't have any development builds available, either because they have all
 
 </Collapsible>
 
-## Prerequisites
-
-- **Install the Orbit app** before following the steps in this guide. You can download it directly from [GitHub releases](https://github.com/expo/orbit/releases) or see the [alternative method](/build/orbit/#installation) to install it.
-- After installing the app, sign in to your Expo account from **Settings**.
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Install the Orbit app">
+    Download Orbit directly from [GitHub releases](https://github.com/expo/orbit/releases), or see
+    the [alternative installation method](/build/orbit/#installation).
+  </Requirement>
+  <Requirement number={2} title="Sign in to your Expo account">
+    After installing the app, sign in to your Expo account from **Settings**.
+  </Requirement>
+</Prerequisites>
 
 ## Preview an update with Expo Orbit
 

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -7,14 +7,17 @@ searchRank: 6
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
 Follow the steps below if you have an existing project and want to add Expo Router. For new projects, see the [Quick start](/router/introduction/#quick-start) in the introduction guide.
 
-### Prerequisites
-
-Make sure your computer is [set up for running an Expo app](/get-started/create-a-project/).
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="Set up your development environment">
+    Make sure your computer is [set up for running an Expo app](/get-started/create-a-project/).
+  </Requirement>
+</Prerequisites>
 
 <Step label="1">
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -9,6 +9,7 @@ import { Download03Icon } from '@expo/styleguide-icons/outline/Download03Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -25,16 +26,22 @@ In this chapter, let's learn how to create a new Expo project and how to get it 
 
 ---
 
-## Prerequisites
+<Prerequisites numberOfRequirements={4}>
+  <Requirement number={1} title="Expo Go on a physical device">
+    Install [Expo Go](https://expo.dev/go) on a physical Android or iOS device.
+  </Requirement>
+  <Requirement number={2} title="Node.js (LTS)">
+    Install [Node.js (LTS version)](https://nodejs.org/en) on your machine.
+  </Requirement>
+  <Requirement number={3} title="A code editor">
+    Install [VS Code](https://code.visualstudio.com/) or any other preferred code editor or IDE.
+  </Requirement>
+  <Requirement number={4} title="A developer machine with a terminal">
+    A macOS, Linux, or Windows (PowerShell and WSL2) with a terminal window open.
+  </Requirement>
+</Prerequisites>
 
-We'll need the following to get started:
-
-- [Expo Go](https://expo.dev/go) installed on a physical device
-- [Node.js (LTS version)](https://nodejs.org/en) installed
-- [VS Code](https://code.visualstudio.com/) or any other preferred code editor or IDE installed
-- A macOS, Linux, or Windows (PowerShell and [WSL2](https://expo.fyi/wsl)) with a terminal window open
-
-The tutorial assumes that you are familiar with TypeScript and React. If you are not familiar with them, check out the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html) and [React's official tutorial](https://react.dev/learn).
+This tutorial assumes you are familiar with TypeScript and React. If you are not, check out the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html) and [React's official tutorial](https://react.dev/learn).
 
 <Step label="1">
 

--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -7,6 +7,7 @@ hasVideoLink: true
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -23,13 +24,22 @@ In this chapter, we'll create our example app's production version and submit it
 
 ---
 
-## Prerequisites
-
-To publish and distribute an app on the Google Play Store, we need:
-
-- **Google Play Developer Account:** Must have a paid developer account. For details on setting one up, visit the [Google Play sign-up page](https://play.google.com/apps/publish/signup/).
-- **Google Service Account key:** We'll need a Google Service Account email and JSON key to automate the app submission process. **Follow the detailed instructions in our guide on [creating a Google Service Account key or downloading it from an existing account ](https://expo.fyi/creating-google-service-account), then return to this guide.** This is optional but required for [automating the release process](#automated-release).
-- **Production build profile:** Ensure that a `production` build profile is present in your **eas.json**, which is added by default.
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Google Play Developer account">
+    A paid Google Play Developer account is required. For details on setting one up, visit the
+    [Google Play sign-up page](https://play.google.com/apps/publish/signup/).
+  </Requirement>
+  <Requirement number={2} title="A production build profile in eas.json">
+    Ensure that a `production` build profile is present in your **eas.json**, which is added by
+    default.
+  </Requirement>
+  <Requirement number={3} title="Google Service Account key (optional)">
+    A Google Service Account email and JSON key is required to [automate the release
+    process](#automated-release). Follow the detailed instructions in [creating a Google Service
+    Account key or downloading it from an existing
+    account](https://expo.fyi/creating-google-service-account), then return to this guide.
+  </Requirement>
+</Prerequisites>
 
 ## Production build for Android
 

--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -24,7 +24,7 @@ In this chapter, we'll create our example app's production version and submit it
 
 ---
 
-<Prerequisites numberOfRequirements={2}>
+<Prerequisites numberOfRequirements={3}>
   <Requirement number={1} title="Google Play Developer account">
     A paid Google Play Developer account is required. For details on setting one up, visit the
     [Google Play sign-up page](https://play.google.com/apps/publish/signup/).

--- a/docs/pages/tutorial/eas/introduction.mdx
+++ b/docs/pages/tutorial/eas/introduction.mdx
@@ -7,6 +7,7 @@ description: An introduction to the tutorial for building apps for Android and i
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 ## About this tutorial
 
@@ -24,13 +25,18 @@ This tutorial covers the following topics:
 
 These topics will give us the foundation needed to use EAS effectively and to approach more advanced topics when needed.
 
-## Prerequisites
+This tutorial is hands-on and designed to be completed in about two hours.
 
-This tutorial is hands-on and designed to be completed in about two hours. You will need an existing Expo project to follow along and set it up locally on your machine. Options include:
+<Prerequisites numberOfRequirements={1}>
+  <Requirement number={1} title="An existing Expo project set up locally">
+    Pick one of the following options to follow along:
 
-- Continuing with the Sticker Smash app from our previous tutorial. If new, download it from [GitHub](https://github.com/expo/examples/tree/master/stickersmash).
-- Starting a new project with [`npx create-expo-app`](/get-started/create-a-project/).
-- Using a bare React Native project. Ensure the `expo` package is installed, which you can do [automatically](/bare/installing-expo-modules/) or [manually](/bare/installing-expo-modules/#manual-installation).
+    - Continue with the Sticker Smash app from the previous tutorial. If new, download it from [GitHub](https://github.com/expo/examples/tree/master/stickersmash).
+    - Start a new project with [`npx create-expo-app`](/get-started/create-a-project/).
+    - Use a bare React Native project. Ensure the `expo` package is installed, which you can do [automatically](/bare/installing-expo-modules/) or [manually](/bare/installing-expo-modules/#manual-installation).
+
+  </Requirement>
+</Prerequisites>
 
 ## Tools
 

--- a/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
@@ -7,6 +7,7 @@ hasVideoLink: true
 
 import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -24,12 +25,18 @@ Development builds for iOS devices are generated in the **.ipa** format, which i
 
 ---
 
-## Prerequisites
-
-Before we begin, ensure you have:
-
-- **Apple Developer Account:** This is required to access [necessary credentials](/app-signing/app-credentials/#ios) for signing our app, as each build needs to be signed to verify that the app comes from a trusted source. EAS Build helps manage these credentials.
-- **Developer Mode activated on iOS 16 and higher:** Installing development builds on your device requires Developer Mode to be enabled. If this is your first time or if it's currently disabled, see these instructions to [activate Developer Mode](/guides/ios-developer-mode/).
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Apple Developer account">
+    Required to access [necessary credentials](/app-signing/app-credentials/#ios) for signing our
+    app, as each build needs to be signed to verify that the app comes from a trusted source. EAS
+    Build helps manage these credentials.
+  </Requirement>
+  <Requirement number={2} title="Developer Mode activated on iOS 16 and higher">
+    Installing development builds on your device requires Developer Mode to be enabled. If this is
+    your first time or if it's currently disabled, see [activate Developer
+    Mode](/guides/ios-developer-mode/).
+  </Requirement>
+</Prerequisites>
 
 ## Provisioning profile
 

--- a/docs/pages/tutorial/eas/ios-production-build.mdx
+++ b/docs/pages/tutorial/eas/ios-production-build.mdx
@@ -6,6 +6,7 @@ hasVideoLink: true
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { ProgressTracker } from '~/ui/components/ProgressTracker';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
@@ -22,12 +23,15 @@ In this chapter, we'll create our example app's production version and submit it
 
 ---
 
-## Prerequisites
-
-To publish and distribute an app on the Apple Play Store, we need:
-
-- **Apple Developer account:** To create one, see [Apple Developer Portal](https://developer.apple.com/account/).
-- **Production build profile:** Ensure that a `production` build profile is present in your **eas.json**, which is added by default.
+<Prerequisites numberOfRequirements={2}>
+  <Requirement number={1} title="Apple Developer account">
+    To create one, see the [Apple Developer Portal](https://developer.apple.com/account/).
+  </Requirement>
+  <Requirement number={2} title="A production build profile in eas.json">
+    Ensure that a `production` build profile is present in your **eas.json**, which is added by
+    default.
+  </Requirement>
+</Prerequisites>
 
 ## Production build for iOS
 

--- a/docs/public/static/diffs/expo-updates-register-root-component.diff
+++ b/docs/public/static/diffs/expo-updates-register-root-component.diff
@@ -1,0 +1,12 @@
+diff --git a/index.js b/index.js
+index 0000000..1111111 100644
+--- a/index.js
++++ b/index.js
+@@ -1,5 +1,4 @@
+-import {AppRegistry} from 'react-native';
+-import {name as appName} from './app.json';
++import {registerRootComponent} from 'expo';
+ import App from './App';
+-
+-AppRegistry.registerComponent(appName, () => App);
++export default registerRootComponent(App);

--- a/docs/ui/components/Prerequisites/Requirement.tsx
+++ b/docs/ui/components/Prerequisites/Requirement.tsx
@@ -1,8 +1,8 @@
 import { mergeClasses } from '@expo/styleguide';
-import { type PropsWithChildren } from 'react';
+import { type PropsWithChildren, type ReactNode } from 'react';
 
 type RequirementProps = PropsWithChildren<{
-  title: string;
+  title: ReactNode;
   number: number;
 }>;
 
@@ -11,7 +11,7 @@ export function Requirement({ title, number, children }: RequirementProps) {
     <div className={mergeClasses('border-default flex gap-1.5 border-t p-5')}>
       <p className="mb-2 text-right font-medium">{number}.</p>
       <div className="flex-1 overflow-hidden">
-        <p className="mb-2 font-medium">{title}</p>
+        <div className="mb-2 flex items-center gap-2 font-medium">{title}</div>
         <div className={mergeClasses('[&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-0!')}>
           {children}
         </div>

--- a/docs/ui/components/Prerequisites/Requirement.tsx
+++ b/docs/ui/components/Prerequisites/Requirement.tsx
@@ -8,10 +8,10 @@ type RequirementProps = PropsWithChildren<{
 
 export function Requirement({ title, number, children }: RequirementProps) {
   return (
-    <div className={mergeClasses('border-default flex gap-1.5 border-t p-5')}>
+    <div className={mergeClasses('border-default flex items-baseline gap-1.5 border-t p-5')}>
       <p className="mb-2 text-right font-medium">{number}.</p>
       <div className="flex-1 overflow-hidden">
-        <div className="mb-2 flex items-center gap-2 font-medium">{title}</div>
+        <div className="mb-2 flex items-baseline gap-2 font-medium">{title}</div>
         <div className={mergeClasses('[&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-0!')}>
           {children}
         </div>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20777

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Converted `Prerequisites` heading / `<Collapsible>` blocks to <Prerequisites>` on multiple pages.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview. Some examples:
- https://pr-45075.expo-docs.pages.dev/deploy/web/#prerequisites
- https://pr-45075.expo-docs.pages.dev/bare/install-dev-builds-in-bare/
- https://pr-45075.expo-docs.pages.dev/tutorial/eas/android-production-build/
- https://pr-45075.expo-docs.pages.dev/build/setup/

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
