### PR TITLE
fix(precompiled): fixed building ExpoModulesJSI as precompiled

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed prebuild dependencies for `ExpoModulesJSI`
 - [iOS] Add async/await overload for StaticAsyncFunction ([#44471](https://github.com/expo/expo/pull/44471) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fixed looking up the `EXConstants.bundle` from the main bundle to allow running with precompiled XCFrameworks. ([#44551](https://github.com/expo/expo/pull/44551) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider. ([#44550](https://github.com/expo/expo/pull/44550) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -22,7 +22,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed prebuild dependencies for `ExpoModulesJSI`
+- [iOS] Fixed prebuild dependencies for `ExpoModulesJSI` ([#45124](https://github.com/expo/expo/pull/45124) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Add async/await overload for StaticAsyncFunction ([#44471](https://github.com/expo/expo/pull/44471) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fixed looking up the `EXConstants.bundle` from the main bundle to allow running with precompiled XCFrameworks. ([#44551](https://github.com/expo/expo/pull/44551) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Fixed Constants.expoConfig returning null due to optional value wrapping in ConstantsProvider. ([#44550](https://github.com/expo/expo/pull/44550) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -110,10 +110,12 @@ Pod::Spec.new do |s|
   s.dependency 'React-NativeModulesApple'
   s.dependency 'React-RCTFabric'
 
+  # ExpoModulesJSI is re-exported by ExpoModulesCore's swiftinterface, so it must be a CocoaPods dep in both source and prebuilt modes.
+  s.dependency 'ExpoModulesJSI'
+
   install_modules_dependencies(s)
 
   if (!Expo::PackagesConfig.instance.try_link_with_prebuilt_xcframework(s))
-    s.dependency 'ExpoModulesJSI'
     s.static_framework = true
     s.header_dir     = 'ExpoModulesCore'
     s.source_files = 'ios/**/*.{h,m,mm,swift,cpp}', 'common/cpp/**/*.{h,cpp}'

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -10,7 +10,8 @@
       "externalDependencies": [
         "ReactNativeDependencies",
         "React",
-        "Hermes"
+        "Hermes",
+        "expo-modules-jsi/ExpoModulesJSI"
       ],
       "swiftLanguageVersions": [
         "6.0"
@@ -30,7 +31,8 @@
           "dependencies": [
             "Hermes",
             "React",
-            "ReactNativeDependencies"
+            "ReactNativeDependencies",
+            "expo-modules-jsi/ExpoModulesJSI"
           ],
           "includeDirectories": [
             "."
@@ -57,6 +59,7 @@
             "Hermes",
             "React",
             "ReactNativeDependencies",
+            "expo-modules-jsi/ExpoModulesJSI",
             "ExpoModulesCore_common_cpp"
           ],
           "linkedFrameworks": [
@@ -91,6 +94,7 @@
             "Hermes",
             "React",
             "ReactNativeDependencies",
+            "expo-modules-jsi/ExpoModulesJSI",
             "ExpoModulesCore_common_cpp",
             "ExpoModulesCore_ios_objc"
           ],

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Added prebuild configuration for `ExpoModulesJSI` to be built with precompiled XCFrameworks.
+- [iOS] Added prebuild configuration for `ExpoModulesJSI` to be built with precompiled XCFrameworks. ([#45124](https://github.com/expo/expo/pull/45124) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,4 +8,6 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Added prebuild configuration for `ExpoModulesJSI` to be built with precompiled XCFrameworks.
+
 ### 💡 Others

--- a/packages/expo-modules-jsi/spm.config.json
+++ b/packages/expo-modules-jsi/spm.config.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../../tools/src/prebuilds/schemas/spm.config.schema.json",
+  "products": [
+    {
+      "name": "ExpoModulesJSI",
+      "podName": "ExpoModulesJSI",
+      "platforms": [
+        "iOS(.v16)"
+      ],
+      "externalDependencies": [
+        "Hermes",
+        "React",
+        "ReactNativeDependencies"
+      ],
+      "customBuild": {
+        "script": "apple/scripts/build-xcframework.sh",
+        "output": "apple/Products/ExpoModulesJSI.xcframework"
+      },
+      "targets": []
+    }
+  ]
+}

--- a/tools/src/prebuilds/Artifacts.ts
+++ b/tools/src/prebuilds/Artifacts.ts
@@ -268,20 +268,6 @@ export const Artifacts = {
     ),
     getValidationPath: (outputPath: string) =>
       path.join(outputPath, ...HERMES_XCFRAMEWORK_RELATIVE_PATH),
-
-    postExtract: async (tarballPath: string, outputPath: string) => {
-      const execAsync = promisify(exec);
-
-      // Extract tarball normally
-      await execAsync(`tar -xzf "${tarballPath}" -C "${outputPath}"`);
-
-      // Remove JSI headers from Hermes — they are always provided by the React
-      // VFS overlay. Keeping them under destroot/include/ causes "redefinition"
-      // errors because #pragma once cannot de-duplicate two different physical
-      // files that contain the same declarations.
-      const jsiHeadersPath = path.join(outputPath, 'destroot', 'include', 'jsi');
-      fs.removeSync(jsiHeadersPath);
-    },
   } as ArtifactConfig,
 
   /**

--- a/tools/src/prebuilds/CustomBuild.ts
+++ b/tools/src/prebuilds/CustomBuild.ts
@@ -39,7 +39,6 @@ async function stagePodsRootAsync(
   const links: [string, string][] = [
     [path.join(artifacts.hermes, 'destroot'), 'hermes-engine/destroot'],
     [path.join(artifacts.react, 'React.xcframework'), 'React-Core-prebuilt/React.xcframework'],
-    [path.join(artifacts.react, 'React-VFS.yaml'), 'React-Core-prebuilt/React-VFS.yaml'],
     [
       path.join(artifacts.reactNativeDependencies, 'ReactNativeDependencies.xcframework'),
       'ReactNativeDependencies/framework/packages/react-native/ReactNativeDependencies.xcframework',
@@ -51,6 +50,17 @@ async function stagePodsRootAsync(
     await fs.remove(link).catch(() => {});
     await fs.ensureSymlink(target, link);
   }
+
+  // Stage React-VFS.yaml as a rewritten copy (not a symlink) so the build
+  // script's `sed s|${PODS_ROOT}/React-Core-prebuilt|...|` substitution finds
+  // the prefix it expects. The cached yaml has absolute cache paths; we
+  // rewrite them to the staged React-Core-prebuilt location.
+  const vfsSource = await fs.readFile(path.join(artifacts.react, 'React-VFS.yaml'), 'utf8');
+  const cachePrefix = path.join(artifacts.react, 'React.xcframework');
+  const stagedPrefix = path.join(stage, 'React-Core-prebuilt', 'React.xcframework');
+  const vfsRewritten = vfsSource.split(cachePrefix).join(stagedPrefix);
+  await fs.writeFile(path.join(stage, 'React-Core-prebuilt', 'React-VFS.yaml'), vfsRewritten);
+
   return stage;
 }
 

--- a/tools/src/prebuilds/CustomBuild.ts
+++ b/tools/src/prebuilds/CustomBuild.ts
@@ -1,0 +1,140 @@
+/**
+ * Escape hatch for products whose xcframework is produced by a package-owned
+ * build script (e.g. expo-modules-jsi). The pipeline stages a synthetic
+ * `PODS_ROOT` from the artifact cache, runs the script, and copies the result
+ * into the standard prebuild output path.
+ */
+
+import { spawn } from 'child_process';
+import fs from 'fs-extra';
+import path from 'path';
+
+import logger from '../Logger';
+import type { DownloadedDependencies } from './Artifacts.types';
+import type { SPMPackageSource } from './ExternalPackage';
+import { Frameworks } from './Frameworks';
+import type { BuildFlavor } from './Prebuilder.types';
+import type { BuildPlatform, SPMProduct } from './SPMConfig.types';
+import { createAsyncSpinner } from './Utils';
+
+const PODS_STAGE_DIRNAME = 'pods-stage';
+
+const PLATFORM_TO_SDK: Partial<Record<BuildPlatform, string>> = {
+  iOS: 'iphoneos',
+  'iOS Simulator': 'iphonesimulator',
+  tvOS: 'appletvos',
+  'tvOS Simulator': 'appletvsimulator',
+};
+
+function customBuildKey(pkg: SPMPackageSource, product: SPMProduct): string {
+  return `${pkg.packageName}/${product.name}`;
+}
+
+// Builds the `PODS_ROOT` layout that `apple/scripts/build-xcframework.sh` reads.
+async function stagePodsRootAsync(
+  pkg: SPMPackageSource,
+  artifacts: DownloadedDependencies
+): Promise<string> {
+  const stage = path.join(pkg.buildPath, PODS_STAGE_DIRNAME);
+  const links: [string, string][] = [
+    [path.join(artifacts.hermes, 'destroot'), 'hermes-engine/destroot'],
+    [path.join(artifacts.react, 'React.xcframework'), 'React-Core-prebuilt/React.xcframework'],
+    [path.join(artifacts.react, 'React-VFS.yaml'), 'React-Core-prebuilt/React-VFS.yaml'],
+    [
+      path.join(artifacts.reactNativeDependencies, 'ReactNativeDependencies.xcframework'),
+      'ReactNativeDependencies/framework/packages/react-native/ReactNativeDependencies.xcframework',
+    ],
+  ];
+  for (const [target, rel] of links) {
+    const link = path.join(stage, rel);
+    await fs.mkdirp(path.dirname(link));
+    await fs.remove(link).catch(() => {});
+    await fs.ensureSymlink(target, link);
+  }
+  return stage;
+}
+
+async function spawnScriptAsync(
+  scriptPath: string,
+  cwd: string,
+  env: NodeJS.ProcessEnv,
+  label: string
+): Promise<void> {
+  const spinner = createAsyncSpinner(label);
+  return new Promise((resolve, reject) => {
+    const child = spawn(scriptPath, [], { cwd, env, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stderr = '';
+    const pipe = (data: Buffer) => {
+      for (const line of data.toString().split('\n')) {
+        const t = line.trim();
+        if (t) spinner.info(t);
+      }
+    };
+    child.stdout.on('data', pipe);
+    child.stderr.on('data', (d) => {
+      stderr += d.toString();
+      pipe(d);
+    });
+    child.on('error', (err) => {
+      spinner.fail(`${label}: ${err.message}`);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      if (code === 0) {
+        spinner.succeed(label);
+        resolve();
+      } else {
+        spinner.fail(`${label} failed (${code})`);
+        reject(new Error(`${scriptPath} exited with code ${code}\n${stderr.trim()}`));
+      }
+    });
+  });
+}
+
+/**
+ * Stages a `PODS_ROOT` and runs the product's customBuild script. The script
+ * always emits a Release-mode xcframework with `BUILD_LIBRARY_FOR_DISTRIBUTION=YES`,
+ * so to avoid rebuilding once per flavor, the result is cached via
+ * `alreadyBuiltProducts` and reused (compose still copies per flavor).
+ */
+export async function runCustomBuildAsync(
+  pkg: SPMPackageSource,
+  product: SPMProduct,
+  artifacts: DownloadedDependencies,
+  platformFilter: BuildPlatform | undefined,
+  alreadyBuiltProducts?: Set<string>
+): Promise<void> {
+  const cb = product.customBuild!;
+  const key = customBuildKey(pkg, product);
+  if (alreadyBuiltProducts?.has(key)) {
+    logger.info(`🛠  ${product.name} already built this run — reusing.`);
+    return;
+  }
+
+  const scriptPath = path.resolve(pkg.path, cb.script);
+  const podsRoot = await stagePodsRootAsync(pkg, artifacts);
+  const sdk = platformFilter && PLATFORM_TO_SDK[platformFilter];
+  const env: NodeJS.ProcessEnv = { ...process.env, PODS_ROOT: podsRoot };
+  if (sdk) env.PLATFORM_NAME = sdk;
+  else delete env.PLATFORM_NAME;
+
+  await spawnScriptAsync(scriptPath, path.dirname(scriptPath), env, `🛠  Building ${product.name}`);
+  alreadyBuiltProducts?.add(key);
+}
+
+/** Copies the script's xcframework into the standard prebuild output path. */
+export async function composeCustomBuildAsync(
+  pkg: SPMPackageSource,
+  product: SPMProduct,
+  flavor: BuildFlavor
+): Promise<void> {
+  const src = path.resolve(pkg.path, product.customBuild!.output);
+  if (!(await fs.pathExists(src))) {
+    throw new Error(`customBuild produced no xcframework at ${src}`);
+  }
+  const dest = Frameworks.getFrameworkPath(pkg.buildPath, product.name, flavor);
+  await fs.mkdirp(path.dirname(dest));
+  await fs.remove(dest);
+  await fs.copy(src, dest);
+  logger.info(`📦 Staged ${product.name}.xcframework (${flavor}).`);
+}

--- a/tools/src/prebuilds/SPMConfig.types.ts
+++ b/tools/src/prebuilds/SPMConfig.types.ts
@@ -203,6 +203,14 @@ export type ProductPlatform =
   | 'tvOS(.v15)'
   | 'macCatalyst(.v15)';
 
+/** Escape hatch: have a package-owned script produce the xcframework instead of the SPM generator. */
+export interface CustomBuild {
+  /** Path to the build script, relative to the package root. */
+  script: string;
+  /** Path to the xcframework the script produces, relative to the package root. */
+  output: string;
+}
+
 /**
  * A Swift Package product definition
  * Products contain their own targets directly
@@ -212,6 +220,8 @@ export interface SPMProduct {
   name: string;
   /** The CocoaPods pod name for this product. Must match the name in the corresponding .podspec file. */
   podName: string;
+  /** When set, the product is built by an external script rather than the SPM generator. */
+  customBuild?: CustomBuild;
   /** The React Native codegen module name (from package.json codegenConfig.name). Only required for packages that use React Native codegen. */
   codegenName?: string;
   /** Supported platforms for this product */

--- a/tools/src/prebuilds/SPMPackage.test.ts
+++ b/tools/src/prebuilds/SPMPackage.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
 import type { SPMProduct } from './SPMConfig.types';
-import { findSiblingProductDependencies } from './SPMPackage';
+import {
+  expandTransitiveExternalDeps,
+  findSiblingProductDependencies,
+  type ExternalDepResolver,
+} from './SPMPackage';
 
 function makeProduct(name: string, targetDeps: string[] = []): SPMProduct {
   return {
@@ -71,5 +75,33 @@ describe('findSiblingProductDependencies', () => {
     };
     const all = [makeProduct('Core'), product];
     assert.deepEqual(findSiblingProductDependencies(product, all), ['Core']);
+  });
+});
+
+// Synthetic resolver for tests. Keys map a `package/Product` to its further
+// externalDeps; anything not in the map resolves to null (matching production).
+const makeResolver = (graph: Record<string, string[]>): ExternalDepResolver =>
+  (dep) => (dep in graph ? graph[dep] : null);
+
+describe('expandTransitiveExternalDeps', () => {
+  it('passes through and deduplicates leaf-only seeds', () => {
+    assert.deepEqual(expandTransitiveExternalDeps(['A', 'B', 'A', 'C', 'B'], () => null), ['A', 'B', 'C']);
+  });
+
+  it('walks transitive deps across multiple levels', () => {
+    const resolver = makeResolver({
+      'pkg-a/A': ['pkg-b/B', 'Hermes'],
+      'pkg-b/B': ['pkg-c/C'],
+      'pkg-c/C': ['Hermes'], // dup with seed-derived Hermes — must dedup
+    });
+    assert.deepEqual(
+      expandTransitiveExternalDeps(['pkg-a/A'], resolver),
+      ['pkg-a/A', 'pkg-b/B', 'Hermes', 'pkg-c/C']
+    );
+  });
+
+  it('terminates on cycles', () => {
+    const resolver = makeResolver({ 'pkg-a/A': ['pkg-b/B'], 'pkg-b/B': ['pkg-a/A'] });
+    assert.deepEqual(expandTransitiveExternalDeps(['pkg-a/A'], resolver), ['pkg-a/A', 'pkg-b/B']);
   });
 });

--- a/tools/src/prebuilds/SPMPackage.test.ts
+++ b/tools/src/prebuilds/SPMPackage.test.ts
@@ -80,12 +80,17 @@ describe('findSiblingProductDependencies', () => {
 
 // Synthetic resolver for tests. Keys map a `package/Product` to its further
 // externalDeps; anything not in the map resolves to null (matching production).
-const makeResolver = (graph: Record<string, string[]>): ExternalDepResolver =>
-  (dep) => (dep in graph ? graph[dep] : null);
+const makeResolver =
+  (graph: Record<string, string[]>): ExternalDepResolver =>
+  (dep) =>
+    dep in graph ? graph[dep] : null;
 
 describe('expandTransitiveExternalDeps', () => {
   it('passes through and deduplicates leaf-only seeds', () => {
-    assert.deepEqual(expandTransitiveExternalDeps(['A', 'B', 'A', 'C', 'B'], () => null), ['A', 'B', 'C']);
+    assert.deepEqual(
+      expandTransitiveExternalDeps(['A', 'B', 'A', 'C', 'B'], () => null),
+      ['A', 'B', 'C']
+    );
   });
 
   it('walks transitive deps across multiple levels', () => {
@@ -94,10 +99,12 @@ describe('expandTransitiveExternalDeps', () => {
       'pkg-b/B': ['pkg-c/C'],
       'pkg-c/C': ['Hermes'], // dup with seed-derived Hermes — must dedup
     });
-    assert.deepEqual(
-      expandTransitiveExternalDeps(['pkg-a/A'], resolver),
-      ['pkg-a/A', 'pkg-b/B', 'Hermes', 'pkg-c/C']
-    );
+    assert.deepEqual(expandTransitiveExternalDeps(['pkg-a/A'], resolver), [
+      'pkg-a/A',
+      'pkg-b/B',
+      'Hermes',
+      'pkg-c/C',
+    ]);
   });
 
   it('terminates on cycles', () => {

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -15,6 +15,7 @@ import { getExternalPackageByProductName } from './ExternalPackage';
 import { Frameworks } from './Frameworks';
 import { BuildFlavor } from './Prebuilder.types';
 import { getPrecompileDir } from '../Directories';
+import { getPackageByName } from '../Packages';
 import {
   ObjcTarget,
   SwiftTarget,
@@ -340,6 +341,50 @@ export function findSiblingProductDependencies(
   }
   return result;
 }
+
+/**
+ * Resolves a dep name to that dep's own `externalDependencies`, or `null` to
+ * leave it as a leaf (cache deps, unknown packages, sibling targets).
+ */
+export type ExternalDepResolver = (depName: string) => string[] | null;
+
+/**
+ * BFS over `seedDeps`, pulling in each resolvable dep's transitive externals.
+ * Preserves first-occurrence order, deduplicates, terminates on cycles.
+ */
+export function expandTransitiveExternalDeps(
+  seedDeps: string[],
+  resolveDeps: ExternalDepResolver
+): string[] {
+  const visited = new Set<string>();
+  const result: string[] = [];
+  const queue: string[] = [...seedDeps];
+  while (queue.length > 0) {
+    const dep = queue.shift()!;
+    if (visited.has(dep)) continue;
+    visited.add(dep);
+    result.push(dep);
+    for (const next of resolveDeps(dep) ?? []) if (!visited.has(next)) queue.push(next);
+  }
+  return result;
+}
+
+/**
+ * Reads `package/Product` deps from the monorepo's spm.config.json files.
+ * Used so a consumer that depends on `expo-modules-core/ExpoModulesCore`
+ * automatically gets ExpoModulesCore's own external deps (e.g. JSI).
+ */
+export const resolveExternalDepsFromMonorepo: ExternalDepResolver = (depName) => {
+  if (!depName.includes('/')) return null;
+  const parts = depName.split('/');
+  const isScoped = parts[0].startsWith('@');
+  const packageName = isScoped ? `${parts[0]}/${parts[1]}` : parts[0];
+  const productName = isScoped ? parts[2] : parts[1];
+  const depPkg = getPackageByName(packageName);
+  if (!depPkg?.hasSwiftPMConfiguration()) return null;
+  const matched = depPkg.getSwiftPMConfiguration().products.find((p) => p.name === productName);
+  return matched?.externalDependencies ?? null;
+};
 
 // Main Export: SPMPackage
 
@@ -1239,9 +1284,11 @@ async function buildPackageSwiftContext(
     return sibling?.externalDependencies || [];
   });
 
-  // Add external dependencies as binary targets
-  const externalDeps = Array.from(
-    new Set([...(product.externalDependencies || []), ...transitiveExternalDeps])
+  // Walk cross-package transitive externalDependencies so the generated
+  // Package.swift includes binary targets for everything reachable.
+  const externalDeps = expandTransitiveExternalDeps(
+    [...(product.externalDependencies ?? []), ...transitiveExternalDeps],
+    resolveExternalDepsFromMonorepo
   );
   for (const depName of externalDeps) {
     spinner.info(`Resolving external dependency: ${depName}`);
@@ -1452,6 +1499,15 @@ async function buildPackageSwiftContext(
         target.dependencies = Array.from(new Set([...deps, ...transitiveExternalDeps]));
       }
     }
+  }
+
+  // Inject cross-package transitive external deps into source target deps so
+  // the Swift compiler can resolve `@_exported import` chains through them.
+  for (const target of product.targets) {
+    if (target.type === 'framework') continue;
+    const deps = target.dependencies ?? [];
+    const expanded = expandTransitiveExternalDeps(deps, resolveExternalDepsFromMonorepo);
+    if (expanded.length !== deps.length) target.dependencies = expanded;
   }
 
   // Process each product's targets

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -375,13 +375,17 @@ export function expandTransitiveExternalDeps(
  * automatically gets ExpoModulesCore's own external deps (e.g. JSI).
  */
 export const resolveExternalDepsFromMonorepo: ExternalDepResolver = (depName) => {
-  if (!depName.includes('/')) return null;
+  if (!depName.includes('/')) {
+    return null;
+  }
   const parts = depName.split('/');
   const isScoped = parts[0].startsWith('@');
   const packageName = isScoped ? `${parts[0]}/${parts[1]}` : parts[0];
   const productName = isScoped ? parts[2] : parts[1];
   const depPkg = getPackageByName(packageName);
-  if (!depPkg?.hasSwiftPMConfiguration()) return null;
+  if (!depPkg?.hasSwiftPMConfiguration()) {
+    return null;
+  }
   const matched = depPkg.getSwiftPMConfiguration().products.find((p) => p.name === productName);
   return matched?.externalDependencies ?? null;
 };

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -209,9 +209,9 @@ export const validatePodNamesAsync = async (
       searchPath = pkg.path;
       podspecPattern = `${podName}.podspec`;
     } else {
-      // Expo packages: podspec could be in root or ios/ subdirectory
+      // Expo packages: podspec could be in root, ios/, or apple/ subdirectory
       searchPath = pkg.path;
-      podspecPattern = `{${podName}.podspec,ios/${podName}.podspec}`;
+      podspecPattern = `{${podName}.podspec,ios/${podName}.podspec,apple/${podName}.podspec}`;
     }
 
     // Look for matching podspec
@@ -223,7 +223,7 @@ export const validatePodNamesAsync = async (
     if (foundPodspecs.length === 0) {
       // Find all podspecs in the package to help debug
       const allPodspecs = await glob(
-        isExternalPackage(pkg) ? '*.podspec' : '{*.podspec,ios/*.podspec}',
+        isExternalPackage(pkg) ? '*.podspec' : '{*.podspec,ios/*.podspec,apple/*.podspec}',
         {
           cwd: searchPath,
           absolute: false,

--- a/tools/src/prebuilds/Verifier.ts
+++ b/tools/src/prebuilds/Verifier.ts
@@ -1000,7 +1000,8 @@ const hasSwiftCode = (frameworkPath: string): boolean => {
  * We only verify that the swiftinterface files exist and have valid structure.
  */
 const verifySwiftInterfaceTypecheck = async (
-  slice: XCFrameworkSlice
+  slice: XCFrameworkSlice,
+  dependencyXcframeworkPaths: string[] = []
 ): Promise<XCFrameworkVerificationResult> => {
   // First check if this framework contains Swift code at all
   if (!hasSwiftCode(slice.frameworkPath)) {
@@ -1020,6 +1021,10 @@ const verifySwiftInterfaceTypecheck = async (
     };
   }
 
+  // Modules declared by sibling xcframeworks (external dependencies). Treat
+  // them as known so @_exported imports of those modules don't false-positive.
+  const dependencyModules = collectModulesFromXcframeworks(dependencyXcframeworkPaths);
+
   // Check that each swiftinterface file exists and is non-empty
   const issues: string[] = [];
   for (const iface of swiftInterfaces) {
@@ -1031,7 +1036,11 @@ const verifySwiftInterfaceTypecheck = async (
       }
 
       // Check for potentially invalid imports
-      const importIssues = await verifySwiftInterfaceImports(iface, slice.frameworkPath);
+      const importIssues = await verifySwiftInterfaceImports(
+        iface,
+        slice.frameworkPath,
+        dependencyModules
+      );
       issues.push(...importIssues);
     } catch (err) {
       issues.push(`${path.basename(iface)}: ${err}`);
@@ -1053,6 +1062,32 @@ const verifySwiftInterfaceTypecheck = async (
 };
 
 /**
+ * Reads the first available slice's modulemap of each xcframework and returns
+ * the union of module names it declares. Used to recognise modules supplied by
+ * sibling xcframeworks during swiftinterface validation.
+ */
+const collectModulesFromXcframeworks = (xcframeworkPaths: string[]): Set<string> => {
+  const modules = new Set<string>();
+  const moduleRe = /(?:framework\s+)?module\s+(\w+)\s*\{/g;
+  for (const xcfw of xcframeworkPaths) {
+    if (!fs.existsSync(xcfw)) continue;
+    for (const slice of fs.readdirSync(xcfw, { withFileTypes: true })) {
+      if (!slice.isDirectory()) continue;
+      const sliceDir = path.join(xcfw, slice.name);
+      const fwName = fs.readdirSync(sliceDir).find((n) => n.endsWith('.framework'));
+      if (!fwName) continue;
+      const mmPath = ['Modules', 'Headers']
+        .map((d) => path.join(sliceDir, fwName, d, 'module.modulemap'))
+        .find((p) => fs.existsSync(p));
+      if (!mmPath) continue;
+      for (const m of fs.readFileSync(mmPath, 'utf8').matchAll(moduleRe)) modules.add(m[1]);
+      break;
+    }
+  }
+  return modules;
+};
+
+/**
  * Verifies that imports in a swiftinterface file are valid.
  * Checks that:
  * 1. Imported modules are either well-known system/SDK modules or defined in the framework's modulemap
@@ -1060,11 +1095,13 @@ const verifySwiftInterfaceTypecheck = async (
  *
  * @param swiftInterfacePath Path to the .swiftinterface file
  * @param frameworkPath Path to the framework containing the swiftinterface
+ * @param dependencyModules Modules declared by sibling xcframeworks; treated as defined
  * @returns Array of issue descriptions (empty if all imports are valid)
  */
 const verifySwiftInterfaceImports = async (
   swiftInterfacePath: string,
-  frameworkPath: string
+  frameworkPath: string,
+  dependencyModules: Set<string> = new Set()
 ): Promise<string[]> => {
   const issues: string[] = [];
   const content = fs.readFileSync(swiftInterfacePath, 'utf8');
@@ -1075,7 +1112,7 @@ const verifySwiftInterfaceImports = async (
 
   // Parse the modulemap to find defined modules
   const moduleMapPath = path.join(frameworkPath, 'Modules', 'module.modulemap');
-  const definedModules = new Set<string>();
+  const definedModules = new Set<string>(dependencyModules);
 
   if (fs.existsSync(moduleMapPath)) {
     const moduleMapContent = fs.readFileSync(moduleMapPath, 'utf8');
@@ -1498,7 +1535,10 @@ const verifySlice = async (
 
   if (!options?.skipSwiftCheck) {
     spinner.info('Verifying Swift interface typecheck...');
-    swiftInterfaceTypecheck = await verifySwiftInterfaceTypecheck(slice);
+    swiftInterfaceTypecheck = await verifySwiftInterfaceTypecheck(
+      slice,
+      dependencyXcframeworkPaths
+    );
   }
 
   // dSYM verification: presence, UUID match, and debug prefix mapping

--- a/tools/src/prebuilds/pipeline/Context.ts
+++ b/tools/src/prebuilds/pipeline/Context.ts
@@ -94,6 +94,11 @@ export interface PrebuildContext {
   // Downloaded artifacts, keyed by flavor (populated lazily during execution)
   artifactsByFlavor: Map<BuildFlavor, DownloadedDependencies | null>;
 
+  // Tracks customBuild products that have been built during this run, so we
+  // only invoke their scripts once even when iterating multiple flavors.
+  // Keys are `${packageName}/${productName}`.
+  customBuiltProducts: Set<string>;
+
   // Iteration pointers (set by Executor before each step)
   currentPackage: SPMPackageSource | null;
   currentProduct: SPMProduct | null;
@@ -160,6 +165,7 @@ export function createContext(request: PrebuildRequest): PrebuildContext {
     artifactsPath: '',
     dependsOn: new Map(),
     artifactsByFlavor: new Map(),
+    customBuiltProducts: new Set(),
     currentPackage: null,
     currentProduct: null,
     currentFlavor: null,

--- a/tools/src/prebuilds/pipeline/Executor.ts
+++ b/tools/src/prebuilds/pipeline/Executor.ts
@@ -220,6 +220,7 @@ async function executePackageStepsInner(
     artifactsPath: rootCtx.artifactsPath,
     dependsOn: rootCtx.dependsOn,
     artifactsByFlavor: rootCtx.artifactsByFlavor,
+    customBuiltProducts: rootCtx.customBuiltProducts,
     currentPackage: null,
     currentProduct: null,
     currentFlavor: null,

--- a/tools/src/prebuilds/pipeline/ProductSteps.ts
+++ b/tools/src/prebuilds/pipeline/ProductSteps.ts
@@ -9,6 +9,7 @@ import path from 'path';
 
 import logger from '../../Logger';
 import { Codegen } from '../Codegen';
+import { composeCustomBuildAsync, runCustomBuildAsync } from '../CustomBuild';
 import { Frameworks } from '../Frameworks';
 import { SPMBuild } from '../SPMBuild';
 import { SPMGenerator } from '../SPMGenerator';
@@ -77,6 +78,9 @@ export const generateStep: Step<PrebuildContext> = {
     const flavor = ctx.currentFlavor!;
     const artifacts = ctx.artifactsByFlavor.get(flavor) ?? undefined;
 
+    // customBuild products own their generation; nothing to do here.
+    if (product.customBuild) return setStage(ctx, 'generate', 'success');
+
     // Ensure codegen is generated for packages that need it (e.g., Fabric components)
     if (Codegen.hasCodegen(pkg)) {
       const generated = await Codegen.ensureCodegenAsync(pkg, (msg) => logger.info(msg));
@@ -115,6 +119,12 @@ export const buildStep: Step<PrebuildContext> = {
     const flavor = ctx.currentFlavor!;
     const artifacts = ctx.artifactsByFlavor.get(flavor) ?? undefined;
 
+    if (product.customBuild) {
+      if (!artifacts) throw new Error(`customBuild ${product.name}: artifacts missing for ${flavor}`);
+      await runCustomBuildAsync(pkg, product, artifacts, ctx.request.platformFilter, ctx.customBuiltProducts);
+      return setStage(ctx, 'build', 'success');
+    }
+
     // Compute hermes include paths for xcodebuild flags.
     // Hermes includes can't go in Package.swift because destroot/include/
     // contains jsi/ headers that conflict with React VFS jsi/ mappings.
@@ -150,6 +160,11 @@ export const composeStep: Step<PrebuildContext> = {
     const pkg = ctx.currentPackage!;
     const product = ctx.currentProduct!;
     const flavor = ctx.currentFlavor!;
+
+    if (product.customBuild) {
+      await composeCustomBuildAsync(pkg, product, flavor);
+      return setStage(ctx, 'compose', 'success');
+    }
 
     await Frameworks.composeXCFrameworkAsync(
       pkg,

--- a/tools/src/prebuilds/pipeline/ProductSteps.ts
+++ b/tools/src/prebuilds/pipeline/ProductSteps.ts
@@ -79,7 +79,10 @@ export const generateStep: Step<PrebuildContext> = {
     const artifacts = ctx.artifactsByFlavor.get(flavor) ?? undefined;
 
     // customBuild products own their generation; nothing to do here.
-    if (product.customBuild) return setStage(ctx, 'generate', 'success');
+    if (product.customBuild) {
+      setStage(ctx, 'generate', 'success');
+      return;
+    }
 
     // Ensure codegen is generated for packages that need it (e.g., Fabric components)
     if (Codegen.hasCodegen(pkg)) {
@@ -120,9 +123,18 @@ export const buildStep: Step<PrebuildContext> = {
     const artifacts = ctx.artifactsByFlavor.get(flavor) ?? undefined;
 
     if (product.customBuild) {
-      if (!artifacts) throw new Error(`customBuild ${product.name}: artifacts missing for ${flavor}`);
-      await runCustomBuildAsync(pkg, product, artifacts, ctx.request.platformFilter, ctx.customBuiltProducts);
-      return setStage(ctx, 'build', 'success');
+      if (!artifacts) {
+        throw new Error(`customBuild ${product.name}: artifacts missing for ${flavor}`);
+      }
+      await runCustomBuildAsync(
+        pkg,
+        product,
+        artifacts,
+        ctx.request.platformFilter,
+        ctx.customBuiltProducts
+      );
+      setStage(ctx, 'build', 'success');
+      return;
     }
 
     // Compute hermes include paths for xcodebuild flags.
@@ -163,7 +175,8 @@ export const composeStep: Step<PrebuildContext> = {
 
     if (product.customBuild) {
       await composeCustomBuildAsync(pkg, product, flavor);
-      return setStage(ctx, 'compose', 'success');
+      setStage(ctx, 'compose', 'success');
+      return;
     }
 
     await Frameworks.composeXCFrameworkAsync(

--- a/tools/src/prebuilds/schemas/spm.config.schema.json
+++ b/tools/src/prebuilds/schemas/spm.config.schema.json
@@ -170,6 +170,22 @@
                     "items": {
                         "$ref": "#/definitions/target"
                     }
+                },
+                "customBuild": {
+                    "type": "object",
+                    "description": "Escape hatch for products whose xcframework is produced by a package-owned build script. When set, the prebuild pipeline skips source / Package.swift generation and runs the script instead.",
+                    "properties": {
+                        "script": {
+                            "type": "string",
+                            "description": "Path to the build script, relative to the package root."
+                        },
+                        "output": {
+                            "type": "string",
+                            "description": "Path to the xcframework the script produces, relative to the package root."
+                        }
+                    },
+                    "required": [ "script", "output" ],
+                    "additionalProperties": false
                 }
             },
             "required": [ "name", "podName", "targets" ],


### PR DESCRIPTION
## Why
Precompiled failed after introducing the new ExpoModulesJSI target bridging C++ and Swift for the JSI members.

## How
Added custom build to prebuilds that calls the build-xcframework.sh to ensure that ExpoModulesJSI is built as part of the prebuild.

- Added custom build fields to spm.config schema
- Added spm.config.json to expo-modules-jsi
- Removed special handling of header files in Hermes artifacts, no longer needed (now aligns with how build-xcframeworks.sh expects the headers)
- Added support for transient dependencies in spm configs
- Updated misplaced ExpoModulesJSI dependency in ExpModulesCore.podspec

## Test-plan

✅ Prebuilt all used packages in release/debug version ✅ Tested in BareExpo both with/without prebuilt xcframeworks

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
