### PR TITLE
[expo-widgets][plugin] Fix duplicate target on repeated prebuild

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 ### 🐛 Bug fixes
 
+- [plugin] Fix duplicate widget target and file references created on repeated `npx expo prebuild` runs. ([#45090](https://github.com/expo/expo/issues/45090) by [@vj2303](https://github.com/vj2303))
 - Add support for `AccessoryWidgetBackground` views from `@expo/ui` in widget rendering. ([#44499](https://github.com/expo/expo/pull/44499) by [@cinques](https://github.com/cinques))
 - Fix `ExpoWidgets.bundle` not copied to widget extension when `use_frameworks` is active. ([#44065](https://github.com/expo/expo/pull/44065) by [@marvwhere](https://github.com/marvwhere))
 - Add missing project root to `watchFolders` in `metro.config.js` ([#43449](https://github.com/expo/expo/pull/43449) by [@kitten](https://github.com/kitten))

--- a/packages/expo-widgets/plugin/build/xcode/withTargetXcodeProject.js
+++ b/packages/expo-widgets/plugin/build/xcode/withTargetXcodeProject.js
@@ -44,6 +44,12 @@ const addToPbxProjectSection_1 = require("./addToPbxProjectSection");
 const addXCConfigurationList_1 = require("./addXCConfigurationList");
 const withTargetXcodeProject = (config, { targetName, bundleIdentifier, deploymentTarget, appleTeamId, getFileUris }) => (0, config_plugins_1.withXcodeProject)(config, (config) => {
     const xcodeProject = config.modResults;
+    // Check if the target already exists to avoid duplicates on repeated prebuilds
+    const nativeTargets = xcodeProject.pbxNativeTargetSection();
+    const existingTarget = Object.values(nativeTargets).find((target) => target.name === targetName);
+    if (existingTarget) {
+        return config;
+    }
     const targetUuid = xcodeProject.generateUuid();
     const groupName = 'Embed Foundation Extensions';
     const xCConfigurationList = (0, addXCConfigurationList_1.addXCConfigurationList)(xcodeProject, {

--- a/packages/expo-widgets/plugin/src/xcode/withTargetXcodeProject.ts
+++ b/packages/expo-widgets/plugin/src/xcode/withTargetXcodeProject.ts
@@ -23,6 +23,16 @@ const withTargetXcodeProject: ConfigPlugin<TargetXcodeProjectProps> = (
 ) =>
   withXcodeProject(config, (config) => {
     const xcodeProject = config.modResults;
+
+    // Check if the target already exists to avoid duplicates on repeated prebuilds
+    const nativeTargets = xcodeProject.pbxNativeTargetSection();
+    const existingTarget = Object.values(nativeTargets).find(
+      (target: any) => target.name === targetName
+    );
+    if (existingTarget) {
+      return config;
+    }
+
     const targetUuid = xcodeProject.generateUuid();
     const groupName = 'Embed Foundation Extensions';
 


### PR DESCRIPTION
## Summary

- Skip widget target creation in `withTargetXcodeProject` if a `PBXNativeTarget` with the same name already exists in the Xcode project
- Prevents duplicate targets and file references from accumulating when running `npx expo prebuild -p ios` multiple times

Fixes https://github.com/expo/expo/issues/45090

## Test plan

- Set up an Expo project with `expo-widgets` configured
- Run `npx expo prebuild -p ios` multiple times
- Verify that only one `ExpoWidgetsTarget` exists in the Xcode project after each run (no duplicates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)