### PR TITLE
[core][ios] Fix constants conversion to JavaScript and add castToJS fast path

### DIFF
--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -132,21 +132,38 @@ public struct Conversions {
   // MARK: - Any to JavaScript
 
   /**
-   Converts an arbitrary native value to a `JavaScriptValue`.
-   Handles Swift primitives, strings, arrays, and dictionaries with `Any` values
-   that can't be statically matched to `JavaScriptRepresentable`.
+   Converts a native value to a `JavaScriptValue`. When the value conforms to `AnyArgument`,
+   the fast path via `getDynamicType().castToJS()` is used. Otherwise falls back to
+   `unknownToJavaScriptValue` which handles type-erased values through `NSNumber`/`NSDictionary` matching.
    */
-  static func anyToJavaScriptValue(_ value: Any, runtime: JavaScriptRuntime) throws -> JavaScriptValue {
-    if let value = value as? JavaScriptRepresentable {
-      return .representing(value: value, in: runtime)
+  static func anyToJavaScriptValue<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if ValueType.self is AnyOptional.Type, Optional.isNil(value) {
+      return .null
     }
+    if let value = value as? AnyArgument {
+      return try type(of: value).getDynamicType().castToJS(value, appContext: appContext)
+    }
+    return try unknownToJavaScriptValue(value, appContext: appContext)
+  }
+
+  /**
+   Slow path for values whose concrete type is erased to `Any`.
+   Kept separate from `anyToJavaScriptValue` so that the default `AnyDynamicType.castToJS`
+   can call this without re-entering the `AnyArgument` check and causing infinite recursion.
+   */
+  static func unknownToJavaScriptValue(_ value: Any, appContext: AppContext) throws -> JavaScriptValue {
+    if let value = value as? JavaScriptRepresentable {
+      return .representing(value: value, in: try appContext.runtime)
+    }
+
+    let runtime = try appContext.runtime
+
     switch value {
     case is Void:
       return .undefined
     case is NSNull:
       return .null
     case let number as NSNumber:
-      // NSNumber wrapping a boolean is also a valid NSNumber, so check for bool first.
       if number === kCFBooleanTrue {
         return .true()
       }
@@ -161,18 +178,18 @@ public struct Conversions {
     case let array as NSArray:
       let jsArray = runtime.createArray(length: array.count)
       for (index, element) in array.enumerated() {
-        try jsArray.set(value: anyToJavaScriptValue(element, runtime: runtime), at: index)
+        try jsArray.set(value: anyToJavaScriptValue(element, appContext: appContext), at: index)
       }
       return jsArray.asValue()
     case let dict as NSDictionary:
       let jsObject = runtime.createObject()
       for (key, element) in dict {
         guard let key = key as? String else { continue }
-        jsObject.setProperty(key, value: try anyToJavaScriptValue(element, runtime: runtime))
+        jsObject.setProperty(key, value: try anyToJavaScriptValue(element, appContext: appContext))
       }
       return jsObject.asValue()
     default:
-      log.warn("anyToJavaScriptValue: unsupported native type '\(type(of: value))', returning undefined")
+      log.warn("unknownToJavaScriptValue: unsupported native type '\(type(of: value))', returning undefined")
       return .undefined
     }
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
@@ -51,7 +51,7 @@ extension AnyDynamicType {
   }
 
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
-    return try Conversions.anyToJavaScriptValue(value, runtime: appContext.runtime)
+    return try Conversions.unknownToJavaScriptValue(value, appContext: appContext)
   }
 
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicArrayType.swift
@@ -56,7 +56,7 @@ internal struct DynamicArrayType: AnyDynamicType {
    */
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
     guard let array = value as? [Any] else {
-      return try Conversions.anyToJavaScriptValue(value, runtime: appContext.runtime)
+      return try Conversions.anyToJavaScriptValue(value, appContext: appContext)
     }
     let runtime = try appContext.runtime
     let jsArray = runtime.createArray(length: array.count)

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicBoolType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicBoolType.swift
@@ -35,6 +35,13 @@ internal struct DynamicBoolType: AnyDynamicType {
     throw Conversions.ConversionToNativeFailedException((kind: jsValue.kind, nativeType: Bool.self))
   }
 
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let value = value as? Bool {
+      return value ? .true() : .false()
+    }
+    throw Conversions.ConversionToJSFailedException((kind: .bool, nativeType: ValueType.self))
+  }
+
   var description: String {
     "Bool"
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
@@ -21,6 +21,17 @@ internal struct DynamicConvertibleType: AnyDynamicType {
     return try innerType.convert(from: value, appContext: appContext)
   }
 
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    let result = try innerType.convertResult(value, appContext: appContext)
+    if let result = result as? JavaScriptValue {
+      return result
+    }
+    if let result = result as? AnyArgument {
+      return try type(of: result).getDynamicType().castToJS(result, appContext: appContext)
+    }
+    return try Conversions.unknownToJavaScriptValue(result, appContext: appContext)
+  }
+
   func convertResult<ResultType>(_ result: ResultType, appContext: AppContext) throws -> Any {
     return try innerType.convertResult(result, appContext: appContext)
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicDictionaryType.swift
@@ -57,7 +57,7 @@ internal struct DynamicDictionaryType: AnyDynamicType {
    */
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
     guard let dict = value as? [AnyHashable: Any] else {
-      return try Conversions.anyToJavaScriptValue(value, runtime: appContext.runtime)
+      return try Conversions.anyToJavaScriptValue(value, appContext: appContext)
     }
     let runtime = try appContext.runtime
     let jsObject = runtime.createObject()

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEitherType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEitherType.swift
@@ -59,6 +59,13 @@ internal struct DynamicEitherType<EitherType: AnyEither>: AnyDynamicType {
     throw NeitherTypeException(types)
   }
 
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let either = value as? EitherType {
+      return try Conversions.anyToJavaScriptValue(either.value, appContext: appContext)
+    }
+    return try Conversions.anyToJavaScriptValue(value, appContext: appContext)
+  }
+
   var description: String {
     let types = eitherType.dynamicTypes()
     return "Either<\(types.map(\.description).joined(separator: ", "))>"

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
@@ -32,6 +32,13 @@ internal struct DynamicEnumType: AnyDynamicType {
     return result
   }
 
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let value = value as? any Enumerable {
+      return try Conversions.anyToJavaScriptValue(value.anyRawValue, appContext: appContext)
+    }
+    throw Conversions.ConversionToJSFailedException((kind: .undefined, nativeType: ValueType.self))
+  }
+
   var description: String {
     "Enum<\(innerType)>"
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicJavaScriptType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicJavaScriptType.swift
@@ -20,6 +20,13 @@ internal struct DynamicJavaScriptType: AnyDynamicType {
     return jsValue
   }
 
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    if let value = value as? JavaScriptValue {
+      return value
+    }
+    throw Conversions.ConversionToJSFailedException((kind: .undefined, nativeType: ValueType.self))
+  }
+
   var description: String {
     return "JavaScriptValue"
   }

--- a/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Objects/ObjectDefinition.swift
@@ -106,11 +106,7 @@ public class ObjectDefinition: AnyDefinition, JavaScriptObjectBuilder {
   @JavaScriptActor
   internal func decorateWithConstants(object: borrowing JavaScriptObject, appContext: AppContext) throws {
     for (key, value) in getLegacyConstants() {
-      if let value = value as? JavaScriptRepresentable {
-        object.setProperty(key, value: value)
-      } else {
-        object.setProperty(key, value: .null)
-      }
+      object.setProperty(key, value: try Conversions.anyToJavaScriptValue(value, appContext: appContext))
     }
 
     for constant in constants.values {

--- a/packages/expo-modules-core/ios/Tests/ConstantsTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ConstantsTests.swift
@@ -57,4 +57,160 @@ struct ConstantsTests {
       }
     }
   }
+
+  struct TestRecord: Record {
+    @Field var name: String = "expo"
+    @Field var version: Int = 55
+  }
+
+  enum TestEnum: String, Enumerable {
+    case active
+    case inactive
+  }
+
+  @Suite
+  @JavaScriptActor
+  struct JavaScriptTests {
+    let appContext: AppContext
+    var runtime: ExpoRuntime {
+      get throws {
+        try appContext.runtime
+      }
+    }
+
+    init() {
+      appContext = AppContext.create()
+
+      let optionalString: String? = "optional value"
+      let optionalInt: Int? = 42
+
+      appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
+        Name("ConstantsModule")
+
+        Constants([
+          "stringValue": "hello",
+          "intValue": 123,
+          "doubleValue": 3.14,
+          "boolValue": true,
+          "nullValue": nil,
+          "nestedDict": ["key": "value", "number": 99] as [String: Any],
+          "arrayValue": [1, 2, 3],
+          "optionalString": optionalString,
+          "optionalInt": optionalInt,
+          "record": TestRecord(),
+          "enum": TestEnum.active,
+          "data": Data([0x48, 0x65, 0x6C, 0x6C, 0x6F]),
+          "arrayBuffer": try! NativeArrayBuffer.copy(data: Data([1, 2, 3, 4])),
+          "size": CGSize(width: 100, height: 200),
+          "colors": [
+            UIColor(red: 1, green: 0, blue: 0, alpha: 1),
+            UIColor(red: 0, green: 0.5, blue: 1, alpha: 0.8),
+          ],
+          "void": (),
+          "eitherString": Either<Bool, String>("hello"),
+          "eitherBool": Either<Bool, String>(true),
+        ])
+      })
+    }
+
+    @Test
+    func `exposes primitive constants to JS`() throws {
+      let module = try runtime.eval("expo.modules.ConstantsModule")
+      let obj = module.getObject()
+
+      #expect(try obj.getProperty("stringValue").asString() == "hello")
+      #expect(try obj.getProperty("intValue").asInt() == 123)
+      #expect(try obj.getProperty("doubleValue").asDouble() == 3.14)
+      #expect(try obj.getProperty("boolValue").asBool() == true)
+    }
+
+    @Test
+    func `exposes null constant to JS`() throws {
+      let value = try runtime.eval("expo.modules.ConstantsModule.nullValue")
+      #expect(value.isNull() == true)
+    }
+
+    @Test
+    func `exposes nested dictionary to JS`() throws {
+      let nested = try runtime.eval("expo.modules.ConstantsModule.nestedDict")
+      #expect(nested.isObject() == true)
+      #expect(try nested.getObject().getProperty("key").asString() == "value")
+      #expect(try nested.getObject().getProperty("number").asInt() == 99)
+    }
+
+    @Test
+    func `exposes array constant to JS`() throws {
+      let array = try runtime.eval("expo.modules.ConstantsModule.arrayValue")
+      #expect(array.isObject() == true)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.arrayValue.length").asInt() == 3)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.arrayValue[0]").asInt() == 1)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.arrayValue[2]").asInt() == 3)
+    }
+
+    @Test
+    func `exposes optional-wrapped values to JS`() throws {
+      let module = try runtime.eval("expo.modules.ConstantsModule")
+      let obj = module.getObject()
+
+      #expect(try obj.getProperty("optionalString").asString() == "optional value")
+      #expect(try obj.getProperty("optionalInt").asInt() == 42)
+    }
+
+    @Test
+    func `exposes record constant to JS`() throws {
+      let record = try runtime.eval("expo.modules.ConstantsModule.record")
+      #expect(record.isObject() == true)
+      #expect(try record.getObject().getProperty("name").asString() == "expo")
+      #expect(try record.getObject().getProperty("version").asInt() == 55)
+    }
+
+    @Test
+    func `exposes enum constant to JS`() throws {
+      let value = try runtime.eval("expo.modules.ConstantsModule.enum")
+      #expect(try value.asString() == "active")
+    }
+
+    @Test
+    func `exposes array buffer constant`() throws {
+      #expect(try runtime.eval("expo.modules.ConstantsModule.arrayBuffer instanceof ArrayBuffer").asBool() == true)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.arrayBuffer.byteLength").asInt() == 4)
+      #expect(try runtime.eval("new Uint8Array(expo.modules.ConstantsModule.arrayBuffer)[0]").asInt() == 1)
+      #expect(try runtime.eval("new Uint8Array(expo.modules.ConstantsModule.arrayBuffer)[3]").asInt() == 4)
+    }
+
+    @Test
+    func `exposes data constant as Uint8Array`() throws {
+      #expect(try runtime.eval("expo.modules.ConstantsModule.data instanceof Uint8Array").asBool() == true)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.data.length").asInt() == 5)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.data[0]").asInt() == 0x48)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.data[4]").asInt() == 0x6F)
+    }
+
+    @Test
+    func `exposes array of convertibles to JS`() throws {
+      #expect(try runtime.eval("expo.modules.ConstantsModule.colors.length").asInt() == 2)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.colors[0]").asString() == "#ff0000ff")
+      #expect(try runtime.eval("expo.modules.ConstantsModule.colors[1]").asString() == "#0080ffcc")
+    }
+
+    @Test
+    func `exposes void constant as undefined`() throws {
+      #expect(try runtime.eval("'void' in expo.modules.ConstantsModule").asBool() == true)
+      #expect(try runtime.eval("expo.modules.ConstantsModule.void").isUndefined() == true)
+    }
+
+    @Test
+    func `exposes either constants to JS`() throws {
+      #expect(try runtime.eval("expo.modules.ConstantsModule.eitherString").asString() == "hello")
+      #expect(try runtime.eval("expo.modules.ConstantsModule.eitherBool").asBool() == true)
+    }
+
+    @Test
+    func `exposes convertible constant to JS`() throws {
+      let size = try runtime.eval("expo.modules.ConstantsModule.size")
+      #expect(size.isObject() == true)
+      #expect(try size.getObject().getProperty("width").asDouble() == 100)
+      #expect(try size.getObject().getProperty("height").asDouble() == 200)
+    }
+  }
 }


### PR DESCRIPTION
## Why

Module constants defined as `[String: Any?]` were not properly converted to JavaScript. The old code in `decorateWithConstants` checked `value as? JavaScriptRepresentable` and fell back to `.null` for anything that didn't match — silently dropping nested dicts, arrays, type-erased optionals, and other valid values.

Also fixes test-suite e2e tests for `expo-image`: https://github.com/expo/expo/actions/runs/24906448453/job/72939785545
They were failing only in the release configuration where `expo-asset` reads `localAssets` exposed as a constant from `expo-updates`, but it was returning `null` instead of an array of assets.

`expo-video` is still failing though, I'll address this separately.

## How
- Replaced the manual `JavaScriptRepresentable` check in `decorateWithConstants` with a single call to `Conversions.anyToJavaScriptValue`, which handles all value types correctly
- Split conversion into `anyToJavaScriptValue` (generic entry point with `AnyArgument` fast path) and `unknownToJavaScriptValue` (slow `NSNumber`/`NSDictionary` fallback) to avoid infinite recursion through default `castToJS` implementations
- Added `castToJS` to `DynamicBoolType`, `DynamicConvertibleType`, `DynamicEitherType`, `DynamicEnumType`, and `DynamicJavaScriptType` so typed values bypass the slow path

## Test plan
- [x] Added 14 JS-level tests for constants: primitives, null, nested dicts, arrays, optionals, records, enums, Data, ArrayBuffer, CGSize, UIColor arrays, void/undefined, and Either types
- [x] All expo-modules-core unit tests passing