### PR TITLE
[core] Enable approachable concurrency upcoming features on iOS

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -3968,7 +3968,7 @@ SPEC CHECKSUMS:
   ExpoMaps: 94294944cff46ad1170ce4f92800adecbcdd04ac
   ExpoMediaLibrary: 2fbddcb06042f43076cf5e495e8237ec2ab95726
   ExpoMeshGradient: 93cf09380e6d86cd7a525da26dfddab2620a8421
-  ExpoModulesCore: 0b10a40c52e82e182c70dbfc12001ec30ba74cbd
+  ExpoModulesCore: 8f144ce25c48aa2c7c6e786e55482d1d9d8689f0
   ExpoModulesJSI: 16f789b94db843249981e5f550e050cc321fe554
   ExpoModulesTestCore: 62ce59e8c8162b449e65467e0421240256ba6732
   ExpoModulesWorklets: 3a4d6451e29822c01c397da92be1f962a0f870fe

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ### 💡 Others
 
+- [iOS] Enabled `NonisolatedNonsendingByDefault` and `InferIsolatedConformances` upcoming Swift features. ([#45293](https://github.com/expo/expo/pull/45293) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Reduced per-call overhead of invoking native functions from JavaScript. ([#45093](https://github.com/expo/expo/pull/45093) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed precompile build failing on `SwiftUIVirtualViewSharedImpl+Private.h` leaking into the public module umbrella. ([#44993](https://github.com/expo/expo/pull/44993) by [@chrfalch](https://github.com/chrfalch))
 - [iOS] Added explicit c++ linkage specifier to `ExpoModulesCore.podspec` to propagate to swift-only targets like Expo Widgets ([#44984](https://github.com/expo/expo/pull/44984) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/ExpoModulesCore.podspec
+++ b/packages/expo-modules-core/ExpoModulesCore.podspec
@@ -86,6 +86,7 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++20',
     'SWIFT_COMPILATION_MODE' => 'wholemodule',
+    'SWIFT_APPROACHABLE_CONCURRENCY' => 'YES',
     'OTHER_SWIFT_FLAGS' => "$(inherited) #{new_arch_enabled ? new_arch_compiler_flags : ''}",
     'HEADER_SEARCH_PATHS' => header_search_paths.join(' '),
     'GCC_PREPROCESSOR_DEFINITIONS' => "$(inherited) EXPO_MODULES_CORE_VERSION=" + package['version'],

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -105,7 +105,13 @@
             "CoreGraphics",
             "CoreMedia",
             "SwiftUI"
-          ]
+          ],
+          "swiftSettings": {
+            "enableUpcomingFeatures": [
+              "NonisolatedNonsendingByDefault",
+              "InferIsolatedConformances"
+            ]
+          }
         }
       ]
     }

--- a/packages/expo-modules-core/spm.config.json
+++ b/packages/expo-modules-core/spm.config.json
@@ -110,6 +110,9 @@
             "enableUpcomingFeatures": [
               "NonisolatedNonsendingByDefault",
               "InferIsolatedConformances"
+            ],
+            "unsafeFlags": [
+              "-no-verify-emitted-module-interface"
             ]
           }
         }

