### PR TITLE
[expo/cli] Add option to configure listening address for `serve` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,8 +127,6 @@ Package-specific changes not released in any SDK will be added here just before 
   - [Android] Introduce `dimezisBlurViewSdk31Plus` blur method. ([#39998](https://github.com/expo/expo/pull/39998) by [@behenate](https://github.com/behenate))
 - **`expo-auth-session`**
   - Added `extraHeaders` option to `TokenRequest` and `RevokeTokenRequest`. ([#31381](https://github.com/expo/expo/pull/31381)) by [@levizimmerman](https://github.com/levizimmerman) and [@lsarni](https://github.com/lsarni) ([#31381](https://github.com/expo/expo/pull/31381) by [@levizimmerman](https://github.com/levizimmerman), [@lsarni](https://github.com/lsarni))
-- **`expo-cli`**
-  - Add `--address` option to `expo serve`. ([#45114](https://github.com/expo/expo/pull/45114)) by [@clement-antoine-xavier](https://github.com/clement-antoine-xavier)
 
 ### 🐛 Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@ Package-specific changes not released in any SDK will be added here just before 
   - [Android] Introduce `dimezisBlurViewSdk31Plus` blur method. ([#39998](https://github.com/expo/expo/pull/39998) by [@behenate](https://github.com/behenate))
 - **`expo-auth-session`**
   - Added `extraHeaders` option to `TokenRequest` and `RevokeTokenRequest`. ([#31381](https://github.com/expo/expo/pull/31381)) by [@levizimmerman](https://github.com/levizimmerman) and [@lsarni](https://github.com/lsarni) ([#31381](https://github.com/expo/expo/pull/31381) by [@levizimmerman](https://github.com/levizimmerman), [@lsarni](https://github.com/lsarni))
+- **`expo-cli`**
+  - Add `--address` option to `expo serve`. ([#45114](https://github.com/expo/expo/pull/45114)) by [@clement-antoine-xavier](https://github.com/clement-antoine-xavier)
 
 ### 🐛 Bug fixes
 
@@ -1881,7 +1883,7 @@ Package-specific changes not released in any SDK will be added here just before 
   - Fix incorrect event emitting tests. ([#28953](https://github.com/expo/expo/pull/28953) by [@aleqsio](https://github.com/aleqsio))
   - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
   - [Android] Remove usage of deprecated internal modules API. ([#28715](https://github.com/expo/expo/pull/28715) by [@lukmccall](https://github.com/lukmccall))
-  - [iOS] Fix pedometer sensor when app goes to background then foreground. ([#29957]https://github.com/expo/expo/pull/29957) by [@rlods](https://github.com/rlods))
+  - [iOS] Fix pedometer sensor when app goes to background then foreground. ([#29957]<https://github.com/expo/expo/pull/29957>) by [@rlods](https://github.com/rlods))
 - **`expo-screen-capture`**
   - Removed redundant usage of `EventEmitter` instance. ([#28946](https://github.com/expo/expo/pull/28946) by [@tsapeta](https://github.com/tsapeta))
   - Updated hook from `useScreenCapturePermissions` to `usePermissions` in the example. ([#30076](https://github.com/expo/expo/pull/30076) by [@mrakesh0608](https://github.com/mrakesh0608))
@@ -3269,7 +3271,7 @@ Package-specific changes not released in any SDK will be added here just before 
 - **`expo-blur`**
   - Enable blurring by default when static rendering. ([#23000](https://github.com/expo/expo/pull/23000) by [@EvanBacon](https://github.com/EvanBacon))
 - **`expo-face-detector`**
-  - Removed face detector from Expo Go on iOS. (https://expo.fyi/face-detector-removed). ([#22619](https://github.com/expo/expo/pull/22619) by [@aleqsio](https://github.com/aleqsio))
+  - Removed face detector from Expo Go on iOS. (<https://expo.fyi/face-detector-removed>). ([#22619](https://github.com/expo/expo/pull/22619) by [@aleqsio](https://github.com/aleqsio))
 - **`expo-gl`**
   - Require explicit prop `enableExperimentalWorkletSupport` to use GLView from Reanimated worklet. ([#22613](https://github.com/expo/expo/pull/22613) by [@wkozyra95](https://github.com/wkozyra95))
 - **`expo-file-system`**
@@ -3883,4 +3885,4 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ## 47.0.0 — 2022-10-28
 
-For changelog entries prior to SDK 47, refer to: https://github.com/expo/expo/blob/ff35557463c0db1cf8683939d752c59baf127f21/CHANGELOG.md#L323
+For changelog entries prior to SDK 47, refer to: <https://github.com/expo/expo/blob/ff35557463c0db1cf8683939d752c59baf127f21/CHANGELOG.md#L323>

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Show Xcode build progress bar in interactive terminals with retry logic for concurrent build DB lock failures. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))
 - Enable parallel CocoaPods code signing to speed up device builds. ([#43529](https://github.com/expo/expo/pull/43529) by [@evanbacon](https://github.com/evanbacon))
 - Prompt before clearing native folders when we detect project as a native module ([#44458](https://github.com/expo/expo/pull/44458) by [@kitten](https://github.com/kitten))
+- Add `--address` option to `expo serve` command. ([#45114](https://github.com/expo/expo/pull/45114)) by [@clement-antoine-xavier](https://github.com/clement-antoine-xavier)
 
 ### 🐛 Bug fixes
 
@@ -1008,8 +1009,8 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
-- Add missing semver dep, handle missing router import ((#32762)[https://github.com/expo/expo/pull/32762] by [@brentvatne](https://github.com/brentvatne))
-- Fix gitignore being modified on blank js project ((#32765)[https://github.com/expo/expo/pull/32765] by [@marklawlor](https://github.com/marklawlor))
+- Add missing semver dep, handle missing router import ([#32762](https://github.com/expo/expo/pull/32762) by [@brentvatne](https://github.com/brentvatne))
+- Fix gitignore being modified on blank js project ([#32765](https://github.com/expo/expo/pull/32765) by [@marklawlor](https://github.com/marklawlor))
 
 ## 0.20.4 — 2024-11-10
 
@@ -2289,7 +2290,7 @@ _This version does not introduce any user-facing changes._
 - Make Expo Metro config for web resolve projects using same `package.json` main fields as Expo Webpack. Behavior can be disabled with `EXPO_METRO_NO_MAIN_FIELD_OVERRIDE`. ([#19529](https://github.com/expo/expo/pull/19529) by [@EvanBacon](https://github.com/EvanBacon))
 - Add web support check to metro web in `expo start`. ([#18428](https://github.com/expo/expo/pull/18428) by [@EvanBacon](https://github.com/EvanBacon))
 - Drop support for experimental Webpack native symbolication. ([#18439](https://github.com/expo/expo/pull/18439) by [@EvanBacon](https://github.com/EvanBacon))
-- Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](https://github.com/Anthony Mittaz))
+- Implement getApplicationIdFromBundle fixing iOS app launch issue with SDK 46. ([#18537](https://github.com/expo/expo/pull/18537) by [@Anthony Mittaz](<https://github.com/Anthony> Mittaz))
 - Change `UNAUTHORIZED_ERROR` to `UNAUTHORIZED` to handle unauthorized errors. ([#18751](https://github.com/expo/expo/pull/18751) by [@EvanBacon](https://github.com/EvanBacon))
 - Catch error thrown when trying to launch redirect page without an application ID defined in `app.json`. ([#19312](https://github.com/expo/expo/pull/19312) by [@esamelson](https://github.com/esamelson))
 - Present intended variadic argument when asserting flags in `npx expo install`. ([#19396](https://github.com/expo/expo/pull/19396) by [@bycedric](https://github.com/bycedric))

--- a/packages/@expo/cli/src/serve/index.ts
+++ b/packages/@expo/cli/src/serve/index.ts
@@ -10,6 +10,7 @@ export const expoServe: Command = async (argv) => {
       // Types
       '--help': Boolean,
       '--port': Number,
+      '--address': String,
 
       // Aliases
       '-h': '--help',
@@ -24,6 +25,7 @@ export const expoServe: Command = async (argv) => {
       [
         chalk`<dir>            Directory of the Expo project. {dim Default: Current working directory}`,
         `--port <number>  Port to host the server on`,
+        `--address <string>  Address to host the server on`,
         `-h, --help       Usage info`,
       ].join('\n')
     );
@@ -45,5 +47,6 @@ export const expoServe: Command = async (argv) => {
     isDefaultDirectory: !args._[0],
     // Parsed options
     port: args['--port'],
+    address: args['--address'],
   }).catch(logCmdError);
 };

--- a/packages/@expo/cli/src/serve/serveAsync.ts
+++ b/packages/@expo/cli/src/serve/serveAsync.ts
@@ -14,6 +14,7 @@ import { resolvePortAsync } from '../utils/port';
 
 type Options = {
   port?: number;
+  address?: string;
   isDefaultDirectory: boolean;
 };
 
@@ -54,7 +55,7 @@ export async function serveAsync(inputDir: string, options: Options) {
   } else {
     await startDynamicServerAsync(serverDist, options);
   }
-  Log.log(`Server running at http://localhost:${options.port}`);
+  Log.log(`Server running at http://${options.address || 'localhost'}:${options.port}`);
   // Detect the type of server we need to setup:
 }
 
@@ -80,7 +81,7 @@ async function startStaticServerAsync(dist: string, options: Options) {
       .pipe(res);
   });
 
-  server.listen(options.port!);
+  server.listen(options.port!, options.address!);
 }
 
 async function startDynamicServerAsync(dist: string, options: Options) {
@@ -153,7 +154,7 @@ async function startDynamicServerAsync(dist: string, options: Options) {
 
   middleware.use(serverHandler);
 
-  middleware.listen(options.port!);
+  middleware.listen(options.port!, options.address!);
 }
 
 function canParseURL(url: string): boolean {


### PR DESCRIPTION
## Why

Currently, `expo serve` always binds to `localhost`, with no way to override the listening address. This limits use cases such as accessing the server from other devices on the network or within containerized environments.

## How

Introduce a new `address` option, similar to the existing `port` configuration, allowing users to specify the interface the server should bind to.

## Test Plan

- Create a new Expo project with default settings  
- Export the project using the Expo CLI  
- Serve the exported project using the CLI and verify the custom address binding  

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
