### PR TITLE
[expo-updates][iOS] Fix crash from force-unwrap of nil error in RelaunchProcedure

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -17,7 +17,8 @@
 
 - Pass absolute path to CLI helpers when creating build manifest, since the underlying functions now handle entry file inputs properly, instead of applying `mainModuleName` semantics to them ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
 - [ios] Fix loading assets in brownfield ([#44724](https://github.com/expo/expo/pull/44724) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- Improve the error message thrown by `setUpdateRequestHeadersOverride` when an override key is not in `updates.requestHeaders`. ([#45044](https://github.com/expo/expo/pull/45044) by [@alanjhughes](https://github.com/alanjhughes)) 
+- Improve the error message thrown by `setUpdateRequestHeadersOverride` when an override key is not in `updates.requestHeaders`. ([#45044](https://github.com/expo/expo/pull/45044) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix crash from force-unwrap of nil error in `RelaunchProcedure`. ([#45174](https://github.com/expo/expo/pull/45174) by [@DORI2001](https://github.com/DORI2001))
 
 ### 💡 Others
 

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
@@ -90,7 +90,7 @@ final class RelaunchProcedure: StateMachineProcedure {
           procedureContext.resetStateAfterRestart()
           procedureContext.onComplete()
         } else {
-          if let error = error {
+          if let error {
             self.logger.error(cause: UpdatesError.relaunchProcedureFailedToRelaunch(cause: error))
           } else {
             self.logger.error(cause: UpdatesError.relaunchProcedureFailedToRelaunch(cause: UpdatesReloadException()))

--- a/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
+++ b/packages/expo-updates/ios/EXUpdates/Procedures/RelaunchProcedure.swift
@@ -90,8 +90,11 @@ final class RelaunchProcedure: StateMachineProcedure {
           procedureContext.resetStateAfterRestart()
           procedureContext.onComplete()
         } else {
-          // swiftlint:disable:next force_unwrapping
-          self.logger.error(cause: UpdatesError.relaunchProcedureFailedToRelaunch(cause: error!))
+          if let error = error {
+            self.logger.error(cause: UpdatesError.relaunchProcedureFailedToRelaunch(cause: error))
+          } else {
+            self.logger.error(cause: UpdatesError.relaunchProcedureFailedToRelaunch(cause: UpdatesReloadException()))
+          }
           self.errorBlock(UpdatesReloadException())
           procedureContext.onComplete()
         }


### PR DESCRIPTION
## Why

\`RelaunchProcedure.swift\` force-unwraps the optional \`error\` parameter on the relaunch completion path:

\`\`\`swift
} else {
  // swiftlint:disable:next force_unwrapping
  self.logger.error(cause: UpdatesError.relaunchProcedureFailedToRelaunch(cause: error!))
  ...
}
\`\`\`

When \`AppLauncherWithDatabase\` finishes with \`success = false\` but no underlying error (for example when \`launchableUpdate\` is \`nil\` after a successful read that produced no usable update), \`error\` is \`nil\` and the app crashes:

\`\`\`
Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value
\`\`\`

This is reproducible after pushing an EAS Update where the rebuilt update isn't compatible and the launcher resolves to no launchable update.

## How

Use optional binding instead of \`!\`:

- If \`error\` is non-nil, log it as before through \`UpdatesError.relaunchProcedureFailedToRelaunch(cause:)\`.
- If \`error\` is nil, fall back to \`UpdatesReloadException\` so we still record a meaningful cause (\`UpdatesReloadException\` is the same type passed into \`errorBlock\` on the next line, and it conforms to \`Error\` through \`CodedError\`).

The other lines in the \`else\` branch (calling \`errorBlock\` and \`onComplete\`) are unchanged.

## Test Plan

- Manual: build an iOS app with expo-updates, configure an EAS update path that resolves to no launchable update, observe that the app no longer crashes and the relaunch failure is logged via the existing \`UpdatesLogger.error(cause:)\` channel.
- Behaviour parity: when \`error\` is non-nil, the message logged is identical to before this change.

## Notes

Mirrors the same defensive pattern already used in \`ErrorRecovery.tryRelaunchFromCache\` (\`if let error = error { ... }\`).

Closes #45154