### PR TITLE
[docs] Extract talks section into transforms module from llms.txt script

### DIFF
--- a/docs/scripts/generate-llms/llms-txt.js
+++ b/docs/scripts/generate-llms/llms-txt.js
@@ -1,18 +1,16 @@
 import frontmatter from 'front-matter';
 import fs from 'node:fs';
 import path from 'node:path';
-import ts from 'typescript';
 
 import { home, learn, general, eas, reference } from '../../constants/navigation.js';
 import { generateCrossLinksSection, toBlockquote } from './shared.js';
+import { buildTalksSections } from './transforms/talks-section.js';
 
 const OUTPUT_DIRECTORY_NAME = 'public';
 const OUTPUT_FILENAME_LLMS_TXT = 'llms.txt';
 const TITLE = 'Expo Documentation';
 const DESCRIPTION =
   'Expo is an open-source React Native framework for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app such as live updates, instantly sharing your app, and web support. The company behind Expo also offers Expo Application Services (EAS), which are deeply integrated cloud services for Expo and React Native apps.';
-const TALKS_TS_PATH = path.join(process.cwd(), 'public/static/talks.ts');
-const TALKS_JS_PATH = path.join(process.cwd(), 'scripts/generate-llms/talks.js');
 
 function generateItemMarkdown(item) {
   return `- [${item.title}](${item.url})${item.description ? `: ${item.description}` : ''}\n`;
@@ -171,84 +169,14 @@ function processSection(node) {
   return section;
 }
 
-function generateVideoUrl(videoId) {
-  return `https://www.youtube.com/watch?v=${videoId}`;
-}
-
-function processTalks(talks, type = 'video') {
-  return talks.map(talk => {
-    if (type === 'podcast' && talk.link) {
-      return {
-        title: talk.title,
-        url: talk.link,
-      };
-    }
-
-    return {
-      title: talk.title,
-      url: talk.videoId ? generateVideoUrl(talk.videoId) : '',
-    };
-  });
-}
-
-async function exportTalksData() {
-  const { TALKS, PODCASTS, LIVE_STREAMS, YOUTUBE_VIDEOS } = await import('./talks.js');
-  return {
-    title: 'Additional Resources',
-    description: 'Collection of talks, podcasts, and live streams from the Expo team',
-    sections: [
-      {
-        title: 'Conference Talks',
-        items: processTalks(TALKS),
-        groups: [],
-        sections: [],
-      },
-      {
-        title: 'Podcasts',
-        items: processTalks(PODCASTS, 'podcast'),
-        groups: [],
-        sections: [],
-      },
-      {
-        title: 'Live Streams',
-        items: processTalks(LIVE_STREAMS),
-        groups: [],
-        sections: [],
-      },
-      {
-        title: 'YouTube Tutorials',
-        items: processTalks(YOUTUBE_VIDEOS),
-        groups: [],
-        sections: [],
-      },
-    ],
-  };
-}
-
-function compileTalksFile() {
-  const inputFileContent = fs.readFileSync(TALKS_TS_PATH, 'utf8');
-  const outputFileContent = ts.transpileModule(inputFileContent, {
-    compilerOptions: {
-      target: ts.ScriptTarget.ESNext,
-      module: ts.ModuleKind.ESNext,
-      moduleResolution: ts.ModuleResolutionKind.Node10,
-    },
-  }).outputText;
-
-  fs.writeFileSync(TALKS_JS_PATH, outputFileContent, 'utf8');
-  console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully compiled talks.ts to talks.js`);
-}
-
 export async function generateLlmsTxt() {
   try {
-    compileTalksFile();
-
     const docSections = Object.values({ home, general, learn, eas, reference: reference.latest })
       .flat()
       .map(processSection)
       .filter(Boolean);
-    const talksData = await exportTalksData();
-    const allSections = [...docSections, ...talksData.sections];
+    const talksSections = await buildTalksSections();
+    const allSections = [...docSections, ...talksSections];
 
     await fs.promises.writeFile(
       path.join(process.cwd(), OUTPUT_DIRECTORY_NAME, OUTPUT_FILENAME_LLMS_TXT),

--- a/docs/scripts/generate-llms/transforms/talks-section.js
+++ b/docs/scripts/generate-llms/transforms/talks-section.js
@@ -1,0 +1,82 @@
+/**
+ * Adds an "Additional Resources" section to llms.txt with content that doesn't
+ * live in the docs nav: conference talks, podcasts, live streams, and YouTube
+ * tutorials. The source of truth is `public/static/talks.ts` (consumed by the
+ * /additional-resources page). We transpile it to `talks.js` at generation
+ * time so this script can `import` it without a TypeScript runtime.
+ *
+ * Isolated from llms-txt.js so the talks list can grow (more types, different
+ * URL shapes) without touching the orchestrator script.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+const TALKS_TS_PATH = path.join(process.cwd(), 'public/static/talks.ts');
+const TALKS_JS_PATH = path.join(process.cwd(), 'scripts/generate-llms/talks.js');
+
+function generateVideoUrl(videoId) {
+  return `https://www.youtube.com/watch?v=${videoId}`;
+}
+
+function processTalks(talks, type = 'video') {
+  return talks.map(talk => {
+    if (type === 'podcast' && talk.link) {
+      return {
+        title: talk.title,
+        url: talk.link,
+      };
+    }
+
+    return {
+      title: talk.title,
+      url: talk.videoId ? generateVideoUrl(talk.videoId) : '',
+    };
+  });
+}
+
+function compileTalksFile() {
+  const inputFileContent = fs.readFileSync(TALKS_TS_PATH, 'utf8');
+  const outputFileContent = ts.transpileModule(inputFileContent, {
+    compilerOptions: {
+      target: ts.ScriptTarget.ESNext,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
+    },
+  }).outputText;
+
+  fs.writeFileSync(TALKS_JS_PATH, outputFileContent, 'utf8');
+  console.log(` \x1b[1m\x1b[32m✓\x1b[0m Successfully compiled talks.ts to talks.js`);
+}
+
+export async function buildTalksSections() {
+  compileTalksFile();
+  const { TALKS, PODCASTS, LIVE_STREAMS, YOUTUBE_VIDEOS } = await import('../talks.js');
+  return [
+    {
+      title: 'Conference Talks',
+      items: processTalks(TALKS),
+      groups: [],
+      sections: [],
+    },
+    {
+      title: 'Podcasts',
+      items: processTalks(PODCASTS, 'podcast'),
+      groups: [],
+      sections: [],
+    },
+    {
+      title: 'Live Streams',
+      items: processTalks(LIVE_STREAMS),
+      groups: [],
+      sections: [],
+    },
+    {
+      title: 'YouTube Tutorials',
+      items: processTalks(YOUTUBE_VIDEOS),
+      groups: [],
+      sections: [],
+    },
+  ];
+}


### PR DESCRIPTION
# Why

Proposal to do some cleanup since we'll be adding more transforms. This will keep the initial `llms-txt.js` file healthy.

Currently, the `llms.txt` generator had ~70 lines of talks-specific code (compiling `public/static/talks.ts`, building Conference Talks, Podcasts, Live Streams, and YouTube Tutorials sections) inlined alongside the nav-walking logic. This bundled an unrelated TypeScript transpile step into the main generator and made it hard to see what was page-derived versus synthetically injected. 

# How

- Add `scripts/generate-llms/transforms/talks-section.js` exporting `buildTalksSections()`. It owns the `talks.ts` to `talks.js` transpile step and returns the four pre-shaped sections that get appended to the nav-derived sections.
- Update `generateLlmsTxt()` in `llms-txt.js` to call `buildTalksSections()` instead of `compileTalksFile()` plus `exportTalksData()`.

# Test Plan

Run `pnpm generate-llms` and see the output of `public/llms.txt` is unchanged.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
