### PR TITLE
[expo-image][ios] Fix Swift 6 strict concurrency errors for Record structs

### DIFF
--- a/packages/expo-image/ios/ContentPosition.swift
+++ b/packages/expo-image/ios/ContentPosition.swift
@@ -9,7 +9,7 @@ typealias ContentPositionValue = Either<Double, String>
  Specifies the alignment of the image within the container's box.
  - Note: Its intention is to behave like the CSS [`object-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/object-position) property.
  */
-struct ContentPosition: Record {
+struct ContentPosition: Record, @unchecked Sendable {
   static let center = Self()
 
   @Field

--- a/packages/expo-image/ios/ImageLoadOptions.swift
+++ b/packages/expo-image/ios/ImageLoadOptions.swift
@@ -2,7 +2,7 @@
 
 import ExpoModulesCore
 
-internal struct ImageLoadOptions: Record {
+internal struct ImageLoadOptions: Record, @unchecked Sendable {
   @Field var maxWidth: Int?
   @Field var maxHeight: Int?
   @Field var tintColor: UIColor? = nil

--- a/packages/expo-image/ios/ImageSource.swift
+++ b/packages/expo-image/ios/ImageSource.swift
@@ -2,7 +2,7 @@
 
 import ExpoModulesCore
 
-struct ImageSource: Record {
+struct ImageSource: Record, @unchecked Sendable {
   @Field
   var width: Double = 0.0
 


### PR DESCRIPTION
# Why

`expo-image` fails to compile with Xcode 26 under Swift 6 strict concurrency checking. Three `Record`-conforming structs — `ContentPosition`, `ImageSource`, and `ImageLoadOptions` — lack `Sendable` conformance, producing errors that block archive builds.

PR #40369 addressed Swift 6 concurrency in `expo-image` for `ImageLoadingFailed`, `ImageLoader`, `PSDCoder`, and `WebPCoder`, but missed these three structs.

Fixes #45142

# How

Add `@unchecked Sendable` conformance to:

- **`ContentPosition`** — has `static let center = Self()`, flagged as non-concurrency-safe on a non-Sendable type
- **`ImageSource`** — captured in `Task` closure in `ImageLoadTask.load()`, triggering "passing closure as a 'sending' parameter risks causing data races"
- **`ImageLoadOptions`** — same as above, captured in the same `Task` closure

All three are value types (`struct`) with no shared mutable state. `@unchecked Sendable` is the established pattern in this package (see `ImageLoadingFailed` in `ImageLoader.swift`).

# Test Plan

- Local release build with Xcode 26 / iPhoneOS26.0.sdk: `xcodebuild -workspace ... -configuration Release` compiles without errors
- Verified on EAS Build (production profile, default build image)