### PR TITLE
docs(`workflows`/`syntax`): change`concurrency > cancel_in_progress` type definition from `boolean` to explicit `true`

### DIFF
--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -522,7 +522,7 @@ concurrency:
 
 | Property             | Type      | Description                                                                                                                                             |
 | -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cancel_in_progress` | `boolean` | If true, new workflow runs started from GitHub will cancel current in-progress runs for the same branch.                                                |
+| `cancel_in_progress` | `true`    | If true, new workflow runs started from GitHub will cancel current in-progress runs for the same branch.                                                |
 | `group`              | `string`  | We do not support custom concurrency groups yet. Set this placeholder value so that when we do support custom groups, your workflow remains compatible. |
 
 ## Control flow

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -520,10 +520,10 @@ concurrency:
 # @end #
 ```
 
-| Property             | Type      | Description                                                                                                                                             |
-| -------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cancel_in_progress` | `true`    | If true, new workflow runs started from GitHub will cancel current in-progress runs for the same branch.                                                |
-| `group`              | `string`  | We do not support custom concurrency groups yet. Set this placeholder value so that when we do support custom groups, your workflow remains compatible. |
+| Property             | Type     | Description                                                                                                                                             |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cancel_in_progress` | `true`   | If true, new workflow runs started from GitHub will cancel current in-progress runs for the same branch.                                                |
+| `group`              | `string` | We do not support custom concurrency groups yet. Set this placeholder value so that when we do support custom groups, your workflow remains compatible. |
 
 ## Control flow
 


### PR DESCRIPTION
This PR fixes the syntax definition in the docs that leads to EAS CI failures during the workflow parsing stage.

# Why

Using the following file contents (that are valid according to the current docs):
```yml
concurrency:
  cancel_in_progress: false
  group: ${{ workflow.filename }}-${{ github.ref }}
```
we end up with a failing EAS job annotated with the following error message: `— Failed to create workflow run. Invalid workflow definition. [concurrency.cancel_in_progress]: Invalid input: expected true.`

Using the following (skipping `cancel_in_progress` altogether) also ends up with the syntax error on the workflow file:
```yml
concurrency:
  group: ${{ workflow.filename }}-${{ github.ref }}
```

<img width="667" height="42" alt="Screenshot 2026-04-29 at 13 44 00" src="https://github.com/user-attachments/assets/1559a55d-2f76-4e02-9b6d-2408eeb6751f" />

# How

I've just read the docs, tried to apply the definition and ended up with the following error message coming from the EAS CI job:
```
— Failed to create workflow run. Invalid workflow definition. [concurrency.cancel_in_progress]: Invalid input: expected true.
```

# Test Plan

This is just the docs change.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
