### PR TITLE
[core][iOS] Collapse two-pass cast in MainValueConverter

### DIFF
--- a/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj
+++ b/apps/bare-expo/ios/BareExpo.xcodeproj/project.pbxproj
@@ -264,7 +264,7 @@
 			);
 			mainGroup = 83CBB9F61A601CBA00E9B192;
 			packageReferences = (
-				B07E3E252FA5EE03002CB39D /* XCLocalSwiftPackageReference "../../../packages/expo-modules-jsi/apple" */,
+				B07E3E252FA5EE03002CB39D /* XCLocalSwiftPackageReference "apple" */,
 			);
 			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
 			projectDirPath = "";
@@ -907,7 +907,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		B07E3E252FA5EE03002CB39D /* XCLocalSwiftPackageReference "../../../packages/expo-modules-jsi/apple" */ = {
+		B07E3E252FA5EE03002CB39D /* XCLocalSwiftPackageReference "apple" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "../../../packages/expo-modules-jsi/apple";
 		};

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/AnyDynamicType.swift
@@ -19,14 +19,17 @@ public protocol AnyDynamicType: CustomStringConvertible, Sendable {
   func equals(_ type: AnyDynamicType) -> Bool
 
   /**
-   Preliminarily casts the given JavaScriptValue to a non-JS value that the other `cast` function can handle.
+   Casts the given JavaScript value to the final wrapped native value, ready to be
+   handed to the function's underlying closure or stored in a record/prop.
    It **must** be run on the thread used by the JavaScript runtime.
    */
   @JavaScriptActor
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any
 
   /**
-   Casts the given value to the wrapped type and returns it as `Any`.
+   Casts the given Swift-side value to the wrapped type and returns it as `Any`.
+   Used by record-field setters, view props, and other non-JS-origin paths that
+   need to coerce a Swift value into the dynamic type's representation.
    NOTE: It may not be just simple type-casting (e.g. when the wrapped type conforms to `Convertible`).
    */
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any
@@ -49,10 +52,6 @@ public protocol AnyDynamicType: CustomStringConvertible, Sendable {
 }
 
 extension AnyDynamicType {
-  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
-    return jsValue.getAny()
-  }
-
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     return value
   }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicConvertibleType.swift
@@ -26,7 +26,7 @@ internal struct DynamicConvertibleType: AnyDynamicType {
       try record.update(withObject: try jsValue.asObject(), appContext: appContext)
       return record
     }
