### PR TITLE
[core][iOS] Route SharedObject events through function conversion path

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -578,6 +578,10 @@ PODS:
   - ExpoModulesWorklets (55.0.12):
     - ExpoModulesCore
     - ExpoModulesJSI
+  - ExpoModulesWorkletsAdapter (55.0.12):
+    - ExpoModulesCore
+    - ExpoModulesJSI
+    - ExpoModulesWorklets
     - RNWorklets
   - ExpoNetwork (55.0.8):
     - ExpoModulesCore
@@ -2186,7 +2190,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-  - react-native-keyboard-controller (1.21.0):
+  - react-native-keyboard-controller (1.21.6):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2198,7 +2202,7 @@ PODS:
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - react-native-keyboard-controller/common (= 1.21.0)
+    - react-native-keyboard-controller/common (= 1.21.6)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-renderercss
@@ -2209,7 +2213,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - react-native-keyboard-controller/common (1.21.0):
+  - react-native-keyboard-controller/common (1.21.6):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -3319,6 +3323,7 @@ DEPENDENCIES:
   - ExpoModulesJSI/Tests (from `../../../packages/expo-modules-jsi/apple`)
   - ExpoModulesTestCore (from `../../../packages/expo-modules-test-core/ios`)
   - ExpoModulesWorklets (from `../../../packages/expo-modules-core`)
+  - ExpoModulesWorkletsAdapter (from `../../../packages/expo-modules-core`)
   - ExpoNetwork (from `../../../packages/expo-network/ios`)
   - ExpoNotifications (from `../../../packages/expo-notifications/ios`)
   - ExpoNotifications/Tests (from `../../../packages/expo-notifications/ios`)
@@ -3390,7 +3395,7 @@ DEPENDENCIES:
   - "React-logger (from `../../../node_modules/.pnpm/react-native@0.85.2_@babel+core@7.29.0_@react-native+jest-preset@0.85.2_@babel+core@7.2_1ba4e579bcf69516e035b5d165f89777/node_modules/react-native/ReactCommon/logger`)"
   - "React-Mapbuffer (from `../../../node_modules/.pnpm/react-native@0.85.2_@babel+core@7.29.0_@react-native+jest-preset@0.85.2_@babel+core@7.2_1ba4e579bcf69516e035b5d165f89777/node_modules/react-native/ReactCommon`)"
   - "React-microtasksnativemodule (from `../../../node_modules/.pnpm/react-native@0.85.2_@babel+core@7.29.0_@react-native+jest-preset@0.85.2_@babel+core@7.2_1ba4e579bcf69516e035b5d165f89777/node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)"
-  - "react-native-keyboard-controller (from `../../../node_modules/.pnpm/react-native-keyboard-controller@1.21.0_react-native-reanimated@4.3.0_patch_hash=1e34e4_cd02e1b4ea6391140214b0aa40af208c/node_modules/react-native-keyboard-controller`)"
+  - "react-native-keyboard-controller (from `../../../node_modules/.pnpm/react-native-keyboard-controller@1.21.6_react-native-reanimated@4.3.0_patch_hash=1e34e4_4a7542518132451a7b077bd8ae3655f6/node_modules/react-native-keyboard-controller`)"
   - "react-native-netinfo (from `../../../node_modules/.pnpm/@react-native-community+netinfo@11.5.2_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_f303a19f4539b0222af26531323c0855/node_modules/@react-native-community/netinfo`)"
   - "react-native-pager-view (from `../../../node_modules/.pnpm/react-native-pager-view@6.9.1_react-native@0.85.2_@babel+core@7.29.0_@react-native+jest_42c16d1948ed01ee7c222c36c8d0a21c/node_modules/react-native-pager-view`)"
   - "react-native-safe-area-context (from `../../../node_modules/.pnpm/react-native-safe-area-context@5.6.2_react-native@0.85.2_@babel+core@7.29.0_@react-nati_61644d84055e7f59795950119a69a708/node_modules/react-native-safe-area-context`)"
@@ -3639,6 +3644,8 @@ EXTERNAL SOURCES:
   ExpoModulesWorklets:
     inhibit_warnings: false
     :path: "../../../packages/expo-modules-core"
+  ExpoModulesWorkletsAdapter:
+    :path: "../../../packages/expo-modules-core"
   ExpoNetwork:
     inhibit_warnings: false
     :path: "../../../packages/expo-network/ios"
@@ -3797,7 +3804,7 @@ EXTERNAL SOURCES:
   React-microtasksnativemodule:
     :path: "../../../node_modules/.pnpm/react-native@0.85.2_@babel+core@7.29.0_@react-native+jest-preset@0.85.2_@babel+core@7.2_1ba4e579bcf69516e035b5d165f89777/node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   react-native-keyboard-controller:
