### PR TITLE
hotfix(cli): Fix single-asset requests not resolving w/o base scale file being present

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Fix mangled async chunk filenames for catch-all routes ([#43547](https://github.com/expo/expo/pull/43547) by [@hassankhan](https://github.com/hassankhan))
 - Consistently resolve `mainModuleName`s using `convertEntryPointToRelative` and fix relative path semantics of `--entry-file` argumnts, which was previously expected to be relative to the server root rather than the project root. This fixes build issues when using export commands for projects in monorepos on Windows ([#44414](https://github.com/expo/expo/pull/44414) by [@kitten](https://github.com/kitten))
 - Avoid writing plugin state to app config when writing the package name or bundle identifier. ([#45136](https://github.com/expo/expo/pull/45136) by [@alanjhughes](https://github.com/alanjhughes))
+- Add temporary single-asset request hotfix for metro 0.83.4-6 and 0.84.0-3 ([#45194](https://github.com/expo/expo/pull/45194) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/patchMetroAssets.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/patchMetroAssets.ts
@@ -1,0 +1,38 @@
+/**
+ * Patches Metro's `getAsset` to work around a bug where scaled assets (e.g. `icon@2x.png`)
+ * fail to resolve when the unscaled base file doesn't exist on disk.
+ *
+ * Metro's `getAsset` validates the base asset path via `fileExistsInFileMap` before resolving
+ * scaled variants. If only scaled files exist (no `@1x` base), the check throws prematurely.
+ *
+ * This patch wraps `getAsset` so that when the `fileExistsInFileMap` check fails, it retries
+ * without it — falling back to Metro's `pathBelongsToRoots` validation which doesn't have
+ * this bug.
+ *
+ * TODO(@kitten): Remove once metro hotfixes is published with the upstream fix.
+ * See: https://github.com/facebook/metro/commit/c6478d78e9ec5a3442a9dc35077d8bf8e3a7d669
+ */
+export function patchMetroGetAsset(): void {
+  // WARN: We assume this gives us the raw CJS module from `metro/Assets`
+  const Assets = require('@expo/metro/metro/Assets');
+  const originalGetAsset = Assets.getAsset;
+
+  Assets.getAsset = async function patchedGetAsset(
+    relativePath: string,
+    projectRoot: string,
+    watchFolders: ReadonlyArray<string>,
+    platform: string | null | undefined,
+    assetExts: ReadonlyArray<string>,
+    // omit:
+    _fileExistsInFileMap?: (absolutePath: string) => boolean
+  ): Promise<Buffer> {
+    return await originalGetAsset(
+      relativePath,
+      projectRoot,
+      watchFolders,
+      platform,
+      assetExts,
+      undefined,
+    );
+  };
+}

--- a/packages/@expo/cli/src/start/server/metro/dev-server/patchMetroAssets.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/patchMetroAssets.ts
@@ -5,10 +5,6 @@
  * Metro's `getAsset` validates the base asset path via `fileExistsInFileMap` before resolving
  * scaled variants. If only scaled files exist (no `@1x` base), the check throws prematurely.
  *
- * This patch wraps `getAsset` so that when the `fileExistsInFileMap` check fails, it retries
- * without it — falling back to Metro's `pathBelongsToRoots` validation which doesn't have
- * this bug.
- *
  * TODO(@kitten): Remove once metro hotfixes is published with the upstream fix.
  * See: https://github.com/facebook/metro/commit/c6478d78e9ec5a3442a9dc35077d8bf8e3a7d669
  */

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -23,6 +23,7 @@ import { MetroTerminalReporter } from './MetroTerminalReporter';
 import { attachAtlasAsync } from './debugging/attachAtlas';
 import { createDebugMiddleware } from './debugging/createDebugMiddleware';
 import { createMetroMiddleware } from './dev-server/createMetroMiddleware';
+import { patchMetroGetAsset } from './dev-server/patchMetroAssets';
 import { runServer, type SecureServerOptions } from './runServer-fork';
 import { withMetroMultiPlatformAsync } from './withMetroMultiPlatform';
 import { events, shouldReduceLogs } from '../../../events';
@@ -297,6 +298,10 @@ export async function instantiateMetroAsync(
   middleware: any;
   messageSocket: MessageSocket;
 }> {
+  // Patch Metro's getAsset to fix scaled asset resolution (e.g. icon@2x.png)
+  // TODO(@kitten): Remove once metro hotfixes are published with the upstream fix
+  patchMetroGetAsset();
+
   const projectRoot = metroBundler.projectRoot;
   const getMetroBundler = () => metro.getBundler().getBundler();
 


### PR DESCRIPTION
# Why

Regressed in: https://github.com/facebook/metro/commit/5ca584bac37b46f4cb171ff0d88dbceaa80f1dc8
Fixed in: https://github.com/facebook/metro/commit/c6478d78e9ec5a3442a9dc35077d8bf8e3a7d669

The fix hasn't been released yet (in progress), but to expedite this (for example, if a user has a minimum release age that just excludes expo packages), we can ship a hotfix for this first.

Will need to be backported to `sdk-55` since it affects both Metro 0.84 and 0.83 in the ranges:
- `0.83.4-6`
- `0.84.0-3`

> [!NOTE]
> This makes this hotfix obsolete for 0.83, so pending an update to this version, we can leave out the backport to sdk-55, in favour of an update: https://github.com/facebook/metro/pull/1700

# How

- Patch `metro/Assets`' `getAssets` function to omit file existence check

This works in its current form but is meant to be highly temporary, and can be dropped once metro issues a patch release for the issue against 0.83.x and 0.84.x

# Test Plan

- Start a dev build (e.g. `apps/bare-expo`) and check asset requests. In `bare-expo`, the row icons in the APIs tab will be missing without this fix

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
