### PR TITLE
[docs] Fix internal links in multiple docs

### DIFF
--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -94,7 +94,7 @@ The defaults are derived from your app config (for example, target names are bas
 ```
 </Collapsible>
 
-See the [`expo-brownfield` API reference](/versions/v55.0.0/sdk/brownfield/) for details on all available options.
+See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for details on all available options.
 
 </Step>
 
@@ -112,7 +112,7 @@ From your Expo project directory, run:
 This will build the AAR and publish it to a Maven repository. By default, it publishes to your local Maven repository (`~/.m2`), but it can also be configured to publish to a remote repository.
 The produced artifact name will be determined by your config plugin settings, in this case `com.username.myproject:brownfield:1.0.0`.
 
-See the [API reference](/versions/v55.0.0/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
+See the [API reference](/versions/latest/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
 
 </Tab>
 <Tab label="iOS">
@@ -128,7 +128,7 @@ When the build process is completed, the output is placed in the **./artifacts**
 - **\{TargetName\}.xcframework** - Your Expo project as a native library
 - **hermesvm.xcframework** - The Hermes JavaScript engine
 
-See the [`expo-brownfield` API reference](/versions/v55.0.0/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
+See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for more details on build options, such as building only debug or release, specifying a custom output directory, and more.
 
 </Tab>
 </Tabs>
@@ -342,6 +342,6 @@ In release builds, the JavaScript bundle is embedded in the artifact (AAR or XCF
 <BoxLink
   title="expo-brownfield API reference"
   description="Explore the full JavaScript API for communication, navigation, and more."
-  href="/versions/v55.0.0/sdk/brownfield/"
+  href="/versions/latest/sdk/brownfield/"
   Icon={BookOpen02Icon}
 />

--- a/docs/pages/guides/expo-ui-swift-ui/index.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/index.mdx
@@ -264,7 +264,7 @@ Combining the Expo UI components and modifiers, you can build a UI like iOS Sett
 
 ### Secondary text styling
 
-Use `foregroundStyle` to apply a [hierarchical style](/versions/v55.0.0/sdk/ui/swift-ui/modifiers/#foregroundstylestyle), which will make text appear lighter and more subtle.
+Use `foregroundStyle` to apply a [hierarchical style](/versions/latest/sdk/ui/swift-ui/modifiers/#foregroundstylestyle), which will make text appear lighter and more subtle.
 
 <Tabs>
   <Tab label="Code">

--- a/docs/pages/versions/v55.0.0/sdk/dev-menu.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/dev-menu.mdx
@@ -12,7 +12,7 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 import { Terminal } from '~/ui/components/Snippet';
 
-The `expo-dev-menu` can be used as a **standalone library** in any Expo project. It is especially useful in [brownfield apps](/versions/v55.0.0/sdk/brownfield/) that don't need the full [`expo-dev-client`](/versions/v55.0.0/sdk/dev-client/) launcher interface.
+The `expo-dev-menu` can be used as a **standalone library** in any Expo project. It is especially useful in [brownfield apps](/versions/latest/sdk/brownfield/) that don't need the full [`expo-dev-client`](/versions/latest/sdk/dev-client/) launcher interface.
 
 `expo-dev-menu` provides a developer menu UI for React Native apps that includes:
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix internal links that were pointing to v55 references. Should be using `/latest/`.


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
