### PR TITLE
[JSI] Flesh out README and CLAUDE.md

### DIFF
--- a/packages/expo-modules-jsi/CLAUDE.md
+++ b/packages/expo-modules-jsi/CLAUDE.md
@@ -1,32 +1,8 @@
 ## Expo Modules JSI
 
-`expo-modules-jsi` provides type-safe Swift bindings to Facebook's JSI (JavaScript Interface) C++ library. It enables native Swift code to interact with JavaScript runtimes (Hermes) through a Swift-first API. Part of the Expo modules ecosystem.
+See [README.md](./README.md) for the public overview: what the package is, the layered architecture, the public API surface, Swift/C++ configuration, installation, and distribution. Don't duplicate that material here &mdash; update the README instead.
 
-## Architecture
-
-Three-layer design bridging JSI C++ to Swift:
-
-1. **Swift Layer** (`apple/Sources/ExpoModulesJSI/`) — Public API. Type-safe wrappers around JSI concepts: `JavaScriptRuntime`, `JavaScriptValue`, `JavaScriptObject`, `JavaScriptFunction`, `JavaScriptPromise`, etc. All JS value types are **non-copyable** (`~Copyable`) and conform to `JavaScriptType`. Uses `JavaScriptRef<T>` to convert to reference semantics when needed (escaping closures, containers).
-
-2. **C++ Utilities Layer** (`apple/Sources/ExpoModulesJSI-Cxx/`) — Internal C++ helpers that bridge Swift and JSI. Headers in `include/`: `JSIUtils.h`, `HostObject.h`, `HostFunctionClosure.h`, `CppError.h`, `RuntimeScheduler.h`, `TypedArray.h`.
-
-3. **JSI / Hermes** — Binary xcframeworks (`React`, `hermes-engine`, `ReactNativeDependencies`) consumed as SPM binary targets.
-
-### Key Design Patterns
-
-- **`@JavaScriptActor`** — Global actor enforcing JS thread safety at compile time. Uses a synchronous executor (no thread hopping). Code must be scheduled onto the JS thread externally via `runtime.schedule()` or `runtime.execute()`.
-- **Non-copyable value types** — All JS wrappers (`JavaScriptValue`, `JavaScriptObject`, etc.) are `~Copyable` to match JSI's ownership semantics. Use `JavaScriptRef<T>` when reference semantics are needed.
-- **C++ interop** — Swift/C++ interoperability is enabled via `.interoperabilityMode(.Cxx)` in Package.swift. APINotes (`apple/APINotes/jsi.apinotes`) control how JSI types are treated by the Swift compiler, e.g. as a value or reference type.
-- **`JavaScriptRepresentable`** — Protocol for converting Swift types to/from JS values. Has default implementations for primitives, String, Array, Dictionary, Optional.
-- **Error bridging** — `capturingCppErrors()` converts C++ exceptions to Swift errors. `CppError` provides thread-safe C++ exception storage.
-
-## Swift & C++ Configuration
-
-- **Swift 6.0** with strict concurrency (`-strict-concurrency=complete`)
-- **C++20** standard
-- **Platforms:** iOS 16.4+, tvOS 16.4+, macOS 13.4+
-- **Library evolution** enabled for binary framework distribution
-- Upcoming Swift features: `NonisolatedNonsendingByDefault`, `InferIsolatedConformances`
+This file holds context that's only useful when working *inside* the package.
 
 ## Directory Structure
 
@@ -35,23 +11,34 @@ apple/
 ├── APINotes/jsi.apinotes          # Controls how JSI C++ types appear in Swift
 ├── Package.swift                  # SPM package definition
 ├── ExpoModulesJSI.podspec         # CocoaPods spec
-├── build.sh                       # Builds .xcframework from SPM package
+├── scripts/                       # Build scripts (e.g. xcframework packaging)
+├── Products/                      # Build output (xcframeworks)
 ├── Sources/
 │   ├── ExpoModulesJSI/            # Main Swift library
 │   │   ├── Contexts/              # Bridging contexts for host functions/objects
 │   │   ├── Extensions/            # Swift extensions (e.g. Task+immediate)
 │   │   ├── Protocols/             # JavaScriptType, JavaScriptRepresentable, etc.
 │   │   ├── Runtime/               # JavaScriptRuntime, JavaScriptActor, JavaScriptRef
