### PR TITLE
[docs] Fix missing trailing periods to BoxLink and VideoBoxLink descriptions

### DIFF
--- a/docs/pages/develop/authentication.mdx
+++ b/docs/pages/develop/authentication.mdx
@@ -36,7 +36,7 @@ If you're using an older version of Expo Router, you can use [redirects](/router
 <VideoBoxLink
   videoId="zHZjJDTTHJg"
   title="Expo Router Protected Routes"
-  description="Learn how to implement an authentication flow with Expo Router"
+  description="Learn how to implement an authentication flow with Expo Router."
 />
 
 </Collapsible>
@@ -176,13 +176,13 @@ The following tutorials cover implementing OAuth on Android, iOS, and web, inclu
 <VideoBoxLink
   videoId="V2YdhR1hVNw"
   title="Google Sign-In with Expo OAuth"
-  description="Learn how to implement Google Sign-In with Expo Router API Routes"
+  description="Learn how to implement Google Sign-In with Expo Router API Routes."
 />
 <br />
 <VideoBoxLink
   videoId="tqxTijhYhp8"
   title="Sign in with Apple using Expo"
-  description="Learn how to implement Sign in with Apple"
+  description="Learn how to implement Sign in with Apple."
 />
 
 <br />

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -78,7 +78,7 @@ Building on EAS servers is useful when:
 
 <BoxLink
   title="Build on EAS"
-  description="How to create your Development Build on EAS"
+  description="How to create your Development Build on EAS."
   href="/develop/development-builds/create-a-build/"
   Icon={BookOpen02Icon}
 />
@@ -136,7 +136,7 @@ All Expo build tools (`npx expo run:android|ios` and `eas build`) will **prebuil
 
 <BoxLink
   title="Continuous Native Generation (CNG)"
-  description="Learn about the philosophy and benefits of Continuous Native Generation (CNG) and Prebuild"
+  description="Learn about the philosophy and benefits of Continuous Native Generation (CNG) and Prebuild."
   href="/workflow/continuous-native-generation/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/develop/development-builds/introduction.mdx
+++ b/docs/pages/develop/development-builds/introduction.mdx
@@ -78,21 +78,21 @@ If you're developing on an Android Device, Android Emulator, or iOS Simulator, a
 
 <BoxLink
   title="Expo Go to development build"
-  description="Learn how to migrate an existing Expo Go project to using development builds"
+  description="Learn how to migrate an existing Expo Go project to using development builds."
   href="/develop/development-builds/expo-go-to-dev-build/"
   Icon={BookOpen02Icon}
 />
 
 <BoxLink
   title="Local app development"
-  description="How to build a development client on your local machine"
+  description="How to build a development client on your local machine."
   href="/guides/local-app-development"
   Icon={BookOpen02Icon}
 />
 
 <BoxLink
   title="Development builds on EAS"
-  description="How to build a development client on EAS"
+  description="How to build a development client on EAS."
   href="/develop/development-builds/create-a-build/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/eas-update/preview.mdx
+++ b/docs/pages/eas-update/preview.mdx
@@ -24,14 +24,14 @@ Development builds are a great way to preview updates from pull requests, direct
 
 <BoxLink
   title="Use GitHub Actions to automate publishing updates"
-  description="Learn how to use GitHub Actions to automate publishing updates with EAS Update"
+  description="Learn how to use GitHub Actions to automate publishing updates with EAS Update."
   href="/eas-update/github-actions/"
   Icon={LayersTwo02Icon}
 />
 
 <BoxLink
   title="Launch preview updates from the EAS dashboard using Orbit"
-  description="Learn how to launch updates with the macOS, Windows, and Linux desktop app Expo Orbit"
+  description="Learn how to launch updates with the macOS, Windows, and Linux desktop app Expo Orbit."
   href="/review/with-orbit/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/guides/expo-ui-swift-ui/index.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/index.mdx
@@ -520,21 +520,21 @@ Because React's promise of _"learn once, write anywhere"_, it now extends to Swi
 
 <BoxLink
   title="Expo UI example"
-  description="Our latest Expo UI examples"
+  description="Our latest Expo UI examples."
   Icon={GithubIcon}
   href="https://github.com/expo/expo/tree/main/apps/native-component-list/src/screens/UI"
 />
 
 <BoxLink
   title="Hot Chocolate app example"
