### PR TITLE
[docs] Add redirects for EAS docs

### DIFF
--- a/docs/common/client-redirects.test.ts
+++ b/docs/common/client-redirects.test.ts
@@ -69,3 +69,25 @@ test('removes null from end of paths', () => {
 test('redirect SDK permissions to the permission guide', () => {
   expect(getRedirectPath('/versions/latest/sdk/permissions/')).toEqual('/guides/permissions/');
 });
+
+test('rewrites /eas/build/** prefix to /build/**', () => {
+  expect(getRedirectPath('/eas/build/introduction/')).toEqual('/build/introduction/');
+});
+
+test('rewrites /eas/update/** prefix to /eas-update/**', () => {
+  expect(getRedirectPath('/eas/update/introduction/')).toEqual('/eas-update/introduction/');
+});
+
+test('rewrites /eas/submit/** prefix to /submit/**', () => {
+  expect(getRedirectPath('/eas/submit/android/')).toEqual('/submit/android/');
+});
+
+test('rewrites /eas/insights/** prefix to /eas-insights/**', () => {
+  expect(getRedirectPath('/eas/insights/introduction/')).toEqual('/eas-insights/introduction/');
+});
+
+test('does not rewrite /eas/** paths that are canonical (workflows, hosting, metadata, ai)', () => {
+  expect(getRedirectPath('/eas/workflows/get-started/')).toEqual('/eas/workflows/get-started/');
+  expect(getRedirectPath('/eas/hosting/introduction/')).toEqual('/eas/hosting/introduction/');
+  expect(getRedirectPath('/eas/metadata/')).toEqual('/eas/metadata/');
+});

--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -36,6 +36,16 @@ export function getRedirectPath(redirectPath: string): string {
     }
   }
 
+  // Catch path-prefix renames that the static `_redirects` rules also handle
+  // at the Cloudflare edge. This branch backstops in-app Next.js client
+  // navigation (e.g. an MDX link to a stale path), which never round-trips
+  // through the edge and would otherwise hit the 404 page.
+  for (const { pattern, replacement } of WILDCARD_RENAMES) {
+    if (pattern.test(redirectPath)) {
+      return redirectPath.replace(pattern, replacement);
+    }
+  }
+
   // Check if the version is documented, replace it with latest if not
   if (!isVersionDocumented(redirectPath)) {
     redirectPath = replaceVersionWithLatest(redirectPath);
@@ -134,6 +144,17 @@ function removeVersionFromPath(path: string) {
 function endsInNull(path: string) {
   return path.endsWith('/null');
 }
+
+// Path-prefix renames. Mirrors the catch-all rules in `public/_redirects` for
+// `/eas/<category>/**` paths that were never canonical. Kept in sync so the
+// client-side fallback handles in-app Next.js navigation that never reaches
+// the edge. See ENG-18522.
+const WILDCARD_RENAMES: { pattern: RegExp; replacement: string }[] = [
+  { pattern: /^\/eas\/build\/(.*)$/, replacement: '/build/$1' },
+  { pattern: /^\/eas\/submit\/(.*)$/, replacement: '/submit/$1' },
+  { pattern: /^\/eas\/update\/(.*)$/, replacement: '/eas-update/$1' },
+  { pattern: /^\/eas\/insights\/(.*)$/, replacement: '/eas-insights/$1' },
+];
 
 // Simple remapping of renamed pages, similar to public/_redirects but in some cases,
 // for reasons I'm not totally clear on, those redirects do not work

--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -145,10 +145,6 @@ function endsInNull(path: string) {
   return path.endsWith('/null');
 }
 
-// Path-prefix renames. Mirrors the catch-all rules in `public/_redirects` for
-// `/eas/<category>/**` paths that were never canonical. Kept in sync so the
-// client-side fallback handles in-app Next.js navigation that never reaches
-// the edge. See ENG-18522.
 const WILDCARD_RENAMES: { pattern: RegExp; replacement: string }[] = [
   { pattern: /^\/eas\/build\/(.*)$/, replacement: '/build/$1' },
   { pattern: /^\/eas\/submit\/(.*)$/, replacement: '/submit/$1' },

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -148,7 +148,6 @@
 
 # Redirects based on Sentry reports
 /push-notifications /push-notifications/overview 301
-/eas/submit /submit/introduction 301
 /development/tools/expo-dev-client /develop/development-builds/introduction 301
 /develop/user-interface/custom-fonts /develop/user-interface/fonts 301
 /workflow/snack /more/glossary-of-terms 301
@@ -367,6 +366,19 @@
 /versions/latest/sdk/ui/jetpack-compose/textinput /versions/latest/sdk/ui/jetpack-compose/textfield 301
 /versions/unversioned/sdk/ui/jetpack-compose/textinput /versions/unversioned/sdk/ui/jetpack-compose/textfield 301
 /versions/v55.0.0/sdk/ui/jetpack-compose/textinput /versions/v55.0.0/sdk/ui/jetpack-compose/textfield 301
+
+# EAS Build, Submit, Update, and Insights predate the /eas/* URL convention;
+# canonical paths are /build/**, /submit/**, /eas-update/**, /eas-insights/**.
+# Catch-all redirects fix old links (e.g. onboarding emails) and LLM-guessed
+# URLs that point at /eas/<category>/**. See ENG-18522.
+/eas/build/* /build/:splat 301
+/eas/build /build/introduction 301
+/eas/submit/* /submit/:splat 301
+/eas/submit /submit/introduction 301
+/eas/update/* /eas-update/:splat 301
+/eas/update /eas-update/introduction 301
+/eas/insights/* /eas-insights/:splat 301
+/eas/insights /eas-insights/introduction 301
 
 # Serve markdown at the sibling /<slug>.md path that AI agents typically request,
 # rewriting to the canonical /<slug>/index.md the build script writes.

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -368,9 +368,6 @@
 /versions/v55.0.0/sdk/ui/jetpack-compose/textinput /versions/v55.0.0/sdk/ui/jetpack-compose/textfield 301
 
 # EAS Build, Submit, Update, and Insights predate the /eas/* URL convention;
-# canonical paths are /build/**, /submit/**, /eas-update/**, /eas-insights/**.
-# Catch-all redirects fix old links (e.g. onboarding emails) and LLM-guessed
-# URLs that point at /eas/<category>/**. See ENG-18522.
 /eas/build/* /build/:splat 301
 /eas/build /build/introduction 301
 /eas/submit/* /submit/:splat 301


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-18522

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add  client and server side redirects for EAS Build, EAS Update, EAS Submit, and EAS Insights.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview, and check if https://pr-45290.expo-docs.pages.dev/eas/build/introduction/ redirect is working.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
