### PR TITLE
[core][Android] Fix `Failed resolution of: Ljava/lang/ClassValue`

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation workletsProject
   }
 
-  implementation("io.github.lukmccall.pika:pika-api:0.1.7-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-api:0.1.8-2.1.20")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ArrayTypeConverter.kt
@@ -64,8 +64,10 @@ class ArrayTypeConverter(
    */
   @Suppress("UNCHECKED_CAST")
   private fun createTypedArray(size: Int): Array<Any?> {
+    val parameterType = arrayType.params.first().jClass
+    val boxedType = parameterType.toBoxedIfPrimitive()
     return java.lang.reflect.Array.newInstance(
-      arrayType.params.first().jClass,
+      boxedType,
       size
     ) as Array<Any?>
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ClassExtensions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/ClassExtensions.kt
@@ -1,0 +1,13 @@
+package expo.modules.kotlin.types
+
+internal fun Class<*>.toBoxedIfPrimitive(): Class<*> = when (this) {
+  Int::class.java -> Integer::class.java
+  Long::class.java -> java.lang.Long::class.java
+  Double::class.java -> java.lang.Double::class.java
+  Float::class.java -> java.lang.Float::class.java
+  Boolean::class.java -> java.lang.Boolean::class.java
+  Byte::class.java -> java.lang.Byte::class.java
+  Short::class.java -> java.lang.Short::class.java
+  Char::class.java -> Character::class.java
+  else -> this
+}

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterCollection.kt
@@ -94,15 +94,3 @@ class TypeConverterCollection<Type : Any>(
     )
   }
 }
-
-private fun Class<*>.toBoxedIfPrimitive(): Class<*> = when (this) {
-  Int::class.java -> Integer::class.java
-  Long::class.java -> java.lang.Long::class.java
-  Double::class.java -> java.lang.Double::class.java
-  Float::class.java -> java.lang.Float::class.java
-  Boolean::class.java -> java.lang.Boolean::class.java
-  Byte::class.java -> java.lang.Byte::class.java
-  Short::class.java -> java.lang.Short::class.java
-  Char::class.java -> java.lang.Character::class.java
-  else -> this
-}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/functions/AnyFunctionTest.kt
@@ -62,7 +62,7 @@ class AnyFunctionTest {
 
     assertThrows<ArgumentCastException>(
       """
-      The 1st argument cannot be cast to type class java.lang.Integer (received class java.lang.String)
+      The 1st argument cannot be cast to type int (received class java.lang.String)
       → Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Integer (java.lang.String and java.lang.Integer are in module java.base of loader 'bootstrap')
       """.trimIndent()
     ) {

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-  implementation("io.github.lukmccall.pika:pika-gradle:0.1.7-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.1.8-2.1.20")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")


### PR DESCRIPTION
# Why

Fixes `Failed resolution of: Ljava/lang/ClassValue`.
The newest version of pika has a fallback if `ClassValue` was not found. 

# Test Plan

- bare-expo ✅ 
  - API 34
  - API 30