### PR TITLE
[go] add expo ui

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExperiencePackagePicker.kt
@@ -80,6 +80,7 @@ import expo.modules.systemui.SystemUIPackage
 import expo.modules.taskManager.TaskManagerModule
 import expo.modules.taskManager.TaskManagerPackage
 import expo.modules.trackingtransparency.TrackingTransparencyModule
+import expo.modules.ui.ExpoUIModule
 import expo.modules.updates.UpdatesPackage
 import expo.modules.video.VideoModule
 import expo.modules.videothumbnails.VideoThumbnailsModule
@@ -156,6 +157,7 @@ object ExperiencePackagePicker : ModulesProvider {
     FontUtilsModule::class.java to null,
     ExpoLinkingModule::class.java to null,
     ExpoRouterModule::class.java to null,
+    ExpoUIModule::class.java to null,
     FileSystemModule::class.java to null,
     FileSystemLegacyModule::class.java to null,
     FontLoaderModule::class.java to null,

--- a/apps/expo-go/android/settings.gradle
+++ b/apps/expo-go/android/settings.gradle
@@ -39,7 +39,6 @@ expoAutolinking.exclude = [
   'expo-maps',
   'expo-network-addons',
   'expo-splash-screen',
-  '@expo/ui',
   'expo-mesh-gradient',
   '@expo/app-integrity',
   '@expo/home',

--- a/apps/expo-go/ios/Podfile
+++ b/apps/expo-go/ios/Podfile
@@ -56,7 +56,6 @@ target 'Expo Go' do
       'expo-network-addons',
       'expo-insights',
       'expo-splash-screen',
-      '@expo/ui',
       '@expo/app-integrity',
       'expo-brownfield',
       'expo-widgets'

--- a/apps/expo-go/package.json
+++ b/apps/expo-go/package.json
@@ -7,6 +7,7 @@
   "author": "Expo",
   "license": "MIT",
   "dependencies": {
+    "@expo/ui": "workspace:*",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,9 @@ importers:
 
   apps/expo-go:
     dependencies:
+      '@expo/ui':
+        specifier: workspace:*
+        version: link:../../packages/expo-ui
       '@expo/vector-icons':
         specifier: ^15.0.2
         version: 15.1.1(expo-font@packages+expo-font)(react-native@0.85.2(@babel/core@7.29.0)(@react-native/jest-preset@0.85.2(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)

--- a/templates/expo-template-default/package.json
+++ b/templates/expo-template-default/package.json
@@ -12,6 +12,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
+    "@expo/ui": "~55.0.1",
     "expo": "~55.0.2",
     "expo-constants": "~55.0.7",
     "expo-device": "~55.0.9",


### PR DESCRIPTION
# Why

close ENG-20850

# How

- add expo-ui to expo-go
- add expo-ui to default template

# Test Plan

- ✅ local build ios expo-go + expo-ui NCL
- ✅ eas build android expo-go + expo-ui NCL

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
