### PR TITLE
[jsi] Make expo-modules-jsi publishable

### DIFF
--- a/packages/expo-modules-jsi/package.json
+++ b/packages/expo-modules-jsi/package.json
@@ -3,7 +3,6 @@
   "version": "55.0.0",
   "description": "The JavaScript Interface for Expo Modules",
   "main": "index.js",
-  "private": true,
   "sideEffects": [],
   "exports": {
     "./package.json": "./package.json",


### PR DESCRIPTION
# Why

`expo-modules-jsi` is currently marked `"private": true` in its package.json, which causes `expotools publish` to filter it out unconditionally — both from the dependency graph and from the publishable set (see `tools/src/publish-packages/tasks/loadRequestedParcels.ts`). The `--canary` flag does not bypass this. Removing the flag makes the package eligible for publishing.

# How

Drop `"private": true` from `packages/expo-modules-jsi/package.json`.

# Test Plan

- Verified locally that the only gate keeping the package out of `expotools publish` is the `private` field.