### PR TITLE
[core][Android] Improve performance of `EnumTypeConverter`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -66,6 +66,7 @@
 - [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
 - Fixed `ExpoModulesMacros` precompiling. ([#44863](https://github.com/expo/expo/pull/44863) by [@kudo](https://github.com/kudo))
 - [Android] Improve performance of `PersistentFileLog`. ([#45058](https://github.com/expo/expo/pull/45058) by [@lukmccall](https://github.com/lukmccall))
+- [Android] Improve performance of `EnumTypeConverter`.
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -66,7 +66,7 @@
 - [Android] Added AsyncFunction support to the functional `ExpoUIView` DSL. ([#44081](https://github.com/expo/expo/pull/44081) by [@kudo](https://github.com/kudo))
 - Fixed `ExpoModulesMacros` precompiling. ([#44863](https://github.com/expo/expo/pull/44863) by [@kudo](https://github.com/kudo))
 - [Android] Improve performance of `PersistentFileLog`. ([#45058](https://github.com/expo/expo/pull/45058) by [@lukmccall](https://github.com/lukmccall))
-- [Android] Improve performance of `EnumTypeConverter`.
+- [Android] Improve performance of `EnumTypeConverter`. ([#45204](https://github.com/expo/expo/pull/45204) by [@lukmccall](https://github.com/lukmccall))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReadableTypeExtensions.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReadableTypeExtensions.kt
@@ -3,15 +3,14 @@ package expo.modules.kotlin
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
-import kotlin.reflect.KClass
 
-fun ReadableType.toKClass(): KClass<*> {
+fun ReadableType.toClass(): Class<*> {
   return when (this) {
-    ReadableType.Null -> Any::class
-    ReadableType.Boolean -> Boolean::class
-    ReadableType.Number -> Number::class
-    ReadableType.String -> String::class
-    ReadableType.Map -> ReadableMap::class
-    ReadableType.Array -> ReadableArray::class
+    ReadableType.Null -> Any::class.java
+    ReadableType.Boolean -> Boolean::class.java
+    ReadableType.Number -> Number::class.java
+    ReadableType.String -> String::class.java
+    ReadableType.Map -> ReadableMap::class.java
+    ReadableType.Array -> ReadableArray::class.java
   }
 }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/exception/CodedException.kt
@@ -71,22 +71,39 @@ open class CodedException(
 inline fun <reified T : CodedException> errorCodeOf(): String =
   CodedException.inferCode(T::class.java)
 
-internal class IncompatibleArgTypeException(
-  argumentType: KClass<*>,
-  desiredType: KClass<*>,
-  cause: Throwable? = null
-) : CodedException(
-  message = "Argument type '$argumentType' is not compatible with expected type '$desiredType'.",
-  cause = cause
-)
+internal class IncompatibleArgTypeException : CodedException {
+  constructor(
+    argumentType: KClass<*>,
+    desiredType: KClass<*>,
+    cause: Throwable? = null
+  ) : super("Argument type '$argumentType' is not compatible with expected type '$desiredType'.", cause)
 
-internal class EnumNoSuchValueException(
-  enumType: KClass<Enum<*>>,
-  enumConstants: Array<out Enum<*>>,
-  value: Any?
-) : CodedException(
-  message = "'$value' is not present in ${enumType.simpleName} enum, it must be one of: ${enumConstants.joinToString(separator = ", ") { "'${it.name}'" }}"
-)
+  constructor(
+    argumentType: KClass<*>,
+    desiredType: Class<*>,
+    cause: Throwable? = null
+  ) : super("Argument type '$argumentType' is not compatible with expected type '${desiredType.simpleName}'.", cause)
+
+  constructor(
+    argumentType: Class<*>,
+    desiredType: Class<*>,
+    cause: Throwable? = null
+  ) : super("Argument type '${argumentType.simpleName}' is not compatible with expected type '${desiredType.simpleName}'.", cause)
+}
+
+internal class EnumNoSuchValueException : CodedException {
+  constructor(
+    enumType: KClass<Enum<*>>,
+    enumConstants: Array<out Enum<*>>,
+    value: Any?
+  ) : super("'$value' is not present in ${enumType.simpleName} enum, it must be one of: ${enumConstants.joinToString(separator = ", ") { "'${it.name}'" }}")
+
+  constructor(
+    enumType: Class<*>,
+    enumConstants: Array<out Enum<*>>,
+    value: Any?
+  ) : super("'$value' is not present in ${enumType.simpleName} enum, it must be one of: ${enumConstants.joinToString(separator = ", ") { "'${it.name}'" }}")
+}
 
 internal class MissingTypeConverter(
   forType: TypeDescriptor
@@ -276,11 +293,10 @@ internal class CollectionElementCastException private constructor(
 }
 
 @DoNotStrip
-class DynamicCastException(
-  type: KClass<*>
-) : CodedException(
-  message = "Could not cast dynamic value to '${type.qualifiedName}'."
-)
+class DynamicCastException : CodedException {
+  constructor(type: KClass<*>) : super("Could not cast dynamic value to '${type.qualifiedName}'.")
+  constructor(type: Class<*>) : super("Could not cast dynamic value to '${type.canonicalName}'.")
+}
 
 @DoNotStrip
 class JavaScriptEvaluateException(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/EnumTypeConverter.kt
@@ -5,16 +5,16 @@ import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.DynamicCastException
 import expo.modules.kotlin.exception.EnumNoSuchValueException
 import expo.modules.kotlin.exception.IncompatibleArgTypeException
-import expo.modules.kotlin.fastPrimaryConstructor
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.logger
-import expo.modules.kotlin.toKClass
-import kotlin.reflect.KClass
+import expo.modules.kotlin.toClass
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
 
 class EnumTypeConverter(
-  private val enumClass: KClass<Enum<*>>
+  private val enumClass: Class<out Enum<*>>
 ) : DynamicAwareTypeConverters<Enum<*>>() {
-  private val enumConstants = requireNotNull(enumClass.java.enumConstants) {
+  private val enumConstants = requireNotNull(enumClass.enumConstants) {
     "Passed type is not an enum type"
   }.also {
     require(it.isNotEmpty()) {
@@ -22,15 +22,12 @@ class EnumTypeConverter(
     }
   }
 
-  private val primaryConstructor = requireNotNull(
-    enumClass.fastPrimaryConstructor
-  ) {
-    "Cannot convert js value to enum without the primary constructor"
-  }
+  private val userFields: List<Field> =
+    enumClass.declaredFields.filter { !Modifier.isStatic(it.modifiers) && !it.isSynthetic }
 
   init {
-    if (!Enumerable::class.java.isAssignableFrom(enumClass.java)) {
-      logger.error("Enum '$enumClass' should inherit from ${Enumerable::class}.")
+    if (!Enumerable::class.java.isAssignableFrom(enumClass)) {
+      logger.error("Enum '${enumClass.simpleName}' should inherit from ${Enumerable::class}.")
     }
   }
 
@@ -39,34 +36,34 @@ class EnumTypeConverter(
   override fun isTrivial() = false
 
   override fun convertFromDynamic(value: Dynamic, context: AppContext?, forceConversion: Boolean): Enum<*> {
-    if (primaryConstructor.parameters.isEmpty()) {
+    if (userFields.isEmpty()) {
       return convertEnumWithoutParameter(
-        value.asString() ?: throw DynamicCastException(String::class),
+        value.asString() ?: throw DynamicCastException(String::class.java),
         enumConstants
       )
-    } else if (primaryConstructor.parameters.size == 1) {
+    } else if (userFields.size == 1) {
       return convertEnumWithParameter(
         value,
         enumConstants,
-        primaryConstructor.parameters.first().name!!
+        userFields.first()
       )
     }
 
-    throw IncompatibleArgTypeException(value.type.toKClass(), enumClass)
+    throw IncompatibleArgTypeException(value.type.toClass(), enumClass)
   }
 
   override fun convertFromAny(value: Any, context: AppContext?, forceConversion: Boolean): Enum<*> {
-    if (primaryConstructor.parameters.isEmpty()) {
+    if (userFields.isEmpty()) {
       return convertEnumWithoutParameter(value as String, enumConstants)
-    } else if (primaryConstructor.parameters.size == 1) {
+    } else if (userFields.size == 1) {
       return convertEnumWithParameter(
         value,
         enumConstants,
-        primaryConstructor.parameters.first().name!!
+        userFields.first()
       )
     }
 
-    throw IncompatibleArgTypeException(value::class, enumClass)
+    throw IncompatibleArgTypeException(value.javaClass, enumClass)
   }
 
   /**
@@ -82,17 +79,14 @@ class EnumTypeConverter(
   }
 
   /**
-   * If the primary constructor take one parameter, we treat this parameter as a enum value.
-   * In that case, we handles two different types: Int and String.
+   * If the primary constructor take one parameter, we treat this parameter as an enum value.
+   * In that case, we handle two different types: Int and String.
    */
   private fun convertEnumWithParameter(
     jsValue: Any,
     enumConstants: Array<out Enum<*>>,
-    parameterName: String
+    field: Field
   ): Enum<*> {
-    val field = enumClass.java.getDeclaredField(parameterName)
-    requireNotNull(field) { "Cannot find a property for $parameterName parameter" }
-
     field.isAccessible = true
 
     val parameterType = field.type
@@ -102,7 +96,7 @@ class EnumTypeConverter(
       enumConstants.find {
         field.get(it) == jsUnwrapValue
       }
-    ) { "Couldn't convert '$jsValue' to ${enumClass.simpleName} where $parameterName is the enum parameter" }
+    ) { "Couldn't convert '$jsValue' to ${enumClass.simpleName} where ${field.name} is the enum parameter" }
   }
 
   private fun Any.unwrapValue(parameterType: Class<*>): Any? {

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/TypeConverterProvider.kt
@@ -52,7 +52,6 @@ import java.net.URI
 import java.net.URL
 import java.nio.file.Path
 import java.time.LocalDate
-import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.time.Duration
 
@@ -135,7 +134,7 @@ object TypeConverterProviderImpl : TypeConverterProvider {
 
     if (jClass.isEnum) {
       @Suppress("UNCHECKED_CAST")
-      return EnumTypeConverter(jClass.kotlin as KClass<Enum<*>>)
+      return EnumTypeConverter(jClass as Class<out Enum<*>>)
     }
 
     val cachedConverter = cachedRecordConverters[jClass]


### PR DESCRIPTION
# Why

Improves the performance of `EnumTypeConverter`, by replacing kotlin with java reflection.
This change reduces both startup time and runtime overhead during enum conversion, making the process faster. 

# Test Plan

- unit-tests ✅ 
- bare-expo ✅ 