### PR TITLE
[docs] Infer counts in Prerequisites and Requirement components

### DIFF
--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -25,8 +25,8 @@ To use `expo-dev-client` in a project that uses [CNG](/workflow/continuous-nativ
 
 </Collapsible>
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="Install and configure the expo package">
+<Prerequisites>
+  <Requirement title="Install and configure the expo package">
     If you created your project with `npx @react-native-community/cli@latest init` and do not have
     any other Expo libraries installed, you will need to [install Expo
     modules](/bare/installing-expo-modules) before proceeding.

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -16,8 +16,8 @@ You may be reading the wrong guide. To use `expo-updates` in a project that uses
 
 </Collapsible>
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="Install and configure the expo package">
+<Prerequisites>
+  <Requirement title="Install and configure the expo package">
     If you created your project with `npx @react-native-community/cli@latest init` and do not have
     any other Expo libraries installed, you will need to [install Expo
     modules](/bare/installing-expo-modules) before proceeding.

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -18,15 +18,14 @@ This guide will walk you through the steps to add a React Native view into an ex
 
 > **info** Another popular technique is what we call the "isolated" approach, where your Expo app is packaged as a library and treated as a black box by the main existing application. See the [isolated approach guide](/brownfield/isolated-approach/) for details.
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Node.js (LTS)">
+<Prerequisites>
+  <Requirement title="Node.js (LTS)">
     Install [Node.js](https://nodejs.org/en/) to run JavaScript code and Expo CLI.
   </Requirement>
-  <Requirement number={2} title="Yarn">
+  <Requirement title="Yarn">
     Install [Yarn](https://yarnpkg.com/) as a package manager for JavaScript dependencies.
   </Requirement>
   <Requirement
-    number={3}
     title={
       <>
         CocoaPods <PlatformTag platform="ios" />

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -19,11 +19,11 @@ This approach is ideal when you want to minimize the impact of React Native on y
 
 > **info** For an alternative approach where React Native is integrated directly into your native project, see the [integrated approach guide](/brownfield/integrated-approach/).
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Node.js (LTS)">
+<Prerequisites>
+  <Requirement title="Node.js (LTS)">
     Install [Node.js](https://nodejs.org/en/) to run JavaScript code and Expo CLI.
   </Requirement>
-  <Requirement number={2} title="Yarn">
+  <Requirement title="Yarn">
     Install [Yarn](https://yarnpkg.com/) as a package manager for JavaScript dependencies.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/build-reference/local-builds.mdx
+++ b/docs/pages/build-reference/local-builds.mdx
@@ -16,8 +16,8 @@ You can run the same build process that is typically run on the EAS Build server
   cmd={['$ eas build --platform android --local', '# or', '$ eas build --platform ios --local']}
 />
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="Authenticate with Expo">
+<Prerequisites>
+  <Requirement title="Authenticate with Expo">
     Run `eas login`, or alternatively, set `EXPO_TOKEN` [using token-based
     authentication](/accounts/programmatic-access).
   </Requirement>

--- a/docs/pages/build-reference/npx-testflight.mdx
+++ b/docs/pages/build-reference/npx-testflight.mdx
@@ -11,15 +11,15 @@ import { CODE } from '~/ui/components/Text';
 
 [`npx testflight`](https://www.npmjs.com/package/testflight) is a CLI tool that walks you through building, signing, and submitting your iOS app to TestFlight.
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="A React Native iOS project">
+<Prerequisites>
+  <Requirement title="A React Native iOS project">
     A React Native iOS project you want to deploy to TestFlight.
   </Requirement>
-  <Requirement number={2} title="Apple Developer account">
+  <Requirement title="Apple Developer account">
     A paid [Apple Developer account](https://developer.apple.com/account/) is required for
     TestFlight distribution.
   </Requirement>
-  <Requirement number={3} title="Expo account">
+  <Requirement title="Expo account">
     Sign up for an [Expo](https://expo.dev/signup) account, if you haven't already.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/build-reference/repack.mdx
+++ b/docs/pages/build-reference/repack.mdx
@@ -11,12 +11,12 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 To learn more about how fingerprint and repack work together to accelerate CI, see [Accelerating Continuous Integration with Fingerprint and Repack in EAS Workflows](https://expo.dev/blog/accelerating-continuous-integration-with-fingerprint-repack-in-eas-workflows) blog post.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="An existing build artifact">
+<Prerequisites>
+  <Requirement title="An existing build artifact">
     A build artifact produced from your Expo project: an APK for Android, or an IPA or **.app**
     bundle for iOS.
   </Requirement>
-  <Requirement number={2} title="Signing credentials (optional)">
+  <Requirement title="Signing credentials (optional)">
     Required if the repacked artifact needs to be installable on a device. For more information, see
     [Signing](#signing).
   </Requirement>

--- a/docs/pages/build-reference/variants.mdx
+++ b/docs/pages/build-reference/variants.mdx
@@ -12,8 +12,8 @@ When creating [development, preview, and production builds](/build/eas-json/#com
 
 This guide provides the steps required to configure multiple (development and production) variants to install and use them on the same device.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="Unique Application ID or Bundle Identifier per variant">
+<Prerequisites>
+  <Requirement title="Unique Application ID or Bundle Identifier per variant">
     To have multiple variants of an app installed on your device, each variant must have a unique
     [Application ID (Android)](/versions/latest/config/app/#package) or [Bundle Identifier
     (iOS)](/versions/latest/config/app/#bundleidentifier).

--- a/docs/pages/build/building-from-github.mdx
+++ b/docs/pages/build/building-from-github.mdx
@@ -10,8 +10,8 @@ import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
 This guide explains how to trigger builds directly from your GitHub repository using the Expo GitHub App.
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Set the image field in eas.json">
+<Prerequisites>
+  <Requirement title="Set the image field in eas.json">
     For the build profiles you want to use with GitHub, specify an [`image`](/eas/json/#image) to use for the native platform in **eas.json**. Use the `latest` image if your project's configuration does not rely on a specific [build image](/build-reference/infrastructure/). For example:
 
 ```json eas.json
@@ -31,10 +31,10 @@ This guide explains how to trigger builds directly from your GitHub repository u
 ```
 
   </Requirement>
-  <Requirement number={2} title="A successful build from your local machine">
+  <Requirement title="A successful build from your local machine">
     To trigger EAS builds from a GitHub repository, you'll need to configure your project for EAS Build and successfully run a build from your computer for each platform that you'd like to support on GitHub. If you haven't successfully run `eas build -p [all|ios|android]` yet, see [Create your first build](/build/setup/) for more information.
   </Requirement>
-  <Requirement number={3} title="Linked GitHub account and app permissions">
+  <Requirement title="Linked GitHub account and app permissions">
     - An Expo user in the organization must have a linked GitHub user with access to the target repository. Check **Account settings** > **Overview** > **User settings** > [**Connections**](https://expo.dev/settings#connections) and verify that your GitHub user account is linked.
     - You must accept the permissions requested by the [Expo GitHub app](https://github.com/settings/installations).
   </Requirement>

--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -9,8 +9,8 @@ import { Terminal } from '~/ui/components/Snippet';
 
 This document outlines how to trigger builds on EAS for your app from a CI environment such as GitHub Actions, Travis CI, and more.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A successful build from your local machine">
+<Prerequisites>
+  <Requirement title="A successful build from your local machine">
     To trigger EAS builds from a CI environment, your app needs to be set up to use EAS Build in non-interactive mode. Run `eas build -p [all|android|ios]` from your local terminal for each platform you want to support on CI, so the `eas build` command can prompt for any additional configuration it needs. That configuration will then be available for future non-interactive runs.
 
     Running a build locally accomplishes the following critical configuration steps:

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -18,8 +18,8 @@ For a small app, builds for Android and iOS platforms trigger within a few minut
 
 > **info** EAS Build is a rapidly evolving service. Before you set out to create a build for your project we recommend consulting the [limitations](/build-reference/limitations) and the other prerequisites below.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="A React Native Android or iOS project">
+<Prerequisites>
+  <Requirement title="A React Native Android or iOS project">
     Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide:
 
     <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
@@ -27,7 +27,7 @@ For a small app, builds for Android and iOS platforms trigger within a few minut
     EAS Build also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 
   </Requirement>
-  <Requirement number={2} title="An Expo account">
+  <Requirement title="An Expo account">
     EAS Build is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan. You can sign up at [expo.dev](https://expo.dev/signup).
 
     Paid subscribers get quality improvements such as additional build concurrencies, priority access to minimize the time your builds spend queueing, and increased limits on build timeouts. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -23,11 +23,11 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 ## Apple App Store
 
-<Prerequisites numberOfRequirements={4}>
-  <Requirement number={1} title="Sign up for an Apple Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for an Apple Developer account">
     An Apple Developer account is required to submit your app to the Apple App Store. You can sign up for an Apple Developer account on the [Apple Developer Portal](https://developer.apple.com/account/).
   </Requirement>
-  <Requirement number={2} title="Include a bundle identifier in app.json">
+  <Requirement title="Include a bundle identifier in app.json">
     Include your app's bundle identifier in **app.json**:
 
     ```json app.json
@@ -39,13 +39,13 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
     ```
 
   </Requirement>
-  <Requirement number={3} title="Install EAS CLI and authenticate with your Expo account">
+  <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
 
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
 
   </Requirement>
-  <Requirement number={4} title="Build a production app">
+  <Requirement title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
 
     <Terminal cmd={['$ eas build --platform ios --profile production']} />
@@ -65,23 +65,23 @@ The command will lead you step by step through the process of submitting the app
 
 ## Google Play Store
 
-<Prerequisites numberOfRequirements={7}>
-  <Requirement number={1} title="Sign up for a Google Play Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for a Google Play Developer account">
     A Google Play Developer account is required to submit your app to the Google Play Store. You can sign up for a Google Play Developer account on the [Google Play Console sign-up page](https://play.google.com/apps/publish/signup/).
   </Requirement>
-  <Requirement number={2} title="Create a Google Service Account">
+  <Requirement title="Create a Google Service Account">
     EAS requires you to upload and configure a Google Service Account Key to submit your Android app to the Google Play Store. You can create one with the [uploading a Google Service Account Key for Play Store submissions with EAS](https://github.com/expo/fyi/blob/main/creating-google-service-account.md) guide.
   </Requirement>
-  <Requirement number={3} title="Create an app on Google Play Console">
+  <Requirement title="Create an app on Google Play Console">
     Create an app by clicking **Create app** in the [Google Play Console](https://play.google.com/apps/publish/).
   </Requirement>
-  <Requirement number={4} title="Install EAS CLI and authenticate with your Expo account">
+  <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
 
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
 
   </Requirement>
-  <Requirement number={5} title="Include a package name in app.json">
+  <Requirement title="Include a package name in app.json">
     Include your app's package name in **app.json**:
 
     ```json app.json
@@ -93,7 +93,7 @@ The command will lead you step by step through the process of submitting the app
     ```
 
   </Requirement>
-  <Requirement number={6} title="Build a production app">
+  <Requirement title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
 
     <Terminal cmd={['$ eas build --platform android --profile production']} />
@@ -101,7 +101,7 @@ The command will lead you step by step through the process of submitting the app
     Alternatively, you can build the app on your own computer with `eas build --platform android --profile production --local` or with Android Studio.
 
   </Requirement>
-  <Requirement number={7} title="Upload your app manually at least once">
+  <Requirement title="Upload your app manually at least once">
     You have to upload your app manually at least once. This is a limitation of the Google Play Store API.
 
     Learn how with the [first submission of an Android app](https://expo.fyi/first-android-submission) guide.

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -10,9 +10,8 @@ import { CODE } from '~/ui/components/Text';
 
 If you are building a universal app, you can quickly deploy your web app using [EAS Hosting](/eas/hosting/introduction/). It is a service for deploying web apps built with Expo Router and React.
 
-<Prerequisites numberOfRequirements={1}>
+<Prerequisites>
   <Requirement
-    number={1}
     title={
       <>
         Set <CODE>expo.web.output</CODE> in app.json

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -95,15 +95,15 @@ Apps that don't use [Continuous Native Generation](/workflow/continuous-native-g
 
 ### Build the native app (Android)
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Expo account">
+<Prerequisites>
+  <Requirement title="Expo account">
     Sign up for an [Expo](https://expo.dev/signup) account, if you haven't already.
   </Requirement>
-  <Requirement number={2} title="EAS CLI">
+  <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
   </Requirement>
-  <Requirement number={3} title="An Android Emulator (optional)">
+  <Requirement title="An Android Emulator (optional)">
     An [Android Emulator](/workflow/android-studio-emulator/) is optional if you want to test your
     app on an emulator.
   </Requirement>
@@ -119,15 +119,15 @@ Read more about [Android builds on EAS](/tutorial/eas/android-development-build)
 
 ### Build the native app (iOS Simulator)
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Expo account">
+<Prerequisites>
+  <Requirement title="Expo account">
     Sign up for an [Expo](https://expo.dev/signup) account, if you haven't already.
   </Requirement>
-  <Requirement number={2} title="EAS CLI">
+  <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
   </Requirement>
-  <Requirement number={3} title="macOS with iOS Simulator installed">
+  <Requirement title="macOS with iOS Simulator installed">
     iOS Simulators are available only on macOS. Make sure you have the [iOS
     Simulator](/workflow/ios-simulator/) installed.
   </Requirement>
@@ -158,15 +158,15 @@ Read more about [iOS Simulator builds on EAS](/tutorial/eas/ios-development-buil
 <Step label="2">
 ### Build the native app (iOS device)
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Expo account">
+<Prerequisites>
+  <Requirement title="Expo account">
     Sign up for an [Expo](https://expo.dev/signup) account, if you haven't already.
   </Requirement>
-  <Requirement number={2} title="EAS CLI">
+  <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
   </Requirement>
-  <Requirement number={3} title="Apple Developer account">
+  <Requirement title="Apple Developer account">
     A paid [Apple Developer](https://developer.apple.com/) account for creating [signing
     credentials](/app-signing/managed-credentials/#generating-app-signing-credentials) so the app
     could be installed on an iOS device.

--- a/docs/pages/eas-update/bundle-diffing.mdx
+++ b/docs/pages/eas-update/bundle-diffing.mdx
@@ -11,10 +11,8 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 Enable bundle diffing to let EAS Update deliver a **bundle patch** when possible. When you publish a new update, EAS Update can generate a smaller file containing only the differences between the bundle currently running on the device and the new bundle. This often reduces update download size significantly.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="Expo SDK 55 or later">
-    Your app must be on Expo SDK 55 or later.
-  </Requirement>
+<Prerequisites>
+  <Requirement title="Expo SDK 55 or later">Your app must be on Expo SDK 55 or later.</Requirement>
 </Prerequisites>
 
 ## Enable bundle diffing

--- a/docs/pages/eas-update/expo-dev-client.mdx
+++ b/docs/pages/eas-update/expo-dev-client.mdx
@@ -17,13 +17,12 @@ import { CODE } from '~/ui/components/Text';
 
 This guide walks through the steps required to load and preview a published update inside a development build using the **Extensions** tab or constructing a specific Update URL.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="A development build installed">
+<Prerequisites>
+  <Requirement title="A development build installed">
     [Create a development build and install it](/develop/development-builds/create-a-build/) on your
     device, Android Emulator, or iOS Simulator.
   </Requirement>
   <Requirement
-    number={2}
     title={
       <>
         <CODE>expo-updates</CODE> installed

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -17,14 +17,14 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
 > **info** If you plan to use EAS Update with EAS Build, we recommend following the [EAS Build setup guide](/build/setup/) before proceeding here. That said, [you can use EAS Update without any other EAS services](/eas-update/standalone-service/).
 
-<Prerequisites numberOfRequirements={4}>
-  <Requirement number={1} title="An Expo account">
+<Prerequisites>
+  <Requirement title="An Expo account">
     EAS Update is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan. You can sign up at [expo.dev/signup](https://expo.dev/signup).
 
     Paid subscribers can publish updates to more users and use more bandwidth and storage. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
 
   </Requirement>
-  <Requirement number={2} title="A React Native project">
+  <Requirement title="A React Native project">
     Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide. Run the following command to create a new project:
 
     <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />
@@ -32,7 +32,7 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
     EAS Update also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 
   </Requirement>
-  <Requirement number={3} title="Expo CLI and the Expo Metro Config">
+  <Requirement title="Expo CLI and the Expo Metro Config">
     If you already run your project with `npx expo [command]` (for example, if you created it with `npx create-expo-app`), you're all set.
 
     If you don't have the `expo` package in your project yet, install it by running the command below and [opt in to using Expo CLI and Metro Config](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios):
@@ -43,7 +43,6 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
   </Requirement>
   <Requirement
-    number={4}
     title={
       <>
         Use <CODE>registerRootComponent</CODE> instead of <CODE>registerComponent</CODE>

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -19,36 +19,35 @@ Instructions are not available for older Expo SDK and React Native versions. Add
 
 > **warning** The following instructions may not work for all projects. The specifics of integrating EAS Update into existing projects depend heavily on the specifics of your app, and so you may need to adapt the instructions to your unique setup. If you encounter issues, [create an issue on GitHub](https://github.com/expo/expo/issues) or open a pull request to suggest improvements to this guide.
 
-<Prerequisites numberOfRequirements={7}>
-  <Requirement number={1} title="A brownfield native project with React Native">
+<Prerequisites>
+  <Requirement title="A brownfield native project with React Native">
     You should have a brownfield native project with React Native installed and configured to render
     a root view. If you don't have this yet, follow the [Integration with Existing
     Apps](https://reactnative.dev/docs/integration-with-existing-apps) guide from the React Native
     documentation and then come back here.
   </Requirement>
-  <Requirement number={2} title="Latest Expo SDK and supported React Native">
+  <Requirement title="Latest Expo SDK and supported React Native">
     Your app must be using the [latest Expo SDK version and its supported React Native
     version](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).
   </Requirement>
-  <Requirement number={3} title="No other update libraries">
+  <Requirement title="No other update libraries">
     Remove any other update library integration from your app, such as `react-native-code-push`, and
     ensure that your app compiles and runs successfully in both debug and release on your supported
     platforms.
   </Requirement>
-  <Requirement number={4} title="Expo modules installed">
+  <Requirement title="Expo modules installed">
     Support for Expo modules (through the `expo` package) must be installed and configured in your
     project. See [Integrating Expo tools into existing native apps](/brownfield/overview/) for more
     information.
   </Requirement>
-  <Requirement number={5} title="metro.config.js extends expo/metro-config">
+  <Requirement title="metro.config.js extends expo/metro-config">
     Your **metro.config.js** [must extend
     `expo/metro-config`](/guides/customizing-metro/#customizing).
   </Requirement>
-  <Requirement number={6} title="babel.config.js extends babel-preset-expo">
+  <Requirement title="babel.config.js extends babel-preset-expo">
     Your **babel.config.js** [must extend `babel-preset-expo`](/versions/latest/config/babel/).
   </Requirement>
   <Requirement
-    number={7}
     title={
       <>
         <CODE>npx expo export</CODE> runs successfully

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -12,8 +12,8 @@ import { A } from '~/ui/components/Text';
 
 EAS Update is the next generation of Expo's updates service. If you're using Classic Updates, this guide will help you upgrade to EAS Update.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="Minimum versions for EAS Update">
+<Prerequisites>
+  <Requirement title="Minimum versions for EAS Update">
     EAS Update requires the following versions or greater:
 
     - Expo SDK 45.0.0 and later

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -61,15 +61,15 @@ Your AI-assisted tools can autonomously write the code, capture screenshots to v
 
 The complete table of [MCP capabilities](#available-mcp-capabilities) documents the tools and prompts Expo MCP Server provides to AI-assisted tools.
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Expo account with an EAS paid plan">
+<Prerequisites>
+  <Requirement title="Expo account with an EAS paid plan">
     An [EAS paid plan](https://expo.dev/pricing) is required to use Expo MCP Server.
   </Requirement>
-  <Requirement number={2} title="An Expo project on the latest SDK">
+  <Requirement title="An Expo project on the latest SDK">
     Create a project with `npx create-expo-app@latest --template default@sdk-55`, or ensure your
     existing project has the latest `expo` package installed.
   </Requirement>
-  <Requirement number={3} title="An AI-assisted tool with remote MCP support">
+  <Requirement title="An AI-assisted tool with remote MCP support">
     Claude Code, Cursor, VS Code, or any other tool with remote MCP server support.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/eas/hosting/custom-domain.mdx
+++ b/docs/pages/eas/hosting/custom-domain.mdx
@@ -12,14 +12,12 @@ Each project can have exactly one custom domain, which is assigned to the produc
 
 > **info** **Note**: Setting up a custom domain is a premium feature and isn't available on the free plan. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing).
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="An EAS Hosting project with a production deployment">
+<Prerequisites>
+  <Requirement title="An EAS Hosting project with a production deployment">
     The custom domain will always load the production deployment. To add a custom domain to your
     project, you need a deployment that's been promoted to production first.
   </Requirement>
-  <Requirement number={2} title="A domain name">
-    You need to own a domain name you want to use.
-  </Requirement>
+  <Requirement title="A domain name">You need to own a domain name you want to use.</Requirement>
 </Prerequisites>
 
 ## Assigning a custom domain

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -23,14 +23,14 @@ This guide will walk you through the process of creating your first web deployme
 
 ---
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="An Expo account">
+<Prerequisites>
+  <Requirement title="An Expo account">
     EAS Hosting is available to anyone with an Expo account, regardless of whether you pay for EAS or use the Free plan. You can sign up at [expo.dev/signup](https://expo.dev/signup).
 
     Paid subscribers can create more deployments, have more bandwidth, storage, and requests, and may set up a custom domain. Learn more about different plans and benefits at [EAS pricing](https://expo.dev/pricing#host).
 
   </Requirement>
-  <Requirement number={2} title="An Expo Router web project">
+  <Requirement title="An Expo Router web project">
     Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide. Run the following command to create a new project:
 
     <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-55']} />

--- a/docs/pages/eas/metadata/getting-started.mdx
+++ b/docs/pages/eas/metadata/getting-started.mdx
@@ -14,8 +14,8 @@ import { Terminal } from '~/ui/components/Snippet';
 
 EAS Metadata enables you to automate and maintain your app store presence from the command line. It uses a [**store.config.json**](./config.mdx#static-store-config) file containing all required app information instead of going through multiple different forms. It also tries to find common pitfalls that could cause app rejections with built-in validation.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="An app on the Apple App Store">
+<Prerequisites>
+  <Requirement title="An app on the Apple App Store">
     EAS Metadata currently only supports the Apple App Store. You need an app registered with Apple
     to manage metadata for.
   </Requirement>

--- a/docs/pages/eas/workflows/examples/create-development-builds.mdx
+++ b/docs/pages/eas/workflows/examples/create-development-builds.mdx
@@ -29,8 +29,8 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 ## Get started
 
-<Prerequisites summary="Prerequisites" numberOfRequirements={2}>
-  <Requirement number={1} title="Set up your environment">
+<Prerequisites>
+  <Requirement title="Set up your environment">
     To get started, you'll need to configure your project and devices to build and run development builds. Learn how to set up your environment for development builds with the following guides:
 
 <BoxLink
@@ -62,7 +62,7 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 />
 
   </Requirement>
-  <Requirement number={2} title="Create build profiles">
+  <Requirement title="Create build profiles">
   After you've configured your project and devices, add the following build profiles to your **eas.json** file.
 
 ```json eas.json

--- a/docs/pages/eas/workflows/examples/deploy-to-production.mdx
+++ b/docs/pages/eas/workflows/examples/deploy-to-production.mdx
@@ -29,8 +29,8 @@ When you're ready to deliver changes to your users, you can build and submit to 
 
 ## Get started
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Set up EAS Build">
+<Prerequisites>
+  <Requirement title="Set up EAS Build">
     To set up EAS Build, follow this guide:
 
     <BoxLink
@@ -42,7 +42,7 @@ When you're ready to deliver changes to your users, you can build and submit to 
 
   </Requirement>
 
-  <Requirement number={2} title="Set up EAS Submit">
+  <Requirement title="Set up EAS Submit">
     To set up EAS Submit, follow the Google Play Store and Apple App Store submissions guides:
 
     <BoxLink
@@ -59,7 +59,7 @@ When you're ready to deliver changes to your users, you can build and submit to 
     />
 
   </Requirement>
-  <Requirement number={3} title="Set up EAS Update">
+  <Requirement title="Set up EAS Update">
   And finally, you'll need to set up EAS Update, which you can do with:
 
 <Terminal cmd={['$ eas update:configure']} />

--- a/docs/pages/eas/workflows/examples/publish-preview-update.mdx
+++ b/docs/pages/eas/workflows/examples/publish-preview-update.mdx
@@ -28,14 +28,14 @@ You can access preview updates in the development build UI and through scannable
 
 ## Get started
 
-<Prerequisites summary="Prerequisites" numberOfRequirements={2}>
-  <Requirement number={1} title="Set up EAS Update">
+<Prerequisites>
+  <Requirement title="Set up EAS Update">
     Your project needs to have [EAS Update](/eas-update/introduction/) setup to publish preview updates. You can set up your project with:
 
     <Terminal cmd={['$ eas update:configure']} />
 
   </Requirement>
-  <Requirement number={2} title="Create new development builds">
+  <Requirement title="Create new development builds">
     After you've configured your project, create new [development builds](/develop/development-builds/create-a-build/) for each platform.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -14,23 +14,23 @@ This page walks you through the process of creating your first EAS Workflows for
 
 ## Get started
 
-<Prerequisites numberOfRequirements={4}>
-  <Requirement number={1} title="Sign up for an Expo account">
+<Prerequisites>
+  <Requirement title="Sign up for an Expo account">
     You'll need to [sign up](https://expo.dev/signup) for an Expo account.
   </Requirement>
-  <Requirement number={2} title="Create a project">
+  <Requirement title="Create a project">
     You'll need to create a project with the following command:
 
     <Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-55']} />
 
   </Requirement>
-  <Requirement number={3} title="Sync the project with EAS">
+  <Requirement title="Sync the project with EAS">
     You'll need to sync the project with EAS with the following command. This will create an EAS project and link it to your local project:
 
     <Terminal cmd={['$ npx eas-cli@latest init']} />
 
   </Requirement>
-  <Requirement number={4} title="Add eas.json">
+  <Requirement title="Add eas.json">
     You'll need to add an `eas.json` file to the root of your project if it doesn't already exist:
 
     <Terminal cmd={['$ touch eas.json && echo "{}" > eas.json']} />

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -16,8 +16,8 @@ Build your project into an Android or iOS app.
 
 Build jobs can be customized so that you can execute custom commands during the build process. See [Custom builds](/custom-builds/get-started/) for more information.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A completed build from your local machine">
+<Prerequisites>
+  <Requirement title="A completed build from your local machine">
     Complete a build with EAS CLI using the same platform and profile as the pre-packaged job. Learn
     how to [create your first build](/build/setup/) to get started.
   </Requirement>
@@ -183,8 +183,8 @@ jobs:
 
 Deploy your application using [EAS Hosting](/eas/hosting/introduction).
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A project set up for EAS Hosting">
+<Prerequisites>
+  <Requirement title="A project set up for EAS Hosting">
     See [Get started with EAS Hosting](/eas/hosting/get-started/#prerequisites) for setup
     instructions.
   </Requirement>
@@ -502,8 +502,8 @@ jobs:
 
 Submit an Android or iOS build to the app store using EAS Submit.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="CI/CD submission configuration">
+<Prerequisites>
+  <Requirement title="CI/CD submission configuration">
     Submission jobs require additional configuration to run within a CI/CD process. See the [Google
     Play Store CI/CD submission guide](/submit/android/#submitting-your-app-using-cicd-services) and
     [Apple App Store CI/CD submission guide](/submit/ios/#submitting-your-app-using-cicd-services)
@@ -602,8 +602,8 @@ jobs:
 
 Distribute iOS builds to TestFlight internal and external testing groups. This is an alternative to the iOS submit job for when you need more advanced TestFlight features. If you need to control test groups, changelog, or Beta App Review submission, use the `testflight` job instead of submit.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="An iOS store build and Apple Developer account">
+<Prerequisites>
+  <Requirement title="An iOS store build and Apple Developer account">
     TestFlight jobs require an iOS build created with `distribution: store` and an Apple Developer
     account configured. See the [TestFlight submission
     guide](/submit/ios/#submitting-your-app-using-cicd-services) for more information.
@@ -708,8 +708,8 @@ jobs:
 
 Publish an update using [EAS Update](/eas-update/introduction/).
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="EAS Update configured">
+<Prerequisites>
+  <Requirement title="EAS Update configured">
     To publish update previews and to send over-the-air updates. Run `npx eas-cli@latest
     update:configure`, then create new builds. Learn more about [configuring EAS
     Update](/eas-update/getting-started/#prerequisites).
@@ -1242,8 +1242,8 @@ jobs:
 
 Automatically post reports of your workflow's completed builds, updates, and deployments to GitHub pull requests. It's particularly useful for providing instant feedback on PR builds, sharing test builds with QR codes for easy device testing, displaying EAS Hosting deployment previews, and automating deployment notifications. You can also override the comment contents by providing the `payload` parameter.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A GitHub repository connected to your project">
+<Prerequisites>
+  <Requirement title="A GitHub repository connected to your project">
     To use the GitHub Comment job, your project must have a GitHub repository connected. Learn how
     to [connect your GitHub repository](/build/building-from-github/) to get started.
   </Requirement>

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -39,19 +39,19 @@ The necessary changes to the native Android and iOS files are minimal and can be
 
 ### Android TV
 
-<Prerequisites numberOfRequirements={4}>
-  <Requirement number={1} title="Node.js (LTS)">
+<Prerequisites>
+  <Requirement title="Node.js (LTS)">
     Install [Node.js (LTS)](https://nodejs.org/en/) on macOS or Linux.
   </Requirement>
-  <Requirement number={2} title="Android Studio (Iguana or later)">
+  <Requirement title="Android Studio (Iguana or later)">
     Install Android Studio Iguana or later.
   </Requirement>
-  <Requirement number={3} title="Android TV system image">
+  <Requirement title="Android TV system image">
     In the Android Studio SDK manager, select the dropdown for the Android SDK you are using (API
     version 31 or later), and make sure an Android TV system image is selected for installation. For
     Apple silicon, choose the ARM 64 image. Otherwise, choose the Intel x86_64 image.
   </Requirement>
-  <Requirement number={4} title="Android TV emulator">
+  <Requirement title="Android TV emulator">
     After installing the Android TV system image, create an Android TV emulator using that image
     (the process is the same as creating an Android phone emulator).
   </Requirement>
@@ -59,14 +59,12 @@ The necessary changes to the native Android and iOS files are minimal and can be
 
 ### Apple TV
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Node.js (LTS)">
+<Prerequisites>
+  <Requirement title="Node.js (LTS)">
     Install [Node.js (LTS)](https://nodejs.org/en/) on macOS.
   </Requirement>
-  <Requirement number={2} title="Xcode 16 or later">
-    Install Xcode 16 or later.
-  </Requirement>
-  <Requirement number={3} title="tvOS SDK 17 or later">
+  <Requirement title="Xcode 16 or later">Install Xcode 16 or later.</Requirement>
+  <Requirement title="tvOS SDK 17 or later">
     tvOS SDK 17 or later is not installed automatically with Xcode. You can install it later with
     `xcodebuild -downloadAllPlatforms`.
   </Requirement>

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -14,8 +14,8 @@ Expo offers a novel approach to work with modern web code directly in a native a
 
 While the Expo native runtime generally does not support elements like `<div>` or `<img>`, there may be instances where you need to quickly incorporate web components. In such cases, DOM components provide a useful solution.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Expo CLI and the Expo Metro Config">
+<Prerequisites>
+  <Requirement title="Expo CLI and the Expo Metro Config">
     If you already run your project with `npx expo [command]` (for example, if you created it with `npx create-expo-app`), you're all set.
 
     If you don't have the `expo` package in your project yet, install it by running the command below and [opt in to using Expo CLI and Metro Config](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios):
@@ -25,7 +25,7 @@ While the Expo native runtime generally does not support elements like `<div>` o
     If the command fails, refer to the [Installing Expo modules](/bare/installing-expo-modules/#manual-installation) guide.
 
   </Requirement>
-  <Requirement number={2} title="Expo Metro Runtime, React DOM, and React Native Web">
+  <Requirement title="Expo Metro Runtime, React DOM, and React Native Web">
     If you are using Expo Router and Expo Web, you can skip this step. Otherwise, install the following packages:
 
     <Terminal cmd={['$ npx expo install @expo/metro-runtime react-dom react-native-web']} />

--- a/docs/pages/guides/expo-ui-swift-ui/extending.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/extending.mdx
@@ -12,17 +12,17 @@ import { CODE } from '~/ui/components/Text';
 
 This guide explains how to create custom SwiftUI components and modifiers that integrate seamlessly with Expo UI.
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title={<><CODE>@expo/ui</CODE> installed</>}>
+<Prerequisites>
+  <Requirement title={<><CODE>@expo/ui</CODE> installed</>}>
     Install `@expo/ui` in your project. See [Building SwiftUI apps with Expo UI](/guides/expo-ui-swift-ui/) for more information.
 
     <Terminal cmd={['$ npx expo install @expo/ui']} />
 
   </Requirement>
-  <Requirement number={2} title="A development build">
+  <Requirement title="A development build">
     Expo UI is not available in Expo Go. Create a [development build](/develop/development-builds/introduction/) of your app.
   </Requirement>
-  <Requirement number={3} title="Familiarity with Expo Modules API and SwiftUI">
+  <Requirement title="Familiarity with Expo Modules API and SwiftUI">
     Basic familiarity with [Expo Modules API](/modules/overview/) and [SwiftUI](https://developer.apple.com/swiftui/) is recommended.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/guides/facebook-authentication.mdx
+++ b/docs/pages/guides/facebook-authentication.mdx
@@ -11,8 +11,8 @@ The [`react-native-fbsdk-next`](https://github.com/thebergamo/react-native-fbsdk
 
 This guide provides additional information on configuring the library with Expo for Android.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A development build">
+<Prerequisites>
+  <Requirement title="A development build">
     The `react-native-fbsdk-next` library can't be used in Expo Go because it requires custom native
     code. Learn more about [adding custom native code to your app](/workflow/customizing/).
   </Requirement>

--- a/docs/pages/guides/google-authentication.mdx
+++ b/docs/pages/guides/google-authentication.mdx
@@ -10,8 +10,8 @@ The [`@react-native-google-signin/google-signin`](https://github.com/react-nativ
 
 This guide provides information on how to configure the library for your project.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A development build">
+<Prerequisites>
+  <Requirement title="A development build">
     The `@react-native-google-signin/google-signin` library can't be used in Expo Go because it
     requires custom native code. Learn more about [adding custom native code to your
     app](/workflow/customizing/).

--- a/docs/pages/guides/ios-developer-mode.mdx
+++ b/docs/pages/guides/ios-developer-mode.mdx
@@ -16,8 +16,8 @@ There are two ways you can enable Developer Mode on your device:
 - Directly on an iOS device
 - By connecting an iOS device with a Mac that has Xcode installed
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A device running iOS 16 or later">
+<Prerequisites>
+  <Requirement title="A device running iOS 16 or later">
     Developer Mode is only required on devices running iOS 16 and later.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/guides/keyboard-handling.mdx
+++ b/docs/pages/guides/keyboard-handling.mdx
@@ -122,13 +122,12 @@ export default function HomeScreen() {
 
 For more complex keyboard interactions, such as larger scrollable entry forms with several text input fields, consider using the [`react-native-keyboard-controller` (Keyboard Controller)](https://kirillzyusko.github.io/react-native-keyboard-controller) library. It offers additional functionality beyond the built-in React Native keyboard APIs, providing consistency across Android and iOS with minimal configuration and offering the native feel users expect.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="A development build">
+<Prerequisites>
+  <Requirement title="A development build">
     The Keyboard Controller library is not included in Expo Go. See [Create a development
     build](/develop/development-builds/create-a-build/) for more information.
   </Requirement>
   <Requirement
-    number={2}
     title={
       <>
         <CODE>react-native-reanimated</CODE> installed

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -14,13 +14,13 @@ import { CODE } from '~/ui/components/Text';
 
 To build your project into an app locally using your machine, you have to manually generate native code before testing the debug build or creating a production build for it to submit to the app store. There are two ways you can build your app locally. This guide provides a brief introduction to both methods and references to other guides that are necessary to create this workflow.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Android Studio">
+<Prerequisites>
+  <Requirement title="Android Studio">
     [Set up Android
     Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build)
     to compile and run Android projects on your local machine.
   </Requirement>
-  <Requirement number={2} title="Xcode">
+  <Requirement title="Xcode">
     [Set up
     Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build)
     to compile and run iOS projects on your local machine.

--- a/docs/pages/guides/local-app-overview.mdx
+++ b/docs/pages/guides/local-app-overview.mdx
@@ -26,13 +26,13 @@ There are different scenarios when you want to build your app on your developer 
 
 > **Note**: Building your app locally complements EAS Build. You can keep using the build service for cloud automation and fall back to local builds for development.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Android Studio">
+<Prerequisites>
+  <Requirement title="Android Studio">
     [Set up Android
     Studio](/get-started/set-up-your-environment/?platform=android&device=physical&mode=development-build&buildEnv=local#set-up-an-android-device-with-a-development-build)
     to compile and run Android projects on your local machine.
   </Requirement>
-  <Requirement number={2} title="Xcode">
+  <Requirement title="Xcode">
     [Set up
     Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-an-ios-device-with-a-development-build)
     to compile and run iOS projects on your local machine.

--- a/docs/pages/guides/local-app-production.mdx
+++ b/docs/pages/guides/local-app-production.mdx
@@ -18,13 +18,13 @@ To create your app's release build (also known as production build) locally, you
 
 Creating a release build locally for Android requires signing it with an [upload key](https://developer.android.com/studio/publish/app-signing#certificates-keystores) and generating an Android Application Bundle (**.aab**). Follow the steps below:
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="OpenJDK installed">
+<Prerequisites>
+  <Requirement title="OpenJDK installed">
     Install an [OpenJDK
     distribution](/get-started/set-up-your-environment/?mode=development-build&buildEnv=local#install-watchman-and-jdk)
     to access the `keytool` command.
   </Requirement>
-  <Requirement number={2} title="android directory generated">
+  <Requirement title="android directory generated">
     If you are using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/),
     run `npx expo prebuild` to generate it.
   </Requirement>
@@ -130,16 +130,16 @@ Google Play Store requires manual app submission when submitting the **.aab** fi
 
 To create an iOS release build locally for Apple App Store, you need to use Xcode which handles the signing and submission process via App Store Connect.
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Apple Developer membership">
+<Prerequisites>
+  <Requirement title="Apple Developer membership">
     A paid Apple Developer membership is required to sign and submit iOS apps.
   </Requirement>
-  <Requirement number={2} title="Xcode installed">
+  <Requirement title="Xcode installed">
     [Install
     Xcode](/get-started/set-up-your-environment/?platform=ios&device=physical&mode=development-build&buildEnv=local#set-up-xcode-and-watchman)
     on your computer.
   </Requirement>
-  <Requirement number={3} title="ios directory generated">
+  <Requirement title="ios directory generated">
     If you are using [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/),
     run `npx expo prebuild` to generate it.
   </Requirement>

--- a/docs/pages/guides/local-https-development.mdx
+++ b/docs/pages/guides/local-https-development.mdx
@@ -11,9 +11,8 @@ import { CODE } from '~/ui/components/Text';
 
 When developing Expo web apps locally, you may need to use HTTPS with your local development environment for testing secure browser APIs. This guide shows you how to set up local HTTPS for Expo web apps.
 
-<Prerequisites numberOfRequirements={1}>
+<Prerequisites>
   <Requirement
-    number={1}
     title={
       <>
         <CODE>mkcert</CODE> installed

--- a/docs/pages/guides/server-components.mdx
+++ b/docs/pages/guides/server-components.mdx
@@ -21,11 +21,11 @@ React Server Components enable a number of exciting capabilities, including:
 
 Expo Router enables support for [React Server Components](https://react.dev/reference/rsc/server-components) on all platforms. This is an early [preview](/more/release-statuses/#preview) of a feature that will be enabled by default in Expo Router.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="A project using Expo Router">
+<Prerequisites>
+  <Requirement title="A project using Expo Router">
     See [Expo Router installation](/router/installation/) if you don't have one yet.
   </Requirement>
-  <Requirement number={2} title="React Native New Architecture">
+  <Requirement title="React Native New Architecture">
     React Native New Architecture is required, and is enabled by default from SDK 52.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -14,8 +14,8 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 
 [Tailwind CSS](https://tailwindcss.com/) is a utility-first CSS framework and can be used with Metro for web projects. This guide explains how to configure your Expo project to use the framework.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A project using Metro for web">
+<Prerequisites>
+  <Requirement title="A project using Metro for web">
     Ensure your project is using Metro for web. Verify this by checking that `web.bundler` is set to `metro` in **app.json**:
 
     ```json app.json

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -8,11 +8,11 @@ import { Terminal } from '~/ui/components/Snippet';
 
 [Bun](https://bun.sh/) is a JavaScript runtime and a drop-in alternative for [Node.js](https://nodejs.org/en). In Expo projects, Bun can be used to install npm packages and run Node.js scripts. The benefits of using Bun are faster package installation than npm, pnpm, or Yarn and [at least 4x faster startup time compared to Node.js](https://bun.sh/docs#design-goals), which gives a huge boost to your local development experience.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Bun installed on your machine">
+<Prerequisites>
+  <Requirement title="Bun installed on your machine">
     [Install Bun](https://bun.sh/docs/installation#installing) to create a new app.
   </Requirement>
-  <Requirement number={2} title="Node.js (LTS)">
+  <Requirement title="Node.js (LTS)">
     A [Node.js (LTS) version](https://nodejs.org/) is still required for the `bun create expo` and
     `bun expo prebuild` commands, which use `npm pack` to download project templates.
   </Requirement>

--- a/docs/pages/guides/using-firebase.mdx
+++ b/docs/pages/guides/using-firebase.mdx
@@ -27,8 +27,8 @@ There are two different ways you can use Firebase in your projects:
 
 React Native supports both the JS SDK and the native SDK. The following sections will guide you through when to use which SDK and all the configuration steps required to use Firebase in your Expo projects.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A Firebase project">
+<Prerequisites>
+  <Requirement title="A Firebase project">
     Create a new Firebase project or use an existing one in the [Firebase
     console](https://console.firebase.google.com/).
   </Requirement>

--- a/docs/pages/guides/using-resend.mdx
+++ b/docs/pages/guides/using-resend.mdx
@@ -20,20 +20,18 @@ This guide demonstrates the **essential steps to integrate Resend with your Expo
 
 ---
 
-<Prerequisites numberOfRequirements={4}>
-  <Requirement number={1} title="A project using Expo Router">
+<Prerequisites>
+  <Requirement title="A project using Expo Router">
     See [Expo Router installation](/router/installation/) if you don't have one yet.
   </Requirement>
-  <Requirement number={2} title="An Expo account">
+  <Requirement title="An Expo account">
     An [Expo account](https://expo.dev/signup) is required to deploy the API route using EAS
     Hosting.
   </Requirement>
-  <Requirement number={3} title="EAS CLI installed globally">
+  <Requirement title="EAS CLI installed globally">
     Install [EAS CLI](/eas/cli/) with `npm install -g eas-cli`.
   </Requirement>
-  <Requirement number={4} title="A Resend account">
-    Sign up at [resend.com](https://resend.com/).
-  </Requirement>
+  <Requirement title="A Resend account">Sign up at [resend.com](https://resend.com/).</Requirement>
 </Prerequisites>
 
 <Step label="1">

--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -14,11 +14,11 @@ Supabase automatically [generates a REST API](https://supabase.com/docs/guides/a
 
 Supabase provides a TypeScript client library called [`supabase-js`](https://supabase.com/docs/reference/javascript/introduction?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) to interact with the REST API. Alternatively, Supabase also exposes a [GraphQL API](https://supabase.com/docs/guides/database/extensions/pg_graphql?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) allowing you to use your favorite GraphQL client (for example, [Apollo Client](https://supabase.github.io/pg_graphql/usage_with_apollo/)) should you wish to.
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="A Supabase project">
+<Prerequisites>
+  <Requirement title="A Supabase project">
     Head over to [database.new](https://database.new?utm_source=expo&utm_medium=referral&utm_term=expo-react-native) to create a new Supabase project.
   </Requirement>
-  <Requirement number={2} title="Project URL and Publishable key">
+  <Requirement title="Project URL and Publishable key">
     Get the **Project URL** from the API settings and **Publishable key** from the API Keys:
 
     1. Go to the [API Settings](https://supabase.com/dashboard/project/_/settings/api) page in the Dashboard.

--- a/docs/pages/modules/existing-library.mdx
+++ b/docs/pages/modules/existing-library.mdx
@@ -11,8 +11,8 @@ There are cases where you may want to integrate the Expo Modules API into an exi
 
 This guide will help you set up your existing React Native library to access Expo Modules API.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="Create expo-module.config.json">
+<Prerequisites>
+  <Requirement title="Create expo-module.config.json">
     Create the [**expo-module.config.json**](/modules/module-config/) file at the root of your project and add an empty object `{}` inside it. You will update it later to enable specific features.
 
     This file is required for [Expo Autolinking](/modules/autolinking/) to recognize your library as an Expo module and automatically link your native code.

--- a/docs/pages/push-notifications/push-notifications-setup.mdx
+++ b/docs/pages/push-notifications/push-notifications-setup.mdx
@@ -35,8 +35,8 @@ If you need finer-grained control over your notifications, communicating directl
 
 </Collapsible>
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="A physical Android or iOS device">
+<Prerequisites>
+  <Requirement title="A physical Android or iOS device">
     Push notifications are not supported on Android Emulators or iOS Simulators. You will need a
     real device to test.
   </Requirement>

--- a/docs/pages/review/with-orbit.mdx
+++ b/docs/pages/review/with-orbit.mdx
@@ -18,12 +18,12 @@ If you don't have any development builds available, either because they have all
 
 </Collapsible>
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Install the Orbit app">
+<Prerequisites>
+  <Requirement title="Install the Orbit app">
     Download Orbit directly from [GitHub releases](https://github.com/expo/orbit/releases), or see
     the [alternative installation method](/build/orbit/#installation).
   </Requirement>
-  <Requirement number={2} title="Sign in to your Expo account">
+  <Requirement title="Sign in to your Expo account">
     After installing the app, sign in to your Expo account from **Settings**.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -13,8 +13,8 @@ import { Step } from '~/ui/components/Step';
 
 Follow the steps below if you have an existing project and want to add Expo Router. For new projects, see the [Quick start](/router/introduction/#quick-start) in the introduction guide.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="Set up your development environment">
+<Prerequisites>
+  <Requirement title="Set up your development environment">
     Make sure your computer is [set up for running an Expo app](/get-started/create-a-project/).
   </Requirement>
 </Prerequisites>

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -12,23 +12,23 @@ This guide outlines how to submit your app to the Google Play Store from your co
 
 ## Submitting your app from your computer
 
-<Prerequisites numberOfRequirements={7}>
-  <Requirement number={1} title="Sign up for a Google Play Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for a Google Play Developer account">
     A Google Play Developer account is required to submit your app to the Google Play Store. You can sign up for a Google Play Developer account on the [Google Play Console sign-up page](https://play.google.com/apps/publish/signup/).
   </Requirement>
-  <Requirement number={2} title="Create an app on Google Play Console">
+  <Requirement title="Create an app on Google Play Console">
     Create an app by clicking **Create app** in the [Google Play Console](https://play.google.com/apps/publish/).
   </Requirement>
-  <Requirement number={3} title="Create a Google Service Account">
+  <Requirement title="Create a Google Service Account">
     EAS requires you to upload and configure a Google Service Account Key to submit your Android app to the Google Play Store. You can create one with the [uploading a Google Service Account Key for Play Store submissions with EAS](https://github.com/expo/fyi/blob/main/creating-google-service-account.md) guide.
   </Requirement>
-  <Requirement number={4} title="Install EAS CLI and authenticate with your Expo account">
+  <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
 
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
 
   </Requirement>
-  <Requirement number={5} title="Include a package name in app.json">
+  <Requirement title="Include a package name in app.json">
     Include your app's package name in **app.json**:
 
     ```json app.json
@@ -40,7 +40,7 @@ This guide outlines how to submit your app to the Google Play Store from your co
     ```
 
   </Requirement>
-  <Requirement number={6} title="Build a production app">
+  <Requirement title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
 
     <Terminal cmd={['$ eas build --platform android --profile production']} />
@@ -48,7 +48,7 @@ This guide outlines how to submit your app to the Google Play Store from your co
     Alternatively, you can build the app on your own computer with `eas build --platform android --profile production --local` or with Android Studio.
 
   </Requirement>
-  <Requirement number={7} title="Upload your app manually at least once">
+  <Requirement title="Upload your app manually at least once">
     You have to upload your app manually at least once. This is a limitation of the Google Play Store API.
 
     Learn how with the [first submission of an Android app](https://expo.fyi/first-android-submission) guide.
@@ -72,23 +72,23 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
 
 ## Submitting your app using CI/CD services
 
-<Prerequisites numberOfRequirements={8}>
-  <Requirement number={1} title="Sign up for a Google Play Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for a Google Play Developer account">
     A Google Play Developer account is required to submit your app to the Google Play Store. You can sign up for a Google Play Developer account on the [Google Play Console sign-up page](https://play.google.com/apps/publish/signup/).
   </Requirement>
-  <Requirement number={2} title="Create an app on Google Play Console">
+  <Requirement title="Create an app on Google Play Console">
     Create an app by clicking **Create app** in the [Google Play Console](https://play.google.com/apps/publish/).
   </Requirement>
-  <Requirement number={3} title="Create a Google Service Account">
+  <Requirement title="Create a Google Service Account">
     EAS requires you to upload and configure a Google Service Account Key to submit your Android app to the Google Play Store. You can create one with the [uploading a Google Service Account Key for Play Store submissions with EAS](https://github.com/expo/fyi/blob/main/creating-google-service-account.md) guide.
   </Requirement>
-  <Requirement number={4} title="Install EAS CLI and authenticate with your Expo account">
+  <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
 
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
 
   </Requirement>
-  <Requirement number={5} title="Include a package name in app.json">
+  <Requirement title="Include a package name in app.json">
     Include your app's package name in **app.json**:
 
     ```json app.json
@@ -100,7 +100,7 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
     ```
 
   </Requirement>
-  <Requirement number={6} title="Upload your Google Service Account key to EAS dashboard">
+  <Requirement title="Upload your Google Service Account key to EAS dashboard">
     Then, you need to upload your Google Service Account key to EAS dashboard under project's credentials.
     <Tabs>
     <Tab label="EAS dashboard">
@@ -131,7 +131,7 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
     </Tabs>
 
   </Requirement>
-  <Requirement number={7} title="Build a production app">
+  <Requirement title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
 
     <Terminal cmd={['$ eas build --platform android --profile production']} />
@@ -139,7 +139,7 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
     Alternatively, you can build the app on your own computer with `eas build --platform android --profile production --local` or with Android Studio.
 
   </Requirement>
-  <Requirement number={8} title="Upload your app manually at least once">
+  <Requirement title="Upload your app manually at least once">
     You have to upload your app manually at least once. This is a limitation of the Google Play Store API.
 
     Learn how with the [first submission of an Android app](https://expo.fyi/first-android-submission) guide.

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -13,11 +13,11 @@ This guide outlines how to submit your app to the Apple App Store from your comp
 
 ## Submitting your app from your computer
 
-<Prerequisites numberOfRequirements={4}>
-  <Requirement number={1} title="Sign up for an Apple Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for an Apple Developer account">
     An Apple Developer account is required to submit your app to the Apple App Store. You can sign up for an Apple Developer account on the [Apple Developer Portal](https://developer.apple.com/account/).
   </Requirement>
-  <Requirement number={2} title="Include a bundle identifier in app.json">
+  <Requirement title="Include a bundle identifier in app.json">
     Include your app's bundle identifier in **app.json**:
 
     ```json app.json
@@ -29,12 +29,12 @@ This guide outlines how to submit your app to the Apple App Store from your comp
     ```
 
   </Requirement>
-  <Requirement number={3} title="Install EAS CLI and authenticate with your Expo account">
+  <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
     
     <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
   </Requirement>
-  <Requirement number={4} title="Build a production app">
+  <Requirement title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
     
     <Terminal cmd={['$ eas build --platform ios --profile production']} />
@@ -89,11 +89,11 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
 
 ## Submitting your app using CI/CD services
 
-<Prerequisites numberOfRequirements={5}>
-  <Requirement number={1} title="Sign up for an Apple Developer account">
+<Prerequisites>
+  <Requirement title="Sign up for an Apple Developer account">
     An Apple Developer account is required to submit your app to the Apple App Store. You can sign up for an Apple Developer account on the [Apple Developer Portal](https://developer.apple.com/account/).
   </Requirement>
-  <Requirement number={2} title="Include a bundle identifier in app.json">
+  <Requirement title="Include a bundle identifier in app.json">
     Include your app's bundle identifier in **app.json**:
 
     ```json app.json
@@ -105,7 +105,7 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
     ```
 
   </Requirement>
-  <Requirement number={3} title="Configure your App Store Connect API Key">
+  <Requirement title="Configure your App Store Connect API Key">
     Run the following command to configure your App Store Connect API Key:
 
     <Terminal cmd={['$ eas credentials --platform ios']} />
@@ -125,7 +125,7 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
     </Collapsible>
 
   </Requirement>
-  <Requirement number={4} title="Provide a submission profile in eas.json">
+  <Requirement title="Provide a submission profile in eas.json">
     Then, you'll need to provide a submission profile in **eas.json** that includes the following fields:
 
     ```json eas.json
@@ -158,7 +158,7 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
     Learn about all the options you can provide in the [eas.json reference](/eas/json/#ios-specific-options-1).
 
   </Requirement>
-  <Requirement number={5} title="Build a production app">
+  <Requirement title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):
     
     <Terminal cmd={['$ eas build --platform ios --profile production']} />

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -26,17 +26,17 @@ In this chapter, let's learn how to create a new Expo project and how to get it 
 
 ---
 
-<Prerequisites numberOfRequirements={4}>
-  <Requirement number={1} title="Expo Go on a physical device">
+<Prerequisites>
+  <Requirement title="Expo Go on a physical device">
     Install [Expo Go](https://expo.dev/go) on a physical Android or iOS device.
   </Requirement>
-  <Requirement number={2} title="Node.js (LTS)">
+  <Requirement title="Node.js (LTS)">
     Install [Node.js (LTS version)](https://nodejs.org/en) on your machine.
   </Requirement>
-  <Requirement number={3} title="A code editor">
+  <Requirement title="A code editor">
     Install [VS Code](https://code.visualstudio.com/) or any other preferred code editor or IDE.
   </Requirement>
-  <Requirement number={4} title="A developer machine with a terminal">
+  <Requirement title="A developer machine with a terminal">
     A macOS, Linux, or Windows (PowerShell and WSL2) with a terminal window open.
   </Requirement>
 </Prerequisites>

--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -24,16 +24,16 @@ In this chapter, we'll create our example app's production version and submit it
 
 ---
 
-<Prerequisites numberOfRequirements={3}>
-  <Requirement number={1} title="Google Play Developer account">
+<Prerequisites>
+  <Requirement title="Google Play Developer account">
     A paid Google Play Developer account is required. For details on setting one up, visit the
     [Google Play sign-up page](https://play.google.com/apps/publish/signup/).
   </Requirement>
-  <Requirement number={2} title="A production build profile in eas.json">
+  <Requirement title="A production build profile in eas.json">
     Ensure that a `production` build profile is present in your **eas.json**, which is added by
     default.
   </Requirement>
-  <Requirement number={3} title="Google Service Account key (optional)">
+  <Requirement title="Google Service Account key (optional)">
     A Google Service Account email and JSON key is required to [automate the release
     process](#automated-release). Follow the detailed instructions in [creating a Google Service
     Account key or downloading it from an existing

--- a/docs/pages/tutorial/eas/introduction.mdx
+++ b/docs/pages/tutorial/eas/introduction.mdx
@@ -27,8 +27,8 @@ These topics will give us the foundation needed to use EAS effectively and to ap
 
 This tutorial is hands-on and designed to be completed in about two hours.
 
-<Prerequisites numberOfRequirements={1}>
-  <Requirement number={1} title="An existing Expo project set up locally">
+<Prerequisites>
+  <Requirement title="An existing Expo project set up locally">
     Pick one of the following options to follow along:
 
     - Continue with the Sticker Smash app from the previous tutorial. If new, download it from [GitHub](https://github.com/expo/examples/tree/master/stickersmash).

--- a/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
@@ -25,13 +25,13 @@ Development builds for iOS devices are generated in the **.ipa** format, which i
 
 ---
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Apple Developer account">
+<Prerequisites>
+  <Requirement title="Apple Developer account">
     Required to access [necessary credentials](/app-signing/app-credentials/#ios) for signing our
     app, as each build needs to be signed to verify that the app comes from a trusted source. EAS
     Build helps manage these credentials.
   </Requirement>
-  <Requirement number={2} title="Developer Mode activated on iOS 16 and higher">
+  <Requirement title="Developer Mode activated on iOS 16 and higher">
     Installing development builds on your device requires Developer Mode to be enabled. If this is
     your first time or if it's currently disabled, see [activate Developer
     Mode](/guides/ios-developer-mode/).

--- a/docs/pages/tutorial/eas/ios-production-build.mdx
+++ b/docs/pages/tutorial/eas/ios-production-build.mdx
@@ -23,11 +23,11 @@ In this chapter, we'll create our example app's production version and submit it
 
 ---
 
-<Prerequisites numberOfRequirements={2}>
-  <Requirement number={1} title="Apple Developer account">
+<Prerequisites>
+  <Requirement title="Apple Developer account">
     To create one, see the [Apple Developer Portal](https://developer.apple.com/account/).
   </Requirement>
-  <Requirement number={2} title="A production build profile in eas.json">
+  <Requirement title="A production build profile in eas.json">
     Ensure that a `production` build profile is present in your **eas.json**, which is added by
     default.
   </Requirement>

--- a/docs/ui/components/Prerequisites/Prerequisites.test.tsx
+++ b/docs/ui/components/Prerequisites/Prerequisites.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import GithubSlugger from 'github-slugger';
+import { PropsWithChildren } from 'react';
+
+import { createHeadingManager } from '~/common/headingManager';
+import { HeadingsContext } from '~/common/withHeadingManager';
+
+import { Prerequisites, Requirement } from '.';
+
+const WrapWithContext = ({ children }: PropsWithChildren) => {
+  const headingManager = createHeadingManager(new GithubSlugger(), { headings: [] });
+  return <HeadingsContext.Provider value={headingManager}>{children}</HeadingsContext.Provider>;
+};
+
+describe('Prerequisites', () => {
+  it('renders a single requirement without the numeric prefix', () => {
+    render(
+      <WrapWithContext>
+        <Prerequisites open>
+          <Requirement title="Only requirement">Body content.</Requirement>
+        </Prerequisites>
+      </WrapWithContext>
+    );
+
+    expect(screen.getByText('Only requirement')).toBeVisible();
+    expect(screen.getByText('Body content.')).toBeVisible();
+    expect(screen.getByText('1 requirement')).toBeVisible();
+    expect(screen.queryByText('1.')).not.toBeInTheDocument();
+  });
+
+  it('renders numbered prefixes when there are multiple requirements', () => {
+    render(
+      <WrapWithContext>
+        <Prerequisites open>
+          <Requirement title="First">Step one body.</Requirement>
+          <Requirement title="Second">Step two body.</Requirement>
+          <Requirement title="Third">Step three body.</Requirement>
+        </Prerequisites>
+      </WrapWithContext>
+    );
+
+    expect(screen.getByText('First')).toBeVisible();
+    expect(screen.getByText('Second')).toBeVisible();
+    expect(screen.getByText('Third')).toBeVisible();
+    expect(screen.getByText('3 requirements')).toBeVisible();
+    expect(screen.getByText('1.')).toBeVisible();
+    expect(screen.getByText('2.')).toBeVisible();
+    expect(screen.getByText('3.')).toBeVisible();
+  });
+});

--- a/docs/ui/components/Prerequisites/Requirement.tsx
+++ b/docs/ui/components/Prerequisites/Requirement.tsx
@@ -1,20 +1,16 @@
 import { mergeClasses } from '@expo/styleguide';
 import { type PropsWithChildren, type ReactNode } from 'react';
 
-type RequirementProps = PropsWithChildren<{
+export type RequirementProps = PropsWithChildren<{
   title: ReactNode;
-  number: number;
 }>;
 
-export function Requirement({ title, number, children }: RequirementProps) {
+export function Requirement({ title, children }: RequirementProps) {
   return (
-    <div className={mergeClasses('border-default flex items-baseline gap-1.5 border-t p-5')}>
-      <p className="mb-2 text-right font-medium">{number}.</p>
-      <div className="flex-1 overflow-hidden">
-        <div className="mb-2 flex items-baseline gap-2 font-medium">{title}</div>
-        <div className={mergeClasses('[&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-0!')}>
-          {children}
-        </div>
+    <div className="flex-1 overflow-hidden">
+      <div className="mb-2 flex items-baseline gap-2 font-medium">{title}</div>
+      <div className={mergeClasses('[&_p]:ml-0 [&_pre>pre]:mt-0 [&>*:last-child]:mb-0!')}>
+        {children}
       </div>
     </div>
   );

--- a/docs/ui/components/Prerequisites/index.tsx
+++ b/docs/ui/components/Prerequisites/index.tsx
@@ -3,7 +3,15 @@ import { TriangleDownIcon } from '@expo/styleguide-icons/custom/TriangleDownIcon
 import { ListIcon } from '@expo/styleguide-icons/outline/ListIcon';
 import { motion } from 'framer-motion';
 import { useRouter } from 'next/compat/router';
-import { type ComponentType, type PropsWithChildren, useEffect, useRef, useState } from 'react';
+import {
+  Children,
+  isValidElement,
+  type ComponentType,
+  type PropsWithChildren,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import withHeadingManager, { HeadingManagerProps } from '~/common/withHeadingManager';
 import { PermalinkIcon } from '~/ui/components/Permalink';
@@ -11,10 +19,6 @@ import { PermalinkIcon } from '~/ui/components/Permalink';
 import { Requirement } from './Requirement';
 
 type PrerequisitesProps = PropsWithChildren<{
-  /**
-   * The number of requirements for the prerequisites.
-   */
-  numberOfRequirements: number;
   /**
    * If the prerequisites should be rendered "open" by default.
    */
@@ -24,12 +28,15 @@ type PrerequisitesProps = PropsWithChildren<{
 
 const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
   ({
-    numberOfRequirements = 1,
     children,
     className,
     headingManager,
     open = false,
   }: PrerequisitesProps & HeadingManagerProps) => {
+    const requirementChildren = Children.toArray(children).filter(
+      child => isValidElement(child) && child.type === Requirement
+    );
+    const numberOfRequirements = requirementChildren.length;
     const router = useRouter();
     const [isOpen, setIsOpen] = useState(open);
     const detailsRef = useRef<HTMLDetailsElement>(null);
@@ -61,7 +68,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
         id={heading.current.slug}
         className={mergeClasses(
           'border-default mb-3 scroll-m-4 rounded-md border p-0',
-          '[&[open]]:shadow-xs',
+          '[[open]]:shadow-xs',
           '[h4+&]:mt-3 [li>&]:mt-3 [p+&]:mt-3',
           className
         )}
@@ -77,7 +84,7 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
             'hocus:bg-subtle'
           )}>
           <div className="flex items-center">
-            <div className="mt-[5px] mr-2 ml-1.5 self-baseline">
+            <div className="mt-1.25 mr-2 ml-1.5 self-baseline">
               <TriangleDownIcon
                 className={mergeClasses(
                   'icon-sm text-icon-default',
@@ -120,7 +127,18 @@ const Prerequisites: ComponentType<PrerequisitesProps> = withHeadingManager(
             height: isOpen ? 'auto' : 0,
           }}
           className="overflow-hidden">
-          <div>{children}</div>
+          <div>
+            {requirementChildren.map((child, index) => (
+              <div
+                key={index}
+                className={mergeClasses('border-default flex items-baseline gap-1.5 border-t p-5')}>
+                {numberOfRequirements > 1 && (
+                  <p className="mb-2 text-right font-medium">{index + 1}.</p>
+                )}
+                {child}
+              </div>
+            ))}
+          </div>
         </motion.div>
       </details>
     );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20814

Follow-up @kadikraman's feedback from https://github.com/expo/expo/pull/45075

# How

- Drop the `numberOfRequirements` prop from `<Prerequisites>`. The component now derives the count from `Children.toArray(children).filter(...)` so authors no longer hand-count their own children.
- Drop the `number` prop from `<Requirement>` entirely. `<Prerequisites>` now owns the numbered row frame (border, padding, the `N.` prefix), and `<Requirement>` is a pure content component with `{ title, children }` only.
- Add `Prerequisites.test.tsx` with two cases: single-requirement (asserts no inline `1.` and the singular "1 requirement" header counter) and multi-requirement (asserts `1.`/`2.`/`3.` and the plural "3 requirements" counter).
- Strip `numberOfRequirements={N}` from 68 `<Prerequisites>` openings across 56 `.mdx` pages.
- Strip `number={N}` from 154 `<Requirement>` openings, including the multiline `<Requirement title={<>...</>}>` shapes.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

-  Run `pnpm test` and all tests should pass.

- See preview. Visually nothing has changed.

<img width="2560" height="2270" alt="CleanShot 2026-04-27 at 23 04 25@2x" src="https://github.com/user-attachments/assets/60abb412-1976-4590-af2f-7bf8f9231d6d" />

<img width="2594" height="930" alt="CleanShot 2026-04-27 at 23 04 33@2x" src="https://github.com/user-attachments/assets/450f3bf1-702b-478e-b1c7-73859f96e936" />

<img width="2586" height="1176" alt="CleanShot 2026-04-27 at 23 04 46@2x" src="https://github.com/user-attachments/assets/c0c57810-f8a4-44f9-9529-b973f6776a7f" />

<img width="2450" height="1894" alt="CleanShot 2026-04-27 at 23 05 00@2x" src="https://github.com/user-attachments/assets/abb1062a-d759-4fcd-83b6-5ad90ffeba3f" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
