### PR TITLE
re-add padding-top to image container in build-a-screen tutorial

### DIFF
--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -427,6 +427,7 @@ const styles = StyleSheet.create({
   },
   imageContainer: {
     flex: 1,
+    paddingTop: 28
   },
   footerContainer: {
     flex: 1 / 3,


### PR DESCRIPTION
Top padding was missing from the final index.tsx page styles

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
While completing the expo tutorial and running the final code locally, my design did not match that of the tutorial, but my code did. The missing piece was the padding needed at the top of the image.
# How
Added the paddingTop: 28 to the imageContainer styles in index.tsx.
<!--
How did you build this feature or fix this bug and why?
-->
N/A
# Test Plan
N/A
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
Follow the tutorial, and you'll see your local design does not match the example images/videos in the tutorial
# Checklist
N/A
<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