-    :path: "../../../node_modules/.pnpm/react-native-keyboard-controller@1.21.0_react-native-reanimated@4.3.0_patch_hash=1e34e4_cd02e1b4ea6391140214b0aa40af208c/node_modules/react-native-keyboard-controller"
+    :path: "../../../node_modules/.pnpm/react-native-keyboard-controller@1.21.6_react-native-reanimated@4.3.0_patch_hash=1e34e4_4a7542518132451a7b077bd8ae3655f6/node_modules/react-native-keyboard-controller"
   react-native-netinfo:
     :path: "../../../node_modules/.pnpm/@react-native-community+netinfo@11.5.2_patch_hash=ced0cb79848978ecc3e780a4d812d94868434_f303a19f4539b0222af26531323c0855/node_modules/@react-native-community/netinfo"
   react-native-pager-view:
@@ -3968,10 +3975,11 @@ SPEC CHECKSUMS:
   ExpoMaps: 94294944cff46ad1170ce4f92800adecbcdd04ac
   ExpoMediaLibrary: 2fbddcb06042f43076cf5e495e8237ec2ab95726
   ExpoMeshGradient: 93cf09380e6d86cd7a525da26dfddab2620a8421
-  ExpoModulesCore: 0b10a40c52e82e182c70dbfc12001ec30ba74cbd
+  ExpoModulesCore: 549c4ec6534357031c563ba7f3bd40eff1f93b3e
   ExpoModulesJSI: 16f789b94db843249981e5f550e050cc321fe554
   ExpoModulesTestCore: 62ce59e8c8162b449e65467e0421240256ba6732
-  ExpoModulesWorklets: 3a4d6451e29822c01c397da92be1f962a0f870fe
+  ExpoModulesWorklets: 3fc573fcc96eb8c457091dde007055ef35d58d70
+  ExpoModulesWorkletsAdapter: 8e561ffec777e8eacf2a2bad53a0edf04cfffa1a
   ExpoNetwork: 15d026c5c28251e0810849c8c01ebc9bc73ad007
   ExpoNotifications: 58a5bf9c5a0a2ee7d1800f9ed26ff17ff3748fde
   ExpoObserve: d5a52bd0670d1b2bc24a1d59cf9322f3c843a045
@@ -4045,7 +4053,7 @@ SPEC CHECKSUMS:
   React-logger: 2c87840a9f6322a1226d0df337d9662f44ea6094
   React-Mapbuffer: 1fc10d873f00aa895836c316a9737ce7d43875ce
   React-microtasksnativemodule: 85ac7286ff84e8fc8e1956233748b8d4b2a6dcea
-  react-native-keyboard-controller: 7d0575fb5c30f0c528bb7cbc72ea3516e0b80611
+  react-native-keyboard-controller: 91fb57a926597b9d16c8438bc88f1142a169715c
   react-native-netinfo: 4319d381f35bc11b53dafebd5cd99c04c66a9fb4
   react-native-pager-view: a3cb9627d41fa2f31ad2b312af6e3f10f831f26d
   react-native-safe-area-context: 91a90d98c310adcc90a511e5aeb6046d7c19d885

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -85,6 +85,70 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - ExpoAgeRange (0.2.10):
+    - ExpoModulesCore
+  - ExpoAppleAuthentication (55.0.8):
+    - ExpoModulesCore
+  - ExpoAppMetrics (0.1.7):
+    - boost
+    - DoubleConversion
+    - ExpoModulesCore
+    - EXUpdatesInterface
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - ExpoAppMetrics/Tests (0.1.7):
+    - boost
+    - DoubleConversion
+    - ExpoModulesCore
+    - EXUpdatesInterface
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - ExpoAsset (55.0.7):
     - ExpoModulesCore
   - ExpoAudio (55.0.8):
@@ -169,6 +233,8 @@ PODS:
     - ExpoModulesCore
   - ExpoLinking (55.0.7):
     - ExpoModulesCore
+  - ExpoLivePhoto (55.0.8):
+    - ExpoModulesCore
   - ExpoLocalAuthentication (55.0.8):
     - ExpoModulesCore
   - ExpoLocalization (55.0.8):
@@ -186,6 +252,8 @@ PODS:
     - ExpoModulesCore
     - ExpoModulesTestCore
     - React-Core
+  - ExpoMeshGradient (55.0.8):
+    - ExpoModulesCore
   - ExpoModulesCore (55.0.12):
     - boost
     - DoubleConversion
@@ -263,6 +331,10 @@ PODS:
   - ExpoModulesWorklets (55.0.12):
     - ExpoModulesCore
     - ExpoModulesJSI
+  - ExpoModulesWorkletsAdapter (55.0.12):
+    - ExpoModulesCore
+    - ExpoModulesJSI
+    - ExpoModulesWorklets
     - RNWorklets
   - ExpoNetwork (55.0.8):
     - ExpoModulesCore
