### PR TITLE
[JSI] Allow host object getters and setters to throw into JS

### DIFF
--- a/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
+++ b/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
@@ -66,4 +66,9 @@ internal final class ReadOnlyExpoModulesPropertyException: GenericException<Stri
       + "the `expo.modules` namespace is owned by the native runtime and its bindings cannot be replaced from JavaScript. "
       + "Define or override behavior inside the native module instead."
   }
+
+  // The default `JavaScriptThrowable.message` is `String(reflecting: self)`, which on
+  // `Exception` resolves to `debugDescription` (name + reason + Swift file:line). For a
+  // JS-facing error we want just `reason`, without leaking native source coordinates.
+  var message: String { reason }
 }

--- a/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
+++ b/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
@@ -41,10 +41,7 @@ internal class ExpoRuntimeInstaller: EXJavaScriptRuntimeManager {
         return appContext?.getNativeModuleObject(moduleName) ?? .undefined
       },
       set: { propertyName, _ in
-        // The modules host object is read-only, but the JSI Swift wrapper's `set`
-        // callback can't currently throw into JavaScript, so we log and ignore.
-        // TODO: switch to a throwing `set` once ExpoModulesJSI supports it.
-        log.warn("Ignoring write to expo.modules.\(propertyName); the modules host object is read-only")
+        throw ReadOnlyExpoModulesPropertyException(propertyName)
       },
       getPropertyNames: { [weak appContext] in
         return appContext?.getModuleNames() ?? []
@@ -56,5 +53,17 @@ internal class ExpoRuntimeInstaller: EXJavaScriptRuntimeManager {
 
     // Define the `global.expo.modules` object as a non-configurable, read-only and enumerable property.
     coreObject.defineProperty("modules", value: modulesHostObject, options: [.enumerable])
+  }
+}
+
+/**
+ Raised when JavaScript code attempts to assign to `expo.modules.*`. Module bindings
+ are owned by the native side and cannot be replaced from JS.
+ */
+internal final class ReadOnlyExpoModulesPropertyException: GenericException<String>, @unchecked Sendable {
+  override var reason: String {
+    "Cannot assign to 'expo.modules.\(param)': "
+      + "the `expo.modules` namespace is owned by the native runtime and its bindings cannot be replaced from JavaScript. "
+      + "Define or override behavior inside the native module instead."
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/CppError.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/CppError.h
@@ -103,6 +103,16 @@ public:
   }
 
   /**
+   Re-publishes an existing `CppError` into the current thread's slot. Used from Swift
+   to relay a `CppError` that was caught from a `throw` (and thus already drained from
+   the slot by `getCurrent`) so the original `jsi::JSError` — including its stack, code
+   and custom properties — can be rethrown into JavaScript.
+   */
+  inline static void setCurrent(CppError cppError) {
+    _current = std::make_unique<CppError>(std::move(cppError));
+  }
+
+  /**
    Sets the current thread's error by creating a `jsi::JSError` from the given message.
    Called from Swift when a host function closure throws a plain error.
    */

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
@@ -33,6 +33,10 @@ public:
   }
 
   inline void set(jsi::Runtime &runtime, const jsi::PropNameID &name, const jsi::Value &value) override {
+    // For read-only host objects (no Swift setter), `_callbacks.set` throws a
+    // `jsi::JSError` directly and the `CppError` check below is never reached.
+    // For writable host objects, a throwing Swift setter routes its error through
+    // `CppError`'s thread-local slot, which we drain and rethrow here.
     _callbacks.set(runtime, name.utf8(runtime).c_str(), value);
     if (auto *error = CppError::getCurrent()) {
       throw error->release();

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <jsi/jsi.h>
 
+#include "CppError.h"
 #include "HostObjectCallbacks.h"
 
 namespace jsi = facebook::jsi;
@@ -22,11 +23,20 @@ public:
   }
 
   inline jsi::Value get(jsi::Runtime &runtime, const jsi::PropNameID &name) override {
-    return _callbacks.get(name.utf8(runtime).c_str());
+    auto result = _callbacks.get(name.utf8(runtime).c_str());
+    // If the Swift getter stored a pending error, rethrow its JSError directly
+    // to preserve all properties (message, code, stack, etc.).
+    if (auto *error = CppError::getCurrent()) {
+      throw error->release();
+    }
+    return result;
   }
 
   inline void set(jsi::Runtime &runtime, const jsi::PropNameID &name, const jsi::Value &value) override {
-    _callbacks.set(name.utf8(runtime).c_str(), value);
+    _callbacks.set(runtime, name.utf8(runtime).c_str(), value);
+    if (auto *error = CppError::getCurrent()) {
+      throw error->release();
+    }
   }
 
   inline std::vector<jsi::PropNameID> getPropertyNames(jsi::Runtime &runtime) override {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObjectCallbacks.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObjectCallbacks.h
@@ -21,14 +21,31 @@ public:
   using PropertyNamesGetter = PropNameIds(Context);
   using Deallocator = void(Context);
 
-  explicit HostObjectCallbacks(Context context, Getter getter, Setter setter, PropertyNamesGetter propertyNamesGetter, Deallocator deallocator)
-  : _context(context), _getter(std::move(getter)), _setter(std::move(setter)), _propertyNamesGetter(std::move(propertyNamesGetter)), _deallocator(std::move(deallocator)) {}
+  explicit HostObjectCallbacks(Context context, Getter getter, Setter *_Nullable setter, PropertyNamesGetter propertyNamesGetter, Deallocator deallocator)
+  : _context(context), _getter(getter), _setter(setter), _propertyNamesGetter(propertyNamesGetter), _deallocator(deallocator) {}
 
   inline facebook::jsi::Value get(const char *_Nonnull name) const {
     return _getter(_context, name);
   }
 
-  inline void set(const char *_Nonnull name, const facebook::jsi::Value &value) const {
+  /**
+   Dispatches to the Swift setter. Throws a `jsi::JSError` if no setter was provided,
+   matching the JS engine's behavior for assignment to a property with no setter.
+
+   Only call from inside a JSI host-object trampoline (e.g. `HostObject::set`). The
+   thrown `jsi::JSError` is only converted into a JS exception if there is an active
+   JSI call frame above this on the stack; calling outside that context will surface
+   the throw as an unhandled C++ exception.
+   */
+  inline void set(facebook::jsi::Runtime &runtime, const char *_Nonnull name, const facebook::jsi::Value &value) const {
+    if (_setter == nullptr) {
+      throw facebook::jsi::JSError(
+        runtime,
+        std::string("Cannot set property '") + name + "' on a read-only host object: "
+          "no setter was provided when the host object was created. "
+          "Pass a `set` closure to `createHostObject` to make this property writable."
+      );
+    }
     _setter(_context, name, (void *)(&value));
   }
 
@@ -43,7 +60,7 @@ public:
 private:
   Context _context;
   Getter *_Nonnull _getter;
-  Setter *_Nonnull _setter;
+  Setter *_Nullable _setter;
   PropertyNamesGetter *_Nonnull _propertyNamesGetter;
   Deallocator *_Nonnull _deallocator;
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -87,6 +87,16 @@ inline jsi::Function createHostFunction(jsi::Runtime &runtime, const char *name,
   return createHostFunction(runtime, propName, closure);
 }
 
+/**
+ Returns whether `object` is backed by any `jsi::HostObject` subclass — this includes
+ host objects created by `expo::HostObject::makeObject`, by other React Native subsystems,
+ and by JS engines themselves. Wraps the templated `jsi::Object::isHostObject<T>` so the
+ check is callable from Swift, where C++ function templates cannot be imported directly.
+ */
+inline bool isHostObject(jsi::Runtime &runtime, const jsi::Object &object) {
+  return object.isHostObject<jsi::HostObject>(runtime);
+}
+
 jsi::Runtime* createHermesRuntime();
 
 inline jsi::Value evaluateJavaScript(jsi::Runtime &runtime, const std::shared_ptr<const jsi::Buffer>& buffer, const std::string& sourceURL) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
@@ -2,21 +2,21 @@
  Context that captures Swift types to pass them to JSI host object as an unmanaged pointer for interoperability with C++.
  */
 internal final class HostObjectContext: Sendable {
-  typealias Getter = @JavaScriptActor (_ propertyName: String) -> JavaScriptValue
-  typealias Setter = @JavaScriptActor (_ propertyName: String, _ value: JavaScriptValue) -> Void
+  typealias Getter = @JavaScriptActor (_ propertyName: String) throws -> JavaScriptValue
+  typealias Setter = @JavaScriptActor (_ propertyName: String, _ value: JavaScriptValue) throws -> Void
   typealias PropertyNamesGetter = @JavaScriptActor () -> [String]
   typealias Deallocator = @JavaScriptActor () -> Void
 
   weak let runtime: JavaScriptRuntime?
   let get: Getter
-  let set: Setter
+  let set: Setter?
   let getPropertyNames: PropertyNamesGetter
   let dealloc: Deallocator
 
   init(
     runtime: JavaScriptRuntime,
     _ get: @escaping Getter,
-    _ set: @escaping Setter,
+    _ set: Setter?,
     _ getPropertyNames: @escaping PropertyNamesGetter,
     _ dealloc: @escaping Deallocator
   ) {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -105,8 +105,8 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    the thrown type to `JavaScriptThrowable` to control the resulting `message` and `code`.
 
    Pass `nil` for `set` to make the host object read-only — assignment from JavaScript
-   then throws a `TypeError`-style error matching the engine's behavior for a property
-   with no setter. `getPropertyNames` and `dealloc` default to no-ops.
+   then throws an `Error` whose message names the property and explains how to make it
+   writable. `getPropertyNames` and `dealloc` default to no-ops.
    */
   public func createHostObject(
     get: @escaping @JavaScriptActor (_ propertyName: String) throws -> JavaScriptValue,
@@ -130,17 +130,20 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
     func setter(context: UnsafeMutableRawPointer, propertyName: UnsafePointer<CChar>, valuePointer: UnsafeMutableRawPointer) {
       let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeUnretainedValue()
-      let value = JavaScriptValue(context.runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
-      let propertyName = String(cString: propertyName)
 
       guard let runtime = context.runtime else {
         FatalError.runtimeLost()
       }
-      // The C++ side never dispatches here when the Swift setter is nil — it
-      // throws a `jsi::JSError` before reaching this trampoline.
       guard let set = context.set else {
+        // Unreachable in practice: when the user passed `nil` for `set`, the call site
+        // below at `expo.HostObjectCallbacks(...)` also passes `nil` to C++, and
+        // `HostObjectCallbacks::set` throws a `jsi::JSError` directly instead of
+        // calling back into Swift.
         return
       }
+      let value = JavaScriptValue(runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
+      let propertyName = String(cString: propertyName)
+
       JavaScriptActor.assumeIsolated {
         forwardingSwiftErrorsToJS(runtime: runtime) {
           try set(propertyName, value)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -100,19 +100,31 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
   /**
    Creates a JavaScript host object with given implementations for property getter, property setter, property names getter and dealloc.
+
+   Errors thrown from `get` or `set` propagate to JavaScript as a thrown `Error`. Conform
+   the thrown type to `JavaScriptThrowable` to control the resulting `message` and `code`.
+
+   Pass `nil` for `set` to make the host object read-only — assignment from JavaScript
+   then throws a `TypeError`-style error matching the engine's behavior for a property
+   with no setter. `getPropertyNames` and `dealloc` default to no-ops.
    */
   public func createHostObject(
-    get: @escaping @JavaScriptActor (_ propertyName: String) -> JavaScriptValue,
-    set: @escaping @JavaScriptActor (_ propertyName: String, _ value: JavaScriptValue) -> Void,
-    getPropertyNames: @escaping @JavaScriptActor () -> [String],
-    dealloc: @escaping @JavaScriptActor () -> Void
+    get: @escaping @JavaScriptActor (_ propertyName: String) throws -> JavaScriptValue,
+    set: (@JavaScriptActor (_ propertyName: String, _ value: JavaScriptValue) throws -> Void)? = nil,
+    getPropertyNames: @escaping @JavaScriptActor () -> [String] = { [] },
+    dealloc: @escaping @JavaScriptActor () -> Void = {}
   ) -> JavaScriptObject {
     func getter(context: UnsafeMutableRawPointer, propertyName: UnsafePointer<CChar>) -> facebook.jsi.Value {
       let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeUnretainedValue()
       let propertyName = String(cString: propertyName)
 
+      guard let runtime = context.runtime else {
+        FatalError.runtimeLost()
+      }
       return JavaScriptActor.assumeIsolated {
-        return context.get(propertyName).asJSIValue()
+        return forwardingSwiftErrorsToJS(runtime: runtime) {
+          return try context.get(propertyName).asJSIValue()
+        }
       }
     }
 
@@ -120,8 +132,19 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
       let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeUnretainedValue()
       let value = JavaScriptValue(context.runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
       let propertyName = String(cString: propertyName)
-      return JavaScriptActor.assumeIsolated {
-        context.set(propertyName, value)
+
+      guard let runtime = context.runtime else {
+        FatalError.runtimeLost()
+      }
+      // The C++ side never dispatches here when the Swift setter is nil — it
+      // throws a `jsi::JSError` before reaching this trampoline.
+      guard let set = context.set else {
+        return
+      }
+      JavaScriptActor.assumeIsolated {
+        forwardingSwiftErrorsToJS(runtime: runtime) {
+          try set(propertyName, value)
+        }
       }
     }
 
@@ -156,7 +179,9 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     }
 
     let context = Unmanaged.passRetained(HostObjectContext(runtime: self, get, set, getPropertyNames, dealloc)).toOpaque()
-    let callbacks = expo.HostObjectCallbacks(context, getter, setter, propertyNamesGetter, deallocate)
+    // Pass a null setter to C++ when the Swift setter is nil so that JS assignment
+    // raises a `jsi::JSError` directly, without crossing the Swift boundary.
+    let callbacks = expo.HostObjectCallbacks(context, getter, set == nil ? nil : setter, propertyNamesGetter, deallocate)
     let hostObject = expo.HostObject.makeObject(pointee, consume callbacks)
 
     return JavaScriptObject(self, hostObject)
@@ -527,19 +552,9 @@ private func createFunctionClosure(runtime: JavaScriptRuntime, name: String? = n
     let argumentsRef = JavaScriptValuesBuffer(runtime, start: argumentsPtr, count: argumentsCount).ref()
 
     return JavaScriptActor.assumeIsolated {
-      do {
+      return forwardingSwiftErrorsToJS(runtime: runtime) {
         let thisValue = JavaScriptValue(runtime, this)
-        let result = try context.call(thisValue, argumentsRef.take())
-        return result.asJSIValue()
-      } catch let throwable as JavaScriptThrowable {
-        // Store the error in thread-local storage so the C++ caller can
-        // retrieve it and throw a jsi::JSError after this closure returns.
-        let jsError = JavaScriptError(runtime, from: throwable)
-        expo.CppError.setCurrent(jsError.toJSError())
-        return .undefined()
-      } catch let error {
-        expo.CppError.setCurrent(runtime.pointee, std.string(String(describing: error)))
-        return .undefined()
+        return try context.call(thisValue, argumentsRef.take()).asJSIValue()
       }
     }
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -138,8 +138,9 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
         // Unreachable in practice: when the user passed `nil` for `set`, the call site
         // below at `expo.HostObjectCallbacks(...)` also passes `nil` to C++, and
         // `HostObjectCallbacks::set` throws a `jsi::JSError` directly instead of
-        // calling back into Swift.
-        return
+        // calling back into Swift. Trap loudly so a future C++ refactor can't silently
+        // swallow assignments.
+        FatalError.readOnlyHostObjectSetterInvoked()
       }
       let value = JavaScriptValue(runtime, valuePointer.assumingMemoryBound(to: facebook.jsi.Value.self).move())
       let propertyName = String(cString: propertyName)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -71,10 +71,16 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return pointee.isFunction(runtime.pointee)
   }
 
-// TODO: `isHostObject` is ambiguous for Swift as it's a template – we need specialization in C++
-//  public func isHostObject() -> Bool {
-//    return pointee.isHostObject(runtime.pointee)
-//  }
+  /**
+   Returns `true` if the object is backed by a `jsi::HostObject`, including host objects
+   created via `JavaScriptRuntime.createHostObject` and ones produced by other native code.
+   */
+  public func isHostObject() -> Bool {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    return expo.isHostObject(runtime.pointee, pointee)
+  }
 
   public func isArrayBuffer() -> Bool {
     guard let runtime else {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
@@ -40,6 +40,10 @@ internal func forwardingSwiftErrorsToJS(
     return try body()
   } catch let throwable as JavaScriptThrowable {
     expo.CppError.setCurrent(JavaScriptError(runtime, from: throwable).toJSError())
+  } catch let cppError as expo.CppError {
+    // Re-thrown by `capturingCppErrors` when nested JSI work raised a JS error; relay
+    // the original so its `jsi::JSError` (with stack, code, custom properties) survives.
+    expo.CppError.setCurrent(cppError)
   } catch let error {
     expo.CppError.setCurrent(runtime.pointee, std.string(String(describing: error)))
   }
@@ -59,6 +63,8 @@ internal func forwardingSwiftErrorsToJS(
     try body()
   } catch let throwable as JavaScriptThrowable {
     expo.CppError.setCurrent(JavaScriptError(runtime, from: throwable).toJSError())
+  } catch let cppError as expo.CppError {
+    expo.CppError.setCurrent(cppError)
   } catch let error {
     expo.CppError.setCurrent(runtime.pointee, std.string(String(describing: error)))
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
@@ -22,3 +22,44 @@ internal func capturingCppErrors<R: ~Copyable>(_ block: () throws -> R) throws -
   }
   return result
 }
+
+/**
+ Runs a Swift trampoline body called from a C++ host callback and forwards any thrown error
+ to `expo::CppError`'s thread-local storage so the C++ side can rethrow it as a `jsi::JSError`.
+ On the failure branch returns `undefined`, since the C++ side will overwrite it by throwing
+ the rethrown `jsi::JSError` before the value is observed by JS. Used by host function and
+ host object getter trampolines on a hot path, hence `@_transparent` to inline into the
+ caller and avoid a function-call boundary.
+ */
+@_transparent
+internal func forwardingSwiftErrorsToJS(
+  runtime: JavaScriptRuntime,
+  _ body: () throws -> facebook.jsi.Value
+) -> facebook.jsi.Value {
+  do {
+    return try body()
+  } catch let throwable as JavaScriptThrowable {
+    expo.CppError.setCurrent(JavaScriptError(runtime, from: throwable).toJSError())
+  } catch let error {
+    expo.CppError.setCurrent(runtime.pointee, std.string(String(describing: error)))
+  }
+  return .undefined()
+}
+
+/**
+ Void overload of `forwardingSwiftErrorsToJS` for host object setter trampolines, which
+ have no return value to propagate.
+ */
+@_transparent
+internal func forwardingSwiftErrorsToJS(
+  runtime: JavaScriptRuntime,
+  _ body: () throws -> Void
+) {
+  do {
+    try body()
+  } catch let throwable as JavaScriptThrowable {
+    expo.CppError.setCurrent(JavaScriptError(runtime, from: throwable).toJSError())
+  } catch let error {
+    expo.CppError.setCurrent(runtime.pointee, std.string(String(describing: error)))
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/Errors.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/Errors.swift
@@ -29,4 +29,17 @@ internal struct FatalError {
   internal static func valuesBufferNotRepresentable() -> Never {
     fatalError("JavaScript values buffer cannot be represented as a single value")
   }
+
+  /**
+   Stops program execution when the Swift setter trampoline runs for a host object that
+   was created with `set: nil`. The C++ `HostObjectCallbacks::set` is supposed to throw a
+   `jsi::JSError` for read-only host objects without re-entering Swift, so reaching this
+   means that contract has drifted — check its null-setter short-circuit.
+   */
+  internal static func readOnlyHostObjectSetterInvoked() -> Never {
+    fatalError(
+      "createHostObject setter trampoline ran despite set: nil — HostObjectCallbacks::set should throw a jsi::JSError for read-only host objects without re-entering Swift. "
+      + "Check that its null-setter short-circuit is still in place."
+    )
+  }
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -408,6 +408,62 @@ struct JavaScriptRuntimeTests {
     #expect(result.getInt() == 7)
   }
 
+  @Test
+  func `host getter that calls failing JS preserves the original error`() throws {
+    try runtime.eval("""
+      globalThis.throwTagged = function () {
+        const e = new Error('inner failure');
+        e.code = 'ERR_INNER';
+        throw e;
+      };
+    """)
+    let throwTagged = runtime.global().getPropertyAsFunction("throwTagged")
+
+    let hostObject = runtime.createHostObject(
+      get: { _ in
+        // Calling JS that throws surfaces an `expo.CppError` wrapping the original
+        // `jsi::JSError`. Letting it propagate exercises the CppError relay path.
+        _ = try throwTagged.call()
+        return .undefined
+      }
+    )
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.foo; null } catch (e) { [e.message, e.code] }
+    """).getArray()
+
+    #expect(result[0].getString() == "inner failure")
+    #expect(result[1].getString() == "ERR_INNER")
+  }
+
+  @Test
+  func `host setter that calls failing JS preserves the original error`() throws {
+    try runtime.eval("""
+      globalThis.throwTagged = function () {
+        const e = new Error('inner setter failure');
+        e.code = 'ERR_SETTER';
+        throw e;
+      };
+    """)
+    let throwTagged = runtime.global().getPropertyAsFunction("throwTagged")
+
+    let hostObject = runtime.createHostObject(
+      get: { _ in .undefined },
+      set: { _, _ in
+        _ = try throwTagged.call()
+      }
+    )
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.foo = 1; null } catch (e) { [e.message, e.code] }
+    """).getArray()
+
+    #expect(result[0].getString() == "inner setter failure")
+    #expect(result[1].getString() == "ERR_SETTER")
+  }
+
   // MARK: - Host function error propagation
 
   @Test

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -129,9 +129,7 @@ struct JavaScriptRuntimeTests {
         }
         return .undefined
       },
-      set: { _, _ in },
-      getPropertyNames: { ["foo"] },
-      dealloc: {}
+      getPropertyNames: { ["foo"] }
     )
 
     #expect(hostObject.getProperty("foo").getInt() == 42)
@@ -154,8 +152,7 @@ struct JavaScriptRuntimeTests {
           storedValue = value.getInt()
         }
       },
-      getPropertyNames: { ["value"] },
-      dealloc: {}
+      getPropertyNames: { ["value"] }
     )
 
     hostObject.setProperty("value", value: 99)
@@ -173,9 +170,7 @@ struct JavaScriptRuntimeTests {
         default: return .undefined
         }
       },
-      set: { _, _ in },
-      getPropertyNames: { ["a", "b"] },
-      dealloc: {}
+      getPropertyNames: { ["a", "b"] }
     )
 
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
@@ -195,15 +190,222 @@ struct JavaScriptRuntimeTests {
         }
         return .undefined
       },
-      set: { _, _ in },
-      getPropertyNames: { ["greeting"] },
-      dealloc: {}
+      getPropertyNames: { ["greeting"] }
     )
 
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
     let result = try runtime.eval("globalThis.hostObj.greeting")
 
     #expect(result.getString() == "hello")
+  }
+
+  @Test
+  func `isHostObject distinguishes host objects from plain ones`() {
+    let hostObject = runtime.createHostObject(
+      get: { _ in .undefined }
+    )
+    let plainObject = runtime.createObject()
+
+    #expect(hostObject.isHostObject() == true)
+    #expect(plainObject.isHostObject() == false)
+  }
+
+  @Test
+  func `host object default getPropertyNames returns no keys in JavaScript`() throws {
+    let hostObject = runtime.createHostObject(
+      get: { _ in .undefined }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    let count = try runtime.eval("Object.keys(globalThis.hostObj).length")
+    #expect(count.getInt() == 0)
+  }
+
+  // MARK: - Host object error propagation
+
+  @Test
+  func `throwing host object setter propagates error to JavaScript`() throws {
+    struct TestError: Error, CustomStringConvertible {
+      var description: String { "set failed" }
+    }
+
+    let hostObject = runtime.createHostObject(
+      get: { _ in .undefined },
+      set: { _, _ in throw TestError() }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.foo = 1; 'no error' } catch (e) { e.message }
+    """)
+
+    #expect(result.getString().contains("set failed"))
+  }
+
+  @Test
+  func `throwing host object setter with JavaScriptThrowable preserves code`() throws {
+    struct TypedError: JavaScriptThrowable {
+      var message: String { "read only" }
+      var code: String { "ERR_READ_ONLY" }
+    }
+
+    let hostObject = runtime.createHostObject(
+      get: { _ in .undefined },
+      set: { _, _ in throw TypedError() }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.foo = 1; null } catch (e) { [e.message, e.code] }
+    """).getArray()
+
+    #expect(result[0].getString() == "read only")
+    #expect(result[1].getString() == "ERR_READ_ONLY")
+  }
+
+  @Test
+  func `throwing host object getter propagates error to JavaScript`() throws {
+    struct TestError: Error, CustomStringConvertible {
+      var description: String { "get failed" }
+    }
+
+    let hostObject = runtime.createHostObject(
+      get: { _ in throw TestError() }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.foo; 'no error' } catch (e) { e.message }
+    """)
+
+    #expect(result.getString().contains("get failed"))
+  }
+
+  @Test
+  func `throwing host object getter with JavaScriptThrowable preserves code`() throws {
+    struct TypedError: JavaScriptThrowable {
+      var message: String { "missing" }
+      var code: String { "ERR_MISSING" }
+    }
+
+    let hostObject = runtime.createHostObject(
+      get: { _ in throw TypedError() }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.foo; null } catch (e) { [e.message, e.code] }
+    """).getArray()
+
+    #expect(result[0].getString() == "missing")
+    #expect(result[1].getString() == "ERR_MISSING")
+  }
+
+  @Test
+  func `host object setter recovers after throwing`() throws {
+    struct TestError: Error, CustomStringConvertible {
+      var description: String { "boom" }
+    }
+    var stored: Int = 0
+    var shouldThrow = true
+
+    let hostObject = runtime.createHostObject(
+      get: { _ in JavaScriptValue(self.runtime, stored) },
+      set: { _, value in
+        if shouldThrow {
+          throw TestError()
+        }
+        stored = value.getInt()
+      },
+      getPropertyNames: { ["value"] }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    // First write throws and is caught in JS.
+    let firstAttempt = try runtime.eval("""
+      try { globalThis.hostObj.value = 1; 'no error' } catch (e) { e.message }
+    """)
+    #expect(firstAttempt.getString().contains("boom"))
+
+    // Subsequent write must succeed — verifies the C++ thread-local error
+    // state is cleared after being rethrown, not leaked to the next call.
+    shouldThrow = false
+    let secondAttempt = try runtime.eval("""
+      try { globalThis.hostObj.value = 7; globalThis.hostObj.value } catch (e) { -1 }
+    """)
+    #expect(secondAttempt.getInt() == 7)
+  }
+
+  @Test
+  func `host object setter error does not pollute later getter`() throws {
+    struct TestError: Error, CustomStringConvertible {
+      var description: String { "set failed" }
+    }
+
+    let hostObject = runtime.createHostObject(
+      get: { name in
+        if name == "ok" {
+          return JavaScriptValue(self.runtime, 123)
+        }
+        return .undefined
+      },
+      set: { _, _ in throw TestError() },
+      getPropertyNames: { ["ok"] }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    // A failing set followed by a successful get must not surface the
+    // earlier set error — checks the thread-local error slot is cleared.
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.value = 1 } catch (e) {}
+      globalThis.hostObj.ok
+    """)
+
+    #expect(result.getInt() == 123)
+  }
+
+  @Test
+  func `read-only host object rejects assignment from JavaScript`() throws {
+    let hostObject = runtime.createHostObject(
+      get: { _ in JavaScriptValue(self.runtime, 1) }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    // No `set` was provided — the C++ side raises a `jsi::JSError` directly,
+    // without crossing the Swift boundary.
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.foo = 1; 'no error' } catch (e) { e.message }
+    """)
+    let message = result.getString()
+
+    #expect(message.contains("read-only host object"))
+    #expect(message.contains("'foo'"))
+  }
+
+  @Test
+  func `non-throwing host object setter does not trigger error`() throws {
+    var stored: Int = 0
+    let hostObject = runtime.createHostObject(
+      get: { _ in JavaScriptValue(self.runtime, stored) },
+      set: { _, value in stored = value.getInt() },
+      getPropertyNames: { ["value"] }
+    )
+
+    runtime.global().setProperty("hostObj", value: hostObject.asValue())
+
+    let result = try runtime.eval("""
+      try { globalThis.hostObj.value = 7; globalThis.hostObj.value } catch (e) { -1 }
+    """)
+
+    #expect(result.getInt() == 7)
   }
 
   // MARK: - Host function error propagation


### PR DESCRIPTION
## Why

Host object `get` and `set` closures couldn't propagate errors to JavaScript. Setters in particular had no way to reject a write — `expo.modules` worked around this by silently logging and ignoring assignments (TODO at `ExpoRuntimeInstaller.swift:46`), and there was no general escape hatch for native code to signal an invalid property access.

## What

- **Throwing closures.** `createHostObject(get:set:...)` now accepts throwing closures for both `get` and `set`. Errors propagate to JavaScript as a thrown `Error`. Conform the thrown type to `JavaScriptThrowable` to control the resulting `message` and `code`. The path mirrors the existing `createFunction` error handling: Swift trampoline catches → `expo::CppError` thread-local → C++ `HostObject::get`/`set` rethrows as `jsi::JSError`.
- **Optional setter for read-only host objects.** Pass `nil` (now the default) for `set` to make the host object read-only. Assignment from JS then raises a `jsi::JSError` directly from C++ without crossing the Swift boundary. `getPropertyNames` and `dealloc` also defaulted (`{ [] }` and `{}`).
- **`JavaScriptObject.isHostObject()`.** Wraps `jsi::Object::isHostObject<jsi::HostObject>` via a small C++ helper, so the templated check is callable from Swift. Returns true for any host-object-backed JS object regardless of which subsystem created it.
- **`forwardingSwiftErrorsToJS` helper.** Two `@_transparent` overloads (`facebook.jsi.Value`-returning + `Void`) replace the duplicated catch ladder in the host-function trampoline and serve the new host-object trampolines. `@_transparent` ensures the generic body is inlined into each call site, erasing any function-call overhead.
- **`expo.modules` now throws on assignment** (`ReadOnlyExpoModulesPropertyException`) instead of swallowing writes.

## Test plan

- [x] New test cases in `JavaScriptRuntimeTests.swift` cover:
  - throwing setter (plain `Error` and `JavaScriptThrowable` with `code`)
  - throwing getter (same pair)
  - setter recovers after throwing (thread-local clear)
  - setter error doesn't pollute later getter (thread-local clear, different angle)
  - read-only host object rejects assignment with the property name in the message
  - default `getPropertyNames` returns no keys
  - `isHostObject` distinguishes host objects from plain ones
- [x] Manually verify in a sample app that `expo.modules.foo = bar` now throws a clear error instead of silently no-op-ing.