### PR TITLE
[bare-expo] Refine benchmarks screen

### DIFF
--- a/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingBridgeModule.kt
+++ b/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingBridgeModule.kt
@@ -2,6 +2,7 @@ package expo.modules.benchmark
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.BaseJavaModule
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -18,6 +19,11 @@ class BenchmarkingBridgeModule : BaseJavaModule() {
     // For some reason, isBlockingSynchronousMethod doesn't let functions be Void/Unit
     // so returning a dummy number
     return 0.0
+  }
+
+  @ReactMethod
+  fun nothingAsync(promise: Promise) {
+    promise.resolve(null)
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
@@ -42,7 +48,7 @@ class BenchmarkingBridgeModule : BaseJavaModule() {
   }
 
   @ReactMethod(isBlockingSynchronousMethod = true)
-  fun echoObject(point: ReadableMap): WritableMap {
+  fun passthroughDict(point: ReadableMap): WritableMap {
     val result = Arguments.createMap()
     result.putDouble("x", point.getDouble("x"))
     result.putDouble("y", point.getDouble("y"))

--- a/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingExpoModule.kt
+++ b/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingExpoModule.kt
@@ -1,15 +1,22 @@
 package expo.modules.benchmark
 
+import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
+import expo.modules.kotlin.sharedobjects.SharedObject
 
 class Point : Record {
   @Field
   var x: Double = 0.0
 
   @Field
+  var y: Double = 0.0
+}
+
+class SharedPoint(appContext: AppContext) : SharedObject(appContext) {
+  var x: Double = 0.0
   var y: Double = 0.0
 }
 
@@ -21,7 +28,15 @@ class BenchmarkingExpoModule : Module() {
       // Do nothing
     }
 
+    AsyncFunction("nothingAsync") {
+      // Do nothing
+    }
+
     Function("addNumbers") { a: Double, b: Double ->
+      a + b
+    }
+
+    AsyncFunction("addNumbersAsync") { a: Double, b: Double ->
       a + b
     }
 
@@ -33,8 +48,33 @@ class BenchmarkingExpoModule : Module() {
       array.sum()
     }
 
-    Function("echoObject") { point: Point ->
+    Function("passthroughDict") { point: Map<String, Any> ->
       point
+    }
+
+    Function("passthroughRecord") { point: Point ->
+      point
+    }
+
+    Function("passthroughSharedObject") { point: SharedPoint ->
+      point
+    }
+
+    Class(SharedPoint::class) {
+      Constructor { x: Double, y: Double ->
+        val point = SharedPoint(appContext)
+        point.x = x
+        point.y = y
+        return@Constructor point
+      }
+
+      Property("x") { point: SharedPoint ->
+        point.x
+      }
+
+      Property("y") { point: SharedPoint ->
+        point.y
+      }
     }
   }
 }

--- a/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingTurboModule.kt
+++ b/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/BenchmarkingTurboModule.kt
@@ -1,6 +1,7 @@
 package expo.modules.benchmark
 
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -18,6 +19,10 @@ class BenchmarkingTurboModule(reactContext: ReactApplicationContext) : NativeBen
     // For some reason, isBlockingSynchronousMethod doesn't let functions be Void/Unit
     // so returning a dummy number
     return 0.0
+  }
+
+  override fun nothingAsync(promise: Promise) {
+    promise.resolve(null)
   }
 
   override fun addNumbers(a: Double, b: Double): Double {
@@ -38,7 +43,7 @@ class BenchmarkingTurboModule(reactContext: ReactApplicationContext) : NativeBen
     return sum
   }
 
-  override fun echoObject(point: ReadableMap): WritableMap {
+  override fun passthroughDict(point: ReadableMap): WritableMap {
     val result = Arguments.createMap()
     result.putDouble("x", point.getDouble("x"))
     result.putDouble("y", point.getDouble("y"))

--- a/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/NativeBenchmarkingTurboModuleSpec.java
+++ b/apps/bare-expo/modules/benchmarking/android/src/main/java/expo/modules/benchmark/NativeBenchmarkingTurboModuleSpec.java
@@ -1,6 +1,7 @@
 package expo.modules.benchmark;
 
 import com.facebook.proguard.annotations.DoNotStrip;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
@@ -26,6 +27,10 @@ public abstract class NativeBenchmarkingTurboModuleSpec extends ReactContextBase
   @DoNotStrip
   public abstract double nothing();
 
+  @ReactMethod
+  @DoNotStrip
+  public abstract void nothingAsync(Promise promise);
+
   @ReactMethod(isBlockingSynchronousMethod = true)
   @DoNotStrip
   public abstract double addNumbers(double a, double b);
@@ -40,5 +45,5 @@ public abstract class NativeBenchmarkingTurboModuleSpec extends ReactContextBase
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   @DoNotStrip
-  public abstract WritableMap echoObject(ReadableMap point);
+  public abstract WritableMap passthroughDict(ReadableMap point);
 }

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingBridgeModule.mm
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingBridgeModule.mm
@@ -9,6 +9,12 @@ RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(double, nothing)
   return 0;
 }
 
+RCT_EXPORT_METHOD(nothingAsync:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+  resolve(nil);
+}
+
 RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(addNumbers:(double)a b:(double)b)
 {
   NSNumber* number = [[NSNumber alloc] initWithDouble:a + b];
@@ -31,7 +37,7 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(foldArray:(NSArray *)array)
   return @(sum);
 }
 
-RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(echoObject:(NSDictionary *)point)
+RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(passthroughDict:(NSDictionary *)point)
 {
   return point;
 }

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
@@ -8,6 +8,11 @@ struct Point: Record {
   var y: Double = 0
 }
 
+final class SharedPoint: SharedObject {
+  var x: Double = 0
+  var y: Double = 0
+}
+
 public final class BenchmarkingExpoModule: Module {
 //  @OptimizedFunction
   private func addNumbersOptimized(a: Double, b: Double) throws -> Double {
@@ -24,28 +29,63 @@ public final class BenchmarkingExpoModule: Module {
 
     Function("nothing") {}
 
+    AsyncFunction("nothingAsync") { () async -> Void in }
+
+    // MARK: - Numbers
+
     Function("addNumbers") { (a: Double, b: Double) in
       return a + b
     }
 
     Function("addNumbersOptimized", addNumbersOptimized)
 
-    Function("addStrings") { (a: String, b: String) in
-      return a + b
-    }
-
-    Function("foldArray") { (array: [Double]) in
-      return array.reduce(0.0, +)
-    }
-
-    Function("echoObject") { (point: Point) in
-      return point
-    }
-
     AsyncFunction("addNumbersAsync") { (a: Double, b: Double) in
       return a + b
     }
 
     AsyncFunction("addNumbersAsyncOptimized", addNumbersAsyncOptimized)
+
+    // MARK: - Strings
+
+    Function("addStrings") { (a: String, b: String) in
+      return a + b
+    }
+
+    // MARK: - Arrays
+
+    Function("foldArray") { (array: [Double]) in
+      return array.reduce(0.0, +)
+    }
+
+    // MARK: - Passthrough
+
+    Function("passthroughDict") { (point: [String: Any]) in
+      return point
+    }
+
+    Function("passthroughRecord") { (point: Point) in
+      return point
+    }
+
+    Function("passthroughSharedObject") { (point: SharedPoint) in
+      return point
+    }
+
+    Class(SharedPoint.self) {
+      Constructor { (x: Double, y: Double) -> SharedPoint in
+        let point = SharedPoint()
+        point.x = x
+        point.y = y
+        return point
+      }
+
+      Property("x") { (point: SharedPoint) in
+        return point.x
+      }
+
+      Property("y") { (point: SharedPoint) in
+        return point.y
+      }
+    }
   }
 }

--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingTurboModule.mm
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingTurboModule.mm
@@ -14,6 +14,11 @@ RCT_EXPORT_MODULE()
   return 0;
 }
 
+- (void)nothingAsync:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject
+{
+  resolve(nil);
+}
+
 - (NSNumber *)addNumbers:(double)a b:(double)b
 {
   NSNumber* number = [[NSNumber alloc] initWithDouble:a + b];
@@ -36,7 +41,7 @@ RCT_EXPORT_MODULE()
   return @(sum);
 }
 
-- (NSDictionary *)echoObject:(NSDictionary *)point
+- (NSDictionary *)passthroughDict:(NSDictionary *)point
 {
   return point;
 }

--- a/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
@@ -1,12 +1,22 @@
-import { requireNativeModule, NativeModule } from 'expo';
+import { requireNativeModule, NativeModule, SharedObject } from 'expo';
+
+export declare class SharedPoint extends SharedObject {
+  constructor(x: number, y: number);
+  readonly x: number;
+  readonly y: number;
+}
 
 declare class BenchmarkingExpoModule extends NativeModule {
   nothing(): void;
+  nothingAsync(): Promise<void>;
   addNumbers(a: number, b: number): number;
   addNumbersOptimized(a: number, b: number): number;
   addStrings(a: string, b: string): string;
   foldArray(array: number[]): number;
-  echoObject(point: { x: number; y: number }): { x: number; y: number };
+  passthroughDict(point: { x: number; y: number }): { x: number; y: number };
+  passthroughRecord(point: { x: number; y: number }): { x: number; y: number };
+  passthroughSharedObject(point: SharedPoint): SharedPoint;
+  SharedPoint: typeof SharedPoint;
   addNumbersAsync(a: number, b: number): Promise<number>;
   addNumbersAsyncOptimized(a: number, b: number): Promise<number>;
 }

--- a/apps/bare-expo/modules/benchmarking/src/NativeBenchmarkingTurboModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/NativeBenchmarkingTurboModule.ts
@@ -2,10 +2,11 @@ import { TurboModule, TurboModuleRegistry } from 'react-native';
 
 export interface Spec extends TurboModule {
   nothing(): number;
+  nothingAsync(): Promise<void>;
   addNumbers(a: number, b: number): number;
   addStrings(a: string, b: string): string;
   foldArray(array: number[]): number;
-  echoObject(point: Object): Object;
+  passthroughDict(point: Object): Object;
 }
 
 export default TurboModuleRegistry.get<Spec>('BenchmarkingTurboModule') as Spec | null;

--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/BenchmarksTable.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/BenchmarksTable.tsx
@@ -45,21 +45,33 @@ export function BenchmarkTable(props: { group: Group; state: State; onRun: () =>
       ]}>
       <View
         style={[
-          styles.headerRow,
+          styles.header,
           {
             backgroundColor: theme.background.subtle,
             borderBottomColor: theme.border.default,
           },
         ]}>
-        <View style={styles.headerTitleColumn}>
+        <View style={styles.headerRow}>
           <Code style={[styles.headerTitle, { color: theme.text.default }]}>{group.title}</Code>
-          <Text style={[styles.headerIterations, { color: theme.text.quaternary }]}>
-            {iterationsOf(group).toLocaleString()}× per benchmark
-          </Text>
+          <View style={styles.headerRightColumn}>
+            <Text style={[styles.headerIterations, { color: theme.text.quaternary }]}>
+              {iterationsOf(group).toLocaleString()}×
+            </Text>
+            <Pressable
+              onPress={onRun}
+              style={({ pressed }) => [
+                styles.runButton,
+                pressed && { backgroundColor: theme.background.element },
+              ]}>
+              <Text style={[styles.runButtonText, { color: theme.text.link }]}>Run</Text>
+            </Pressable>
+          </View>
         </View>
-        <Pressable onPress={onRun} style={styles.runButton}>
-          <Text style={[styles.runButtonText, { color: theme.text.link }]}>Run</Text>
-        </Pressable>
+        {group.description && (
+          <Text style={[styles.headerDescription, { color: theme.text.secondary }]}>
+            {group.description}
+          </Text>
+        )}
       </View>
       {group.benchmarks.map((benchmark, index) => {
         const cell = state[benchmarkIdOf(group, benchmark)];
@@ -233,30 +245,42 @@ const styles = StyleSheet.create({
     marginBottom: 16,
     overflow: 'hidden',
   },
-  headerRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
+  header: {
     paddingHorizontal: 12,
     paddingVertical: 10,
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
-  headerTitleColumn: {
-    flex: 1,
-    paddingRight: 12,
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  headerRightColumn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
   },
   headerTitle: {
+    flex: 1,
     fontSize: 16,
     fontWeight: '600',
   },
   headerIterations: {
     fontSize: 12,
-    marginTop: 2,
     fontVariant: ['tabular-nums'],
   },
+  headerDescription: {
+    fontSize: 12,
+    lineHeight: 16,
+    marginTop: 6,
+  },
   runButton: {
-    paddingHorizontal: 8,
-    paddingVertical: 4,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginTop: -10,
+    marginRight: -12,
+    marginBottom: -10,
   },
   runButtonText: {
     fontSize: 15,

--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/ModulesBenchmarksScreen.tsx
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/ModulesBenchmarksScreen.tsx
@@ -97,9 +97,14 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-function yieldToEventLoop(): Promise<void> {
+// Delay between marking a benchmark as running and actually starting it.
+// Long enough for the press feedback to settle and the "running…" state to
+// paint before the JS thread gets occupied by the benchmark body.
+const PRE_BENCHMARK_DELAY_MS = 150;
+
+function delay(ms: number): Promise<void> {
   return new Promise((resolve) => {
-    return setTimeout(resolve, 0);
+    return setTimeout(resolve, ms);
   });
 }
 
@@ -139,7 +144,7 @@ export default function ModulesBenchmarksScreen() {
     }
 
     dispatch({ type: ActionType.MarkRunning, benchmarkId });
-    await yieldToEventLoop();
+    await delay(PRE_BENCHMARK_DELAY_MS);
 
     const iterations = iterationsOf(group);
 

--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
@@ -1,8 +1,10 @@
 import { BridgeModule, ExpoModule, TurboModule } from 'benchmarking';
+import { Platform } from 'react-native';
 
 import { BenchmarkRun } from './ModulesBenchmarksHistory';
 
 const DEFAULT_ITERATIONS = 100_000;
+const DEFAULT_ASYNC_ITERATIONS = Platform.OS === 'ios' ? DEFAULT_ITERATIONS : 25_000;
 
 export enum BenchmarkStatus {
   Idle = 'idle',
@@ -22,6 +24,7 @@ export type Group = {
   id: string;
   title: string;
   iterations?: number;
+  description?: string;
   benchmarks: Benchmark[];
 };
 
@@ -64,6 +67,8 @@ export const GROUPS: Group[] = [
   {
     id: 'nothing',
     title: 'nothing()',
+    description:
+      'Synchronous no-op host function. Measures the raw JS↔native boundary cost with no arguments and no return value.',
     benchmarks: [
       {
         id: 'expo',
@@ -101,8 +106,52 @@ export const GROUPS: Group[] = [
     ],
   },
   {
+    id: 'nothingAsync',
+    title: 'nothingAsync()',
+    description:
+      'Asynchronous no-op host function. Each iteration `await`s a Promise that resolves on the JS thread, so it measures Promise allocation and resolution on top of the boundary cost.',
+    iterations: DEFAULT_ASYNC_ITERATIONS,
+    benchmarks: [
+      {
+        id: 'expo',
+        label: 'ExpoModule',
+        available: ExpoModule?.nothingAsync != null,
+        async run(iterations) {
+          await ExpoModule.nothingAsync();
+          return timeAsync(iterations, () => {
+            return ExpoModule.nothingAsync();
+          });
+        },
+      },
+      {
+        id: 'turbo',
+        label: 'TurboModule',
+        available: TurboModule?.nothingAsync != null,
+        async run(iterations) {
+          await TurboModule!.nothingAsync();
+          return timeAsync(iterations, () => {
+            return TurboModule!.nothingAsync();
+          });
+        },
+      },
+      {
+        id: 'bridge',
+        label: 'BridgeModule',
+        available: BridgeModule?.nothingAsync != null,
+        async run(iterations) {
+          await BridgeModule.nothingAsync();
+          return timeAsync(iterations, () => {
+            return BridgeModule.nothingAsync();
+          });
+        },
+      },
+    ],
+  },
+  {
     id: 'addNumbers',
     title: 'addNumbers(a, b)',
+    description:
+      'Synchronous call with two `Double` arguments returning a `Double`. Stresses argument coercion and primitive return — the closest analogue to a typical JSI host function.',
     benchmarks: [
       {
         id: 'expo',
@@ -153,6 +202,9 @@ export const GROUPS: Group[] = [
   {
     id: 'addNumbersAsync',
     title: 'addNumbersAsync(a, b)',
+    description:
+      'Asynchronous variant of `addNumbers`. Adds Promise allocation/resolution on top of the argument coercion overhead. Only Expo Module is implemented — no Turbo or Bridge counterpart.',
+    iterations: DEFAULT_ASYNC_ITERATIONS,
     benchmarks: [
       {
         id: 'expo',
@@ -181,6 +233,8 @@ export const GROUPS: Group[] = [
   {
     id: 'addStrings',
     title: 'addStrings(a, b)',
+    description:
+      'Synchronous call with two short `String` arguments returning a concatenated `String`. Highlights JSI string conversion, UTF decoding, and Swift `String` allocation cost.',
     benchmarks: [
       {
         id: 'expo',
@@ -218,42 +272,68 @@ export const GROUPS: Group[] = [
     ],
   },
   {
-    id: 'echoObject',
-    title: 'echoObject({ x, y })',
+    id: 'passthrough',
+    title: 'passthrough({ x, y })',
+    description:
+      'Synchronous round-trip of a 2D point represented in three different ways. Compares `[String: Any]` dictionary, `Record`, and `SharedObject` decoding/encoding within Expo Modules. TurboModule and BridgeModule provide a dictionary baseline.',
     benchmarks: [
       {
-        id: 'expo',
-        label: 'ExpoModule',
-        available: ExpoModule?.echoObject != null,
+        id: 'expo-dict',
+        label: 'ExpoModule (dictionary)',
+        available: ExpoModule?.passthroughDict != null,
         async run(iterations) {
           const point = { x: 1.5, y: 2.5 };
-          ExpoModule.echoObject(point);
+          ExpoModule.passthroughDict(point);
           return timeSync(iterations, () => {
-            ExpoModule.echoObject(point);
+            ExpoModule.passthroughDict(point);
           });
         },
       },
       {
-        id: 'turbo',
-        label: 'TurboModule',
-        available: TurboModule?.echoObject != null,
+        id: 'expo-record',
+        label: 'ExpoModule (record)',
+        available: ExpoModule?.passthroughRecord != null,
         async run(iterations) {
           const point = { x: 1.5, y: 2.5 };
-          TurboModule!.echoObject(point);
+          ExpoModule.passthroughRecord(point);
           return timeSync(iterations, () => {
-            TurboModule!.echoObject(point);
+            ExpoModule.passthroughRecord(point);
           });
         },
       },
       {
-        id: 'bridge',
-        label: 'BridgeModule',
-        available: BridgeModule?.echoObject != null,
+        id: 'expo-shared',
+        label: 'ExpoModule (shared object)',
+        available: ExpoModule?.passthroughSharedObject != null && ExpoModule?.SharedPoint != null,
+        async run(iterations) {
+          const point = new ExpoModule.SharedPoint(1.5, 2.5);
+          ExpoModule.passthroughSharedObject(point);
+          return timeSync(iterations, () => {
+            ExpoModule.passthroughSharedObject(point);
+          });
+        },
+      },
+      {
+        id: 'turbo-dict',
+        label: 'TurboModule (dictionary)',
+        available: TurboModule?.passthroughDict != null,
         async run(iterations) {
           const point = { x: 1.5, y: 2.5 };
-          BridgeModule.echoObject(point);
+          TurboModule!.passthroughDict(point);
           return timeSync(iterations, () => {
-            BridgeModule.echoObject(point);
+            TurboModule!.passthroughDict(point);
+          });
+        },
+      },
+      {
+        id: 'bridge-dict',
+        label: 'BridgeModule (dictionary)',
+        available: BridgeModule?.passthroughDict != null,
+        async run(iterations) {
+          const point = { x: 1.5, y: 2.5 };
+          BridgeModule.passthroughDict(point);
+          return timeSync(iterations, () => {
+            BridgeModule.passthroughDict(point);
           });
         },
       },
@@ -262,6 +342,8 @@ export const GROUPS: Group[] = [
   {
     id: 'foldArray',
     title: 'foldArray(numbers)',
+    description:
+      'Synchronous call with a 10-element `Double` array, returning the sum. Measures array decoding from JS, including per-element coercion.',
     benchmarks: [
       {
         id: 'expo',


### PR DESCRIPTION
## Summary

Refines the modules benchmarks screen in `native-component-list` and adds a few new benchmarks across all three module flavors (Expo, Turbo, Bridge).

### UI changes

- Optional per-group description rendered as a full-width row beneath the title.
- Iterations count moved next to the Run button (top-right of each group).
- Subtle background fill on the Run button while pressed.
- 150 ms delay after pressing Run so the `running…` state actually paints before the JS thread gets occupied.

### New benchmarks

- `nothingAsync()` — async no-op host function on Expo, Turbo, and Bridge modules. Pairs with the existing sync `nothing()` to expose the cost of Promise allocation/resolution.
- `addNumbersAsync(a, b)` — added to Android Expo Module to match iOS.
- `passthrough({ x, y })` group replaces `echoObject({ x, y })`. Compares three Expo Module representations of the same point — `[String: Any]` dictionary, `Record`, and `SharedObject` — alongside dictionary baselines from TurboModule and BridgeModule.

### Implementation notes

- A new `SharedPoint` SharedObject class is registered on the Expo benchmarking module (iOS + Android) with `(x, y)` constructor and read-only `x`/`y` properties.
- BridgeModule and TurboModule were renamed `echoObject` → `passthroughDict` so the comparison axis is consistent across frameworks.
- Async groups default to fewer iterations on Android (25k vs 100k on iOS) since the Promise round-trip is meaningfully slower there.

<!-- disable:changelog-checks -->

## Test plan

- [x] Open native-component-list, run each benchmark group on iOS — all rows produce results, descriptions render correctly, Run button hit area feels right.
- [x] Same on Android.
- [x] Press Run, verify `running…` shows briefly before the work starts.

<img width="50%" src="https://github.com/user-attachments/assets/83a5a0c2-48d6-494f-868e-737402074329" />
