### PR TITLE
[go] use newer eas worker image

### DIFF
--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -22,7 +22,7 @@
         }
       },
       "ios": {
-        "image": "sdk-54",
+        "image": "macos-sequoia-15.6-xcode-26.2",
         "cocoapods": "1.16.2",
         "resourceClass": "medium",
         "env": {

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -10,7 +10,7 @@
       "node": "22.17.1",
       "credentialsSource": "local",
       "android": {
-        "image": "sdk-54",
+        "image": "ubuntu-24.04-jdk-17-ndk-r27b-sdk-55",
         "resourceClass": "large",
         "env": {
           "EAS_BUILD_PLATFORM": "android",


### PR DESCRIPTION
# Why

resolve build error https://expo.dev/accounts/expo-ci/projects/unversioned-expo-go/workflows/019df16e-2d36-7b6a-af24-2317e51ac6d6

```

❌  (../../packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift:12:21)

  10 |  */
  11 | public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error {
> 12 |   internal weak let runtime: JavaScriptRuntime?
     |                     ^ 'weak' must be a mutable variable, because it may change at runtime
  13 |   internal let pointee: facebook.jsi.Value
  14 | 
  15 |   /**
```

# How

- use xcode 26.6 that supports `weak let`
- also bump android worker. `sdk-54` is confusing here because we are going to work on sdk 56

# Test Plan

expo-go ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
