### PR TITLE
[observe-tester] Fix simulator detection in test:ios script

### DIFF
--- a/apps/observe-tester/scripts/test-ios.sh
+++ b/apps/observe-tester/scripts/test-ios.sh
@@ -1,24 +1,55 @@
 #!/usr/bin/env bash
 # Run the iOS unit-test schemes for ExpoAppMetrics and ExpoObserve against
-# whichever iOS simulator is currently booted. Boot a simulator first
-# (e.g. via `xcrun simctl boot <name>` or by opening Simulator.app) and
-# then run `pnpm test:ios` from this app's directory.
+# the currently booted iOS simulator. If none is booted, the newest
+# available iPhone simulator is booted automatically.
 
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
-UDID=$(xcrun simctl list devices available -j | \
-  jq -r '.devices | to_entries | map(select(.key|test("iOS"))) | .[-1].value | map(select(.isAvailable)) | .[0].udid')
+UDID=$(xcrun simctl list devices booted -j | \
+  jq -r '[.devices | to_entries[] | select(.key|test("iOS")) | .value[]] | .[0].udid // empty')
+
+if [[ -z "$UDID" ]]; then
+  PICK=$(xcrun simctl list devices available -j | jq -r '
+    [ .devices | to_entries[]
+      | select(.key | test("SimRuntime\\.iOS-"))
+      | .key as $rt
+      | (($rt | capture("iOS-(?<maj>[0-9]+)(-(?<min>[0-9]+))?")) as $v
+         | (($v.maj|tonumber) * 1000 + (($v.min // "0")|tonumber))) as $ver
+      | .value[]
+      | select(.isAvailable)
+      | {udid, name, ver: $ver, iphone: (.name | test("^iPhone"))}
+    ]
+    | sort_by([-.ver, (if .iphone then 0 else 1 end), .name])
+    | .[0] | "\(.udid)\t\(.name)" // empty')
+
+  if [[ -z "$PICK" ]]; then
+    echo "error: no iOS simulator is booted and none is available to boot." >&2
+    echo "Install an iOS simulator runtime via Xcode (Settings > Components), then rerun \`pnpm test:ios\`." >&2
+    exit 1
+  fi
+
+  UDID=${PICK%%$'\t'*}
+  NAME=${PICK#*$'\t'}
+  echo "No simulator booted; booting $NAME ($UDID)..."
+  xcrun simctl boot "$UDID"
+fi
 
 echo "Running iOS unit tests against simulator: $UDID"
+
+if command -v xcbeautify >/dev/null 2>&1; then
+  FORMATTER=(xcbeautify)
+else
+  FORMATTER=(cat)
+fi
 
 xcodebuild test \
   -workspace ios/Observe.xcworkspace \
   -scheme ExpoAppMetrics-Unit-Tests \
-  -destination "id=$UDID"
+  -destination "id=$UDID" | "${FORMATTER[@]}"
 
 xcodebuild test \
   -workspace ios/Observe.xcworkspace \
   -scheme ExpoObserve-Unit-Tests \
-  -destination "id=$UDID"
+  -destination "id=$UDID" | "${FORMATTER[@]}"


### PR DESCRIPTION
# Why

Running `pnpm test:ios` was failing with `id=null` reaching xcodebuild. The jq query picked the last iOS runtime by lexicographic order rather than the actually-booted device, and didn't filter for booted state at all despite the script's comment saying it should.

# How

- Look up the booted iOS simulator via `simctl list devices booted`.
- If none is booted, pick the newest available iPhone simulator (highest iOS version, iPhones preferred over iPads) and `simctl boot` it.
- Fall back to a clear actionable error only when no iOS runtime is installed at all.
- Pipe `xcodebuild` through `xcbeautify` when it's available, otherwise pass output through unchanged.

# Test Plan

- `pnpm test:ios` with no simulator booted &rarr; auto-boots iPhone 17 Pro Max and runs.
- `pnpm test:ios` with a simulator already booted &rarr; reuses it.
- `pnpm test:ios` with no iOS runtimes installed &rarr; clear error, no `id=null`.
