### PR TITLE
[docs] Add info about `<Prerequisites>` in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -603,6 +603,27 @@ import { Terminal } from '~/ui/components/Snippet';
 />
 ```
 
+### Use `Prerequisites` for setup checklists
+
+When a guide depends on the reader having a specific environment or prior step in place, wrap the requirements in a `Prerequisites` component. It renders as a collapsible block and threads each requirement's title through the page heading manager so it can be linked.
+
+```mdx
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
+
+<Prerequisites>
+  <Requirement title="Set up your development environment">
+    Make sure your computer is [set up for running an Expo app](/get-started/create-a-project/).
+  </Requirement>
+  <Requirement title="Install EAS CLI">Run `npm install -g eas-cli` and log in.</Requirement>
+</Prerequisites>
+```
+
+Pass `open` to render the block expanded by default:
+
+```mdx
+<Prerequisites open>...</Prerequisites>
+```
+
 ### Use callouts
 
 Four different types of callouts can be used with markdown syntax for `> ...` blockquote. Each callout represents a purpose.


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20889

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add info about `<Prerequisites>` in README.md as a subsection where other components are listed.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
