### PR TITLE
[docs] Add "Included in Expo Go" label in Expo UI

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/datetimepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/datetimepicker.mdx
@@ -3,7 +3,7 @@ title: DateTimePicker
 description: A date and time picker compatible with @react-native-community/datetimepicker.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android', 'ios']
+platforms: ['android', 'ios', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/index.mdx
@@ -4,7 +4,7 @@ sidebar_title: Overview
 description: Components and APIs that serve as drop-in replacements for popular React Native community libraries.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android', 'ios']
+platforms: ['android', 'ios', 'expo-go']
 ---
 
 The following components provide API-compatible replacements for popular React Native community libraries, powered by `@expo/ui` native components (Jetpack Compose on Android and SwiftUI on iOS).

--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/segmentedcontrol.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/segmentedcontrol.mdx
@@ -3,7 +3,7 @@ title: SegmentedControl
 description: A segmented control compatible with @react-native-segmented-control/segmented-control.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android', 'ios', 'web']
+platforms: ['android', 'ios', 'web', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/index.mdx
@@ -4,7 +4,7 @@ sidebar_title: Overview
 description: A set of components that allow you to build UIs directly with Jetpack Compose and SwiftUI from React.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android', 'ios', 'tvos']
+platforms: ['android', 'ios', 'tvos', 'expo-go']
 hideTOC: true
 ---
 

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/alertdialog.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/alertdialog.mdx
@@ -3,7 +3,7 @@ title: AlertDialog
 description: A Jetpack Compose AlertDialog component for displaying native alert dialogs.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/badge.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/badge.mdx
@@ -3,7 +3,7 @@ title: Badge
 description: A Jetpack Compose Badge component for displaying status indicators and counts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/badgedbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/badgedbox.mdx
@@ -3,7 +3,7 @@ title: BadgedBox
 description: A Jetpack Compose BadgedBox component for overlaying badges on content.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/basicalertdialog.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/basicalertdialog.mdx
@@ -3,7 +3,7 @@ title: BasicAlertDialog
 description: A Jetpack Compose BasicAlertDialog component for displaying dialogs with custom content.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/bottomsheet.mdx
@@ -3,7 +3,7 @@ title: ModalBottomSheet
 description: A Jetpack Compose ModalBottomSheet component that presents content from the bottom of the screen.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/box.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/box.mdx
@@ -3,7 +3,7 @@ title: Box
 description: A Jetpack Compose Box component for stacking child elements.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/button.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/button.mdx
@@ -3,7 +3,7 @@ title: Button
 description: Jetpack Compose Button components for displaying native Material3 buttons.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/card.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/card.mdx
@@ -3,7 +3,7 @@ title: Card
 description: A Jetpack Compose Card component for displaying content in a styled container.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/carousel.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/carousel.mdx
@@ -3,7 +3,7 @@ title: Carousel
 description: Jetpack Compose Carousel components for displaying scrollable collections of items.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/checkbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/checkbox.mdx
@@ -3,7 +3,7 @@ title: Checkbox
 description: A Jetpack Compose Checkbox component for selection controls.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/chip.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/chip.mdx
@@ -3,7 +3,7 @@ title: Chip
 description: Jetpack Compose Chip components for displaying compact elements.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/colors.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/colors.mdx
@@ -3,7 +3,7 @@ title: Material Colors
 description: Read the Material 3 color palette (including Material 3 Dynamic Colors) from JavaScript.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/column.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/column.mdx
@@ -3,7 +3,7 @@ title: Column
 description: A Jetpack Compose Column component for placing children vertically.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/datetimepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/datetimepicker.mdx
@@ -3,7 +3,7 @@ title: DateTimePicker
 description: A Jetpack Compose DateTimePicker component for selecting dates and times.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/divider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/divider.mdx
@@ -3,7 +3,7 @@ title: Divider
 description: Jetpack Compose Divider components for creating visual separators.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dockedsearchbar.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dockedsearchbar.mdx
@@ -3,7 +3,7 @@ title: DockedSearchBar
 description: A Jetpack Compose DockedSearchBar component for displaying an inline search input.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -3,7 +3,7 @@ title: DropdownMenu
 description: A Jetpack Compose DropdownMenu component for displaying dropdown menus.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
@@ -3,7 +3,7 @@ title: ExposedDropdownMenuBox
 description: A Jetpack Compose ExposedDropdownMenuBox component for displaying a dropdown menu with a customizable anchor.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/floatingactionbutton.mdx
@@ -3,7 +3,7 @@ title: FloatingActionButton
 description: Jetpack Compose FloatingActionButton components following Material Design 3.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/flowrow.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/flowrow.mdx
@@ -3,7 +3,7 @@ title: FlowRow
 description: A Jetpack Compose FlowRow component for wrapping children horizontally.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/horizontalfloatingtoolbar.mdx
@@ -3,7 +3,7 @@ title: HorizontalFloatingToolbar
 description: A Jetpack Compose HorizontalFloatingToolbar component for displaying a floating action bar.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/host.mdx
@@ -3,7 +3,7 @@ title: Host
 description: A Jetpack Compose Host component for bridging React Native and Jetpack Compose.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
@@ -3,7 +3,7 @@ title: Icon
 description: A Jetpack Compose Icon component for displaying icons.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/iconbutton.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/iconbutton.mdx
@@ -3,7 +3,7 @@ title: IconButton
 description: Jetpack Compose IconButton components for displaying native Material3 icon buttons.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
@@ -4,7 +4,7 @@ sidebar_title: Overview
 description: Jetpack Compose components for building native Android interfaces with @expo/ui.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 isAlpha: true
 hideTOC: true
 ---

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazycolumn.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazycolumn.mdx
@@ -3,7 +3,7 @@ title: LazyColumn
 description: A Jetpack Compose LazyColumn component for displaying scrollable lists.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazyrow.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/lazyrow.mdx
@@ -3,7 +3,7 @@ title: LazyRow
 description: A Jetpack Compose LazyRow component for displaying horizontally scrolling lists.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/listitem.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/listitem.mdx
@@ -3,7 +3,7 @@ title: ListItem
 description: A Jetpack Compose ListItem component for displaying structured list entries.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/modifiers.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/modifiers.mdx
@@ -3,7 +3,7 @@ title: Modifiers
 description: Jetpack Compose layout modifiers for @expo/ui components.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/progress.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/progress.mdx
@@ -3,7 +3,7 @@ title: Progress Indicators
 description: Jetpack Compose progress indicator components for displaying operation status.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/pulltorefreshbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/pulltorefreshbox.mdx
@@ -3,7 +3,7 @@ title: PullToRefreshBox
 description: A Jetpack Compose PullToRefreshBox component for pull-to-refresh interactions.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/radiobutton.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/radiobutton.mdx
@@ -3,7 +3,7 @@ title: RadioButton
 description: A Jetpack Compose RadioButton component for single-selection controls.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/rnhostview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/rnhostview.mdx
@@ -3,7 +3,7 @@ title: RNHostView
 description: A component that enables React Native views inside Jetpack Compose.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/row.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/row.mdx
@@ -3,7 +3,7 @@ title: Row
 description: A Jetpack Compose Row component for placing children horizontally.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/searchbar.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/searchbar.mdx
@@ -3,7 +3,7 @@ title: SearchBar
 description: A Jetpack Compose SearchBar component for search input functionality.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/segmentedbutton.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/segmentedbutton.mdx
@@ -3,7 +3,7 @@ title: SegmentedButton
 description: Jetpack Compose Segmented Button components for single or multi-choice selection.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/shape.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/shape.mdx
@@ -3,7 +3,7 @@ title: Shape
 description: A Jetpack Compose Shape component for drawing geometric shapes.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/slider.mdx
@@ -3,7 +3,7 @@ title: Slider
 description: A Jetpack Compose Slider component for selecting values from a range.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/spacer.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/spacer.mdx
@@ -3,7 +3,7 @@ title: Spacer
 description: A Jetpack Compose Spacer component for adding flexible space between elements.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/surface.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/surface.mdx
@@ -3,7 +3,7 @@ title: Surface
 description: A Jetpack Compose Surface component for styled content containers.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/switch.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/switch.mdx
@@ -3,7 +3,7 @@ title: Switch
 description: A Jetpack Compose Switch component for toggle controls.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/text.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/text.mdx
@@ -3,7 +3,7 @@ title: Text
 description: A Jetpack Compose Text component for displaying styled text.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -3,7 +3,7 @@ title: TextField
 description: Jetpack Compose TextField components for native Material3 text input.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/togglebutton.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/togglebutton.mdx
@@ -3,7 +3,7 @@ title: ToggleButton
 description: Jetpack Compose ToggleButton components for displaying native Material3 toggle buttons.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/tooltip.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/tooltip.mdx
@@ -3,7 +3,7 @@ title: Tooltip
 description: Jetpack Compose Tooltip components for displaying contextual information on long-press.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['android']
+platforms: ['android', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/accessorywidgetbackground.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/accessorywidgetbackground.mdx
@@ -3,7 +3,7 @@ title: AccessoryWidgetBackground
 description: A SwiftUI adaptive background view that provides a standard appearance based on the the widget's environment.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios']
+platforms: ['ios', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
@@ -3,7 +3,7 @@ title: BottomSheet
 description: A SwiftUI BottomSheet component that presents content from the bottom of the screen.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/button.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/button.mdx
@@ -3,7 +3,7 @@ title: Button
 description: A SwiftUI Button component for displaying native buttons.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/colorpicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/colorpicker.mdx
@@ -3,7 +3,7 @@ title: ColorPicker
 description: A SwiftUI ColorPicker component for selecting colors.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios']
+platforms: ['ios', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/confirmationdialog.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/confirmationdialog.mdx
@@ -3,7 +3,7 @@ title: ConfirmationDialog
 description: A SwiftUI ConfirmationDialog component for presenting confirmation prompts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/contextmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/contextmenu.mdx
@@ -3,7 +3,7 @@ title: ContextMenu
 description: A SwiftUI ContextMenu component for displaying context menus.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/controlgroup.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/controlgroup.mdx
@@ -3,7 +3,7 @@ title: ControlGroup
 description: A SwiftUI ControlGroup component for grouping interactive controls.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/datepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/datepicker.mdx
@@ -3,7 +3,7 @@ title: DatePicker
 description: A SwiftUI DatePicker component for selecting dates and times.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios']
+platforms: ['ios', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/disclosuregroup.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/disclosuregroup.mdx
@@ -3,7 +3,7 @@ title: DisclosureGroup
 description: A SwiftUI DisclosureGroup component for displaying expandable content.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios']
+platforms: ['ios', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/divider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/divider.mdx
@@ -3,7 +3,7 @@ title: Divider
 description: A SwiftUI Divider component for creating visual separators.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/form.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/form.mdx
@@ -3,7 +3,7 @@ title: Form
 description: A SwiftUI Form component for collecting user input in a structured layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/gauge.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/gauge.mdx
@@ -3,7 +3,7 @@ title: Gauge
 description: A SwiftUI Gauge component for displaying progress with visual indicators.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios']
+platforms: ['ios', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/group.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/group.mdx
@@ -3,7 +3,7 @@ title: Group
 description: A SwiftUI Group component for grouping views without affecting layout.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
@@ -3,7 +3,7 @@ title: Host
 description: A SwiftUI Host component that enables SwiftUI components in React Native.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/hstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/hstack.mdx
@@ -3,7 +3,7 @@ title: HStack
 description: A SwiftUI HStack component for horizontal layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/image.mdx
@@ -3,7 +3,7 @@ title: Image
 description: A SwiftUI Image component for displaying SF Symbols.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
@@ -4,7 +4,7 @@ sidebar_title: Overview
 description: SwiftUI components for building native iOS interfaces with @expo/ui.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 isBeta: true
 hasVideoLink: true
 ---

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/label.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/label.mdx
@@ -3,7 +3,7 @@ title: Label
 description: A SwiftUI Label component for displaying text with an icon.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/lazyhstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/lazyhstack.mdx
@@ -3,7 +3,7 @@ title: LazyHStack
 description: A SwiftUI LazyHStack component for lazy horizontal layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/lazyvstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/lazyvstack.mdx
@@ -3,7 +3,7 @@ title: LazyVStack
 description: A SwiftUI LazyVStack component for lazy vertical layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/link.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/link.mdx
@@ -3,7 +3,7 @@ title: Link
 description: A SwiftUI Link component for displaying clickable links.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/list.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/list.mdx
@@ -3,7 +3,7 @@ title: List
 description: A SwiftUI List component for displaying scrollable lists of items.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
@@ -3,7 +3,7 @@ title: Menu
 description: A SwiftUI Menu component for displaying dropdown menus.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/modifiers.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/modifiers.mdx
@@ -3,7 +3,7 @@ title: Modifiers
 description: SwiftUI view modifiers for customizing component appearance and behavior.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/namespace.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/namespace.mdx
@@ -3,7 +3,7 @@ title: Namespace
 description: A Namespace component that allows you create Namespaces in SwiftUI
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/overlay.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/overlay.mdx
@@ -3,7 +3,7 @@ title: Overlay
 description: A SwiftUI Overlay component for layering content on top of another view.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvOS']
+platforms: ['ios', 'tvOS', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/picker.mdx
@@ -3,7 +3,7 @@ title: Picker
 description: A SwiftUI Picker component for selecting options from a list.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/popover.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/popover.mdx
@@ -3,7 +3,7 @@ title: Popover
 description: A SwiftUI Popover component for displaying content in a floating overlay.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios']
+platforms: ['ios', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/progressview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/progressview.mdx
@@ -3,7 +3,7 @@ title: ProgressView
 description: A SwiftUI ProgressView component for displaying progress indicators.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/rnhostview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/rnhostview.mdx
@@ -3,7 +3,7 @@ title: RNHostView
 description: A component that enables React Native views inside SwiftUI.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/scrollview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/scrollview.mdx
@@ -3,7 +3,7 @@ title: ScrollView
 description: A SwiftUI ScrollView component for scrollable content.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/section.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/section.mdx
@@ -3,7 +3,7 @@ title: Section
 description: A SwiftUI Section component for grouping content within lists and forms.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/securefield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/securefield.mdx
@@ -3,7 +3,7 @@ title: SecureField
 description: A SwiftUI SecureField component for password input.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/slider.mdx
@@ -3,7 +3,7 @@ title: Slider
 description: A SwiftUI Slider component for selecting values from a range.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios']
+platforms: ['ios', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/spacer.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/spacer.mdx
@@ -3,7 +3,7 @@ title: Spacer
 description: A SwiftUI Spacer component for flexible spacing.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/text.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/text.mdx
@@ -3,7 +3,7 @@ title: Text
 description: A SwiftUI Text component for displaying styled text with support for nested texts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
@@ -3,7 +3,7 @@ title: TextField
 description: A SwiftUI TextField component for text input.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/toggle.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/toggle.mdx
@@ -3,7 +3,7 @@ title: Toggle
 description: A SwiftUI Toggle component for displaying native toggles.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/vstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/vstack.mdx
@@ -3,7 +3,7 @@ title: VStack
 description: A SwiftUI VStack component for vertical layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/zstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/zstack.mdx
@@ -3,7 +3,7 @@ title: ZStack
 description: A SwiftUI ZStack component for overlapping layouts.
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
-platforms: ['ios', 'tvos']
+platforms: ['ios', 'tvos', 'expo-go']
 ---
 
 import APISection from '~/components/plugins/APISection';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20806

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add `expo-go` platform tag in Expo UI references. Applied to unversioned only so they are included in SDK beta cut off (which is coming soon).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2500" height="772" alt="CleanShot 2026-04-27 at 19 21 40@2x" src="https://github.com/user-attachments/assets/78b0db9f-522c-4095-9f09-f363b7fb9686" />

<img width="2516" height="846" alt="CleanShot 2026-04-27 at 19 21 35@2x" src="https://github.com/user-attachments/assets/275a0778-5e0b-438d-a030-f5156301b283" />

<img width="2470" height="704" alt="CleanShot 2026-04-27 at 19 21 29@2x" src="https://github.com/user-attachments/assets/f1244199-5124-423d-bddf-dcaa2c650847" />



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
