### PR TITLE
fix(precompile) added expo-ui back to the list of precompiled packages

### DIFF
--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -27,7 +27,7 @@ const IOS_PREBUILD_PACKAGES = [
   'expo-modules-core',
   'expo-print',
   'expo-sensors',
-  //'expo-ui', // Until we have support for worklets (3rd party frameworks) in prebuilds, we can't include this package because it has a dependency on react-native-worklets
+  'expo-ui',
   'expo-video',
 ];
 


### PR DESCRIPTION
# Why

After merging #45026 we support Expo Worklets as XCFrameworks and can therefore also support ExpoUI as XCFrameworks.

# How

This PR re-enables Expo UI as XCFramework by adding it to list of packages to build.

# Test-plan

Run `et publish-packages --dry` to verify

