### PR TITLE
[core][jsi] Fix host object dealloc callback not being invoked

### DIFF
--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -62,11 +62,13 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
   /**
    Underlying JSI runtime of the running app.
    */
-  public var _runtime: ExpoRuntime? {
+  private var _runtime: ExpoRuntime? {
     didSet {
-      if _runtime == nil {
+      if _runtime == nil && oldValue != nil {
         destroy()
-      } else if _runtime != oldValue {
+        return
+      }
+      if _runtime != nil && _runtime != oldValue {
         JavaScriptActor.assumeIsolated {
           // Try to install the core object automatically when the runtime changes.
           try? prepareRuntime()
@@ -577,6 +579,7 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
       // Otherwise the JSCRuntime asserts may fail on deallocation.
       releaseRuntimeObjects()
     }
+    _runtime = nil
   }
 
   /**

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -149,7 +149,10 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     }
 
     func deallocate(context: UnsafeMutableRawPointer) {
-      Unmanaged<HostObjectContext>.fromOpaque(context).release()
+      let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeRetainedValue()
+      JavaScriptActor.assumeIsolated {
+        context.dealloc()
+      }
     }
 
     let context = Unmanaged.passRetained(HostObjectContext(runtime: self, get, set, getPropertyNames, dealloc)).toOpaque()


### PR DESCRIPTION
## Why

When the JSI runtime is destroyed (e.g. on reload), it destroys all host objects. The C++ `HostObject::~HostObject()` calls the `deallocate` callback, which was supposed to invoke the Swift `dealloc` closure that calls `appContext.destroy()`. But the `deallocate` function only called `Unmanaged.release()` — it never called `context.dealloc()`. So JSI objects held by ModuleHolders were never released before the runtime died.

When `didInitializeRuntime:` was called again with the new runtime, ARC released the old `AppContext`. Its `ModuleHolder` deinit chain tried to destroy `JavaScriptObject` structs whose `jsi::Pointer::~Pointer()` called `ptr_->invalidate()` on dangling PointerValues — crashing with `EXC_BAD_ACCESS (code=1, address=0x0)`.

## How

- Call the user-provided `dealloc` closure in `createHostObject`'s deallocate callback. Previously it only released the `HostObjectContext` without invoking the closure, so `appContext.destroy()` never fired when the runtime tore down the host object.
- Nil out `_runtime` in `AppContext.destroy()` so the dead runtime reference is dropped after cleanup.
- Guard the `_runtime` didSet to prevent recursion when `destroy()` sets it to nil.

## Test plan

- [x] Verify the app no longer crashes on reload