### PR TITLE
[expo-sqlite] re-render SQLiteProvider when only children change

### DIFF
--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - Add explicit secure context error for `web/wa-sqlite/AccessHandlePoolVFS.js` ([#40605](https://github.com/expo/expo/pull/40605) by [@BDav24](https://github.com/BDav24))
+- Fix `SQLiteProvider` skipping re-renders when only `children` change. ([#45099](https://github.com/expo/expo/pull/45099) by [@vladlenskiy](https://github.com/vladlenskiy))
 
 ### 💡 Others
 

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `SQLiteProvider` skipping re-renders when only `children` change. ([#45099](https://github.com/expo/expo/pull/45099) by [@vladlenskiy](https://github.com/vladlenskiy))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-21

--- a/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
+++ b/packages/expo-sqlite/src/__tests__/hooks-test.ios.tsx
@@ -63,6 +63,27 @@ describe(useSQLiteContext, () => {
     openDatabaseSpy.mockRestore();
   });
 
+  it('should re-render when only `children` changes', async () => {
+    function App({ flag }: { flag: boolean }) {
+      return (
+        <SQLiteProvider databaseName=":memory:">
+          {flag ? <Text>after</Text> : <Text>before</Text>}
+        </SQLiteProvider>
+      );
+    }
+
+    const { rerender } = render(<App flag={false} />);
+    await waitFor(() => {
+      expect(screen.queryByText('before')).not.toBeNull();
+    });
+
+    rerender(<App flag />);
+    await waitFor(() => {
+      expect(screen.queryByText('after')).not.toBeNull();
+    });
+    expect(screen.queryByText('before')).toBeNull();
+  });
+
   it('should return the same SQLite instance on subsequent calls', async () => {
     const wrapper = ({ children }: React.PropsWithChildren) => (
       <SQLiteProvider databaseName=":memory:">{children}</SQLiteProvider>

--- a/packages/expo-sqlite/src/hooks.tsx
+++ b/packages/expo-sqlite/src/hooks.tsx
@@ -118,7 +118,8 @@ export const SQLiteProvider = memo(
     prevProps.directory === nextProps.directory &&
     prevProps.onInit === nextProps.onInit &&
     prevProps.onError === nextProps.onError &&
-    prevProps.useSuspense === nextProps.useSuspense
+    prevProps.useSuspense === nextProps.useSuspense &&
+    prevProps.children === nextProps.children
 );
 
 /**
@@ -169,10 +170,11 @@ function SQLiteProviderSuspense({
   children,
   onInit,
 }: Omit<SQLiteProviderProps, 'onError' | 'useSuspense'>) {
+  const stableOptions = useDeepStableValue(options);
   const databasePromise = getDatabaseAsync({
     databaseName,
     directory,
-    options,
+    options: stableOptions,
     assetSource,
     onInit,
   });
@@ -193,13 +195,15 @@ function SQLiteProviderNonSuspense({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
+  const stableOptions = useDeepStableValue(options);
+
   useEffect(() => {
     async function setup() {
       try {
         const db = await openDatabaseWithInitAsync({
           databaseName,
           directory,
-          options,
+          options: stableOptions,
           assetSource,
           onInit,
         });
@@ -226,7 +230,7 @@ function SQLiteProviderNonSuspense({
       databaseRef.current = null;
       setLoading(true);
     };
-  }, [databaseName, directory, options, onInit]);
+  }, [databaseName, directory, stableOptions, onInit]);
 
   if (error != null) {
     const handler =
@@ -331,6 +335,22 @@ export async function importDatabaseFromAssetAsync(
     asset.localUri,
     assetSource.forceOverwrite ?? false
   );
+}
+
+/**
+ * Returns the previous reference while `value` remains deeply equal.
+ */
+function useDeepStableValue<T>(value: T): T {
+  const ref = useRef(value);
+  if (
+    !deepEqual(
+      ref.current as { [key: string]: any } | undefined,
+      value as { [key: string]: any } | undefined
+    )
+  ) {
+    ref.current = value;
+  }
+  return ref.current;
 }
 
 /**


### PR DESCRIPTION
Closes #44671.

`SQLiteProvider` was memoized with a custom comparator, but the comparator did not check `children`. Because of that, changing only the children could be skipped when the rest of the props stayed the same.

This adds `children` to the comparator and keeps `options` stable for the setup effect, so inline `options={{ ... }}` values do not cause the database to reopen on every parent render.

Added a regression test for updating only `children`. Also verified that the existing inline `options={{ ... }}` test still passes.