### PR TITLE
[app-metrics][ios] Add polymorphic session decoding

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3939,7 +3939,7 @@ SPEC CHECKSUMS:
   ExpoAgeRange: 87dd980cb26e47b1108e24c39bcfb88a9ab1030e
   ExpoAppIntegrity: 7e3ae77f96e3a3f742fe318d7aac24b66a7bead0
   ExpoAppleAuthentication: c8096cd35e4e4f88aec34fcbfcd9deae7cea04d3
-  ExpoAppMetrics: 1ec61573f49055c518fa80569b93d317ac55c2ac
+  ExpoAppMetrics: 3320bd4a3d48e76932a0faf20fee771bb5067f94
   ExpoAsset: 595cc0587b67afaaedddca79d4c1cf506400cb27
   ExpoAudio: 40c883c60ed3bb17ecb3744a00732fb47029535b
   ExpoBackgroundFetch: ee315c8d1a54a3f358fc0cedb68e808e95935c57

--- a/packages/expo-app-metrics/ios/ExpoAppMetrics.podspec
+++ b/packages/expo-app-metrics/ios/ExpoAppMetrics.podspec
@@ -44,5 +44,8 @@ Pod::Spec.new do |s|
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = 'Tests'
+    test_spec.pod_target_xcconfig = {
+      'OTHER_LDFLAGS' => '-lc++'
+    }
   end
 end

--- a/packages/expo-app-metrics/ios/Sessions/SessionCoder.swift
+++ b/packages/expo-app-metrics/ios/Sessions/SessionCoder.swift
@@ -1,0 +1,37 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/**
+ Codable wrapper that picks the right `Session` subclass based on the encoded `type` field.
+
+ Sessions are stored as `[Session]` on `Entry`, but the JSON decoder cannot know which
+ subclass to instantiate from the array element type alone. This wrapper peeks at the `type`
+ field, then decodes the same payload as the corresponding subclass.
+ */
+struct SessionCoder: Codable {
+  let session: Session
+
+  init(_ session: Session) {
+    self.session = session
+  }
+
+  private enum TypeKey: String, CodingKey {
+    case type
+  }
+
+  init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: TypeKey.self)
+    let type = try container.decodeIfPresent(Session.SessionType.self, forKey: .type) ?? .unknown
+    switch type {
+    case .main:
+      self.session = try MainSession(from: decoder)
+    case .foreground:
+      self.session = try ForegroundSession(from: decoder)
+    case .screen, .custom, .unknown:
+      self.session = try Session(from: decoder)
+    }
+  }
+
+  func encode(to encoder: any Encoder) throws {
+    try session.encode(to: encoder)
+  }
+}

--- a/packages/expo-app-metrics/ios/Storage/MetricsStorage.swift
+++ b/packages/expo-app-metrics/ios/Storage/MetricsStorage.swift
@@ -62,6 +62,17 @@ public final class MetricsStorage: Sendable {
   }
 
   /**
+   Returns all main sessions across the current and historical entries, ordered with the
+   current launch first.
+   */
+  @AppMetricsActor
+  public func getAllMainSessions() -> [MainSession] {
+    return getAllEntries()
+      .flatMap({ $0.sessions })
+      .compactMap({ $0 as? MainSession })
+  }
+
+  /**
    Returns unexpired and non-empty entries.
    */
   @AppMetricsActor
@@ -96,6 +107,32 @@ public final class MetricsStorage: Sendable {
 
     public var metricsCount: Int {
       return sessions.reduce(0) { $0 + $1.metrics.count }
+    }
+
+    // MARK: - Codable
+
+    private enum CodingKeys: String, CodingKey {
+      case id, app, device, date, environment, sessions
+    }
+
+    public init(from decoder: any Decoder) throws {
+      let values = try decoder.container(keyedBy: CodingKeys.self)
+      id = try values.decode(Int.self, forKey: .id)
+      app = try values.decode(AppInfo.self, forKey: .app)
+      device = try values.decode(DeviceInfo.self, forKey: .device)
+      date = try values.decode(Date.self, forKey: .date)
+      environment = try values.decodeIfPresent(String.self, forKey: .environment)
+      sessions = try values.decodeIfPresent([SessionCoder].self, forKey: .sessions)?.map { $0.session } ?? []
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+      try container.encode(id, forKey: .id)
+      try container.encode(app, forKey: .app)
+      try container.encode(device, forKey: .device)
+      try container.encode(date, forKey: .date)
+      try container.encodeIfPresent(environment, forKey: .environment)
+      try container.encode(sessions.map(SessionCoder.init), forKey: .sessions)
     }
 
     // MARK: - Equatable

--- a/packages/expo-app-metrics/ios/Tests/MetricsStorageTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/MetricsStorageTests.swift
@@ -212,4 +212,157 @@ struct MetricsStorageTests {
       #expect(entry.sessions.count == 0)
     }
   }
