### PR TITLE
[doctor] add check for both expo-router and react-navigation installed in the same project

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add version to the `--verbose` output ([#44592](https://github.com/expo/expo/pull/44592) by [@kitten](https://github.com/kitten))
 - Add check that warns about invalid `overrides`/`resolutions` for critical package versions ([#44770](https://github.com/expo/expo/pull/44770) by [@kitten](https://github.com/kitten))
 - add a warning when mixing `@expo/vector-icons` and `react-native-vector-icons` or packages from `@react-native-vector-icons` ([#37958](https://github.com/expo/expo/pull/37958) by [@vonovak](https://github.com/vonovak))
+- Add check for both expo-router and react-navigation installed in same project ([#45323](https://github.com/expo/expo/pull/45323) by [@Ubax](https://github.com/Ubax))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-doctor/src/checks/ExpoRouterReactNavigationCheck.ts
+++ b/packages/expo-doctor/src/checks/ExpoRouterReactNavigationCheck.ts
@@ -1,0 +1,40 @@
+import type { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+
+export class ExpoRouterReactNavigationCheck implements DoctorCheck {
+  description = 'Check that @react-navigation packages are not installed alongside expo-router';
+
+  sdkVersionRange = '>=56.0.0 <57.0.0';
+
+  async runAsync({ pkg }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const hasExpoRouter = !!(
+      pkg.dependencies?.['expo-router'] || pkg.devDependencies?.['expo-router']
+    );
+    if (!hasExpoRouter) {
+      return { isSuccessful: true, issues: [], advice: [] };
+    }
+
+    const reactNavigationDeps = [
+      ...Object.keys(pkg.dependencies ?? {}),
+      ...Object.keys(pkg.devDependencies ?? {}),
+    ]
+      .filter((name) => name.startsWith('@react-navigation/'))
+      .filter((name, index, all) => all.indexOf(name) === index)
+      .sort();
+
+    if (reactNavigationDeps.length === 0) {
+      return { isSuccessful: true, issues: [], advice: [] };
+    }
+
+    const list = reactNavigationDeps.map((n) => `"${n}"`).join(', ');
+
+    return {
+      isSuccessful: false,
+      issues: [
+        `As of SDK 56, expo-router is no longer compatible with react-navigation. The following @react-navigation packages are installed as direct dependencies and should be removed: ${list}.`,
+      ],
+      advice: [
+        `Remove these packages from your package.json and replace any direct \`@react-navigation/*\` imports in your code with their expo-router equivalents. See https://docs.expo.dev/router/migrate/sdk-55-to-56/ for more information.`,
+      ],
+    };
+  }
+}

--- a/packages/expo-doctor/src/checks/__tests__/ExpoRouterReactNavigationCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/ExpoRouterReactNavigationCheck.test.ts
@@ -1,0 +1,161 @@
+import { ExpoRouterReactNavigationCheck } from '../ExpoRouterReactNavigationCheck';
+
+const additionalProjectProps = {
+  exp: {
+    name: 'name',
+    slug: 'slug',
+    sdkVersion: '56.0.0',
+  },
+  projectRoot: '/tmp/project',
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+describe('runAsync', () => {
+  it('returns isSuccessful = true if expo-router is not installed', async () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        dependencies: { '@react-navigation/native': '^7.0.0' },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toEqual([]);
+  });
+
+  it('returns isSuccessful = true if expo-router is installed but no @react-navigation/* package is', async () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        dependencies: { 'expo-router': '^6.0.0' },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+    expect(result.issues).toEqual([]);
+  });
+
+  it('returns isSuccessful = false if expo-router and @react-navigation/native are both in dependencies', async () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        dependencies: {
+          'expo-router': '^6.0.0',
+          '@react-navigation/native': '^7.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]).toContain('@react-navigation/native');
+    expect(result.advice).toHaveLength(1);
+  });
+
+  it('returns isSuccessful = false if @react-navigation/* is in devDependencies', async () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        dependencies: { 'expo-router': '^6.0.0' },
+        devDependencies: { '@react-navigation/stack': '^7.0.0' },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues[0]).toContain('@react-navigation/stack');
+  });
+
+  it('returns isSuccessful = false if expo-router is in devDependencies', async () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        devDependencies: {
+          'expo-router': '^6.0.0',
+          '@react-navigation/native': '^7.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    expect(result.issues[0]).toContain('@react-navigation/native');
+  });
+
+  it('lists every offending @react-navigation/* package in the message, sorted', async () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        dependencies: {
+          'expo-router': '^6.0.0',
+          '@react-navigation/stack': '^7.0.0',
+          '@react-navigation/native': '^7.0.0',
+          '@react-navigation/bottom-tabs': '^7.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    const message = result.issues[0];
+    const nativeIdx = message.indexOf('@react-navigation/native');
+    const stackIdx = message.indexOf('@react-navigation/stack');
+    const tabsIdx = message.indexOf('@react-navigation/bottom-tabs');
+    expect(tabsIdx).toBeGreaterThan(-1);
+    expect(nativeIdx).toBeGreaterThan(tabsIdx);
+    expect(stackIdx).toBeGreaterThan(nativeIdx);
+  });
+
+  it('ignores peerDependencies (the check targets app projects, not libraries)', async () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        peerDependencies: {
+          'expo-router': '^6.0.0',
+          '@react-navigation/native': '^7.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeTruthy();
+  });
+
+  it('handles same package in both dependencies and devDependencies without duplicating it in the message', async () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    const result = await check.runAsync({
+      pkg: {
+        name: 'name',
+        version: '1.0.0',
+        dependencies: {
+          'expo-router': '^6.0.0',
+          '@react-navigation/native': '^7.0.0',
+        },
+        devDependencies: {
+          '@react-navigation/native': '^7.0.0',
+        },
+      },
+      ...additionalProjectProps,
+    });
+    expect(result.isSuccessful).toBeFalsy();
+    const occurrences = result.issues[0].match(/@react-navigation\/native/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it('has sdkVersionRange = >=56.0.0 <57.0.0', () => {
+    const check = new ExpoRouterReactNavigationCheck();
+    expect(check.sdkVersionRange).toBe('>=56.0.0 <57.0.0');
+  });
+});

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -13,6 +13,7 @@ import { DependencyVersionOverrideCheck } from '../checks/DependencyVersionOverr
 import { DirectPackageInstallCheck } from '../checks/DirectPackageInstallCheck';
 import { ExpoConfigCommonIssueCheck } from '../checks/ExpoConfigCommonIssueCheck';
 import { ExpoConfigSchemaCheck } from '../checks/ExpoConfigSchemaCheck';
+import { ExpoRouterReactNavigationCheck } from '../checks/ExpoRouterReactNavigationCheck';
 import { GlobalPackageInstalledLocallyCheck } from '../checks/GlobalPackageInstalledLocallyCheck';
 import { IllegalPackageCheck } from '../checks/IllegalPackageCheck';
 import { InstalledDependencyVersionCheck } from '../checks/InstalledDependencyVersionCheck';
@@ -52,6 +53,7 @@ export function resolveChecksInScope(exp: ExpoConfig, pkg: PackageJSONConfig): D
     new GlobalPackageInstalledLocallyCheck(),
     new DirectPackageInstallCheck(),
     new PeerDependencyChecks(),
+    new ExpoRouterReactNavigationCheck(),
     new AutolinkingDependencyDuplicatesCheck(),
     new VectorIconsCheck(),
 


### PR DESCRIPTION
# Why

As of SDK 56, having both router and react-navigation installed in the same project, suggests an issue or need to perform the router migration. Add the expo-doctor check for better visibility

# How

1. Detect if both are installed
2. Show error and migration guide link for next steps

# Test Plan

1. CI
2. Router project with `@react-navigation` installed directly as dependency

<img width="727" height="184" alt="Screenshot 2026-05-04 at 10 00 53" src="https://github.com/user-attachments/assets/0ab91384-1ddb-40c9-804f-e5fb40d5d241" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
