### PR TITLE
[test-suite] Fix CryptoAES test

### DIFF
--- a/apps/test-suite/tests/CryptoAES.ts
+++ b/apps/test-suite/tests/CryptoAES.ts
@@ -142,7 +142,7 @@ export async function test({ describe, it, expect, beforeAll }) {
 
         const sealedData = await aesEncryptAsync(base64Plaintext, key);
         expect(sealedData).toBeDefined();
-        expect(sealedData.ciphertext.length).toBeGreaterThan(0);
+        expect(sealedData.combinedSize).toBeGreaterThan(0);
         expect(sealedData.ivSize).toBe(DEFAULT_IV_LENGTH);
         expect(sealedData.tagSize).toBe(DEFAULT_TAG_LENGTH);
 


### PR DESCRIPTION
# Why

Fixed failing AES Crypto test

# How

Context:
`sealedData.ciphertext` is a function. Incorrect `ciphertext.length` was there unnoticed until we migrated to ExpoModulesJSI, which [I guess] stopped resolving "property 'length' of a function" to a non-zero value

Replaced this value with actual combined length property

# Test Plan

- CryptoAES test-suite (iOS and Android)
- ```js
   function foo() { }
   console.log(foo.length) // 0
   ```