-│   │   │   └── Values/            # JS value wrappers (Object, Array, Function, Promise, etc.)
+│   │   │   └── Values/            # JS value wrappers (Value, Object, Array, Function, ArrayBuffer, TypedArray, Promise, BigInt, Error, WeakObject)
 │   │   └── Utilities/             # Error handling, DeferredPromise, helpers
-│   ├── ExpoModulesJSI-Cxx/        # C++ utilities bridging Swift ↔ JSI
-│   │   ├── include/               # C++ headers (JSIUtils, HostObject, CppError, etc.)
-│   │   └── TypedArray.cpp         # Typed array implementation
-│   └── ExpoModulesJSI-RuntimeProvider/  # ObjC++ bridge for runtime provisioning
+│   └── ExpoModulesJSI-Cxx/        # C++ utilities bridging Swift ↔ JSI
+│       ├── include/               # C++ headers
+│       ├── JSIUtils.cpp
+│       └── TypedArray.cpp
 ├── Tests/                         # Swift Testing suites, one per type
 ```
 
-Root-level files (`package.json`, `index.js`, `expo-module.config.json`, etc.) are npm package scaffolding — the actual implementation is entirely in `apple/`.
+C++ headers in `apple/Sources/ExpoModulesJSI-Cxx/include/`: `CppError.h`, `HostFunctionClosure.h`, `HostObject.h`, `HostObjectCallbacks.h`, `JSIUtils.h`, `MemoryBuffer.h`, `NativeState.h`, `RetainedSwiftPointer.h`, `RuntimeScheduler.h`, `TypedArray.h`.
+
+Root-level files (`package.json`, `index.js`, `expo-module.config.json`, etc.) are npm package scaffolding &mdash; the actual implementation is entirely in `apple/`. The npm package has no JS runtime code; `index.js` exports null.
+
+## Build
+
+See README.md for the rationale (Swift/C++ interop is contained inside this package, so consumers link a prebuilt xcframework instead of building from sources). Operational notes:
+
+- `apple/scripts/build-xcframework.sh` is the real build, invoked from the podspec's `script_phase` and run automatically as part of the host app's compilation. It shells out to SPM, hashes inputs to skip no-op rebuilds, and writes additive per-platform slices into `apple/Products/ExpoModulesJSI.xcframework`. Cache lives in `apple/.xcframework-slices/` and `.DerivedData` / `.build` next to the package.
+- `apple/scripts/create-stub-xcframework.sh` runs as the podspec's `prepare_command` to materialize an empty xcframework so CocoaPods inserts the copy/embed phases. The primary path for the stub is `ensure_expo_modules_jsi_stub_xcframework` in `expo-modules-autolinking`; `prepare_command` is a fallback because CocoaPods skips it on cache hits.
+- Run the script manually with `PODS_ROOT=/path/to/Pods apple/scripts/build-xcframework.sh [--clean]`, or `pnpm build` from the package root. `PLATFORM_NAME` narrows it to a single platform (e.g. `iphonesimulator`).
 
 ## Testing
 
@@ -72,8 +59,4 @@ struct JavaScriptRuntimeTests {
 
 Tests are in `apple/Tests/` and each file covers one type. Some suites use the global actor `@JavaScriptActor` for executor isolation.
 
-## Distribution
-
-- **CocoaPods** via `apple/ExpoModulesJSI.podspec` — distributes as a static framework with vendored `ExpoModulesJSI.xcframework`
-- **SPM** via `apple/Package.swift`
-- The npm package (`expo-modules-jsi`) has no JS runtime code — `index.js` exports null
+Run them with `pnpm test` from the package root, which calls `apple/scripts/test.sh`. The script needs an installed host app's `Pods` directory (defaults to `$EXPO_ROOT_DIR/apps/bare-expo/ios/Pods`); override with `PODS_ROOT`. It symlinks React / hermesvm / ReactNativeDependencies xcframeworks into `apple/.test-frameworks/` so SPM can resolve them as relative-path binary targets, generates the `jsi` modulemap, and runs `xcodebuild test` against an iOS Simulator (override with `DESTINATION`). Extra args pass through to xcodebuild &mdash; e.g. `pnpm test -only-testing TestName`.

--- a/packages/expo-modules-jsi/README.md
+++ b/packages/expo-modules-jsi/README.md
@@ -7,4 +7,94 @@
   </a>
 </p>
 
-`expo-modules-jsi` provides type-safe Swift bindings to Facebook's JSI (JavaScript Interface) C++ library. It enables native Swift code to interact with JavaScript runtimes (Hermes) through a Swift-first API. Part of the Expo modules ecosystem.
+`expo-modules-jsi` provides type-safe Swift bindings to React Native's JSI (JavaScript Interface) C++ library. It lets native Swift code interact with the JavaScript runtime (Hermes) through a Swift-first API and is the foundation that newer parts of `expo-modules-core` build on.
+
+This package has no JavaScript runtime code &mdash; it is consumed natively on iOS via CocoaPods or Swift Package Manager. The npm package only exists so the native sources can be autolinked into your app.
+
+# Architecture
+
+Three-layer design bridging JSI C++ to Swift:
+
+1. **Swift Layer** (`apple/Sources/ExpoModulesJSI/`) &mdash; Public API. Type-safe wrappers around JSI concepts: `JavaScriptRuntime`, `JavaScriptValue`, `JavaScriptObject`, `JavaScriptFunction`, etc. All JS value types are non-copyable (`~Copyable`) and conform to `JavaScriptType`. Use `JavaScriptRef<T>` to convert to reference semantics when needed (escaping closures, containers).
+2. **C++ Utilities Layer** (`apple/Sources/ExpoModulesJSI-Cxx/`) &mdash; Internal C++ helpers that bridge Swift and JSI.
+3. **JSI / Hermes** &mdash; Binary xcframeworks (`React`, `hermes-engine`, `ReactNativeDependencies`) consumed as SPM binary targets.
+
+# Public API
+
+- `JavaScriptRuntime` &mdash; entry point for evaluating scripts, scheduling work on the JS thread, and creating values.
+- `JavaScriptValue`, `JavaScriptObject`, `JavaScriptArray`, `JavaScriptFunction`, `JavaScriptArrayBuffer`, `JavaScriptTypedArray`, `JavaScriptPromise`, `JavaScriptBigInt`, `JavaScriptError`, `JavaScriptWeakObject` &mdash; non-copyable (`~Copyable`) wrappers around their JSI counterparts.
+- `JavaScriptRef<T>` &mdash; turns any of the above into a reference type for use in escaping closures and containers.
+- `JavaScriptRepresentable` &mdash; protocol for converting Swift types to and from JS values, with default implementations for primitives, `String`, `Array`, `Dictionary`, and `Optional`.
+- `@JavaScriptActor` &mdash; global actor that enforces JS-thread isolation at compile time. The executor is synchronous (no thread hopping); code must be scheduled onto the JS thread externally via `runtime.schedule()` or `runtime.execute()`.
+- Error bridging &mdash; `capturingCppErrors()` converts C++ exceptions into Swift errors; `CppError` provides thread-safe C++ exception storage.
+
+C++ interoperability is enabled with `.interoperabilityMode(.Cxx)`, and `apple/APINotes/jsi.apinotes` controls how individual JSI types surface in Swift.
+
+# Swift & C++ Configuration
+
+- **Swift 6.0** with strict concurrency (`-strict-concurrency=complete`)
+- **C++20** standard
+- **Platforms:** iOS 16.4+, tvOS 16.4+, macOS 13.4+
+- **Library evolution** enabled for binary framework distribution
+- Upcoming Swift features: `NonisolatedNonsendingByDefault`, `InferIsolatedConformances`
+
+# Installation
+
+This package is not meant to be installed directly. It ships as a transitive native dependency of [`expo-modules-core`](../expo-modules-core), which is included in any Expo project. Adding it to your app's `package.json` is unnecessary and unsupported.
+
+# Distribution
+
+- **CocoaPods** via `apple/ExpoModulesJSI.podspec` &mdash; distributed as a static framework with a vendored `ExpoModulesJSI.xcframework`.
+- **Swift Package Manager** via `apple/Package.swift`.
+
+# Building
+
+The package can't be consumed from sources directly: it relies on Swift/C++ interop, which is a per-target compiler setting. Source distribution would force every Expo module that depends on it &mdash; and transitively the host app &mdash; to enable Swift/C++ interop too, which is invasive and significantly increases build times for each module. Instead, the sources are compiled into a binary `ExpoModulesJSI.xcframework` that consumers link against, so Swift/C++ interop stays contained inside this package.
+
+The build is wired up in `apple/ExpoModulesJSI.podspec`:
+
+- A `script_phase` runs `apple/scripts/build-xcframework.sh` before headers on every build of the host app. The script invokes SPM under the hood, applies hash-based caching to skip rebuilds when sources haven't changed, and produces additive per-platform slices in `apple/Products/ExpoModulesJSI.xcframework`.
+- A `prepare_command` runs `apple/scripts/create-stub-xcframework.sh` so CocoaPods generates the "Copy XCFrameworks" and "Embed Pods Frameworks" build phases even before the real xcframework exists.
+- The xcframework is declared as `vendored_frameworks`, so dependents see it as a regular binary dependency with no interop flags of their own.
+
+You can also build and test the package directly:
+
+```sh
+pnpm build   # rebuild the xcframework outside of a Pods install
+pnpm test    # run the Swift Testing suite on an iOS Simulator
+```
+
+`pnpm test` runs against an installed host app's `Pods` directory (defaults to `apps/bare-expo`); set `PODS_ROOT` to point at a different one. Extra arguments are forwarded to `xcodebuild` (e.g. `pnpm test -only-testing TestName`).
+
+# Using JSI types from a module
+
+Module authors don't import `ExpoModulesJSI` directly &mdash; `expo-modules-core` re-exports its types, so `import ExpoModulesCore` is enough. The Expo Modules API marshals JSI values automatically when you declare them in a `ModuleDefinition`:
+
+```swift
+import ExpoModulesCore
+
+public class MyModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("MyModule")
+
+    Function("printString") { (value: JavaScriptValue) in
+      print(value.getString())
+    }
+  }
+}
+```
+
+For lower-level access, reach the runtime through the module's `appContext`. Schedule work onto the JS thread to call into JSI safely:
+
+```swift
+AsyncFunction("evaluate") {
+  try appContext?.runtime.schedule(priority: .immediate) {
+    let result = try appContext?.runtime.eval("1 + 2")
+    print(result?.getInt() ?? 0)
+  }
+}
+```
+
+# Contributing
+
+Contributions are very welcome! Please refer to the guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).


### PR DESCRIPTION
## Why

`packages/expo-modules-jsi` shipped with placeholder docs. This PR fills out the README so consumers can understand what the package is, why it ships as a binary xcframework, and how to build/test it &mdash; and trims `CLAUDE.md` to agent-only context that complements the README rather than duplicating it.

## What

**README.md**
- Architecture overview (Swift layer, C++ utilities, JSI/Hermes binary frameworks)
- Public API surface: `JavaScriptRuntime`, the full set of value wrappers (Value, Object, Array, Function, ArrayBuffer, TypedArray, Promise, BigInt, Error, WeakObject), `JavaScriptRef<T>`, `JavaScriptRepresentable`, `@JavaScriptActor`, error bridging
- Swift / C++ configuration and platform requirements
- Note that the package is a transitive native dependency of `expo-modules-core` and shouldn't be installed directly
- Distribution (CocoaPods + SPM)
- Why the package ships as a prebuilt xcframework: source distribution would force every Expo module (and the host app) to enable Swift/C++ interop, which is invasive and significantly increases each module's build time
- Build / test workflow via `pnpm build` and `pnpm test`, including `PODS_ROOT` override and `xcodebuild` arg pass-through
- Minimal Swift usage example

**CLAUDE.md**
- Trimmed to agent-only context with a pointer back to the README for the public overview
- Updated directory tree to match reality (no `build.sh` / `RuntimeProvider`; added `scripts/`, `Products/`, `JSITools.cpp`)
- Expanded C++ header list
- Build & testing operational notes covering script-phase invocation, hash-based caching, the stub xcframework, and the `pnpm test` host-app dependency

## Dependency

This PR documents the `pnpm build` / `pnpm test` scripts introduced in #45249 and should land **after** that PR.

## Test plan

- [x] Read both files end-to-end on GitHub
- [x] Verify rendering of code blocks and markdown