### PR TITLE
[tools] Add precompiled to publish pipeline

### DIFF
--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 
 import { addPublishedLabelToPullRequests } from './addPublishedLabelToPullRequests';
 import { addTemplateTarball } from './addTemplateTarball';
+import { bundleIOSPrebuilds } from './bundleIOSPrebuilds';
 import { checkEnvironmentTask } from './checkEnvironmentTask';
 import { checkPackagesIntegrity } from './checkPackagesIntegrity';
 import { checkRepositoryStatus } from './checkRepositoryStatus';
@@ -59,9 +60,9 @@ const cleanWorkingTree = new Task<TaskArgs>(
         });
         // Remove tarballs.
         await Git.cleanAsync({
-          recursive: false,
+          recursive: true,
           force: true,
-          paths: ['packages/**/*.tgz', 'templates/**/*.tgz'],
+          paths: ['packages/**/*.tgz', 'packages/**/prebuilds/**', 'templates/**/*.tgz'],
         });
       },
       'Cleaned up the working tree'
@@ -93,6 +94,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       commitStagedChanges,
       pushCommittedChanges,
       publishAndroidArtifacts,
+      bundleIOSPrebuilds,
       publishPackages,
       updateVersionsEndpoint,
       grantTeamAccessToPackages,


### PR DESCRIPTION
# Why

We only added precompiled to publish pipeline in sdk 55 branch, we should add this to main as well

# How

`gcp 9465540c5bbde9e1b7974950fd6c5d499f1e3cb3`

# Test Plan

N / A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
