### PR TITLE
[core][ios] Dispatch view lookup to main thread when called from JS thread

### DIFF
--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -186,8 +186,14 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
 
   // MARK: - UI
 
+  /**
+   Looks up a view by its React tag. Ensures the lookup runs on the main thread.
+   */
   public func findView<ViewType>(withTag viewTag: Int, ofType type: ViewType.Type) -> ViewType? {
-    return hostWrapper?.findView(withTag: viewTag) as? ViewType
+    // TODO: Migrate to @MainActor to get compile-time thread safety instead of runtime dispatch
+    return performSynchronouslyOnMainThread {
+      return hostWrapper?.findView(withTag: viewTag) as? ViewType
+    }
   }
 
   // MARK: - Running on specific queues

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSwiftUIViewType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSwiftUIViewType.swift
@@ -33,9 +33,6 @@ internal struct DynamicSwiftUIViewType<ViewType: ExpoSwiftUIView>: AnyDynamicTyp
     guard let viewTag = value as? Int else {
       throw InvalidViewTagException()
     }
-    guard Thread.isMainThread else {
-      throw NonMainThreadException()
-    }
     // Direct match, the virtual view's content type matches exactly.
     // e.g. View(SlotView.self)
     // Both the production (`SwiftUIVirtualView`, NSObject-based) and dev
@@ -44,24 +41,27 @@ internal struct DynamicSwiftUIViewType<ViewType: ExpoSwiftUIView>: AnyDynamicTyp
     // `findView` lookup needs to know about both. Without this, dev builds
     // would fall through to the `ViewWrapper` branch below, which recursively
     // unwraps and is not strictly equivalent to returning `contentView` as-is.
-    if let view = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.SwiftUIVirtualView<ViewType.Props, ViewType>.self) {
-      return view.contentView
+    // TODO: Migrate to @MainActor to get compile-time thread safety instead of runtime dispatch
+    return try performSynchronouslyOnMainThread {
+      if let view = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.SwiftUIVirtualView<ViewType.Props, ViewType>.self) {
+        return view.contentView
+      }
+      if let view = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.SwiftUIVirtualViewDev<ViewType.Props, ViewType>.self) {
+        return view.contentView
+      }
+      // For wrapper types
+      // e.g. ExpoUIView(SecureFieldView.self)
+      if let provider = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.ViewWrapper.self),
+         let innerView = provider.getWrappedView() as? ViewType {
+        return innerView
+      }
+      // For views using WithHostingView protocol.
+      // e.g. View(HostView.self) where HostView conforms to WithHostingView
+      guard let view = appContext.findView(withTag: viewTag, ofType: AnyExpoSwiftUIHostingView.self) else {
+        throw Exceptions.SwiftUIViewNotFound((tag: viewTag, type: innerType.self))
+      }
+      return view.getContentView()
     }
-    if let view = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.SwiftUIVirtualViewDev<ViewType.Props, ViewType>.self) {
-      return view.contentView
-    }
-    // For wrapper types
-    // e.g. ExpoUIView(SecureFieldView.self)
-    if let provider = appContext.findView(withTag: viewTag, ofType: ExpoSwiftUI.ViewWrapper.self),
-       let innerView = provider.getWrappedView() as? ViewType {
-      return innerView
-    }
-    // For views using WithHostingView protocol.
-    // e.g. View(HostView.self) where HostView conforms to WithHostingView
-    guard let view = appContext.findView(withTag: viewTag, ofType: AnyExpoSwiftUIHostingView.self) else {
-      throw Exceptions.SwiftUIViewNotFound((tag: viewTag, type: innerType.self))
-    }
-    return view.getContentView()
   }
 
   var description: String {

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicViewType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicViewType.swift
@@ -33,9 +33,6 @@ internal struct DynamicViewType: AnyDynamicType {
     guard let viewTag = value as? Int else {
       throw InvalidViewTagException()
     }
-    guard Thread.isMainThread else {
-      throw NonMainThreadException()
-    }
     guard let view = appContext.findView(withTag: viewTag, ofType: innerType.self) else {
       throw Exceptions.ViewNotFound((tag: viewTag, type: innerType.self))
     }
@@ -63,11 +60,5 @@ private func findViewTag(_ value: JavaScriptValue) -> Int? {
 internal final class InvalidViewTagException: Exception {
   override var reason: String {
     "The view tag must be a number"
-  }
-}
-
-internal final class NonMainThreadException: Exception {
-  override var reason: String {
-    "All operations on the views must run from the main UI thread"
   }
 }

--- a/packages/expo-modules-core/ios/Utilities/Utilities.swift
+++ b/packages/expo-modules-core/ios/Utilities/Utilities.swift
@@ -103,6 +103,17 @@ internal func performSynchronouslyOnMainActor<Result: Sendable>(_ closure: @Main
 }
 
 /**
+ Like `performSynchronouslyOnMainActor` but without the `Sendable` constraint on the result,
+ for cases where the returned value cannot satisfy `Sendable`.
+ */
+internal func performSynchronouslyOnMainThread<Result>(_ closure: () throws -> Result) rethrows -> Result {
+  if Thread.isMainThread {
+    return try closure()
+  }
+  return try DispatchQueue.main.sync(execute: closure)
+}
+
+/**
  A collection of utility functions for various Expo Modules common tasks.
  */
 public struct Utilities {


### PR DESCRIPTION
## Summary

- `DynamicViewType` and `DynamicSwiftUIViewType` threw `NonMainThreadException` when `AsyncFunction` view functions were called from the JS thread, because the view tag → UIView lookup requires the main thread.
- Moved the main-thread dispatch into `AppContext.findView` and `DynamicSwiftUIViewType.cast` so the lookup is always safe regardless of the calling thread.
- Removed the `NonMainThreadException` guard and class, since thread safety is now handled at the dispatch level.

## Test plan

- Open `bareexpo://components/video/fullscreen` on iOS simulator and tap "Enter Fullscreen" — should enter fullscreen without crashing.
- Verified expo-video e2e fullscreen test passes in CI.
- Verified `focus`, `blur`, `setText` and `setSelection` methods on the `TextFieldView` from `expo-ui`
