### PR TITLE
[go][Android] Fix reload in Updates

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoUpdatesModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/core/modules/ExpoGoUpdatesModule.kt
@@ -10,6 +10,7 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.updates.IUpdatesController
 import expo.modules.updates.logging.UpdatesLogEntry
 import expo.modules.updates.logging.UpdatesLogReader
+import expo.modules.updates.reloadscreen.ReloadScreenOptions
 import expo.modules.updates.statemachine.UpdatesStateContext
 import host.exp.exponent.kernel.KernelConstants
 import host.exp.exponent.kernel.KernelProvider
@@ -51,7 +52,7 @@ class ExpoGoUpdatesModule(experienceProperties: Map<String, Any?>) : Module() {
       } ?: mapOf()
     }
 
-    AsyncFunction("reload") { promise: Promise ->
+    AsyncFunction("reload") { options: ReloadScreenOptions?, promise: Promise ->
       KernelProvider.instance.reloadVisibleExperience(manifestUrl!!, true)
       promise.resolve(null)
     }


### PR DESCRIPTION
# Why

Function signature changed
```
 ERROR  [Error: Uncaught (in promise, id: 0) Error: Received 1 arguments, but 0 was expected]
```

# How

Update function signature.

# Test Plan

Run NCL in expo go

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
