### PR TITLE
[ios][screen-orientation] Fix QA issues

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed per-screen orientation not working with expo-dev-client by searching child VCs for react-native-screens orientation when an intermediate VC blocks the traversal. ([#44181](https://github.com/expo/expo/pull/44181) by [@vonovak](https://github.com/vonovak))
-- [iOS] Fixed `lockAsync` silently failing when flipping between previously-applied masks.
+- [iOS] Fixed `lockAsync` silently failing when flipping between previously-applied masks. ([#45239](https://github.com/expo/expo/pull/45239) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed per-screen orientation not working with expo-dev-client by searching child VCs for react-native-screens orientation when an intermediate VC blocks the traversal. ([#44181](https://github.com/expo/expo/pull/44181) by [@vonovak](https://github.com/vonovak))
+- [iOS] Fixed `lockAsync` silently failing when flipping between previously-applied masks.
 
 ### 💡 Others
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -93,10 +93,11 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
         let windowScene = self.rootViewController?.view.window?.windowScene
         windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientationMask))
         self.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
-      } else {
-        UIDevice.current.setValue(newOrientation.rawValue, forKey: "orientation")
-        UIViewController.attemptRotationToDeviceOrientation()
       }
+      // requestGeometryUpdate's validation cache isn't invalidated by setNeedsUpdate, so flipping
+      // between previously-applied narrow masks gets rejected. The legacy KVO path bypasses it.
+      UIDevice.current.setValue(newOrientation.rawValue, forKey: "orientation")
+      UIViewController.attemptRotationToDeviceOrientation()
 
       if self.currentScreenOrientation == .unknown {
         // CurrentScreenOrientation might be unknown (especially just after launch), but at this point we already know it.

--- a/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationRegistry.swift
@@ -94,8 +94,6 @@ public class ScreenOrientationRegistry: NSObject, UIApplicationDelegate {
         windowScene?.requestGeometryUpdate(.iOS(interfaceOrientations: orientationMask))
         self.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
       }
-      // requestGeometryUpdate's validation cache isn't invalidated by setNeedsUpdate, so flipping
-      // between previously-applied narrow masks gets rejected. The legacy KVO path bypasses it.
       UIDevice.current.setValue(newOrientation.rawValue, forKey: "orientation")
       UIViewController.attemptRotationToDeviceOrientation()
 

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -85,8 +85,9 @@ class ScreenOrientationViewController: UIViewController {
   override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
     super.viewWillTransition(to: size, with: coordinator)
 
-    // Update after the transition ends, this ensures that the trait collection passed to didUpdateDimensionsEvent is already updated
-    coordinator.animate(alongsideTransition: { [weak self] _ in
+    // Use the completion block, windowScene.interfaceOrientation is still stale during the
+    // alongside-transition closure, which makes viewDidTransition read .unknown.
+    coordinator.animate(alongsideTransition: nil) { [weak self] _ in
       guard let self = self, let windowInterfaceOrientation = self.windowInterfaceOrientation else {
         return
       }
@@ -95,7 +96,7 @@ class ScreenOrientationViewController: UIViewController {
         self.screenOrientationRegistry.viewDidTransition(toOrientation: windowInterfaceOrientation)
       }
       self.previousInterfaceOrientation = windowInterfaceOrientation
-    })
+    }
   }
 
   /// Finds the VC whose subtree has a react-native-screens screen with orientation set.


### PR DESCRIPTION
# Why
`lockAsync` was silently failing on iOS causing the tests to timeout because we never got a response.

# How
It was caused by using to wrong closure in `coordinator.animate`. `alongsideTransition` happens mid rotation so the `interfaceOrientation` has not been updated yet or could be `.unknown`. Switch from `coordinator.animate(alongsideTransition:)` to the completion block, so `windowScene.interfaceOrientation` is read after the rotation completes.

# Test Plan
Bare expo

<img width="450" height="978" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-30 at 10 45 07" src="https://github.com/user-attachments/assets/00198abe-34f0-4ce4-8e51-9d152fc8dac8" />
