### PR TITLE
[cli] Resolve entry points outside server root via Metro watchFolders

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -90,6 +90,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
+- Resolve entry points outside server root via Metro `watchFolders`. ([#45288](https://github.com/expo/expo/pull/45288) by [@motiz88](https://github.com/motiz88))
 - Prevent opening Expo Go on Apple Watch. ([#44147](https://github.com/expo/expo/pull/44147) by [@EvanBacon](https://github.com/EvanBacon))
 - Support files >= 2 GiB in AFC device upload ([#43755](https://github.com/expo/expo/pull/43755) by [@yocontra](https://github.com/yocontra))
 - Revert the `-quiet` change to ensure build env vars are always printed. ([#43906](https://github.com/expo/expo/pull/43906) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -145,7 +145,9 @@ export abstract class BundlerDevServer {
 
   /** Get the manifest middleware function. */
   protected async getManifestMiddlewareAsync(
-    options: Pick<BundlerStartOptions, 'minify' | 'mode' | 'privateKeyPath'> = {}
+    options: Pick<BundlerStartOptions, 'minify' | 'mode' | 'privateKeyPath'> & {
+      watchFolders?: readonly string[];
+    } = {}
   ) {
     const Middleware = require('./middleware/ExpoGoManifestHandlerMiddleware')
       .ExpoGoManifestHandlerMiddleware as typeof import('./middleware/ExpoGoManifestHandlerMiddleware').ExpoGoManifestHandlerMiddleware;
@@ -157,6 +159,7 @@ export abstract class BundlerDevServer {
       minify: options.minify,
       isNativeWebpack: this.name === 'webpack' && this.isTargetingNative(),
       privateKeyPath: options.privateKeyPath,
+      watchFolders: options.watchFolders,
     });
     return middleware;
   }

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -6,7 +6,7 @@
  */
 import type { ExpoConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
-import { getMetroServerRoot, resolveRelativeEntryPoint } from '@expo/config/paths';
+import { getMetroServerRoot } from '@expo/config/paths';
 import baseJSBundle from '@expo/metro/metro/DeltaBundler/Serializers/baseJSBundle';
 import {
   sourceMapGeneratorNonBlocking,
@@ -91,6 +91,7 @@ import { createDomComponentsMiddleware } from '../middleware/DomComponentsMiddle
 import { FaviconMiddleware } from '../middleware/FaviconMiddleware';
 import { HistoryFallbackMiddleware } from '../middleware/HistoryFallbackMiddleware';
 import { InterstitialPageMiddleware } from '../middleware/InterstitialPageMiddleware';
+import { resolveRelativeEntryPoint } from '../middleware/ManifestMiddleware';
 import { RuntimeRedirectMiddleware } from '../middleware/RuntimeRedirectMiddleware';
 import { ServeStaticMiddleware } from '../middleware/ServeStaticMiddleware';
 import type { ExpoMetroOptions } from '../middleware/metroOptions';
@@ -583,7 +584,9 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     );
 
     const resolvedMainModuleName =
-      mainModuleName ?? './' + resolveRelativeEntryPoint(this.projectRoot, { platform });
+      mainModuleName ??
+      './' +
+        resolveRelativeEntryPoint(this.projectRoot, { platform }, this.metro!._config.watchFolders);
     return await this.metroImportAsArtifactsAsync(resolvedMainModuleName, {
       splitChunks: isExporting && !env.EXPO_NO_BUNDLE_SPLITTING,
       platform,
@@ -695,7 +698,11 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       mode,
       environment: 'client',
       reactCompiler,
-      mainModuleName: resolveRelativeEntryPoint(this.projectRoot, { platform }),
+      mainModuleName: resolveRelativeEntryPoint(
+        this.projectRoot,
+        { platform },
+        this.metro!._config.watchFolders
+      ),
       lazy: !env.EXPO_NO_METRO_LAZY,
       baseUrl,
       isExporting,
@@ -1352,7 +1359,10 @@ export class MetroBundlerDevServer extends BundlerDevServer {
     process.env.EXPO_DEV_SERVER_ORIGIN = `${protocol}://localhost:${options.port}`;
 
     if (!options.isExporting) {
-      const manifestMiddleware = await this.getManifestMiddlewareAsync(options);
+      const manifestMiddleware = await this.getManifestMiddlewareAsync({
+        ...options,
+        watchFolders: metro._config.watchFolders,
+      });
 
       // Important that we noop source maps for context modules as soon as possible.
       prependMiddleware(middleware, new ContextModuleSourceMapsMiddleware().getHandler());

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroBundlerDevServer-test.ts
@@ -78,6 +78,7 @@ function createDevServerForStaticPageTests() {
     asyncRoutes: false,
   };
   devServer['getDevServerUrlOrAssert'] = jest.fn(() => 'http://localhost:8081');
+  devServer['metro'] = { _config: { watchFolders: [] } } as any;
   return devServer;
 }
 

--- a/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ManifestMiddleware.ts
@@ -1,12 +1,14 @@
 import type { ExpoConfig, ExpoGoConfig, PackageJSONConfig, ProjectConfig } from '@expo/config';
 import { getConfig } from '@expo/config';
-import { resolveRelativeEntryPoint } from '@expo/config/paths';
+import { convertEntryPointToRelative, resolveEntryPoint } from '@expo/config/paths';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
+import path from 'path';
 import { resolve } from 'url';
 
 import { ExpoMiddleware } from './ExpoMiddleware';
 import {
+  convertPathToModuleSpecifier,
   createBundleUrlPath,
   getBaseUrlFromExpoConfig,
   getAsyncRoutesFromExpoConfig,
@@ -66,7 +68,40 @@ export type ManifestMiddlewareOptions = {
   constructUrl: UrlCreator['constructUrl'];
   isNativeWebpack?: boolean;
   privateKeyPath?: string;
+  watchFolders?: readonly string[];
 };
+
+export function resolveRelativeEntryPoint(
+  projectRoot: string,
+  props: { platform?: string; pkg?: PackageJSONConfig },
+  watchFolders?: readonly string[]
+): string {
+  const absoluteEntry = resolveEntryPoint(projectRoot, props);
+  const relative = convertEntryPointToRelative(projectRoot, absoluteEntry);
+
+  if (!relative.startsWith('..') || !watchFolders?.length) {
+    return relative;
+  }
+
+  for (let i = 0; i < watchFolders.length; i++) {
+    const watchFolder = watchFolders[i]!;
+    if (!path.isAbsolute(watchFolder)) {
+      debug(`Expected watchFolders[${i}] to be an absolute path, got: ${watchFolder}`);
+      continue;
+    }
+    if (absoluteEntry.startsWith(watchFolder + path.sep) || absoluteEntry === watchFolder) {
+      let relativeToWatch = convertPathToModuleSpecifier(
+        absoluteEntry.slice(watchFolder.length + 1)
+      );
+      if (relativeToWatch.endsWith('.js')) {
+        relativeToWatch = relativeToWatch.slice(0, -3);
+      }
+      return '[metro-watchFolders]/' + i + '/' + relativeToWatch;
+    }
+  }
+
+  return relative;
+}
 
 /** Base middleware creator for serving the Expo manifest (like the index.html but for native runtimes). */
 export abstract class ManifestMiddleware<
@@ -74,6 +109,7 @@ export abstract class ManifestMiddleware<
 > extends ExpoMiddleware {
   private initialProjectConfig: ProjectConfig;
   private platformBundlers: PlatformBundlers;
+  private watchFolders: readonly string[] | undefined;
 
   constructor(
     protected projectRoot: string,
@@ -88,6 +124,7 @@ export abstract class ManifestMiddleware<
     );
     this.initialProjectConfig = getConfig(projectRoot);
     this.platformBundlers = getPlatformBundlers(projectRoot, this.initialProjectConfig.exp);
+    this.watchFolders = options.watchFolders;
   }
 
   /** Exposed for testing. */
@@ -157,9 +194,9 @@ export abstract class ManifestMiddleware<
       return 'index';
     }
 
-    const entry = resolveRelativeEntryPoint(this.projectRoot, props);
-    debug(`Resolved entry point: ${entry} (project root: ${this.projectRoot})`);
-    return entry;
+    const resolved = resolveRelativeEntryPoint(this.projectRoot, props, this.watchFolders);
+    debug(`Resolved entry point: ${resolved} (project root: ${this.projectRoot})`);
+    return resolved;
   }
 
   /** Parse request headers into options. */

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ManifestMiddleware-test.ts
@@ -8,7 +8,7 @@ import * as ProjectDevices from '../../../project/devices';
 import { getPlatformBundlers } from '../../platformBundlers';
 import { createTemplateHtmlFromExpoConfigAsync } from '../../webTemplate';
 import type { ManifestRequestInfo } from '../ManifestMiddleware';
-import { ManifestMiddleware } from '../ManifestMiddleware';
+import { ManifestMiddleware, resolveRelativeEntryPoint } from '../ManifestMiddleware';
 import type { ServerRequest, ServerResponse } from '../server.types';
 
 class MockServerResponse extends PassThrough {
@@ -35,7 +35,8 @@ jest.mock('../resolveAssets', () => ({
 }));
 jest.mock('@expo/config/paths', () => ({
   ...jest.requireActual('@expo/config/paths'),
-  resolveRelativeEntryPoint: () => 'index',
+  resolveEntryPoint: jest.fn(() => '/index.js'),
+  convertEntryPointToRelative: jest.fn(() => 'index'),
 }));
 jest.mock('@expo/config', () => ({
   getNameFromConfig: jest.fn(jest.requireActual('@expo/config').getNameFromConfig),
@@ -341,5 +342,81 @@ describe('getHandler', () => {
     expect(next).not.toHaveBeenCalled();
     // Ensure the user sees the error in the terminal.
     expect(Log.exception).toHaveBeenCalled();
+  });
+});
+
+describe('resolveRelativeEntryPoint', () => {
+  const { resolveEntryPoint, convertEntryPointToRelative } = require('@expo/config/paths') as {
+    resolveEntryPoint: jest.Mock;
+    convertEntryPointToRelative: jest.Mock;
+  };
+
+  afterEach(() => {
+    resolveEntryPoint.mockReset();
+    resolveEntryPoint.mockReturnValue('/index.js');
+    convertEntryPointToRelative.mockReset();
+    convertEntryPointToRelative.mockReturnValue('index');
+  });
+
+  it('uses convertEntryPointToRelative when no watchFolders', () => {
+    resolveEntryPoint.mockReturnValueOnce('/project/index.js');
+    expect(resolveRelativeEntryPoint('/project', { platform: 'ios' })).toBe('index');
+  });
+
+  it('uses convertEntryPointToRelative when entry is inside server root', () => {
+    resolveEntryPoint.mockReturnValueOnce('/project/index.js');
+    convertEntryPointToRelative.mockReturnValueOnce('index');
+    expect(
+      resolveRelativeEntryPoint('/project', { platform: 'ios' }, ['/workspace/packages'])
+    ).toBe('index');
+  });
+
+  it('uses convertEntryPointToRelative when entry is outside root but not in any watchFolder', () => {
+    resolveEntryPoint.mockReturnValueOnce('/other/entry.js');
+    convertEntryPointToRelative.mockReturnValueOnce('../../other/entry');
+    expect(
+      resolveRelativeEntryPoint('/project', { platform: 'ios' }, ['/workspace/packages'])
+    ).toBe('../../other/entry');
+  });
+
+  it('rewrites to [metro-watchFolders] prefix when entry is outside root and inside a watch folder', () => {
+    resolveEntryPoint.mockReturnValueOnce('/workspace/.scratch/node_modules/expo-router/entry.js');
+    convertEntryPointToRelative.mockReturnValueOnce(
+      '../../.scratch/node_modules/expo-router/entry'
+    );
+    expect(
+      resolveRelativeEntryPoint('/project', { platform: 'ios' }, [
+        '/workspace/.scratch/node_modules',
+      ])
+    ).toBe('[metro-watchFolders]/0/expo-router/entry');
+  });
+
+  it('uses the correct watch folder index', () => {
+    resolveEntryPoint.mockReturnValueOnce('/workspace/.scratch/node_modules/expo-router/entry.js');
+    convertEntryPointToRelative.mockReturnValueOnce(
+      '../../.scratch/node_modules/expo-router/entry'
+    );
+    expect(
+      resolveRelativeEntryPoint('/project', { platform: 'ios' }, [
+        '/workspace/other',
+        '/workspace/.scratch/node_modules',
+      ])
+    ).toBe('[metro-watchFolders]/1/expo-router/entry');
+  });
+
+  it('strips .js extension from watchFolder-relative path', () => {
+    resolveEntryPoint.mockReturnValueOnce('/watchdir/lib/main.js');
+    convertEntryPointToRelative.mockReturnValueOnce('../../watchdir/lib/main');
+    expect(resolveRelativeEntryPoint('/project', { platform: 'ios' }, ['/watchdir'])).toBe(
+      '[metro-watchFolders]/0/lib/main'
+    );
+  });
+
+  it('preserves non-.js extensions in watchFolder-relative path', () => {
+    resolveEntryPoint.mockReturnValueOnce('/watchdir/lib/main.tsx');
+    convertEntryPointToRelative.mockReturnValueOnce('../../watchdir/lib/main.tsx');
+    expect(resolveRelativeEntryPoint('/project', { platform: 'ios' }, ['/watchdir'])).toBe(
+      '[metro-watchFolders]/0/lib/main.tsx'
+    );
   });
 });


### PR DESCRIPTION
Thread the Metro config's watchFolders array through to the manifest middleware and the SSR/static bundle entry point resolution so that [metro-watchFolders]/<index>/<relative> URLs are used when the entry is outside the server root but inside a configured watch folder.

This fixes "Unable to resolve module" errors in monorepo or virtual- filesystem setups where node_modules is symlinked to a different filesystem location (e.g. via EdenFS autoscratch).

Supersedes https://github.com/expo/expo/pull/45010

Depends on https://github.com/facebook/metro/pull/1708 and other bugfixes in that stack - not yet released in any Metro version.

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
