### PR TITLE
[ui] remove workaround for ios universal host

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -112,6 +112,7 @@
 - [iOS] Fixed build error when using precompiled `ExpoModulesCore.xcframework`. ([#45016](https://github.com/expo/expo/pull/45016) by [@kudo](https://github.com/kudo))
 - [Android] Improved application startup performance by reducing reflection. ([#45021](https://github.com/expo/expo/pull/45021) by [@lukmccall](https://github.com/lukmccall))
 - [jetpack-compose] Added `expand` and `partialExpand` to `ModalBottomSheet`. ([#44682](https://github.com/expo/expo/pull/44682) by [@kudo](https://github.com/kudo))
+- Removed iOS universal `Host` workaround. ([#45173](https://github.com/expo/expo/pull/45173) by [@kudo](https://github.com/kudo))
 
 ## 55.0.1 — 2026-02-25
 

--- a/packages/expo-ui/build/universal/Host/index.ios.d.ts
+++ b/packages/expo-ui/build/universal/Host/index.ios.d.ts
@@ -1,3 +1,2 @@
-import { type HostProps } from '@expo/ui/swift-ui';
-export declare function Host(props: HostProps): import("react/jsx-runtime").JSX.Element;
+export { Host } from '@expo/ui/swift-ui';
 //# sourceMappingURL=index.ios.d.ts.map

--- a/packages/expo-ui/build/universal/Host/index.ios.d.ts.map
+++ b/packages/expo-ui/build/universal/Host/index.ios.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.ios.d.ts","sourceRoot":"","sources":["../../../src/universal/Host/index.ios.tsx"],"names":[],"mappings":"AAAA,OAAO,EAAuB,KAAK,SAAS,EAAE,MAAM,mBAAmB,CAAC;AAExE,wBAAgB,IAAI,CAAC,KAAK,EAAE,SAAS,2CAapC"}
+{"version":3,"file":"index.ios.d.ts","sourceRoot":"","sources":["../../../src/universal/Host/index.ios.tsx"],"names":[],"mappings":"AAAA,OAAO,EAAE,IAAI,EAAE,MAAM,mBAAmB,CAAC"}

--- a/packages/expo-ui/src/universal/Host/index.ios.tsx
+++ b/packages/expo-ui/src/universal/Host/index.ios.tsx
@@ -1,16 +1,1 @@
-import { Host as SwiftUIHost, type HostProps } from '@expo/ui/swift-ui';
-
-export function Host(props: HostProps) {
-  // When matchContents is true, enable useViewportSizeMeasurement so that
-  // SwiftUI children receive a non-zero size proposal. Without this, the
-  // default ZStackLayout passes through the initial zero proposal from RN,
-  // causing flexible views like Text to compress to nothing.
-  const needsViewport = props.matchContents && !props.useViewportSizeMeasurement;
-
-  return (
-    <SwiftUIHost
-      {...props}
-      useViewportSizeMeasurement={needsViewport || props.useViewportSizeMeasurement}
-    />
-  );
-}
+export { Host } from '@expo/ui/swift-ui';


### PR DESCRIPTION
# Why

since #44642, we don't need the previous workaround for viewport measurement

# How

remove the workaround and export Host directly

# Test Plan

tested NCL universal components on ios

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
