### PR TITLE
fix(precompile): pin Xcode to 26.4.1 for iOS precompiled XCFrameworks

### DIFF
--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           submodules: true
 
-      - name: Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: Switch to Xcode 26.4
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
 
       - name: Add bin to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   prebuild:
-    runs-on: macos-15
+    runs-on: macos-26-arm64
     timeout-minutes: 120
     permissions:
       contents: read
@@ -38,8 +38,8 @@ jobs:
         with:
           submodules: true
 
-      - name: Switch to Xcode 26.4
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
+      - name: Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
 
       - name: Add bin to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           submodules: true
 
-      - name: Switch to Xcode 26.4
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
+      - name: Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
 
       - name: Add bin to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   publish-canaries:
     if: github.repository == 'expo/expo'
-    runs-on: macos-15
+    runs-on: macos-26-arm64
     timeout-minutes: 120
     env:
       NODE_AUTH_TOKEN: ${{ secrets.EXPO_BOT_NPM_TOKEN }}
@@ -29,8 +29,8 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 26.4
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: 🔨 Add bin to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -29,8 +29,8 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
       - name: 🔨 Add bin to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -28,8 +28,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
       - name: 🔨 Add bin to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -28,8 +28,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 26.4
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: 🔨 Add bin to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm

--- a/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
@@ -25,8 +25,8 @@ jobs:
     image: latest
     steps:
       - uses: eas/checkout
-      - name: Switch to Xcode 26.4
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
+      - name: Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - id: detect
         name: Detect changed packages
         outputs: [packages]

--- a/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
@@ -22,11 +22,9 @@ jobs:
   smoke_test:
     name: Prebuild XCFrameworks (Debug)
     runs_on: macos-large
-    image: latest
+    image: macos-tahoe-26.4-xcode-26.4
     steps:
       - uses: eas/checkout
-      - name: Switch to Xcode 26.4.1
-        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - id: detect
         name: Detect changed packages
         outputs: [packages]

--- a/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/ios-prebuild-xcframeworks-smoke.yml
@@ -25,6 +25,8 @@ jobs:
     image: latest
     steps:
       - uses: eas/checkout
+      - name: Switch to Xcode 26.4
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.app
       - id: detect
         name: Detect changed packages
         outputs: [packages]

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -73,6 +73,7 @@ We use our fork of React Native for building Expo Go, but it is not used otherwi
 
 **How:**
 
+- Make sure Xcode 26.4 is installed in `/Applications` (it can coexist with newer Xcodes). `et publish-packages` automatically points the iOS prebuild step at it via `DEVELOPER_DIR` regardless of which Xcode is active, and fails fast with a clear error if 26.4 isn't found. This pin matters because the npm-bundled iOS xcframeworks embed the producing Swift compiler version in their `.swiftinterface` headers, and Swift refuses to consume an interface produced by a newer compiler — publishing on a newer Xcode would break every EAS Build worker and consumer on an older one.
 - Run `et publish-packages`. Talk to @tsapeta for more details/information.
 - Run `et sync-bundled-native-modules` to sync the `bundledNativeModules.json` file with www.
 
@@ -163,6 +164,7 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 
 **How:**
 
