### PR TITLE
[ncl] Remove unnecessary header inside localization screen

### DIFF
--- a/apps/native-component-list/src/screens/LocalizationScreen.tsx
+++ b/apps/native-component-list/src/screens/LocalizationScreen.tsx
@@ -45,8 +45,6 @@ export default function LocalizationScreen() {
 
         <HeadingText>Calendars in Preference Order</HeadingText>
         <MonoText>{JSON.stringify(Localization.getCalendars(), null, 2)}</MonoText>
-
-        <HeadingText>Localization Table</HeadingText>
       </View>
     </ScrollView>
   );


### PR DESCRIPTION
# Why

Removes the unnecessary header inside the localization screen