### PR TITLE
[docs] Update Extending Jetpack Compose to use Prerequisite component

### DIFF
--- a/docs/pages/guides/expo-ui-jetpack-compose/extending.mdx
+++ b/docs/pages/guides/expo-ui-jetpack-compose/extending.mdx
@@ -5,20 +5,27 @@ description: Learn how to create custom Jetpack Compose components and modifiers
 platforms: ['android']
 ---
 
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
+import { CODE } from '~/ui/components/Text';
 
 This guide explains how to create custom Jetpack Compose components and modifiers that integrate seamlessly with Expo UI.
 
-## Prerequisites
+<Prerequisites>
+  <Requirement title={<><CODE>@expo/ui</CODE> installed</>}>
+    See [Building Jetpack Compose apps with Expo UI](/versions/latest/sdk/ui/jetpack-compose/) for more information.
 
-Before you begin, make sure you have:
+    <Terminal cmd={['$ npx expo install @expo/ui']} />
 
-- `@expo/ui` installed in your project. See [Building Jetpack Compose apps with Expo UI](/versions/latest/sdk/ui/jetpack-compose/) for more information.
-- A [development build](/develop/development-builds/introduction/) of your app (Expo UI is not available in Expo Go).
-- Basic familiarity with [Expo Modules API](/modules/overview/) and [Jetpack Compose](https://developer.android.com/jetpack/compose).
-
-<Terminal cmd={['$ npx expo install @expo/ui']} />
+  </Requirement>
+  <Requirement title="A development build of your app">
+    Expo UI is not available in Expo Go. Create a [development build](/develop/development-builds/introduction/) of your app.
+  </Requirement>
+  <Requirement title="Basic familiarity with Expo Modules API and Jetpack Compose">
+    Familiarity with [Expo Modules API](/modules/overview/) and [Jetpack Compose](https://developer.android.com/jetpack/compose).
+  </Requirement>
+</Prerequisites>
 
 ## Creating a custom component
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
<img width="2572" height="770" alt="CleanShot 2026-05-03 at 13 27 12@2x" src="https://github.com/user-attachments/assets/c2258a17-7a43-4395-83bf-de3ecd4baef7" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Update Extending Jetpack Compose to use `Prerequisite` component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