@@ -271,6 +343,68 @@ PODS:
   - ExpoNotifications/Tests (55.0.10):
     - ExpoModulesCore
     - ExpoModulesTestCore
+  - ExpoObserve (0.1.7):
+    - boost
+    - DoubleConversion
+    - EASClient
+    - ExpoAppMetrics
+    - ExpoModulesCore
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
+  - ExpoObserve/Tests (0.1.7):
+    - boost
+    - DoubleConversion
+    - EASClient
+    - ExpoAppMetrics
+    - ExpoModulesCore
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - ExpoPrint (55.0.8):
     - ExpoModulesCore
   - ExpoRouter (55.0.2):
@@ -338,6 +472,10 @@ PODS:
     - UMAppLoader
   - ExpoTrackingTransparency (55.0.8):
     - ExpoModulesCore
+  - ExpoUI (55.0.1):
+    - ExpoModulesCore
+    - ExpoModulesWorklets
+    - React-RCTFabric
   - ExpoVideo (55.0.9):
     - ExpoModulesCore
   - ExpoVideoThumbnails (55.0.9):
@@ -3634,7 +3772,7 @@ PODS:
     - RNWorklets
     - SocketRocket
     - Yoga
-  - RNScreens (4.24.0):
+  - RNScreens (4.25.0-beta.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -3661,10 +3799,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 4.24.0)
+    - RNScreens/common (= 4.25.0-beta.1)
     - SocketRocket
     - Yoga
-  - RNScreens/common (4.24.0):
+  - RNScreens/common (4.25.0-beta.1):
     - boost
     - DoubleConversion
     - fast_float
@@ -4004,6 +4142,10 @@ DEPENDENCIES:
   - EXManifests/Tests (from `../../../packages/expo-manifests/ios`)
   - Expo (from `../../../packages/expo`)
   - Expo/Tests (from `../../../packages/expo`)
+  - ExpoAgeRange (from `../../../packages/expo-age-range/ios`)
+  - ExpoAppleAuthentication (from `../../../packages/expo-apple-authentication/ios`)
+  - ExpoAppMetrics (from `../../../packages/expo-app-metrics/ios`)
+  - ExpoAppMetrics/Tests (from `../../../packages/expo-app-metrics/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
   - ExpoAudio (from `../../../packages/expo-audio/ios`)
   - ExpoBackgroundFetch (from `../../../packages/expo-background-fetch/ios`)
@@ -4036,6 +4178,7 @@ DEPENDENCIES:
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
   - ExpoLinearGradient (from `../../../packages/expo-linear-gradient/ios`)
   - ExpoLinking (from `../../../packages/expo-linking/ios`)
+  - ExpoLivePhoto (from `../../../packages/expo-live-photo/ios`)
   - ExpoLocalAuthentication (from `../../../packages/expo-local-authentication/ios`)
   - ExpoLocalization (from `../../../packages/expo-localization/ios`)
   - ExpoLocation (from `../../../packages/expo-location/ios`)
@@ -4043,15 +4186,19 @@ DEPENDENCIES:
   - ExpoMailComposer (from `../../../packages/expo-mail-composer/ios`)
   - ExpoMediaLibrary (from `../../../packages/expo-media-library/ios`)
   - ExpoMediaLibrary/Tests (from `../../../packages/expo-media-library/ios`)
+  - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
   - ExpoModulesCore/Tests (from `../../../packages/expo-modules-core`)
   - ExpoModulesJSI (from `../../../packages/expo-modules-jsi/apple`)
   - ExpoModulesJSI/Tests (from `../../../packages/expo-modules-jsi/apple`)
   - ExpoModulesTestCore (from `../../../packages/expo-modules-test-core/ios`)
   - ExpoModulesWorklets (from `../../../packages/expo-modules-core`)
+  - ExpoModulesWorkletsAdapter (from `../../../packages/expo-modules-core`)
   - ExpoNetwork (from `../../../packages/expo-network/ios`)
   - ExpoNotifications (from `../../../packages/expo-notifications/ios`)
   - ExpoNotifications/Tests (from `../../../packages/expo-notifications/ios`)
+  - ExpoObserve (from `../../../packages/expo-observe/ios`)
+  - ExpoObserve/Tests (from `../../../packages/expo-observe/ios`)
   - ExpoPrint (from `../../../packages/expo-print/ios`)
   - ExpoRouter (from `../../../packages/expo-router/ios`)
   - ExpoRouter/Tests (from `../../../packages/expo-router/ios`)
@@ -4069,6 +4216,7 @@ DEPENDENCIES:
   - ExpoTaskManager (from `../../../packages/expo-task-manager/ios`)
   - ExpoTaskManager/Tests (from `../../../packages/expo-task-manager/ios`)
   - ExpoTrackingTransparency (from `../../../packages/expo-tracking-transparency/ios`)
+  - ExpoUI (from `../../../packages/expo-ui/ios`)
   - ExpoVideo (from `../../../packages/expo-video/ios`)
   - ExpoVideoThumbnails (from `../../../packages/expo-video-thumbnails/ios`)
   - ExpoWebBrowser (from `../../../packages/expo-web-browser/ios`)
@@ -4179,7 +4327,7 @@ DEPENDENCIES:
   - "RNDateTimePicker (from `../../../node_modules/.pnpm/@react-native-community+datetimepicker@9.1.0_expo@packages+expo_react-native@0.85.2_@ba_f8e06d76087279dd44164a8c975e0850/node_modules/@react-native-community/datetimepicker`)"
   - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.31.1_react-native@0.85.2_@babel+core@7.29.0_@react-nativ_f78985ff31676485766600bfef3239a5/node_modules/react-native-gesture-handler`)"
   - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.3.0_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_eda565d3f67be15d7dda9b0be7008390/node_modules/react-native-reanimated`)"
-  - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.24.0_react-native@0.85.2_@babel+core@7.29.0_@react-native+jest-p_0a251b93e2f75317d8d5c6510fd39979/node_modules/react-native-screens`)"
+  - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.25.0-beta.1_react-native@0.85.2_@babel+core@7.29.0_@react-native_44f021255a9c2abec1791ca078467a98/node_modules/react-native-screens`)"
   - "RNSVG (from `../../../node_modules/.pnpm/react-native-svg@15.15.4_react-native@0.85.2_@babel+core@7.29.0_@react-native+jest-pres_ad5ed717b7cc12448deb4bef3fad356b/node_modules/react-native-svg`)"
   - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.8.1_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_873264ea98792c8e9864fbfb4aec03b2/node_modules/react-native-worklets`)"
   - SocketRocket (~> 0.7.1)
