### PR TITLE
[ui][Android] Mark `TextSpanRecord` with `OptimizedRecord`

### DIFF
--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
@@ -222,8 +222,7 @@ interface TextSpanStyle {
   val shadow: TextShadowRecord?
 }
 
-// TODO(@lukmccall): Figure out why it's crashing with `Attempt to invoke virtual method 'io.github.lukmccall.pika.PIntrospectionData expo.modules.ui.TextSpanRecord$Companion.__PIntrospectionData()' on a null object reference`
-// @OptimizedRecord
+@OptimizedRecord
 data class TextSpanRecord(
   @Field override val text: String = "",
   @Field val children: List<TextSpanRecord>? = null,


### PR DESCRIPTION
# Why

Marks `TextSpanRecord` with `OptimizedRecord`.
The previous issue: 
```
Attempt to invoke virtual method 'io.github.lukmccall.pika.PIntrospectionData expo.modules.ui.TextSpanRecord$Companion.__PIntrospectionData()' on a null object reference
```
was fixed in pika 0.1.9.

# Test Plan

- bare-expo ✅ 