### PR TITLE
[test-suite] Only check location scope on iOS

### DIFF
--- a/apps/test-suite/tests/Location.js
+++ b/apps/test-suite/tests/Location.js
@@ -69,7 +69,9 @@ export async function test(t) {
         const permission = await Location.requestForegroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
-        t.expect(permission.scope).toBe('whenInUse');
+        if (Platform.OS === 'ios') {
+          t.expect(permission.scope).toBe('whenInUse');
+        }
       });
     });
 
@@ -78,7 +80,9 @@ export async function test(t) {
         const permission = await Location.getForegroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
-        t.expect(permission.scope).toBe('whenInUse');
+        if (Platform.OS === 'ios') {
+          t.expect(permission.scope).toBe('whenInUse');
+        }
       });
     });
 
@@ -87,7 +91,9 @@ export async function test(t) {
         const permission = await Location.requestBackgroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
-        t.expect(permission.scope).toBe('always');
+        if (Platform.OS === 'ios') {
+          t.expect(permission.scope).toBe('always');
+        }
       });
     });
 
@@ -96,7 +102,9 @@ export async function test(t) {
         const permission = await Location.getBackgroundPermissionsAsync();
         t.expect(permission.granted).toBe(true);
         t.expect(permission.status).toBe(Location.PermissionStatus.GRANTED);
-        t.expect(permission.scope).toBe('always');
+        if (Platform.OS === 'ios') {
+          t.expect(permission.scope).toBe('always');
+        }
       });
     });
 


### PR DESCRIPTION
# Why

Only checks the location scope on iOS. It's not available on Android or the web.