@@ -4247,6 +4395,12 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-manifests/ios"
   Expo:
     :path: "../../../packages/expo"
+  ExpoAgeRange:
+    :path: "../../../packages/expo-age-range/ios"
+  ExpoAppleAuthentication:
+    :path: "../../../packages/expo-apple-authentication/ios"
+  ExpoAppMetrics:
+    :path: "../../../packages/expo-app-metrics/ios"
   ExpoAsset:
     :path: "../../../packages/expo-asset/ios"
   ExpoAudio:
@@ -4305,6 +4459,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-linear-gradient/ios"
   ExpoLinking:
     :path: "../../../packages/expo-linking/ios"
+  ExpoLivePhoto:
+    :path: "../../../packages/expo-live-photo/ios"
   ExpoLocalAuthentication:
     :path: "../../../packages/expo-local-authentication/ios"
   ExpoLocalization:
@@ -4317,6 +4473,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-mail-composer/ios"
   ExpoMediaLibrary:
     :path: "../../../packages/expo-media-library/ios"
+  ExpoMeshGradient:
+    :path: "../../../packages/expo-mesh-gradient/ios"
   ExpoModulesCore:
     :path: "../../../packages/expo-modules-core"
   ExpoModulesJSI:
@@ -4325,10 +4483,14 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-modules-test-core/ios"
   ExpoModulesWorklets:
     :path: "../../../packages/expo-modules-core"
+  ExpoModulesWorkletsAdapter:
+    :path: "../../../packages/expo-modules-core"
   ExpoNetwork:
     :path: "../../../packages/expo-network/ios"
   ExpoNotifications:
     :path: "../../../packages/expo-notifications/ios"
+  ExpoObserve:
+    :path: "../../../packages/expo-observe/ios"
   ExpoPrint:
     :path: "../../../packages/expo-print/ios"
   ExpoRouter:
@@ -4359,6 +4521,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-task-manager/ios"
   ExpoTrackingTransparency:
     :path: "../../../packages/expo-tracking-transparency/ios"
+  ExpoUI:
+    :path: "../../../packages/expo-ui/ios"
   ExpoVideo:
     :path: "../../../packages/expo-video/ios"
   ExpoVideoThumbnails:
@@ -4555,7 +4719,7 @@ EXTERNAL SOURCES:
   RNReanimated:
     :path: "../../../node_modules/.pnpm/react-native-reanimated@4.3.0_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_eda565d3f67be15d7dda9b0be7008390/node_modules/react-native-reanimated"
   RNScreens:
