### PR TITLE
[image-picker][android] Force `com.canhub.cropper.CropImageActivity` to be unexported

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -16,7 +16,7 @@
 - fix potential `null` mime type reported ([#43734](https://github.com/expo/expo/pull/43734) by [@vonovak](https://github.com/vonovak))
 - [android] fix cropper default colors in light mode ([#42437](https://github.com/expo/expo/pull/42437) by [@fobos531](https://github.com/fobos531))
 - [iOS] Fix `base64` result not being a JPEG data. ([#43806](https://github.com/expo/expo/pull/43806) by [@barthap](https://github.com/barthap))
-- [android] Fix potential vulnerability in `com.canhub.cropper.CropImageActivity` being exported.
+- [android] Fix potential vulnerability in `com.canhub.cropper.CropImageActivity` being exported. ([#45357](https://github.com/expo/expo/pull/45357) by [@behenate](https://github.com/behenate))
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fix potential `null` mime type reported ([#43734](https://github.com/expo/expo/pull/43734) by [@vonovak](https://github.com/vonovak))
 - [android] fix cropper default colors in light mode ([#42437](https://github.com/expo/expo/pull/42437) by [@fobos531](https://github.com/fobos531))
 - [iOS] Fix `base64` result not being a JPEG data. ([#43806](https://github.com/expo/expo/pull/43806) by [@barthap](https://github.com/barthap))
+- [android] Fix potential vulnerability in `com.canhub.cropper.CropImageActivity` being exported.
 
 ### 💡 Others
 

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -21,6 +21,12 @@
         android:value="" />
     </service>
 
+    <!-- Prevent external apps from directly invoking the underlying cropper library activity.
+         The library declares this activity with exported="true". -->
+    <activity
+      android:name="com.canhub.cropper.CropImageActivity"
+      android:exported="false"
+      tools:replace="android:exported" />
     <activity
       android:name="expo.modules.imagepicker.ExpoCropImageActivity"
       android:theme="@style/Base.Theme.AppCompat"


### PR DESCRIPTION
# Why

ENG-20969

`com.canhub.cropper.CropImageActivity` is always exported, which may lead to security issues.

# How

Add an entry in `AndroidManifest` of the image-picker to override the exported status of CropImageActivity. We don't need it to be exported.

# Test Plan

Cleaned the app/build folder and checked the merged manifest - the activity is no longer exported.
Also checked in BareExpo on a Pixel 8 - The image picker still works without issues

