### PR TITLE
[iOS] Migrate OptimizedFunction to use ExpoModulesJSI API

### DIFF
--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
@@ -14,20 +14,11 @@ final class SharedPoint: SharedObject {
 }
 
 public final class BenchmarkingExpoModule: Module {
-//  @OptimizedFunction
-  private func addNumbersOptimized(a: Double, b: Double) throws -> Double {
-    return a + b
-  }
-
-//  @OptimizedFunction
-  private func addNumbersAsyncOptimized(a: Double, b: Double) throws -> Double {
-    return a + b
-  }
-
   public func definition() -> ModuleDefinition {
     Name("BenchmarkingExpoModule")
 
     Function("nothing") {}
+    Function("nothingOptimized", nothingOptimized())
 
     AsyncFunction("nothingAsync") { () async -> Void in }
 
@@ -37,19 +28,21 @@ public final class BenchmarkingExpoModule: Module {
       return a + b
     }
 
-    Function("addNumbersOptimized", addNumbersOptimized)
+    Function("addNumbersOptimized", addNumbersOptimized())
 
     AsyncFunction("addNumbersAsync") { (a: Double, b: Double) in
       return a + b
     }
 
-    AsyncFunction("addNumbersAsyncOptimized", addNumbersAsyncOptimized)
+    AsyncFunction("addNumbersAsyncOptimized", addNumbersAsyncOptimized())
 
     // MARK: - Strings
 
     Function("addStrings") { (a: String, b: String) in
       return a + b
     }
+
+    Function("addStringsOptimized", addStringsOptimized())
 
     // MARK: - Arrays
 
@@ -87,5 +80,23 @@ public final class BenchmarkingExpoModule: Module {
         return point.y
       }
     }
+  }
+
+  @OptimizedFunction
+  private func nothingOptimized() -> Void {}
+
+  @OptimizedFunction
+  private func addNumbersOptimized(a: Double, b: Double) throws -> Double {
+    return a + b
+  }
+
+  @OptimizedFunction
+  private func addNumbersAsyncOptimized(a: Double, b: Double) throws -> Double {
+    return a + b
+  }
+
+  @OptimizedFunction
+  private func addStringsOptimized(a: String, b: String) throws -> String {
+    return a + b
   }
 }

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
@@ -34,7 +34,7 @@ public final class BenchmarkingExpoModule: Module {
       return a + b
     }
 
-    AsyncFunction("addNumbersAsyncOptimized", addNumbersAsyncOptimized())
+    AsyncFunction("addNumbersAsyncOptimized", addNumbersOptimized())
 
     // MARK: - Strings
 
