### PR TITLE
[cli] Stop prebuild from writing plugin state to app config

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fix `react-native-web` install check being unconditional ([#44450](https://github.com/expo/expo/pull/44450) by [@kitten](https://github.com/kitten))
 - Fix mangled async chunk filenames for catch-all routes ([#43547](https://github.com/expo/expo/pull/43547) by [@hassankhan](https://github.com/hassankhan))
 - Consistently resolve `mainModuleName`s using `convertEntryPointToRelative` and fix relative path semantics of `--entry-file` argumnts, which was previously expected to be relative to the server root rather than the project root. This fixes build issues when using export commands for projects in monorepos on Windows ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
+- Avoid writing plugin state to app config when writing the package name or bundle identifier.
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -35,7 +35,7 @@
 - Fix `react-native-web` install check being unconditional ([#44450](https://github.com/expo/expo/pull/44450) by [@kitten](https://github.com/kitten))
 - Fix mangled async chunk filenames for catch-all routes ([#43547](https://github.com/expo/expo/pull/43547) by [@hassankhan](https://github.com/hassankhan))
 - Consistently resolve `mainModuleName`s using `convertEntryPointToRelative` and fix relative path semantics of `--entry-file` argumnts, which was previously expected to be relative to the server root rather than the project root. This fixes build issues when using export commands for projects in monorepos on Windows ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
-- Avoid writing plugin state to app config when writing the package name or bundle identifier.
+- Avoid writing plugin state to app config when writing the package name or bundle identifier. ([#45136](https://github.com/expo/expo/pull/45136) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
+++ b/packages/@expo/cli/src/utils/getOrPromptApplicationId.ts
@@ -121,9 +121,7 @@ async function promptForBundleIdWithInitialAsync(
   if (
     await attemptModification(
       projectRoot,
-      {
-        ios: { ...(exp.ios || {}), bundleIdentifier },
-      },
+      { ios: { bundleIdentifier } },
       { ios: { bundleIdentifier } }
     )
   ) {
@@ -262,12 +260,8 @@ async function promptForPackageWithInitialAsync(
   if (
     await attemptModification(
       projectRoot,
-      {
-        android: { ...(exp.android || {}), package: packageName },
-      },
-      {
-        android: { package: packageName },
-      }
+      { android: { package: packageName } },
+      { android: { package: packageName } }
     )
   ) {
     Log.log(chalk.gray`\u203A Android package name: ${packageName}`);


### PR DESCRIPTION
# Why

When prebuild prompts for the package name or bundle identifier, it writes more than that field. `getOrPromptForPackageAsync` spreads the entire config into `modifyConfigAsync`, which then merges it into `app.json`. Two issues happen after this:

1. Any plugin that calls `withPermissions` mutates permissions in-memory. The spread captures those permissions and writes them into `app.json`. Once a permission is in `app.json`'s permissions array, later opting out via the plugin (e.g. `expo-audio`'s `recordAudioAndroid: false`) has no effect, the manifest mod reads the array from `app.json`.

2. `modifyConfigAsync` uses `deepmerge`, whose default array strategy is to concatenate them. If we already have a permissions array and the user removes the package name and re-runs prebuild, the same permissions get appended again causing duplicates.

# How
In `getOrPromptApplicationId`,  drop the  spread from both call sites. This will only add the package name or bundle identifier

# Test Plan
Tested in the sandbox app and confirmed the manifest was in the expected state and also the app config is not altered.
