### PR TITLE
fix(expo-video)[Android]: prevent crash in FullscreenPlayerActivity when VideoView is unmounted before finish()

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Prevent crash in `FullscreenPlayerActivity` when `VideoView` is unmounted before `finish()` completes. ([#45199](https://github.com/expo/expo/pull/45199) by [@DORI2001](https://github.com/DORI2001))
 - [iOS] Fix crash when loading PHAsset url fails ([#43373](https://github.com/expo/expo/pull/43373) by [@fractalbeauty](https://github.com/fractalbeauty))
 - [iOS] Fix crashes when `VideoTrack` properties are non-finite. ([#44108](https://github.com/expo/expo/pull/44108) by [@behenate](https://github.com/behenate))
 - [Android] Fix PiP exiting immediately after auto-entering from fullscreen. ([#44157](https://github.com/expo/expo/pull/44157) by [@behenate](https://github.com/behenate))

--- a/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/FullscreenPlayerActivity.kt
@@ -123,7 +123,13 @@ class FullscreenPlayerActivity : Activity(), VideoManagerListener {
   override fun finish() {
     super.finish()
     didFinish = true
-    videoViewId?.let { VideoManager.getVideoView(it).attachPlayer() }
+    videoViewId?.let {
+      try {
+        VideoManager.getVideoView(it).attachPlayer()
+      } catch (e: VideoViewNotFoundException) {
+        Log.w("ExpoVideo", "VideoView $it already unmounted when finishing fullscreen — skipping attachPlayer")
+      }
+    }
 
     // Disable the exit transition
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {


### PR DESCRIPTION
Fixes #45192.

## Problem

`FullscreenPlayerActivity.finish()` calls `VideoManager.getVideoView(id)` unconditionally. If the React component hosting the `VideoView` has been unmounted while the fullscreen activity is still alive (e.g. the user backgrounds the app, the OS recycles the component, and then the user navigates back), `VideoManager` no longer holds a reference to that view and throws `VideoViewNotFoundException`. This propagates as a fatal `RuntimeException` crash.

The race is intermittent but reliably reproducible with constrained emulator resources.

## Fix

Wrap the `getVideoView` call in `finish()` in a try-catch. If the view is already gone, log a warning and skip `attachPlayer()` — there is nothing to attach to, and the activity is closing anyway.