### PR TITLE
[expo-modules-core][iOS] Guard against null eventEmitter in SwiftUI virtual view dispatchEvent

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -42,6 +42,7 @@
 - Fixed runtime crash when missing `Host` component for SwiftUI or Jetpack Compose components. ([#44118](https://github.com/expo/expo/pull/44118) by [@kudo](https://github.com/kudo))
 - [iOS] Restore pre-ExpoModulesJSI `Record` conversion behavior by hydrating only declared fields, preserving `undefined` handling for object properties, and emitting typed records directly to JS. ([#45085](https://github.com/expo/expo/pull/45085) by [@barthap](https://github.com/barthap))
 - Fix reading EXConstants.bundle when using prebuilds + brownfield with SPM ([#45148](https://github.com/expo/expo/pull/45148) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Guard against null `eventEmitter` in `SwiftUIVirtualView.dispatchEvent` to prevent SIGSEGV after view teardown. ([#45175](https://github.com/expo/expo/pull/45175) by [@DORI2001](https://github.com/DORI2001))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewSharedImpl+Private.h
+++ b/packages/expo-modules-core/ios/Core/Views/SwiftUI/SwiftUIVirtualViewSharedImpl+Private.h
@@ -135,6 +135,9 @@ namespace react = facebook::react;
 
 - (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload
 {
+  if (!_eventEmitter) {
+    return;
+  }
   const auto &eventEmitter = static_cast<const expo::ExpoViewEventEmitter &>(*_eventEmitter);
 
   eventEmitter.dispatch([normalizeEventName(eventName) UTF8String], [payload](jsi::Runtime &runtime) {


### PR DESCRIPTION
## Why

\`SwiftUIVirtualViewSharedImpl+Private.h\`'s \`dispatchEvent:payload:\` dereferences \`_eventEmitter\` without checking whether it has been reset:

\`\`\`objc
- (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload
{
  const auto &eventEmitter = static_cast<const expo::ExpoViewEventEmitter &>(*_eventEmitter);
  ...
}
\`\`\`

When a SwiftUI view (e.g. \`TextField\` from \`@expo/ui\`) fires an event after the React Native view hierarchy has been torn down, \`_eventEmitter\` is null and the dispatch segfaults:

\`\`\`
Exception Type:  EXC_BAD_ACCESS (SIGSEGV)
Exception Subtype: KERN_INVALID_ADDRESS at 0x0000000000000030

Thread 0 Crashed:
0   React       std::weak_ptr<facebook::react::EventDispatcher const>::lock() const + 0
1   React       facebook::react::EventEmitter::dispatchEvent(...) + 72
3   <App>       expo::ExpoViewEventEmitter::dispatch(...) + 52
4   <App>       -[SwiftUIVirtualViewObjC dispatchEvent:payload:] + 308
\`\`\`

The teardown sequence calls \`_eventEmitter.reset()\` (line 101 of the same file) before SwiftUI's deferred event delivery happens, so the dispatch needs to be a no-op once the emitter is gone.

\`ExpoFabricViewObjC.mm\` already has this exact null guard (added in #42628 / #42634, expo-modules-core 55.0.6); this PR brings the SwiftUI virtual view path in line.

## How

Add the same early return:

\`\`\`objc
- (void)dispatchEvent:(nonnull NSString *)eventName payload:(nullable id)payload
{
  if (!_eventEmitter) {
    return;
  }
  ...
}
\`\`\`

## Test Plan

- Manual repro from #45054 (\`@expo/ui\` \`TextField\` inside a SwiftUI \`Host\` followed by component unmount → app no longer crashes).
- Behaviour parity: when \`_eventEmitter\` is set, dispatching is unchanged.

Closes #45054