### PR TITLE
[expo-ui] use LocalContentColor for default Icon and Text colors

### DIFF
--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/TextView.kt
@@ -3,6 +3,7 @@ package expo.modules.ui
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -264,7 +265,7 @@ data class TextProps(
 private fun AnnotatedString.Builder.appendSpans(spans: List<TextSpanRecord>, context: Context?) {
   for (span in spans) {
     val style = SpanStyle(
-      color = colorToComposeColorOrNull(span.color) ?: androidx.compose.ui.graphics.Color.Unspecified,
+      color = colorToComposeColorOrNull(span.color) ?: LocalContentColor.current,
       fontSize = span.fontSize?.sp ?: androidx.compose.ui.unit.TextUnit.Unspecified,
       fontWeight = span.fontWeight?.toComposeFontWeight(),
       fontStyle = span.fontStyle?.toComposeFontStyle(),

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/icon/IconView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/icon/IconView.kt
@@ -7,6 +7,7 @@ import android.graphics.drawable.Drawable
 import android.net.Uri
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -103,7 +104,7 @@ class IconView(context: Context, appContext: AppContext) :
       Icon(
         painter = painter,
         contentDescription = contentDescription,
-        tint = tint?.compose ?: androidx.compose.ui.graphics.Color.Unspecified,
+        tint = tint?.compose ?: LocalContentColor.current,
         modifier = Modifier
           .then(iconSize?.let { Modifier.size(it.dp) } ?: Modifier)
           .then(ModifierRegistry.applyModifiers(modifiers, appContext, this@Content, globalEventDispatcher))


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
