### PR TITLE
[docs] remove alpha/beta for expo-ui

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/index.mdx
@@ -5,13 +5,10 @@ description: Jetpack Compose components for building native Android interfaces w
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['android', 'expo-go']
-isAlpha: true
 hideTOC: true
 ---
 
 import { APIInstallSection } from '~/components/plugins/InstallSection';
-
-> **important** **This library is currently in [alpha](/more/release-statuses/#alpha) and will frequently experience breaking changes.** It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 The Jetpack Compose components in `@expo/ui/jetpack-compose` allow you to build fully native Android interfaces using Jetpack Compose from React Native.
 

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/index.mdx
@@ -5,7 +5,6 @@ description: SwiftUI components for building native iOS interfaces with @expo/ui
 sourceCodeUrl: 'https://github.com/expo/expo/tree/main/packages/expo-ui'
 packageName: '@expo/ui'
 platforms: ['ios', 'tvos', 'expo-go']
-isBeta: true
 hasVideoLink: true
 ---
 
@@ -15,8 +14,6 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { CODE } from '~/ui/components/Text';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
-
-> **important** **This library is currently in [beta](/more/release-statuses/#beta) and subject to breaking changes.** It is not available in the Expo Go app &mdash; use [development builds](/develop/development-builds/introduction/) to try it out.
 
 The SwiftUI components in `@expo/ui/swift-ui` allow you to build fully native iOS interfaces using SwiftUI from React Native.
 


### PR DESCRIPTION
# Why

expo-ui for sdk 56. update missing piece from #45129
close ENG-20850

# How

remove alpha/beta status for the unversioned expo-ui docs

# Test Plan

local docs

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