@@ -87,11 +87,6 @@ public final class BenchmarkingExpoModule: Module {
 
   @OptimizedFunction
   private func addNumbersOptimized(a: Double, b: Double) throws -> Double {
-    return a + b
-  }
-
-  @OptimizedFunction
-  private func addNumbersAsyncOptimized(a: Double, b: Double) throws -> Double {
     return a + b
   }
 

--- a/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
@@ -8,10 +8,12 @@ export declare class SharedPoint extends SharedObject {
 
 declare class BenchmarkingExpoModule extends NativeModule {
   nothing(): void;
+  nothingOptimized(): void;
   nothingAsync(): Promise<void>;
   addNumbers(a: number, b: number): number;
   addNumbersOptimized(a: number, b: number): number;
   addStrings(a: string, b: string): string;
+  addStringsOptimized(a: string, b: string): string;
   foldArray(array: number[]): number;
   passthroughDict(point: { x: number; y: number }): { x: number; y: number };
   passthroughRecord(point: { x: number; y: number }): { x: number; y: number };

--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
@@ -82,6 +82,17 @@ export const GROUPS: Group[] = [
         },
       },
       {
+        id: 'expo-optimized',
+        label: 'ExpoModule (optimized)',
+        available: ExpoModule?.nothingOptimized != null,
+        async run(iterations) {
+          ExpoModule.nothingOptimized();
+          return timeSync(iterations, () => {
+            ExpoModule.nothingOptimized();
+          });
+        },
+      },
+      {
         id: 'turbo',
         label: 'TurboModule',
         available: TurboModule?.nothing != null,
@@ -244,6 +255,17 @@ export const GROUPS: Group[] = [
           ExpoModule.addStrings('hello ', 'world');
           return timeSync(iterations, () => {
             ExpoModule.addStrings('hello ', 'world');
+          });
+        },
+      },
+      {
+        id: 'expo-optimized',
+        label: 'ExpoModule (optimized)',
+        available: ExpoModule?.addStringsOptimized != null,
+        async run(iterations) {
+          ExpoModule.addStringsOptimized('hello ', 'world');
+          return timeSync(iterations, () => {
+            ExpoModule.addStringsOptimized('hello ', 'world');
           });
         },
       },

--- a/packages/expo-modules-core/common/cpp/JSI/TestingSyncJSCallInvoker.h
+++ b/packages/expo-modules-core/common/cpp/JSI/TestingSyncJSCallInvoker.h
@@ -14,7 +14,7 @@ namespace react = facebook::react;
 namespace expo {
 
 /**
- * Dummy CallInvoker that invokes everything immediately.
+ * Dummy CallInvoker that invokes everything immediately on the calling thread.
  * Used in the test environment to check the async flow.
  */
 class TestingSyncJSCallInvoker : public react::CallInvoker {

--- a/packages/expo-modules-core/ios/Core/Functions/OptimizedAsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/OptimizedAsyncFunctionDefinition.swift
@@ -50,15 +50,21 @@ public struct OptimizedAsyncFunctionDefinition: AnyAsyncFunctionDefinition, @unc
 
   @JavaScriptActor
   public func build(appContext: AppContext) throws -> JavaScriptObject {
-    // TODO: Re-implement optimized async function registration using the new JSI API.
-    // The old implementation used NSInvocation with ObjC type encoding to bypass
-    // JavaScriptValue boxing for primitive types, dispatching to a background queue
-    // and returning a JS Promise. See OptimizedSyncFunctionDefinition for more context.
-    throw Exception(
-      name: "OptimizedFunctionUnavailable",
-      description: "OptimizedAsyncFunctionDefinition is not yet implemented with the new JSI API",
-      code: "ERR_OPTIMIZED_FUNCTION_UNAVAILABLE"
-    )
+    let runtime = try appContext.runtime
+    var object = runtime.createObject()
+    runtime.withUnsafePointee { runtimePointer in
+      object.withUnsafeMutablePointee { objectPointer in
+        OptimizedFunctionUtils.createAsyncFunction(
+          name: name,
+          intoObject: objectPointer,
+          runtimePointer: runtimePointer,
+          typeEncoding: typeEncoding,
+          argsCount: argsCount,
+          block: block
+        )
+      }
+    }
+    return object
   }
 
   // MARK: - AnyAsyncFunctionDefinition

--- a/packages/expo-modules-core/ios/Core/Functions/OptimizedSyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/OptimizedSyncFunctionDefinition.swift
@@ -62,16 +62,20 @@ public struct OptimizedSyncFunctionDefinition: AnySyncFunctionDefinition, @unche
   }
 
   public func build(appContext: AppContext, in runtime: JavaScriptRuntime) throws -> JavaScriptObject {
-    // TODO: Re-implement optimized function registration using the new JSI API.
-    // The old implementation used NSInvocation with ObjC type encoding to bypass
-    // JavaScriptValue boxing for primitive types. This needs a new approach
-    // that works with Swift/C++ interop — either a C++ helper in ExpoModulesJSI-Cxx
-    // or a pure Swift solution using the type encoding to read jsi::Value args directly.
-    throw Exception(
-      name: "OptimizedFunctionUnavailable",
-      description: "OptimizedSyncFunctionDefinition is not yet implemented with the new JSI API",
-      code: "ERR_OPTIMIZED_FUNCTION_UNAVAILABLE"
-    )
+    var object = runtime.createObject()
+    runtime.withUnsafePointee { runtimePointer in
+      object.withUnsafeMutablePointee { objectPointer in
+        OptimizedFunctionUtils.createSyncFunction(
+          name: name,
+          intoObject: objectPointer,
+          runtimePointer: runtimePointer,
+          typeEncoding: typeEncoding,
+          argsCount: argsCount,
+          block: block
+        )
+      }
+    }
+    return object
   }
 
   // MARK: - Descriptor Factory

--- a/packages/expo-modules-core/ios/ExpoModulesCore.h
+++ b/packages/expo-modules-core/ios/ExpoModulesCore.h
@@ -32,6 +32,7 @@
 #import <ExpoModulesCore/EXTaskServiceInterface.h>
 #import <ExpoModulesCore/EXJSIInstaller.h>
 #import <ExpoModulesCore/EXSharedObjectUtils.h>
+#import <ExpoModulesCore/EXOptimizedFunctionUtils.h>
 #import <ExpoModulesCore/EXExportedModule.h>
 #import <ExpoModulesCore/EXSingletonModule.h>
 #import <ExpoModulesCore/EXUtilities.h>

--- a/packages/expo-modules-core/ios/JS/EXOptimizedFunctionUtils.h
+++ b/packages/expo-modules-core/ios/JS/EXOptimizedFunctionUtils.h
@@ -1,0 +1,41 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ Bridges optimized function calls from Swift to C++/JSI.
+ Uses NSInvocation with ObjC type encoding to call `@convention(block)` closures
+ directly from jsi::Value arguments, bypassing JavaScriptValue boxing.
+ */
+NS_SWIFT_NAME(OptimizedFunctionUtils)
+@interface EXOptimizedFunctionUtils : NSObject
+
+/**
+ Creates a sync optimized JSI host function and moves it into the object at `objectPointer`.
+ The object pointer must point to a valid `jsi::Object` whose contents will be replaced.
+ */
++ (void)createSyncFunction:(nonnull NSString *)name
+              intoObject:(nonnull void *)objectPointer
+          runtimePointer:(nonnull void *)runtimePointer
+            typeEncoding:(nonnull NSString *)typeEncoding
+               argsCount:(NSInteger)argsCount
+                   block:(nonnull id)block
+    NS_SWIFT_NAME(createSyncFunction(name:intoObject:runtimePointer:typeEncoding:argsCount:block:));
+
+/**
+ Creates an async optimized JSI host function and moves it into the object at `objectPointer`.
+ The object pointer must point to a valid `jsi::Object` whose contents will be replaced.
+ */
++ (void)createAsyncFunction:(nonnull NSString *)name
+               intoObject:(nonnull void *)objectPointer
+           runtimePointer:(nonnull void *)runtimePointer
+             typeEncoding:(nonnull NSString *)typeEncoding
+                argsCount:(NSInteger)argsCount
+                    block:(nonnull id)block
+    NS_SWIFT_NAME(createAsyncFunction(name:intoObject:runtimePointer:typeEncoding:argsCount:block:));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/expo-modules-core/ios/JS/EXOptimizedFunctionUtils.mm
+++ b/packages/expo-modules-core/ios/JS/EXOptimizedFunctionUtils.mm
@@ -2,8 +2,6 @@
 
 #import <ExpoModulesCore/EXOptimizedFunctionUtils.h>
 
-#include <algorithm>
-
 #include <jsi/jsi.h>
 #include <ReactCommon/CallInvoker.h>
 #include <ReactCommon/TurboModuleUtils.h>
@@ -140,14 +138,21 @@ void parseTypeEncoding(NSString *typeEncoding, NSInteger argsCount, jsi::Runtime
 }
 
 /**
- Sets each JS argument on the invocation, capping the loop at the declared
- argument count so extras passed by JS are silently ignored (matching JS-native
- call semantics) rather than reading past `argTypes` and writing past the
- invocation's argument list.
+ Sets each JS argument on the invocation. Throws a JS error when the call site
+ passed a different number of arguments than the optimized function declares,
+ since the sync path reuses a cached invocation (omitted args would keep stale
+ values) and the async path would otherwise leave fresh slots uninitialized.
  */
 void setInvocationArguments(NSInvocation *invocation, const std::string &argTypes, jsi::Runtime &runtime, const jsi::Value *args, size_t count) {
-  size_t argLimit = std::min(count, argTypes.size());
-  for (size_t i = 0; i < argLimit; i++) {
+  if (count != argTypes.size()) {
+    throw jsi::JSError(
+      runtime,
+      "Received " + std::to_string(count) +
+      " arguments, but " + std::to_string(argTypes.size()) +
+      " was expected"
+    );
+  }
+  for (size_t i = 0; i < argTypes.size(); i++) {
     setInvocationArgument(invocation, i + 1, argTypes[i], runtime, args[i]);
   }
 }

--- a/packages/expo-modules-core/ios/JS/EXOptimizedFunctionUtils.mm
+++ b/packages/expo-modules-core/ios/JS/EXOptimizedFunctionUtils.mm
@@ -1,0 +1,336 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import <ExpoModulesCore/EXOptimizedFunctionUtils.h>
+
+#include <algorithm>
+
+#include <jsi/jsi.h>
+#include <ReactCommon/CallInvoker.h>
+#include <ReactCommon/TurboModuleUtils.h>
+#include <react/bridging/CallbackWrapper.h>
+#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+#include <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
+
+namespace jsi = facebook::jsi;
+namespace react = facebook::react;
+
+namespace {
+
+void setInvocationArgument(NSInvocation *invocation, NSUInteger index, char typeEncoding, jsi::Runtime &runtime, const jsi::Value &value) {
+  switch (typeEncoding) {
+    case 'd':
+    case 'f': {
+      double doubleValue = value.getNumber();
+      [invocation setArgument:&doubleValue atIndex:index];
+      break;
+    }
+    case 'q':
+    case 'l':
+    case 'i':
+    case 's':
+    case 'c': {
+      long long intValue = (long long)value.getNumber();
+      [invocation setArgument:&intValue atIndex:index];
+      break;
+    }
+    case 'B': {
+      bool boolValue = value.getBool();
+      [invocation setArgument:&boolValue atIndex:index];
+      break;
+    }
+    case '@': {
+      NSString *stringValue = [NSString stringWithUTF8String:value.asString(runtime).utf8(runtime).c_str()];
+      [invocation setArgument:&stringValue atIndex:index];
+      break;
+    }
+    default:
+      throw std::runtime_error(std::string("Unsupported argument type encoding: ") + typeEncoding);
+  }
+}
+
+jsi::Value getInvocationReturnValue(NSInvocation *invocation, char returnType, jsi::Runtime &runtime) {
+  switch (returnType) {
+    case 'v':
+      return jsi::Value::undefined();
+    case 'd':
+    case 'f': {
+      double returnValue;
+      [invocation getReturnValue:&returnValue];
+      return jsi::Value(returnValue);
+    }
+    case 'q':
+    case 'l':
+    case 'i':
+    case 's':
+    case 'c': {
+      long long returnValue;
+      [invocation getReturnValue:&returnValue];
+      return jsi::Value((double)returnValue);
+    }
+    case 'B': {
+      bool returnValue;
+      [invocation getReturnValue:&returnValue];
+      return jsi::Value(returnValue);
+    }
+    case '@': {
+      __unsafe_unretained NSString *returnValue = nil;
+      [invocation getReturnValue:&returnValue];
+      if (returnValue) {
+        return jsi::String::createFromUtf8(runtime, [returnValue UTF8String]);
+      }
+      return jsi::Value::null();
+    }
+    default:
+      throw std::runtime_error(std::string("Unsupported return type encoding: ") + returnType);
+  }
+}
+
+id getInvocationReturnValueAsObjC(NSInvocation *invocation, char returnType) {
+  switch (returnType) {
+    case 'v':
+      return nil;
+    case 'd':
+    case 'f': {
+      double ret;
+      [invocation getReturnValue:&ret];
+      return @(ret);
+    }
+    case 'q':
+    case 'l':
+    case 'i':
+    case 's':
+    case 'c': {
+      long long ret;
+      [invocation getReturnValue:&ret];
+      return @(ret);
+    }
+    case 'B': {
+      bool ret;
+      [invocation getReturnValue:&ret];
+      return @(ret);
+    }
+    case '@': {
+      __unsafe_unretained NSString *ret = nil;
+      [invocation getReturnValue:&ret];
+      return ret;
+    }
+    default:
+      return nil;
+  }
+}
+
+/**
+ Parses a method-signature `typeEncoding` string into an `NSMethodSignature` plus
+ a per-argument type-encoding string and a return-type character. Throws a JS
+ error in the given runtime if the encoding is invalid.
+ */
+void parseTypeEncoding(NSString *typeEncoding, NSInteger argsCount, jsi::Runtime &runtime, const char *errorContext, NSMethodSignature **outSignature, std::string *outArgTypes, char *outReturnType) {
+  NSMethodSignature *signature = [NSMethodSignature signatureWithObjCTypes:[typeEncoding UTF8String]];
+  if (!signature) {
+    throw jsi::JSError(runtime, std::string(errorContext) + ": " + std::string([typeEncoding UTF8String]));
+  }
+  std::string argTypes((size_t)argsCount, '\0');
+  for (NSInteger i = 0; i < argsCount; i++) {
+    argTypes[i] = [signature getArgumentTypeAtIndex:i + 1][0];
+  }
+  *outSignature = signature;
+  *outArgTypes = std::move(argTypes);
+  *outReturnType = [signature methodReturnType][0];
+}
+
+/**
+ Sets each JS argument on the invocation, capping the loop at the declared
+ argument count so extras passed by JS are silently ignored (matching JS-native
+ call semantics) rather than reading past `argTypes` and writing past the
+ invocation's argument list.
+ */
+void setInvocationArguments(NSInvocation *invocation, const std::string &argTypes, jsi::Runtime &runtime, const jsi::Value *args, size_t count) {
+  size_t argLimit = std::min(count, argTypes.size());
+  for (size_t i = 0; i < argLimit; i++) {
+    setInvocationArgument(invocation, i + 1, argTypes[i], runtime, args[i]);
+  }
+}
+
+jsi::Value convertNSExceptionToJSError(jsi::Runtime &runtime, NSException *exception) {
+  NSString *code = exception.userInfo[@"code"] ?: @"ERR_UNKNOWN";
+  NSString *message = exception.userInfo[@"message"] ?: exception.reason ?: @"Unknown error";
+  auto jsMessage = jsi::String::createFromUtf8(runtime, [message UTF8String]);
+  auto error = runtime.global()
+    .getProperty(runtime, "Error")
+    .asObject(runtime)
+    .asFunction(runtime)
+    .callAsConstructor(runtime, {jsi::Value(runtime, jsMessage)});
+  auto jsCode = jsi::String::createFromUtf8(runtime, [code UTF8String]);
+  error.asObject(runtime).setProperty(runtime, "code", jsi::Value(runtime, jsCode));
+  return error;
+}
+
+jsi::Value convertObjCToJSI(jsi::Runtime &runtime, id value) {
+  if (!value || [value isKindOfClass:[NSNull class]]) {
+    return jsi::Value::undefined();
+  }
+  if ([value isKindOfClass:[NSNumber class]]) {
+    NSNumber *number = (NSNumber *)value;
+    if (strcmp([number objCType], @encode(BOOL)) == 0) {
+      return jsi::Value([number boolValue]);
+    }
+    return jsi::Value([number doubleValue]);
+  }
+  if ([value isKindOfClass:[NSString class]]) {
+    return jsi::String::createFromUtf8(runtime, [(NSString *)value UTF8String]);
+  }
+  return jsi::Value::undefined();
+}
+
+} // anonymous namespace
+
+@implementation EXOptimizedFunctionUtils
+
++ (void)createSyncFunction:(NSString *)name
+              intoObject:(void *)objectPointer
+          runtimePointer:(void *)runtimePointer
+            typeEncoding:(NSString *)typeEncoding
+               argsCount:(NSInteger)argsCount
+                   block:(id)block
+{
+  auto &runtime = *reinterpret_cast<jsi::Runtime *>(runtimePointer);
+  auto &object = *reinterpret_cast<jsi::Object *>(objectPointer);
+
+  NSMethodSignature *signature;
+  std::string argTypes;
+  char returnType;
+  parseTypeEncoding(typeEncoding, argsCount, runtime, "Invalid type encoding for optimized function", &signature, &argTypes, &returnType);
+
+  // Pre-create and cache NSInvocation (JS execution is single-threaded).
+  NSInvocation *cachedInvocation = [NSInvocation invocationWithMethodSignature:signature];
+  [cachedInvocation setTarget:block];
+
+  auto propName = jsi::PropNameID::forUtf8(runtime, [name UTF8String]);
+  auto function = jsi::Function::createFromHostFunction(
+    runtime, propName, (unsigned int)argsCount,
+    [block, cachedInvocation, argTypes, returnType](
+      jsi::Runtime &runtime, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+
+    @try {
+      setInvocationArguments(cachedInvocation, argTypes, runtime, args, count);
+      [cachedInvocation invoke];
+      return getInvocationReturnValue(cachedInvocation, returnType, runtime);
+    } @catch (NSException *exception) {
+      throw jsi::JSError(runtime, convertNSExceptionToJSError(runtime, exception));
+    }
+  });
+
+  // Move the function into the caller's object, replacing its contents.
+  // jsi::Function is a subclass of jsi::Object, so move-assigning is valid.
+  object = std::move(function);
+}
+
++ (void)createAsyncFunction:(NSString *)name
+               intoObject:(void *)objectPointer
+           runtimePointer:(void *)runtimePointer
+             typeEncoding:(NSString *)typeEncoding
+                argsCount:(NSInteger)argsCount
+                    block:(id)block
+{
+  auto &runtime = *reinterpret_cast<jsi::Runtime *>(runtimePointer);
+  auto &object = *reinterpret_cast<jsi::Object *>(objectPointer);
+
+  NSMethodSignature *signature;
+  std::string argTypes;
+  char returnType;
+  parseTypeEncoding(typeEncoding, argsCount, runtime, "Invalid type encoding for optimized async function", &signature, &argTypes, &returnType);
+
+  // Build a `CallInvoker` from the runtime's scheduler binding so the resolve
+  // and reject callbacks are dispatched back onto the JS thread. When no
+  // binding is installed (plain runtimes, e.g. unit tests) the invocation runs
+  // inline on the calling thread — see the inline branch in the host function.
+  std::shared_ptr<react::CallInvoker> callInvoker;
+  if (auto binding = react::RuntimeSchedulerBinding::getBinding(runtime)) {
+    callInvoker = std::make_shared<react::RuntimeSchedulerCallInvoker>(binding->getRuntimeScheduler());
+  }
+
+  auto propName = jsi::PropNameID::forUtf8(runtime, [name UTF8String]);
+  auto function = jsi::Function::createFromHostFunction(
+    runtime, propName, (unsigned int)argsCount,
+    [block, signature, argTypes, returnType, callInvoker](
+      jsi::Runtime &runtime, const jsi::Value &thisVal, const jsi::Value *args, size_t count) -> jsi::Value {
+
+    // Create a fresh NSInvocation per call — async calls can overlap.
+    NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+    [invocation setTarget:block];
+
+    setInvocationArguments(invocation, argTypes, runtime, args, count);
+    // Retain arguments so strings survive the cross-thread dispatch.
+    [invocation retainArguments];
+
+    if (!callInvoker) {
+      // No scheduler binding (plain runtimes, e.g. unit tests). Run the
+      // invocation inline so we never escape the JS thread, mirroring the
+      // sync host function path.
+      auto promiseSetup = [invocation, returnType](jsi::Runtime &rt, std::shared_ptr<react::Promise> promise) {
+        @try {
+          [invocation invoke];
+          id result = getInvocationReturnValueAsObjC(invocation, returnType);
+          promise->resolve(convertObjCToJSI(rt, result));
+        } @catch (NSException *exception) {
+          promise->reject_.call(rt, convertNSExceptionToJSError(rt, exception));
+        }
+      };
+      return react::createPromiseAsJSIValue(runtime, std::move(promiseSetup));
+    }
+
+    auto promiseSetup = [invocation, returnType, callInvoker](jsi::Runtime &rt, std::shared_ptr<react::Promise> promise) {
+      // Wrap resolve/reject as long-lived, thread-safe weak references.
+      // The wrappers funnel calls back onto the JS thread via the call invoker
+      // and tear themselves down after the first settlement.
+      auto weakResolve = react::CallbackWrapper::createWeak(std::move(promise->resolve_), rt, callInvoker);
+      auto weakReject = react::CallbackWrapper::createWeak(std::move(promise->reject_), rt, callInvoker);
+
+      dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        @try {
+          [invocation invoke];
+          id result = getInvocationReturnValueAsObjC(invocation, returnType);
+
+          auto strongResolve = weakResolve.lock();
+          auto strongReject = weakReject.lock();
+          if (!strongResolve || !strongReject) {
+            return;
+          }
+          strongResolve->jsInvoker().invokeAsync([weakResolve, weakReject, result](jsi::Runtime &rt) {
+            auto resolve = weakResolve.lock();
+            auto reject = weakReject.lock();
+            if (!resolve || !reject) {
+              return;
+            }
+            resolve->callback().call(rt, convertObjCToJSI(rt, result));
+            resolve->destroy();
+            reject->destroy();
+          });
+        } @catch (NSException *exception) {
+          auto strongResolve = weakResolve.lock();
+          auto strongReject = weakReject.lock();
+          if (!strongResolve || !strongReject) {
+            return;
+          }
+          strongReject->jsInvoker().invokeAsync([weakResolve, weakReject, exception](jsi::Runtime &rt) {
+            auto resolve = weakResolve.lock();
+            auto reject = weakReject.lock();
+            if (!resolve || !reject) {
+              return;
+            }
+            reject->callback().call(rt, convertNSExceptionToJSError(rt, exception));
+            resolve->destroy();
+            reject->destroy();
+          });
+        }
+      });
+    };
+
+    return react::createPromiseAsJSIValue(runtime, std::move(promiseSetup));
+  });
+
+  object = std::move(function);
+}
+
+@end

--- a/packages/expo-modules-core/ios/Tests/OptimizedFunctionTests.swift
+++ b/packages/expo-modules-core/ios/Tests/OptimizedFunctionTests.swift
@@ -1,0 +1,270 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Foundation
+import Testing
+
+@testable import ExpoModulesCore
+
+@Suite("OptimizedFunction", .serialized)
+@JavaScriptActor
+struct OptimizedFunctionTests {
+  let appContext: AppContext
+
+  init() {
+    self.appContext = AppContext.create()
+
+    appContext.moduleRegistry.register(holder: mockModuleHolder(appContext) {
+      Name("TestModule")
+
+      Function(
+        "addNumbers",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "d@?dd",
+          argsCount: 2,
+          block: ({ (a: Double, b: Double) -> Double in
+            return a + b
+          } as @convention(block) (Double, Double) -> Double) as AnyObject
+        )
+      )
+
+      Function(
+        "addInts",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "q@?qq",
+          argsCount: 2,
+          block: ({ (a: Int64, b: Int64) -> Int64 in
+            return a + b
+          } as @convention(block) (Int64, Int64) -> Int64) as AnyObject
+        )
+      )
+
+      Function(
+        "concat",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "@@?@@",
+          argsCount: 2,
+          block: ({ (a: String, b: String) -> String in
+            return a + b
+          } as @convention(block) (String, String) -> String) as AnyObject
+        )
+      )
+
+      Function(
+        "negate",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "B@?B",
+          argsCount: 1,
+          block: ({ (value: Bool) -> Bool in
+            return !value
+          } as @convention(block) (Bool) -> Bool) as AnyObject
+        )
+      )
+
+      Function(
+        "noop",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "v@?",
+          argsCount: 0,
+          block: ({ () -> Void in
+            return
+          } as @convention(block) () -> Void) as AnyObject
+        )
+      )
+
+      AsyncFunction(
+        "addNumbersAsync",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "d@?dd",
+          argsCount: 2,
+          block: ({ (a: Double, b: Double) -> Double in
+            return a + b
+          } as @convention(block) (Double, Double) -> Double) as AnyObject
+        )
+      )
+
+      AsyncFunction(
+        "concatAsync",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "@@?@@",
+          argsCount: 2,
+          block: ({ (a: String, b: String) -> String in
+            return a + b
+          } as @convention(block) (String, String) -> String) as AnyObject
+        )
+      )
+
+      // Mirrors the throwing wrapper that the @OptimizedFunction macro generates:
+      // a Swift error becomes an NSException whose userInfo carries `code` and `message`.
+      Function(
+        "throwing",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "d@?d",
+          argsCount: 1,
+          block: ({ (value: Double) -> Double in
+            let exception = NSException(
+              name: NSExceptionName("OptimizedTestError"),
+              reason: "intentional failure",
+              userInfo: [
+                "name": "OptimizedTestError",
+                "code": "ERR_OPTIMIZED_TEST",
+                "message": "intentional failure"
+              ]
+            )
+            exception.raise()
+            return value
+          } as @convention(block) (Double) -> Double) as AnyObject
+        )
+      )
+
+      AsyncFunction(
+        "piAsync",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "d@?",
+          argsCount: 0,
+          block: ({ () -> Double in
+            return 3.14
+          } as @convention(block) () -> Double) as AnyObject
+        )
+      )
+
+      AsyncFunction(
+        "throwingAsync",
+        OptimizedSyncFunctionDefinition.createDescriptor(
+          typeEncoding: "d@?d",
+          argsCount: 1,
+          block: ({ (value: Double) -> Double in
+            let exception = NSException(
+              name: NSExceptionName("OptimizedAsyncTestError"),
+              reason: "intentional async failure",
+              userInfo: [
+                "name": "OptimizedAsyncTestError",
+                "code": "ERR_OPTIMIZED_ASYNC_TEST",
+                "message": "intentional async failure"
+              ]
+            )
+            exception.raise()
+            return value
+          } as @convention(block) (Double) -> Double) as AnyObject
+        )
+      )
+    })
+  }
+
+  var runtime: ExpoRuntime {
+    get throws {
+      try appContext.runtime
+    }
+  }
+
+  // MARK: - Sync
+
+  @Test
+  func `adds two doubles`() async throws {
+    let result = try await runtime.evalAsync("expo.modules.TestModule.addNumbers(2.5, 3.25)")
+    #expect(result.isNumber() == true)
+    #expect(result.getDouble() == 5.75)
+  }
+
+  @Test
+  func `adds two integers`() async throws {
+    let result = try await runtime.evalAsync("expo.modules.TestModule.addInts(40, 2)")
+    #expect(result.isNumber() == true)
+    #expect(result.getDouble() == 42.0)
+  }
+
+  @Test
+  func `concatenates two strings`() async throws {
+    let result = try await runtime.evalAsync("expo.modules.TestModule.concat('Hello, ', 'world!')")
+    #expect(result.isString() == true)
+    #expect(result.getString() == "Hello, world!")
+  }
+
+  @Test
+  func `negates a boolean`() async throws {
+    let trueResult = try await runtime.evalAsync("expo.modules.TestModule.negate(false)")
+    #expect(trueResult.isBool() == true)
+    #expect(trueResult.getBool() == true)
+
+    let falseResult = try await runtime.evalAsync("expo.modules.TestModule.negate(true)")
+    #expect(falseResult.isBool() == true)
+    #expect(falseResult.getBool() == false)
+  }
+
+  @Test
+  func `returns undefined for void return type`() async throws {
+    let result = try await runtime.evalAsync("expo.modules.TestModule.noop()")
+    #expect(result.isUndefined() == true)
+  }
+
+  // MARK: - Async
+
+  @Test
+  func `resolves with a number`() async throws {
+    let result = try await runtime.evalAsync("expo.modules.TestModule.addNumbersAsync(10, 32)")
+    #expect(result.isNumber() == true)
+    #expect(result.getDouble() == 42.0)
+  }
+
+  @Test
+  func `resolves with a string`() async throws {
+    let result = try await runtime.evalAsync("expo.modules.TestModule.concatAsync('async ', 'works')")
+    #expect(result.isString() == true)
+    #expect(result.getString() == "async works")
+  }
+
+  // MARK: - Exceptions
+
+  @Test
+  func `surfaces an NSException as a JS Error with a code`() async throws {
+    let result = try await runtime.evalAsync("""
+      (() => {
+        try {
+          expo.modules.TestModule.throwing(1);
+          return null;
+        } catch (error) {
+          return { message: error.message, code: error.code };
+        }
+      })()
+      """)
+    let error = try result.asObject()
+    #expect(try error.getProperty("message").asString() == "intentional failure")
+    #expect(try error.getProperty("code").asString() == "ERR_OPTIMIZED_TEST")
+  }
+
+  @Test
+  func `resolves a no-arg async call`() async throws {
+    let result = try await runtime.evalAsync("expo.modules.TestModule.piAsync()")
+    #expect(result.isNumber() == true)
+    #expect(result.getDouble() == 3.14)
+  }
+
+  @Test
+  func `rejects with a JS Error when an NSException is raised`() async throws {
+    let result = try await runtime.evalAsync("""
+      expo.modules.TestModule.throwingAsync(1).then(
+        () => null,
+        (error) => ({ message: error.message, code: error.code })
+      )
+      """)
+    let error = try result.asObject()
+    #expect(try error.getProperty("message").asString() == "intentional async failure")
+    #expect(try error.getProperty("code").asString() == "ERR_OPTIMIZED_ASYNC_TEST")
+  }
+
+  @Test
+  func `keeps overlapping async calls isolated`() async throws {
+    // Fires both promises and awaits the joined result, so the two NSInvocations
+    // run concurrently from the helper's perspective. Verifies they do not share
+    // state (e.g. arguments leaking between calls).
+    let result = try await runtime.evalAsync("""
+      Promise.all([
+        expo.modules.TestModule.addNumbersAsync(1, 2),
+        expo.modules.TestModule.addNumbersAsync(10, 20)
+      ])
+      """)
+    let array = try result.asArray()
+    #expect(array.length == 2)
+    #expect(try array.getValue(at: 0).asDouble() == 3.0)
+    #expect(try array.getValue(at: 1).asDouble() == 30.0)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/OptimizedFunctionTests.swift
+++ b/packages/expo-modules-core/ios/Tests/OptimizedFunctionTests.swift
@@ -252,6 +252,41 @@ struct OptimizedFunctionTests {
   }
 
   @Test
+  func `throws when fewer arguments than declared are passed`() async throws {
+    let error = try await #require(throws: ScriptEvaluationError.self) {
+      return try await runtime.evalAsync("expo.modules.TestModule.addNumbers(1)")
+    }
+    #expect(error.message == "Received 1 arguments, but 2 was expected")
+  }
+
+  @Test
+  func `throws when more arguments than declared are passed`() async throws {
+    let error = try await #require(throws: ScriptEvaluationError.self) {
+      return try await runtime.evalAsync("expo.modules.TestModule.addNumbers(1, 2, 3)")
+    }
+    #expect(error.message == "Received 3 arguments, but 2 was expected")
+  }
+
+  @Test
+  func `async call throws when fewer arguments than declared are passed`() async throws {
+    // Argument count is validated synchronously, so the host function throws
+    // before a promise is ever returned.
+    let error = try await #require(throws: ScriptEvaluationError.self) {
+      return try await runtime.evalAsync("expo.modules.TestModule.addNumbersAsync(1)")
+    }
+    #expect(error.message == "Received 1 arguments, but 2 was expected")
+  }
+
+  @Test
+  func `propagates the host-function error to Swift when uncaught in JS`() async throws {
+    // When the JS source doesn't catch the error, JSI surfaces it as a C++
+    // exception and `evalAsync` rethrows it as a Swift error.
+    await #expect(throws: (any Error).self) {
+      try await runtime.evalAsync("expo.modules.TestModule.addNumbers(1)")
+    }
+  }
+
+  @Test
   func `keeps overlapping async calls isolated`() async throws {
     // Fires both promises and awaits the joined result, so the two NSInvocations
     // run concurrently from the helper's perspective. Verifies they do not share

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -367,6 +367,26 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
   }
 
   /**
+   Provides scoped access to a raw pointer to the underlying `facebook.jsi.Object`.
+   The pointer is valid only for the duration of the closure and must not be stored or escaped.
+   */
+  public func withUnsafePointee<R>(_ body: (UnsafeRawPointer) throws -> R) rethrows -> R {
+    return try withUnsafeBytes(of: pointee) { bytes in
+      return try body(bytes.baseAddress!)
+    }
+  }
+
+  /**
+   Provides scoped mutable access to a raw pointer to the underlying `facebook.jsi.Object`.
+   The pointer is valid only for the duration of the closure and must not be stored or escaped.
+   */
+  public mutating func withUnsafeMutablePointee<R>(_ body: (UnsafeMutableRawPointer) throws -> R) rethrows -> R {
+    return try withUnsafeMutableBytes(of: &pointee) { bytes in
+      return try body(bytes.baseAddress!)
+    }
+  }
+
+  /**
    Creates a weak reference to the object. If the only references to an object are these, the object is eligible for GC.
    */
   public func createWeak() -> JavaScriptWeakObject {


### PR DESCRIPTION
## Why

`@OptimizedFunction` was disabled when the JSI layer was rewritten in #44337. This restores it on top of the new `ExpoModulesJSI` API so optimized sync and async functions are usable again.

## How

- New `EXOptimizedFunctionUtils` ObjC++ helper that builds JSI host functions from a type-encoding string and a `@convention(block)` closure, bypassing `JavaScriptValue` boxing for primitive types.
- `OptimizedSyncFunctionDefinition.build` and `OptimizedAsyncFunctionDefinition.build` create an empty `JavaScriptObject`, hand its raw `jsi::Object` pointer to the helper, and let the helper move-assign a `jsi::Function` into it.
- Async path uses `createPromiseAsJSIValue` + `CallbackWrapper` + `RuntimeSchedulerCallInvoker` (the same pattern the old `EXJavaScriptRuntime` used) to bounce resolve/reject back onto the JS thread. When no scheduler binding is installed (plain runtimes used by unit tests) the helper runs the invocation inline so JSI is never touched off-thread.
- Added `JavaScriptObject.withUnsafePointee` / `withUnsafeMutablePointee` to expose the underlying `jsi::Object` pointer to the helper.
- Re-enabled `@OptimizedFunction` on the bare-expo benchmark module's `addNumbersOptimized` / `addNumbersAsyncOptimized`.

## Test Plan

- New `OptimizedFunctionTests` Swift Testing suite covering:
  - Sync calls for every supported type encoding (`d`, `q`, `@`, `B`, `v`).
  - Async calls with no args, with multiple args, and concurrent calls via `Promise.all`.
  - NSException → JS Error bridging on both sync and async paths, including the `code` property carried in `userInfo`.
- Bare-expo benchmark screen exercises the production code path end-to-end (background-queue invocation + cross-thread resolution).