### PR TITLE
[core][iOS] Optimize function call overhead

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -42,6 +42,7 @@
 
 ### 💡 Others
 
+- [iOS] Reduced per-call overhead of invoking native functions from JavaScript. ([#45093](https://github.com/expo/expo/pull/45093) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed precompile build failing on `SwiftUIVirtualViewSharedImpl+Private.h` leaking into the public module umbrella. ([#44993](https://github.com/expo/expo/pull/44993) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Added explicit c++ linkage specifier to `ExpoModulesCore.podspec` to propagate to swift-only targets like Expo Widgets ([#44984](https://github.com/expo/expo/pull/44984) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Rewrote the core type system, definitions, `AppContext`, and worklets integration on top of the new `ExpoModulesJSI` package. ([#44337](https://github.com/expo/expo/pull/44337) by [@tsapeta](https://github.com/tsapeta))

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -148,7 +148,12 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
    */
   internal private(set) lazy var coreModuleHolder = ModuleHolder(appContext: self, module: coreModule, name: nil)
 
-  internal private(set) lazy var converter = MainValueConverter(appContext: self)
+  internal var converter: MainValueConverter {
+    // MainValueConverter is ~Copyable so it can't be stored in a lazy var (which uses Optional internally).
+    // This is zero-cost at runtime — the struct contains only an unowned pointer to self, so constructing
+    // it is a single pointer store with no allocations, reference counting, or weak-ref side table work.
+    return MainValueConverter(appContext: self)
+  }
 
   /**
    Designated initializer without modules provider.

--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -4,30 +4,31 @@ public struct Conversions {
   /**
    Converts an array to tuple. Because of tuples nature, it's not possible to convert an array of any size, so we can support only up to some fixed size.
    */
-  static func toTuple(_ array: [Any?]) throws -> Any? {
+  @_transparent
+  static func toTuple<Args>(_ array: [Any]) throws -> Args? {
     switch array.count {
     case 0:
-      return ()
+      return () as? Args
     case 1:
-      return (array[0])
+      return (array[0]) as? Args
     case 2:
-      return (array[0], array[1])
+      return (array[0], array[1]) as? Args
     case 3:
-      return (array[0], array[1], array[2])
+      return (array[0], array[1], array[2]) as? Args
     case 4:
-      return (array[0], array[1], array[2], array[3])
+      return (array[0], array[1], array[2], array[3]) as? Args
     case 5:
-      return (array[0], array[1], array[2], array[3], array[4])
+      return (array[0], array[1], array[2], array[3], array[4]) as? Args
     case 6:
-      return (array[0], array[1], array[2], array[3], array[4], array[5])
+      return (array[0], array[1], array[2], array[3], array[4], array[5]) as? Args
     case 7:
-      return (array[0], array[1], array[2], array[3], array[4], array[5], array[6])
+      return (array[0], array[1], array[2], array[3], array[4], array[5], array[6]) as? Args
     case 8:
-      return (array[0], array[1], array[2], array[3], array[4], array[5], array[6], array[7])
+      return (array[0], array[1], array[2], array[3], array[4], array[5], array[6], array[7]) as? Args
     case 9:
-      return (array[0], array[1], array[2], array[3], array[4], array[5], array[6], array[7], array[8])
+      return (array[0], array[1], array[2], array[3], array[4], array[5], array[6], array[7], array[8]) as? Args
     case 10:
-      return (array[0], array[1], array[2], array[3], array[4], array[5], array[6], array[7], array[8], array[9])
+      return (array[0], array[1], array[2], array[3], array[4], array[5], array[6], array[7], array[8], array[9]) as? Args
     default:
       throw TooManyArgumentsException((count: array.count, limit: 10))
     }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
@@ -24,12 +24,10 @@ internal struct DynamicDictionaryType: AnyDynamicType {
   }
 
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
-    let converter = appContext.converter
-
     if let jsObject = try? jsValue.asObject() {
       var result: [AnyHashable: Any] = [:]
       for key in jsObject.getPropertyNames() {
-        result[key] = try converter.toNative(jsObject.getProperty(key), valueType)
+        result[key] = try appContext.converter.toNative(jsObject.getProperty(key), valueType)
       }
       return result
     }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicNumberType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicNumberType.swift
@@ -15,13 +15,22 @@ internal struct DynamicNumberType<NumberType>: AnyDynamicType {
 
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
     if jsValue.isNumber() {
+      // Fast paths for common types avoid expensive `as? any BinaryFloatingPoint` conformance lookups.
+      let double = jsValue.getDouble()
+      if NumberType.self == Double.self {
+        return double
+      }
+      if NumberType.self == Int.self {
+        return Int(double.rounded())
+      }
+      if NumberType.self == Float.self {
+        return Float(double)
+      }
       if let FloatingPointType = NumberType.self as? any BinaryFloatingPoint.Type {
-        return FloatingPointType.init(jsValue.getDouble())
+        return FloatingPointType.init(double)
       }
       if let IntegerType = NumberType.self as? any BinaryInteger.Type {
-        // JS stores all numbers as doubles, so using `getDouble` makes more sense
-        // than `getInt` and lets us do schoolbook rounding instead of floor.
-        return IntegerType.init(jsValue.getDouble().rounded())
+        return IntegerType.init(double.rounded())
       }
     }
     throw Conversions.ConversionToNativeFailedException((kind: jsValue.kind, nativeType: numberType))
@@ -59,6 +68,16 @@ internal struct DynamicNumberType<NumberType>: AnyDynamicType {
   }
 
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    // Fast paths for common types avoid expensive `as? any BinaryFloatingPoint` conformance lookups.
+    if let value = value as? Double {
+      return .number(value)
+    }
+    if let value = value as? Int {
+      return .number(Double(value))
+    }
+    if let value = value as? Float {
+      return .number(Double(value))
+    }
     if let value = value as? any BinaryFloatingPoint {
       return .number(Double(value))
     }

--- a/packages/expo-modules-core/ios/Core/Functions/AnyFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AnyFunctionDefinition.swift
@@ -36,25 +36,6 @@ internal protocol AnyFunctionDefinition: AnyDefinition, JavaScriptObjectBuilder,
   var takesOwner: Bool { get set }
 }
 
-extension AnyFunctionDefinition {
-  var requiredArgumentsCount: Int {
-    var trailingOptionalArgumentsCount: Int = 0
-
-    for dynamicArgumentType in dynamicArgumentTypes.reversed() {
-      if dynamicArgumentType is DynamicOptionalType {
-        trailingOptionalArgumentsCount += 1
-      } else {
-        break
-      }
-    }
-    return argumentsCount - trailingOptionalArgumentsCount
-  }
-
-  var argumentsCount: Int {
-    return dynamicArgumentTypes.count
-  }
-}
-
 internal final class FunctionCallException: GenericException<String>, @unchecked Sendable {
   override var reason: String {
     "Calling the '\(param)' function has failed"

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -115,7 +115,7 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
       let returnedValue: ReturnType
 
       do {
-        guard let argumentsTuple = try Conversions.toTuple(nativeArguments) as? Args else {
+        guard let argumentsTuple: Args = try Conversions.toTuple(nativeArguments) else {
           throw ArgumentConversionException()
         }
         returnedValue = try body(argumentsTuple)

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -59,6 +59,12 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
     self.dynamicArgumentTypes = dynamicArgumentTypes
     self.returnType = returnType
     self.body = body
+
+    self.trailingOptionalArgumentsCount = dynamicArgumentTypes
+      .dropLast(takesPromise ? 1 : 0)
+      .reversed()
+      .prefix(while: { $0 is DynamicOptionalType })
+      .count
   }
 
   // MARK: - AnyFunction
@@ -67,8 +73,14 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
 
   let dynamicArgumentTypes: [AnyDynamicType]
 
+  private let trailingOptionalArgumentsCount: Int
+
   var argumentsCount: Int {
     return dynamicArgumentTypes.count - (takesOwner ? 1 : 0) - (takesPromise ? 1 : 0)
+  }
+
+  var requiredArgumentsCount: Int {
+    return argumentsCount - trailingOptionalArgumentsCount
   }
 
   var takesOwner: Bool = false
@@ -198,24 +210,4 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
   }
 }
 
-extension AsyncFunctionDefinition {
-  var requiredArgumentsCount: Int {
-    var trailingOptionalArgumentsCount: Int = 0
 
-    let reversedArgumentTypes = dynamicArgumentTypes.reversed()
-
-    let reversedArgumentsToIterate: any Sequence<AnyDynamicType> = takesPromise
-      ? reversedArgumentTypes.dropFirst()
-      : reversedArgumentTypes
-
-    for dynamicArgumentType in reversedArgumentsToIterate {
-      if dynamicArgumentType is DynamicOptionalType {
-        trailingOptionalArgumentsCount += 1
-      } else {
-        break
-      }
-    }
-
-    return argumentsCount - trailingOptionalArgumentsCount
-  }
-}

--- a/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
@@ -30,6 +30,10 @@ public class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>: AnyCo
     self.name = name
     self.body = body
     self.dynamicArgumentTypes = dynamicArgumentTypes
+    self.trailingOptionalArgumentsCount = dynamicArgumentTypes
+      .reversed()
+      .prefix(while: { $0 is DynamicOptionalType })
+      .count
   }
 
   // MARK: - AnyFunction
@@ -38,8 +42,14 @@ public class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>: AnyCo
 
   let dynamicArgumentTypes: [AnyDynamicType]
 
+  private let trailingOptionalArgumentsCount: Int
+
   var argumentsCount: Int {
     return dynamicArgumentTypes.count - (takesOwner ? 1 : 0)
+  }
+
+  var requiredArgumentsCount: Int {
+    return argumentsCount - trailingOptionalArgumentsCount
   }
 
   var takesOwner: Bool = false

--- a/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/ConcurrentFunctionDefinition.swift
@@ -57,21 +57,23 @@ public class ConcurrentFunctionDefinition<Args, FirstArgType, ReturnType>: AnyCo
 
   @JavaScriptActor
   func call(_ appContext: AppContext, this: JavaScriptValue, arguments: consuming JavaScriptValuesBuffer) async throws -> JavaScriptValue {
-    let nativeArguments = NonisolatedUnsafeVar<[Any]>([])
-
     do {
       try validateArgumentsNumber(function: self, received: arguments.count)
 
       // Arguments must be converted on the JS thread, before we jump to another thread.
-      nativeArguments.value = try toNativeClosureArguments(converter: appContext.converter, fn: self, this: this, arguments: arguments)
+      let nativeArguments = try toNativeClosureArguments(converter: appContext.converter, fn: self, this: this, arguments: arguments)
 
-      guard let argumentsTuple = try Conversions.toTuple(nativeArguments.value) as? Args else {
+      guard let argumentsTuple: Args = try Conversions.toTuple(nativeArguments) else {
         throw ArgumentConversionException()
       }
-      let returnValue = if requiresMainActor {
-        try await callBodyOnMainActor(consume argumentsTuple)
+      // Safe to mark as nonisolated(unsafe) — the tuple contains fully converted native values
+      // with no references back to JS objects, so it can safely cross the actor boundary.
+      nonisolated(unsafe) let nonisolatedArgumentsTuple = argumentsTuple
+
+      let returnValue: ReturnType = if requiresMainActor {
+        try await callBodyOnMainActor(nonisolatedArgumentsTuple)
       } else {
-        try await body(consume argumentsTuple)
+        try await body(nonisolatedArgumentsTuple)
       }
 
       return try await appContext.runtime.execute {

--- a/packages/expo-modules-core/ios/Core/Functions/OptimizedAsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/OptimizedAsyncFunctionDefinition.swift
@@ -35,6 +35,11 @@ public struct OptimizedAsyncFunctionDefinition: AnyAsyncFunctionDefinition, @unc
     return argsCount
   }
 
+  public var requiredArgumentsCount: Int {
+    // Optimized functions don't support optional arguments, so all args are required.
+    return argsCount
+  }
+
   public var takesOwner: Bool = false
 
   public func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {

--- a/packages/expo-modules-core/ios/Core/Functions/OptimizedSyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/OptimizedSyncFunctionDefinition.swift
@@ -33,6 +33,11 @@ public struct OptimizedSyncFunctionDefinition: AnySyncFunctionDefinition, @unche
     return argsCount
   }
 
+  public var requiredArgumentsCount: Int {
+    // Optimized functions don't support optional arguments, so all args are required.
+    return argsCount
+  }
+
   public var takesOwner: Bool = false
 
   public func call(by owner: AnyObject?, withArguments args: [Any], appContext: AppContext, callback: @escaping (FunctionCallResult) -> ()) {

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -143,14 +143,12 @@ internal func toNativeClosureArguments<F: AnyFunctionDefinition>(
   this: JavaScriptValue,
   arguments: borrowing JavaScriptValuesBuffer
 ) throws -> [Any] {
-  let receivedArgumentsCount = arguments.count
-
-  if !fn.takesOwner && receivedArgumentsCount == 0 {
+  if !fn.takesOwner, fn.argumentsCount == 0 {
     return []
   }
 
-  // This array will include the owner (if needed) and function arguments.
   var nativeArguments: [Any] = []
+  nativeArguments.reserveCapacity(fn.dynamicArgumentTypes.count)
 
   // If the function takes the owner, convert it and add to the final arguments.
   if fn.takesOwner, !this.isUndefined(), let ownerType = fn.dynamicArgumentTypes.first {
@@ -158,16 +156,20 @@ internal func toNativeClosureArguments<F: AnyFunctionDefinition>(
     nativeArguments.append(nativeOwner)
   }
 
-  // Convert JS values to non-JS native types desired by the function.
-  let dynamicTypesWithoutOwner = Array(fn.dynamicArgumentTypes.dropFirst(nativeArguments.count))
-  nativeArguments.append(
-    contentsOf: try converter.toNative(arguments, dynamicTypesWithoutOwner)
-  )
+  // Convert JS values to native types desired by the function.
+  let typeOffset = nativeArguments.count
+  for i in 0..<arguments.count {
+    let type = fn.dynamicArgumentTypes[typeOffset + i]
+    do {
+      try nativeArguments.append(converter.toNative(arguments[i], type))
+    } catch {
+      throw ArgumentCastException((index: i, type: type)).causedBy(error)
+    }
+  }
 
   // Fill in with nils in place of missing optional arguments.
-  if receivedArgumentsCount < fn.argumentsCount {
-    let missingOptionals = Array(repeating: Any?.none as Any, count: fn.argumentsCount - receivedArgumentsCount)
-    nativeArguments.append(contentsOf: missingOptionals)
+  for _ in arguments.count..<fn.argumentsCount {
+    nativeArguments.append(Any?.none as Any)
   }
   return nativeArguments
 }

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -71,6 +71,7 @@ public class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunc
   // MARK: - AnySyncFunctionDefinition
 
   @JavaScriptActor
+  @discardableResult
   func runBody(_ appContext: AppContext, in runtime: JavaScriptRuntime, this: JavaScriptValue, arguments: consuming JavaScriptValuesBuffer) throws(Exception) -> Any {
     do {
       try validateArgumentsNumber(function: self, received: arguments.count)
@@ -125,16 +126,22 @@ public class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunc
   }
 }
 
+@_transparent
 @JavaScriptActor
-internal func toNativeClosureArguments(
-  converter: MainValueConverter,
-  fn: AnyFunctionDefinition,
+internal func toNativeClosureArguments<F: AnyFunctionDefinition>(
+  converter: borrowing MainValueConverter,
+  fn: borrowing F,
   this: JavaScriptValue,
   arguments: borrowing JavaScriptValuesBuffer
 ) throws -> [Any] {
+  let receivedArgumentsCount = arguments.count
+
+  if !fn.takesOwner && receivedArgumentsCount == 0 {
+    return []
+  }
+
   // This array will include the owner (if needed) and function arguments.
   var nativeArguments: [Any] = []
-  let receivedArgumentsCount = arguments.count
 
   // If the function takes the owner, convert it and add to the final arguments.
   if fn.takesOwner, !this.isUndefined(), let ownerType = fn.dynamicArgumentTypes.first {

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -86,8 +86,7 @@ public class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunc
     do {
       try validateArgumentsNumber(function: self, received: arguments.count)
       let nativeArguments = try toNativeClosureArguments(converter: appContext.converter, fn: self, this: this, arguments: arguments)
-
-      guard let argumentsTuple = try Conversions.toTuple(nativeArguments) as? Args else {
+      guard let argumentsTuple: Args = try Conversions.toTuple(nativeArguments) else {
         throw ArgumentConversionException()
       }
       return try body(argumentsTuple) as Any

--- a/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/SyncFunctionDefinition.swift
@@ -52,6 +52,10 @@ public class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunc
     self.dynamicArgumentTypes = dynamicArgumentTypes
     self.returnType = returnType
     self.body = body
+    self.trailingOptionalArgumentsCount = dynamicArgumentTypes
+      .reversed()
+      .prefix(while: { $0 is DynamicOptionalType })
+      .count
   }
 
   // MARK: - AnyFunction
@@ -62,8 +66,14 @@ public class SyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnySyncFunc
 
   let returnType: AnyDynamicType
 
+  private let trailingOptionalArgumentsCount: Int
+
   var argumentsCount: Int {
     return dynamicArgumentTypes.count - (takesOwner ? 1 : 0)
+  }
+
+  var requiredArgumentsCount: Int {
+    return argumentsCount - trailingOptionalArgumentsCount
   }
 
   var takesOwner: Bool = false

--- a/packages/expo-modules-core/ios/Core/JavaScriptUtils.swift
+++ b/packages/expo-modules-core/ios/Core/JavaScriptUtils.swift
@@ -8,7 +8,8 @@ import ExpoModulesJSI
  Validates whether the number of received arguments is enough to call the given function.
  Throws `InvalidArgsNumberException` otherwise.
  */
-internal func validateArgumentsNumber(function: AnyFunctionDefinition, received: Int) throws {
+@_transparent
+internal func validateArgumentsNumber<F: AnyFunctionDefinition>(function: borrowing F, received: Int) throws {
   let argumentsCount = function.argumentsCount
   let requiredArgumentsCount = function.requiredArgumentsCount
 

--- a/packages/expo-modules-core/ios/Core/MainValueConverter.swift
+++ b/packages/expo-modules-core/ios/Core/MainValueConverter.swift
@@ -5,8 +5,9 @@ import ExpoModulesJSI
 /**
  A converter associated with the specific app context that delegates value conversions to the dynamic type converters.
  */
-public struct MainValueConverter {
-  private(set) weak var appContext: AppContext?
+public struct MainValueConverter: ~Copyable {
+  // Safe to use unowned — the converter is a lazy property of AppContext, so AppContext always outlives it.
+  unowned let appContext: AppContext
 
   /**
    Casts the given JavaScriptValue to a non-JS value.
@@ -14,9 +15,6 @@ public struct MainValueConverter {
    */
   @JavaScriptActor
   public func toNative(_ value: JavaScriptValue, _ type: AnyDynamicType) throws -> Any {
-    guard let appContext else {
-      throw Exceptions.AppContextLost()
-    }
     let rawValue = try type.cast(jsValue: value, appContext: appContext)
     return try type.cast(rawValue, appContext: appContext)
   }
@@ -41,10 +39,8 @@ public struct MainValueConverter {
   /**
    Converts the given value to the type compatible with JavaScript.
    */
+  @JavaScriptActor
   public func toJS(_ value: Any, _ type: AnyDynamicType) throws -> JavaScriptValue {
-    guard let appContext else {
-      throw Exceptions.AppContextLost()
-    }
     let result = Conversions.convertFunctionResult(value, appContext: appContext, dynamicType: type)
     return try type.castToJS(result, appContext: appContext)
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -286,16 +286,14 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return createFunction(name) { this, arguments in
       let promise = JavaScriptPromise(self)
 
-      // Need to switch to reference semantics as Task escapes the closure (consumes on capture).
       // Arguments buffer needs to be copied to ensure safe async access.
-      let thisRef = this.ref()
       let argumentsRef = arguments.copy().ref()
 
       // Switch to asynchronous context.
       self.schedule(taskName: "[JS] Async function \(name)") {
         // Invoke the asynchronous function and resolve/reject the promise.
         do {
-          let result = try await function(thisRef.take(), argumentsRef.take())
+          let result = try await function(this, argumentsRef.take())
           promise.resolve(result)
         } catch {
           promise.reject(error)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -6,7 +6,10 @@ internal import jsi
  Used mainly to pass function arguments from C++ to Swift.
  */
 public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
-  internal weak let runtime: JavaScriptRuntime?
+  // Safe to use unowned — the buffer's lifetime is scoped to a host function call,
+  // so the runtime is always alive while the buffer exists.
+  internal unowned let runtime: JavaScriptRuntime
+
   internal nonisolated(unsafe) let bufferPointer: UnsafeMutableBufferPointer<facebook.jsi.Value>
   private let ownsMemory: Bool
 
@@ -46,21 +49,15 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   }
 
   public subscript(index: Int) -> JavaScriptValue {
-    guard let runtime else {
-      FatalError.runtimeLost()
-    }
     return JavaScriptValue(runtime, bufferPointer[index])
   }
 
   @discardableResult
   internal consuming func set<T: JSIRepresentable>(value: borrowing T, atIndex index: Int) -> JavaScriptValuesBuffer where T: ~Copyable {
-    guard let jsiRuntime = runtime?.pointee else {
-      FatalError.runtimeLost()
-    }
     guard (0..<count).contains(index) else {
       FatalError.valuesBufferIndexOutRange(index: index, capacity: count)
     }
-    bufferPointer.initializeElement(at: index, to: value.toJSIValue(in: jsiRuntime))
+    bufferPointer.initializeElement(at: index, to: value.toJSIValue(in: runtime.pointee))
     return self
   }
 
@@ -81,9 +78,6 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
    */
   @JavaScriptActor
   public func copy() -> JavaScriptValuesBuffer {
-    guard let runtime else {
-      FatalError.runtimeLost()
-    }
     let bufferCopy = JavaScriptValuesBuffer.copying(in: runtime, buffer: bufferPointer)
     return JavaScriptValuesBuffer(runtime, buffer: bufferCopy, ownsMemory: true)
   }


### PR DESCRIPTION
## Summary

Reduces the per-call overhead of invoking native Swift functions from JavaScript through the Expo Modules JSI layer. These optimizations target hot paths identified via Xcode Instruments Time Profiler traces.

Key changes:
- Eliminate weak-reference side table churn by using `unowned` references in `MainValueConverter` (~Copyable) and `JavaScriptValuesBuffer`, where lifetimes are guaranteed by scoping
- Enable compiler devirtualization by making `validateArgumentsNumber` and `toNativeClosureArguments` generic over `<F: AnyFunctionDefinition>` instead of taking existential parameters, with `@_transparent` to force inlining even at `-Onone`
- Cache `trailingOptionalArgumentsCount` at init time instead of recomputing it on every call
- Add concrete type fast paths (Double, Int, Float) in `DynamicNumberType` before expensive `swift_conformsToProtocol` existential conformance lookups
- Make `Conversions.toTuple` generic to eliminate a runtime downcast at each call site

## Test plan

- [x] Run expo-modules-core native tests
- [x] Run benchmark app — verify sync, async, and concurrent function calls work without crashes
- [x] Verify no regressions in apps using Expo Modules

It's looking really good in benchmarks. No-op function call is now much faster than in Turbo modules, adding numbers is very close and adding strings is slightly faster. Probably there is still some space for improvements, but this should be enough for now.

| Before | After |
| ---- | ---- |
| ![](https://github.com/user-attachments/assets/6c1cf251-e8e3-4d5d-a621-e61004f0912f) | ![](https://github.com/user-attachments/assets/30c862a5-c37c-4025-9c9c-4a2cbaf979b0) |

<!-- disable:changelog-checks -->