### PR TITLE
[docs] Correct the Gradle JVM args in build infrastructure documentation

### DIFF
--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: September 17th, 2025
+modificationDate: April 30th, 2026
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4
@@ -44,15 +44,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 - [npm cache deployed with Kubernetes](/build-reference/caching/#javascript-dependencies)
 - [Maven cache deployed with Kubernetes](/build-reference/caching/#android-dependencies)
-- Global Gradle configuration in **~/.gradle/gradle.properties**:
-
-  ```ini ~/.gradle/gradle.properties
-  org.gradle.jvmargs=-Xmx14g -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-  org.gradle.parallel=true
-  org.gradle.configureondemand=true
-  org.gradle.daemon=false
-  ```
-
+- Gradle JVM args are injected via the `GRADLE_OPTS` environment variable when the build environment is provisioned. See [Gradle JVM args](#gradle-jvm-args) below.
 - Global npm configuration in **~/.npmrc**:
 
   ```ini ~/.npmrc
@@ -67,6 +59,44 @@ Android builders run on virtual machines in an isolated environment. Every build
   npmRegistryServer: 'http://npm.production.caches.eas-build.internal'
   enableImmutableInstalls: false
   ```
+
+### Gradle JVM args
+
+EAS Build sets the `GRADLE_OPTS` environment variable on the build VM before Gradle runs. The values depend on the [resource class](/eas/json/#resourceclass) you select:
+
+| Resource class | `-Xmx` (max heap) |
+| -------------- | ----------------- |
+| `medium`       | `4g`              |
+| `large`        | `8g`              |
+
+In addition to `-Xmx`, the worker passes the following JVM args to the Gradle build JVM via `-Dorg.gradle.jvmargs`:
+
+- `-XX:MaxMetaspaceSize=1g`
+- `-XX:+HeapDumpOnOutOfMemoryError`
+- `-Dfile.encoding=UTF-8`
+
+The worker also sets these top-level Gradle properties on `GRADLE_OPTS`:
+
+- `-Dorg.gradle.parallel=true`
+- `-Dorg.gradle.daemon=false`
+
+> **warning** The worker sets `org.gradle.jvmargs` via `GRADLE_OPTS`, which overrides any `org.gradle.jvmargs` defined in your project's **gradle.properties**.
+
+#### Overriding `GRADLE_OPTS` in eas.json
+
+You can replace the worker default by setting `GRADLE_OPTS` under a build profile's `env` in **eas.json**. Project env values take precedence over the worker default.
+
+```json eas.json
+{
+  "build": {
+    "production": {
+      "env": {
+        "GRADLE_OPTS": "-Dorg.gradle.jvmargs=\"-Xmx6g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8\" -Dorg.gradle.parallel=true -Dorg.gradle.daemon=false"
+      }
+    }
+  }
+}
+```
 
 ### Android server images
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: April 30th, 2026
+modificationDate: May 12th, 2026
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -82,21 +82,9 @@ The worker also sets these top-level Gradle properties on `GRADLE_OPTS`:
 
 > **warning** The worker sets `org.gradle.jvmargs` via `GRADLE_OPTS`, which overrides any `org.gradle.jvmargs` defined in your project's **gradle.properties**.
 
-#### Overriding `GRADLE_OPTS` in eas.json
+#### Overriding `GRADLE_OPTS`
 
-You can replace the worker default by setting `GRADLE_OPTS` under a build profile's `env` in **eas.json**. Project environment values take precedence over the worker's default values.
-
-```json eas.json
-{
-  "build": {
-    "production": {
-      "env": {
-        "GRADLE_OPTS": "-Dorg.gradle.jvmargs=\"-Xmx6g -XX:MaxMetaspaceSize=1g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8\" -Dorg.gradle.parallel=true -Dorg.gradle.daemon=false"
-      }
-    }
-  }
-}
-```
+You can replace the worker default by setting `GRADLE_OPTS` under a build profile's [`env`](/eas/json/#env) in **eas.json**, in a [workflow file](/eas/workflows/syntax/#jobsjob_idenv), or with [EAS Environment Variables](/eas/environment-variables/). Project environment values take precedence over the worker's default values.
 
 ### Android server images
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -62,7 +62,7 @@ Android builders run on virtual machines in an isolated environment. Every build
 
 ### Gradle JVM args
 
-EAS Build sets the `GRADLE_OPTS` environment variable on the build VM before Gradle runs. The values depend on the [resource class](/eas/json/#resourceclass) you select:
+EAS Build sets the `GRADLE_OPTS` environment variable on the build VM (the worker) before Gradle runs. The values depend on the [resource class](/eas/json/#resourceclass) you select:
 
 | Resource class | `-Xmx` (max heap) |
 | -------------- | ----------------- |
@@ -84,7 +84,7 @@ The worker also sets these top-level Gradle properties on `GRADLE_OPTS`:
 
 #### Overriding `GRADLE_OPTS` in eas.json
 
-You can replace the worker default by setting `GRADLE_OPTS` under a build profile's `env` in **eas.json**. Project env values take precedence over the worker default.
+You can replace the worker default by setting `GRADLE_OPTS` under a build profile's `env` in **eas.json**. Project environment values take precedence over the worker's default values.
 
 ```json eas.json
 {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

This PR partly addresses this issue: https://github.com/expo/eas-cli/issues/3682.

In the issue, the user reports that the documentation of Gradle JVM args doesn't match the actual `GRADLE_OPTS` set in builds.

# How

<!--
How did you build this feature or fix this bug and why?
-->

I have compared the documentation with the worker code (https://github.com/expo/eas-cli/blob/8229dc826513845d82ac4279d0b62394623935cf/packages/worker/src/env.ts#L84-L105), and confirmed the discrepancy.

To clarify the Gradle opts, I've created a dedicated sub-section in "Build reference -> Infrastructure" documentation. Apart from clarifying the `GRADLE_OPTS` value, I have also added a warning about those opts overriding JVM args set in a project's `gradle.properties`; I have also provided an information about the possibility to override the `GRADLE_OPTS` by specifying them in `env` manually.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tested manually

<img width="987" height="792" alt="image" src="https://github.com/user-attachments/assets/536e616c-5d3c-4c6d-a424-7037f1145765" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
