### PR TITLE
[expo-router] fix RNScreensTabCompat to be compatible with new RNS version

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Fix `Stack.Screen.Title` string/number concatenation. ([#44213](https://github.com/expo/expo/pull/44213) by [@jakex7](https://github.com/jakex7))
 - [android] Use `tint` prop name instead of `tintColor` for Jetpack Compose icons ([#44427](https://github.com/expo/expo/pull/44427) by [@hassankhan](https://github.com/hassankhan))
 - Disable touch events on unfocused native tab screens ([#44778](https://github.com/expo/expo/pull/44778) by [@cortinico](https://github.com/cortinico))
+- fix RNScreensTabCompat to be compatible with new RNS version ([#45321](https://github.com/expo/expo/pull/45321) by [@Ubax](https://github.com/Ubax))
 
 ### 💡 Others
 

--- a/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
+++ b/packages/expo-router/ios/LinkPreview/LinkPreviewNativeNavigation.swift
@@ -150,10 +150,10 @@ internal class LinkPreviewNativeNavigation {
     if let result =
       enumeratedViews
       .first(where: { _, view in
-        guard let tabKey = RNScreensTabCompat.tabKey(from: view) else {
+        guard let screenKey = RNScreensTabCompat.screenKey(from: view) else {
           return false
         }
-        return tabKeys.contains(tabKey)
+        return tabKeys.contains(screenKey)
       }) {
       return (result.offset, result.element)
     }
@@ -179,8 +179,8 @@ internal class LinkPreviewNativeNavigation {
           return view
         }
       } else if let nextView = nextResponder as? UIView,
-        let tabKey = RNScreensTabCompat.tabKey(from: nextView),
-        tabKeys.contains(tabKey) {
+        let screenKey = RNScreensTabCompat.screenKey(from: nextView),
+        tabKeys.contains(screenKey) {
           return nextView
       }
       currentResponder = nextResponder

--- a/packages/expo-router/ios/LinkPreview/RNScreensTabCompat.swift
+++ b/packages/expo-router/ios/LinkPreview/RNScreensTabCompat.swift
@@ -4,26 +4,26 @@ import UIKit
 /// we detect tab views by checking `responds(to:)` for expected selectors
 /// and read properties via KVC.
 enum RNScreensTabCompat {
-  private static let tabKeyName = "tabKey"
+  private static let screenKeyName = "screenKey"
   private static let controllerName = "controller"
   private static let reactViewControllerName = "reactViewController"
 
-  private static let tabKeySelector = NSSelectorFromString(tabKeyName)
+  private static let screenKeySelector = NSSelectorFromString(screenKeyName)
   private static let controllerSelector = NSSelectorFromString(controllerName)
   private static let reactViewControllerSelector = NSSelectorFromString(reactViewControllerName)
 
   // MARK: - Type check
 
-  /// A view is a tab screen if it has a `tabKey` property — specific to RNScreens tab views.
+  /// A view is a tab screen if it has a `screenKey` property — specific to RNScreens tab views.
   static func isTabScreen(_ view: UIView) -> Bool {
-    view.responds(to: tabKeySelector)
+    view.responds(to: screenKeySelector)
   }
 
   // MARK: - Property access via KVC
 
-  static func tabKey(from view: UIView) -> String? {
-    guard view.responds(to: tabKeySelector) else { return nil }
-    return view.value(forKey: tabKeyName) as? String
+  static func screenKey(from view: UIView) -> String? {
+    guard view.responds(to: screenKeySelector) else { return nil }
+    return view.value(forKey: screenKeyName) as? String
   }
 
   /// Calls `reactViewController()` dynamically via `perform(_:)`, then returns `.tabBarController`.

--- a/packages/expo-router/ios/Tests/RNScreensTabCompatTests.swift
+++ b/packages/expo-router/ios/Tests/RNScreensTabCompatTests.swift
@@ -5,9 +5,9 @@ import UIKit
 
 // MARK: - Mock views
 
-/// Mock tab screen: has @objc tabKey property, mimicking RNScreens tab screen views.
+/// Mock tab screen: has @objc screenKey property, mimicking RNScreens tab screen views.
 private class MockTabScreenView: UIView {
-  @objc var tabKey: String?
+  @objc var screenKey: String?
 }
 
 /// Mock tab host: has @objc controller property, mimicking RNScreens tab host views.
@@ -22,7 +22,7 @@ private class MockTabHostWithBadController: UIView {
 
 /// Mock view with a reactViewController() method that returns a UIViewController.
 private class MockTabScreenWithReactVC: UIView {
-  @objc var tabKey: String?
+  @objc var screenKey: String?
   private var _reactViewController: UIViewController?
 
   func configure(reactViewController: UIViewController) {
@@ -62,27 +62,27 @@ struct RNScreensTabCompatUnitTests {
     }
   }
 
-  @Suite("tabKey")
+  @Suite("screenKey")
   @MainActor
-  struct TabKey {
+  struct ScreenKey {
     @Test
     func `reads value`() {
       let tabScreen = MockTabScreenView()
-      tabScreen.tabKey = "home"
-      #expect(RNScreensTabCompat.tabKey(from: tabScreen) == "home")
+      tabScreen.screenKey = "home"
+      #expect(RNScreensTabCompat.screenKey(from: tabScreen) == "home")
     }
 
     @Test
-    func `returns nil for nil tab key`() {
+    func `returns nil for nil screen key`() {
       let tabScreen = MockTabScreenView()
-      tabScreen.tabKey = nil
-      #expect(RNScreensTabCompat.tabKey(from: tabScreen) == nil)
+      tabScreen.screenKey = nil
+      #expect(RNScreensTabCompat.screenKey(from: tabScreen) == nil)
     }
 
     @Test
     func `returns nil for plain UIView`() {
       let plainView = UIView()
-      #expect(RNScreensTabCompat.tabKey(from: plainView) == nil)
+      #expect(RNScreensTabCompat.screenKey(from: plainView) == nil)
     }
   }
 
@@ -134,7 +134,7 @@ struct RNScreensTabCompatUnitTests {
       tabBarController.viewControllers = [childVC]
 
       let mockView = MockTabScreenWithReactVC()
-      mockView.tabKey = "tab1"
+      mockView.screenKey = "tab1"
       mockView.configure(reactViewController: childVC)
       childVC.view.addSubview(mockView)
 
@@ -145,16 +145,16 @@ struct RNScreensTabCompatUnitTests {
     @Test
     func `returns nil when reactViewController returns nil`() {
       let mockView = MockTabScreenWithReactVC()
-      mockView.tabKey = "tab1"
+      mockView.screenKey = "tab1"
       // Don't configure — reactViewController() returns nil
       #expect(RNScreensTabCompat.tabBarController(fromTabScreen: mockView) == nil)
     }
 
     @Test
     func `returns nil when no reactViewController method`() {
-      // MockTabScreenView has tabKey but no reactViewController() method
+      // MockTabScreenView has screenKey but no reactViewController() method
       let mockView = MockTabScreenView()
-      mockView.tabKey = "tab1"
+      mockView.screenKey = "tab1"
       #expect(RNScreensTabCompat.tabBarController(fromTabScreen: mockView) == nil)
     }
 
@@ -171,7 +171,7 @@ struct RNScreensTabCompatUnitTests {
       navController.viewControllers = [childVC]
 
       let mockView = MockTabScreenWithReactVC()
-      mockView.tabKey = "tab1"
+      mockView.screenKey = "tab1"
       mockView.configure(reactViewController: childVC)
       childVC.view.addSubview(mockView)
 
@@ -187,7 +187,7 @@ struct RNScreensTabCompatUnitTests {
 struct RNScreensAPIContractTests {
 
   @Test
-  func `tab screen class responds to tabKey`() throws {
+  func `tab screen class responds to screenKey`() throws {
     let cls = NSClassFromString("RNSTabsScreenComponentView")
       ?? NSClassFromString("RNSBottomTabsScreenComponentView")
     guard let cls else {
@@ -195,7 +195,7 @@ struct RNScreensAPIContractTests {
       return
     }
     let view = try #require((cls as? UIView.Type)?.init(), "Failed to instantiate tab screen class")
-    #expect(view.responds(to: NSSelectorFromString("tabKey")))
+    #expect(view.responds(to: NSSelectorFromString("screenKey")))
   }
 
   @Test


### PR DESCRIPTION
# Why

In the `4.25.0-beta.1` release of screens `tabKey` was renamed to `screenKey` to make it consistend between stack and tabs - https://github.com/software-mansion/react-native-screens/pull/3750. This change caused our `RNScreensTabCompat` tests to fail.

# How

Change `tabKey` to `screenKey`

# Test Plan

1. CI
2. router-e2e

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
