### PR TITLE
[docs] Update compatibility tables versions for SDK 56

### DIFF
--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -1,6 +1,20 @@
 {
   "sdkVersions": [
     {
+      "sdk": "56.0.0",
+      "android": "7+",
+      "compileSdkVersion": "36",
+      "targetSdkVersion": "36",
+      "buildToolsVersion": "36.0.0",
+      "ios": "16.4+",
+      "xcode": "26.2+",
+      "react-native": "0.85",
+      "react-native-web": "0.21.0",
+      "react-native-tvos": "0.85-stable",
+      "react": "19.2.3",
+      "node": "22.x.x"
+    },
+    {
       "sdk": "55.0.0",
       "android": "7+",
       "compileSdkVersion": "36",

--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -12,7 +12,7 @@
       "react-native-web": "0.21.0",
       "react-native-tvos": "0.85-stable",
       "react": "19.2.3",
-      "node": "22.x.x"
+      "node": "22.13.x"
     },
     {
       "sdk": "55.0.0",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20803

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add SDK 56 specific versions in `ui/components/SDKTables/sdk-versions.json` file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- For React and React Native, see changelog draft
- For iOS version, see https://github.com/expo/expo/blob/main/templates/expo-template-bare-minimum/ios/Podfile#L20
- For Node.js version, I reached out to @kitten and he confirmed in docs we should specify Node.js v 22.x.x.
- For Android versions, see https://github.com/expo/expo/blob/main/apps/expo-go/android/gradle/libs.versions.toml where `compileSdk`, `targetSdk`, and `buildTools` are defined.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
