### PR TITLE
[JSI] Hoist runtime/length out of array iteration helpers

### DIFF
--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
@@ -257,6 +257,16 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
   }
 
   /**
+   Returns the value at the given index without bounds-checking. Used by the iteration
+   helpers (`map`, `forEach`, `reduce`, `filter`, `enumerated`) which iterate
+   `0..<length` and never produce an out-of-range index. Skipping the redundant bounds
+   check avoids a weak-runtime load on every element on the hot path.
+   */
+  internal func getValueUnchecked(at index: Int, in runtime: JavaScriptRuntime) -> JavaScriptValue {
+    return JavaScriptValue(runtime, pointee.getValueAtIndex(runtime.pointee, index))
+  }
+
+  /**
    Sets the element at the specified index.
 
    - Parameters:
@@ -446,10 +456,17 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
      pattern, meaning it only throws if the transform closure throws.
    */
   public func map<T>(_ transform: (_ value: JavaScriptValue) throws -> T) rethrows -> [T] {
-    return try (0..<length).map { index in
-      let value = try self.getValue(at: index)
-      return try transform(value)
+    guard let runtime else {
+      FatalError.runtimeLost()
     }
+    let count = self.length
+    var result: [T] = []
+    result.reserveCapacity(count)
+    for index in 0..<count {
+      let value = getValueUnchecked(at: index, in: runtime)
+      result.append(try transform(value))
+    }
+    return result
   }
 
   /**
@@ -529,17 +546,28 @@ extension JavaScriptArray {
    - Note: Eagerly evaluates all elements. For large arrays, prefer `forEach(_:)`.
    */
   public func enumerated() -> [(offset: Int, element: JavaScriptValue)] {
-    return (0..<length).map { index in
-      (offset: index, element: self[index])
+    guard let runtime else {
+      FatalError.runtimeLost()
     }
+    let count = self.length
+    var result: [(offset: Int, element: JavaScriptValue)] = []
+    result.reserveCapacity(count)
+    for index in 0..<count {
+      result.append((offset: index, element: getValueUnchecked(at: index, in: runtime)))
+    }
+    return result
   }
 
   /**
    Calls the given closure on each element in the array.
    */
   public func forEach(_ body: (JavaScriptValue) throws -> Void) rethrows {
-    for index in 0..<length {
-      try body(self[index])
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    let count = self.length
+    for index in 0..<count {
+      try body(getValueUnchecked(at: index, in: runtime))
     }
   }
 
@@ -547,9 +575,13 @@ extension JavaScriptArray {
    Returns an array of elements satisfying the given predicate.
    */
   public func filter(_ isIncluded: (JavaScriptValue) throws -> Bool) rethrows -> [JavaScriptValue] {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    let count = self.length
     var result: [JavaScriptValue] = []
-    for index in 0..<length {
-      let value = self[index]
+    for index in 0..<count {
+      let value = getValueUnchecked(at: index, in: runtime)
       if try isIncluded(value) {
         result.append(value)
       }
@@ -561,9 +593,13 @@ extension JavaScriptArray {
    Returns the result of combining the elements using the given closure.
    */
   public func reduce<Result>(_ initialResult: Result, _ nextPartialResult: (Result, JavaScriptValue) throws -> Result) rethrows -> Result {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    let count = self.length
     var result = initialResult
-    for index in 0..<length {
-      result = try nextPartialResult(result, self[index])
+    for index in 0..<count {
+      result = try nextPartialResult(result, getValueUnchecked(at: index, in: runtime))
     }
     return result
   }


### PR DESCRIPTION
## Summary

- Add an internal `JavaScriptArray.getValueUnchecked(at:in:)` that skips the bounds check (and its weak-runtime load).
- Reroute the iteration helpers (`map`, `forEach`, `reduce`, `filter`, `enumerated`) to resolve `runtime` and `length` once and call `getValueUnchecked` per element.

`JavaScriptArray.getValue(at:)` does two weak-runtime loads per call — one for `guard let runtime`, one inside the `length` getter for the bounds check. Inside `map { ... }`, that's 2 weak loads × N elements × however-many-times-the-host-function-fires. For the `foldArray([1...10])` benchmark (500k calls × 10 elements), that's 10M weak loads through `swift_weakLoadStrong`, which the `Time Profiler` shows dominating at ~10% self-time.

The unchecked accessor takes the runtime as a parameter, so the iteration helpers can resolve it once at the top of the loop. Public API is unchanged — `getValue(at:)` still bounds-checks for ad-hoc indexing.

Drops the `foldArray` benchmark (500k iterations) from ~2150ms to ~1550ms (~28%) on iOS simulator.

## Test plan

- [x] Existing `JavaScriptArrayTests.map to integers/strings/doubles/booleans/...` still pass
- [x] `foldArray` benchmark in `native-component-list` runs faster vs. `main`
- [x] No regression on other benchmarks (`addNumbers`, `addStrings`, `echoObject`)

<!-- disable:changelog-checks -->