+
+  @AppMetricsActor
+  @Suite("Polymorphic session decoding")
+  struct PolymorphicSessionDecodingTests {
+    @Test
+    func `restores a MainSession as a MainSession`() throws {
+      let storage = MetricsStorage(fileName: "test_polymorphic_main")
+      let session = MainSession()
+      storage.currentEntry.add(session: session)
+      session.receiveMetric(Metric(category: .appStartup, name: "test", value: 1.0))
+      try storage.commit()
+
+      let restoredStorage = MetricsStorage(fileName: "test_polymorphic_main")
+      let restoredSession = try #require(restoredStorage.historicalEntries.first?.sessions.first)
+      #expect(restoredSession is MainSession)
+      #expect(restoredSession.type == .main)
+    }
+
+    @Test
+    func `restores a ForegroundSession as a ForegroundSession`() throws {
+      let storage = MetricsStorage(fileName: "test_polymorphic_foreground")
+      let session = ForegroundSession()
+      storage.currentEntry.add(session: session)
+      session.receiveMetric(Metric(category: .session, name: "test", value: 1.0))
+      try storage.commit()
+
+      let restoredStorage = MetricsStorage(fileName: "test_polymorphic_foreground")
+      let restoredSession = try #require(restoredStorage.historicalEntries.first?.sessions.first)
+      #expect(restoredSession is ForegroundSession)
+      #expect(restoredSession.type == .foreground)
+    }
+
+    @Test
+    func `restores mixed session types in their original order`() throws {
+      let storage = MetricsStorage(fileName: "test_polymorphic_mixed")
+      let mainSession = MainSession()
+      let foregroundSession = ForegroundSession()
+      // `add(session:)` inserts at index 0, so the foreground session ends up first.
+      storage.currentEntry.add(session: mainSession)
+      storage.currentEntry.add(session: foregroundSession)
+      mainSession.receiveMetric(Metric(category: .appStartup, name: "test", value: 1.0))
+      foregroundSession.receiveMetric(Metric(category: .session, name: "test", value: 1.0))
+      try storage.commit()
+
+      let restoredStorage = MetricsStorage(fileName: "test_polymorphic_mixed")
+      let restoredSessions = try #require(restoredStorage.historicalEntries.first?.sessions)
+      #expect(restoredSessions.count == 2)
+      #expect(restoredSessions[0] is ForegroundSession)
+      #expect(restoredSessions[1] is MainSession)
+    }
+
+    @Test
+    func `falls back to base Session for unknown type`() throws {
+      let json: [String: Any] = [
+        "id": "00000000-0000-0000-0000-000000000000",
+        "startDate": "2025-11-16T20:37:00Z",
+        "metrics": [],
+      ]
+      let data = try JSONSerialization.data(withJSONObject: json, options: [])
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = .iso8601
+      let coder = try decoder.decode(SessionCoder.self, from: data)
+      #expect(coder.session is MainSession == false)
+      #expect(coder.session is ForegroundSession == false)
+      #expect(coder.session.type == .unknown)
+    }
+
+    @Test
+    func `decodes legacy JSON written before polymorphic decoding`() throws {
+      // Sessions encoded by versions up to and including 0.1.9 used synthesized Codable.
+      // `SessionCoder` reads the same field names from the same shape, so existing
+      // on-disk files written by those versions must keep decoding.
+      let json: [String: Any] = [
+        "id": 0,
+        "app": [
+          "appVersion": "16.0",
+          "appId": "com.apple.dt.xctest.tool",
+          "buildNumber": "24419",
+          "appName": "xctest",
+          "clientVersion": "0.1.9",
+          "reactNativeVersion": "0.85.2",
+          "expoSdkVersion": "55.0.11",
+          "easBuildId": "xxxx-xxxxxxxxxxxxxxx-xxxx-xxxx-xxxxxxxxxxxxxx",
+        ],
+        "device": [
+          "modelIdentifier": "iPhone 17 Pro Max",
+          "modelName": "iPhone",
+          "systemVersion": "26.1",
+          "systemName": "iOS",
+        ],
+        "date": "2025-11-16T20:37:00Z",
+        "sessions": [
+          [
+            "id": "11111111-1111-1111-1111-111111111111",
+            "type": "main",
+            "startDate": "2025-11-16T20:37:00Z",
+            "endDate": "2025-11-16T20:38:00Z",
+            "metrics": [
+              ["category": "appStartup", "name": "test", "value": 1.5, "timestamp": "2025-11-16T20:37:30Z"],
+            ],
+          ],
+          [
+            "id": "22222222-2222-2222-2222-222222222222",
+            "type": "foreground",
+            "startDate": "2025-11-16T20:37:05Z",
+            "endDate": "2025-11-16T20:37:50Z",
+            "metrics": [],
+          ],
+        ],
+      ]
+      let data = try JSONSerialization.data(withJSONObject: json, options: [])
+      let decoder = JSONDecoder()
+      decoder.dateDecodingStrategy = .iso8601
+      let entry = try decoder.decode(MetricsStorage.Entry.self, from: data)
+
+      #expect(entry.sessions.count == 2)
+      let mainSession = try #require(entry.sessions.first)
+      #expect(mainSession is MainSession)
+      #expect(mainSession.id == "11111111-1111-1111-1111-111111111111")
+      #expect(mainSession.metrics.count == 1)
+      #expect(mainSession.metrics.first?.value == 1.5)
+
+      let foregroundSession = try #require(entry.sessions.last)
+      #expect(foregroundSession is ForegroundSession)
+      #expect(foregroundSession.id == "22222222-2222-2222-2222-222222222222")
+      #expect(foregroundSession.metrics.isEmpty)
+    }
+
+    @Test
+    func `getAllMainSessions returns only MainSession instances across entries`() throws {
+      let storage = MetricsStorage(fileName: "test_polymorphic_accessor")
+      // Current entry: one main + one foreground.
+      let currentMain = MainSession()
+      let currentForeground = ForegroundSession()
+      storage.currentEntry.add(session: currentMain)
+      storage.currentEntry.add(session: currentForeground)
+      currentMain.receiveMetric(Metric(category: .appStartup, name: "test", value: 1.0))
+      // Historical entry: one main + one foreground, persisted via commit + reload.
+      let historicalMain = MainSession()
+      let historicalForeground = ForegroundSession()
+      storage.currentEntry.add(session: historicalMain)
+      storage.currentEntry.add(session: historicalForeground)
+      historicalMain.receiveMetric(Metric(category: .appStartup, name: "test", value: 2.0))
+      try storage.commit()
+
+      let restoredStorage = MetricsStorage(fileName: "test_polymorphic_accessor")
+      // The new launch creates a fresh current entry with no sessions, so all main sessions
+      // come from the restored historical entry.
+      let mainSessions = restoredStorage.getAllMainSessions()
+      #expect(mainSessions.count == 2)
+      #expect(mainSessions.allSatisfy({ $0.type == .main }))
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Sessions persisted as `[Session]` on `Entry` were always rehydrated as the base `Session`, dropping subclass-specific fields and behavior. Introduce `SessionCoder`, a Codable wrapper that peeks at the encoded `type` field and decodes the payload as the matching subclass (`MainSession`, `ForegroundSession`, or base `Session` as a fallback).
- Wire `SessionCoder` into `Entry` via custom Codable so the existing JSON shape is preserved and previously written files keep decoding.
- Expose `MetricsStorage.getAllMainSessions()` for callers that need a flat iteration over main sessions across the current and historical entries.

## Test plan

- [x] New `PolymorphicSessionDecodingTests` sub-suite covers: `MainSession` round-trip preserves type, `ForegroundSession` round-trip preserves type, mixed types decode in order, unknown/missing type falls back to base `Session`, `getAllMainSessions()` filters correctly, and a fixture-based regression test that decodes JSON in the shape written by versions ≤ 0.1.9.
- [x] Existing `MetricsStorageTests` still pass locally.
