### PR TITLE
[docs] Add Linux support for Expo Orbit and other minor updates

### DIFF
--- a/docs/pages/additional-resources/index.mdx
+++ b/docs/pages/additional-resources/index.mdx
@@ -26,7 +26,7 @@ The following resources are useful for learning about Expo tooling and services.
 - [expo/vscode-expo](https://github.com/expo/vscode-expo) - VS Code extension for working with Expo tools.
 - [expo/vscode-expo-theme](https://github.com/expo/vscode-expo-theme) - VS Code theme created by Expo team.
 - [expo/fyi](https://github.com/expo/fyi) - Troubleshooting guides for Expo tools and services.
-- [expo/orbit](https://github.com/expo/orbit) - Launch builds and start simulators from your macOS menu bar and Windows task bar.
+- [expo/orbit](https://github.com/expo/orbit) - Launch builds and start simulators from your macOS menu bar, Windows task bar, or Linux system tray.
 
 ### Documentation
 

--- a/docs/pages/build/orbit.mdx
+++ b/docs/pages/build/orbit.mdx
@@ -7,7 +7,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-[Expo Orbit](https://expo.dev/orbit) for macOS and Windows enables faster to install and launch builds or updates from EAS, local files, or run Snack projects, on simulators and physical devices.
+[Expo Orbit](https://expo.dev/orbit) for macOS, Windows, and Linux enables faster to install and launch builds or updates from EAS, local files, or run Snack projects, on simulators and physical devices.
 
 <ContentSpotlight file="orbit/basic-features.mp4" />
 
@@ -26,7 +26,7 @@ Before Orbit, installing builds or updates from EAS (on Android and iOS physical
 
 ## Installation
 
-> **info** Orbit relies on the Android SDK on both macOS and Windows and `xcrun` for device management only on macOS, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode](/workflow/ios-simulator/).
+> **info** Orbit relies on the Android SDK on macOS, Windows, and Linux, and `xcrun` for device management only on macOS, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode](/workflow/ios-simulator/).
 
 <Tabs>
 
@@ -42,9 +42,13 @@ If you want Orbit to start when you log in automatically, click on the Orbit ico
 
 <Tab label="Windows">
 
-> **important** Orbit for Windows is in [beta](/more/release-statuses/#beta) and is only compatible with x64 and x86 machines. Compatibility for other architectures will be added in the future.
-
 You can download Orbit for Windows directly from the [GitHub releases](https://github.com/expo/orbit/releases).
+
+</Tab>
+
+<Tab label="Linux">
+
+You can download Orbit for Linux directly from the [GitHub releases](https://github.com/expo/orbit/releases). Both `.deb` (Debian and Ubuntu) and `.rpm` (Fedora and RHEL) packages are available.
 
 </Tab>
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -65,7 +65,7 @@ You can also use `npx expo-doctor --help` to display usage information.
 
 ## Orbit
 
-Orbit is a macOS and Windows app that enables:
+Orbit is a macOS, Windows, and Linux app that enables:
 
 - Install and launch builds from EAS on physical devices and emulators.
 - Install and launch updates from EAS on Android Emulators or iOS Simulators.
@@ -91,15 +91,19 @@ If you want Orbit to start when you log in automatically, click on the Orbit ico
 
 <Tab label="Windows">
 
-> **important** Orbit for Windows is in [beta](/more/release-statuses/#beta) and is only compatible with x64 and x86 machines. Compatibility for other architectures will be added in the future.
-
 You can download Orbit for Windows directly from the [GitHub releases](https://github.com/expo/orbit/releases).
+
+</Tab>
+
+<Tab label="Linux">
+
+You can download Orbit for Linux directly from the [GitHub releases](https://github.com/expo/orbit/releases). Both `.deb` (Debian and Ubuntu) and `.rpm` (Fedora and RHEL) packages are available.
 
 </Tab>
 
 </Tabs>
 
-> **info** Orbit relies on the Android SDK on both macOS and Windows and `xcrun` for device management only on macOS, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode](/workflow/ios-simulator/).
+> **info** Orbit relies on the Android SDK on macOS, Windows, and Linux, and `xcrun` for device management only on macOS, which requires setting up both [Android Studio](/workflow/android-studio-emulator/) and [Xcode](/workflow/ios-simulator/).
 
 {/* TODO: (@aman) to add update https://docs.expo.dev/build/orbit/ with instructions on how to actually use Expo Orbit with EAS Build, add link to https://docs.expo.dev/review/with-orbit/ to add the following section */}
 {/* ### Usage */}

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -219,7 +219,7 @@ A file named **expo-module.config.json** that lives in the root directory of a [
 
 ### Expo Orbit
 
-[Expo Orbit](/build/orbit/) is an application for macOS and Windows that enables faster installation and launching of builds or updates from EAS, local files, or Snack projects, on devices or emulators/simulators.
+[Expo Orbit](/build/orbit/) is an application for macOS, Windows, and Linux that enables faster installation and launching of builds or updates from EAS, local files, or Snack projects, on devices or emulators/simulators.
 
 ### Expo Router
 

--- a/docs/pages/review/with-orbit.mdx
+++ b/docs/pages/review/with-orbit.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 
-[Expo Orbit](https://expo.dev/orbit) is a macOS and Windows app designed to speed up installing and running builds from EAS. It makes running your builds and updates as easy as pressing **Open in Orbit**.
+[Expo Orbit](https://expo.dev/orbit) is a macOS, Windows, and Linux app designed to speed up installing and running builds from EAS. It makes running your builds and updates as easy as pressing **Open in Orbit**.
 
 <Collapsible summary="How does automatic installation and launching of updates work?">
 

--- a/docs/pages/tutorial/eas/android-development-build.mdx
+++ b/docs/pages/tutorial/eas/android-development-build.mdx
@@ -84,7 +84,7 @@ This section provides the methods available for running the development build on
 [Expo Orbit](https://expo.dev/orbit) allows for seamless installation of the development build on an Android device. To use this method:
 
 - Connect our Android device to our local machine using USB.
-- Open the Orbit menu bar app.
+- Open the Orbit app.
 - Select the **Device** in the Orbit app.
 
 <ContentSpotlight

--- a/docs/pages/tutorial/eas/introduction.mdx
+++ b/docs/pages/tutorial/eas/introduction.mdx
@@ -40,7 +40,7 @@ This tutorial is hands-on and designed to be completed in about two hours.
 
 ## Tools
 
-[Expo Orbit](https://expo.dev/orbit) to manage and launch builds with one click on macOS and Windows.
+[Expo Orbit](https://expo.dev/orbit) to manage and launch builds with one click on macOS, Windows, and Linux.
 
 If you want to install and run the build locally on your machine simultaneously, you can use Android Emulator or iOS Simulator. To set them up, see the following:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20815

# How

- Update the intro sentence in `docs/pages/build/orbit.mdx`, `docs/pages/develop/tools.mdx`, `docs/pages/review/with-orbit.mdx`, `docs/pages/more/glossary-of-terms.mdx`, and `docs/pages/tutorial/eas/introduction.mdx` to read "macOS, Windows, and Linux" instead of "macOS and Windows".
- Update the bullet in `docs/pages/additional-resources/index.mdx` to read "macOS menu bar, Windows task bar, or Linux system tray".
- Update the "Orbit relies on the Android SDK..." info callout in `docs/pages/build/orbit.mdx` and `docs/pages/develop/tools.mdx` to include Linux.
- - Add a new `<Tab label="Linux">` block to the `<Tabs>` install section in both `docs/pages/build/orbit.mdx` and `docs/pages/develop/tools.mdx`. 
- Remove the "Orbit for Windows is in beta and is only compatible with x64 and x86 machines" callout from the Windows tab in both pages, since the Orbit README no longer marks Windows as beta.
- In `docs/pages/tutorial/eas/android-development-build.mdx`, change "Open the Orbit menu bar app." to "Open the Orbit app." since Linux + Android is a valid development combo and "menu bar app" is macOS-specific phrasing. The two iOS-context tutorial pages keep the "menu bar app" wording because iOS development requires macOS.

# Test Plan

Run the docs locally with `pnpm dev` and verify each updated page renders correctly:

- `/build/orbit/`: install section shows three tabs (macOS, Windows, Linux). Windows tab no longer has the beta callout. Linux tab points at GitHub releases and mentions `.deb` and `.rpm`. Intro paragraph and Android SDK callout both mention Linux.
- `/develop/tools/`: same three-tab install section and Linux mentions.
- `/review/with-orbit/`: intro sentence mentions all three platforms.
- `/more/glossary-of-terms/#expo-orbit`: glossary entry mentions all three platforms.
- `/tutorial/eas/introduction/`: tools section mentions all three platforms.
- `/additional-resources/`: `expo/orbit` bullet mentions Linux system tray.
- `/tutorial/eas/android-development-build/`: step 87 reads "Open the Orbit app." with no "menu bar" qualifier.


<img width="2398" height="658" alt="CleanShot 2026-04-27 at 23 28 03@2x" src="https://github.com/user-attachments/assets/aee1dea7-2a12-4681-aeb7-089d107addb7" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
