### PR TITLE
[docs] Fix typo and update the position of llms.txt blockquote

### DIFF
--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -372,12 +372,6 @@ export default function DocumentationPage({
             />
           )}
           {title && <Separator />}
-          <blockquote className="sr-only">
-            <p>
-              For the complete documentation index, see <A href="/llms.txt">llms.txt</A>. Use this
-              Use this file to discover all available pages.
-            </p>
-          </blockquote>
           {children}
         </main>
         <Footer

--- a/docs/components/DocumentationPage.tsx
+++ b/docs/components/DocumentationPage.tsx
@@ -372,6 +372,12 @@ export default function DocumentationPage({
             />
           )}
           {title && <Separator />}
+          <blockquote className="sr-only">
+            <p>
+              For the complete documentation index, see <A href="/llms.txt">llms.txt</A>. Use this
+              file to discover all available pages.
+            </p>
+          </blockquote>
           {children}
         </main>
         <Footer

--- a/docs/scripts/agent-instructions.ts
+++ b/docs/scripts/agent-instructions.ts
@@ -42,5 +42,7 @@ curl -X POST https://api.expo.dev/v2/feedback/docs-send -H 'Content-Type: applic
 Only submit when you have something specific and actionable to report.
 
 </AgentInstructions>
+
+> For the complete documentation index, see [llms.txt](/llms.txt). Use this file to discover all available pages.
 `;
 }

--- a/docs/scripts/agent-instructions.ts
+++ b/docs/scripts/agent-instructions.ts
@@ -42,7 +42,5 @@ curl -X POST https://api.expo.dev/v2/feedback/docs-send -H 'Content-Type: applic
 Only submit when you have something specific and actionable to report.
 
 </AgentInstructions>
-
-> For the complete documentation index, see [llms.txt](/llms.txt). Use this file to discover all available pages.
 `;
 }


### PR DESCRIPTION
# Why

Resolves [ENG-20784]


# How

- Removed the duplicated `Use this` from the intro callout text.

# Test Plan

Open a link in preview, go to its `/index.md` URL and see the blockquote appearing after a page's description in its editorial content.

http://pr-45106.expo-docs.pages.dev/get-started/create-a-project/index.md
