### PR TITLE
[docs] Update/remove deprecated terminology around "bare"

### DIFF
--- a/docs/pages/bare/upgrade.mdx
+++ b/docs/pages/bare/upgrade.mdx
@@ -5,7 +5,7 @@ description: View file-by-file diffs of all the changes you need to make to your
 
 import { TemplateBareMinimumDiffViewer } from '~/ui/components/TemplateBareMinimumDiffViewer';
 
-If you manage your native projects (previously known as bare workflow), to [upgrade to the latest Expo SDK](/workflow/upgrading-expo-sdk-walkthrough/), you have to make changes to your native projects. It can be a complex process to find which native file changes and what to update in which file.
+If you manage your native projects (**android** and **ios** directories), to [upgrade to the latest Expo SDK](/workflow/upgrading-expo-sdk-walkthrough/), you have to make changes to your native projects. It can be a complex process to find which native file changes and what to update in which file.
 
 The following guide provides diffs to compare native project files between your project's current SDK version and the target SDK version you want to upgrade. You can use them to make changes to your project depending on the `expo` package version your project uses. The tools on this page are similar to [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/). However, they are oriented around projects that use Expo modules and related tooling.
 

--- a/docs/pages/build-reference/ios-builds.mdx
+++ b/docs/pages/build-reference/ios-builds.mdx
@@ -17,7 +17,7 @@ The first phase happens on your computer. EAS CLI is in charge of completing the
 1. Prepare the credentials needed for the build.
    - Depending on the value of `builds.ios.PROFILE_NAME.credentialsSource`, the credentials are obtained from either the local **credentials.json** file or from the EAS servers. If the `remote` mode is selected but no credentials exist yet, you're offered to generate them.
 
