### PR TITLE
[test-suite] Remove `LinearGradient` on Android

### DIFF
--- a/apps/test-suite/TestModules.ts
+++ b/apps/test-suite/TestModules.ts
@@ -60,7 +60,6 @@ export function getTestModules() {
     require('./tests/CryptoAES'),
     require('./tests/KeepAwake'),
     require('./tests/Blur'),
-    require('./tests/LinearGradient'),
     require('./tests/HTML'),
     require('./tests/FirebaseJSSDK'),
     require('./tests/ImageManipulator'),
@@ -68,6 +67,10 @@ export function getTestModules() {
     require('./tests/Fetch'),
     require('./tests/SQLite')
   );
+
+  if (Platform.OS !== 'android') {
+    modules.push(require('./tests/LinearGradient'));
+  }
 
   if (['android', 'ios'].includes(Platform.OS)) {
     modules.push(require('./tests/Blob'));

--- a/apps/test-suite/tests/LinearGradient.js
+++ b/apps/test-suite/tests/LinearGradient.js
@@ -7,6 +7,8 @@ import { mountAndWaitFor as originalMountAndWaitFor } from './helpers';
 export const name = 'LinearGradient';
 const style = { width: 200, height: 200 };
 
+// This tests are excluded on Android because they frequently break the emulator on GitHub Actions, and we don't know why.
+// See TestModules.ts
 export async function test(
   { it, describe, beforeAll, jasmine, afterAll, expect, afterEach, beforeEach },
   { setPortalChild, cleanupPortal }
@@ -19,12 +21,8 @@ export async function test(
     originalMountAndWaitFor(child, propName, setPortalChild);
 
   describe(name, () => {
-    // Skip on Android because the test frequently breaks the emulator on GitHub
-    // Actions, and we don't know why
-    if (Platform.OS !== 'android') {
-      it(`renders`, async () => {
-        await mountAndWaitFor(<LinearGradient colors={['red', 'blue']} style={style} />);
-      });
-    }
+    it(`renders`, async () => {
+      await mountAndWaitFor(<LinearGradient colors={['red', 'blue']} style={style} />);
+    });
   });
 }

--- a/apps/test-suite/tests/LinearGradient.js
+++ b/apps/test-suite/tests/LinearGradient.js
@@ -1,6 +1,5 @@
 import { LinearGradient } from 'expo-linear-gradient';
 import React from 'react';
-import { Platform } from 'react-native';
 
 import { mountAndWaitFor as originalMountAndWaitFor } from './helpers';
 


### PR DESCRIPTION
# Why

Removes `LinearGradient` on Android. The `LinearGradient` was empty on Android anyway. However, the empty `describe` leads to errors. 

