### PR TITLE
Fix/android emulator connection refused

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -2516,6 +2516,7 @@ _This version does not introduce any user-facing changes._
 - Skip font parsing on prebuild. ([#17184](https://github.com/expo/expo/pull/17184) by [@EvanBacon](https://github.com/EvanBacon))
 - [ci] Fix `typecheck`. ([#17145](https://github.com/expo/expo/pull/17145) by [@EvanBacon](https://github.com/EvanBacon))
 - Close development session when CLI is stopped ([#17170](https://github.com/expo/expo/pull/17170) by [@FiberJW](https://github.com/FiberJW))
+- Fixed an issue where the CLI would crash when connecting to third-party emulators like LDPlayer. ([@brsgrlr](https://github.com/brsgrlr))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -2516,7 +2516,7 @@ _This version does not introduce any user-facing changes._
 - Skip font parsing on prebuild. ([#17184](https://github.com/expo/expo/pull/17184) by [@EvanBacon](https://github.com/EvanBacon))
 - [ci] Fix `typecheck`. ([#17145](https://github.com/expo/expo/pull/17145) by [@EvanBacon](https://github.com/EvanBacon))
 - Close development session when CLI is stopped ([#17170](https://github.com/expo/expo/pull/17170) by [@FiberJW](https://github.com/FiberJW))
-- Fixed an issue where the CLI would crash when connecting to third-party emulators like LDPlayer. ([@brsgrlr](https://github.com/brsgrlr))
+- Fixed an issue where the CLI would crash when connecting to third-party emulators like LDPlayer. ([@brsgrlr](https://github.com/brsgrlr)) ([#45295](https://github.com/expo/expo/pull/45295) by [@brsgrlr](https://github.com/brsgrlr))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -300,14 +300,26 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
  * @param device.pid a value like `emulator-5554` from `abd devices`
  */
 export async function getAdbNameForDeviceIdAsync(device: DeviceContext): Promise<string | null> {
-  const results = await getServer().runAsync(adbArgs(device.pid, 'emu', 'avd', 'name'));
+  try {
+    const results = await getServer().runAsync(adbArgs(device.pid, 'emu', 'avd', 'name'));
 
-  if (results.match(/could not connect to TCP port .*: Connection refused/)) {
-    // Can also occur when the emulator does not exist.
-    throw new CommandError('EMULATOR_NOT_FOUND', results);
+    // Some versions of ADB might return the error string instead of throwing an exception.
+    if (results.match(/could not connect to TCP port .*: Connection refused/)) {
+      // Fallback to PID for third-party emulators (like LDPlayer or BlueStacks) 
+      // that do not support the emulator console/telnet port.
+      return device.pid;
+    }
+
+    return sanitizeAdbDeviceName(results) ?? null;
+  } catch (error: any) {
+    // Handle cases where the command fails with a non-zero exit code due to connection refusal.
+    if (error.message?.match(/could not connect to TCP port .*: Connection refused/)) {
+      return device.pid;
+    }
+    
+    // Re-throw if the error is unrelated to telnet connection issues.
+    throw error;
   }
-
-  return sanitizeAdbDeviceName(results) ?? null;
 }
 
 export async function isDeviceBootedAsync({

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -301,24 +301,15 @@ export async function getAttachedDevicesAsync(): Promise<Device[]> {
  */
 export async function getAdbNameForDeviceIdAsync(device: DeviceContext): Promise<string | null> {
   try {
+    // Attempt to get the AVD name via the emulator console
     const results = await getServer().runAsync(adbArgs(device.pid, 'emu', 'avd', 'name'));
-
-    // Some versions of ADB might return the error string instead of throwing an exception.
-    if (results.match(/could not connect to TCP port .*: Connection refused/)) {
-      // Fallback to PID for third-party emulators (like LDPlayer or BlueStacks) 
-      // that do not support the emulator console/telnet port.
-      return device.pid;
-    }
-
     return sanitizeAdbDeviceName(results) ?? null;
   } catch (error: any) {
-    // Handle cases where the command fails with a non-zero exit code due to connection refusal.
-    if (error.message?.match(/could not connect to TCP port .*: Connection refused/)) {
-      return device.pid;
-    }
-    
-    // Re-throw if the error is unrelated to telnet connection issues.
-    throw error;
+    // If the 'emu' command fails (common on third-party emulators like LDPlayer 
+    // where the telnet port is not available or localized errors occur),
+    // we fallback to the device PID as the name to prevent a fatal crash.
+    debug(`Could not get AVD name for device ${device.pid}: ${error.message}`);
+    return device.pid;
   }
 }
 


### PR DESCRIPTION
fix(cli): prevent crash when getting AVD name on third-party emulators (e.g. Bluestacks, LDPlayer)

Proposed Change:
Third-party emulators like Bluestacks and LDPlayer often use port 5554 for ADB instead of the standard Emulator Console (Telnet). When Expo CLI attempts to run emu avd name, it fails with a Connection refused error because the telnet port is unavailable, causing a fatal crash.

This change introduces a fallback mechanism. If the telnet connection is refused, the function now returns the device PID as a fallback instead of throwing a CommandError. This allows the CLI to proceed with the deployment process on these emulators.

# Why
Third-party Android emulators (such as LDPlayer, BlueStacks, and Nox) often map port 5554 directly to ADB services instead of the standard Emulator Console (Telnet).

When the Expo CLI detects a device named emulator-5554, it attempts to fetch the AVD name by running emu avd name. Because these emulators do not provide a Telnet console on that port, the command fails with a Connection refused error. Currently, the CLI treats this as a fatal CommandError, which causes the entire process to crash and prevents developers from using the "a" shortcut in the Terminal UI.

This fix ensures that the developer experience is not interrupted by fallbacking to a known identifier (the PID) when the high-level AVD name cannot be retrieved.

# How
I have modified packages/@expo/cli/src/start/platforms/android/adb.ts to wrap the getAdbNameForDeviceIdAsync logic in a try-catch block.

It specifically looks for the Connection refused error string in both the command output and the caught error message.

Instead of throwing a fatal CommandError, it now returns the device.pid as a fallback.

This allows the getAttachedDevicesAsync function to resolve successfully and continue the deployment process via standard ADB commands.

# Test Plan
Start a third-party emulator that occupies port 5554 (e.g., LDPlayer).

Confirm the device is listed as emulator-5554 via adb devices.

Run npx expo start in a React Native project.

Press "a" to open on Android.

Expected Result: The CLI should no longer crash with 10061 or Connection refused. It should successfully identify the device (using the PID as the name) and proceed to install/open Expo Go.

# Checklist
[x] I added a changelog.md entry

[x] This diff will work correctly for npx expo prebuild & EAS Build.

[x] Conforms with the Documentation Writing Style Guide.
