### PR TITLE
[app-metrics][ios] Capture and attribute MetricKit crash reports

### DIFF
--- a/packages/expo-app-metrics/ios/AppMetrics.swift
+++ b/packages/expo-app-metrics/ios/AppMetrics.swift
@@ -1,9 +1,25 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 import ExpoModulesCore
 
+#if !os(tvOS)
+import MetricKit
+#endif
+
 public struct AppMetrics {
   #if !os(tvOS)
   static let metricKitSubscriber = MetricKitSubscriber()
+
+  /**
+   Registers the MetricKit subscriber to receive diagnostic and performance payloads.
+   Even though MetricKit doesn't work on the simulator, it prints some logs (probably once a day)
+   that are piped to the terminal when using the `expo run:ios` command.
+   To avoid them, we explicitly don't register the subscriber on the simulator.
+   */
+  static func registerMetricKitSubscriber() {
+    #if !targetEnvironment(simulator)
+    MXMetricManager.shared.add(metricKitSubscriber)
+    #endif
+  }
   #endif
 
   public static let storage = MetricsStorage()

--- a/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
+++ b/packages/expo-app-metrics/ios/CrashReporting/CrashReport.swift
@@ -1,0 +1,176 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/**
+ Structured crash report extracted from MetricKit's `MXCrashDiagnostic`.
+ */
+public struct CrashReport: Codable, Sendable {
+  /** Mach exception type (e.g. EXC_BAD_ACCESS, EXC_CRASH). */
+  public let exceptionType: Int?
+
+  /** Processor-specific exception code. */
+  public let exceptionCode: Int?
+
+  /** Unix signal number (e.g. SIGSEGV = 11, SIGABRT = 6). */
+  public let signal: Int?
+
+  /** Human-readable description of the termination reason. */
+  public let terminationReason: String?
+
+  /** Memory region info for bad-access crashes. */
+  public let virtualMemoryRegionInfo: String?
+
+  /** Objective-C exception details, available when the crash was caused by an unhandled NSException. */
+  public let exceptionReason: ExceptionReason?
+
+  /** Call stack tree as a JSON string, suitable for off-device symbolication. */
+  public let callStackTree: String?
+
+  /** App version at the time of the crash. */
+  public let appVersion: String
+
+  /** Timestamp range start of the diagnostic payload. */
+  public let timestampBegin: Date
+
+  /** Timestamp range end of the diagnostic payload. */
+  public let timestampEnd: Date
+
+  /**
+   Picks the most likely `MainSession` that this crash report belongs to.
+
+   MetricKit only gives us the diagnostic payload's time window (`timestampBegin` to
+   `timestampEnd`, typically a 24-hour bucket), not an exact crash time. We approximate
+   the match in two passes:
+
+   1. Among sessions started within the window, prefer the one that never finished
+      (`endDate == nil`) — an unfinished main session is a strong signal of a crash.
+   2. If none match, fall back to the session with the latest `startDate` still within
+      the window. Returns `nil` if no session falls within the window at all.
+   */
+  func findMatchingSession(in mainSessions: [MainSession]) -> MainSession? {
+    let candidates = mainSessions.filter { session in
+      return session.startDate >= timestampBegin && session.startDate <= timestampEnd
+    }
+    if candidates.isEmpty {
+      return nil
+    }
+    let unfinished = candidates.filter({ $0.endDate == nil })
+    if let session = unfinished.max(by: { $0.startDate < $1.startDate }) {
+      return session
+    }
+    return candidates.max(by: { $0.startDate < $1.startDate })
+  }
+
+  /**
+   Objective-C exception details from `MXCrashDiagnosticObjectiveCExceptionReason`.
+   */
+  public struct ExceptionReason: Codable, Sendable {
+    /** Human-readable exception summary. */
+    public let composedMessage: String
+
+    /** Exception message template before argument substitution. */
+    public let formatString: String
+
+    /** Arguments substituted into the format string. */
+    public let arguments: [String]
+
+    /** Human-readable exception type (e.g. "NSInvalidArgumentException"). */
+    public let exceptionType: String
+
+    /** Exception class name (e.g. "NSException"). */
+    public let className: String
+
+    /** Exception name field. */
+    public let exceptionName: String
+  }
+}
+
+// MARK: - MetricKit
+
+#if !os(tvOS)
+import MetricKit
+
+extension CrashReport {
+  init(diagnostic: MXCrashDiagnostic, payload: MXDiagnosticPayload) {
+    self.exceptionType = diagnostic.exceptionType?.intValue
+    self.exceptionCode = diagnostic.exceptionCode?.intValue
+    self.signal = diagnostic.signal?.intValue
+    self.terminationReason = diagnostic.terminationReason as String?
+    self.virtualMemoryRegionInfo = diagnostic.virtualMemoryRegionInfo as String?
+    self.callStackTree = String(data: diagnostic.callStackTree.jsonRepresentation(), encoding: .utf8)
+    self.appVersion = diagnostic.applicationVersion
+    self.timestampBegin = payload.timeStampBegin
+    self.timestampEnd = payload.timeStampEnd
+
+    if #available(iOS 17.0, *), let reason = diagnostic.exceptionReason {
+      self.exceptionReason = ExceptionReason(
+        composedMessage: reason.composedMessage as String,
+        formatString: reason.formatString as String,
+        arguments: reason.arguments.map { $0 as String },
+        exceptionType: reason.exceptionType as String,
+        className: reason.className as String,
+        exceptionName: reason.exceptionName as String
+      )
+    } else {
+      self.exceptionReason = nil
+    }
+  }
+}
+#endif
+
+// MARK: - CustomStringConvertible
+
+extension CrashReport: CustomStringConvertible {
+  public var description: String {
+    var lines: [String] = ["[CrashReport] App version: \(appVersion)"]
+
+    if let exceptionType {
+      lines.append("  Exception: type=\(exceptionName(for: exceptionType)) code=\(exceptionCode.map(String.init) ?? "unknown")")
+    }
+    if let signal {
+      lines.append("  Signal: \(signalName(for: signal)) (\(signal))")
+    }
+    if let terminationReason {
+      lines.append("  Termination reason: \(terminationReason)")
+    }
+    if let virtualMemoryRegionInfo {
+      lines.append("  VM region: \(virtualMemoryRegionInfo)")
+    }
+    if let exceptionReason {
+      lines.append("  ObjC exception: \(exceptionReason.exceptionType) (\(exceptionReason.className))")
+      lines.append("    \(exceptionReason.composedMessage)")
+    }
+
+    let formatter = ISO8601DateFormatter()
+    lines.append("  Time window: \(formatter.string(from: timestampBegin)) – \(formatter.string(from: timestampEnd))")
+
+    return lines.joined(separator: "\n")
+  }
+}
+
+private func exceptionName(for type: Int) -> String {
+  switch type {
+  case 1: return "EXC_BAD_ACCESS"
+  case 2: return "EXC_BAD_INSTRUCTION"
+  case 3: return "EXC_ARITHMETIC"
+  case 4: return "EXC_EMULATION"
+  case 5: return "EXC_SOFTWARE"
+  case 6: return "EXC_BREAKPOINT"
+  case 10: return "EXC_CRASH"
+  case 11: return "EXC_RESOURCE"
+  case 12: return "EXC_GUARD"
+  default: return "EXC_\(type)"
+  }
+}
+
+private func signalName(for signal: Int) -> String {
+  switch signal {
+  case 4: return "SIGILL"
+  case 5: return "SIGTRAP"
+  case 6: return "SIGABRT"
+  case 8: return "SIGFPE"
+  case 9: return "SIGKILL"
+  case 10: return "SIGBUS"
+  case 11: return "SIGSEGV"
+  default: return "SIG\(signal)"
+  }
+}

