### PR TITLE
[docs] Add Vale rule for the Prerequisites component

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -29,3 +29,8 @@ BasedOnStyles =
 [**/pages/versions/latest/**]
 Vale = NO
 BasedOnStyles =
+
+# README.md is contributor docs, not user-facing pages, so the <Prerequisites>
+# component does not apply there.
+[**/README.md]
+expo-docs.Prerequisites = NO

--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -30,7 +30,6 @@ BasedOnStyles =
 Vale = NO
 BasedOnStyles =
 
-# README.md is contributor docs, not user-facing pages, so the <Prerequisites>
-# component does not apply there.
+# README.md is contributor docs, not user-facing pages, so the <Prerequisites> component does not apply there.
 [**/README.md]
 expo-docs.Prerequisites = NO

--- a/docs/.vale/writing-styles/expo-docs/Prerequisites.yml
+++ b/docs/.vale/writing-styles/expo-docs/Prerequisites.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Use the <Prerequisites> component instead of a markdown 'Prerequisites' heading with a bulleted checklist."
+link: 'https://github.com/expo/expo/blob/main/docs/README.md#use-prerequisites-for-setup-checklists'
+level: warning
+scope: raw
+raw:
+  - '\n#{2,4}\s+Prerequisites\s*\n+(?:[^\n]*\n){0,5}-\s'


### PR DESCRIPTION
# Why

The `<Prerequisites>` component renders setup checklists as a collapsible, anchored block, but authors sometimes ship plain `## Prerequisites` markdown headings followed by bulleted lists instead. 

One example: the Jetpack Compose `extending.mdx` page recently shipped that way while the SwiftUI sibling page already used the component. Catching the divergence in lint avoids a manual sweep on every PR.



# How

Adds an `existence`-style rule at `docs/.vale/writing-styles/expo-docs/Prerequisites.yml` that runs against raw MDX. The regex flags an H2 to H4 `Prerequisites` heading followed within five lines by a markdown bullet (`- `), using `scope: raw` so the match spans lines. 

The rule's `link` points to the existing "Use `Prerequisites` for setup checklists" section in `docs/README.md` so the warning resolves to authoring guidance. `docs/.vale.ini` adds a path-scoped exception for `README.md`.


# Test Plan

- Paste a mock `## Prerequisites` heading followed by a `- ` bullet into any page to confirm the warning fires
- Run `pnpm lint-prose` to see this rule's invocation as an example.
<img width="1890" height="346" alt="CleanShot 2026-05-03 at 13 38 37@2x" src="https://github.com/user-attachments/assets/0523cd89-e22d-40b9-ad25-9c93f19f9305" />

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).