### PR TITLE
[docs] Remove unused `useRef` hook from Notifications example

### DIFF
--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -70,7 +70,7 @@ Check out the example Snack below to see Notifications in action, make sure to u
 <SnackInline label='Push Notifications' dependencies={['expo-device', 'expo-constants', 'expo-notifications']}>
 
 ```tsx
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, Button, Platform } from 'react-native';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';

--- a/docs/pages/versions/v53.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/notifications.mdx
@@ -60,7 +60,7 @@ Check out the example Snack below to see Notifications in action, make sure to u
 <SnackInline label='Push Notifications' dependencies={['expo-device', 'expo-constants', 'expo-notifications']}>
 
 ```tsx
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, Button, Platform } from 'react-native';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';

--- a/docs/pages/versions/v54.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/notifications.mdx
@@ -70,7 +70,7 @@ Check out the example Snack below to see Notifications in action, make sure to u
 <SnackInline label='Push Notifications' dependencies={['expo-device', 'expo-constants', 'expo-notifications']}>
 
 ```tsx
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, Button, Platform } from 'react-native';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';

--- a/docs/pages/versions/v55.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/notifications.mdx
@@ -70,7 +70,7 @@ Check out the example Snack below to see Notifications in action, make sure to u
 <SnackInline label='Push Notifications' dependencies={['expo-device', 'expo-constants', 'expo-notifications']}>
 
 ```tsx
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { Text, View, Button, Platform } from 'react-native';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/45130

# How

<!--
How did you build this feature or fix this bug and why?
-->

Remove unused `useRef` hook from Notifications example in its reference

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
