### PR TITLE
[modules-jsi][ios] Fix JS object leak in JavaScriptValuesBuffer

### DIFF
--- a/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
@@ -120,6 +120,14 @@ struct SharedObjectTests {
     #expect(try isReturningItself.asBool() == true)
   }
 
+  @Test
+  func `releases the native object when JS reference is garbage-collected`() throws {
+    let registrySizeBefore = appContext.sharedObjectRegistry.size
+    try runtime.eval("(() => { new expo.modules.SharedObjectModule.SharedObjectExample() })()")
+    try runtime.eval("gc() && gc() && gc()")
+    #expect(appContext.sharedObjectRegistry.size == registrySizeBefore)
+  }
+
   // MARK: - Native object
 
   @Test

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -44,6 +44,9 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
 
   deinit {
     if ownsMemory {
+      // Run the destructor for each `jsi::Value` so they release their strong refs to JS objects.
+      // Without this, calling host functions through this buffer leaks every JS-object argument.
+      bufferPointer.deinitialize()
       bufferPointer.deallocate()
     }
   }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptValuesBufferTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptValuesBufferTests.swift
@@ -1,0 +1,63 @@
+import Testing
+import ExpoModulesJSI
+
+@Suite
+@JavaScriptActor
+struct JavaScriptValuesBufferTests {
+  let runtime = JavaScriptRuntime()
+
+  @Test
+  func `allocate with values populates count and subscript`() throws {
+    let buffer = JavaScriptValuesBuffer.allocate(in: runtime, with: 1, "two", true)
+    #expect(buffer.count == 3)
+    #expect(try buffer[0].asInt() == 1)
+    #expect(try buffer[1].asString() == "two")
+    #expect(try buffer[2].asBool() == true)
+  }
+
+  @Test
+  func `empty buffer has zero count and deinits cleanly`() {
+    let buffer = JavaScriptValuesBuffer.allocate(in: runtime, capacity: 0)
+    #expect(buffer.count == 0)
+    // Deinit running cleanly is the assertion — no crash on deallocate of an empty buffer.
+  }
+
+  @Test
+  func `copy produces an independent buffer with the same values`() throws {
+    let original = JavaScriptValuesBuffer.allocate(in: runtime, with: 42, "hello")
+    let duplicate = original.copy()
+
+    #expect(duplicate.count == original.count)
+    #expect(try duplicate[0].asInt() == 42)
+    #expect(try duplicate[1].asString() == "hello")
+  }
+
+  @Test
+  func `map enumerates values in order`() {
+    let buffer = JavaScriptValuesBuffer.allocate(in: runtime, with: 1, 2, 3)
+    let values = buffer.map { value, _ in (try? value.asInt()) ?? 0 }
+    #expect(values == [1, 2, 3])
+  }
+
+  @Test
+  func `does not leak the JS object referenced as an argument`() throws {
+    // Regression test for a bug where `JavaScriptValuesBuffer.deinit` deallocated
+    // the underlying memory without first running the destructors of the contained
+    // `jsi::Value`s, leaking each value's strong ref to its JS object. Calling any
+    // JS function via `JavaScriptValuesBuffer` would silently leak its arguments.
+    let object = runtime.createObject()
+    let weak = object.createWeak()
+
+    // Allocate a buffer that captures the JS object as an argument; the result is
+    // discarded and `deinit` runs at the end of this statement. If `deinit` skipped
+    // `deinitialize`, the contained `jsi::Value` would still hold a strong ref and
+    // the weak handle would survive `gc()`.
+    _ = JavaScriptValuesBuffer.allocate(in: runtime, with: object.asValue())
+    _ = consume object
+
+    try runtime.eval("gc() && gc() && gc()")
+
+    let stillAlive = weak.lock() != nil
+    #expect(stillAlive == false)
+  }
+}


### PR DESCRIPTION
## Summary

- `JavaScriptValuesBuffer.deinit` was calling `deallocate()` on the underlying buffer without first running `deinitialize()`. Each contained `jsi::Value` holds a strong ref to a JS object; without running their destructors, those refs leaked.
- Affects every host function call path that goes through `JavaScriptValuesBuffer.allocate(in:with:)` — most notably `JavaScriptObject.defineProperty(...)`, which is invoked during every SharedObject registration in core. Net effect: SharedObjects created from JS were never garbage-collected, even after their JS-side references were dropped.
- One-line fix in `JavaScriptValuesBuffer.swift`. New `JavaScriptValuesBufferTests.swift` covers basic invariants (allocate/copy/map/empty) plus a focused regression test for the deinit. A cross-package regression test in `SharedObjectTests.swift` confirms the SharedObject GC release path now works.

## Test plan

- [x] Run the ExpoModulesJSI test suite — `JavaScriptValuesBufferTests` passes.
- [x] Run ExpoModulesCore iOS tests — the new `releases the native object when JS reference is garbage-collected` test in `SharedObjectTests` passes.
- [x] Without the deinit fix, the regression tests fail (verified locally).

<!-- disable:changelog-checks -->