### PR TITLE
[filesystem][Android] Mark `FileMode` as enum

### DIFF
--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.sharedobjects.SharedRef
+import expo.modules.kotlin.types.Enumerable
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -12,10 +13,8 @@ import java.io.RandomAccessFile
 import java.nio.ByteBuffer
 import java.nio.channels.FileChannel
 import kotlin.math.min
-import expo.modules.kotlin.types.OptimizedRecord
 
-@OptimizedRecord
-enum class FileMode(val descriptor: String) : Record {
+enum class FileMode(val descriptor: String) : Enumerable {
   /** Read-only */
   READ("r"),
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFileHandle.kt
@@ -3,7 +3,6 @@ package expo.modules.filesystem
 import android.content.ContentResolver
 import android.net.Uri
 import expo.modules.kotlin.exception.Exceptions
-import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.sharedobjects.SharedRef
 import expo.modules.kotlin.types.Enumerable
 import java.io.File


### PR DESCRIPTION
# Why

`FileMode` was marked as a Record even if it's an enum. 


# Test Plan

- bare-expo ✅ 