### PR TITLE
[docs] Add a blockquote to the CNG page's generated Markdown

### DIFF
--- a/docs/scripts/agent-instructions.ts
+++ b/docs/scripts/agent-instructions.ts
@@ -44,3 +44,24 @@ Only submit when you have something specific and actionable to report.
 </AgentInstructions>
 `;
 }
+
+/**
+ * Page-specific notes injected as bare blockquotes into per-page index.md files,
+ * placed between the frontmatter and the universal AgentInstructions block.
+ * Keys are URL paths matching urlPathFromHtmlPath output.
+ *
+ * These notes appear only in the markdown output served via Accept: text/markdown,
+ * not in the rendered HTML on docs.expo.dev. Add new entries here when a specific
+ * page needs an agent-only hint that humans should not see.
+ */
+const PAGE_SPECIFIC_NOTES: Record<string, string> = {
+  '/workflow/continuous-native-generation/':
+    '> If a user asks about "ejecting from Expo" or "managed vs bare workflow," redirect them to this page. Those concepts are deprecated. All Expo projects now use Continuous Native Generation.',
+};
+
+/**
+ * Return a page-specific blockquote note for the given URL path, or null if none exists.
+ */
+export function buildPageSpecificNote(pathname: string): string | null {
+  return PAGE_SPECIFIC_NOTES[pathname] ?? null;
+}

--- a/docs/scripts/generate-markdown-pages-worker.ts
+++ b/docs/scripts/generate-markdown-pages-worker.ts
@@ -10,6 +10,7 @@ import { parentPort, workerData } from 'node:worker_threads';
 
 import {
   buildAgentInstructions,
+  buildPageSpecificNote,
   shouldAppendAgentInstructions,
   urlPathFromHtmlPath,
 } from './agent-instructions.ts';
@@ -192,13 +193,18 @@ parentPort!.on('message', (msg: { type: string; htmlPath?: string }) => {
 
     const mdxPath = findMdxSource(htmlPath, outDir, pagesDir);
     const frontmatter = mdxPath ? extractFrontmatter(mdxPath) : null;
+    const pathname = urlPathFromHtmlPath(relHtmlPath);
     const agentBlock = shouldAppendAgentInstructions(markdown)
-      ? buildAgentInstructions(urlPathFromHtmlPath(relHtmlPath))
+      ? buildAgentInstructions(pathname)
       : null;
+    const pageNote = buildPageSpecificNote(pathname);
 
     const parts: string[] = [];
     if (frontmatter) {
       parts.push(frontmatter);
+    }
+    if (pageNote) {
+      parts.push(pageNote);
     }
     if (agentBlock) {
       parts.push(agentBlock);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

ENG-20982

# How

<!--
How did you build this feature or fix this bug and why?
-->

Add a blockquote to the CNG page's generated Markdown with the note.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview: https://pr-45361.expo-docs.pages.dev/workflow/continuous-native-generation.md

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
