### PR TITLE
[docs] Remove unused import of useRef in setup example

### DIFF
--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -82,7 +82,7 @@ Add the `expo-notifications` plugin in the `plugins` array of your [app config](
 The code below shows a working example of how to register for, send, and receive push notifications in a React Native app. Copy and paste it into your project:
 
 ```tsx App.tsx
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, Button, Platform } from 'react-native';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';


### PR DESCRIPTION
# Why

Housekeeping 

# How

Deleted unused useRef

# Test Plan

I copied and pasted the code into my application and my code editor is no longer complaining about the unused useRef.
I also searched the page for useRef and the only instance was in the import.
