### PR TITLE
[expo][docs] useExpoDOMWebView by default

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -35,9 +35,35 @@ While the Expo native runtime generally does not support elements like `<div>` o
 
 ## Usage
 
+<Tabs>
+
+<Tab label="SDK 56 and later">
+
+Starting in SDK 56, DOM components use [`@expo/dom-webview`](https://www.npmjs.com/package/@expo/dom-webview) by default and no additional install is required.
+
+If you want to use `react-native-webview` instead, install it and opt out via the `dom` prop:
+
+<Terminal cmd={['$ npx expo install react-native-webview']} />
+
+```tsx App.tsx (native)
+import DOMComponent from './my-component';
+
+export default function App() {
+  return <DOMComponent dom={{ useExpoDOMWebView: false }} />;
+}
+```
+
+</Tab>
+
+<Tab label="SDK 55 and earlier">
+
 Install `react-native-webview` in your project:
 
 <Terminal cmd={['$ npx expo install react-native-webview']} />
+
+</Tab>
+
+</Tabs>
 
 To render a React component to the DOM, add the `'use dom'` directive to the top of the web component file:
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -39,7 +39,7 @@ While the Expo native runtime generally does not support elements like `<div>` o
 
 <Tab label="SDK 56 and later">
 
-Starting in SDK 56, DOM components use [`@expo/dom-webview`](https://www.npmjs.com/package/@expo/dom-webview) by default and no additional install is required.
+DOM components use [`@expo/dom-webview`](https://www.npmjs.com/package/@expo/dom-webview) by default and no additional install is required.
 
 If you want to use `react-native-webview` instead, install it and opt out via the `dom` prop:
 

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Bumped minimum iOS/tvOS version to 16.4, macOS to 13.4. ([#43296](https://github.com/expo/expo/pull/43296) by [@tsapeta](https://github.com/tsapeta))
 - Use `expo/fetch` as default fetch. ([#44987](https://github.com/expo/expo/pull/44987) by [@kudo](https://github.com/kudo))
+- [dom] Use `@expo/dom-webview` as default webview for DOM components. ([#45224](https://github.com/expo/expo/pull/45224) by [@kudo](https://github.com/kudo))
 
 ### 🎉 New features
 

--- a/packages/expo/build/dom/dom.types.d.ts
+++ b/packages/expo/build/dom/dom.types.d.ts
@@ -26,7 +26,7 @@ export interface DOMProps extends Omit<RNWebViewProps, 'source'> {
     matchContents?: boolean;
     /**
      * Whether to use the `@expo/dom-webview` as the underlying WebView implementation.
-     * @default false
+     * @default true
      */
     useExpoDOMWebView?: boolean;
     /**

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -79,6 +79,7 @@
     "@expo/config": "workspace:~55.0.8",
     "@expo/config-plugins": "workspace:~55.0.6",
     "@expo/devtools": "workspace:55.0.2",
+    "@expo/dom-webview": "workspace:~55.0.3",
     "@expo/fingerprint": "workspace:0.16.5",
     "@expo/local-build-cache-provider": "workspace:55.0.6",
     "@expo/log-box": "workspace:55.0.7",

--- a/packages/expo/src/dom/dom.types.ts
+++ b/packages/expo/src/dom/dom.types.ts
@@ -33,7 +33,7 @@ export interface DOMProps extends Omit<RNWebViewProps, 'source'> {
 
   /**
    * Whether to use the `@expo/dom-webview` as the underlying WebView implementation.
-   * @default false
+   * @default true
    */
   useExpoDOMWebView?: boolean;
 

--- a/packages/expo/src/dom/webview-wrapper.tsx
+++ b/packages/expo/src/dom/webview-wrapper.tsx
@@ -69,7 +69,7 @@ const RawWebView = React.forwardRef<object, Props>((props, ref) => {
     );
   }
 
-  const useExpoDOMWebView = dom?.useExpoDOMWebView ?? false;
+  const useExpoDOMWebView = dom?.useExpoDOMWebView ?? true;
   const webView = resolveWebView(useExpoDOMWebView);
   const webviewRef = React.useRef<WebViewRef>(null);
   const domImperativeHandlePropsRef = React.useRef<string[]>([]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3339,6 +3339,9 @@ importers:
       '@expo/devtools':
         specifier: workspace:55.0.2
         version: link:../@expo/devtools
+      '@expo/dom-webview':
+        specifier: workspace:~55.0.3
+        version: link:../@expo/dom-webview
       '@expo/fingerprint':
         specifier: workspace:0.16.5
         version: link:../@expo/fingerprint
@@ -3400,9 +3403,6 @@ importers:
         specifier: ^0.1.1
         version: 0.1.1
     devDependencies:
-      '@expo/dom-webview':
-        specifier: workspace:*
-        version: link:../@expo/dom-webview
       '@expo/metro-runtime':
         specifier: workspace:*
         version: link:../@expo/metro-runtime
@@ -19210,6 +19210,18 @@ snapshots:
     optionalDependencies:
       jest: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2))
 
+  '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2)))(react-native@0.85.2(@babel/core@7.29.0)(@react-native/jest-preset@0.85.2(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      jest-matcher-utils: 30.3.0
+      picocolors: 1.1.1
+      pretty-format: 30.3.0
+      react: 19.2.3
+      react-native: 0.85.2(@babel/core@7.29.0)(@react-native/jest-preset@0.85.2(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+      react-test-renderer: 19.2.3(react@19.2.3)
+      redent: 3.0.0
+    optionalDependencies:
+      jest: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2))
+
   '@testing-library/react-native@13.3.3(jest@29.7.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2)))(react-native@0.85.2(@babel/core@7.29.0)(@react-native/jest-preset@0.85.2(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       jest-matcher-utils: 30.3.0
@@ -20915,6 +20927,22 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  create-jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -23223,6 +23251,26 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+    optional: true
+
+  jest-cli@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
 
   jest-cli@29.7.0(@types/node@25.5.0)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2)):
     dependencies:
@@ -23621,6 +23669,19 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+    optional: true
+
+  jest@29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2)):
+    dependencies:
+      '@jest/core': 29.7.0(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@25.5.0)(typescript@6.0.2))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros


### PR DESCRIPTION
# Why

close ENG-20791

# How

- `useExpoDOMWebView` by default
- add `@expo/dom-webview` to dependencies of the expo package
- update docs

# Test Plan

- [05-use-dom](https://github.com/expo/expo/tree/main/apps/router-e2e/__e2e__/05-use-dom) test cases

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
