### PR TITLE
feat(expo-auth-session): bubble up error from WebBrowser

### DIFF
--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fixed `promptAsync` returning `{ type: 'cancel' }` instead of `{ type: 'error' }` when iOS `ASWebAuthenticationSession` fails with a native error (e.g. missing Associated Domains entitlement for HTTPS callbacks). The `errorCode` field now contains the native error message.
+- Fixed `promptAsync` returning `{ type: 'cancel' }` instead of `{ type: 'error' }` when iOS `ASWebAuthenticationSession` fails with a native error (e.g. missing Associated Domains entitlement for HTTPS callbacks). The `errorCode` field now contains the native error message. ([#45152](https://github.com/expo/expo/pull/45152) by [@danielma](https://github.com/danielma))
 
 ### 💡 Others
 

--- a/packages/expo-auth-session/CHANGELOG.md
+++ b/packages/expo-auth-session/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed `promptAsync` returning `{ type: 'cancel' }` instead of `{ type: 'error' }` when iOS `ASWebAuthenticationSession` fails with a native error (e.g. missing Associated Domains entitlement for HTTPS callbacks). The `errorCode` field now contains the native error message.
+
 ### 💡 Others
 
 ## 55.0.6 — 2026-02-25

--- a/packages/expo-auth-session/src/AuthRequest.ts
+++ b/packages/expo-auth-session/src/AuthRequest.ts
@@ -186,7 +186,11 @@ export class AuthRequest implements Omit<AuthRequestConfig, 'state'> {
       throw new Error('An unexpected error occurred');
     }
     if (result.type !== 'success') {
-      return { type: result.type };
+      if ('error' in result && result.error) {
+        return { type: 'error', errorCode: result.error, error: null, params: {}, authentication: null, url: '' };
+      } else {
+        return { type: result.type };
+      }
     }
 
     return this.parseReturnUrl(result.url);

--- a/packages/expo-auth-session/src/__tests__/AuthRequest-test.ts
+++ b/packages/expo-auth-session/src/__tests__/AuthRequest-test.ts
@@ -1,6 +1,11 @@
+import * as WebBrowser from 'expo-web-browser';
 import { AuthRequest } from '../AuthRequest';
 import { CodeChallengeMethod, Prompt } from '../AuthRequest.types';
 import { getQueryParams } from '../QueryParams';
+
+jest.mock('expo-web-browser', () => ({
+  openAuthSessionAsync: jest.fn(),
+}));
 
 jest.mock('expo-crypto', () => ({
   getRandomValues: jest.fn((x) => x),
@@ -195,4 +200,46 @@ it(`loads an auth request without pkce`, async () => {
   expect(request.codeVerifier).not.toBeDefined();
 
   expect(typeof request.state).toBe('string');
+});
+
+describe('promptAsync error handling', () => {
+  const mockOpenAuthSession = WebBrowser.openAuthSessionAsync as jest.Mock;
+
+  beforeEach(() => {
+    mockOpenAuthSession.mockReset();
+  });
+
+  it(`returns { type: 'error' } when WebBrowser result has an error field`, async () => {
+    const errorMessage =
+      "The operation couldn't be completed. Application with identifier com.example.app is not associated with domain example.com.";
+    mockOpenAuthSession.mockResolvedValue({ type: 'cancel', error: errorMessage });
+
+    const request = new AuthRequest({
+      clientId: 'test',
+      scopes: [],
+      redirectUri: 'foo://bar',
+      state: 'teststate',
+    });
+    await request.makeAuthUrlAsync(mockDiscovery);
+
+    const result = await request.promptAsync(mockDiscovery);
+    expect(result.type).toBe('error');
+    if (result.type !== 'error') throw new Error('Invalid type for test');
+    expect(result.errorCode).toBe(errorMessage);
+  });
+
+  it(`returns { type: 'cancel' } when WebBrowser result has no error field`, async () => {
+    mockOpenAuthSession.mockResolvedValue({ type: 'cancel' });
+
+    const request = new AuthRequest({
+      clientId: 'test',
+      scopes: [],
+      redirectUri: 'foo://bar',
+      state: 'teststate',
+    });
+    await request.makeAuthUrlAsync(mockDiscovery);
+
+    const result = await request.promptAsync(mockDiscovery);
+    expect(result.type).toBe('cancel');
+  });
 });

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🎉 New features
 
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
-- Added optional `error` field to `WebBrowserResult` to expose the native error message returned by iOS `ASWebAuthenticationSession` when an auth session fails (e.g. missing Associated Domains entitlement for HTTPS callbacks).
+- Added optional `error` field to `WebBrowserResult` to expose the native error message returned by iOS `ASWebAuthenticationSession` when an auth session fails (e.g. missing Associated Domains entitlement for HTTPS callbacks). ([#45152](https://github.com/expo/expo/pull/45152) by [@danielma](https://github.com/danielma))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🎉 New features
 
 - Expose a typed config plugin function ([#44098](https://github.com/expo/expo/pull/44098) by [@zoontek](https://github.com/zoontek))
+- Added optional `error` field to `WebBrowserResult` to expose the native error message returned by iOS `ASWebAuthenticationSession` when an auth session fails (e.g. missing Associated Domains entitlement for HTTPS callbacks).
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-web-browser/src/WebBrowser.types.ts
+++ b/packages/expo-web-browser/src/WebBrowser.types.ts
@@ -223,6 +223,12 @@ export type WebBrowserResult = {
    * Type of the result.
    */
   type: WebBrowserResultType;
+  /**
+   * Error message returned by the native layer, present on iOS when `ASWebAuthenticationSession`
+   * fails (e.g. missing Associated Domains entitlement for HTTPS callbacks).
+   * @platform ios
+   */
+  error?: string | null;
 };
 
 // @needsAudit @docsMissing


### PR DESCRIPTION
# Why

When using iOS universal links (ref https://github.com/expo/expo/pull/42695 https://github.com/expo/expo/pull/44452), it's possible to get errors back from attempting to launch th`ASWebAuthenticationSession` (that's what #44452 is all about).

That PR is great for making the behavior opt-in, but a remaining problem is that the error itself isn't available at all to library users.

The real world use case for this is that sometimes the AASA isn't loaded fast enough, and first-launch users who try to login get stuck in `cancel` loops. It seems this [happens](https://developer.apple.com/forums/thread/797535) [reasonably](https://developer.apple.com/forums/thread/805416) [frequently](https://community.auth0.com/t/ios-application-not-recognizing-auth0-associated-domain/134847/27).

In our app, I'm using a combination of `type === "cancel"` and a timer to detect this loop and falling back to a custom scheme, but it would be great to be able to capture the real error instead.

# How

First, I've updated `expo-web-browser` types to match the shape that potentially returns:

```js
 { url: null, error: "The operation couldn't be completed. Application with identifier...", type: "cancel" }
```

Second, change `expo-auth-session` to look for the object shape that comes back, and correctly return a `{ type: "error" }` response with the message. This makes it far easier to debug/handle these issues.

# Test Plan

Create an Expo app _without_ the `webcredentials` entitlement, and attempt to start an auth session with `preferUniversalLinks`. You should now get an error back with the system error.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