-  description="An example app replicating the YVR Hot Chocolate Fest app with Expo UI"
+  description="An example app replicating the YVR Hot Chocolate Fest app with Expo UI."
   Icon={GithubIcon}
   href="https://github.com/expo/hot-chocolate"
 />
 
 <BoxLink
   title="Expo UI example replicate to TV"
-  description="TVOS support to Expo UI"
+  description="TVOS support to Expo UI."
   Icon={GithubIcon}
   href="https://github.com/douglowder/ExpoUITV"
 />

--- a/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/unversioned/sdk/keyboard-controller.mdx
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 
 <BoxLink
   title="Advanced keyboard handling"
-  description="Learn more about advanced keyboard handling examples with Keyboard Controller"
+  description="Learn more about advanced keyboard handling examples with Keyboard Controller."
   Icon={BookOpen02Icon}
   href="/guides/keyboard-handling/#advanced-keyboard-handling-with-keyboard-controller"
 />

--- a/docs/pages/versions/unversioned/sdk/updates.mdx
+++ b/docs/pages/versions/unversioned/sdk/updates.mdx
@@ -40,7 +40,7 @@ The remote service must implement the [Expo Updates protocol](/technical-specs/e
 
 <BoxLink
   title="Custom Expo Updates Server"
-  description="Example implementation of a custom server and an app using that server"
+  description="Example implementation of a custom server and an app using that server."
   href="https://github.com/expo/custom-expo-updates-server"
   Icon={GithubIcon}
 />

--- a/docs/pages/versions/v53.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/updates.mdx
@@ -40,7 +40,7 @@ The remote service must implement the [Expo Updates protocol](/technical-specs/e
 
 <BoxLink
   title="Custom Expo Updates Server"
-  description="Example implementation of a custom server and an app using that server"
+  description="Example implementation of a custom server and an app using that server."
   href="https://github.com/expo/custom-expo-updates-server"
   Icon={GithubIcon}
 />

--- a/docs/pages/versions/v54.0.0/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/keyboard-controller.mdx
@@ -84,7 +84,7 @@ const styles = StyleSheet.create({
 
 <BoxLink
   title="Advanced keyboard handling"
-  description="Learn more about advanced keyboard handling examples with Keyboard Controller"
+  description="Learn more about advanced keyboard handling examples with Keyboard Controller."
   Icon={BookOpen02Icon}
   href="/guides/keyboard-handling/#advanced-keyboard-handling-with-keyboard-controller"
 />

--- a/docs/pages/versions/v54.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/updates.mdx
@@ -40,7 +40,7 @@ The remote service must implement the [Expo Updates protocol](/technical-specs/e
 
 <BoxLink
   title="Custom Expo Updates Server"
-  description="Example implementation of a custom server and an app using that server"
+  description="Example implementation of a custom server and an app using that server."
   href="https://github.com/expo/custom-expo-updates-server"
   Icon={GithubIcon}
 />

--- a/docs/pages/versions/v55.0.0/sdk/keyboard-controller.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/keyboard-controller.mdx
@@ -83,7 +83,7 @@ const styles = StyleSheet.create({
 
 <BoxLink
   title="Advanced keyboard handling"
-  description="Learn more about advanced keyboard handling examples with Keyboard Controller"
+  description="Learn more about advanced keyboard handling examples with Keyboard Controller."
   Icon={BookOpen02Icon}
   href="/guides/keyboard-handling/#advanced-keyboard-handling-with-keyboard-controller"
 />

--- a/docs/pages/versions/v55.0.0/sdk/updates.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/updates.mdx
@@ -40,7 +40,7 @@ The remote service must implement the [Expo Updates protocol](/technical-specs/e
 
 <BoxLink
   title="Custom Expo Updates Server"
-  description="Example implementation of a custom server and an app using that server"
+  description="Example implementation of a custom server and an app using that server."
   href="https://github.com/expo/custom-expo-updates-server"
   Icon={GithubIcon}
 />


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20816

# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix missing trailing periods to `BoxLink` and `VideoBoxLink` descriptions in multiple docs.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
