### PR TITLE
[ncl] Unify crop function in ImageManipulator example

### DIFF
--- a/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
+++ b/apps/native-component-list/src/screens/ImageManipulatorScreen.tsx
@@ -93,7 +93,7 @@ export default function ImageManipulatorScreen() {
       originX: 0,
       originY: 0,
       width: image.width! / 2,
-      height: image.height! / 2,
+      height: image.height!,
     });
     refreshImage();
   }


### PR DESCRIPTION
# Why

Unify the crop function in the ImageManipulator example. In the legacy example, we were cropping half of the image, not 3/4

# Test Plan

- NCL ✅ 