### PR TITLE
[core][Android] Use pika index-based property dispatch

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation workletsProject
   }
 
-  implementation("io.github.lukmccall.pika:pika-api:0.1.9-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-api:0.2.1-2.1.20")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/PropsParsingStrategy.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/PropsParsingStrategy.kt
@@ -54,7 +54,7 @@ sealed interface PropsParsingStrategy<Props : ComposeProps> {
         prop.name to ComposeViewProp(
           prop.name,
           AnyType(propType),
-          prop.getter as (Any) -> Any?
+          prop::get as (Any) -> Any?
         )
       }
     }
@@ -76,7 +76,7 @@ sealed interface PropsParsingStrategy<Props : ComposeProps> {
         prop.name to ComposeViewProp(
           prop.name,
           AnyType(propType),
-          prop.getter as (Any) -> Any?
+          prop::get as (Any) -> Any?
         )
       }
     }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/records/RecordTypeConverter.kt
@@ -202,7 +202,7 @@ class IntrospectableRecordConversionStrategy<T : Record>(
         PropertyDescriptor(
           key = propertyName,
           typeDescriptor = propertyTypeDescriptor,
-          setter = property.setter as (Any, Any?) -> Unit,
+          setter = property::set as (Any, Any?) -> Unit,
           typeConverter = converterProvider.obtainTypeConverter(propertyTypeDescriptor),
           isRequired = isRequired
         )

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-  implementation("io.github.lukmccall.pika:pika-gradle:0.1.9-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.2.1-2.1.20")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")


### PR DESCRIPTION
# Why

Replace per-property getter/setter lambdas in Pika-generated `$Companion` classes with index-based dispatch (`when(Int)` → JVM `tableswitch`). Each property previously generated two `ExternalSyntheticLambda` classes (getter + setter) that were loaded and verified by ART at startup. Now a single `__pika$PropertyGet`/`__pika$PropertySet` method handles all properties via direct field access.
     

# How

```
                                                                                                                                                                                                                   
Simpleperf Traces (CPU time @ ~2 GHz)                                                                                                                                                                            
 
┌───────────────────┬────────┬───────┬───────────────┐                                                                                                                                                           
│      Thread       │ Before │ After │     Saved     │
├───────────────────┼────────┼───────┼───────────────┤
│ Total             │ 9.57s  │ 8.28s │ -1.28s (-13%) │
├───────────────────┼────────┼───────┼───────────────┤
│ Main              │ 2.06s  │ 1.89s │ -0.16s        │                                                                                                                                                           
├───────────────────┼────────┼───────┼───────────────┤                                                                                                                                                           
│ DefaultDispatch   │ 1.27s  │ 0.44s │ -0.82s (-65%) │                                                                                                                                                           
├───────────────────┼────────┼───────┼───────────────┤                                                                                                                                                           
│ pool-3 (verifier) │ 0.82s  │ 0.68s │ -0.14s        │
└───────────────────┴────────┴───────┴───────────────┘                                                                                                                                                           
                
Class Verification at Startup                                                                                                                                                                                    
                
┌─────────────────────────┬─────────────────┬─────────────────┬────────────────────────────┐                                                                                                                     
│       Class type        │     Before      │      After      │           Delta            │
├─────────────────────────┼─────────────────┼─────────────────┼────────────────────────────┤
│ Total VerifyClass       │ 9,687 (1,496ms) │ 8,892 (1,490ms) │ -795 classes               │
├─────────────────────────┼─────────────────┼─────────────────┼────────────────────────────┤
│ ExternalSyntheticLambda │ 1,607 (25ms)    │ 754 (18ms)      │ -853 eliminated            │                                                                                                                     
├─────────────────────────┼─────────────────┼─────────────────┼────────────────────────────┤                                                                                                                     
│ $Companion              │ 700 (127ms)     │ 495 (27ms)      │ -205, -100ms               │                                                                                                                     
├─────────────────────────┼─────────────────┼─────────────────┼────────────────────────────┤                                                                                                                     
│ $__Pika                 │ 0               │ 219 (33ms)      │ +219 (replaces Companions) │
└─────────────────────────┴─────────────────┴─────────────────┴────────────────────────────┘                                                                                                                     
                
What Changed                                                                                                                                                                                                     
                
- $__Pika replaces $Companion with index-based property dispatch (when(Int) → tableswitch) instead of per-property getter/setter lambdas                                                                         
- 853 ExternalSyntheticLambda classes no longer loaded at startup (all from expo.modules.* property accessors)
- $Companion verification dropped from 127ms → 27ms (removed synthetic accessor overhead)                                                                                                                        
- Module registration: 435ms → 284ms (-35%)                                                                                                                                                                      
                                                      
```

# Test Plan

- bare-expo ✅ 