### PR TITLE
fix(cli): Derive whether `expo-router` is installed from autolinking result, if available

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/createExpoAutolinkingResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/createExpoAutolinkingResolver.ts
@@ -39,7 +39,8 @@ const KNOWN_STICKY_DEPENDENCIES = [
 ];
 
 const AUTOLINKING_PLATFORMS = ['android', 'ios', 'web'] as const;
-type AutolinkingPlatform = (typeof AUTOLINKING_PLATFORMS)[number];
+
+export type AutolinkingPlatform = (typeof AUTOLINKING_PLATFORMS)[number];
 
 const escapeDependencyName = (dependency: string) =>
   dependency.replace(/[*.?()[\]]/g, (x) => `\\${x}`);

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -18,7 +18,10 @@ import { resolveFrom } from '@expo/require-utils';
 import fs from 'fs';
 import path from 'path';
 
-import type { AutolinkingModuleResolverInput } from './createExpoAutolinkingResolver';
+import type {
+  AutolinkingModuleResolverInput,
+  AutolinkingPlatform,
+} from './createExpoAutolinkingResolver';
 import {
   createAutolinkingModuleResolverInput,
   createAutolinkingModuleResolver,
@@ -198,9 +201,10 @@ export function withExtendedResolver(
     },
   };
 
-  const isExpoRouterInstalled = !!resolveFrom(config.projectRoot, 'expo-router/package.json', {
-    skipNodePath: true,
-  });
+  const isExpoRouterInstalled = hasExpoRouterModule(
+    config.projectRoot,
+    autolinkingModuleResolverInput
+  );
 
   let _universalAliases: [RegExp, string][] | null;
 
@@ -1029,4 +1033,19 @@ export async function withMetroMultiPlatformAsync(
 
 function isDirectoryIn(targetPath: string, rootPath: string) {
   return targetPath.startsWith(rootPath) && targetPath.length >= rootPath.length;
+}
+
+function hasExpoRouterModule(
+  projectRoot: string,
+  autolinkingModuleResolverInput: AutolinkingModuleResolverInput | undefined
+) {
+  if (autolinkingModuleResolverInput) {
+    // If we have autolinking enabled, we can skip resolution
+    const platform = Object.keys(autolinkingModuleResolverInput)[0] as AutolinkingPlatform;
+    return !!autolinkingModuleResolverInput[platform]?.resolvedModulePaths['expo-router'];
+  } else {
+    return !!resolveFrom(projectRoot, 'expo-router/package.json', {
+      skipNodePath: true,
+    });
+  }
 }


### PR DESCRIPTION
# Why

We can do a bit better than #45164 in accuracy by using the autolinking output instead. This will make sure that we're only detecting `expo-router` when it's been found by autolinking, which is a little more precise than the resolution, especially for `expo/expo`, where an unclean install may make it resolvable.

# How

- Replace resolution with `expo-router` detection from autolinking, if autolinking module resolution is enabled

# Test Plan

- Ran `apps/bare-expo`, doesn't detect `expo-router`
- Ran `apps/router-e2e`, does detect `expo-router`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
