### PR TITLE
[sdk-55] chore: Upgrade to `metro@0.83.7`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Bump to `@expo/metro@55.1.1` and `metro@0.83.7` ([#45206](https://github.com/expo/expo/pull/45206) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.26 — 2026-04-22

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -48,7 +48,7 @@
     "@expo/image-utils": "^0.8.13",
     "@expo/json-file": "^10.0.13",
     "@expo/log-box": "55.0.11",
-    "@expo/metro": "~55.1.0",
+    "@expo/metro": "~55.1.1",
     "@expo/metro-config": "~55.0.17",
     "@expo/osascript": "^2.4.2",
     "@expo/package-manager": "^1.10.4",

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -20,9 +20,9 @@ import {
 import { resolveGoogleServicesFile, resolveManifestAssets } from './resolveAssets';
 import { parsePlatformHeader, RuntimePlatform } from './resolvePlatform';
 import { ServerNext, ServerRequest, ServerResponse } from './server.types';
+import { getActorDisplayName, getUserAsync } from '../../../api/user/user';
 import { isEnableHermesManaged } from '../../../export/exportHermes';
 import * as Log from '../../../log';
-import { getActorDisplayName, getUserAsync } from '../../../api/user/user';
 import { env } from '../../../utils/env';
 import * as ProjectDevices from '../../project/devices';
 import { UrlCreator } from '../UrlCreator';

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Bump to `@expo/metro@55.1.1` and `metro@0.83.7` ([#45206](https://github.com/expo/expo/pull/45206) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.17 — 2026-04-21

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.20.0",
     "@babel/generator": "^7.20.5",
     "@expo/config": "~55.0.15",
-    "@expo/metro": "~55.1.0",
+    "@expo/metro": "~55.1.1",
     "@expo/env": "~2.1.1",
     "@expo/json-file": "~10.0.13",
     "@expo/spawn-async": "^1.7.2",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -85,7 +85,7 @@
   "devDependencies": {
     "@babel/core": "^7.26.0",
     "@types/babel__core": "^7.20.5",
-    "@expo/metro": "~55.1.0",
+    "@expo/metro": "~55.1.1",
     "expo-module-scripts": "^55.0.2",
     "jest": "^29.2.1",
     "react-refresh": "^0.14.2"

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -39,7 +39,7 @@
     "@expo/config": "~55.0.15",
     "@expo/env": "~2.1.1",
     "@expo/json-file": "~10.0.13",
-    "@expo/metro": "~55.1.0",
+    "@expo/metro": "~55.1.1",
     "@expo/schemer": "2.1.4",
     "@expo/spawn-async": "^1.7.2",
     "@types/debug": "^4.1.8",

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Bump to `@expo/metro@55.1.1` and `metro@0.83.7` ([#45206](https://github.com/expo/expo/pull/45206) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 55.0.18 — 2026-04-28

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -84,7 +84,7 @@
     "@expo/fingerprint": "0.16.6",
     "@expo/local-build-cache-provider": "55.0.11",
     "@expo/log-box": "55.0.11",
-    "@expo/metro": "~55.1.0",
+    "@expo/metro": "~55.1.1",
     "@expo/metro-config": "55.0.17",
     "@expo/vector-icons": "^15.0.2",
     "@ungap/structured-clone": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1554,25 +1554,25 @@
     zod "^3.25.76"
     zod-to-json-schema "^3.24.6"
 
-"@expo/metro@~55.1.0":
-  version "55.1.0"
-  resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-55.1.0.tgz#fd465b17898a8e1b1ba6b73bafa9cf760636303b"
-  integrity sha512-bb/LOncsz9KiP6cHmMy0MCDG1COZOn+k+pRpDrvJUmxLdOOuniJSYyCc/Dgv1bR9E/6YR+fh3EXGg9MUrVNy4Q==
+"@expo/metro@~55.1.1":
+  version "55.1.1"
+  resolved "https://registry.yarnpkg.com/@expo/metro/-/metro-55.1.1.tgz#6d164d2c9dde03967c4480f72c7cbea39ac156c8"
+  integrity sha512-/wfXo5hTuAVpVLG/4hzlmD9NBGJkzkmBEMm/4VICajYRbj7y8OmqqPWbbymzHiBiHB6tI9BnsyXpQM6zVZEECg==
   dependencies:
-    metro "0.83.6"
-    metro-babel-transformer "0.83.6"
-    metro-cache "0.83.6"
-    metro-cache-key "0.83.6"
-    metro-config "0.83.6"
-    metro-core "0.83.6"
-    metro-file-map "0.83.6"
-    metro-minify-terser "0.83.6"
-    metro-resolver "0.83.6"
-    metro-runtime "0.83.6"
-    metro-source-map "0.83.6"
-    metro-symbolicate "0.83.6"
-    metro-transform-plugins "0.83.6"
-    metro-transform-worker "0.83.6"
+    metro "0.83.7"
+    metro-babel-transformer "0.83.7"
+    metro-cache "0.83.7"
+    metro-cache-key "0.83.7"
+    metro-config "0.83.7"
+    metro-core "0.83.7"
+    metro-file-map "0.83.7"
+    metro-minify-terser "0.83.7"
+    metro-resolver "0.83.7"
+    metro-runtime "0.83.7"
+    metro-source-map "0.83.7"
+    metro-symbolicate "0.83.7"
+    metro-transform-plugins "0.83.7"
+    metro-transform-worker "0.83.7"
 
 "@expo/mux@^1.0.7":
   version "1.0.7"
@@ -11471,61 +11471,61 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-metro-babel-transformer@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.83.6.tgz#0cf874436382ffe61c7f11ed816da859bb1fcdbd"
-  integrity sha512-1AnuazBpzY3meRMr04WUw14kRBkV0W3Ez+AA75FAeNpRyWNN5S3M3PHLUbZw7IXq7ZeOzceyRsHStaFrnWd+8w==
+metro-babel-transformer@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-babel-transformer/-/metro-babel-transformer-0.83.7.tgz#8448c7a550571de87d00e97c1a7139c6b6900e4a"
+  integrity sha512-sBqBkt6kNut/88bv+Ucvm4yqdPetbvAEsHzi3MAgJEifOSYYzX5Z5Kgw3TFOrwf/mHJTOBG2ONlaMHoyfP15TA==
   dependencies:
     "@babel/core" "^7.25.2"
     flow-enums-runtime "^0.0.6"
     hermes-parser "0.35.0"
-    metro-cache-key "0.83.6"
+    metro-cache-key "0.83.7"
     nullthrows "^1.1.1"
 
-metro-cache-key@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.83.6.tgz#293ccb950b588efafd84dc57dee7a15d6a4a40e2"
-  integrity sha512-5gdK4PVpgNOHi7xCGrgesNP1AuOA2TiPqpcirGXZi4RLLzX1VMowpkgTVtBfpQQCqWoosQF9yrSo9/KDQg1eBg==
+metro-cache-key@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-cache-key/-/metro-cache-key-0.83.7.tgz#59e647cf6dd6297e43d0bd7ab927db48c6ba80b5"
+  integrity sha512-W1c2Nmx8MiJTJt+eWhMO08z9VKi3kZOaz99IYGdqeqDgY9j+yZjXl62rUav4Di0heZfh4/n2s722PqRL1OODeg==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-cache@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.83.6.tgz#aadaef9bfd87559e4264b2b05c06c597bb2ddae4"
-  integrity sha512-DpvZE32feNkqfZkI4Fic7YI/Kw8QP9wdl1rC4YKPrA77wQbI9vXbxjmfkCT/EGwBTFOPKqvIXo+H3BNe93YyiQ==
+metro-cache@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-cache/-/metro-cache-0.83.7.tgz#73ab7857ba6267b78f6374396829d660a67deccf"
+  integrity sha512-E9SRePXQ1Zvlj79VcOk57q7VC7rMHMFQ+jhmPHBiq+dJ0bJB5BL87lWZF6oh5X76Cci5tpDuQNaDwwuSCToEeg==
   dependencies:
     exponential-backoff "^3.1.1"
     flow-enums-runtime "^0.0.6"
     https-proxy-agent "^7.0.5"
-    metro-core "0.83.6"
+    metro-core "0.83.7"
 
-metro-config@0.83.6, metro-config@^0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.83.6.tgz#74ddbbb6f34b8103b37140f8de1d34068a4122ef"
-  integrity sha512-G5622400uNtnAMlppEA5zkFAZltEf7DSGhOu09BkisCxOlVMWfdosD/oPyh4f2YVQsc1MBYyp4w6OzbExTYarg==
+metro-config@0.83.7, metro-config@^0.83.6:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-config/-/metro-config-0.83.7.tgz#fc88f4f75992744d6d64bf27c6a2f11b10e9fcfb"
+  integrity sha512-83mjWFbFOt2GeJ6pFIum5mSnc1uTsZJAtD8o4ej0s4NVsYsA7fB+pHvTfHhFrpeMONaobu2riKavkPei05Er/Q==
   dependencies:
     connect "^3.6.5"
     flow-enums-runtime "^0.0.6"
     jest-validate "^29.7.0"
-    metro "0.83.6"
-    metro-cache "0.83.6"
-    metro-core "0.83.6"
-    metro-runtime "0.83.6"
+    metro "0.83.7"
+    metro-cache "0.83.7"
+    metro-core "0.83.7"
+    metro-runtime "0.83.7"
     yaml "^2.6.1"
 
-metro-core@0.83.6, metro-core@^0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.83.6.tgz#60fbd0abcc0e313161b94869b3bb0b9622de4acc"
-  integrity sha512-l+yQ2fuIgR//wszUlMrrAa9+Z+kbKazd0QOh0VQY7jC4ghb7yZBBSla/UMYRBZZ6fPg9IM+wD3+h+37a5f9etw==
+metro-core@0.83.7, metro-core@^0.83.6:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-core/-/metro-core-0.83.7.tgz#45cc9eebd979c75021015f190dbd023e833bdd16"
+  integrity sha512-6yn3w1wnltT6RQl7p7YES2l95ArC+mWrOssEiH8p5/DDrJS65/szf9LsC9JrBv8c5DdvSY3V3f0GRYg0Ox7hCg==
   dependencies:
     flow-enums-runtime "^0.0.6"
     lodash.throttle "^4.1.1"
-    metro-resolver "0.83.6"
+    metro-resolver "0.83.7"
 
-metro-file-map@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.83.6.tgz#9f79308e73ffca6340eb7c2ca2a74db9fef822d1"
-  integrity sha512-Jg3oN604C7GWbQwFAUXt8KsbMXeKfsxbZ5HFy4XFM3ggTS+ja9QgUmq9B613kgXv3G4M6rwiI6cvh9TRly4x3w==
+metro-file-map@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-file-map/-/metro-file-map-0.83.7.tgz#1d0d47db8a76631f0fed2112edad5fec462aec50"
+  integrity sha512-+j0F1m+FQYVAQ6syf+mwhIPV5GoFQrkInX8bppuc50IzNsZbMrp8R5H/Sx/K2daQ3YEa9F/XwkeZT8gzJfgeCw==
   dependencies:
     debug "^4.4.0"
     fb-watchman "^2.0.0"
@@ -11537,60 +11537,60 @@ metro-file-map@0.83.6:
     nullthrows "^1.1.1"
     walker "^1.0.7"
 
-metro-minify-terser@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.83.6.tgz#994697c91c0bea86201509d15d8b204b6d210e59"
-  integrity sha512-Vx3/Ne9Q+EIEDLfKzZUOtn/rxSNa/QjlYxc42nvK4Mg8mB6XUgd3LXX5ZZVq7lzQgehgEqLrbgShJPGfeF8PnQ==
+metro-minify-terser@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-minify-terser/-/metro-minify-terser-0.83.7.tgz#2de0b70f8cd58e9383b014313a1d9e7babe8d878"
+  integrity sha512-MfJar2IS4tBRuLb9svwb0Gu5l9BsH+pcRm8eGcEi/wy8MzZinfinh5dFLt2nWkocnulIgtGB5NkFDdbXqMXKhQ==
   dependencies:
     flow-enums-runtime "^0.0.6"
     terser "^5.15.0"
 
-metro-resolver@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.83.6.tgz#4e0a975b76474cd1a51d62ff426ea372e8d7777d"
-  integrity sha512-lAwR/FsT1uJ5iCt4AIsN3boKfJ88aN8bjvDT5FwBS0tKeKw4/sbdSTWlFxc7W/MUTN5RekJ3nQkJRIWsvs28tA==
+metro-resolver@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-resolver/-/metro-resolver-0.83.7.tgz#84b2e2749f0dba0e1c204764d01c21892157cf1c"
+  integrity sha512-WSJIENlMcoSsuz66IfBHOkgfp3KJt2UW2TnEHPf1b8pIG2eEXNOVmo2+03A0H17WY2XGXWgxL0CG7FAopqgB1A==
   dependencies:
     flow-enums-runtime "^0.0.6"
 
-metro-runtime@0.83.6, metro-runtime@^0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.83.6.tgz#77eec399263a4be97c2c3938cfd0f84c584821c9"
-  integrity sha512-WQPua1G2VgYbwRn6vSKxOhTX7CFbSf/JdUu6Nd8bZnPXckOf7HQ2y51NXNQHoEsiuawathrkzL8pBhv+zgZFmg==
+metro-runtime@0.83.7, metro-runtime@^0.83.6:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-runtime/-/metro-runtime-0.83.7.tgz#3606a71c94a4ef862b7a0e43156b35f7a4e4cf17"
+  integrity sha512-9GKkJURaB2iyYoEExKnedzAHzxmKtSi+k0tsZUvMoU27tBZJElchYt7JH/Ai/XzYAI9lCAaV7u5HZSI8J5Z+wQ==
   dependencies:
     "@babel/runtime" "^7.25.0"
     flow-enums-runtime "^0.0.6"
 
-metro-source-map@0.83.6, metro-source-map@^0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.83.6.tgz#65465faaf98664e1e5f2719db00c354a4d67697e"
-  integrity sha512-AqJbOMMpeyyM4iNI91pchqDIszzNuuHApEhg6OABqZ+9mjLEqzcIEQ/fboZ7x74fNU5DBd2K36FdUQYPqlGClA==
+metro-source-map@0.83.7, metro-source-map@^0.83.6:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-source-map/-/metro-source-map-0.83.7.tgz#6208e72427c987e66a9ec23ebaee0b3cc76dd16c"
+  integrity sha512-JgA1h7oc1a1jydBe1GhVFsUoMYo3wLPk7oRA32rjlDsq+sP2JLt9x2p2lWbNSxTm/u8NV4VRid3hvEJgcX8tKw==
   dependencies:
     "@babel/traverse" "^7.29.0"
     "@babel/types" "^7.29.0"
     flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-symbolicate "0.83.6"
+    metro-symbolicate "0.83.7"
     nullthrows "^1.1.1"
-    ob1 "0.83.6"
+    ob1 "0.83.7"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-symbolicate@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.83.6.tgz#8c16c187ac92cd4dc7e381ec7a482b110484ba18"
-  integrity sha512-4nvkmv9T7ozhprlPwk/+xm0SVPsxly5kYyMHdNaOlFemFz4df9BanvD46Ac6OISu/4Idinzfk2KVb++6OfzPAQ==
+metro-symbolicate@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-symbolicate/-/metro-symbolicate-0.83.7.tgz#ee10cfbafb5ed5ae5f04a565c496fd772afb3f5c"
+  integrity sha512-g4suyxw20WOHWI680c+Kq4wC/NF+Hx5pRH9afrMp+sMTxqLeKcPR1Xf4wMhsjlbvx7LbIREdke6q928jEjvJWw==
   dependencies:
     flow-enums-runtime "^0.0.6"
     invariant "^2.2.4"
-    metro-source-map "0.83.6"
+    metro-source-map "0.83.7"
     nullthrows "^1.1.1"
     source-map "^0.5.6"
     vlq "^1.0.0"
 
-metro-transform-plugins@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.83.6.tgz#ce7a3d835fde900198dd311b3c40b9e50f64c8c6"
-  integrity sha512-V+zoY2Ul0v0BW6IokJkTud3raXmDdbdwkUQ/5eiSoy0jKuKMhrDjdH+H5buCS5iiJdNbykOn69Eip+Sqymkodg==
+metro-transform-plugins@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-transform-plugins/-/metro-transform-plugins-0.83.7.tgz#9fc9b4c209ca2fdc1e720a9fefde7c20f32ab5ad"
+  integrity sha512-Ss0FpBiZDjX2kwhukMDl5sNdYK8T/06IPqxNE4H6PTlRlfs9q11cef13c/xESY/Pm4VCkp1yJUZO3kXzvMxQFA==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/generator" "^7.29.1"
@@ -11599,29 +11599,29 @@ metro-transform-plugins@0.83.6:
     flow-enums-runtime "^0.0.6"
     nullthrows "^1.1.1"
 
-metro-transform-worker@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.83.6.tgz#4428abd954c2661658633dd613fb5a733cde338d"
-  integrity sha512-G5kDJ/P0ZTIf57t3iyAd5qIXbj2Wb1j7WtIDh82uTFQHe2Mq2SO9aXG9j1wI+kxZlIe58Z22XEXIKMl89z0ibQ==
+metro-transform-worker@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro-transform-worker/-/metro-transform-worker-0.83.7.tgz#1ba8980f660630f7dfbf52fcf2b7bd6e4ae4528b"
+  integrity sha512-UegCo7ygB2fT64mRK2nbAjQVJ1zSwIIHy8d96jJv2nKZFDaViYBiughEdu5HM/Ceq0WN3LZrZk3zhl9aoiLYFw==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/generator" "^7.29.1"
     "@babel/parser" "^7.29.0"
     "@babel/types" "^7.29.0"
     flow-enums-runtime "^0.0.6"
-    metro "0.83.6"
-    metro-babel-transformer "0.83.6"
-    metro-cache "0.83.6"
-    metro-cache-key "0.83.6"
-    metro-minify-terser "0.83.6"
-    metro-source-map "0.83.6"
-    metro-transform-plugins "0.83.6"
+    metro "0.83.7"
+    metro-babel-transformer "0.83.7"
+    metro-cache "0.83.7"
+    metro-cache-key "0.83.7"
+    metro-minify-terser "0.83.7"
+    metro-source-map "0.83.7"
+    metro-transform-plugins "0.83.7"
     nullthrows "^1.1.1"
 
-metro@0.83.6, metro@^0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/metro/-/metro-0.83.6.tgz#1b42929143729d854c25a40f0568f955ba70895e"
-  integrity sha512-pbdndsAZ2F/ceopDdhVbttpa/hfLzXPJ/husc+QvQ33R0D9UXJKzTn5+OzOXx4bpQNtAKF2bY88cCI3Zl44xDQ==
+metro@0.83.7, metro@^0.83.6:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/metro/-/metro-0.83.7.tgz#8357495dfea9e11d34ea15c0a1e2acd508ee5559"
+  integrity sha512-SPaPEyvTsTmd0LpT7RaZciQyDw2i/JB7+iY9L5VfBo72+psescFxBqpI1TL9dnL+pmnfkU+l/J1mEEGLeF65EQ==
   dependencies:
     "@babel/code-frame" "^7.29.0"
     "@babel/core" "^7.25.2"
@@ -11631,7 +11631,6 @@ metro@0.83.6, metro@^0.83.6:
     "@babel/traverse" "^7.29.0"
     "@babel/types" "^7.29.0"
     accepts "^2.0.0"
-    chalk "^4.0.0"
     ci-info "^2.0.0"
     connect "^3.6.5"
     debug "^4.4.0"
@@ -11644,18 +11643,18 @@ metro@0.83.6, metro@^0.83.6:
     jest-worker "^29.7.0"
     jsc-safe-url "^0.2.2"
     lodash.throttle "^4.1.1"
-    metro-babel-transformer "0.83.6"
-    metro-cache "0.83.6"
-    metro-cache-key "0.83.6"
-    metro-config "0.83.6"
-    metro-core "0.83.6"
-    metro-file-map "0.83.6"
-    metro-resolver "0.83.6"
-    metro-runtime "0.83.6"
-    metro-source-map "0.83.6"
-    metro-symbolicate "0.83.6"
-    metro-transform-plugins "0.83.6"
-    metro-transform-worker "0.83.6"
+    metro-babel-transformer "0.83.7"
+    metro-cache "0.83.7"
+    metro-cache-key "0.83.7"
+    metro-config "0.83.7"
+    metro-core "0.83.7"
+    metro-file-map "0.83.7"
+    metro-resolver "0.83.7"
+    metro-runtime "0.83.7"
+    metro-source-map "0.83.7"
+    metro-symbolicate "0.83.7"
+    metro-transform-plugins "0.83.7"
+    metro-transform-worker "0.83.7"
     mime-types "^3.0.1"
     nullthrows "^1.1.1"
     serialize-error "^2.1.0"
@@ -12175,10 +12174,10 @@ nwsapi@^2.2.2:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
   integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
 
-ob1@0.83.6:
-  version "0.83.6"
-  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.83.6.tgz#7506c02651efe4c6d3ab19884fe3d91a56fca555"
-  integrity sha512-m/xZYkwcjo6UqLMrUICEB3iHk7Bjt3RSR7KXMi6Y1MO/kGkPhoRmfUDF6KAan3rLAZ7ABRqnQyKUTwaqZgUV4w==
+ob1@0.83.7:
+  version "0.83.7"
+  resolved "https://registry.yarnpkg.com/ob1/-/ob1-0.83.7.tgz#0f9a9461ee3c3048eacd40893fee3385d42d8731"
+  integrity sha512-9M5kpuOLyTPogMtZiQUIxdAZxl7Dxs6tVBbJErSumsqGMuhVSoUbkfeZ3XNPpLpwBBtqY5QDUzGwggLHX3slQg==
   dependencies:
     flow-enums-runtime "^0.0.6"
 


### PR DESCRIPTION
# Summary

Changes within range: https://github.com/facebook/metro/compare/v0.83.6...v0.83.7

Upgrades to `@expo/metro@55.1.1-0` (temporary prerelease) / `metro@0.83.7`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
