### PR TITLE
[docs] Add rel="alternate" markdown link in page head

### DIFF
--- a/docs/common/routes.ts
+++ b/docs/common/routes.ts
@@ -87,6 +87,15 @@ export const getCanonicalUrl = (path: string) => {
   }
 };
 
+export const getMarkdownPath = (asPath: string) => {
+  const path = asPath.split('?')[0].split('#')[0];
+  if (path === '' || path === '/') {
+    return '/index.md';
+  }
+  const stripped = path.endsWith('/') ? path.slice(0, -1) : path;
+  return stripped + '.md';
+};
+
 export const isRouteActive = (
   info?: NavigationRoute | NavigationRouteWithSection,
   asPath?: string,

--- a/docs/components/DocumentationHead.tsx
+++ b/docs/components/DocumentationHead.tsx
@@ -1,14 +1,25 @@
 import NextHead from 'next/head';
 import type { PropsWithChildren } from 'react';
 
-type HeadProps = PropsWithChildren<{ title?: string; description?: string; canonicalUrl?: string }>;
+type HeadProps = PropsWithChildren<{
+  title?: string;
+  description?: string;
+  canonicalUrl?: string;
+  markdownPath?: string;
+}>;
 
 const BASE_OG_URL = 'https://og.expo.dev/?theme=docs';
 
 const BASE_TITLE = 'Expo Documentation';
 const BASE_DESCRIPTION = `Expo is an open-source platform for making universal native apps for Android, iOS, and the web with JavaScript and React.`;
 
-const DocumentationHead = ({ title, description, canonicalUrl, children }: HeadProps) => {
+const DocumentationHead = ({
+  title,
+  description,
+  canonicalUrl,
+  markdownPath,
+  children,
+}: HeadProps) => {
   const OGImageURL = `${BASE_OG_URL}&title=${encodeURIComponent(title ?? BASE_TITLE)}&description=${encodeURIComponent(description ?? BASE_DESCRIPTION)}`;
 
   return (
@@ -19,6 +30,7 @@ const DocumentationHead = ({ title, description, canonicalUrl, children }: HeadP
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       <link rel="icon" type="image/png" href="/static/images/favicon.ico" sizes="32x32" />
       {canonicalUrl && <link rel="canonical" href={canonicalUrl} />}
+      {markdownPath && <link rel="alternate" type="text/markdown" href={markdownPath} />}
 
       <meta name="description" content={description === '' ? BASE_DESCRIPTION : description} />
       <meta property="og:title" content={title} />

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -75,6 +75,7 @@ export default function DocumentationPage({
       : null;
   const sidebarScrollPosition = process?.browser ? window.__sidebarScroll : 0;
   const currentPath = router?.asPath ?? '';
+  const markdownPath = RoutesUtils.getMarkdownPath(currentPath);
   const isLatestSdkPage = currentPath.startsWith('/versions/latest/sdk/');
   const isLatestConfigPage = currentPath.startsWith('/versions/latest/config/');
   const isAskAIEligiblePage = isLatestSdkPage || isLatestConfigPage;
@@ -324,7 +325,11 @@ export default function DocumentationPage({
         isChatExpanded={isAskAIExpanded}>
         {breadcrumbSchema && <StructuredData id="breadcrumb-list" data={breadcrumbSchema} />}
         {techArticleSchema && <StructuredData id="tech-article" data={techArticleSchema} />}
-        <DocumentationHead title={title} description={description} canonicalUrl={canonicalUrl}>
+        <DocumentationHead
+          title={title}
+          description={description}
+          canonicalUrl={canonicalUrl}
+          markdownPath={markdownPath}>
           {hideFromSearch !== true && (
             <meta
               name="docsearch:version"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20789

Stacked on https://github.com/expo/expo/pull/45077

This closes that gap with a standard `<link rel="alternate" type="text/markdown">` tag so HTML-fetching agents can find the `.md`.

This PR ships the HTML side only. The matching HTTP `Link` response header is planned as a follow-up in a separate PR.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added an optional `markdownPath` prop to `DocumentationHead` that renders `<link rel="alternate" type="text/markdown" href={markdownPath}>` when provided, mirroring how `canonicalUrl` is handled.
- Added `getMarkdownPath` helper to `common/routes.ts`. Handles the root-page special case (`/` maps to `/index.md`) and strips trailing slashes so `/foo/` becomes `/foo.md`.
- Updated `DocumentationPage` to compute `markdownPath` from `router.asPath` and pass it to `DocumentationHead`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

## Preview

- Use preview to open a docs page.
- Open Developer Tools in the browser.
- Search for `<link rel="alternate" type="text/markdown"` and verify that the page contains `href=/...md`.


## Local

Run `pnpm dev` and verify:

- `curl -s http://localhost:3002/get-started/create-a-project/ | grep 'rel="alternate" type="text/markdown"'` returns `<link rel="alternate" type="text/markdown" href="/get-started/create-a-project.md"/>`.
- Nested page `/versions/latest/sdk/router/color/` emits `href="/versions/latest/sdk/router/color.md"`.
- Existing `<link rel="canonical">`, Open Graph, and Twitter tags still render correctly.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
