### PR TITLE
[et] Add missing deps to BareExpo before running android publish

### DIFF
--- a/tools/src/publish-packages/tasks/ensureBareExpoDependencies.ts
+++ b/tools/src/publish-packages/tasks/ensureBareExpoDependencies.ts
@@ -1,0 +1,87 @@
+import JsonFile from '@expo/json-file';
+import spawnAsync from '@expo/spawn-async';
+import chalk from 'chalk';
+import path from 'path';
+
+import { selectPackagesToPublish } from './selectPackagesToPublish';
+import { EXPO_DIR } from '../../Constants';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
+
+const { green, yellow } = chalk;
+
+const BARE_EXPO_PACKAGE_JSON = path.join(EXPO_DIR, 'apps/bare-expo/package.json');
+
+/**
+ * Adds any publishable native packages that are missing from `apps/bare-expo`'s
+ * dependencies as `workspace:*` deps and runs `pnpm install`.
+ *
+ * This is necessary because the Android publish step invokes Gradle inside `apps/bare-expo/android`
+ * and relies on Expo autolinking to register each package as a `:<pkg>` Gradle
+ * subproject. Autolinking only walks BareExpo's own dependency graph, so any
+ * native package that BareExpo doesn't depend on (e.g. `expo-router`) won't be
+ * registered and `:<pkg>:expoPublish` fails with "project not found".
+ *
+ */
+export const ensureBareExpoDependencies = new Task<TaskArgs>(
+  {
+    name: 'ensureBareExpoDependencies',
+    dependsOn: [selectPackagesToPublish],
+  },
+  async (parcels: Parcel[], options: CommandOptions) => {
+    if (options.templatesOnly || options.skipAndroidArtifacts) {
+      return;
+    }
+
+    const nativeParcels = parcels.filter((parcel) => {
+      const moduleConfig = parcel.pkg.expoModuleConfig;
+      if (!moduleConfig) {
+        return false;
+      }
+      return (
+        moduleConfig.platforms?.includes('android') || moduleConfig.platforms?.includes('apple')
+      );
+    });
+
+    if (nativeParcels.length === 0) {
+      return;
+    }
+
+    const packageJson = await JsonFile.readAsync(BARE_EXPO_PACKAGE_JSON);
+    const dependencies = (packageJson.dependencies ?? {}) as Record<string, string>;
+    const devDependencies = (packageJson.devDependencies ?? {}) as Record<string, string>;
+
+    const missing: string[] = [];
+    for (const { pkg } of nativeParcels) {
+      const name = pkg.packageName;
+      if (!(name in dependencies) && !(name in devDependencies)) {
+        missing.push(name);
+      }
+    }
+
+    if (missing.length === 0) {
+      return;
+    }
+
+    logger.info('\n📦 Adding missing native packages to bare-expo...');
+    for (const name of missing) {
+      logger.log('  ', `${green('+')} ${yellow(name)}`);
+      dependencies[name] = 'workspace:*';
+    }
+
+    packageJson.dependencies = sortKeys(dependencies);
+    await JsonFile.writeAsync(BARE_EXPO_PACKAGE_JSON, packageJson);
+
+    logger.log('  ', 'Running pnpm install...');
+    await spawnAsync('pnpm', ['install', '--no-frozen-lockfile'], {
+      cwd: EXPO_DIR,
+      stdio: 'inherit',
+    });
+    logger.success('  ', 'Linked missing native packages into bare-expo.');
+  }
+);
+
+function sortKeys<T>(obj: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(Object.entries(obj).sort(([a], [b]) => a.localeCompare(b)));
+}

--- a/tools/src/publish-packages/tasks/publishAndroidPackages.ts
+++ b/tools/src/publish-packages/tasks/publishAndroidPackages.ts
@@ -5,12 +5,13 @@ import { glob } from 'glob';
 import inquirer from 'inquirer';
 import path from 'path';
 
+import { ensureBareExpoDependencies } from './ensureBareExpoDependencies';
+import { updateAndroidProjects } from './updateAndroidProjects';
 import { EXPO_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { ExpoModuleConfig, Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import type { CommandOptions, Parcel, TaskArgs } from '../types';
-import { updateAndroidProjects } from './updateAndroidProjects';
 
 const EXCLUDE = ['expo-module-template'];
 
@@ -85,7 +86,7 @@ async function cleanupStaleBuildDirectories(): Promise<void> {
 export const publishAndroidArtifacts = new Task<TaskArgs>(
   {
     name: 'publishAndroidArtifacts',
-    dependsOn: [updateAndroidProjects],
+    dependsOn: [updateAndroidProjects, ensureBareExpoDependencies],
   },
   async (parcels: Parcel[], options: CommandOptions) => {
     // If only templates are being published, skip Android artifacts step entirely

--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -98,6 +98,7 @@ export const cleanWorkingTree = new Task<TaskArgs>(
             'packages/expo/bundledNativeModules.json',
             'packages/**/expo-module.config.json',
             'packages/**/build.gradle',
+            'pnpm-lock.yaml',
             'templates/*/package.json',
           ],
         });

--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -45,7 +45,11 @@ const cleanWorkingTree = new Task<TaskArgs>(
         // JSON files are automatically added to the index after previous tasks.
         await Git.checkoutAsync({
           ref: 'HEAD',
-          paths: ['packages/**/expo-module.config.json'],
+          paths: [
+            'apps/bare-expo/package.json',
+            'packages/**/expo-module.config.json',
+            'pnpm-lock.yaml',
+          ],
         });
         // Remove local repositories.
         await Git.cleanAsync({


### PR DESCRIPTION
# Why

After removing `expo-router` from BareExpo's dependency list (https://github.com/expo/expo/pull/45156), our publishing script stopped working 

Add explanation here

# How

Add a new required task to `publishAndroidArtifacts` that ensures BareExpo has all the dependencies we want to publish installed 

# Test Plan

publishing canaries ci should be green  https://github.com/expo/expo/actions/runs/25119087998/job/73614423221

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