--- a/packages/expo-app-metrics/ios/MetricKitSubscriber.swift
+++ b/packages/expo-app-metrics/ios/MetricKitSubscriber.swift
@@ -10,20 +10,6 @@ import MetricKit
 // We could use it as a source for metrics that we can't measure in other ways, e.g. CPU usage.
 
 final class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber, Sendable {
-  override init() {
-    super.init()
-
-    // Even though MetricKit doesn't work on the simulator, it prints some logs (probably once a day)
-    // that are piped to the terminal when using the `expo run:ios` command.
-    // To avoid them, we explicitly don't register the subscriber on the simulator.
-    // Example of the log:
-    // [libapp_launch_measurement.dylib] Failed to send CA Event tor app launch measurements tor ca_event_type: o event_name: com.apple.app_launch_measurement.FirstFramePresentationMetric
-    #if !targetEnvironment(simulator)
-    // Auto registration
-    MXMetricManager.shared.add(self)
-    #endif
-  }
-
   /**
    Receives payloads with performance metrics like CPU and memory usage.
    Sent periodically (usually every 24 hours), or when your app gets steady usage.
@@ -34,10 +20,31 @@ final class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber, Sendable {
 
   /**
    Receives payloads with diagnostic data like crash logs, hang reports, and more.
-   Sent immediately when something critical happens — like a crash.
+   Delivered on the next app launch after the event occurs.
    */
   func didReceive(_ payloads: [MXDiagnosticPayload]) {
     prettyPrintPayloads(payloads)
+
+    let crashReports = payloads.flatMap { payload in
+      return (payload.crashDiagnostics ?? []).map { diagnostic in
+        return CrashReport(diagnostic: diagnostic, payload: payload)
+      }
+    }
+    AppMetricsActor.isolated {
+      let mainSessions = AppMetrics.storage.getAllMainSessions()
+      var didStoreAny = false
+      for crashReport in crashReports {
+        if let session = crashReport.findMatchingSession(in: mainSessions) {
+          session.storeCrashReport(crashReport)
+          didStoreAny = true
+        } else {
+          logger.warn("[AppMetrics] Received crash report with no matching session:\n\(crashReport)")
+        }
+      }
+      if didStoreAny {
+        try? AppMetrics.storage.commit()
+      }
+    }
   }
 }
 

