### PR TITLE
[dev-launcher] Support disabling auto launch and onboarding

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [Android] Add NDS service discovery.
 - [plugin] Add option to disable tools button by default. ([#44251](https://github.com/expo/expo/pull/44251) by [@alanjhughes](https://github.com/alanjhughes))
 - Support loading embedded bundles. ([#44396](https://github.com/expo/expo/pull/44396) by [@alanjhughes](https://github.com/alanjhughes))
+- [plugin] Add `skipOnboarding` and `showMenuAtLaunch` options to set menu's onboarding and auto-launch defaults, useful for E2E and CI builds.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -15,7 +15,7 @@
 - [Android] Add NDS service discovery.
 - [plugin] Add option to disable tools button by default. ([#44251](https://github.com/expo/expo/pull/44251) by [@alanjhughes](https://github.com/alanjhughes))
 - Support loading embedded bundles. ([#44396](https://github.com/expo/expo/pull/44396) by [@alanjhughes](https://github.com/alanjhughes))
-- [plugin] Add `skipOnboarding` and `showMenuAtLaunch` options to set menu's onboarding and auto-launch defaults, useful for E2E and CI builds.
+- [plugin] Add `skipOnboarding` and `showMenuAtLaunch` options to set menu's onboarding and auto-launch defaults, useful for E2E and CI builds. ([#45167](https://github.com/expo/expo/pull/45167) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -282,7 +282,7 @@ class DevLauncherController private constructor(
   }
 
   fun launchDefaultUrlOrNavigateToLauncher(scope: CoroutineScope, defaultLaunchUrl: Uri, activityToBeInvalidated: ReactActivity?) {
-    scope.launch{
+    scope.launch {
       try {
         loadApp(defaultLaunchUrl, activityToBeInvalidated)
       } catch (_: Throwable) {

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.d.ts
@@ -55,6 +55,21 @@ export type PluginConfigOptions = {
      * @default false
      */
     embeddedBundle?: boolean;
+    /**
+     * Skip the dev menu onboarding popup on first launch. Useful for E2E tests and CI
+     * builds where the onboarding overlay would block automated input.
+     *
+     * @default false
+     */
+    skipOnboarding?: boolean;
+    /**
+     * Automatically open the dev menu when the app launches. Set to `false` to suppress
+     * the auto-launch in development builds where the dev menu would interfere (E2E tests,
+     * automated UI runs).
+     *
+     * @default true
+     */
+    showMenuAtLaunch?: boolean;
 };
 /**
  * @ignore

--- a/packages/expo-dev-launcher/plugin/build/pluginConfig.js
+++ b/packages/expo-dev-launcher/plugin/build/pluginConfig.js
@@ -28,6 +28,14 @@ const schema = {
             type: 'boolean',
             nullable: true,
         },
+        skipOnboarding: {
+            type: 'boolean',
+            nullable: true,
+        },
+        showMenuAtLaunch: {
+            type: 'boolean',
+            nullable: true,
+        },
         android: {
             type: 'object',
             properties: {
@@ -51,6 +59,14 @@ const schema = {
                 },
                 defaultLaunchURL: {
                     type: 'string',
+                    nullable: true,
+                },
+                skipOnboarding: {
+                    type: 'boolean',
+                    nullable: true,
+                },
+                showMenuAtLaunch: {
+                    type: 'boolean',
                     nullable: true,
                 },
             },
@@ -79,6 +95,14 @@ const schema = {
                 },
                 defaultLaunchURL: {
                     type: 'string',
+                    nullable: true,
+                },
+                skipOnboarding: {
+                    type: 'boolean',
+                    nullable: true,
+                },
+                showMenuAtLaunch: {
+                    type: 'boolean',
                     nullable: true,
                 },
             },

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -121,6 +121,20 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
             return config;
         });
     }
+    const iOSSkipOnboarding = props.ios?.skipOnboarding ?? props.skipOnboarding;
+    if (iOSSkipOnboarding !== undefined) {
+        config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
+            config.modResults['EXDevMenuIsOnboardingFinished'] = iOSSkipOnboarding;
+            return config;
+        });
+    }
+    const iOSShowMenuAtLaunch = props.ios?.showMenuAtLaunch ?? props.showMenuAtLaunch;
+    if (iOSShowMenuAtLaunch !== undefined) {
+        config = (0, config_plugins_1.withInfoPlist)(config, (config) => {
+            config.modResults['EXDevMenuShowsAtLaunch'] = iOSShowMenuAtLaunch;
+            return config;
+        });
+    }
     const androidLaunchMode = props.android?.launchMode ??
         props.launchMode ??
         props.android?.launchModeExperimental ??
@@ -148,6 +162,22 @@ exports.default = (0, config_plugins_1.createRunOncePlugin)((config, props = {})
         config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
             const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
             config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'EXDevClientEmbeddedBundle', String(true));
+            return config;
+        });
+    }
+    const androidSkipOnboarding = props.android?.skipOnboarding ?? props.skipOnboarding;
+    if (androidSkipOnboarding !== undefined) {
+        config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+            const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'EXDevMenuIsOnboardingFinished', String(androidSkipOnboarding));
+            return config;
+        });
+    }
+    const androidShowMenuAtLaunch = props.android?.showMenuAtLaunch ?? props.showMenuAtLaunch;
+    if (androidShowMenuAtLaunch !== undefined) {
+        config = (0, config_plugins_1.withAndroidManifest)(config, (config) => {
+            const mainApplication = config_plugins_1.AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+            config_plugins_1.AndroidConfig.Manifest.addMetaDataItemToMainApplication(mainApplication, 'EXDevMenuShowsAtLaunch', String(androidShowMenuAtLaunch));
             return config;
         });
     }

--- a/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
+++ b/packages/expo-dev-launcher/plugin/src/pluginConfig.ts
@@ -59,6 +59,21 @@ export type PluginConfigOptions = {
    * @default false
    */
   embeddedBundle?: boolean;
+  /**
+   * Skip the dev menu onboarding popup on first launch. Useful for E2E tests and CI
+   * builds where the onboarding overlay would block automated input.
+   *
+   * @default false
+   */
+  skipOnboarding?: boolean;
+  /**
+   * Automatically open the dev menu when the app launches. Set to `false` to suppress
+   * the auto-launch in development builds where the dev menu would interfere (E2E tests,
+   * automated UI runs).
+   *
+   * @default true
+   */
+  showMenuAtLaunch?: boolean;
 };
 
 const schema: JSONSchema<PluginConfigType> = {
@@ -87,6 +102,14 @@ const schema: JSONSchema<PluginConfigType> = {
       type: 'boolean',
       nullable: true,
     },
+    skipOnboarding: {
+      type: 'boolean',
+      nullable: true,
+    },
+    showMenuAtLaunch: {
+      type: 'boolean',
+      nullable: true,
+    },
     android: {
       type: 'object',
       properties: {
@@ -110,6 +133,14 @@ const schema: JSONSchema<PluginConfigType> = {
         },
         defaultLaunchURL: {
           type: 'string',
+          nullable: true,
+        },
+        skipOnboarding: {
+          type: 'boolean',
+          nullable: true,
+        },
+        showMenuAtLaunch: {
+          type: 'boolean',
           nullable: true,
         },
       },
@@ -138,6 +169,14 @@ const schema: JSONSchema<PluginConfigType> = {
         },
         defaultLaunchURL: {
           type: 'string',
+          nullable: true,
+        },
+        skipOnboarding: {
+          type: 'boolean',
+          nullable: true,
+        },
+        showMenuAtLaunch: {
+          type: 'boolean',
           nullable: true,
         },
       },

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -152,6 +152,22 @@ export default createRunOncePlugin<PluginConfigType>(
       });
     }
 
+    const iOSSkipOnboarding = props.ios?.skipOnboarding ?? props.skipOnboarding;
+    if (iOSSkipOnboarding !== undefined) {
+      config = withInfoPlist(config, (config) => {
+        config.modResults['EXDevMenuIsOnboardingFinished'] = iOSSkipOnboarding;
+        return config;
+      });
+    }
+
+    const iOSShowMenuAtLaunch = props.ios?.showMenuAtLaunch ?? props.showMenuAtLaunch;
+    if (iOSShowMenuAtLaunch !== undefined) {
+      config = withInfoPlist(config, (config) => {
+        config.modResults['EXDevMenuShowsAtLaunch'] = iOSShowMenuAtLaunch;
+        return config;
+      });
+    }
+
     const androidLaunchMode =
       props.android?.launchMode ??
       props.launchMode ??
@@ -200,6 +216,34 @@ export default createRunOncePlugin<PluginConfigType>(
           mainApplication,
           'EXDevClientEmbeddedBundle',
           String(true)
+        );
+        return config;
+      });
+    }
+
+    const androidSkipOnboarding = props.android?.skipOnboarding ?? props.skipOnboarding;
+    if (androidSkipOnboarding !== undefined) {
+      config = withAndroidManifest(config, (config) => {
+        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+          mainApplication,
+          'EXDevMenuIsOnboardingFinished',
+          String(androidSkipOnboarding)
+        );
+        return config;
+      });
+    }
+
+    const androidShowMenuAtLaunch = props.android?.showMenuAtLaunch ?? props.showMenuAtLaunch;
+    if (androidShowMenuAtLaunch !== undefined) {
+      config = withAndroidManifest(config, (config) => {
+        const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(config.modResults);
+
+        AndroidConfig.Manifest.addMetaDataItemToMainApplication(
+          mainApplication,
+          'EXDevMenuShowsAtLaunch',
+          String(androidShowMenuAtLaunch)
         );
         return config;
       });

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -18,7 +18,7 @@
 - [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
 - [iOS] Fix deadlock in `DevMenuPackagerConnectionHandler.setup`. ([#44405](https://github.com/expo/expo/pull/44405) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Remove `#Preview` SwiftUI blocks that cause build failures when consuming the package as a dependency. ([#44775](https://github.com/expo/expo/pull/44775) by [@fabriziocucci](https://github.com/fabriziocucci))
-- [iOS] Fix dev menu auto-launch not triggering. The `updateAutoLaunchObserver()` now called from `setAppContext`.
+- [iOS] Fix dev menu auto-launch not triggering. The `updateAutoLaunchObserver()` now called from `setAppContext`. ([#45167](https://github.com/expo/expo/pull/45167) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fix react-native version resolution in podspec ([#44178](https://github.com/expo/expo/pull/44178) by [@kitten](https://github.com/kitten))
 - [iOS] Fix deadlock in `DevMenuPackagerConnectionHandler.setup`. ([#44405](https://github.com/expo/expo/pull/44405) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Remove `#Preview` SwiftUI blocks that cause build failures when consuming the package as a dependency. ([#44775](https://github.com/expo/expo/pull/44775) by [@fabriziocucci](https://github.com/fabriziocucci))
+- [iOS] Fix dev menu auto-launch not triggering. The `updateAutoLaunchObserver()` now called from `setAppContext`.
 
 ### 💡 Others
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuFragment.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuFragment.kt
@@ -73,6 +73,7 @@ class DevMenuFragment(
 
   private fun showMenuAtLaunch() {
     val reactHost = reactHostHolder.get() ?: return
+    preferences.showsAtLaunch = false
 
     // If the React Context is already initialized, we can open the menu right away.
     if (reactHost.currentReactContext != null) {

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.os.Bundle
 import expo.modules.devmenu.helpers.preferences
 
 private const val DEV_SETTINGS_PREFERENCES = "expo.modules.devmenu.sharedpreferences"
@@ -55,15 +56,18 @@ class DevMenuDefaultPreferences(
 ) : DevMenuPreferences {
   private val sharedPreferences = application.getSharedPreferences(DEV_SETTINGS_PREFERENCES, MODE_PRIVATE)
 
-  private val fabDefault: Boolean = try {
-    val ai = application.packageManager.getApplicationInfo(
+  private val metaData: Bundle? = try {
+    application.packageManager.getApplicationInfo(
       application.packageName,
       PackageManager.GET_META_DATA
-    )
-    ai.metaData?.getString("EXDevMenuShowFloatingActionButton")?.toBoolean() ?: true
+    ).metaData
   } catch (_: Exception) {
-    true
+    null
   }
+
+  private val fabDefault = metaDataBool("EXDevMenuShowFloatingActionButton", true)
+  private val showsAtLaunchDefault = metaDataBool("EXDevMenuShowsAtLaunch", true)
+  private val isOnboardingFinishedDefault = metaDataBool("EXDevMenuIsOnboardingFinished", false)
 
   private val listeners = mutableListOf<() -> Unit>()
 
@@ -71,6 +75,9 @@ class DevMenuDefaultPreferences(
   private val mainListener = SharedPreferences.OnSharedPreferenceChangeListener { _, _ ->
     listeners.forEach { it() }
   }
+
+  private fun metaDataBool(key: String, fallback: Boolean): Boolean =
+    metaData?.getBoolean(key, fallback) ?: fallback
 
   init {
     sharedPreferences.registerOnSharedPreferenceChangeListener(mainListener)
@@ -94,10 +101,10 @@ class DevMenuDefaultPreferences(
     by preferences(sharedPreferences, true)
 
   override var showsAtLaunch: Boolean
-    by preferences(sharedPreferences, false)
+    by preferences(sharedPreferences, showsAtLaunchDefault)
 
   override var isOnboardingFinished: Boolean
-    by preferences(sharedPreferences, false)
+    by preferences(sharedPreferences, isOnboardingFinishedDefault)
 
   override var showFab: Boolean
     by preferences(sharedPreferences, fabDefault)

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -212,6 +212,7 @@ open class DevMenuManager: NSObject {
     } else {
       isReactAppRunning = false
     }
+    updateAutoLaunchObserver()
   }
 
   @objc
@@ -228,6 +229,7 @@ open class DevMenuManager: NSObject {
 
     DispatchQueue.main.async {
       self.openMenu()
+      UserDefaults.standard.set(false, forKey: showsAtLaunchKey)
     }
   }
 

--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -27,14 +27,16 @@ public class DevMenuPreferences: Module {
    */
   static func setup() {
     let fabDefault = Bundle.main.object(forInfoDictionaryKey: showFloatingActionButtonKey) as? Bool
+    let showsAtLaunchDefault = Bundle.main.object(forInfoDictionaryKey: showsAtLaunchKey) as? Bool
+    let isOnboardingFinishedDefault = Bundle.main.object(forInfoDictionaryKey: isOnboardingFinishedKey) as? Bool
 
     #if os(tvOS)
     UserDefaults.standard.register(defaults: [
       motionGestureEnabledKey: false,
       touchGestureEnabledKey: false,
       keyCommandsEnabledKey: true,
-      showsAtLaunchKey: false,
-      isOnboardingFinishedKey: true,
+      showsAtLaunchKey: showsAtLaunchDefault ?? false,
+      isOnboardingFinishedKey: isOnboardingFinishedDefault ?? true,
       showFloatingActionButtonKey: fabDefault ?? false
     ])
     #else
@@ -42,8 +44,8 @@ public class DevMenuPreferences: Module {
       motionGestureEnabledKey: true,
       touchGestureEnabledKey: true,
       keyCommandsEnabledKey: true,
-      showsAtLaunchKey: false,
-      isOnboardingFinishedKey: false,
+      showsAtLaunchKey: showsAtLaunchDefault ?? true,
+      isOnboardingFinishedKey: isOnboardingFinishedDefault ?? false,
       showFloatingActionButtonKey: fabDefault ?? true
     ])
     #endif


### PR DESCRIPTION
# Why
In CI, users may want to disable the auto launch and onboarding behaviour but we don't currently expose a way to do this. 

# How
Adds two more options to the config plugin. `skipOnboarding` and `showMenuAtLaunch`. I also fixed and issue on ios where auto launch wasn't working after we moved to RN 0.84. 

# Test Plan
Tested in the sandbox app. 
