### PR TITLE
fix: invalidate cache for UIBarButtonItem for modal dismiss and reopen

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [Android] Fix @expo/ui divider in toolbar. ([#44209](https://github.com/expo/expo/pull/44209) by [@jakex7](https://github.com/jakex7))
 - Fix `Stack.Screen.Title` string/number concatenation. ([#44213](https://github.com/expo/expo/pull/44213) by [@jakex7](https://github.com/jakex7))
 - [android] Use `tint` prop name instead of `tintColor` for Jetpack Compose icons ([#44427](https://github.com/expo/expo/pull/44427) by [@hassankhan](https://github.com/hassankhan))
+- [ios] Fix `Stack.Toolbar` bottom items losing icons and actions after reopening modal screens ([#44493](https://github.com/expo/expo/issues/44493))
 - Disable touch events on unfocused native tab screens ([#44778](https://github.com/expo/expo/pull/44778) by [@cortinico](https://github.com/cortinico))
 
 ### 💡 Others

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -30,7 +30,7 @@
 - [Android] Fix @expo/ui divider in toolbar. ([#44209](https://github.com/expo/expo/pull/44209) by [@jakex7](https://github.com/jakex7))
 - Fix `Stack.Screen.Title` string/number concatenation. ([#44213](https://github.com/expo/expo/pull/44213) by [@jakex7](https://github.com/jakex7))
 - [android] Use `tint` prop name instead of `tintColor` for Jetpack Compose icons ([#44427](https://github.com/expo/expo/pull/44427) by [@hassankhan](https://github.com/hassankhan))
-- [ios] Fix `Stack.Toolbar` bottom items losing icons and actions after reopening modal screens ([#44493](https://github.com/expo/expo/issues/44493))
+- [ios] Fix `Stack.Toolbar` bottom items losing icons and actions after reopening modal screens ([#44493](https://github.com/expo/expo/issues/44493)) ([#45209](https://github.com/expo/expo/pull/45209) by [@jeferson-sb](https://github.com/jeferson-sb))
 - Disable touch events on unfocused native tab screens ([#44778](https://github.com/expo/expo/pull/44778) by [@cortinico](https://github.com/cortinico))
 
 ### 💡 Others

--- a/packages/expo-router/ios/Toolbar/RouterToolbarHostView.swift
+++ b/packages/expo-router/ios/Toolbar/RouterToolbarHostView.swift
@@ -41,6 +41,12 @@ class RouterToolbarHostView: RouterViewWithLogger, LinkPreviewMenuUpdatable {
     }
   }
 
+  private func invalidateToolbarItems() {
+    for item in toolbarItemsMap.values {
+      item.invalidateBarButtonItem()
+    }
+  }
+
   func updateToolbarItems() {
     // If update already scheduled, skip - the pending async block will handle it
     if hasPendingToolbarUpdate {
@@ -167,6 +173,7 @@ class RouterToolbarHostView: RouterViewWithLogger, LinkPreviewMenuUpdatable {
   override func didMoveToWindow() {
     super.didMoveToWindow()
     if window == nil {
+      invalidateToolbarItems()
       // View was removed from window - hide toolbar and clear items
       // Use cached controller since responder chain may be broken
       if let controller = cachedController {
@@ -174,6 +181,9 @@ class RouterToolbarHostView: RouterViewWithLogger, LinkPreviewMenuUpdatable {
       }
       cachedController = nil  // Clear cache when removed from window
     } else {
+      // Modal reopen can reuse the same mounted RouterToolbarItemViews. Force fresh
+      // UIBarButtonItem instances so UIKit doesn't reuse stale targets/images.
+      invalidateToolbarItems()
       // View was added to window - update toolbar items
       updateToolbarItems()
     }

--- a/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
+++ b/packages/expo-router/ios/Toolbar/RouterToolbarItemView.swift
@@ -60,6 +60,10 @@ class RouterToolbarItemView: RouterViewWithLogger {
     onSelected()
   }
 
+  func invalidateBarButtonItem() {
+    currentBarButtonItem = nil
+  }
+
   var barButtonItem: UIBarButtonItem {
     if let item = currentBarButtonItem {
       return item

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbar.integration.test.ios.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbar.integration.test.ios.tsx
@@ -1,6 +1,7 @@
-import { screen, within } from '@testing-library/react-native';
+import { act, screen, within } from '@testing-library/react-native';
 import { Text, View } from 'react-native';
 
+import { router } from '../../../imperative-api';
 import { renderRouter } from '../../../testing-library';
 import Stack from '../../StackClient';
 
@@ -408,6 +409,65 @@ describe('Stack.Toolbar integration tests', () => {
         type: 'button',
         icon: { type: 'sfSymbol', name: 'gear' },
       });
+    });
+  });
+
+  describe('modal reopen flow', () => {
+    it('mounts bottom toolbar items again after dismissing and reopening a modal screen', () => {
+      const onPress = jest.fn();
+
+      renderRouter({
+        _layout: () => (
+          <Stack>
+            <Stack.Screen name="index" />
+            <Stack.Screen name="modal" options={{ presentation: 'modal' }} />
+          </Stack>
+        ),
+        index: () => <View testID="index" />,
+        modal: () => (
+          <>
+            <Stack.Toolbar>
+              <Stack.Toolbar.Button icon="xmark" onPress={onPress}>
+                Close
+              </Stack.Toolbar.Button>
+            </Stack.Toolbar>
+            <View testID="modal" />
+          </>
+        ),
+      });
+
+      expect(screen.getByTestId('index')).toBeVisible();
+
+      act(() => router.push('/modal'));
+
+      expect(screen.getByTestId('modal')).toBeVisible();
+      expect(MockedRouterToolbarHost).toHaveBeenCalledTimes(1);
+      expect(MockedRouterToolbarItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onSelected: onPress,
+          systemImageName: 'xmark',
+          title: 'Close',
+        }),
+        undefined
+      );
+
+      jest.clearAllMocks();
+
+      act(() => router.back());
+      expect(screen.getByTestId('index')).toBeVisible();
+
+      act(() => router.push('/modal'));
+
+      expect(screen.getByTestId('modal')).toBeVisible();
+      expect(MockedRouterToolbarHost).toHaveBeenCalledTimes(1);
+      expect(MockedRouterToolbarItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          onSelected: onPress,
+          systemImageName: 'xmark',
+          title: 'Close',
+        }),
+        undefined
+      );
     });
   });
 });


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fixes #44493

# How

<!--
How did you build this feature or fix this bug and why?
-->

The bottom Stack.Toolbar items on iOS were reusing cached `UIBarButtonItem` instances across modal/formSheet dismiss + reopen, which matches the report of missing icons and dead onPress handlers on the second open. The fix is not to rebuild the button but only invalidate when host leaves the window and re-enters

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Test against the repo
https://github.com/andveloper/expo-router-stack-toolbar-modal-mre/tree/main

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