-    return jsValue.getAny()
+    return try innerType.convert(from: jsValue.getAny(), appContext: appContext)
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEitherType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEitherType.swift
@@ -19,8 +19,7 @@ internal struct DynamicEitherType<EitherType: AnyEither>: AnyDynamicType {
     let types = eitherType.dynamicTypes()
 
     for type in types {
-      if let preliminaryValue = try? type.cast(jsValue: jsValue, appContext: appContext),
-        let value = try? type.cast(preliminaryValue, appContext: appContext) {
+      if let value = try? type.cast(jsValue: jsValue, appContext: appContext) {
         return EitherType(value)
       }
     }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEncodableType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEncodableType.swift
@@ -18,6 +18,11 @@ internal struct DynamicEncodableType: AnyDynamicType {
     return false
   }
 
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    // TODO: Create DynamicDecodableType and reuse it here – that would work perfectly with Codable types
+    fatalError("DynamicEncodableType can only cast to JavaScript, not from")
+  }
+
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     // TODO: Create DynamicDecodableType and reuse it here – that would work perfectly with Codable types
     fatalError("DynamicEncodableType can only cast to JavaScript, not from")

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEnumType.swift
@@ -25,8 +25,9 @@ internal struct DynamicEnumType: AnyDynamicType {
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
-    // Idempotent: `MainValueConverter.toNative` calls this after `cast(jsValue:)`,
-    // which already hydrates the enum. Pass it through unchanged in that case.
+    // Pass through values that are already the hydrated enum, e.g. when called from
+    // record-field setters with a `[String: Any]` dictionary that already contains the
+    // enum case (rather than its raw value).
     if let value = value as? any Enumerable, type(of: value) == innerType {
       return value
     }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicRawType.swift
@@ -17,6 +17,10 @@ internal struct DynamicRawType<InnerType>: AnyDynamicType {
     return type is Self
   }
 
+  func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
+    return try cast(jsValue.getAny(), appContext: appContext)
+  }
+
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
     if let value = value as? InnerType {
       return value

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSwiftUIViewType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSwiftUIViewType.swift
@@ -17,13 +17,13 @@ internal struct DynamicSwiftUIViewType<ViewType: ExpoSwiftUIView>: AnyDynamicTyp
   }
 
   /**
-   Casts from the React component instance to the view tag (`Int`).
+   Resolves the React component instance to the native SwiftUI view via its tag.
    */
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
     guard let viewTag = findViewTag(jsValue) else {
       throw InvalidViewTagException()
     }
-    return viewTag
+    return try cast(viewTag, appContext: appContext)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicValueOrUndefinedType.swift
@@ -18,8 +18,8 @@ internal struct DynamicValueOrUndefinedType<InnerType: AnyArgument>: AnyDynamicT
     if jsValue.isUndefined() {
       return ValueOrUndefined<InnerType>.undefined
     }
-
-    return try dynamicInnerType.cast(jsValue: jsValue, appContext: appContext)
+    let unwrapped = try dynamicInnerType.cast(jsValue: jsValue, appContext: appContext) as! InnerType
+    return ValueOrUndefined<InnerType>.value(unwrapped: unwrapped)
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicViewType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicViewType.swift
@@ -17,13 +17,13 @@ internal struct DynamicViewType: AnyDynamicType {
   }
 
   /**
-   Casts from the React component instance to the view tag (`Int`).
+   Resolves the React component instance to the native view via its tag.
    */
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
     guard let viewTag = findViewTag(jsValue) else {
       throw InvalidViewTagException()
     }
-    return viewTag
+    return try cast(viewTag, appContext: appContext)
   }
 
   /**

--- a/packages/expo-modules-core/ios/Core/MainValueConverter.swift
+++ b/packages/expo-modules-core/ios/Core/MainValueConverter.swift
@@ -15,8 +15,7 @@ public struct MainValueConverter: ~Copyable {
    */
   @JavaScriptActor
   public func toNative(_ value: JavaScriptValue, _ type: AnyDynamicType) throws -> Any {
-    let rawValue = try type.cast(jsValue: value, appContext: appContext)
-    return try type.cast(rawValue, appContext: appContext)
+    return try type.cast(jsValue: value, appContext: appContext)
   }
 
   /**
@@ -29,7 +28,7 @@ public struct MainValueConverter: ~Copyable {
       let type = types[index]
 
       do {
-        return try toNative(value.copy(), type)
+        return try toNative(value, type)
       } catch {
         throw ArgumentCastException((index: index, type: type)).causedBy(error)
       }

--- a/packages/expo-modules-core/ios/Core/Records/Field.swift
+++ b/packages/expo-modules-core/ios/Core/Records/Field.swift
@@ -119,9 +119,7 @@ public final class Field<Type: AnyArgument>: AnyFieldInternal, @unchecked Sendab
 
   @JavaScriptActor
   internal func castValue(jsValue: JavaScriptValue, appContext: AppContext) throws -> Type? {
-    let rawValue = try fieldType.cast(jsValue: jsValue, appContext: appContext)
-    let convertedValue = try fieldType.cast(rawValue, appContext: appContext)
-    return convertedValue as? Type
+    return try fieldType.cast(jsValue: jsValue, appContext: appContext) as? Type
   }
 }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
@@ -257,6 +257,16 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
   }
 
   /**
+   Returns the value at the given index without bounds-checking. Used by the iteration
+   helpers (`map`, `forEach`, `reduce`, `filter`, `enumerated`) which iterate
+   `0..<length` and never produce an out-of-range index. Skipping the redundant bounds
+   check avoids a weak-runtime load on every element on the hot path.
+   */
+  internal func getValueUnchecked(at index: Int, in runtime: JavaScriptRuntime) -> JavaScriptValue {
+    return JavaScriptValue(runtime, pointee.getValueAtIndex(runtime.pointee, index))
+  }
+
+  /**
    Sets the element at the specified index.
 
    - Parameters:
@@ -446,10 +456,17 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
      pattern, meaning it only throws if the transform closure throws.
    */
   public func map<T>(_ transform: (_ value: JavaScriptValue) throws -> T) rethrows -> [T] {
-    return try (0..<length).map { index in
-      let value = try self.getValue(at: index)
-      return try transform(value)
+    guard let runtime else {
+      FatalError.runtimeLost()
     }
+    let count = self.length
+    var result: [T] = []
+    result.reserveCapacity(count)
+    for index in 0..<count {
+      let value = getValueUnchecked(at: index, in: runtime)
+      result.append(try transform(value))
+    }
+    return result
   }
 
   /**
@@ -529,17 +546,28 @@ extension JavaScriptArray {
    - Note: Eagerly evaluates all elements. For large arrays, prefer `forEach(_:)`.
    */
   public func enumerated() -> [(offset: Int, element: JavaScriptValue)] {
-    return (0..<length).map { index in
-      (offset: index, element: self[index])
+    guard let runtime else {
+      FatalError.runtimeLost()
     }
+    let count = self.length
+    var result: [(offset: Int, element: JavaScriptValue)] = []
+    result.reserveCapacity(count)
+    for index in 0..<count {
+      result.append((offset: index, element: getValueUnchecked(at: index, in: runtime)))
+    }
+    return result
   }
 
   /**
    Calls the given closure on each element in the array.
    */
   public func forEach(_ body: (JavaScriptValue) throws -> Void) rethrows {
-    for index in 0..<length {
-      try body(self[index])
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    let count = self.length
+    for index in 0..<count {
+      try body(getValueUnchecked(at: index, in: runtime))
     }
   }
 
@@ -547,9 +575,13 @@ extension JavaScriptArray {
    Returns an array of elements satisfying the given predicate.
    */
   public func filter(_ isIncluded: (JavaScriptValue) throws -> Bool) rethrows -> [JavaScriptValue] {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    let count = self.length
     var result: [JavaScriptValue] = []
-    for index in 0..<length {
-      let value = self[index]
+    for index in 0..<count {
+      let value = getValueUnchecked(at: index, in: runtime)
       if try isIncluded(value) {
         result.append(value)
       }
@@ -561,9 +593,13 @@ extension JavaScriptArray {
    Returns the result of combining the elements using the given closure.
    */
   public func reduce<Result>(_ initialResult: Result, _ nextPartialResult: (Result, JavaScriptValue) throws -> Result) rethrows -> Result {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    let count = self.length
     var result = initialResult
-    for index in 0..<length {
-      result = try nextPartialResult(result, self[index])
+    for index in 0..<count {
+      result = try nextPartialResult(result, getValueUnchecked(at: index, in: runtime))
     }
     return result
   }


### PR DESCRIPTION
## Summary

`MainValueConverter.toNative` previously called `cast(jsValue:)` followed by `cast(_:)` on every argument. The second pass was redundant in the JS path: every `Dynamic*Type.cast(jsValue:)` already produces the final wrapped native value. Particularly expensive for typed arrays — re-running every element through `DynamicNumberType.cast<A>(_:)` and its `as? any BinaryFloatingPoint` existential checks.

This change:
- Drops the second `cast(_:)` call from `MainValueConverter.toNative` and `Field.castValue(jsValue:)`.
- Inlines the second-pass logic into `cast(jsValue:)` for types that used to depend on it: `DynamicConvertibleType` (calls `innerType.convert(from:)` directly), `DynamicViewType` / `DynamicSwiftUIViewType` (resolve view tag → `UIView` in one step), `DynamicValueOrUndefinedType` (wraps in `.value(unwrapped:)`).
- Simplifies `DynamicEitherType.cast(jsValue:)` to a single-pass loop.
- Removes the default `cast(jsValue:)` impl from `AnyDynamicType` — every conformer now declares it explicitly. `DynamicEncodableType` and `DynamicRawType` gained explicit implementations.

`cast(_:)` stays on the protocol for non-JS callers (record fields hydrated from `[String: Any]`, view-prop setters).

Drops `foldArray` from ~1550ms to ~1130ms over 500k iterations on iOS simulator.

## Stacking

Stacked on #45317 — review after that one.

## Test plan

- [x] `DynamicEnumTypeTests` pass
- [x] `ValueOrUndefinedSpec` passes
- [x] `FunctionTests` (especially `Either`, `ValueOrUndefined`, record field) pass
- [x] `RecordSpec` passes
- [x] expo-ui modifiers (which call `Record.init(from: Dict)`) still work
- [x] `foldArray` benchmark in `native-component-list` runs faster vs. `@tsapeta/ios/optimize-array-iteration`

<!-- disable:changelog-checks -->