### PR TITLE
[constants][Android] Migrate off deprecated Constants {} block

### DIFF
--- a/packages/expo-constants/CHANGELOG.md
+++ b/packages/expo-constants/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [Android] Migrate `ConstantsModule` off the deprecated `Constants {}` definition block to per-key `Constant(name) { value }` registrations. ([#45097](https://github.com/expo/expo/pull/45097) by [@siddarthkay](https://github.com/siddarthkay))
+
 ## 56.0.16 — 2026-05-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsModule.kt
+++ b/packages/expo-constants/android/src/main/java/expo/modules/constants/ConstantsModule.kt
@@ -1,7 +1,6 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 package expo.modules.constants
 
-import expo.modules.interfaces.constants.ConstantsInterface
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
@@ -10,8 +9,8 @@ class ConstantsModule : Module() {
   override fun definition() = ModuleDefinition {
     Name("ExponentConstants")
 
-    Constants {
-      return@Constants appContext.service<ConstantsInterface>()?.constants ?: emptyMap()
+    appContext.service<ConstantsService>()?.constants?.forEach { (key, value) ->
+      Constant(key) { value }
     }
 
     AsyncFunction<String?>("getWebViewUserAgentAsync") {


### PR DESCRIPTION
# Why

I see this warning in `gradle` output when using `expo-constants` in one of my react-native apps and I decided to finally fix it upstream.

<img width="1365" height="705" alt="Screenshot 2026-04-25 at 10 27 55 PM" src="https://github.com/user-attachments/assets/a2d3864c-b5ac-4460-baa0-ab4bf894e145" />

# How

Opening the project in Android Studio also shows this deprecation warning. With my fix the deprecation warning goes away.

<img width="1459" height="766" alt="Screenshot 2026-04-25 at 10 35 44 PM" src="https://github.com/user-attachments/assets/8ff88976-8db9-4c63-9a54-39fc81452381" />

note: the `ConstantsModule class is never used` warning is a false positive and can be ignored

# Test Plan



# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
