### PR TITLE
fix(expo-notifications)[iOS]: guard against crash in BackgroundEventTransformer when notification body is a primitive

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Guard against crash in `BackgroundEventTransformer` when notification body is a primitive type. ([#45198](https://github.com/expo/expo/pull/45198) by [@DORI2001](https://github.com/DORI2001))
 - [web] fix `getDevicePushTokenAsync` export ([#44413](https://github.com/expo/expo/pull/44413) by [@vonovak](https://github.com/vonovak))
 - [ios] fix unhandled promise rejection in `getRegistrationInfoAsync`, relax keychain accessibility to allow access after device unlocked. ([#43829](https://github.com/expo/expo/pull/43829) by [@jmalmo](https://github.com/jmalmo))
 - [ios] Fixed `requestPermissionsAsync` returning raw permission result without several documented fields ([#43555](https://github.com/expo/expo/pull/43555) by [@vonovak](https://github.com/vonovak))

--- a/packages/expo-notifications/ios/ExpoNotifications/Notifications/Background/BackgroundEventTransformer.swift
+++ b/packages/expo-notifications/ios/ExpoNotifications/Notifications/Background/BackgroundEventTransformer.swift
@@ -17,12 +17,20 @@ public class BackgroundEventTransformer {
 
     // the payload is emitted as a JSON string for alignment with Android
     let jsonData: String? = {
-      do {
-        if let bodyDict = payload["body"] {
-          let data = try JSONSerialization.data(withJSONObject: bodyDict, options: [])
-          return String(data: data, encoding: .utf8)
-        }
+      guard let body = payload["body"] else {
         return nil
+      }
+      // Primitive string bodies are used directly; JSONSerialization only accepts
+      // NSDictionary / NSArray at the top level and throws NSException otherwise.
+      if let bodyString = body as? String {
+        return bodyString
+      }
+      guard JSONSerialization.isValidJSONObject(body) else {
+        return nil
+      }
+      do {
+        let data = try JSONSerialization.data(withJSONObject: body, options: [])
+        return String(data: data, encoding: .utf8)
       } catch {
         return nil
       }

--- a/packages/expo-notifications/ios/Tests/BackgroundEventTransformerSpec.swift
+++ b/packages/expo-notifications/ios/Tests/BackgroundEventTransformerSpec.swift
@@ -10,6 +10,48 @@ class BackgroundEventTransformerSpec: ExpoSpec {
 
     describe("BackgroundEventTransformerSpec") {
 
+      context("given a remote notification payload with a primitive body") {
+        it("which has a string body, uses the string directly as dataString without crashing") {
+          // Given
+          let inputPayload: [AnyHashable: Any] = [
+            "aps": [
+              "content-available": 1
+            ],
+            "body": "plain string body",
+            "experienceId": "@brents/microfoam",
+            "projectId": "f19296df-44bd-482a-90bb-2af254c6ac42",
+            "scopeKey": "@brents/microfoam"
+          ]
+
+          // When
+          let result = BackgroundEventTransformer.transform(inputPayload)
+
+          // Then
+          let data = result["data"] as? [String: Any]
+          expect(data?["dataString"] as? String).to(equal("plain string body"))
+        }
+
+        it("which has a numeric body, sets dataString to nil without crashing") {
+          // Given
+          let inputPayload: [AnyHashable: Any] = [
+            "aps": [
+              "content-available": 1
+            ],
+            "body": 42,
+            "experienceId": "@brents/microfoam",
+            "projectId": "f19296df-44bd-482a-90bb-2af254c6ac42",
+            "scopeKey": "@brents/microfoam"
+          ]
+
+          // When
+          let result = BackgroundEventTransformer.transform(inputPayload)
+
+          // Then
+          let data = result["data"] as? [String: Any]
+          expect(data?["dataString"]).to(beNil())
+        }
+      }
+
       context("given a remote notification payload") {
         it("which is a headless background notification, transforms the payload into the expected format") {
           // Given


### PR DESCRIPTION
Fixes #43889.

## Problem

`BackgroundEventTransformer.transform` crashes with `NSInvalidArgumentException` when `payload["body"]` is a primitive type (e.g. `String`, `Number`, `Bool`) instead of a dictionary or array.

`JSONSerialization.data(withJSONObject:options:)` only accepts `NSDictionary` or `NSArray` as the top-level object. Passing any other type raises an `NSException`, which is **not** catchable by Swift's `do-catch` — so the crash bypasses the existing error handling entirely.

This is iOS-specific and reproducible any time a push notification is sent with a raw string body.

## Fix

1. Return `nil` early if `body` is absent.
2. If `body` is a `String`, return it directly — no serialization needed.
3. Guard with `JSONSerialization.isValidJSONObject()` before calling `data(withJSONObject:)` so non-serializable primitives (numbers, booleans) also return `nil` safely instead of crashing.

The `do-catch` block now only wraps the actual serialization call where Swift errors are possible.