-1. **Bare** projects require an additional step: check whether the Xcode project is configured to be buildable on the EAS servers (to ensure the correct bundle identifier and Apple Team ID are set).
+1. Projects that manage their own native directories (**android** and **ios**), require an additional step: check whether the Xcode project is configured to be buildable on the EAS servers (to ensure the correct bundle identifier and Apple Team ID are set).
 1. Create the tarball containing a copy of the repository. Actual behavior depends on the [VCS workflow](https://expo.fyi/eas-vcs-workflow) you are using.
 1. Upload the project tarball to a private Google Cloud Storage (GCS) bucket and send the build request to EAS Build.
 
@@ -39,7 +39,7 @@ In this next phase, this is what happens when EAS Build picks up your request:
    - Write the Provisioning Profile to the **~/Library/MobileDevice/Provisioning Profiles** directory.
    - Verify that the Distribution Certificate and Provisioning Profile match (every Provisioning Profile is assigned to a particular Distribution Certificate and cannot be used for building the iOS with any other certificate).
 
-1. Additional step for **managed** projects: Run `npx expo prebuild` to convert the project to a bare one. This step will use the versioned Expo CLI.
+1. Additional step for projects using Continuous Native Generation (CNG): Run `npx expo prebuild` to generate **android** and **ios** directories. This step will use the versioned Expo CLI.
 1. Restore a previously saved cache identified by the `cache.key` value in the [build profile](/build/eas-json).
 1. Run `pod install` in the **ios** directory inside your project.
 1. Run the `eas-build-post-install` script from **package.json** if defined.

--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -56,17 +56,17 @@ The `expo` npm package enables a suite of incredible features for React Native a
 
 > **info** All features are free, optional, and can be used independently of each other. Unused features add no additional bloat to your app.
 
-| Feature                                                                             | With `expo` | Without `expo` (bare React Native) |
-| ----------------------------------------------------------------------------------- | ----------- | ---------------------------------- |
-| Develop complex apps **entirely** in JavaScript.                                    | <YesIcon /> | <NoIcon />                         |
-| Write JSI native modules with Swift and Kotlin.                                     | <YesIcon /> | <NoIcon />                         |
-| Develop apps without Xcode or Android Studio.                                       | <YesIcon /> | <NoIcon />                         |
-| Create and share example apps in the browser with [Snack](https://snack.expo.dev/). | <YesIcon /> | <NoIcon />                         |
-| Major upgrades without native changes.                                              | <YesIcon /> | <NoIcon />                         |
-| First-class TypeScript support.                                                     | <YesIcon /> | <NoIcon />                         |
-| Install natively compatible libraries from the command line.                        | <YesIcon /> | <NoIcon />                         |
-| Develop performant websites with the same codebase.                                 | <YesIcon /> | <NoIcon />                         |
-| [Tunnel](/more/expo-cli/#tunneling) your dev server to any device.                  | <YesIcon /> | <NoIcon />                         |
+| Feature                                                                             | With `expo` | Without `expo` (existing React Native) |
+| ----------------------------------------------------------------------------------- | ----------- | -------------------------------------- |
+| Develop complex apps **entirely** in JavaScript.                                    | <YesIcon /> | <NoIcon />                             |
+| Write JSI native modules with Swift and Kotlin.                                     | <YesIcon /> | <NoIcon />                             |
+| Develop apps without Xcode or Android Studio.                                       | <YesIcon /> | <NoIcon />                             |
+| Create and share example apps in the browser with [Snack](https://snack.expo.dev/). | <YesIcon /> | <NoIcon />                             |
+| Major upgrades without native changes.                                              | <YesIcon /> | <NoIcon />                             |
+| First-class TypeScript support.                                                     | <YesIcon /> | <NoIcon />                             |
+| Install natively compatible libraries from the command line.                        | <YesIcon /> | <NoIcon />                             |
+| Develop performant websites with the same codebase.                                 | <YesIcon /> | <NoIcon />                             |
+| [Tunnel](/more/expo-cli/#tunneling) your dev server to any device.                  | <YesIcon /> | <NoIcon />                             |
 
 ## Services
 

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -135,7 +135,7 @@ To test your new splash screen, build your app for [internal distribution](/tuto
 
 <Collapsible summary="Not using prebuild?">
 
-If your app does not use [Expo Prebuild](/more/glossary-of-terms/#prebuild) (formerly the _managed workflow_) to generate the native **android** and **ios** directories, then changes in the app config will have no effect. For more information, see [how you can customize the configuration manually](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
+If your app does not use [Expo Prebuild](/more/glossary-of-terms/#prebuild) to generate the native **android** and **ios** directories, then changes in the app config will have no effect. For more information, see [how you can customize the configuration manually](https://github.com/expo/expo/tree/main/packages/expo-splash-screen#-installation-in-bare-react-native-projects).
 
 </Collapsible>
 

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -178,7 +178,7 @@ Here are a few examples of some common redirect URI patterns you may end up usin
 In some cases there will be anywhere between 1 to 3 slashes (`/`).
 
 - **Environment:**
-  - Bare workflow
+  - Existing React Native apps
     - `npx expo prebuild`
   - Standalone builds in the App or Play Store or testing locally
     - Android: `eas build` or `npx expo run:android`

--- a/docs/pages/more/expo-cli.mdx
+++ b/docs/pages/more/expo-cli.mdx
@@ -53,7 +53,7 @@ Expo CLI is included in the `expo` package. You can install it with npm or yarn:
 
 <Terminal cmd={['$ yarn add expo']} />
 
-> Projects that are not using [Expo Prebuild](#prebuild) (also referred to as _Bare projects_) will need to perform additional setup to ensure all custom Expo bundling features work: [Metro: Bare workflow setup](/versions/latest/config/metro#bare-workflow-setup).
+> Projects that are not using [Expo Prebuild](#prebuild) will need to perform additional setup to ensure all custom Expo bundling features work: [Metro: Bare workflow setup](/versions/latest/config/metro/#existing-react-native-apps).
 
 ## Develop
 

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -52,6 +52,8 @@ Projects can configure how Babel is used by modifying the [**babel.config.js**](
 
 ### Bare workflow
 
+> **warning** [**Deprecated**](/more/release-statuses/#deprecated): Expo no longer separates "managed" and "bare" workflows. All projects use the same architecture based on Continuous Native Generation (CNG). Run npx expo prebuild to generate native directories when you need native access. Config plugins let you customize native configuration declaratively.
+
 Describes the approach when the native projects (in the **android** and **ios** directories) are versioned in Git and maintained manually. It's typical for **existing "bare" React Native apps** where you manually make changes to the native projects. There is freedom to customize them but also high maintenance overhead.
 
 This is in contrast to using [app config and prebuild](/workflow/continuous-native-generation), where the native projects are not versioned. Instead, they are generated on demand using the `npx expo prebuild`, which is the [recommended approach](/workflow/continuous-native-generation).

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -52,9 +52,9 @@ Projects can configure how Babel is used by modifying the [**babel.config.js**](
 
 ### Bare workflow
 
-> **warning** [**Deprecated**](/more/release-statuses/#deprecated): Expo no longer separates "managed" and "bare" workflows. All projects use the same architecture based on Continuous Native Generation (CNG). Run npx expo prebuild to generate native directories when you need native access. Config plugins let you customize native configuration declaratively.
+> **warning** [**Deprecated**](/more/release-statuses/#deprecated): Expo no longer separates "managed" and "bare" workflows. All projects use the same architecture based on Continuous Native Generation (CNG). Run `npx expo prebuild` to generate native directories when you need native access. Config plugins let you customize native configuration declaratively.
 
-Describes the approach when the native projects (in the **android** and **ios** directories) are versioned in Git and maintained manually. It's typical for **existing "bare" React Native apps** where you manually make changes to the native projects. There is freedom to customize them but also high maintenance overhead.
+Describes the approach when the native projects (in the **android** and **ios** directories) are versioned in Git and maintained manually. It's typical for **existing React Native apps** where you manually make changes to the native projects. There is freedom to customize them but also high maintenance overhead.
 
 This is in contrast to using [app config and prebuild](/workflow/continuous-native-generation), where the native projects are not versioned. Instead, they are generated on demand using the `npx expo prebuild`, which is the [recommended approach](/workflow/continuous-native-generation).
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -635,7 +635,7 @@ const anotherWorker = new Worker(new URL(path, window.location.href));
 
 Using a variable in the `Worker` constructor is not supported for bundling. To inspect the internal URL, you may use the internal syntax `require.unstable_resolveWorker('./path/to/worker.js')` to get the URL fragment.
 
-## Bare workflow setup
+## Existing React Native apps
 
 > This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/more/glossary-of-terms/#prebuild) for fully automated setup.
 

--- a/docs/pages/versions/v53.0.0/config/metro.mdx
+++ b/docs/pages/versions/v53.0.0/config/metro.mdx
@@ -621,7 +621,7 @@ const anotherWorker = new Worker(new URL(path, window.location.href));
 
 Using a variable in the `Worker` constructor is not supported for bundling. To inspect the internal URL, you may use the internal syntax `require.unstable_resolveWorker('./path/to/worker.js')` to get the URL fragment.
 
-## Bare workflow setup
+## Existing React Native apps
 
 > This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/more/glossary-of-terms/#prebuild) for fully automated setup.
 

--- a/docs/pages/versions/v54.0.0/config/metro.mdx
+++ b/docs/pages/versions/v54.0.0/config/metro.mdx
@@ -633,7 +633,7 @@ const anotherWorker = new Worker(new URL(path, window.location.href));
 
 Using a variable in the `Worker` constructor is not supported for bundling. To inspect the internal URL, you may use the internal syntax `require.unstable_resolveWorker('./path/to/worker.js')` to get the URL fragment.
 
-## Bare workflow setup
+## Existing React Native apps
 
 > This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/more/glossary-of-terms/#prebuild) for fully automated setup.
 

--- a/docs/pages/versions/v55.0.0/config/metro.mdx
+++ b/docs/pages/versions/v55.0.0/config/metro.mdx
@@ -635,7 +635,7 @@ const anotherWorker = new Worker(new URL(path, window.location.href));
 
 Using a variable in the `Worker` constructor is not supported for bundling. To inspect the internal URL, you may use the internal syntax `require.unstable_resolveWorker('./path/to/worker.js')` to get the URL fragment.
 
-## Bare workflow setup
+## Existing React Native apps
 
 > This guide is versioned and will need to be revisited when upgrading/downgrading Expo. Alternatively, use [Expo Prebuild](/more/glossary-of-terms/#prebuild) for fully automated setup.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-20835

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update/remove deprecated terminology around "bare".

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See diff and proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
