### PR TITLE
[docs] Remove "built on top of React Navigation" verbiage

### DIFF
--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -69,7 +69,7 @@ Expo provides some dev tools plugins for common debugging tasks. Follow the inst
 
 ### React Navigation
 
-Inspired by [`@react-navigation/devtools`](https://github.com/react-navigation/react-navigation/tree/main/packages/devtools), the React Navigation dev tools plugin allows seeing the history of [React Navigation](https://reactnavigation.org/) actions and state. You can also rewind to previous points in your navigation history and send deep links to your app. Since Expo Router is built upon React Navigation, this plugin is fully compatible with [Expo Router](/router/introduction).
+Inspired by [`@react-navigation/devtools`](https://github.com/react-navigation/react-navigation/tree/main/packages/devtools), the React Navigation dev tools plugin allows seeing the history of [React Navigation](https://reactnavigation.org/) actions and state. You can also rewind to previous points in your navigation history and send deep links to your app. This plugin is fully compatible with [Expo Router](/router/introduction).
 
 To use the plugin, start by installing the package:
 

--- a/docs/pages/develop/app-navigation.mdx
+++ b/docs/pages/develop/app-navigation.mdx
@@ -29,7 +29,7 @@ The library offers platform-specific look-and-feel with smooth animations and ge
 
 ## Expo Router (recommended for Expo projects)
 
-Expo Router is a file-based routing library for Expo and React Native projects and is a built on top of React Navigation. By following the **app** directory convention, it turns files into routes and is integrated with Expo for [Expo CLI](/more/expo-cli/) and bundling without additional setup. The library also adds features such as typed routes, dynamic routes, lazy bundling in development, static rendering for the web, and automatic deep linking.
+Expo Router is a file-based routing library for Expo and React Native projects. By following the **app** directory convention, it turns files into routes and is integrated with Expo for [Expo CLI](/more/expo-cli/) and bundling without additional setup. The library also adds features such as typed routes, dynamic routes, lazy bundling in development, static rendering for the web, and automatic deep linking.
 
 New Expo projects created with `npx create-expo-app@latest --template default@sdk-55` include Expo Router by default so you can ship cross-platform navigation quickly while still being able to reach for React Navigation APIs when needed.
 

--- a/docs/pages/router/basics/core-concepts.mdx
+++ b/docs/pages/router/basics/core-concepts.mdx
@@ -39,11 +39,9 @@ This is achieved through [platform-specific file extensions](/router/advanced/pl
 
 In Expo Router, the **src/app** directory is exclusively for defining your app's routes. Other parts of your app, like components, hooks, utilities, and so on, should be placed in other directories such as **src/components**, **src/hooks**, and **src/constants**. If you put a non-route inside the **src/app** directory, Expo Router will attempt to treat it like a route.
 
-### 7. It's still React Navigation under the hood
+### 7. Customizing stack and tab navigators
 
-While this may sound quite a bit different from React Navigation, Expo Router is actually built on top of React Navigation. You can think of Expo Router as an Expo CLI optimization that translates your file structure into React Navigation components that you previously defined in your own code.
-
-This also means that you can often refer to React Navigation documentation for how to style or configure navigation, as the default stack and tab navigators use the exact same options.
+Stack and tab navigators accept a wide range of configuration options for headers, animations, gestures, and more. See the [Stack](/router/advanced/stack/) and [Tabs](/router/advanced/tabs/) guides for the full list of options and examples.
 
 ## The rules of Expo Router applied
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -74,7 +74,7 @@ Now, you can start your project by running:
 
 ## Key features
 
-- **Native**: Built on top of our powerful [React Navigation suite](https://reactnavigation.org/), Expo Router navigation is truly native and platform-optimized by default.
+- **Native**: Expo Router navigation is truly native and platform-optimized by default.
 - **Shareable**: Every screen in your app is automatically [deep linkable](/linking/overview/), making any route in your app shareable with links.
 - **Offline-first**: Apps are cached and run offline-first, with automatic updates when you publish a new version. Handles all incoming native URLs without a network connection or server.
 - **Optimized**: Routes are automatically optimized with [lazy-evaluation in production](/router/web/async-routes/), and deferred bundling in development.
@@ -124,9 +124,7 @@ Yes, Expo Router is the framework for universal React Native apps. Due to the de
 
 <Collapsible summary="Why should I use Expo Router over React Navigation?">
 
-Expo Router and React Navigation are both libraries from the Expo team. We built Expo Router on top of React Navigation to enable the benefits of file-based routing. Expo Router is a superset of React Navigation, meaning you can use any React Navigation components and APIs with Expo Router.
-
-If file-based routing isn't right for your project, you can drop down to React Navigation and set up routes, types, and links manually.
+Expo Router and React Navigation are both libraries from the Expo team. Expo Router takes a file-based approach, where routes are derived from your file structure from the **app** directory. It also has built-in support for typed routes, automatic deep linking, and static rendering for the web. React Navigation lets you define navigators and routes manually in code. Choose whichever model fits your project.
 
 </Collapsible>
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -124,7 +124,7 @@ Yes, Expo Router is the framework for universal React Native apps. Due to the de
 
 <Collapsible summary="Why should I use Expo Router over React Navigation?">
 
-Expo Router and React Navigation are both libraries from the Expo team. Expo Router takes a file-based approach, where routes are derived from your file structure from the **app** directory. It also has built-in support for typed routes, automatic deep linking, and static rendering for the web. React Navigation lets you define navigators and routes manually in code. Choose whichever model fits your project.
+Expo Router takes a file-based approach, where routes are derived from your file structure from the **app** directory. It also has built-in support for typed routes, automatic deep linking, and static rendering for the web. React Navigation lets you define navigators and routes manually in code. Choose whichever model fits your project.
 
 </Collapsible>
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -74,7 +74,7 @@ Now, you can start your project by running:
 
 ## Key features
 
-- **Native**: Expo Router navigation is truly native and platform-optimized by default.
+- **Native**: Built on top of [React Native Screens](https://github.com/software-mansion/react-native-screens), Expo Router navigation is truly native and platform-optimized by default.
 - **Shareable**: Every screen in your app is automatically [deep linkable](/linking/overview/), making any route in your app shareable with links.
 - **Offline-first**: Apps are cached and run offline-first, with automatic updates when you publish a new version. Handles all incoming native URLs without a network connection or server.
 - **Optimized**: Routes are automatically optimized with [lazy-evaluation in production](/router/web/async-routes/), and deferred bundling in development.

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -11,7 +11,7 @@ The original **Expo for web** version was based on Webpack 4 and focused primari
 
 Expo Router is the new approach to building powerful universal apps that run on web and native. This guide will help you migrate your existing website to Expo Router.
 
-Both React Navigation and Expo Router are Expo frameworks for routing and navigation. Expo Router is a wrapper around React Navigation and has many shared concepts.
+Both React Navigation and Expo Router are Expo frameworks for routing and navigation with shared concepts.
 
 ## Pitch
 

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -11,8 +11,6 @@ The original **Expo for web** version was based on Webpack 4 and focused primari
 
 Expo Router is the new approach to building powerful universal apps that run on web and native. This guide will help you migrate your existing website to Expo Router.
 
-Both React Navigation and Expo Router are Expo frameworks for routing and navigation with shared concepts.
-
 ## Pitch
 
 > **warning** `@expo/webpack-config` is [deprecated](/more/release-statuses/#deprecated) and not receiving any new feature updates.

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -8,7 +8,7 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 
-Both React Navigation and Expo Router are Expo frameworks for routing and navigation. Expo Router is a wrapper around React Navigation and many of the concepts are the same.
+Both React Navigation and Expo Router are Expo frameworks for routing and navigation with shared concepts.
 
 ## Pitch
 

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -8,8 +8,6 @@ import { Collapsible } from '~/ui/components/Collapsible';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal, DiffBlock } from '~/ui/components/Snippet';
 
-Both React Navigation and Expo Router are Expo frameworks for routing and navigation with shared concepts.
-
 ## Pitch
 
 Along with all the benefits of React Navigation, Expo Router enables automatic deep linking, [type safety](/router/reference/typed-routes), [deferred bundling](/router/web/async-routes), [static rendering on web](/router/web/static-rendering), and more.

--- a/docs/pages/versions/unversioned/sdk/router/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/index.mdx
@@ -14,7 +14,7 @@ import APISection from '~/components/plugins/APISection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/ConfigSection';
 
-`expo-router` is a routing library for React Native and web apps. It enables navigation management using a file-based routing system and provides native navigation components and is built on top of [React Navigation](https://reactnavigation.org/).
+`expo-router` is a routing library for React Native and web apps. It enables navigation management using a file-based routing system and provides native navigation components.
 
 <BoxLink
   title="Expo Router guides"


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20810


# How

- `docs/pages/develop/app-navigation.mdx`: removed the "is built on top of React Navigation" clause from the Expo Router intro paragraph.
- `docs/pages/router/basics/core-concepts.mdx`: rewrote rule #7 to be about customizing the stack and tab navigators, pointing at Expo Router's own `/router/advanced/stack/` and `/router/advanced/tabs/` guides instead of asserting an internal dependency on React Navigation.
- `docs/pages/router/introduction.mdx`: dropped the "Built on top of our powerful React Navigation suite" qualifier from the **Native** key feature bullet, and rewrote the "Why should I use Expo Router over React Navigation?" collapsible to frame the two as alternative Expo libraries rather than claiming Expo Router is a superset.
- `docs/pages/router/migrate/from-expo-webpack.mdx` and `docs/pages/router/migrate/from-react-navigation.mdx`: changed "Expo Router is a wrapper around React Navigation" to "with shared concepts".
- `docs/pages/debugging/devtools-plugins.mdx`: dropped the "Since Expo Router is built upon React Navigation" justification before the compatibility statement.

# Test Plan

See preview for the following pages

- `/develop/app-navigation/`
- `/router/basics/core-concepts/`
- `/router/introduction/`
- `/router/migrate/from-expo-webpack/`
- `/router/migrate/from-react-navigation/`
- `/debugging/devtools-plugins/`


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
