### PR TITLE
[expo-go] Fix RCTHost/RCTModuleRegistry typing

### DIFF
--- a/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Core/EXKernel.m
@@ -109,20 +109,16 @@ NSString * const kEXReloadActiveAppRequest = @"EXReloadActiveAppRequest";
 
 - (id)nativeModuleForAppManager:(EXReactAppManager *)appManager named:(NSString *)moduleName
 {
-  id host = appManager.reactHost;
-  
-  if (host) {
-    id module = [[host moduleRegistry] moduleForName:[moduleName UTF8String]];
+  if (appManager.reactHost) {
+    id module = [appManager.reactModuleRegistry moduleForName:[moduleName UTF8String]];
     if (module) {
       return module;
     }
   } else {
     // Host can be null if the record is in an error state and never created a host.
-    if (host) {
-      DDLogError(@"Host does not support the API");
-    }
+    DDLogError(@"Host does not support the API");
   }
-  
+
   return nil;
 }
 

--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppExceptionHandler.m
@@ -72,16 +72,11 @@ RCT_NOT_IMPLEMENTED(- (instancetype)init)
                                stack:(nullable NSArray *)stack
                          exceptionId:(NSNumber *)exceptionId
 {
-  RCTRedBox *redbox = (RCTRedBox *)[[[self _hostForRecord] moduleRegistry] moduleForName:"RedBox"];
+  RCTRedBox *redbox = (RCTRedBox *)[_appRecord.appManager.reactModuleRegistry moduleForName:"RedBox"];
   [redbox updateErrorMessage:message withStack:stack];
 }
 
 #pragma mark - internal
-
-- (id)_hostForRecord
-{
-  return _appRecord.appManager.reactHost;
-}
 
 - (BOOL)_isProdHome
 {

--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.h
@@ -2,6 +2,7 @@
 #import <UIKit/UIKit.h>
 #import <Expo/RCTAppDelegateUmbrella.h>
 #import <React/RCTBridgeDelegate.h>
+#import <React/RCTBridgeModule.h>
 #import <React/RCTReloadCommand.h>
 
 #import "EXAppFetcher.h"
@@ -44,6 +45,7 @@ typedef enum EXReactAppManagerStatus {
 @property (nonatomic, readonly) NSString *scopedDocumentDirectory;
 @property (nonatomic, readonly) NSString *scopedCachesDirectory;
 @property (nonatomic, strong) id reactHost;
+@property (nonatomic, readonly) RCTModuleRegistry *reactModuleRegistry;
 @property (nonatomic, strong) ExpoAppInstance *expoAppInstance;
 @property (nonatomic, assign) id<EXReactAppManagerUIDelegate> delegate;
 @property (nonatomic, weak) EXKernelAppRecord *appRecord;

--- a/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
+++ b/apps/expo-go/ios/Exponent/Kernel/ReactAppManager/EXReactAppManager.mm
@@ -11,6 +11,7 @@
 #import "EXAppViewController.h"
 #import <ExpoModulesCore/EXModuleRegistryProvider.h>
 #import <EXConstants/EXConstantsService.h>
+#import <ReactCommon/RCTHost.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 
 // When `use_frameworks!` is used, the generated Swift header is inside modules.
@@ -76,6 +77,10 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 
 - (id)reactHost {
   return _expoAppInstance.reactNativeFactory.rootViewFactory.reactHost;
+}
+
+- (RCTModuleRegistry *)reactModuleRegistry {
+  return ((RCTHost *)self.reactHost).moduleRegistry;
 }
 
 - (void)setAppRecord:(EXKernelAppRecord *)appRecord
@@ -510,7 +515,7 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 
 - (RCTDevSettings *)_devSettings
 {
-  return (RCTDevSettings *)[[self.reactHost moduleRegistry] moduleForName:"DevSettings"];
+  return (RCTDevSettings *)[self.reactModuleRegistry moduleForName:"DevSettings"];
 }
 
 - (BOOL)isHotLoadingEnabled
@@ -525,7 +530,7 @@ NSString *const RCTInstanceDidLoadBundle = @"RCTInstanceDidLoadBundle";
 
 - (BOOL)isPerfMonitorAvailable
 {
-  id perfMonitor = [[self.reactHost moduleRegistry] moduleForName:"PerfMonitor"];
+  id perfMonitor = [self.reactModuleRegistry moduleForName:"PerfMonitor"];
   return perfMonitor != nil && [self enablesDeveloperTools];
 }
 

--- a/apps/expo-go/ios/Exponent/Kernel/Services/EXUpdatesManager.m
+++ b/apps/expo-go/ios/Exponent/Kernel/Services/EXUpdatesManager.m
@@ -45,7 +45,7 @@ ofDownloadWithManifest:(EXManifestsManifest * _Nullable)manifest
              };
   }
   if (appRecord.status == kEXKernelAppRecordStatusRunning) {
-    RCTEventDispatcher *dispatcher = [[appRecord.appManager.reactHost moduleRegistry] moduleForName:"EventDispatcher"];
+    RCTEventDispatcher *dispatcher = [appRecord.appManager.reactModuleRegistry moduleForName:"EventDispatcher"];
     [dispatcher sendAppEventWithName:EXUpdatesEventName body:@[EXUpdatesEventName, body]];
   }
 }

