### PR TITLE
[app-metrics][android] Implement getAllSessions and track session end timestamps

### DIFF
--- a/apps/observe-tester/app/(tabs)/(sessions)/sessions/[id].tsx
+++ b/apps/observe-tester/app/(tabs)/(sessions)/sessions/[id].tsx
@@ -22,10 +22,6 @@ export default function SessionDetail() {
 
   useFocusEffect(
     useCallback(() => {
-      if (Platform.OS !== 'ios') {
-        setLoaded(true);
-        return;
-      }
       AppMetrics.getAllSessions().then((sessions) => {
         setSession(sessions.find((s) => s.id === id) ?? null);
         setLoaded(true);

--- a/apps/observe-tester/app/(tabs)/(sessions)/sessions/index.tsx
+++ b/apps/observe-tester/app/(tabs)/(sessions)/sessions/index.tsx
@@ -41,11 +41,7 @@ export default function SessionsList() {
 
   useFocusEffect(
     useCallback(() => {
-      if (Platform.OS === 'ios') {
-        refresh();
-      } else {
-        setLoaded(true);
-      }
+      refresh();
     }, [refresh])
   );
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -3,9 +3,9 @@ package expo.modules.appmetrics
 import android.content.Context
 import expo.modules.appmetrics.appstartup.AppStartupManager
 import expo.modules.appmetrics.memory.MemoryMetricsManager
+import expo.modules.appmetrics.storage.JsSession
 import expo.modules.appmetrics.storage.Metric
 import expo.modules.appmetrics.storage.SessionManager
-import expo.modules.appmetrics.storage.toJsSession
 import expo.modules.appmetrics.updates.UpdatesMonitoring
 import expo.modules.appmetrics.updates.UpdatesStateEvent
 import expo.modules.appmetrics.utils.TimeUtils
@@ -116,7 +116,7 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       AsyncFunction("getStoredEntries") Coroutine { -> sessionManager.getAllSessions() }
 
       AsyncFunction("getAllSessions") Coroutine { ->
-        sessionManager.getAllSessions().map { it.toJsSession() }
+        sessionManager.getAllSessions().map { JsSession.fromSessionWithMetrics(it) }
       }
 
       AsyncFunction("takeMemoryUsageSnapshotAsync") Coroutine { sessionId: String? ->

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -5,6 +5,7 @@ import expo.modules.appmetrics.appstartup.AppStartupManager
 import expo.modules.appmetrics.memory.MemoryMetricsManager
 import expo.modules.appmetrics.storage.Metric
 import expo.modules.appmetrics.storage.SessionManager
+import expo.modules.appmetrics.storage.toJsSession
 import expo.modules.appmetrics.updates.UpdatesMonitoring
 import expo.modules.appmetrics.updates.UpdatesStateEvent
 import expo.modules.appmetrics.utils.TimeUtils
@@ -65,12 +66,21 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       OnCreate {
         sessionManager = SessionManager(context)
 
-        // Deactivate all sessions from previous app runs
+        appSessionId = sessionManager.createSessionId()
+
+        // Persist the session row eagerly so it's visible to readers
+        // (`getAllSessions`, `addCustomMetricToSession`, …) before any startup
+        // metrics arrive. Older app runs are deactivated in the same coroutine
+        // to keep the order well-defined.
         scope.launch {
           sessionManager.deactivateAllSessionsBefore(moduleCreationTimestamp)
+          sessionManager.startSessionWithIdAt(
+            sessionId = appSessionId,
+            timestamp = TimeUtils.getProcessStartTimestamp(),
+            metadata = metadata
+          )
         }
 
-        appSessionId = sessionManager.createSessionId()
         memoryMetricsManager = MemoryMetricsManager(
           context = context,
           sessionManager = sessionManager
@@ -93,6 +103,10 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       }
 
       AsyncFunction("getStoredEntries") Coroutine { -> sessionManager.getAllSessions() }
+
+      AsyncFunction("getAllSessions") Coroutine { ->
+        sessionManager.getAllSessions().map { it.toJsSession() }
+      }
 
       AsyncFunction("takeMemoryUsageSnapshotAsync") Coroutine { sessionId: String? ->
         return@Coroutine memoryMetricsManager.takeMemorySnapshot(sessionId)
@@ -155,14 +169,9 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
   // TODO(@lukmccall): Potential race condition - multiple coroutines could enter the block simultaneously, causing duplicates.
   internal suspend fun saveStartupMetricsIfNotSaved() {
     if (!didSaveStartupMetrics) {
-      // This function should be called, after all startup events are collected
-      // This seems to be the best place right now, because it will not slow down the app startup
-      sessionManager.startSessionWithIdAndMetricsAt(
-        id = appSessionId,
-        timestamp = TimeUtils.getProcessStartTimestamp(),
-        metrics = AppStartupManager.metrics,
-        metadata = metadata
-      )
+      // The session row is written eagerly in `OnCreate`, so we only need to
+      // attach the startup metrics here once they've been collected.
+      sessionManager.addMetrics(AppStartupManager.metrics, sessionId = appSessionId)
       didSaveStartupMetrics = true
     }
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -20,6 +20,7 @@ import expo.modules.updatesinterface.UpdatesControllerRegistry
 import expo.modules.updatesinterface.UpdatesStateChangeListener
 import expo.modules.updatesinterface.UpdatesStateChangeSubscription
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -40,6 +41,11 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
   private val moduleCreationTimestamp = TimeUtils.getCurrentTimestampInISOFormat()
 
   lateinit var sessionManager: SessionManager
+
+  // Tracks the in-flight session-row INSERT kicked off in `OnCreate`. `OnDestroy`
+  // joins it before stamping `endTimestamp` so the UPDATE doesn't race with the
+  // INSERT and silently no-op.
+  private var sessionStartJob: Job? = null
 
   private var didSaveStartupMetrics: Boolean = false
 
@@ -69,12 +75,12 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
 
         appSessionId = sessionManager.createSessionId()
 
-        // Persist the session row synchronously so it's visible to readers
+        // Persist the session row eagerly so it's visible to readers
         // (`getAllSessions`, `addCustomMetricToSession`, …) before any startup
-        // metrics arrive, and so `OnDestroy` can rely on the row existing when
-        // it stamps `endTimestamp`. Older app runs are deactivated in the same
-        // block to keep the order well-defined.
-        runBlocking {
+        // metrics arrive. Older app runs are deactivated in the same coroutine
+        // to keep the order well-defined. The `Job` is captured so `OnDestroy`
+        // can wait for the INSERT before stamping `endTimestamp`.
+        sessionStartJob = scope.launch {
           sessionManager.deactivateAllSessionsBefore(moduleCreationTimestamp)
           sessionManager.startSessionWithIdAt(
             sessionId = appSessionId,
@@ -107,8 +113,11 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
       OnDestroy {
         // `modulesQueue` is cancelled immediately after this hook returns, so
         // run the UPDATE on the calling thread to make sure the end timestamp
-        // is persisted before teardown.
+        // is persisted before teardown. Joining `sessionStartJob` first
+        // guarantees the INSERT lands before the UPDATE so the stamp doesn't
+        // silently no-op on a missing row.
         runBlocking {
+          sessionStartJob?.join()
           sessionManager.stopSession(appSessionId)
         }
       }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -21,6 +21,7 @@ import expo.modules.updatesinterface.UpdatesStateChangeListener
 import expo.modules.updatesinterface.UpdatesStateChangeSubscription
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 
 class AppMetricsModule : Module(), UpdatesStateChangeListener {
@@ -68,11 +69,12 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
 
         appSessionId = sessionManager.createSessionId()
 
-        // Persist the session row eagerly so it's visible to readers
+        // Persist the session row synchronously so it's visible to readers
         // (`getAllSessions`, `addCustomMetricToSession`, …) before any startup
-        // metrics arrive. Older app runs are deactivated in the same coroutine
-        // to keep the order well-defined.
-        scope.launch {
+        // metrics arrive, and so `OnDestroy` can rely on the row existing when
+        // it stamps `endTimestamp`. Older app runs are deactivated in the same
+        // block to keep the order well-defined.
+        runBlocking {
           sessionManager.deactivateAllSessionsBefore(moduleCreationTimestamp)
           sessionManager.startSessionWithIdAt(
             sessionId = appSessionId,
@@ -100,6 +102,15 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
 
       OnActivityDestroys {
         subscription?.remove()
+      }
+
+      OnDestroy {
+        // `modulesQueue` is cancelled immediately after this hook returns, so
+        // run the UPDATE on the calling thread to make sure the end timestamp
+        // is persisted before teardown.
+        runBlocking {
+          sessionManager.stopSession(appSessionId)
+        }
       }
 
       AsyncFunction("getStoredEntries") Coroutine { -> sessionManager.getAllSessions() }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -26,7 +26,7 @@ object MetricsConstants {
 
 @Database(
   entities = [Metric::class, Session::class],
-  version = 13,
+  version = 14,
   exportSchema = false
 )
 abstract class MetricsDatabase : RoomDatabase() {
@@ -62,6 +62,7 @@ abstract class MetricsDatabase : RoomDatabase() {
 data class Session(
   @PrimaryKey @Field val id: String,
   @Field val startTimestamp: String, // ISO 8601 date string
+  @Field val endTimestamp: String? = null, // ISO 8601 date string. `null` while the session is still active.
   @Field val isActive: Boolean = true,
   // Environment
   @Field val environment: String? = null,
@@ -147,13 +148,16 @@ interface SessionDao {
   @Query("SELECT * FROM sessions WHERE id = :id")
   suspend fun getById(id: String): Session?
 
-  @Query("UPDATE sessions SET isActive = :isActive WHERE id = :id")
-  suspend fun updateActiveStatus(
+  @Query("UPDATE sessions SET isActive = 0, endTimestamp = :endTimestamp WHERE id = :id")
+  suspend fun stopSessionAt(
     id: String,
-    isActive: Boolean
+    endTimestamp: String
   )
 
-  @Query("UPDATE sessions SET isActive = 0 WHERE startTimestamp < :timestamp")
+  // Stamps stale sessions as ended at `:timestamp`. Used at module creation
+  // to clean up sessions left behind when the previous process died (force-quit,
+  // OOM kill, crash) without an `OnActivityDestroys` callback.
+  @Query("UPDATE sessions SET isActive = 0, endTimestamp = :timestamp WHERE startTimestamp < :timestamp AND endTimestamp IS NULL")
   suspend fun deactivateAllSessionsBefore(timestamp: String)
 
   @Query("UPDATE sessions SET environment = :environment WHERE id = :id")

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -160,6 +160,13 @@ interface SessionDao {
   @Query("UPDATE sessions SET isActive = 0, endTimestamp = :timestamp WHERE startTimestamp < :timestamp AND endTimestamp IS NULL")
   suspend fun deactivateAllSessionsBefore(timestamp: String)
 
+  // Drops sessions whose `startTimestamp` is older than the cutoff. Cascade
+  // deletes their metrics via the foreign-key relation. Live (`isActive = 1`)
+  // sessions are excluded so a long-running process doesn't lose its current
+  // session out from under it.
+  @Query("DELETE FROM sessions WHERE startTimestamp < :cutoffTimestamp AND isActive = 0")
+  suspend fun deleteSessionsOlderThan(cutoffTimestamp: String)
+
   @Query("UPDATE sessions SET environment = :environment WHERE id = :id")
   suspend fun updateEnvironment(
     id: String,

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -135,9 +135,6 @@ interface MetricDao {
 
   @Delete
   suspend fun delete(metrics: List<Metric>)
-
-  @Query("DELETE FROM metrics WHERE timestamp < :cutoffTimestamp")
-  suspend fun deleteMetricsOlderThan(cutoffTimestamp: String)
 }
 
 @Dao

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -90,7 +90,10 @@ class SessionManager(
   }
 
   suspend fun stopSession(sessionId: String) {
-    database.sessionDao().updateActiveStatus(sessionId, isActive = false)
+    database.sessionDao().stopSessionAt(
+      sessionId,
+      endTimestamp = TimeUtils.getCurrentTimestampInISOFormat()
+    )
   }
 
   suspend fun addMetrics(

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -128,17 +128,9 @@ class SessionManager(
     database.sessionDao().deactivateAllSessionsBefore(timestamp)
   }
 
-  suspend fun cleanupOldMetrics() {
-    val cutoffTimestamp = TimeUtils.getTimestampInISOFormatFromPast(MetricsConstants.SECONDS_TO_REMOVE_OLD_METRICS)
-    database.metricDao().deleteMetricsOlderThan(cutoffTimestamp)
-  }
-
   /**
-   * Prunes sessions whose `startTimestamp` is older than the metric retention
-   * window. Sessions with no metrics at all (e.g. a launch that never recorded
-   * anything because the user quit immediately) wouldn't otherwise be reached
-   * by `cleanupOldMetrics` + cascade-delete, since there are no metrics to
-   * expire.
+   * Prunes inactive sessions whose `startTimestamp` is older than the
+   * retention window. Their metrics are removed via the foreign-key cascade.
    */
   suspend fun cleanupOldSessions() {
     val cutoffTimestamp = TimeUtils.getTimestampInISOFormatFromPast(MetricsConstants.SECONDS_TO_REMOVE_OLD_METRICS)

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -133,6 +133,18 @@ class SessionManager(
     database.metricDao().deleteMetricsOlderThan(cutoffTimestamp)
   }
 
+  /**
+   * Prunes sessions whose `startTimestamp` is older than the metric retention
+   * window. Sessions with no metrics at all (e.g. a launch that never recorded
+   * anything because the user quit immediately) wouldn't otherwise be reached
+   * by `cleanupOldMetrics` + cascade-delete, since there are no metrics to
+   * expire.
+   */
+  suspend fun cleanupOldSessions() {
+    val cutoffTimestamp = TimeUtils.getTimestampInISOFormatFromPast(MetricsConstants.SECONDS_TO_REMOVE_OLD_METRICS)
+    database.sessionDao().deleteSessionsOlderThan(cutoffTimestamp)
+  }
+
   suspend fun updateEnvironmentForActiveSessions(environment: String) {
     database.sessionDao().updateEnvironmentForActiveSessions(environment)
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
@@ -1,5 +1,7 @@
 package expo.modules.appmetrics.storage
 
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
@@ -11,38 +13,59 @@ import kotlinx.serialization.json.doubleOrNull
 import kotlinx.serialization.json.longOrNull
 
 /**
- * Reshapes a [SessionWithMetrics] into the JS-facing `Session` shape. The
- * Room schema uses different field names (`startTimestamp` / `endTimestamp`)
- * and nests the entity under `session`; we flatten and rename here so JS code
- * consumes the same shape it would expect from any other consumer.
+ * JS-facing shape of a session. Field names mirror the TypeScript `Session`
+ * type (`startDate` / `endDate`), distinct from the Room column names
+ * (`startTimestamp` / `endTimestamp`).
  *
  * `type` is hard-coded to `"main"` since the per-launch session opened in
  * `AppMetricsModule.OnCreate` is the only one we track. A future change
  * should add a real `type` column and lifecycle hooks for
  * foreground/screen/custom sessions.
  */
-internal fun SessionWithMetrics.toJsSession(): Map<String, Any?> {
-  return mapOf(
-    "id" to session.id,
-    "type" to "main",
-    "startDate" to session.startTimestamp,
-    "endDate" to session.endTimestamp,
-    "metrics" to metrics.map { it.toJsMap() }
-  )
+data class JsSession(
+  @Field val id: String,
+  @Field val type: String,
+  @Field val startDate: String,
+  @Field val endDate: String?,
+  @Field val metrics: List<JsMetric>
+) : Record {
+  companion object {
+    fun fromSessionWithMetrics(value: SessionWithMetrics): JsSession =
+      JsSession(
+        id = value.session.id,
+        type = "main",
+        startDate = value.session.startTimestamp,
+        endDate = value.session.endTimestamp,
+        metrics = value.metrics.map { JsMetric.fromMetric(it) }
+      )
+  }
 }
 
-private fun Metric.toJsMap(): Map<String, Any?> {
-  return mapOf(
-    "metricId" to metricId,
-    "sessionId" to sessionId,
-    "timestamp" to timestamp,
-    "category" to category,
-    "name" to name,
-    "value" to value,
-    "routeName" to routeName,
-    "updateId" to updateId,
-    "params" to decodeJsonObject(params)
-  )
+data class JsMetric(
+  @Field val metricId: String,
+  @Field val sessionId: String,
+  @Field val timestamp: String,
+  @Field val category: String,
+  @Field val name: String,
+  @Field val value: Double,
+  @Field val routeName: String?,
+  @Field val updateId: String?,
+  @Field val params: Map<String, Any?>?
+) : Record {
+  companion object {
+    fun fromMetric(metric: Metric): JsMetric =
+      JsMetric(
+        metricId = metric.metricId,
+        sessionId = metric.sessionId,
+        timestamp = metric.timestamp,
+        category = metric.category,
+        name = metric.name,
+        value = metric.value,
+        routeName = metric.routeName,
+        updateId = metric.updateId,
+        params = decodeJsonObject(metric.params)
+      )
+  }
 }
 
 /**

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
@@ -1,0 +1,80 @@
+package expo.modules.appmetrics.storage
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * Reshapes a [SessionWithMetrics] into the JS-facing `Session` shape. The
+ * Room schema uses different field names (`startTimestamp` / `endTimestamp`)
+ * and nests the entity under `session`; we flatten and rename here so JS code
+ * consumes the same shape it would expect from any other consumer.
+ *
+ * `type` is hard-coded to `"main"` since the per-launch session opened in
+ * `AppMetricsModule.OnCreate` is the only one we track. A future change
+ * should add a real `type` column and lifecycle hooks for
+ * foreground/screen/custom sessions.
+ */
+internal fun SessionWithMetrics.toJsSession(): Map<String, Any?> {
+  return mapOf(
+    "id" to session.id,
+    "type" to "main",
+    "startDate" to session.startTimestamp,
+    "endDate" to session.endTimestamp,
+    "metrics" to metrics.map { it.toJsMap() }
+  )
+}
+
+private fun Metric.toJsMap(): Map<String, Any?> {
+  return mapOf(
+    "metricId" to metricId,
+    "sessionId" to sessionId,
+    "timestamp" to timestamp,
+    "category" to category,
+    "name" to name,
+    "value" to value,
+    "routeName" to routeName,
+    "updateId" to updateId,
+    "params" to decodeJsonObject(params)
+  )
+}
+
+/**
+ * Decodes a JSON-encoded object string into a `Map<String, Any?>` whose values
+ * are plain Kotlin primitives (`String`, `Long`, `Double`, `Boolean`, `List`,
+ * `Map`, or `null`). Returns `null` if the input is `null`/empty or if parsing
+ * fails — JS code treats `null` as "no extras".
+ */
+private fun decodeJsonObject(jsonString: String?): Map<String, Any?>? {
+  if (jsonString.isNullOrEmpty()) {
+    return null
+  }
+  return runCatching {
+    val element = Json.decodeFromString<JsonElement>(jsonString)
+    if (element !is JsonObject) {
+      return@runCatching null
+    }
+    element.mapValues { (_, v) -> jsonElementToAny(v) }
+  }.getOrNull()
+}
+
+private fun jsonElementToAny(element: JsonElement): Any? {
+  return when (element) {
+    is JsonNull -> null
+    is JsonPrimitive -> when {
+      element.isString -> element.content
+      else -> element.booleanOrNull
+        ?: element.longOrNull
+        ?: element.doubleOrNull
+        ?: element.content
+    }
+    is JsonObject -> element.mapValues { (_, v) -> jsonElementToAny(v) }
+    is JsonArray -> element.map { jsonElementToAny(it) }
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
@@ -27,7 +27,10 @@ data class JsSession(
   @Field val type: String,
   @Field val startDate: String,
   @Field val endDate: String?,
-  @Field val metrics: List<JsMetric>
+  @Field val metrics: List<JsMetric>,
+  // Android doesn't collect log events yet; emitted as an empty list so
+  // consumers can rely on the same shape iOS produces.
+  @Field val logs: List<Any> = emptyList()
 ) : Record {
   companion object {
     fun fromSessionWithMetrics(value: SessionWithMetrics): JsSession =

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
@@ -654,6 +654,45 @@ class SessionManagerTest {
       assertEquals(0, sessionManager.getAllSessions().size)
     }
 
+  @Test
+  fun `cleanupOldSessions removes inactive sessions older than the retention window`() =
+    runTest {
+      // Arrange — three sessions across the cutoff. We can't pick a static
+      // timestamp like the other tests because the retention window is computed
+      // from `now`, so we anchor against the current time.
+      val now = System.currentTimeMillis()
+      val retentionMs = MetricsConstants.SECONDS_TO_REMOVE_OLD_METRICS * 1000
+      val isoFormatter = java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", java.util.Locale.US)
+        .apply { timeZone = java.util.TimeZone.getTimeZone("UTC") }
+
+      val staleStoppedId = "stale-stopped"
+      val staleActiveId = "stale-active"
+      val freshStoppedId = "fresh-stopped"
+
+      val staleStart = isoFormatter.format(java.util.Date(now - retentionMs - 60_000))
+      val freshStart = isoFormatter.format(java.util.Date(now - 60_000))
+
+      sessionManager.startSessionWithIdAt(staleStoppedId, staleStart)
+      sessionManager.stopSession(staleStoppedId)
+
+      sessionManager.startSessionWithIdAt(staleActiveId, staleStart)
+      // Intentionally not stopped — simulates a long-running session.
+
+      sessionManager.startSessionWithIdAt(freshStoppedId, freshStart)
+      sessionManager.stopSession(freshStoppedId)
+
+      // Act
+      sessionManager.cleanupOldSessions()
+
+      // Assert — only the stopped, stale session is gone. The active stale
+      // session is preserved (we don't pull a session out from under a
+      // long-running process), and the fresh stopped session is preserved.
+      val remaining = sessionManager.getAllSessions().map { it.session.id }.toSet()
+      assertFalse("stale stopped session should be cleaned up", remaining.contains(staleStoppedId))
+      assertTrue("stale but active session should be preserved", remaining.contains(staleActiveId))
+      assertTrue("fresh stopped session should be preserved", remaining.contains(freshStoppedId))
+    }
+
   // endregion
 
   // region Helper Methods

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
@@ -208,6 +208,21 @@ class SessionManagerTest {
     }
 
   @Test
+  fun `stopSession stamps endTimestamp`() =
+    runTest {
+      // Arrange
+      val sessionId = "test-session"
+      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
+
+      // Act
+      sessionManager.stopSession(sessionId)
+
+      // Assert
+      val stopped = sessionManager.getAllSessions().single()
+      assertNotNull("endTimestamp should be set after stopSession", stopped.session.endTimestamp)
+    }
+
+  @Test
   fun `deactivateAllSessionsBefore deactivates old sessions only`() =
     runTest {
       // Arrange
@@ -223,6 +238,46 @@ class SessionManagerTest {
       val activeSessions = sessionManager.getAllActiveSessions()
       assertEquals(1, activeSessions.size)
       assertEquals(newSession, activeSessions[0].session.id)
+    }
+
+  @Test
+  fun `deactivateAllSessionsBefore stamps endTimestamp on orphan sessions`() =
+    runTest {
+      // Arrange — a session left active across launches (force-killed process,
+      // OOM, etc.). On the next module create we deactivate it, and the cutoff
+      // timestamp is the heuristic end-time we record.
+      val orphan = "orphan-session"
+      sessionManager.startSessionWithIdAt(orphan, "2025-01-01T00:00:00.000Z")
+
+      // Act
+      val cutoff = "2025-01-10T00:00:00.000Z"
+      sessionManager.deactivateAllSessionsBefore(cutoff)
+
+      // Assert
+      val deactivated = sessionManager.getAllSessions().single { it.session.id == orphan }
+      assertFalse(deactivated.session.isActive)
+      assertEquals(cutoff, deactivated.session.endTimestamp)
+    }
+
+  @Test
+  fun `deactivateAllSessionsBefore preserves existing endTimestamps`() =
+    runTest {
+      // Arrange — a session that was properly stopped via stopSession should
+      // keep its real end time even if it predates the deactivate cutoff.
+      val cleanlyStopped = "clean-session"
+      sessionManager.startSessionWithIdAt(cleanlyStopped, "2025-01-01T00:00:00.000Z")
+      sessionManager.stopSession(cleanlyStopped)
+      val originalEnd = sessionManager.getAllSessions()
+        .single { it.session.id == cleanlyStopped }
+        .session.endTimestamp
+      assertNotNull("precondition: stopSession should have stamped endTimestamp", originalEnd)
+
+      // Act
+      sessionManager.deactivateAllSessionsBefore("2025-01-10T00:00:00.000Z")
+
+      // Assert — the cleanly-stopped session keeps its original end time.
+      val preserved = sessionManager.getAllSessions().single { it.session.id == cleanlyStopped }
+      assertEquals(originalEnd, preserved.session.endTimestamp)
     }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
@@ -1,9 +1,7 @@
 package expo.modules.appmetrics.storage
 
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
-import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -38,94 +36,68 @@ class SessionMappersTest {
   )
 
   @Test
-  fun `toJsSession exposes the JS-facing field names`() {
+  fun `JsSession_fromSessionWithMetrics exposes the JS-facing field names`() {
     val swm = SessionWithMetrics(
       session = makeSession(id = "abc", startTimestamp = "2025-06-15T10:00:00.000Z"),
       metrics = emptyList()
     )
 
-    val js = swm.toJsSession()
+    val js = JsSession.fromSessionWithMetrics(swm)
 
-    assertEquals("abc", js["id"])
-    assertEquals("main", js["type"])
-    assertEquals("2025-06-15T10:00:00.000Z", js["startDate"])
-    assertNull(js["endDate"])
-    assertEquals(emptyList<Any>(), js["metrics"])
+    assertEquals("abc", js.id)
+    assertEquals("main", js.type)
+    assertEquals("2025-06-15T10:00:00.000Z", js.startDate)
+    assertNull(js.endDate)
+    assertEquals(emptyList<JsMetric>(), js.metrics)
   }
 
   @Test
-  fun `toJsSession surfaces endDate when set`() {
+  fun `JsSession_fromSessionWithMetrics surfaces endDate when set`() {
     val swm = SessionWithMetrics(
       session = makeSession(endTimestamp = "2025-01-02T00:00:00.000Z"),
       metrics = emptyList()
     )
 
-    val js = swm.toJsSession()
+    val js = JsSession.fromSessionWithMetrics(swm)
 
-    assertEquals("2025-01-02T00:00:00.000Z", js["endDate"])
+    assertEquals("2025-01-02T00:00:00.000Z", js.endDate)
   }
 
   @Test
-  fun `toJsSession decodes Metric_params from JSON`() {
-    val swm = SessionWithMetrics(
-      session = makeSession(),
-      metrics = listOf(
-        makeMetric(params = """{"screen":"Home","attempt":3,"flag":true}""")
-      )
-    )
+  fun `JsMetric_fromMetric decodes params from JSON`() {
+    val metric = makeMetric(params = """{"screen":"Home","attempt":3,"flag":true}""")
 
-    @Suppress("UNCHECKED_CAST")
-    val metrics = swm.toJsSession()["metrics"] as List<Map<String, Any?>>
-    assertEquals(1, metrics.size)
+    val js = JsMetric.fromMetric(metric)
 
-    @Suppress("UNCHECKED_CAST")
-    val params = metrics.single()["params"] as Map<String, Any?>
-    assertEquals("Home", params["screen"])
-    assertEquals(3L, params["attempt"])
-    assertEquals(true, params["flag"])
+    val params = js.params
+    assertEquals("Home", params?.get("screen"))
+    assertEquals(3L, params?.get("attempt"))
+    assertEquals(true, params?.get("flag"))
   }
 
   @Test
-  fun `toJsSession yields null params when storage column is null`() {
-    val swm = SessionWithMetrics(
-      session = makeSession(),
-      metrics = listOf(makeMetric(params = null))
-    )
+  fun `JsMetric_fromMetric yields null params when storage column is null`() {
+    val js = JsMetric.fromMetric(makeMetric(params = null))
 
-    @Suppress("UNCHECKED_CAST")
-    val metrics = swm.toJsSession()["metrics"] as List<Map<String, Any?>>
-    assertNull(metrics.single()["params"])
+    assertNull(js.params)
   }
 
   @Test
-  fun `toJsSession yields null params when storage column is malformed JSON`() {
-    val swm = SessionWithMetrics(
-      session = makeSession(),
-      metrics = listOf(makeMetric(params = "{ this is not valid json"))
-    )
+  fun `JsMetric_fromMetric yields null params when storage column is malformed JSON`() {
+    val js = JsMetric.fromMetric(makeMetric(params = "{ this is not valid json"))
 
-    @Suppress("UNCHECKED_CAST")
-    val metrics = swm.toJsSession()["metrics"] as List<Map<String, Any?>>
-    assertNull(metrics.single()["params"])
+    assertNull(js.params)
   }
 
   @Test
-  fun `toJsSession copies metric scalar fields verbatim`() {
-    val swm = SessionWithMetrics(
-      session = makeSession(),
-      metrics = listOf(
-        makeMetric(metricId = "m-42", sessionId = "session-1")
-      )
-    )
+  fun `JsMetric_fromMetric copies scalar fields verbatim`() {
+    val js = JsMetric.fromMetric(makeMetric(metricId = "m-42", sessionId = "session-1"))
 
-    @Suppress("UNCHECKED_CAST")
-    val metric = (swm.toJsSession()["metrics"] as List<Map<String, Any?>>).single()
-    assertEquals("m-42", metric["metricId"])
-    assertEquals("session-1", metric["sessionId"])
-    assertEquals("appStartup", metric["category"])
-    assertEquals("timeToInteractive", metric["name"])
-    assertEquals(1.5, metric["value"])
-    assertEquals("2025-01-01T00:00:01.000Z", metric["timestamp"])
-    assertTrue("metricId key should be present", metric.containsKey("metricId"))
+    assertEquals("m-42", js.metricId)
+    assertEquals("session-1", js.sessionId)
+    assertEquals("appStartup", js.category)
+    assertEquals("timeToInteractive", js.name)
+    assertEquals(1.5, js.value, 0.0)
+    assertEquals("2025-01-01T00:00:01.000Z", js.timestamp)
   }
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
@@ -1,0 +1,131 @@
+package expo.modules.appmetrics.storage
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class SessionMappersTest {
+  private fun makeSession(
+    id: String = "session-1",
+    startTimestamp: String = "2025-01-01T00:00:00.000Z",
+    endTimestamp: String? = null
+  ): Session = Session(
+    id = id,
+    startTimestamp = startTimestamp,
+    endTimestamp = endTimestamp,
+    isActive = endTimestamp == null
+  )
+
+  private fun makeMetric(
+    metricId: String = "metric-1",
+    sessionId: String = "session-1",
+    params: String? = null
+  ): Metric = Metric(
+    metricId = metricId,
+    sessionId = sessionId,
+    timestamp = "2025-01-01T00:00:01.000Z",
+    category = "appStartup",
+    name = "timeToInteractive",
+    value = 1.5,
+    params = params
+  )
+
+  @Test
+  fun `toJsSession exposes the JS-facing field names`() {
+    val swm = SessionWithMetrics(
+      session = makeSession(id = "abc", startTimestamp = "2025-06-15T10:00:00.000Z"),
+      metrics = emptyList()
+    )
+
+    val js = swm.toJsSession()
+
+    assertEquals("abc", js["id"])
+    assertEquals("main", js["type"])
+    assertEquals("2025-06-15T10:00:00.000Z", js["startDate"])
+    assertNull(js["endDate"])
+    assertEquals(emptyList<Any>(), js["metrics"])
+  }
+
+  @Test
+  fun `toJsSession surfaces endDate when set`() {
+    val swm = SessionWithMetrics(
+      session = makeSession(endTimestamp = "2025-01-02T00:00:00.000Z"),
+      metrics = emptyList()
+    )
+
+    val js = swm.toJsSession()
+
+    assertEquals("2025-01-02T00:00:00.000Z", js["endDate"])
+  }
+
+  @Test
+  fun `toJsSession decodes Metric_params from JSON`() {
+    val swm = SessionWithMetrics(
+      session = makeSession(),
+      metrics = listOf(
+        makeMetric(params = """{"screen":"Home","attempt":3,"flag":true}""")
+      )
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    val metrics = swm.toJsSession()["metrics"] as List<Map<String, Any?>>
+    assertEquals(1, metrics.size)
+
+    @Suppress("UNCHECKED_CAST")
+    val params = metrics.single()["params"] as Map<String, Any?>
+    assertEquals("Home", params["screen"])
+    assertEquals(3L, params["attempt"])
+    assertEquals(true, params["flag"])
+  }
+
+  @Test
+  fun `toJsSession yields null params when storage column is null`() {
+    val swm = SessionWithMetrics(
+      session = makeSession(),
+      metrics = listOf(makeMetric(params = null))
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    val metrics = swm.toJsSession()["metrics"] as List<Map<String, Any?>>
+    assertNull(metrics.single()["params"])
+  }
+
+  @Test
+  fun `toJsSession yields null params when storage column is malformed JSON`() {
+    val swm = SessionWithMetrics(
+      session = makeSession(),
+      metrics = listOf(makeMetric(params = "{ this is not valid json"))
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    val metrics = swm.toJsSession()["metrics"] as List<Map<String, Any?>>
+    assertNull(metrics.single()["params"])
+  }
+
+  @Test
+  fun `toJsSession copies metric scalar fields verbatim`() {
+    val swm = SessionWithMetrics(
+      session = makeSession(),
+      metrics = listOf(
+        makeMetric(metricId = "m-42", sessionId = "session-1")
+      )
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    val metric = (swm.toJsSession()["metrics"] as List<Map<String, Any?>>).single()
+    assertEquals("m-42", metric["metricId"])
+    assertEquals("session-1", metric["sessionId"])
+    assertEquals("appStartup", metric["category"])
+    assertEquals("timeToInteractive", metric["name"])
+    assertEquals(1.5, metric["value"])
+    assertEquals("2025-01-01T00:00:01.000Z", metric["timestamp"])
+    assertTrue("metricId key should be present", metric.containsKey("metricId"))
+  }
+}

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -136,8 +136,7 @@ class BaseObservabilityManager(
 
   suspend fun cleanup() {
     pendingMetricsManager.cleanupOldPendingMetrics()
-    // TODO(@ubax): Move sessionManager.cleanupOld* calls out of eas observe
-    sessionManager.cleanupOldMetrics()
+    // TODO(@ubax): Move sessionManager.cleanupOldSessions out of eas observe
     sessionManager.cleanupOldSessions()
   }
 }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -136,7 +136,8 @@ class BaseObservabilityManager(
 
   suspend fun cleanup() {
     pendingMetricsManager.cleanupOldPendingMetrics()
-    // TODO(@ubax): Move sessionManager.cleanupOldMetrics() out of eas observe
+    // TODO(@ubax): Move sessionManager.cleanupOld* calls out of eas observe
     sessionManager.cleanupOldMetrics()
+    sessionManager.cleanupOldSessions()
   }
 }

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -753,7 +753,7 @@ class BaseObservabilityManagerTest {
   // region Cleanup tests
 
   @Test
-  fun `cleanup calls both cleanupOldPendingMetrics and cleanupOldMetrics`() =
+  fun `cleanup prunes pending metrics, stale metrics, and stale sessions`() =
     runTest {
       // Arrange
       val manager = createManager()
@@ -764,6 +764,7 @@ class BaseObservabilityManagerTest {
       // Assert
       coVerify(exactly = 1) { mockPendingMetricsManager.cleanupOldPendingMetrics() }
       coVerify(exactly = 1) { mockSessionManager.cleanupOldMetrics() }
+      coVerify(exactly = 1) { mockSessionManager.cleanupOldSessions() }
     }
 
   // endregion

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -753,7 +753,7 @@ class BaseObservabilityManagerTest {
   // region Cleanup tests
 
   @Test
-  fun `cleanup prunes pending metrics, stale metrics, and stale sessions`() =
+  fun `cleanup prunes pending metrics and stale sessions`() =
     runTest {
       // Arrange
       val manager = createManager()
@@ -763,7 +763,6 @@ class BaseObservabilityManagerTest {
 
       // Assert
       coVerify(exactly = 1) { mockPendingMetricsManager.cleanupOldPendingMetrics() }
-      coVerify(exactly = 1) { mockSessionManager.cleanupOldMetrics() }
       coVerify(exactly = 1) { mockSessionManager.cleanupOldSessions() }
     }
 


### PR DESCRIPTION
## Summary

Implements `AppMetrics.getAllSessions()` on Android to match the iOS surface, and gives the Android `Session` schema a real end-of-session timestamp.

- **`AsyncFunction("getAllSessions")`** parallel to the iOS one. The native side reshapes each session into the iOS-flavoured shape JS already expects (`id`, `type`, `startDate`, `endDate`, `metrics[]`) so screens consume a single shape regardless of platform. `Metric.params` (stored as a JSON string) is decoded into a plain object before the bridge crossing.
- **`endTimestamp` column** on the `Session` Room entity (DB version 13 → 14, destructive migration per the project's existing policy). `SessionDao.updateActiveStatus` is replaced with `stopSessionAt`, which records when a session was stopped alongside flipping `isActive`.
- **Eager session creation** in `OnCreate` so the row is visible to readers (`getAllSessions`, `addCustomMetricToSession`, …) before any startup metrics arrive — previously the row only landed once `markInteractive` (or the background-entered hook) fired `saveStartupMetricsIfNotSaved`.
- **Stale-session pruning.** As a followup to eager session creation, a new `SessionManager.cleanupOldSessions()` runs alongside `cleanupOldMetrics` in the periodic cleanup. Drops inactive sessions whose `startTimestamp` is older than the 7-day retention window so empty launch-then-quit rows don't accumulate. Active sessions are skipped.
- **Tester app**: drops the iOS-only guards on the session list and detail screens so they render on Android too.
- **Killed-session cleanup.** `deactivateAllSessionsBefore` (run at module create) now also stamps `endTimestamp` on rows it deactivates, but only when `endTimestamp IS NULL`, so sessions stopped cleanly via `stopSessionAt` keep their accurate end times. Sessions whose process was force-killed or OOM-killed (no `OnActivityDestroys` callback) get an `endTimestamp` of the next launch's `OnCreate` timestamp — a small over-estimate, but always populated and always after the start.

### Known limitations

- `type` is hard-coded to `"main"` since Android doesn't yet distinguish session types — the per-launch session opened in `AppMetricsModule.OnCreate` is the only one we track. A future change should add a real `type` column and lifecycle hooks for foreground/screen/custom sessions.
- No `crashReport` field on the JS-shape map yet (Android doesn't have crash-report integration).
- `endTimestamp` for force-killed sessions is approximate (stamped on the next launch). A heartbeat-write pattern — update `endTimestamp` on every metric write — would give better accuracy. Worth a follow-up if precise end-times matter.

## Test plan

- [x] `:expo-app-metrics:compileReleaseKotlin` succeeds.
- [x] `:expo-app-metrics:testDebugUnitTest` passes.
- [x] Tester app launches on Android and shows the current session in the Sessions tab without needing to tap `markInteractive` first.
- [x] Tapping a session opens the detail screen with metrics rendered correctly (no escaped JSON strings for `params`).
- [x] iOS sessions screen still works (no regression from the dropped iOS-only guards).
- [x] Force-killing the app from the recents view and reopening also shows the previous session as ended (stamped at the next launch's start).

<img width="520" alt="android-get-all-sessions-scaled" src="https://github.com/user-attachments/assets/a52dc38f-617a-4590-9b7e-5b59c5880158" />