-    :path: "../../../node_modules/.pnpm/react-native-screens@4.24.0_react-native@0.85.2_@babel+core@7.29.0_@react-native+jest-p_0a251b93e2f75317d8d5c6510fd39979/node_modules/react-native-screens"
+    :path: "../../../node_modules/.pnpm/react-native-screens@4.25.0-beta.1_react-native@0.85.2_@babel+core@7.29.0_@react-native_44f021255a9c2abec1791ca078467a98/node_modules/react-native-screens"
   RNSVG:
     :path: "../../../node_modules/.pnpm/react-native-svg@15.15.4_react-native@0.85.2_@babel+core@7.29.0_@react-native+jest-pres_ad5ed717b7cc12448deb4bef3fad356b/node_modules/react-native-svg"
   RNWorklets:
@@ -4577,6 +4741,9 @@ SPEC CHECKSUMS:
   EXJSONUtils: 475f1af3d20fbd99268694df81d096817092aa89
   EXManifests: ad24b3a497444eee9e07cc8590b09974ba369050
   Expo: be6381e9c1390a5be199a157939b52ef0a461dc0
+  ExpoAgeRange: 87dd980cb26e47b1108e24c39bcfb88a9ab1030e
+  ExpoAppleAuthentication: c8096cd35e4e4f88aec34fcbfcd9deae7cea04d3
+  ExpoAppMetrics: f534609a5bbd43849f843c6cca0a3c37d68a75f9
   ExpoAsset: 595cc0587b67afaaedddca79d4c1cf506400cb27
   ExpoAudio: 40c883c60ed3bb17ecb3744a00732fb47029535b
   ExpoBackgroundFetch: ee315c8d1a54a3f358fc0cedb68e808e95935c57
@@ -4606,18 +4773,22 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: 72475c0e8644ad4dae17742bde04d5a0fe4ad4f9
   ExpoLinearGradient: 76405dc81ad27c300347829ed90ba26e7597e846
   ExpoLinking: 8505f5b8fa023e82b9d3ac7be1f1241f35b415dd
+  ExpoLivePhoto: cebdeea82761402e1bb2e0b61bd1622d889c729e
   ExpoLocalAuthentication: efe64e98f2686d8bd0bd04300ba5ed360b3d0100
   ExpoLocalization: 19a0300c9fe626c884ce65cbbc421f9980bd5636
   ExpoLocation: 957da1f900af30208ee9245590dbd50c9d267709
   ExpoLogBox: 4a892fbcf6e343ffc1a6b714dcdc04a754d7e42f
   ExpoMailComposer: edd4f46a26ea55ff0e3a83ef0192e79f647911c8
   ExpoMediaLibrary: 2fbddcb06042f43076cf5e495e8237ec2ab95726
-  ExpoModulesCore: d39abb48e55d828ac2abd4800e226244bcdb6447
+  ExpoMeshGradient: 93cf09380e6d86cd7a525da26dfddab2620a8421
+  ExpoModulesCore: d1fc51bb17e5202cb90bab6502631597572f8cfc
   ExpoModulesJSI: 16f789b94db843249981e5f550e050cc321fe554
   ExpoModulesTestCore: 62ce59e8c8162b449e65467e0421240256ba6732
-  ExpoModulesWorklets: 3a4d6451e29822c01c397da92be1f962a0f870fe
+  ExpoModulesWorklets: 3fc573fcc96eb8c457091dde007055ef35d58d70
+  ExpoModulesWorkletsAdapter: 8e561ffec777e8eacf2a2bad53a0edf04cfffa1a
   ExpoNetwork: 15d026c5c28251e0810849c8c01ebc9bc73ad007
   ExpoNotifications: 58a5bf9c5a0a2ee7d1800f9ed26ff17ff3748fde
+  ExpoObserve: d764d07ad6d364d3df9f45605ae00aeb187b4afa
   ExpoPrint: 884afdcfe9adea0d36f121353652d0cfa7963deb
   ExpoRouter: 617b413f30eb9fa39b210e4261814b13afd0418b
   ExpoScreenCapture: fe37f0547515f17434b002dcda5e1725fc61fe6f
@@ -4633,6 +4804,7 @@ SPEC CHECKSUMS:
   ExpoSystemUI: 45304f7673a470749a0fc099b09ba0a23d1a89c2
   ExpoTaskManager: a06f59b8f5777b647a1707b3d21f5e9717cd157d
   ExpoTrackingTransparency: a980b930c8e2affc688dd93940dc5b88f55c875b
+  ExpoUI: e6e61b9aa1424349659c6cb1165adee716a89b69
   ExpoVideo: eca730ba53ec45c2a188aa9dbfe11f7f809d66a1
   ExpoVideoThumbnails: 2340f0b7f599c9ce6ba49a885f783de919cf4dd3
   ExpoWebBrowser: b65b3921741b51c5513e2a369f59c37076987d9b
