### PR TITLE
[expo-cli] add EXPO_ROUTER_DISABLE_RN_NAVIGATION_REWRITE for more granular control of react-navigation rewrites

### DIFF
--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -691,17 +691,27 @@ export function withExtendedResolver(
         }
       }
 
-      if (!env.EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK) {
+      if (
+        !env.EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK ||
+        !env.EXPO_ROUTER_DISABLE_RN_NAVIGATION_REWRITE
+      ) {
         // TODO(@ubax): Remove this rewrite once we published migration guide for library authors
         if (isExpoRouterInstalled && moduleName.startsWith('@react-navigation/')) {
           const filePath = context.originModulePath;
-          if (!filePath.includes('node_modules')) {
+          const isInNodeModules = filePath.includes('node_modules');
+          if (!env.EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK && !isInNodeModules) {
             // TODO(@ubax): Add link to migration guide, once it is published
             throw new Error(
               'As of SDK 56, expo-router is no longer compatible with react-navigation. For more information, see [MIGRATION_GUIDE_URL]. You can disable this check by setting the environment variable EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1.'
             );
           }
-          if (moduleName === '@react-navigation/core') {
+
+          // TODO(@ubax): Remove this rewrite once we published migration guide for library authors
+          if (
+            !env.EXPO_ROUTER_DISABLE_RN_NAVIGATION_REWRITE &&
+            isInNodeModules &&
+            moduleName === '@react-navigation/core'
+          ) {
             // We already checked if expo-router resolves
             return doResolve('expo-router');
           }

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -271,9 +271,14 @@ class Env {
     return boolish('EXPO_UNSTABLE_WEB_MODAL', false);
   }
 
-  /** Disable @react-navigation checks for expo-router projects */
+  /** Disable the error thrown when an expo-router project imports `@react-navigation/*` from app code. */
   get EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK(): boolean {
     return boolish('EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK', false);
+  }
+
+  /** Disable rewriting `@react-navigation/core` imports from `node_modules` to `expo-router` in expo-router projects. */
+  get EXPO_ROUTER_DISABLE_RN_NAVIGATION_REWRITE(): boolean {
+    return boolish('EXPO_ROUTER_DISABLE_RN_NAVIGATION_REWRITE', false);
   }
 
   /** Disable by falsy value live binding in experimental import export support. Enabled by default. */


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
