### PR TITLE
fix(metro-config): Fix incorrect `BABEL_ENV` restoration in Babel transformer

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Respect `enableBabelRCLookup` in `loadBabelConfig` to skip Babel config file discovery ([#44841](https://github.com/expo/expo/pull/44841) by [@zoontek](https://github.com/zoontek))
 - Fix mangled async chunk filenames for catch-all routes ([#43547](https://github.com/expo/expo/pull/43547) by [@hassankhan](https://github.com/hassankhan))
 - Fixed DOM Components rendering issues on Android 9 devices. ([#43156](https://github.com/expo/expo/pull/43156) by [@kudo](https://github.com/kudo))
+- Fix `BABEL_ENV` being incorrectly restored ([#45348](https://github.com/expo/expo/pull/45348) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-config/build/babel-transformer.js
+++ b/packages/@expo/metro-config/build/babel-transformer.js
@@ -145,7 +145,7 @@ plugins, }) => {
     }
     finally {
         // Restore the old process.env.BABEL_ENV
-        if (OLD_BABEL_ENV != null) {
+        if (OLD_BABEL_ENV == null) {
             // We have to treat this as a special case because writing undefined to
             // an environment variable coerces it to the string 'undefined'. To
             // unset it, we must delete it.

--- a/packages/@expo/metro-config/src/babel-transformer.ts
+++ b/packages/@expo/metro-config/src/babel-transformer.ts
@@ -222,7 +222,7 @@ const transform: BabelTransformer['transform'] = ({
     return { ast: result.ast, metadata: result.metadata };
   } finally {
     // Restore the old process.env.BABEL_ENV
-    if (OLD_BABEL_ENV != null) {
+    if (OLD_BABEL_ENV == null) {
       // We have to treat this as a special case because writing undefined to
       // an environment variable coerces it to the string 'undefined'. To
       // unset it, we must delete it.


### PR DESCRIPTION
# Why

Resolves #44687

A typo in the Babel transformer here means that `BABEL_ENV` is incorrectly restored to the incorrect value.

See: https://github.com/facebook/metro/blob/5c4606f242b142f05efb082b2a5c8ea2445e0971/packages/metro-babel-transformer/src/index.js#L144
Regressed in #44366 / #44320

# How

- Fix inverted condition

# Test Plan

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
