### PR TITLE
feat(cli): Add EXPO_IOS_SIMULATOR_UDID env var to target specific iOS simulator

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### 🎉 New features
 
+- Add `EXPO_IOS_SIMULATOR_UDID` env var to target a specific iOS simulator when running `expo start --ios` or pressing `i` in the dev server. Useful for running multiple simulators against multiple dev servers in parallel. by [@sstur](https://github.com/sstur)
 - Output logs to `.expo` folder for agent processes. ([#44146](https://github.com/expo/expo/pull/44146) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow `expo start`, `expo export`, and `expo config` to work without `react-native` installed for web-only projects. ([#44294](https://github.com/expo/expo/pull/44294) by [@EvanBacon](https://github.com/EvanBacon))
 - Pass optional name to metro require for async modules. ([#44224](https://github.com/expo/expo/pull/44224) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `EXPO_IOS_SIMULATOR_UDID` env var to target a specific iOS simulator when running `expo start --ios` or pressing `i` in the dev server. Useful for running multiple simulators against multiple dev servers in parallel. by [@sstur](https://github.com/sstur)
+- Add `EXPO_IOS_SIMULATOR_UDID` env var to target a specific iOS simulator when running `expo start --ios` or pressing `i` in the dev server. Useful for running multiple simulators against multiple dev servers in parallel. by [@sstur](https://github.com/sstur) ([#45226](https://github.com/expo/expo/pull/45226) by [@sstur](https://github.com/sstur))
 - Output logs to `.expo` folder for agent processes. ([#44146](https://github.com/expo/expo/pull/44146) by [@EvanBacon](https://github.com/EvanBacon))
 - Allow `expo start`, `expo export`, and `expo config` to work without `react-native` installed for web-only projects. ([#44294](https://github.com/expo/expo/pull/44294) by [@EvanBacon](https://github.com/EvanBacon))
 - Pass optional name to metro require for async modules. ([#44224](https://github.com/expo/expo/pull/44224) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/AppleDeviceManager.ts
@@ -14,6 +14,7 @@ import {
 import { promptAppleDeviceAsync } from './promptAppleDevice';
 import * as SimControl from './simctl';
 import { delayAsync, waitForActionAsync } from '../../../utils/delay';
+import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { isInteractive } from '../../../utils/interactive';
 import { parsePlistAsync } from '../../../utils/plist';
@@ -80,6 +81,12 @@ export class AppleDeviceManager extends DeviceManager<SimControl.Device> {
   }: BaseResolveDeviceProps<
     Partial<Pick<SimControl.Device, 'udid' | 'osType'>>
   > = {}): Promise<AppleDeviceManager> {
+    // Allow targeting a specific simulator via env var. Skipped when
+    // `shouldPrompt` is true so users can still pick interactively (Shift+I
+    // in the dev server interface).
+    if (!device && !shouldPrompt && env.EXPO_IOS_SIMULATOR_UDID) {
+      device = { udid: env.EXPO_IOS_SIMULATOR_UDID };
+    }
     if (shouldPrompt) {
       const devices = await getSelectableSimulatorsAsync(device);
       device = await promptAppleDeviceAsync(devices, device?.osType);

--- a/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleDeviceManager-test.ts
+++ b/packages/@expo/cli/src/start/platforms/ios/__tests__/AppleDeviceManager-test.ts
@@ -7,6 +7,15 @@ jest.mock('../simctl', () => ({
   openAppIdAsync: jest.fn(),
   openUrlAsync: jest.fn(),
   getInfoPlistValueAsync: jest.fn(),
+  bootAsync: jest.fn(async ({ udid }: { udid: string }) => ({ udid, name: 'iPhone' }) as any),
+}));
+jest.mock('../getBestSimulator', () => ({
+  getBestBootedSimulatorAsync: jest.fn(async () => null),
+  getBestUnbootedSimulatorAsync: jest.fn(async () => null),
+  getSelectableSimulatorsAsync: jest.fn(async () => []),
+}));
+jest.mock('../promptAppleDevice', () => ({
+  promptAppleDeviceAsync: jest.fn(async () => ({ udid: 'prompted-udid' })),
 }));
 
 const asDevice = (device: Partial<Device>): Device => device as Device;
@@ -80,6 +89,41 @@ describe('ensureExpoGoAsync', () => {
     await expect(device.ensureExpoGoAsync('51.0.0')).rejects.toThrow(
       /Expo Go is not supported on Apple Watch/
     );
+  });
+});
+
+describe('resolveAsync', () => {
+  const originalUdid = process.env.EXPO_IOS_SIMULATOR_UDID;
+  afterEach(() => {
+    if (originalUdid === undefined) {
+      delete process.env.EXPO_IOS_SIMULATOR_UDID;
+    } else {
+      process.env.EXPO_IOS_SIMULATOR_UDID = originalUdid;
+    }
+  });
+
+  it('boots the simulator from EXPO_IOS_SIMULATOR_UDID when set', async () => {
+    process.env.EXPO_IOS_SIMULATOR_UDID = 'env-udid';
+    const { bootAsync } = require('../simctl');
+    const manager = await AppleDeviceManager.resolveAsync();
+    expect(bootAsync).toHaveBeenCalledWith({ udid: 'env-udid' });
+    expect(manager.identifier).toBe('env-udid');
+  });
+
+  it('ignores EXPO_IOS_SIMULATOR_UDID when shouldPrompt is true', async () => {
+    process.env.EXPO_IOS_SIMULATOR_UDID = 'env-udid';
+    const { promptAppleDeviceAsync } = require('../promptAppleDevice');
+    const { bootAsync } = require('../simctl');
+    await AppleDeviceManager.resolveAsync({ shouldPrompt: true });
+    expect(promptAppleDeviceAsync).toHaveBeenCalled();
+    expect(bootAsync).toHaveBeenCalledWith({ udid: 'prompted-udid' });
+  });
+
+  it('prefers an explicit device argument over EXPO_IOS_SIMULATOR_UDID', async () => {
+    process.env.EXPO_IOS_SIMULATOR_UDID = 'env-udid';
+    const { bootAsync } = require('../simctl');
+    await AppleDeviceManager.resolveAsync({ device: { udid: 'explicit-udid' } });
+    expect(bootAsync).toHaveBeenCalledWith({ udid: 'explicit-udid' });
   });
 });
 

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -188,6 +188,11 @@ class Env {
     return string('EXPO_ADB_USER', '0');
   }
 
+  /** Default iOS simulator UDID to target when running `expo start --ios` or pressing `i` in the dev server. Skipped when the user explicitly picks a simulator via the Shift+I prompt. Useful for running multiple simulators against multiple dev servers in parallel. */
+  get EXPO_IOS_SIMULATOR_UDID(): string {
+    return string('EXPO_IOS_SIMULATOR_UDID', '');
+  }
+
   /** Used internally to enable E2E utilities. This behavior is not stable to external users. */
   get __EXPO_E2E_TEST(): boolean {
     return boolish('__EXPO_E2E_TEST', false);


### PR DESCRIPTION
**tl;dr** Add `EXPO_IOS_SIMULATOR_UDID` env var to target a specific simulator.

This allows us to tell `expo start --ios` (and the `i` keypress) to open a specific iOS simulator instead of choosing an arbitrary booted one. Useful for running multiple dev environments / worktrees each with its own expo dev server and simulator.

The env var is bypassed when the user explicitly opens the picker via Shift+I (`shouldPrompt: true`), so interactive selection still works. If no env var is present preserve the existing behavior.

# Why

When running multiple worktrees or copies of a project in parallel you might want each to have its own expo dev server and its own iOS Simulator. There is currently no way to tell `expo start` which simulator to target open when pressing "i" or when passing the "-i" or "--ios" flag.

`AppleDeviceManager.resolveAsync` falls back to `getBestBootedSimulatorAsync`, which returns whichever booted simulator it finds first.

# How

In `AppleDeviceManager.resolveAsync`, before the existing prompt/auto-pick logic, populate `device` from `process.env.EXPO_IOS_SIMULATOR_UDID` if:

1. No `device` was passed in by the caller (preserves the existing `expo run:ios --device` path, where the explicit argument always wins), and
2. `shouldPrompt` is false (so `Shift+I` still opens the interactive picker — env var users can opt out per-keypress).

The rest of `resolveAsync` is unchanged: the resulting `{ udid }` flows through `ensureSimulatorOpenAsync` exactly as a normal selection would, so booting, OS-type fallback, and error handling are all reused.

# Test Plan

Added three unit tests in `AppleDeviceManager-test.ts` covering the three branches:

- `boots the simulator from EXPO_IOS_SIMULATOR_UDID when set` — env var alone routes to the named UDID.
- `ignores EXPO_IOS_SIMULATOR_UDID when shouldPrompt is true` — `Shift+I` still calls `promptAppleDeviceAsync`.
- `prefers an explicit device argument over EXPO_IOS_SIMULATOR_UDID` — `expo run:ios --device …` is unaffected.

Manual verification on macOS with two iOS Simulators booted simultaneously:

1. **Without the env var** — `npx expo start --ios` opens on whichever simulator `getBestBootedSimulatorAsync` returns. Confirms unchanged default behavior.
2. **With the env var** — `EXPO_IOS_SIMULATOR_UDID=<udid> npx expo start --ios` deep-links into the targeted simulator regardless of boot order.
3. **`i` keypress in the running dev server** — picks up the env var and targets the same simulator.
4. **`Shift+I` keypress** — env var ignored, interactive picker shown.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