@@ -4752,7 +4924,7 @@ SPEC CHECKSUMS:
   RNDateTimePicker: 73ffdd45f0ce1d00ff981031679a05206e619fdc
   RNGestureHandler: f0d7f370292ab1ff422eac5a6cbae6feef14bb98
   RNReanimated: 7a13e1d8ccabef6780dce63cfd66999a63233497
-  RNScreens: 7f643ee0fd1407dc5085c7795460bd93da113b8f
+  RNScreens: 16bd039e76f91145275890a1e1cf848b98c1da7a
   RNSVG: c9d7c940ad9655eba72c5b9ca7b017c95bb58083
   RNWorklets: 67e8351cb9accf602a4c7fe62b3d2cd1967aa61e
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
@@ -4775,6 +4947,6 @@ SPEC CHECKSUMS:
   Yoga: 6eb5d794e5d7a35a2750bb469e2e5320d41492f5
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: cd6045f91d2ea37f1012b961820f37cc8d7d9bc0
+PODFILE CHECKSUM: 620498ff1ae46c9e3a34535dd3dcc2129b61d2b9
 
 COCOAPODS: 1.16.2

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions. ([#44122](https://github.com/expo/expo/pull/44122) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Exposed a shared OkHttpClient instance through AppContext with new coroutine-friendly extensions. ([#44854](https://github.com/expo/expo/pull/44854) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Allow compile-time optimization of compose view props when the property class is annotated with `@OptimizedComposeProps`. ([#45021](https://github.com/expo/expo/pull/45021) by [@lukmccall](https://github.com/lukmccall))
+- [iOS] Fixed `SharedObject.emit` dropping `NativeArrayBuffer` values in events.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -19,7 +19,7 @@
 - [iOS] Added a polyfill for Swift [`Mutex`](https://developer.apple.com/documentation/synchronization/mutex) for older platform versions. ([#44122](https://github.com/expo/expo/pull/44122) by [@tsapeta](https://github.com/tsapeta))
 - [Android] Exposed a shared OkHttpClient instance through AppContext with new coroutine-friendly extensions. ([#44854](https://github.com/expo/expo/pull/44854) by [@lukmccall](https://github.com/lukmccall))
 - [Android] Allow compile-time optimization of compose view props when the property class is annotated with `@OptimizedComposeProps`. ([#45021](https://github.com/expo/expo/pull/45021) by [@lukmccall](https://github.com/lukmccall))
-- [iOS] Fixed `SharedObject.emit` dropping `NativeArrayBuffer` values in events.
+- [iOS] Fixed `SharedObject.emit` dropping `NativeArrayBuffer` values in events ([#45257](https://github.com/expo/expo/pull/45257) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-modules-core/common/cpp/EventEmitter.cpp
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.cpp
@@ -197,7 +197,7 @@ jsi::Value createEventSubscription(jsi::Runtime &runtime, const std::string &eve
 
 #pragma mark - Public API
 
-void emitEvent(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const std::vector<jsi::Value> &arguments) {
+void emitEvent(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const std::vector<jsi::Value> &arguments) {
   emitEvent(runtime, emitter, eventName, arguments.data(), arguments.size());
 }
 

--- a/packages/expo-modules-core/common/cpp/EventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.h
@@ -97,6 +97,11 @@ public:
 void emitEvent(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const std::vector<jsi::Value> &arguments);
 
 /**
+ Same as above but takes a raw `jsi::Value` pointer and count.
+ */
+void emitEvent(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const jsi::Value *args, size_t count);
+
+/**
  Gets `expo.EventEmitter` class from the given runtime.
  */
 jsi::Function getClass(jsi::Runtime &runtime);

--- a/packages/expo-modules-core/common/cpp/EventEmitter.h
+++ b/packages/expo-modules-core/common/cpp/EventEmitter.h
@@ -94,7 +94,7 @@ public:
  Emits an event with the given name and arguments to the emitter object.
  Does nothing if the given object is not an instance of the EventEmitter class.
  */
-void emitEvent(jsi::Runtime &runtime, jsi::Object &emitter, const std::string &eventName, const std::vector<jsi::Value> &arguments);
+void emitEvent(jsi::Runtime &runtime, const jsi::Object &emitter, const std::string &eventName, const std::vector<jsi::Value> &arguments);
 
 /**
  Same as above but takes a raw `jsi::Value` pointer and count.

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -97,13 +97,27 @@ public extension SharedObject { // swiftlint:disable:this no_grouping_extension
       }
 
       // Convert native arguments to JS, just like function results
-      let arguments = argumentPairs.map { argument, dynamicType in
-        return Conversions.convertFunctionResult(argument, appContext: appContext, dynamicType: dynamicType)
+      let jsArguments: [JavaScriptValue]
+      do {
+        jsArguments = try argumentPairs.map { argument, dynamicType in
+          try dynamicType.convertToJS(argument, appContext: appContext)
+        }
+      } catch {
+        log.warn("Failed to convert arguments for event '\(event)' on \(type(of: self)): \(error)")
+        return
       }
+
+      let argumentsBuffer = JavaScriptValuesBuffer.copying(in: runtime, values: jsArguments)
 
       runtime.withUnsafePointee { runtimePtr in
         jsValue.withUnsafePointee { objectPtr in
-          JSUtils.emitEvent(event, runtimePointer: runtimePtr, objectPointer: objectPtr, withArguments: arguments)
+          JSUtils.emitEvent(
+            event,
+            runtimePointer: runtimePtr,
+            objectPointer: objectPtr,
+            argumentsPointer: argumentsBuffer.rawBaseAddress,
+            argumentCount: UInt(argumentsBuffer.count)
+          )
         }
       }
     }

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -103,7 +103,7 @@ public extension SharedObject { // swiftlint:disable:this no_grouping_extension
           try dynamicType.convertToJS(argument, appContext: appContext)
         }
       } catch {
-        log.warn("Failed to convert arguments for event '\(event)' on \(type(of: self)): \(error)")
+        log.warn("Failed to convert arguments for event '\(event)' on \(type(of: self)); the event will not be emitted: \(error)")
         return
       }
 

--- a/packages/expo-modules-core/ios/JS/EXJSUtils.h
+++ b/packages/expo-modules-core/ios/JS/EXJSUtils.h
@@ -15,4 +15,13 @@ NS_SWIFT_NAME(JSUtils)
     objectPointer:(nonnull const void *)objectPointer
     withArguments:(nonnull NSArray<id> *)arguments;
 
+/**
+ Same as above but takes a raw `facebook::jsi::Value` pointer and count.
+ */
++ (void)emitEvent:(nonnull NSString *)eventName
+   runtimePointer:(nonnull void *)runtimePointer
+    objectPointer:(nonnull const void *)objectPointer
+ argumentsPointer:(nullable const void *)argumentsPointer
+    argumentCount:(NSUInteger)argumentCount;
+
 @end

--- a/packages/expo-modules-core/ios/JS/EXJSUtils.mm
+++ b/packages/expo-modules-core/ios/JS/EXJSUtils.mm
@@ -22,4 +22,22 @@
   expo::EventEmitter::emitEvent(runtime, object, [eventName UTF8String], jsiArguments);
 }
 
++ (void)emitEvent:(nonnull NSString *)eventName
+   runtimePointer:(nonnull void *)runtimePointer
+    objectPointer:(nonnull const void *)objectPointer
+ argumentsPointer:(nullable const void *)argumentsPointer
+    argumentCount:(NSUInteger)argumentCount
+{
+  auto &runtime = *static_cast<jsi::Runtime *>(runtimePointer);
+  auto object = static_cast<const jsi::Value *>(objectPointer)->asObject(runtime);
+
+  if (argumentCount == 0 || argumentsPointer == nullptr) {
+    expo::EventEmitter::emitEvent(runtime, object, [eventName UTF8String], nullptr, 0);
+    return;
+  }
+
+  auto *args = static_cast<const jsi::Value *>(argumentsPointer);
+  expo::EventEmitter::emitEvent(runtime, object, [eventName UTF8String], args, static_cast<size_t>(argumentCount));
+}
+
 @end

--- a/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
@@ -167,7 +167,10 @@ struct SharedObjectTests {
       .eval("sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()")
       .asObject()
 
-    try runtime.eval("sharedObject.addListener('buffer event', (payload) => { result = payload })")
+    try runtime.eval([
+      "result = null",
+      "sharedObject.addListener('buffer event', (payload) => { result = payload })"
+    ])
 
     let nativeObject = appContext.sharedObjectRegistry.toNativeObject(jsObject)
 
@@ -186,7 +189,10 @@ struct SharedObjectTests {
 
     nativeObject?.emit(event: "buffer event", arguments: payload)
 
-    let result = try runtime.eval("result").asObject()
+    let resultValue = try runtime.eval("result")
+    #expect(!resultValue.isNull() && !resultValue.isUndefined())
+
+    let result = try resultValue.asObject()
     let dataProperty = result.getProperty("data")
 
     #expect(dataProperty.isArrayBuffer())

--- a/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
@@ -160,6 +160,43 @@ struct SharedObjectTests {
     #expect(try result.getProperty("string").asString() == "test")
     #expect(try result.getProperty("record").asObject().getProperty("boolean").asBool() == true)
   }
+
+  @Test
+  func `emits NativeArrayBuffer`() throws {
+    let jsObject = try runtime
+      .eval("sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()")
+      .asObject()
+
+    try runtime.eval("sharedObject.addListener('buffer event', (payload) => { result = payload })")
+
+    let nativeObject = appContext.sharedObjectRegistry.toNativeObject(jsObject)
+
+    let nativeBuffer = NativeArrayBuffer.allocate(size: 16, initializeToZero: false)
+    nativeBuffer.withUnsafeBytes { raw in
+      let mutable = UnsafeMutableRawPointer(mutating: raw.baseAddress!)
+      for index in 0..<16 {
+        mutable.storeBytes(of: UInt8(index + 1), toByteOffset: index, as: UInt8.self)
+      }
+    }
+
+    let payload: [String: Any] = [
+      "data": nativeBuffer,
+      "length": 16
+    ]
+
+    nativeObject?.emit(event: "buffer event", arguments: payload)
+
+    let result = try runtime.eval("result").asObject()
+    let dataProperty = result.getProperty("data")
+
+    #expect(dataProperty.isArrayBuffer())
+    #expect(try result.getProperty("length").asInt() == 16)
+
+    let firstByte = try runtime.eval("new Uint8Array(result.data)[0]").asInt()
+    let lastByte = try runtime.eval("new Uint8Array(result.data)[15]").asInt()
+    #expect(firstByte == 1)
+    #expect(lastByte == 16)
+  }
 }
 
 // MARK: - Test Helpers

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Added `JavaScriptValuesBuffer.copying(in:values:)` and `rawBaseAddress` for forwarding pre-converted JS values across the Swift/ObjC++ boundary. ([#45257](https://github.com/expo/expo/pull/45257) by [@alanjhughes](https://github.com/alanjhughes))
+
 ### 🐛 Bug fixes
 
 - [iOS] Added prebuild configuration for `ExpoModulesJSI` to be built with precompiled XCFrameworks. ([#45124](https://github.com/expo/expo/pull/45124) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -147,12 +147,15 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   }
 
   /**
-   Allocates a new owning buffer that copies each `JavaScriptValue` from the given array.
+   Allocates a new owning buffer holding a runtime-aware copy of each value's
+   underlying `facebook.jsi.Value`. The given `JavaScriptValue`s must all belong
+   to `runtime`; mixing runtimes will crash deep inside JSI.
    */
   @JavaScriptActor
   public static func copying(in runtime: JavaScriptRuntime, values: [JavaScriptValue]) -> JavaScriptValuesBuffer {
     let buffer = UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: values.count)
     for (index, value) in values.enumerated() {
+      assert(value.runtime === runtime, "JavaScriptValue belongs to a different runtime than the buffer being initialized")
       buffer.initializeElement(at: index, to: facebook.jsi.Value(runtime.pointee, value.pointee))
     }
     return JavaScriptValuesBuffer(runtime, buffer: buffer, ownsMemory: true)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -22,6 +22,15 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   }
 
   /**
+   A type-erased raw pointer to the first value of the buffer, suitable for
+   passing across Swift/ObjC++ boundaries where `facebook.jsi.Value` cannot
+   appear in a public signature.
+   */
+  public var rawBaseAddress: UnsafeRawPointer? {
+    return baseAddress.map { UnsafeRawPointer($0) }
+  }
+
+  /**
    The number of values in the buffer.
    */
   public var count: Int {
@@ -135,5 +144,17 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
       copy.initializeElement(at: index, to: facebook.jsi.Value(runtime.pointee, buffer[index]))
     }
     return copy
+  }
+
+  /**
+   Allocates a new owning buffer that copies each `JavaScriptValue` from the given array.
+   */
+  @JavaScriptActor
+  public static func copying(in runtime: JavaScriptRuntime, values: [JavaScriptValue]) -> JavaScriptValuesBuffer {
+    let buffer = UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: values.count)
+    for (index, value) in values.enumerated() {
+      buffer.initializeElement(at: index, to: facebook.jsi.Value(runtime.pointee, value.pointee))
+    }
+    return JavaScriptValuesBuffer(runtime, buffer: buffer, ownsMemory: true)
   }
 }


### PR DESCRIPTION
## Why

After #44337 emitting an event whose payload contains a `NativeArrayBuffer` produces `undefined` on the JS side. This breaks one of the new features in expo-audio where users have direct access to the microphone buffer.

We replaced the Obj-C `EXNativeArrayBuffer` with a a Swift `NativeArrayBuffer`. Function returns were
migrated to the Swift path `dynamicType.convertToJS()`, but `SharedObject.emit` was left, which can no longer recognize the value, so it falls through to `jsi::Value::undefined()`.

## How
Route `SharedObject.emit` through the same `convertToJS` path as function returns. Convert each argument in Swift, pack the resulting `JavaScriptValue`s into a `jsi::Value` buffer, and forward straight to `expo::EventEmitter::emitEvent`.

## Test Plan
Bare expo
Added a new test