+- Make sure Xcode 26.4 is installed in `/Applications` (see [§0.6](#06-publish-next-packages) for why; `et publish-packages` will use it automatically).
 - From the main branch, run `et publish-packages` and publish all packages with changes.
 - From the main branch, run `et sync-bundled-native-modules` to sync the `bundledNativeModules.json` file with www.
 - If there are any packages for which a patch was cherry-picked to the release branch AND a new feature (requiring a minor version bump) was added on main in the meantime, you will need to publish a patch release of that package from the release branch which does not include the new feature.

--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -73,7 +73,7 @@ We use our fork of React Native for building Expo Go, but it is not used otherwi
 
 **How:**
 
-- Make sure Xcode 26.4 is installed in `/Applications` (it can coexist with newer Xcodes). `et publish-packages` automatically points the iOS prebuild step at it via `DEVELOPER_DIR` regardless of which Xcode is active, and fails fast with a clear error if 26.4 isn't found. This pin matters because the npm-bundled iOS xcframeworks embed the producing Swift compiler version in their `.swiftinterface` headers, and Swift refuses to consume an interface produced by a newer compiler — publishing on a newer Xcode would break every EAS Build worker and consumer on an older one.
+- Make sure Xcode 26.4.1 is installed in `/Applications` (it can coexist with newer Xcodes). `et publish-packages` automatically points the iOS prebuild step at it via `DEVELOPER_DIR` regardless of which Xcode is active, and fails fast with a clear error if 26.4.1 isn't found. This pin matters because the npm-bundled iOS xcframeworks embed the producing Swift compiler version in their `.swiftinterface` headers, and Swift refuses to consume an interface produced by a newer compiler — publishing on a newer Xcode would break every EAS Build worker and consumer on an older one.
 - Run `et publish-packages`. Talk to @tsapeta for more details/information.
 - Run `et sync-bundled-native-modules` to sync the `bundledNativeModules.json` file with www.
 
@@ -164,7 +164,7 @@ Web is comparatively well-tested in CI, so a few manual smoke tests suffice for 
 
 **How:**
 
-- Make sure Xcode 26.4 is installed in `/Applications` (see [§0.6](#06-publish-next-packages) for why; `et publish-packages` will use it automatically).
+- Make sure Xcode 26.4.1 is installed in `/Applications` (see [§0.6](#06-publish-next-packages) for why; `et publish-packages` will use it automatically).
 - From the main branch, run `et publish-packages` and publish all packages with changes.
 - From the main branch, run `et sync-bundled-native-modules` to sync the `bundledNativeModules.json` file with www.
 - If there are any packages for which a patch was cherry-picked to the release branch AND a new feature (requiring a minor version bump) was added on main in the meantime, you will need to publish a patch release of that package from the release branch which does not include the new feature.

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.test.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.test.ts
@@ -9,15 +9,15 @@ import {
 
 describe('parseXcodeVersion', () => {
   it('parses a normal `xcodebuild -version` output', () => {
-    assert.equal(parseXcodeVersion('Xcode 26.0\nBuild version 16A5318g\n'), '26.0');
+    assert.equal(parseXcodeVersion('Xcode 26.4.1\nBuild version 16A5318g\n'), '26.4.1');
   });
 
-  it('normalizes a major-only Xcode version to major.minor', () => {
-    assert.equal(parseXcodeVersion('Xcode 26\nBuild version 16A5318g\n'), '26.0');
+  it('normalizes a major-only Xcode version to major.minor.patch', () => {
+    assert.equal(parseXcodeVersion('Xcode 26\nBuild version 16A5318g\n'), '26.0.0');
   });
 
-  it('strips the patch component from an Xcode version', () => {
-    assert.equal(parseXcodeVersion('Xcode 26.0.1\n'), '26.0');
+  it('normalizes a major.minor Xcode version to major.minor.patch', () => {
+    assert.equal(parseXcodeVersion('Xcode 26.4\n'), '26.4.0');
   });
 
   it('returns null when the expected prefix is missing', () => {
@@ -57,12 +57,12 @@ describe('ensureSupportedToolchainAsync', () => {
       async () => '26.2',
       async () => [
         {
-          developerDir: '/Applications/Xcode_26.4.app/Contents/Developer',
+          developerDir: '/Applications/Xcode_26.4.1.app/Contents/Developer',
           xcode: SUPPORTED_XCODE_VERSION,
         },
       ]
     );
-    assert.equal(process.env.DEVELOPER_DIR, '/Applications/Xcode_26.4.app/Contents/Developer');
+    assert.equal(process.env.DEVELOPER_DIR, '/Applications/Xcode_26.4.1.app/Contents/Developer');
     restore();
     assert.equal(process.env.DEVELOPER_DIR, undefined);
   });
@@ -74,12 +74,12 @@ describe('ensureSupportedToolchainAsync', () => {
       async () => '27.0',
       async () => [
         {
-          developerDir: '/Applications/Xcode_26.4.app/Contents/Developer',
+          developerDir: '/Applications/Xcode_26.4.1.app/Contents/Developer',
           xcode: SUPPORTED_XCODE_VERSION,
         },
       ]
     );
-    assert.equal(process.env.DEVELOPER_DIR, '/Applications/Xcode_26.4.app/Contents/Developer');
+    assert.equal(process.env.DEVELOPER_DIR, '/Applications/Xcode_26.4.1.app/Contents/Developer');
     restore();
     assert.equal(process.env.DEVELOPER_DIR, prior);
   });

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.test.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.test.ts
@@ -1,0 +1,142 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  ensureSupportedToolchainAsync,
+  parseXcodeVersion,
+  SUPPORTED_XCODE_VERSION,
+} from './bundleIOSPrebuilds';
+
+describe('parseXcodeVersion', () => {
+  it('parses a normal `xcodebuild -version` output', () => {
+    assert.equal(parseXcodeVersion('Xcode 26.0\nBuild version 16A5318g\n'), '26.0');
+  });
+
+  it('normalizes a major-only Xcode version to major.minor', () => {
+    assert.equal(parseXcodeVersion('Xcode 26\nBuild version 16A5318g\n'), '26.0');
+  });
+
+  it('strips the patch component from an Xcode version', () => {
+    assert.equal(parseXcodeVersion('Xcode 26.0.1\n'), '26.0');
+  });
+
+  it('returns null when the expected prefix is missing', () => {
+    assert.equal(parseXcodeVersion('something else entirely'), null);
+  });
+});
+
+describe('ensureSupportedToolchainAsync', () => {
+  let previousDeveloperDir: string | undefined;
+
+  beforeEach(() => {
+    previousDeveloperDir = process.env.DEVELOPER_DIR;
+  });
+
+  afterEach(() => {
+    if (previousDeveloperDir === undefined) {
+      delete process.env.DEVELOPER_DIR;
+    } else {
+      process.env.DEVELOPER_DIR = previousDeveloperDir;
+    }
+  });
+
+  it('does not touch DEVELOPER_DIR when active toolchain matches', async () => {
+    delete process.env.DEVELOPER_DIR;
+    const restore = await ensureSupportedToolchainAsync(
+      async () => SUPPORTED_XCODE_VERSION,
+      async () => []
+    );
+    assert.equal(process.env.DEVELOPER_DIR, undefined);
+    restore();
+    assert.equal(process.env.DEVELOPER_DIR, undefined);
+  });
+
+  it('sets DEVELOPER_DIR when switching, and unsets it on restore', async () => {
+    delete process.env.DEVELOPER_DIR;
+    const restore = await ensureSupportedToolchainAsync(
+      async () => '26.2',
+      async () => [
+        {
+          developerDir: '/Applications/Xcode_26.4.app/Contents/Developer',
+          xcode: SUPPORTED_XCODE_VERSION,
+        },
+      ]
+    );
+    assert.equal(process.env.DEVELOPER_DIR, '/Applications/Xcode_26.4.app/Contents/Developer');
+    restore();
+    assert.equal(process.env.DEVELOPER_DIR, undefined);
+  });
+
+  it('preserves a prior DEVELOPER_DIR value across switch + restore', async () => {
+    const prior = '/Applications/Xcode_27.0.app/Contents/Developer';
+    process.env.DEVELOPER_DIR = prior;
+    const restore = await ensureSupportedToolchainAsync(
+      async () => '27.0',
+      async () => [
+        {
+          developerDir: '/Applications/Xcode_26.4.app/Contents/Developer',
+          xcode: SUPPORTED_XCODE_VERSION,
+        },
+      ]
+    );
+    assert.equal(process.env.DEVELOPER_DIR, '/Applications/Xcode_26.4.app/Contents/Developer');
+    restore();
+    assert.equal(process.env.DEVELOPER_DIR, prior);
+  });
+
+  it('throws with a what/why/how message when no supported toolchain is available', async () => {
+    delete process.env.DEVELOPER_DIR;
+    await assert.rejects(
+      ensureSupportedToolchainAsync(
+        async () => '26.2',
+        async () => []
+      ),
+      (err: Error) => {
+        assert.match(err.message, /Active toolchain is Xcode 26\.2/);
+        assert.match(err.message, new RegExp(`Xcode ${SUPPORTED_XCODE_VERSION}`));
+        assert.match(err.message, /No Xcode-shaped apps found in \/Applications/);
+        assert.match(err.message, /developer\.apple\.com/);
+        assert.match(err.message, /--skip-ios-prebuilds/);
+        return true;
+      }
+    );
+    assert.equal(process.env.DEVELOPER_DIR, undefined);
+  });
+
+  it('lists discovered Xcodes in the throw message when none match', async () => {
+    delete process.env.DEVELOPER_DIR;
+    await assert.rejects(
+      ensureSupportedToolchainAsync(
+        async () => '26.2',
+        async () => [
+          {
+            developerDir: '/Applications/Xcode_26.2.app/Contents/Developer',
+            xcode: '26.2',
+          },
+          {
+            developerDir: '/Applications/Xcode_15.4.app/Contents/Developer',
+            xcode: '15.4',
+          },
+        ]
+      ),
+      (err: Error) => {
+        assert.match(err.message, /Found in \/Applications/);
+        assert.match(err.message, /Xcode 26\.2 at \/Applications\/Xcode_26\.2\.app/);
+        assert.match(err.message, /Xcode 15\.4 at \/Applications\/Xcode_15\.4\.app/);
+        return true;
+      }
+    );
+  });
+
+  it('does not mutate DEVELOPER_DIR when the throw path is taken', async () => {
+    const prior = '/Applications/Xcode_27.0.app/Contents/Developer';
+    process.env.DEVELOPER_DIR = prior;
+    await assert.rejects(
+      ensureSupportedToolchainAsync(
+        async () => '27.0',
+        async () => []
+      )
+    );
+    assert.equal(process.env.DEVELOPER_DIR, prior);
+  });
+});

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -15,15 +15,15 @@ import { CommandOptions, Parcel, TaskArgs } from '../types';
  * older one, which breaks consumers who haven't yet upgraded. Keep in sync with the CI
  * workflows that publish artifacts (see .github/workflows/publish-canaries.yml).
  */
-export const SUPPORTED_XCODE_VERSION = '26.4';
+export const SUPPORTED_XCODE_VERSION = '26.4.1';
 
 type InstalledXcode = { developerDir: string; xcode: string | null };
 
-// Returns major.minor (`Xcode 26.4.1` → `26.4`); `null` when the prefix isn't found.
+// Returns major.minor.patch (`Xcode 26.4` → `26.4.0`); `null` when the prefix isn't found.
 export function parseXcodeVersion(output: string): string | null {
-  const match = output.match(/Xcode\s+(\d+)(?:\.(\d+))?/);
+  const match = output.match(/Xcode\s+(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
   if (!match) return null;
-  return `${match[1]}.${match[2] ?? '0'}`;
+  return `${match[1]}.${match[2] ?? '0'}.${match[3] ?? '0'}`;
 }
 
 async function readXcodeVersionAsync(developerDir?: string): Promise<string | null> {

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -5,9 +5,94 @@ import { loadRequestedParcels } from './loadRequestedParcels';
 import { PACKAGES_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
-import { runWithSpinner } from '../../Utils';
+import { runWithSpinner, spawnAsync } from '../../Utils';
 import { runPrebuildPackagesAsync } from '../../commands/PrebuildPackages';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
+
+/**
+ * Xcode version that prebuilds must be built with. Each Xcode bundles a specific Swift
+ * compiler, and `.swiftinterface` files emitted by a newer Swift cannot be parsed by an
+ * older one, which breaks consumers who haven't yet upgraded. Keep in sync with the CI
+ * workflows that publish artifacts (see .github/workflows/publish-canaries.yml).
+ */
+export const SUPPORTED_XCODE_VERSION = '26.4';
+
+type InstalledXcode = { developerDir: string; xcode: string | null };
+
+// Returns major.minor (`Xcode 26.4.1` → `26.4`); `null` when the prefix isn't found.
+export function parseXcodeVersion(output: string): string | null {
+  const match = output.match(/Xcode\s+(\d+)(?:\.(\d+))?/);
+  if (!match) return null;
+  return `${match[1]}.${match[2] ?? '0'}`;
+}
+
+async function readXcodeVersionAsync(developerDir?: string): Promise<string | null> {
+  const env = developerDir ? { ...process.env, DEVELOPER_DIR: developerDir } : process.env;
+  try {
+    const { stdout } = await spawnAsync('xcodebuild', ['-version'], { env });
+    return parseXcodeVersion(stdout);
+  } catch {
+    return null;
+  }
+}
+
+async function listInstalledXcodesAsync(): Promise<InstalledXcode[]> {
+  const entries = await fs.promises.readdir('/Applications').catch(() => [] as string[]);
+  const xcodeApps = entries.filter((n) => /^Xcode.*\.app$/i.test(n));
+  return Promise.all(
+    xcodeApps.map(async (name) => {
+      const developerDir = path.join('/Applications', name, 'Contents', 'Developer');
+      const xcode = await readXcodeVersionAsync(developerDir);
+      return { developerDir, xcode };
+    })
+  );
+}
+
+// Returns a restorer that undoes any DEVELOPER_DIR mutation (no-op if none).
+// `readActive` / `listInstalled` are injection seams for tests.
+export async function ensureSupportedToolchainAsync(
+  readActive: () => Promise<string | null> = () => readXcodeVersionAsync(),
+  listInstalled: () => Promise<InstalledXcode[]> = listInstalledXcodesAsync
+): Promise<() => void> {
+  const active = await readActive();
+  if (active === SUPPORTED_XCODE_VERSION) {
+    logger.log(`   Using active toolchain: Xcode ${active}`);
+    return () => {};
+  }
+
+  const installed = await listInstalled();
+  const match = installed.find((t) => t.xcode === SUPPORTED_XCODE_VERSION);
+  if (match) {
+    const previous = process.env.DEVELOPER_DIR;
+    process.env.DEVELOPER_DIR = match.developerDir;
+    logger.log(
+      `   Switched DEVELOPER_DIR to ${match.developerDir} for this run (will reset after).`
+    );
+    return () => {
+      if (previous === undefined) {
+        delete process.env.DEVELOPER_DIR;
+      } else {
+        process.env.DEVELOPER_DIR = previous;
+      }
+    };
+  }
+
+  const activeDescription = active
+    ? `Active toolchain is Xcode ${active}`
+    : 'No active Xcode toolchain detected';
+  const found =
+    installed.length > 0
+      ? `Found in /Applications: ${installed
+          .map((t) => `Xcode ${t.xcode ?? '?'} at ${t.developerDir}`)
+          .join('; ')}.`
+      : `No Xcode-shaped apps found in /Applications.`;
+  throw new Error(
+    `${activeDescription}, but iOS prebuilds must be built with Xcode ${SUPPORTED_XCODE_VERSION}. ` +
+      `Newer Swift compilers emit module interfaces that older consumer toolchains cannot parse, which breaks compilation for downstream consumers. ` +
+      `${found} ` +
+      `Install Xcode ${SUPPORTED_XCODE_VERSION} from https://developer.apple.com/download/all/ (it can coexist with other Xcodes), or rerun with \`--skip-ios-prebuilds\` if you don't need fresh artifacts.`
+  );
+}
 
 /**
  * Packages whose iOS prebuilt xcframeworks should be bundled into the npm tarball.
@@ -59,79 +144,85 @@ export const bundleIOSPrebuilds = new Task<TaskArgs>(
       return;
     }
 
-    const result = await runPrebuildPackagesAsync(relevantParcels, {
-      clean: false,
-      cleanCache: false,
-      skipGenerate: false,
-      skipArtifacts: false,
-      skipBuild: false,
-      skipCompose: false,
-      skipVerify: false,
-      verbose: false,
-      bundleSharedDeps: true,
-    });
+    const restoreToolchain = await ensureSupportedToolchainAsync();
 
-    if (result.exitCode !== 0) {
-      logger.error(`iOS prebuild failed with exit code ${result.exitCode}`);
-      if (result.errorLogPath) {
-        logger.error(`Error log: ${result.errorLogPath}`);
+    try {
+      const result = await runPrebuildPackagesAsync(relevantParcels, {
+        clean: false,
+        cleanCache: false,
+        skipGenerate: false,
+        skipArtifacts: false,
+        skipBuild: false,
+        skipCompose: false,
+        skipVerify: false,
+        verbose: false,
+        bundleSharedDeps: true,
+      });
+
+      if (result.exitCode !== 0) {
+        logger.error(`iOS prebuild failed with exit code ${result.exitCode}`);
+        if (result.errorLogPath) {
+          logger.error(`Error log: ${result.errorLogPath}`);
+        }
+
+        const errorDetails = result.errors
+          .map((e) => `  - [${e.packageName}/${e.productName}] ${e.stage}: ${e.error.message}`)
+          .join('\n');
+        const errorMessage = errorDetails
+          ? `iOS prebuild pipeline failed:\n${errorDetails}`
+          : 'iOS prebuild pipeline failed';
+        throw new Error(errorMessage);
       }
 
-      const errorDetails = result.errors
-        .map((e) => `  - [${e.packageName}/${e.productName}] ${e.stage}: ${e.error.message}`)
-        .join('\n');
-      const errorMessage = errorDetails
-        ? `iOS prebuild pipeline failed:\n${errorDetails}`
-        : 'iOS prebuild pipeline failed';
-      throw new Error(errorMessage);
-    }
+      // Copy built tarballs into each package's prebuilds/ directory
+      for (const pkgName of IOS_PREBUILD_PACKAGES) {
+        const parcel = parcels.find(
+          (p) => p.pkg.packageName === pkgName || p.pkg.packageSlug === pkgName
+        );
+        if (!parcel) {
+          logger.warn(`Package ${pkgName} not found in parcels, skipping prebuild bundling`);
+          continue;
+        }
 
-    // Copy built tarballs into each package's prebuilds/ directory
-    for (const pkgName of IOS_PREBUILD_PACKAGES) {
-      const parcel = parcels.find(
-        (p) => p.pkg.packageName === pkgName || p.pkg.packageSlug === pkgName
-      );
-      if (!parcel) {
-        logger.warn(`Package ${pkgName} not found in parcels, skipping prebuild bundling`);
-        continue;
-      }
+        await runWithSpinner(
+          `Bundling iOS prebuilds into ${pkgName}`,
+          async () => {
+            for (const flavor of FLAVORS) {
+              const srcDir = path.join(
+                PRECOMPILE_BUILD_DIR,
+                pkgName,
+                'output',
+                flavor,
+                'xcframeworks'
+              );
+              const destDir = path.join(
+                parcel.pkg.path,
+                'prebuilds',
+                'output',
+                flavor,
+                'xcframeworks'
+              );
 
-      await runWithSpinner(
-        `Bundling iOS prebuilds into ${pkgName}`,
-        async () => {
-          for (const flavor of FLAVORS) {
-            const srcDir = path.join(
-              PRECOMPILE_BUILD_DIR,
-              pkgName,
-              'output',
-              flavor,
-              'xcframeworks'
-            );
-            const destDir = path.join(
-              parcel.pkg.path,
-              'prebuilds',
-              'output',
-              flavor,
-              'xcframeworks'
-            );
+              if (!fs.existsSync(srcDir)) {
+                logger.warn(`  No ${flavor} xcframeworks found at ${srcDir}`);
+                continue;
+              }
 
-            if (!fs.existsSync(srcDir)) {
-              logger.warn(`  No ${flavor} xcframeworks found at ${srcDir}`);
-              continue;
-            }
+              await fs.promises.mkdir(destDir, { recursive: true });
 
-            await fs.promises.mkdir(destDir, { recursive: true });
-
-            const files = await fs.promises.readdir(srcDir);
-            for (const file of files) {
-              if (file.endsWith('.tar.gz')) {
-                await fs.promises.copyFile(path.join(srcDir, file), path.join(destDir, file));
+              const files = await fs.promises.readdir(srcDir);
+              for (const file of files) {
+                if (file.endsWith('.tar.gz')) {
+                  await fs.promises.copyFile(path.join(srcDir, file), path.join(destDir, file));
+                }
               }
             }
-          }
-        },
-        `Bundled iOS prebuilds into ${pkgName}`
-      );
+          },
+          `Bundled iOS prebuilds into ${pkgName}`
+        );
+      }
+    } finally {
+      restoreToolchain();
     }
   }
 );


### PR DESCRIPTION
## Why

**DO NOT MERGE UNTIL:**

- https://github.com/expo/workflow-orchestration/pull/801 
- https://github.com/expo/turtle-v2/pull/2556

`et publish-packages` is often run on local dev machines, making the version of XCode unclear. XCframeworks is forwards compatible with future versions of the Swift compiler - not backwards. Therefore we need to build using the lowest EAS build XCode when publishing.

We decided to require Xcode 26.4.1 for building in SDK 56 

**NOTE**: REQUIRES Xcode 26.4.1 images on our runners - _keep as draft until done_

## How

Updated `et publish-packages` to check and verify that Xcode 26.4.1 is installed, and to automatically set DEVELOPER_DIR to the correct Xcode path or fail when running publish-packages.

- Updated workflows now uses Xcode 26.4.1:
  - Canaries workflow
  - Smoke-test XCFramework workflow
  - External xcframeworks workflow 

## Test-plan

✅ Added unit tests.
✅ Changed to Xcode 26.2 as standard and verified that Xcode 26.4.1 was activated 
✅ Removed Xcode 26.4.1 from system and verified it fails

(Using the app `Xcodes` to have multiple versions of Xcode installed for testing)

