### PR TITLE
[expo-crypto] move digest to the module queue

### DIFF
--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🎉 New features
 
+- Move digest to the module queue. ([#45271](https://github.com/expo/expo/pull/45271) by [@rustle](https://github.com/rustle))
+
 ### 🐛 Bug fixes
 
 - Access `crypto` on `globalThis` rather than just `window.crypto` ([#43405](https://github.com/expo/expo/pull/43405) by [@bradleyayers](https://github.com/bradleyayers))

--- a/packages/expo-crypto/android/src/main/java/expo/modules/crypto/CryptoModule.kt
+++ b/packages/expo-crypto/android/src/main/java/expo/modules/crypto/CryptoModule.kt
@@ -18,7 +18,7 @@ class CryptoModule : Module() {
     Function("digestString", this@CryptoModule::digestString)
     AsyncFunction("digestStringAsync", this@CryptoModule::digestString)
     Function("getRandomValues", this@CryptoModule::getRandomValues)
-    Function("digest", this@CryptoModule::digest)
+    AsyncFunction("digestAsync", this@CryptoModule::digestAsync)
     Function("randomUUID") {
       UUID.randomUUID().toString()
     }
@@ -42,12 +42,9 @@ class CryptoModule : Module() {
     }
   }
 
-  private fun digest(algorithm: DigestAlgorithm, output: TypedArray, data: TypedArray) {
-    val messageDigest = MessageDigest.getInstance(algorithm.value).apply { update(data.toDirectBuffer()) }
-
-    val digest: ByteArray = messageDigest.digest()
-    val outputLength = min(digest.size, output.byteLength)
-    output.write(digest, 0, outputLength)
+  private fun digestAsync(algorithm: DigestAlgorithm, data: ByteArray): ByteArray {
+    val messageDigest = MessageDigest.getInstance(algorithm.value).apply { update(data) }
+    return messageDigest.digest()
   }
 
   private fun getRandomValues(typedArray: TypedArray) {

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -13,7 +13,7 @@ public class CryptoModule: Module {
 
     Function("getRandomValues", getRandomValues)
 
-    Function("digest", digest)
+    AsyncFunction("digestAsync", digestAsync)
 
     Function("randomUUID") {
       UUID().uuidString.lowercased()
@@ -54,9 +54,15 @@ private func getRandomValues(array: TypedArray) throws -> TypedArray {
   return array
 }
 
-private func digest(algorithm: DigestAlgorithm, output: TypedArray, data: TypedArray) {
-  let outputPtr = output.rawPointer.assumingMemoryBound(to: UInt8.self)
-  _ = algorithm.digest(data.rawPointer, UInt32(data.byteLength), outputPtr)
+private func digestAsync(algorithm: DigestAlgorithm, data: Data) -> Data {
+  let length = Int(algorithm.digestLength)
+  var digest = [UInt8](repeating: 0, count: length)
+
+  data.withUnsafeBytes { bytes in
+    let _ = algorithm.digest(bytes.baseAddress, UInt32(data.count), &digest)
+  }
+
+  return Data(digest)
 }
 
 private final class LossyConversionException: Exception {


### PR DESCRIPTION
# Why

avoids hiccups in UI when hashing a larger buffer

# How

Move work to moduleQueue. The JS side of the world uses digestAsync when it's available so this shouldn't break existing apps.

# Test Plan

Manual testing on Android and iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