--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
@@ -3,7 +3,6 @@
 #import "ExpoAppInstance.h"
 #import <RCTAppSetupUtils.h>
 #import <React/CoreModulesPlugins.h>
-#import <ExpoModulesCore/EXRuntime.h>
 #import <ExpoModulesCore/EXHostWrapper.h>
 #import <ExpoModulesCore-Swift.h>
 
@@ -45,13 +44,13 @@
   }
 }
 
-- (void)host:(nonnull RCTHost *)host didInitializeRuntime:(jsi::Runtime &)runtime
+- (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime
 {
   ExpoAppInstance *appInstance = (ExpoAppInstance *)self.delegate;
   EXAppContext *appContext = [appInstance createExpoGoAppContext];
 
   // Inject and decorate the `global.expo` object
-  appContext._runtime = [[EXRuntime alloc] initWithRuntime:runtime];
+  [appContext setRuntime:&runtime];
   [appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
 
   [appContext registerNativeModules];


### PR DESCRIPTION
## Why

A few Expo Go callers were using `[reactHost moduleRegistry]` to look up native modules. `EXReactAppManager.reactHost` is typed as `id` (RCTHost is a C++ header, so the property can't be typed strongly without making the header C++-only). Two unrelated classes in the runtime expose a `moduleRegistry` selector — Expo's own `EXModuleRegistry` and React Native's `RCTModuleRegistry` — and clang resolves the selector ambiguously, producing build errors like:

```
no visible @interface for 'EXModuleRegistry' declares the selector 'moduleForName:'
```

## How

Adds a typed `reactModuleRegistry` accessor on `EXReactAppManager`. The implementation lives in `EXReactAppManager.mm` (which can include `<ReactCommon/RCTHost.h>` since it's already C++), so the casting is contained in one place. `.m` callers pick up the right return type via the public `RCTModuleRegistry *` declaration in the `.h`.

Three `.m` callers updated to use the new accessor instead of casting at every call site:
- `EXUpdatesManager.m` — `EventDispatcher` lookup
- `EXReactAppExceptionHandler.m` — `RedBox` lookup (also drops a now-unused private `_hostForRecord` helper)
- `EXKernel.m` — generic `nativeModuleForAppManager:named:`. Cleans up an unreachable `if (host)` branch in the `else` that was preventing the warning log from firing when the host is null.

Also tracks an `expo-modules-core` API change in `ExpoGoReactNativeFactory.mm`: the JSI runtime is passed via `-setRuntime:` (a `jsi::Runtime *`) instead of being wrapped in an `EXRuntime` instance.

## Test plan

- [x] Builds Expo Go locally
- [x] No `.m` files were promoted to `.mm` (no new C++ exposure in pure-ObjC headers)

Note that the CI job will fail as #45228 is needed as well. This PR is just a prerequisite to fix this workflow.