### PR TITLE
[app-metrics][ios] Make MainSession public

### DIFF
--- a/packages/expo-app-metrics/ios/Sessions/MainSession.swift
+++ b/packages/expo-app-metrics/ios/Sessions/MainSession.swift
@@ -4,7 +4,7 @@
  Main session starts from launching the app to its termination. Some metrics like the app startup can only be tracked once and globally.
  In the future this class will also hold subsessions such as for time spent on a specific screen/route or user-initiated sessions.
  */
-internal final class MainSession: Session, @unchecked Sendable {
+public final class MainSession: Session, @unchecked Sendable {
   let appStartupMonitor = AppStartupMonitoring()
   let updatesMonitor = UpdatesMonitoring()
   let frameMetricsRecorder = FrameMetricsRecorder()


### PR DESCRIPTION
## Why

Fixes the iOS build, which broke after #45111. `MetricsStorage.getAllMainSessions()` is declared `public` but returned `[MainSession]`, which was `internal` — Swift rejects that:

> method cannot be declared public because its result uses an internal type

See https://github.com/expo/expo/actions/runs/24988950439/job/73169407990.

## How

Promote `MainSession` to `public`. Its base class `Session` is already public; the internal stored properties (`appStartupMonitor`, `updatesMonitor`) keep their access levels and aren't part of the public surface.

## Test plan

- [x] iOS bare-expo CI build passes