### PR TITLE
[docs] Fix SwiftUI DatePicker locale, timeZone, and disabled examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/datepicker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/datepicker.mdx
@@ -169,9 +169,12 @@ export default function GraphicalDatePickerExample() {
 
 ## Disabled picker
 
+You can make the picker non-interactive using the `disabled` modifier.
+
 ```tsx DisabledDatePickerExample.tsx
 import { useState } from 'react';
 import { Host, DatePicker } from '@expo/ui/swift-ui';
+import { disabled } from '@expo/ui/swift-ui/modifiers';
 
 export default function DisabledDatePickerExample() {
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -185,7 +188,7 @@ export default function DisabledDatePickerExample() {
         onDateChange={date => {
           setSelectedDate(date);
         }}
-        disabled
+        modifiers={[disabled()]}
       />
     </Host>
   );
@@ -194,11 +197,12 @@ export default function DisabledDatePickerExample() {
 
 ## Custom locale
 
-Use the `locale` prop to display the picker in a specific locale.
+Apply the `environment` modifier with the `locale` key to display the picker in a specific locale.
 
 ```tsx LocaleDatePickerExample.tsx
 import { useState } from 'react';
 import { Host, DatePicker } from '@expo/ui/swift-ui';
+import { environment } from '@expo/ui/swift-ui/modifiers';
 
 export default function LocaleDatePickerExample() {
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -212,7 +216,7 @@ export default function LocaleDatePickerExample() {
         onDateChange={date => {
           setSelectedDate(date);
         }}
-        locale="fr_FR"
+        modifiers={[environment('locale', 'fr_FR')]}
       />
     </Host>
   );
@@ -221,11 +225,12 @@ export default function LocaleDatePickerExample() {
 
 ## Custom time zone
 
-Use the `timeZone` prop to display the picker in a specific IANA time zone.
+Apply the `environment` modifier with the `timeZone` key to display the picker in a specific IANA time zone.
 
 ```tsx TimeZoneDatePickerExample.tsx
 import { useState } from 'react';
 import { Host, DatePicker } from '@expo/ui/swift-ui';
+import { environment } from '@expo/ui/swift-ui/modifiers';
 
 export default function TimeZoneDatePickerExample() {
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -239,61 +244,7 @@ export default function TimeZoneDatePickerExample() {
         onDateChange={date => {
           setSelectedDate(date);
         }}
-        timeZone="Asia/Tokyo"
-      />
-    </Host>
-  );
-}
-```
-
-## Custom locale
-
-Use the `locale` prop to display the picker in a specific locale.
-
-```tsx LocaleDatePickerExample.tsx
-import { useState } from 'react';
-import { Host, DatePicker } from '@expo/ui/swift-ui';
-
-export default function LocaleDatePickerExample() {
-  const [selectedDate, setSelectedDate] = useState(new Date());
-
-  return (
-    <Host matchContents>
-      <DatePicker
-        title="Sélectionner la date"
-        selection={selectedDate}
-        displayedComponents={['date']}
-        onDateChange={date => {
-          setSelectedDate(date);
-        }}
-        locale="fr_FR"
-      />
-    </Host>
-  );
-}
-```
-
-## Custom time zone
-
-Use the `timeZone` prop to display the picker in a specific IANA time zone.
-
-```tsx TimeZoneDatePickerExample.tsx
-import { useState } from 'react';
-import { Host, DatePicker } from '@expo/ui/swift-ui';
-
-export default function TimeZoneDatePickerExample() {
-  const [selectedDate, setSelectedDate] = useState(new Date());
-
-  return (
-    <Host matchContents>
-      <DatePicker
-        title="Tokyo time"
-        selection={selectedDate}
-        displayedComponents={['date', 'hourAndMinute']}
-        onDateChange={date => {
-          setSelectedDate(date);
-        }}
-        timeZone="Asia/Tokyo"
+        modifiers={[environment('timeZone', 'Asia/Tokyo')]}
       />
     </Host>
   );

--- a/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/datepicker.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/swift-ui/datepicker.mdx
@@ -169,9 +169,12 @@ export default function GraphicalDatePickerExample() {
 
 ## Disabled picker
 
+You can make the picker non-interactive using the `disabled` modifier.
+
 ```tsx DisabledDatePickerExample.tsx
 import { useState } from 'react';
 import { Host, DatePicker } from '@expo/ui/swift-ui';
+import { disabled } from '@expo/ui/swift-ui/modifiers';
 
 export default function DisabledDatePickerExample() {
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -185,7 +188,7 @@ export default function DisabledDatePickerExample() {
         onDateChange={date => {
           setSelectedDate(date);
         }}
-        disabled
+        modifiers={[disabled()]}
       />
     </Host>
   );
@@ -194,11 +197,12 @@ export default function DisabledDatePickerExample() {
 
 ## Custom locale
 
-Use the `locale` prop to display the picker in a specific locale.
+Apply the `environment` modifier with the `locale` key to display the picker in a specific locale.
 
 ```tsx LocaleDatePickerExample.tsx
 import { useState } from 'react';
 import { Host, DatePicker } from '@expo/ui/swift-ui';
+import { environment } from '@expo/ui/swift-ui/modifiers';
 
 export default function LocaleDatePickerExample() {
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -212,7 +216,7 @@ export default function LocaleDatePickerExample() {
         onDateChange={date => {
           setSelectedDate(date);
         }}
-        locale="fr_FR"
+        modifiers={[environment('locale', 'fr_FR')]}
       />
     </Host>
   );
@@ -221,11 +225,12 @@ export default function LocaleDatePickerExample() {
 
 ## Custom time zone
 
-Use the `timeZone` prop to display the picker in a specific IANA time zone.
+Apply the `environment` modifier with the `timeZone` key to display the picker in a specific IANA time zone.
 
 ```tsx TimeZoneDatePickerExample.tsx
 import { useState } from 'react';
 import { Host, DatePicker } from '@expo/ui/swift-ui';
+import { environment } from '@expo/ui/swift-ui/modifiers';
 
 export default function TimeZoneDatePickerExample() {
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -239,61 +244,7 @@ export default function TimeZoneDatePickerExample() {
         onDateChange={date => {
           setSelectedDate(date);
         }}
-        timeZone="Asia/Tokyo"
-      />
-    </Host>
-  );
-}
-```
-
-## Custom locale
-
-Use the `locale` prop to display the picker in a specific locale.
-
-```tsx LocaleDatePickerExample.tsx
-import { useState } from 'react';
-import { Host, DatePicker } from '@expo/ui/swift-ui';
-
-export default function LocaleDatePickerExample() {
-  const [selectedDate, setSelectedDate] = useState(new Date());
-
-  return (
-    <Host matchContents>
-      <DatePicker
-        title="Sélectionner la date"
-        selection={selectedDate}
-        displayedComponents={['date']}
-        onDateChange={date => {
-          setSelectedDate(date);
-        }}
-        locale="fr_FR"
-      />
-    </Host>
-  );
-}
-```
-
-## Custom time zone
-
-Use the `timeZone` prop to display the picker in a specific IANA time zone.
-
-```tsx TimeZoneDatePickerExample.tsx
-import { useState } from 'react';
-import { Host, DatePicker } from '@expo/ui/swift-ui';
-
-export default function TimeZoneDatePickerExample() {
-  const [selectedDate, setSelectedDate] = useState(new Date());
-
-  return (
-    <Host matchContents>
-      <DatePicker
-        title="Tokyo time"
-        selection={selectedDate}
-        displayedComponents={['date', 'hourAndMinute']}
-        onDateChange={date => {
-          setSelectedDate(date);
-        }}
-        timeZone="Asia/Tokyo"
+        modifiers={[environment('timeZone', 'Asia/Tokyo')]}
       />
     </Host>
   );


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Fixes #45305.

The SwiftUI `DatePicker` documentation listed `locale`, `timeZone`, and `disabled` as component props on `<DatePicker>`. However, `DatePickerProps` (in `packages/expo-ui/src/swift-ui/DatePicker/index.tsx`) doesn't expose any of them. They are actually applied through these modifiers:
  - `disabled` -> `disabled()` (from `@expo/ui/swift-ui/modifiers`)
  - `locale` ->`environment('locale', ...)`
  - `timeZone` -> `environment('timeZone', ...)`

Additionally, the `## Custom locale` and `## Custom time zone` sections were also duplicated in the page (each appeared twice).

# How
<!--
How did you build this feature or fix this bug and why?
-->

- Rewrote the "Disabled picker", "Custom locale", and "Custom time zone" examples to apply the values via the `modifiers` prop, matching the real usage in `apps/native-component-list/src/screens/UI/DatePickerScreen.ios.tsx`.
- Removed the duplicated `## Custom locale` and `## Custom time zone` sections.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Ran the docs site locally with `pnpm dev` and verified the DatePicker page renders the updated "Disabled picker", "Custom locale", and "Custom time zone" sections without duplicates and that the code snippets are syntactically valid.



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