--- a/tools/src/prebuilds/SPMConfig.types.ts
+++ b/tools/src/prebuilds/SPMConfig.types.ts
@@ -134,6 +134,8 @@ export interface ObjcTarget extends SourceTarget {
 export interface SwiftSettings {
   /** Names of upcoming Swift features to enable (passed to `.enableUpcomingFeature`). */
   enableUpcomingFeatures?: string[];
+  /** Raw compiler flags passed via `.unsafeFlags()`, e.g. `-no-verify-emitted-module-interface`. */
+  unsafeFlags?: string[];
 }
 
 /**

--- a/tools/src/prebuilds/SPMConfig.types.ts
+++ b/tools/src/prebuilds/SPMConfig.types.ts
@@ -129,11 +129,21 @@ export interface ObjcTarget extends SourceTarget {
 }
 
 /**
+ * Swift-specific build settings, mirrored from SwiftPM's `SwiftSetting` API.
+ */
+export interface SwiftSettings {
+  /** Names of upcoming Swift features to enable (passed to `.enableUpcomingFeature`). */
+  enableUpcomingFeatures?: string[];
+}
+
+/**
  * A Swift source target
  */
 export interface SwiftTarget extends SourceTarget {
   /** Target type identifier */
   type: 'swift';
+  /** Swift-specific compiler settings, mirrored from SwiftPM's `SwiftSetting` API. */
+  swiftSettings?: SwiftSettings;
 }
 
 /**

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -846,6 +846,11 @@ function buildSwiftSettings(
   for (const feature of target?.swiftSettings?.enableUpcomingFeatures ?? []) {
     settings.push(`.enableUpcomingFeature("${feature}")`);
   }
+  const userUnsafeFlags = target?.swiftSettings?.unsafeFlags ?? [];
+  if (userUnsafeFlags.length > 0) {
+    const quoted = userUnsafeFlags.map((f) => `"${f}"`).join(', ');
+    settings.push(`.unsafeFlags([${quoted}])`);
+  }
 
   // Common C++ flags (not path-dependent)
   // Note: -fcxx-modules is intentionally omitted (see buildCSettings comment).

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -842,6 +842,11 @@ function buildSwiftSettings(
   // Define RCT_NEW_ARCH_ENABLED for Fabric support
   settings.push('.define("RCT_NEW_ARCH_ENABLED")');
 
+  // Per-target Swift settings from spm.config.json
+  for (const feature of target?.swiftSettings?.enableUpcomingFeatures ?? []) {
+    settings.push(`.enableUpcomingFeature("${feature}")`);
+  }
+
   // Common C++ flags (not path-dependent)
   // Note: -fcxx-modules is intentionally omitted (see buildCSettings comment).
   const commonCxxFlags: string[] = ['-Xcc', '-fmodules'];

--- a/tools/src/prebuilds/schemas/spm.config.schema.json
+++ b/tools/src/prebuilds/schemas/spm.config.schema.json
@@ -461,6 +461,19 @@
                     "type": "boolean",
                     "description": "Whether to expose headers as public module headers. Set to false to make headers private/internal, which prevents Clang from building a module from them. Default is true.",
                     "default": true
+                },
+                "swiftSettings": {
+                    "type": "object",
+                    "description": "Swift-specific compiler settings, mirrored from SwiftPM's SwiftSetting API.",
+                    "properties": {
+                        "enableUpcomingFeatures": {
+                            "type": "array",
+                            "description": "Names of upcoming Swift features to enable (passed to .enableUpcomingFeature in Package.swift).",
+                            "items": { "type": "string" },
+                            "default": [ ]
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "required": [ "type", "name", "path" ],

--- a/tools/src/prebuilds/schemas/spm.config.schema.json
+++ b/tools/src/prebuilds/schemas/spm.config.schema.json
@@ -471,6 +471,12 @@
                             "description": "Names of upcoming Swift features to enable (passed to .enableUpcomingFeature in Package.swift).",
                             "items": { "type": "string" },
                             "default": [ ]
+                        },
+                        "unsafeFlags": {
+                            "type": "array",
+                            "description": "Raw compiler flags passed via .unsafeFlags() in Package.swift (e.g. '-no-verify-emitted-module-interface').",
+                            "items": { "type": "string" },
+                            "default": [ ]
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
## Why

Adopt two of the three Swift upcoming features bundled under "Approachable Concurrency" in `ExpoModulesCore`. Both reduce executor hopping and concurrency boilerplate without changing public API or runtime semantics for downstream module authors.

- [`NonisolatedNonsendingByDefault`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0461-async-function-isolation.md) — `nonisolated func ... async` runs on the caller's actor instead of hopping to the generic executor (opt out with `@concurrent`).
- [`InferIsolatedConformances`](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0470-isolated-conformances.md) — when an actor-isolated type conforms to a non-isolated protocol, the conformance is inferred as isolated to that actor, removing per-witness `nonisolated` boilerplate.

The third bundled flag — `MainActor`-default isolation — is intentionally **not** adopted. Most of `ExpoModulesCore`'s hot path runs on the JS thread (`@JavaScriptActor`), so a `MainActor` default would invert the right answer everywhere and trip strict-isolation checks across the JSI bridge layer.

## Scope of impact

Audited the package before flipping the flags:

- **`NonisolatedNonsendingByDefault`** — zero non-test `nonisolated func ... async` declarations in `ExpoModulesCore`. The two async funcs in core (`ConcurrentFunctionDefinition.call`, `callBodyOnMainActor`) are explicitly `@JavaScriptActor` / `@MainActor`. The single `Task { ... }` site is explicitly `@MainActor`.
- **`InferIsolatedConformances`** — the actor-annotated public classes (`ExpoAppDelegateSubscriberManager`, `ExpoAppDelegateSubscriberRepository`) use `@preconcurrency`, which short-circuits the inference. Other actor-annotated types either have no Swift protocol conformances or only inherit from Obj-C bases.

Net: zero observable behavior change in core, and zero impact on third-party modules — the flags only affect how core's own source is compiled. ABI, public API signatures, and the type of the `@Sendable async` factory closures are unchanged. Module authors using `AsyncFunction { ... }` continue to work as before.

`expo-modules-jsi` already enables both flags in its hand-rolled `Package.swift`; this brings `expo-modules-core` in line.

## Changes

- **`ExpoModulesCore.podspec`** — sets `SWIFT_APPROACHABLE_CONCURRENCY = YES` in `pod_target_xcconfig`. In Swift 6 mode this expands to exactly the two upcoming features above (without flipping `MainActor`-default isolation), and is what Xcode 26 uses for new projects. Stuffing the equivalent `-enable-upcoming-feature` flags into `OTHER_SWIFT_FLAGS` would also work, but leaves the Xcode build-settings UI showing the features as NO and risks conflicting `-enable-`/`-disable-upcoming-feature` flags landing on the same swiftc invocation.
- **`spm.config.json` schema** — adds two new fields on Swift targets, both mirroring SwiftPM's `SwiftSetting` API: `swiftSettings.enableUpcomingFeatures: string[]` (one `.enableUpcomingFeature("…")` per entry) and `swiftSettings.unsafeFlags: string[]` (a single `.unsafeFlags([…])` directive). No equivalent of `SWIFT_APPROACHABLE_CONCURRENCY` exists on the SwiftPM side — `"ApproachableConcurrency"` is not a valid upcoming-feature name in swiftc itself.
- **`expo-modules-core/spm.config.json`** — opts in with the two feature names *and* `-no-verify-emitted-module-interface`. The latter is needed because `NonisolatedNonsendingByDefault` causes swiftc to emit `nonisolated(nonsending)` in the generated `.swiftinterface`, which the round-trip verifier rejects when ABI-stable distribution (`BUILD_LIBRARY_FOR_DISTRIBUTION=YES`) is on. Matches the flag `expo-modules-jsi`'s hand-rolled `Package.swift` already passes for the same reason.

## Test plan

- [x] `pnpm tsc --noEmit` in `tools/` — clean.
- [x] `pod install` + iOS build of `bare-expo` — clean.
- [x] Xcode build settings UI shows both features as YES — `$(SWIFT_APPROACHABLE_CONCURRENCY)` after the switch to the meta-setting.
- [x] `et prebuild expo-modules-core --skip-build` — generated `Package.swift` contains the two `.enableUpcomingFeature` entries plus `.unsafeFlags(["-no-verify-emitted-module-interface"])` on the Swift target.
- [ ] Run the iOS unit test target on the same build to confirm no concurrency-related regressions surface.