### PR TITLE
[expo-cli] change expo-rotuer detection to use package.json instead of resolve

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type { ExpoConfig, Platform } from '@expo/config';
+import { type ExpoConfig, type Platform, getPackageJson } from '@expo/config';
 import type Bundler from '@expo/metro/metro/Bundler';
 import type { ConfigT } from '@expo/metro/metro-config';
 import type {
@@ -198,7 +198,10 @@ export function withExtendedResolver(
     },
   };
 
-  const isExpoRouterResolvable = !!resolveFrom.silent(config.projectRoot, 'expo-router');
+  const pkg = getPackageJson(config.projectRoot);
+  const isExpoRouterProject =
+    (pkg.dependencies && 'expo-router' in pkg.dependencies) ||
+    (pkg.main && pkg.main === 'expo-router/entry');
 
   let _universalAliases: [RegExp, string][] | null;
 
@@ -684,7 +687,7 @@ export function withExtendedResolver(
       }
 
       // TODO(@ubax): Remove this rewrite once we published migration guide for library authors
-      if (moduleName.startsWith('@react-navigation/') && isExpoRouterResolvable) {
+      if (moduleName.startsWith('@react-navigation/') && isExpoRouterProject) {
         const filePath = context.originModulePath;
         if (!filePath.includes('node_modules')) {
           // TODO(@ubax): Add link to migration guide, once it is published


### PR DESCRIPTION
# Why

The metro plugin was detecting wether the project is using `expo-router` based on resolution. This was incorrect in the mono-repo scenario, where expo-router could be resolved from project root, but not from application level.

# How

Instead of checking wether `expo-router` can be resolved, check the `package.json` for `expo-router` dependency or entrypoint

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