--- a/packages/expo-app-metrics/ios/Sessions/MainSession.swift
+++ b/packages/expo-app-metrics/ios/Sessions/MainSession.swift
@@ -9,6 +9,12 @@ public final class MainSession: Session, @unchecked Sendable {
   let updatesMonitor = UpdatesMonitoring()
   let frameMetricsRecorder = FrameMetricsRecorder()
 
+  /**
+   Crash report associated with this session, if the app crashed during it.
+   Mutations go through `storeCrashReport(_:)` so they happen on the actor.
+   */
+  nonisolated(unsafe) public private(set) var crashReport: CrashReport?
+
   // MARK: - Metrics
 
   init() {
@@ -16,14 +22,50 @@ public final class MainSession: Session, @unchecked Sendable {
     self.appStartupMonitor.addReceiver(self)
     self.updatesMonitor.addReceiver(self)
 
+    #if !os(tvOS)
+    AppMetrics.registerMetricKitSubscriber()
+    #endif
+
     AppMetricsActor.isolated { [self] in
       self.frameMetricsRecorder.start()
     }
   }
 
+  /**
+   Test-only initializer that builds a session with explicit values and skips registering it
+   with the global storage. Do not use from production code.
+   */
+  init(id: String, startDate: Date, endDate: Date?) {
+    super.init(id: id, type: .main, startDate: startDate, endDate: endDate)
+  }
+
+  // MARK: - Crash reports
+
+  /**
+   Stores a crash report on this session and logs it. The caller is responsible for
+   committing the storage.
+   */
+  @AppMetricsActor
+  func storeCrashReport(_ crashReport: CrashReport) {
+    logger.warn("[AppMetrics] Received crash report:\n\(crashReport)")
+    self.crashReport = crashReport
+  }
+
   // MARK: - Codable
 
+  private enum CodingKeys: String, CodingKey {
+    case crashReport
+  }
+
   required init(from decoder: any Decoder) throws {
+    let values = try decoder.container(keyedBy: CodingKeys.self)
+    crashReport = try values.decodeIfPresent(CrashReport.self, forKey: .crashReport)
     try super.init(from: decoder)
+  }
+
+  public override func encode(to encoder: any Encoder) throws {
+    try super.encode(to: encoder)
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(crashReport, forKey: .crashReport)
   }
 }

--- a/packages/expo-app-metrics/ios/Sessions/Session.swift
+++ b/packages/expo-app-metrics/ios/Sessions/Session.swift
@@ -36,6 +36,17 @@ public class Session: Codable, MetricsReceiver {
   }
 
   /**
+   Test-only initializer that builds a session with explicit values and skips registering it
+   with the global storage. Do not use from production code.
+   */
+  init(id: String, type: SessionType, startDate: Date, endDate: Date?) {
+    self.id = id
+    self.type = type
+    self.startDate = startDate
+    self.endDate = endDate
+  }
+
+  /**
    Whether the session is still running, i.e. did not end yet.
    */
   var isActive: Bool {

--- a/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/CrashReportTests.swift
@@ -1,0 +1,119 @@
+import Testing
+
+@testable import ExpoAppMetrics
+
+@AppMetricsActor
+@Suite("CrashReport")
+struct CrashReportTests {
+  @AppMetricsActor
+  @Suite("findMatchingSession")
+  struct FindMatchingSessionTests {
+    @Test
+    func `prefers an unfinished session inside the window`() {
+      let windowEnd = Date.now
+      let windowStart = windowEnd.addingTimeInterval(-3600)
+
+      let unfinished = MainSession(
+        id: "unfinished",
+        startDate: windowEnd.addingTimeInterval(-1800),
+        endDate: nil
+      )
+      let finished = MainSession(
+        id: "finished",
+        startDate: windowEnd.addingTimeInterval(-1200),
+        endDate: windowEnd.addingTimeInterval(-600)
+      )
+
+      let report = makeCrashReport(timestampBegin: windowStart, timestampEnd: windowEnd)
+      let match = report.findMatchingSession(in: [finished, unfinished])
+      #expect(match?.id == "unfinished")
+    }
+
+    @Test
+    func `picks the latest unfinished session when multiple are in the window`() {
+      let windowEnd = Date.now
+      let windowStart = windowEnd.addingTimeInterval(-3600)
+
+      let earlier = MainSession(
+        id: "earlier",
+        startDate: windowEnd.addingTimeInterval(-2400),
+        endDate: nil
+      )
+      let later = MainSession(
+        id: "later",
+        startDate: windowEnd.addingTimeInterval(-1200),
+        endDate: nil
+      )
+
+      let report = makeCrashReport(timestampBegin: windowStart, timestampEnd: windowEnd)
+      let match = report.findMatchingSession(in: [earlier, later])
+      #expect(match?.id == "later")
+    }
+
+    @Test
+    func `falls back to the latest finished session in the window`() {
+      let windowEnd = Date.now
+      let windowStart = windowEnd.addingTimeInterval(-3600)
+
+      let earlier = MainSession(
+        id: "earlier",
+        startDate: windowEnd.addingTimeInterval(-2400),
+        endDate: windowEnd.addingTimeInterval(-2000)
+      )
+      let later = MainSession(
+        id: "later",
+        startDate: windowEnd.addingTimeInterval(-1200),
+        endDate: windowEnd.addingTimeInterval(-600)
+      )
+
+      let report = makeCrashReport(timestampBegin: windowStart, timestampEnd: windowEnd)
+      let match = report.findMatchingSession(in: [earlier, later])
+      #expect(match?.id == "later")
+    }
+
+    @Test
+    func `returns nil when no session is in the window`() {
+      let windowEnd = Date.now
+      let windowStart = windowEnd.addingTimeInterval(-3600)
+
+      let beforeWindow = MainSession(
+        id: "before",
+        startDate: windowStart.addingTimeInterval(-1000),
+        endDate: nil
+      )
+      let afterWindow = MainSession(
+        id: "after",
+        startDate: windowEnd.addingTimeInterval(1000),
+        endDate: nil
+      )
+
+      let report = makeCrashReport(timestampBegin: windowStart, timestampEnd: windowEnd)
+      let match = report.findMatchingSession(in: [beforeWindow, afterWindow])
+      #expect(match == nil)
+    }
+
+    @Test
+    func `returns nil when the input is empty`() {
+      let report = makeCrashReport(
+        timestampBegin: Date.now.addingTimeInterval(-3600),
+        timestampEnd: Date.now
+      )
+      #expect(report.findMatchingSession(in: []) == nil)
+    }
+  }
+}
+
+private func makeCrashReport(timestampBegin: Date, timestampEnd: Date) -> CrashReport {
+  return CrashReport(
+    exceptionType: 1,
+    exceptionCode: 1,
+    signal: 11,
+    terminationReason: nil,
+    virtualMemoryRegionInfo: nil,
+    exceptionReason: nil,
+    callStackTree: nil,
+    appVersion: "1.0.0",
+    timestampBegin: timestampBegin,
+    timestampEnd: timestampEnd
+  )
+}


### PR DESCRIPTION
## Summary
- Pull the rich fields out of `MXCrashDiagnostic` (Mach exception, signal, termination reason, VM region, ObjC exception details, call stack JSON) into a new `CrashReport` struct, and persist it on the `MainSession` where the crash actually happened.
- MetricKit delivers diagnostics on the next launch, so the subscriber walks all historical main sessions via `MetricsStorage.getAllMainSessions()` and picks the best match for each report: prefer an unfinished session inside the payload's time window (a strong crash signal), and fall back to the latest session in that window if none is unfinished. Unmatched reports are logged. Storage is committed once per batch.
- Fixes the MetricKit subscriber registration — it was a lazy `static let` that nothing accessed, so the subscriber never observed payloads.

## Test plan
- [x] New `findMatchingSession` unit tests cover: prefers unfinished over finished in window, picks latest unfinished when multiple are in window, falls back to latest finished, returns nil when no session is in window, returns nil for empty input.
- [x] Existing `MetricsStorageTests` and `ForegroundSessionTests` still pass locally.
- [x] On-device smoke test via the simulation entry point (in a follow-up PR alongside the JS-side changes).
