### PR TITLE
[create-expo] Add prompt for version

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Generate `AGENTS.md`, `CLAUDE.md`, and `.claude/settings.json` for new projects to provide AI coding agents with Expo-specific guidance and the `expo` skills plugin. Use `--no-agents-md` to skip. ([#44618](https://github.com/expo/expo/pull/44618) by [@EvanBacon](https://github.com/EvanBacon))
+- Prompt for the Expo SDK version when scaffolding the default template. ([#45369](https://github.com/expo/expo/pull/45369) by [@brentvatne](https://github.com/brentvatne))
 
 ### 🐛 Bug fixes
 

--- a/packages/create-expo/e2e/__tests__/index-test.ts
+++ b/packages/create-expo/e2e/__tests__/index-test.ts
@@ -39,7 +39,7 @@ it('creates a full basic project by default', async () => {
   await executePassing([projectName]);
 
   expectFileExists(projectName, 'package.json');
-  expectFileExists(projectName, 'app/_layout.tsx');
+  expectFileExists(projectName, 'src/app/_layout.tsx');
   expectFileExists(projectName, '.gitignore');
   expectFileExists(projectName, 'app.json');
   // expect(fileExists(projectName, 'node_modules')).toBeTruthy();
@@ -89,7 +89,7 @@ it('uses pnpm', async () => {
   expect(results.stdout).toMatch(/pnpm install/);
 
   expectFileExists(projectName, 'package.json');
-  expectFileExists(projectName, 'app/_layout.tsx');
+  expectFileExists(projectName, 'src/app/_layout.tsx');
   expectFileExists(projectName, '.gitignore');
   // Check if it skipped install
   expectFileNotExists(projectName, 'node_modules');
@@ -113,7 +113,7 @@ it('uses Bun', async () => {
   expect(results.stdout).toMatch(/bun install/);
 
   expectFileExists(projectName, 'package.json');
-  expectFileExists(projectName, 'app/_layout.tsx');
+  expectFileExists(projectName, 'src/app/_layout.tsx');
   expectFileExists(projectName, '.gitignore');
   // Check if it skipped install
   expectFileNotExists(projectName, 'node_modules');
@@ -131,7 +131,7 @@ it('uses npm', async () => {
   expect(results.stdout).toMatch(/npm install/);
 
   expectFileExists(projectName, 'package.json');
-  expectFileExists(projectName, 'app/_layout.tsx');
+  expectFileExists(projectName, 'src/app/_layout.tsx');
   expectFileExists(projectName, '.gitignore');
   // Check if it skipped install
   expectFileNotExists(projectName, 'node_modules');
@@ -149,7 +149,7 @@ it('uses yarn', async () => {
   expect(results.stdout).toMatch(/yarn install/);
 
   expectFileExists(projectName, 'package.json');
-  expectFileExists(projectName, 'app/_layout.tsx');
+  expectFileExists(projectName, 'src/app/_layout.tsx');
   expectFileExists(projectName, '.gitignore');
   // Check if it skipped install
   expectFileNotExists(projectName, 'node_modules');
@@ -162,7 +162,7 @@ describe('yes', () => {
     await executePassing([projectName, '--no-install', '--yes']);
 
     expectFileExists(projectName, 'package.json');
-    expectFileExists(projectName, 'app/_layout.tsx');
+    expectFileExists(projectName, 'src/app/_layout.tsx');
     expectFileExists(projectName, '.gitignore');
     expectFileNotExists(projectName, 'node_modules');
   });
@@ -173,7 +173,7 @@ describe('yes', () => {
     await executePassing([projectName, '--no-install', '-y']);
 
     expectFileExists(projectName, 'package.json');
-    expectFileExists(projectName, 'app/_layout.tsx');
+    expectFileExists(projectName, 'src/app/_layout.tsx');
     expectFileExists(projectName, '.gitignore');
     expectFileNotExists(projectName, 'node_modules');
   });
@@ -184,7 +184,7 @@ describe('yes', () => {
     await executePassing([projectName, '--no-install', '--yes', '--template', 'blank']);
 
     expectFileExists(projectName, 'package.json');
-    expectFileExists(projectName, 'app/_layout.tsx');
+    expectFileExists(projectName, 'src/app/_layout.tsx');
     expectFileExists(projectName, '.gitignore');
     // Check if it skipped install
     expectFileNotExists(projectName, 'node_modules');
@@ -292,7 +292,7 @@ xdescribe('templates', () => {
     }
 
     expectFileExists(projectName, 'package.json');
-    expectFileExists(projectName, 'app/_layout.tsx');
+    expectFileExists(projectName, 'src/app/_layout.tsx');
     expectFileExists(projectName, '.gitignore');
     // Check if it skipped install
     expectFileNotExists(projectName, 'node_modules');

--- a/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
+++ b/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
@@ -103,30 +103,30 @@ describe(applySdkVersionToTemplateAsync, () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
   });
 
-  it('pins to the latest released SDK without prompting when --yes is set', async () => {
-    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+  it('passes through unchanged without prompting or fetching when --yes is set', async () => {
     expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: true })).toBe(
-      'expo-template-default@sdk-55'
+      'expo-template-default'
     );
     expect(mockPrompts).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('pins to the latest released SDK without prompting in CI', async () => {
+  it('passes through unchanged without prompting or fetching in CI', async () => {
     process.env.CI = 'true';
-    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
     expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
-      'expo-template-default@sdk-55'
+      'expo-template-default'
     );
     expect(mockPrompts).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('pins to the latest released SDK without prompting when stdin is not a TTY', async () => {
+  it('passes through unchanged without prompting or fetching when stdin is not a TTY', async () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
-    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
     expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
-      'expo-template-default@sdk-55'
+      'expo-template-default'
     );
     expect(mockPrompts).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('skips the prompt when the template already has a tag', async () => {
@@ -198,19 +198,6 @@ describe(applySdkVersionToTemplateAsync, () => {
     expect(output).not.toMatch(/Tip:/);
     expect(output).not.toMatch(/--template/);
     expect(output).not.toMatch(/--example/);
-    logSpy.mockRestore();
-  });
-
-  it('logs the resolved template with the project name in non-interactive mode', async () => {
-    process.env.CI = 'true';
-    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
-    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
-    await applySdkVersionToTemplateAsync('expo-template-default', {
-      yes: false,
-      projectName: 'my-app',
-    });
-    const output = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n');
-    expect(output).toMatch(/Creating .*my-app.* using the .*expo-template-default@sdk-55/);
     logSpy.mockRestore();
   });
 

--- a/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
+++ b/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
@@ -1,0 +1,197 @@
+import prompts from 'prompts';
+
+import { applySdkVersionToTemplateAsync, fetchSdkVersionsAsync } from '../promptSdkVersion';
+
+jest.mock('prompts');
+const mockPrompts = prompts as unknown as jest.Mock;
+
+const fetchMock = jest.fn();
+beforeAll(() => {
+  // @ts-expect-error - polyfill global fetch for tests
+  global.fetch = fetchMock;
+});
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  mockPrompts.mockReset();
+  delete process.env.CI;
+  delete process.env.EXPO_BETA;
+});
+
+const sampleSdkVersions = {
+  '40.0.0': { releaseNoteUrl: 'https://example.com/sdk-40', isDeprecated: true },
+  '52.0.0': { releaseNoteUrl: 'https://example.com/sdk-52' },
+  '53.0.0': { releaseNoteUrl: 'https://example.com/sdk-53' },
+  '54.0.0': { releaseNoteUrl: 'https://example.com/sdk-54' },
+  '55.0.0': { releaseNoteUrl: 'https://example.com/sdk-55' },
+  // No releaseNoteUrl yet — still in development.
+  '56.0.0': {},
+};
+
+function mockVersionsResponse({
+  expoGoSdkVersion,
+  sdkVersions = sampleSdkVersions,
+}: {
+  expoGoSdkVersion?: string;
+  sdkVersions?: Record<string, { releaseNoteUrl?: string; isDeprecated?: boolean; beta?: boolean }>;
+} = {}) {
+  fetchMock.mockResolvedValue({
+    ok: true,
+    json: async () => ({ expoGoSdkVersion, sdkVersions }),
+  });
+}
+
+describe(fetchSdkVersionsAsync, () => {
+  it('returns null when the endpoint is unreachable', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    expect(await fetchSdkVersionsAsync()).toBeNull();
+  });
+
+  it('returns null on a non-ok response', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: async () => ({}) });
+    expect(await fetchSdkVersionsAsync()).toBeNull();
+  });
+
+  it('uses entries with a releaseNoteUrl as released SDKs', async () => {
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    expect(await fetchSdkVersionsAsync()).toEqual({
+      latest: 55,
+      expoGoCompatible: 54,
+      available: [55, 54, 53, 52],
+    });
+  });
+
+  it('skips deprecated and beta entries even if they have a releaseNoteUrl', async () => {
+    mockVersionsResponse({
+      sdkVersions: {
+        '52.0.0': { releaseNoteUrl: 'https://example.com', isDeprecated: true },
+        '53.0.0': { releaseNoteUrl: 'https://example.com', beta: true },
+        '54.0.0': { releaseNoteUrl: 'https://example.com' },
+      },
+      expoGoSdkVersion: '54.0.0',
+    });
+    expect(await fetchSdkVersionsAsync()).toEqual({
+      latest: 54,
+      expoGoCompatible: 54,
+      available: [54],
+    });
+  });
+
+  it('returns null expoGoCompatible when the field is missing', async () => {
+    mockVersionsResponse({});
+    expect(await fetchSdkVersionsAsync()).toEqual({
+      latest: 55,
+      expoGoCompatible: null,
+      available: [55, 54, 53, 52],
+    });
+  });
+
+  it('returns null when no entries have a releaseNoteUrl', async () => {
+    mockVersionsResponse({ sdkVersions: { '56.0.0': {} } });
+    expect(await fetchSdkVersionsAsync()).toBeNull();
+  });
+});
+
+describe(applySdkVersionToTemplateAsync, () => {
+  it('skips the prompt when --yes is set', async () => {
+    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: true })).toBe(
+      'expo-template-default'
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the prompt in CI', async () => {
+    process.env.CI = 'true';
+    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
+      'expo-template-default'
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the prompt when the template already has a tag', async () => {
+    expect(
+      await applySdkVersionToTemplateAsync('expo-template-default@sdk-54', { yes: false })
+    ).toBe('expo-template-default@sdk-54');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('skips the prompt for unknown templates', async () => {
+    expect(await applySdkVersionToTemplateAsync('some-third-party-template', { yes: false })).toBe(
+      'some-third-party-template'
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('passes through unchanged when the versions endpoint fails', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
+      'expo-template-default'
+    );
+    expect(mockPrompts).not.toHaveBeenCalled();
+  });
+
+  it('appends the chosen SDK tag for the latest option', async () => {
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    mockPrompts.mockResolvedValueOnce({ answer: 55 });
+    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
+      'expo-template-default@sdk-55'
+    );
+  });
+
+  it('shows the "For beginners" choice with the SDK number in the description', async () => {
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    mockPrompts.mockResolvedValueOnce({ answer: 54 });
+    await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
+    const promptCall = mockPrompts.mock.calls[0][0];
+    expect(promptCall.choices).toEqual([
+      { title: 'Latest (SDK 55)', value: 55, description: 'recommended for most projects' },
+      {
+        title: 'For learning with Expo Go (SDK 54)',
+        value: 54,
+        description: 'Compatible with Expo Go on App Store and Play Store',
+      },
+      { title: 'Other SDK version…', value: 'other' },
+    ]);
+  });
+
+  it('omits the "For beginners" choice when expoGoSdkVersion is missing', async () => {
+    mockVersionsResponse({});
+    mockPrompts.mockResolvedValueOnce({ answer: 55 });
+    await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
+    const promptCall = mockPrompts.mock.calls[0][0];
+    expect(promptCall.choices).toEqual([
+      { title: 'Latest (SDK 55)', value: 55, description: 'recommended for most projects' },
+      { title: 'Other SDK version…', value: 'other' },
+    ]);
+  });
+
+  it('omits the "For beginners" choice when the compatible SDK matches latest', async () => {
+    mockVersionsResponse({
+      sdkVersions: { '54.0.0': { releaseNoteUrl: 'https://example.com' } },
+      expoGoSdkVersion: '54.0.0',
+    });
+    mockPrompts.mockResolvedValueOnce({ answer: 54 });
+    await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
+    const promptCall = mockPrompts.mock.calls[0][0];
+    expect(promptCall.choices).toEqual([
+      { title: 'Latest (SDK 54)', value: 54, description: 'recommended for most projects' },
+      { title: 'Other SDK version…', value: 'other' },
+    ]);
+  });
+
+  it('handles the "Other SDK version" submenu', async () => {
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    mockPrompts.mockResolvedValueOnce({ answer: 'other' }).mockResolvedValueOnce({ sdkAnswer: 53 });
+    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
+      'expo-template-default@sdk-53'
+    );
+    expect(mockPrompts).toHaveBeenCalledTimes(2);
+    const submenuCall = mockPrompts.mock.calls[1][0];
+    expect(submenuCall.choices).toEqual([
+      { title: 'SDK 55', value: 55 },
+      { title: 'SDK 54', value: 54 },
+      { title: 'SDK 53', value: 53 },
+      { title: 'SDK 52', value: 52 },
+    ]);
+  });
+});

--- a/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
+++ b/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
@@ -93,19 +93,40 @@ describe(fetchSdkVersionsAsync, () => {
 });
 
 describe(applySdkVersionToTemplateAsync, () => {
-  it('skips the prompt when --yes is set', async () => {
-    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: true })).toBe(
-      'expo-template-default'
-    );
-    expect(fetchMock).not.toHaveBeenCalled();
+  // Force TTY for the interactive tests below; non-interactive cases override.
+  let originalIsTTY: boolean | undefined;
+  beforeEach(() => {
+    originalIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
   });
 
-  it('skips the prompt in CI', async () => {
-    process.env.CI = 'true';
-    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
-      'expo-template-default'
+  it('pins to the latest released SDK without prompting when --yes is set', async () => {
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: true })).toBe(
+      'expo-template-default@sdk-55'
     );
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mockPrompts).not.toHaveBeenCalled();
+  });
+
+  it('pins to the latest released SDK without prompting in CI', async () => {
+    process.env.CI = 'true';
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
+      'expo-template-default@sdk-55'
+    );
+    expect(mockPrompts).not.toHaveBeenCalled();
+  });
+
+  it('pins to the latest released SDK without prompting when stdin is not a TTY', async () => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
+      'expo-template-default@sdk-55'
+    );
+    expect(mockPrompts).not.toHaveBeenCalled();
   });
 
   it('skips the prompt when the template already has a tag', async () => {
@@ -122,7 +143,7 @@ describe(applySdkVersionToTemplateAsync, () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('passes through unchanged when the versions endpoint fails', async () => {
+  it('passes through unchanged when the versions endpoint fails interactively', async () => {
     fetchMock.mockRejectedValue(new Error('network down'));
     expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
       'expo-template-default'
@@ -138,13 +159,35 @@ describe(applySdkVersionToTemplateAsync, () => {
     );
   });
 
-  it('shows the "For beginners" choice with the SDK number in the description', async () => {
+  it('prints a "Creating … Alternatively" lead-in with --template/--example before the prompt', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    mockPrompts.mockResolvedValueOnce({ answer: 55 });
+    await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
+    const output = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n');
+    expect(output).toMatch(/Creating a project using the .*default.* template\. Alternatively:/);
+    expect(output).toMatch(/--template/);
+    expect(output).toMatch(/--example/);
+    logSpy.mockRestore();
+  });
+
+  it('logs the resolved template in non-interactive mode', async () => {
+    process.env.CI = 'true';
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
+    const output = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n');
+    expect(output).toMatch(/Creating an Expo project using the .*expo-template-default@sdk-55/);
+    logSpy.mockRestore();
+  });
+
+  it('shows the "For learning with Expo Go" choice with the SDK number in the description', async () => {
     mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
     mockPrompts.mockResolvedValueOnce({ answer: 54 });
     await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
     const promptCall = mockPrompts.mock.calls[0][0];
     expect(promptCall.choices).toEqual([
-      { title: 'Latest (SDK 55)', value: 55, description: 'recommended for most projects' },
+      { title: 'Latest (SDK 55)', value: 55, description: 'Recommended for most projects' },
       {
         title: 'For learning with Expo Go (SDK 54)',
         value: 54,
@@ -154,18 +197,18 @@ describe(applySdkVersionToTemplateAsync, () => {
     ]);
   });
 
-  it('omits the "For beginners" choice when expoGoSdkVersion is missing', async () => {
+  it('omits the "For learning with Expo Go" choice when expoGoSdkVersion is missing', async () => {
     mockVersionsResponse({});
     mockPrompts.mockResolvedValueOnce({ answer: 55 });
     await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
     const promptCall = mockPrompts.mock.calls[0][0];
     expect(promptCall.choices).toEqual([
-      { title: 'Latest (SDK 55)', value: 55, description: 'recommended for most projects' },
+      { title: 'Latest (SDK 55)', value: 55, description: 'Recommended for most projects' },
       { title: 'Other SDK version…', value: 'other' },
     ]);
   });
 
-  it('omits the "For beginners" choice when the compatible SDK matches latest', async () => {
+  it('omits the "For learning with Expo Go" choice when the compatible SDK matches latest', async () => {
     mockVersionsResponse({
       sdkVersions: { '54.0.0': { releaseNoteUrl: 'https://example.com' } },
       expoGoSdkVersion: '54.0.0',
@@ -174,7 +217,7 @@ describe(applySdkVersionToTemplateAsync, () => {
     await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
     const promptCall = mockPrompts.mock.calls[0][0];
     expect(promptCall.choices).toEqual([
-      { title: 'Latest (SDK 54)', value: 54, description: 'recommended for most projects' },
+      { title: 'Latest (SDK 54)', value: 54, description: 'Recommended for most projects' },
       { title: 'Other SDK version…', value: 'other' },
     ]);
   });

--- a/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
+++ b/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
@@ -33,7 +33,7 @@ function mockVersionsResponse({
   sdkVersions = sampleSdkVersions,
 }: {
   expoGoSdkVersion?: string;
-  sdkVersions?: Record<string, { releaseNoteUrl?: string; isDeprecated?: boolean; beta?: boolean }>;
+  sdkVersions?: Record<string, { releaseNoteUrl?: string; isDeprecated?: boolean }>;
 } = {}) {
   fetchMock.mockResolvedValue({
     ok: true,
@@ -61,11 +61,10 @@ describe(fetchSdkVersionsAsync, () => {
     });
   });
 
-  it('skips deprecated and beta entries even if they have a releaseNoteUrl', async () => {
+  it('skips deprecated entries even if they have a releaseNoteUrl', async () => {
     mockVersionsResponse({
       sdkVersions: {
-        '52.0.0': { releaseNoteUrl: 'https://example.com', isDeprecated: true },
-        '53.0.0': { releaseNoteUrl: 'https://example.com', beta: true },
+        '53.0.0': { releaseNoteUrl: 'https://example.com', isDeprecated: true },
         '54.0.0': { releaseNoteUrl: 'https://example.com' },
       },
       expoGoSdkVersion: '54.0.0',
@@ -103,28 +102,40 @@ describe(applySdkVersionToTemplateAsync, () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
   });
 
-  it('passes through unchanged without prompting or fetching when --yes is set', async () => {
+  it('pins to the latest SDK without prompting when --yes is set with the default template', async () => {
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
     expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: true })).toBe(
-      'expo-template-default'
+      'expo-template-default@sdk-55'
     );
     expect(mockPrompts).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('passes through unchanged without prompting or fetching in CI', async () => {
+  it('pins to the latest SDK without prompting in CI with the default template', async () => {
     process.env.CI = 'true';
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
     expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
-      'expo-template-default'
+      'expo-template-default@sdk-55'
     );
     expect(mockPrompts).not.toHaveBeenCalled();
-    expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it('passes through unchanged without prompting or fetching when stdin is not a TTY', async () => {
+  it('pins to the latest SDK without prompting when stdin is not a TTY with the default template', async () => {
     Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
     expect(await applySdkVersionToTemplateAsync('expo-template-default', { yes: false })).toBe(
-      'expo-template-default'
+      'expo-template-default@sdk-55'
     );
+    expect(mockPrompts).not.toHaveBeenCalled();
+  });
+
+  it('passes through to npm `latest` non-interactively when --template is specified', async () => {
+    process.env.CI = 'true';
+    expect(
+      await applySdkVersionToTemplateAsync('expo-template-tabs', {
+        yes: false,
+        showAlternatives: false,
+      })
+    ).toBe('expo-template-tabs');
     expect(mockPrompts).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
+++ b/packages/create-expo/src/__tests__/promptSdkVersion.test.ts
@@ -159,25 +159,58 @@ describe(applySdkVersionToTemplateAsync, () => {
     );
   });
 
-  it('prints a "Creating … Alternatively" lead-in with --template/--example before the prompt', async () => {
+  it('prints a "Creating …" line and a Tip stanza after the SDK is picked', async () => {
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
     mockPrompts.mockResolvedValueOnce({ answer: 55 });
     await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
     const output = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n');
-    expect(output).toMatch(/Creating a project using the .*default.* template\. Alternatively:/);
+    expect(output).toMatch(/Creating a project using the .*default.* template\./);
+    expect(output).toMatch(/Tip:/);
     expect(output).toMatch(/--template/);
     expect(output).toMatch(/--example/);
     logSpy.mockRestore();
   });
 
-  it('logs the resolved template in non-interactive mode', async () => {
+  it('uses the project name in the lead-in when provided', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    mockPrompts.mockResolvedValueOnce({ answer: 55 });
+    await applySdkVersionToTemplateAsync('expo-template-default', {
+      yes: false,
+      projectName: 'my-app',
+    });
+    const output = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n');
+    expect(output).toMatch(/Creating .*my-app.* using the .*default.* template/);
+    logSpy.mockRestore();
+  });
+
+  it('hides the alternatives stanza when showAlternatives is false', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
+    mockPrompts.mockResolvedValueOnce({ answer: 55 });
+    await applySdkVersionToTemplateAsync('expo-template-tabs', {
+      yes: false,
+      showAlternatives: false,
+    });
+    const output = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n');
+    expect(output).toMatch(/Creating a project using the .*tabs.* template\./);
+    expect(output).not.toMatch(/Tip:/);
+    expect(output).not.toMatch(/--template/);
+    expect(output).not.toMatch(/--example/);
+    logSpy.mockRestore();
+  });
+
+  it('logs the resolved template with the project name in non-interactive mode', async () => {
     process.env.CI = 'true';
     const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     mockVersionsResponse({ expoGoSdkVersion: '54.0.0' });
-    await applySdkVersionToTemplateAsync('expo-template-default', { yes: false });
+    await applySdkVersionToTemplateAsync('expo-template-default', {
+      yes: false,
+      projectName: 'my-app',
+    });
     const output = logSpy.mock.calls.map((c) => String(c[0] ?? '')).join('\n');
-    expect(output).toMatch(/Creating an Expo project using the .*expo-template-default@sdk-55/);
+    expect(output).toMatch(/Creating .*my-app.* using the .*expo-template-default@sdk-55/);
     logSpy.mockRestore();
   });
 

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -201,10 +201,10 @@ async function createExampleAsync(inputPath: string, props: Options): Promise<vo
   // Ensure the example exists after performing remapping and deprecation checks.
   await ensureExampleExists(resolvedExample);
 
-  // Log the status after aliases and deprecated examples are handled.
-  console.log(chalk`Creating an Expo project using the {cyan ${resolvedExample}} example.\n`);
-
   const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
+  console.log(
+    chalk`Creating {cyan ${path.basename(projectRoot)}} using the {cyan ${resolvedExample}} example.\n`
+  );
   await fs.promises.mkdir(projectRoot, { recursive: true });
 
   // Setup telemetry attempt after a reasonable point.

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -14,6 +14,7 @@ import * as Template from './Template';
 import { generateAgentFiles } from './generateAgentFiles';
 import { promptTemplateAsync } from './legacyTemplates';
 import { Log } from './log';
+import { applySdkVersionToTemplateAsync } from './promptSdkVersion';
 import type { PackageManagerName } from './resolvePackageManager';
 import {
   configurePackageManager,
@@ -100,9 +101,6 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     resolvedTemplate = await promptTemplateAsync();
   } else {
     resolvedTemplate = props.template ?? null;
-    console.log(
-      chalk`Creating an Expo project using the {cyan ${resolvedTemplate ?? 'default'}} template.\n`
-    );
     if (!resolvedTemplate) {
       console.log(
         chalk`{gray To choose from all available templates ({underline https://github.com/expo/expo/tree/main/templates}) pass in the --template arg:}`
@@ -114,6 +112,13 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
       console.log(chalk`  {gray $} ${formatSelfCommand()} {cyan --example}\n`);
     }
   }
+
+  resolvedTemplate = await applySdkVersionToTemplateAsync(
+    resolvedTemplate ?? 'expo-template-default',
+    { yes: props.yes }
+  );
+
+  console.log(chalk`Creating an Expo project using the {cyan ${resolvedTemplate}} template.\n`);
 
   const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
   await fs.promises.mkdir(projectRoot, { recursive: true });

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -102,12 +102,17 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     resolvedTemplate = props.template ?? null;
   }
 
+  const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
+
   resolvedTemplate = await applySdkVersionToTemplateAsync(
     resolvedTemplate ?? 'expo-template-default',
-    { yes: props.yes }
+    {
+      yes: props.yes,
+      showAlternatives: !props.template,
+      projectName: path.basename(projectRoot),
+    }
   );
 
-  const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
   await fs.promises.mkdir(projectRoot, { recursive: true });
 
   // Setup telemetry attempt after a reasonable point.

--- a/packages/create-expo/src/createAsync.ts
+++ b/packages/create-expo/src/createAsync.ts
@@ -20,7 +20,6 @@ import {
   configurePackageManager,
   installDependenciesAsync,
   resolvePackageManager,
-  formatSelfCommand,
 } from './resolvePackageManager';
 import { assertFolderEmpty, assertValidName, resolveProjectRootAsync } from './resolveProjectRoot';
 import {
@@ -101,24 +100,12 @@ async function createTemplateAsync(inputPath: string, props: Options): Promise<v
     resolvedTemplate = await promptTemplateAsync();
   } else {
     resolvedTemplate = props.template ?? null;
-    if (!resolvedTemplate) {
-      console.log(
-        chalk`{gray To choose from all available templates ({underline https://github.com/expo/expo/tree/main/templates}) pass in the --template arg:}`
-      );
-      console.log(chalk`  {gray $} ${formatSelfCommand()} {cyan --template}\n`);
-      console.log(
-        chalk`{gray To choose from all available examples ({underline https://github.com/expo/examples}) pass in the --example arg:}`
-      );
-      console.log(chalk`  {gray $} ${formatSelfCommand()} {cyan --example}\n`);
-    }
   }
 
   resolvedTemplate = await applySdkVersionToTemplateAsync(
     resolvedTemplate ?? 'expo-template-default',
     { yes: props.yes }
   );
-
-  console.log(chalk`Creating an Expo project using the {cyan ${resolvedTemplate}} template.\n`);
 
   const projectRoot = await resolveProjectRootArgAsync(inputPath, props);
   await fs.promises.mkdir(projectRoot, { recursive: true });

--- a/packages/create-expo/src/promptSdkVersion.ts
+++ b/packages/create-expo/src/promptSdkVersion.ts
@@ -98,19 +98,16 @@ export async function applySdkVersionToTemplateAsync(
     return template;
   }
 
-  const versions = await fetchSdkVersionsAsync();
-  if (!versions) {
+  // Non-interactive runs fall through to the template's npm `latest` dist-tag.
+  if (yes || env.CI || !process.stdin.isTTY) {
     logCreatingProject(template, projectName);
     return template;
   }
 
-  // Non-interactive runs use the latest released SDK rather than falling back
-  // to the npm `latest` dist-tag, which is pinned to the SDK currently shipping
-  // in the App Store / Play Store version of Expo Go.
-  if (yes || env.CI || !process.stdin.isTTY) {
-    const pinned = `${name}@sdk-${versions.latest}`;
-    logCreatingProject(pinned, projectName);
-    return pinned;
+  const versions = await fetchSdkVersionsAsync();
+  if (!versions) {
+    logCreatingProject(template, projectName);
+    return template;
   }
 
   const selectedSdk = await promptSdkVersionAsync(versions, name, showAlternatives, projectName);

--- a/packages/create-expo/src/promptSdkVersion.ts
+++ b/packages/create-expo/src/promptSdkVersion.ts
@@ -13,7 +13,7 @@ const debug = require('debug')('expo:init:sdk') as typeof console.log;
 // `expoGoSdkVersion` reports the SDK currently shipping in store Expo Go and
 // is treated as optional — when absent, the "For learning with Expo Go" choice
 // is hidden.
-const VERSIONS_URL = 'https://exp.host/--/api/v2/versions';
+const VERSIONS_URL = 'https://api.expo.dev/v2/versions';
 
 type VersionsResponse = {
   expoGoSdkVersion?: string;

--- a/packages/create-expo/src/promptSdkVersion.ts
+++ b/packages/create-expo/src/promptSdkVersion.ts
@@ -1,0 +1,174 @@
+import chalk from 'chalk';
+import prompts from 'prompts';
+
+import { ALIASES } from './legacyTemplates';
+import { Log } from './log';
+import { env } from './utils/env';
+import { splitNpmNameAndTag } from './utils/npm';
+
+const debug = require('debug')('expo:init:sdk') as typeof console.log;
+
+/**
+ * The Expo versions endpoint is the source of truth for SDK selection:
+ * - `sdkVersions` entries with a `releaseNoteUrl` are considered released
+ *   (anything without one is canary/in-development).
+ * - The top-level `expoGoSdkVersion` field reports which SDK is currently
+ *   shipping in the App Store / Play Store version of Expo Go. We treat that
+ *   field as optional so older API responses just hide the "For beginners"
+ *   choice instead of breaking the prompt.
+ */
+const VERSIONS_URL = 'https://exp.host/--/api/v2/versions';
+
+type VersionsResponse = {
+  expoGoSdkVersion?: string;
+  sdkVersions?: Record<string, { releaseNoteUrl?: string; isDeprecated?: boolean; beta?: boolean }>;
+};
+
+type SdkVersionsSummary = {
+  /** Highest released SDK major version (highest entry with a releaseNoteUrl). */
+  latest: number;
+  /** Major SDK version currently shipping in the App Store / Play Store version of Expo Go. */
+  expoGoCompatible: number | null;
+  /** All released SDK major versions, sorted descending. */
+  available: number[];
+};
+
+export async function fetchSdkVersionsAsync(): Promise<SdkVersionsSummary | null> {
+  let json: VersionsResponse;
+  try {
+    const response = await fetch(VERSIONS_URL);
+    if (!response.ok) {
+      debug(`versions endpoint returned ${response.status}`);
+      return null;
+    }
+    json = (await response.json()) as VersionsResponse;
+  } catch (error) {
+    debug('Failed to fetch versions endpoint:', error);
+    return null;
+  }
+
+  const sdkVersions = json.sdkVersions ?? {};
+  const available = Object.entries(sdkVersions)
+    .filter(([, info]) => !!info.releaseNoteUrl && !info.isDeprecated && !info.beta)
+    .map(([version]) => parseSdkMajor(version))
+    .filter((major): major is number => major != null)
+    .sort((a, b) => b - a);
+
+  const latest = available[0];
+  if (latest == null) {
+    return null;
+  }
+
+  return {
+    latest,
+    expoGoCompatible: parseSdkMajor(json.expoGoSdkVersion),
+    available,
+  };
+}
+
+function parseSdkMajor(version: string | undefined): number | null {
+  const major = parseInt(version?.split('.')[0] ?? '', 10);
+  return Number.isFinite(major) ? major : null;
+}
+
+/**
+ * If the resolved template is an Expo-published template without an explicit
+ * SDK tag, prompt the user to pick which Expo SDK to use and return the
+ * template name with the chosen SDK tag appended.
+ *
+ * Returns the template unchanged if the user is non-interactive, the template
+ * already targets a specific version, or we can't reach the versions endpoint.
+ */
+export async function applySdkVersionToTemplateAsync(
+  template: string,
+  { yes }: { yes: boolean }
+): Promise<string> {
+  if (yes || env.CI || env.EXPO_BETA) {
+    return template;
+  }
+
+  const [name, tag] = splitNpmNameAndTag(template);
+  if (tag) {
+    return template;
+  }
+  if (!isKnownExpoTemplate(name)) {
+    return template;
+  }
+
+  const versions = await fetchSdkVersionsAsync();
+  if (!versions) {
+    return template;
+  }
+
+  const selectedSdk = await promptSdkVersionAsync(versions);
+  if (selectedSdk == null) {
+    return template;
+  }
+
+  return `${name}@sdk-${selectedSdk}`;
+}
+
+function isKnownExpoTemplate(name: string): boolean {
+  if (ALIASES.includes(name)) {
+    return true;
+  }
+  // Short aliases like `default` and `blank` are expanded to `expo-template-*` later.
+  return ALIASES.includes(`expo-template-${name}`);
+}
+
+async function promptSdkVersionAsync(versions: SdkVersionsSummary): Promise<number | null> {
+  const { latest, expoGoCompatible, available } = versions;
+
+  const choices: prompts.Choice[] = [
+    {
+      title: `Latest (SDK ${latest})`,
+      value: latest,
+      description: 'recommended for most projects',
+    },
+  ];
+
+  if (expoGoCompatible != null && expoGoCompatible !== latest) {
+    choices.push({
+      title: `For learning with Expo Go (SDK ${expoGoCompatible})`,
+      value: expoGoCompatible,
+      description: 'Compatible with Expo Go on App Store and Play Store',
+    });
+  }
+
+  choices.push({ title: 'Other SDK version…', value: 'other' });
+
+  const { answer } = await prompts({
+    type: 'select',
+    name: 'answer',
+    message: 'Choose an Expo SDK version:',
+    choices,
+  });
+
+  if (answer == null) {
+    Log.log();
+    Log.log(chalk`Specify the SDK version, example: {cyan --template default@${latest}}`);
+    process.exit(1);
+  }
+
+  if (answer !== 'other') {
+    return answer as number;
+  }
+
+  const { sdkAnswer } = await prompts({
+    type: 'select',
+    name: 'sdkAnswer',
+    message: 'Choose an SDK version:',
+    choices: available.slice(0, 4).map((sdk) => ({
+      title: `SDK ${sdk}`,
+      value: sdk,
+    })),
+  });
+
+  if (sdkAnswer == null) {
+    Log.log();
+    Log.log(chalk`Specify the SDK version, example: {cyan --template default@${latest}}`);
+    process.exit(1);
+  }
+
+  return sdkAnswer as number;
+}

--- a/packages/create-expo/src/promptSdkVersion.ts
+++ b/packages/create-expo/src/promptSdkVersion.ts
@@ -3,20 +3,16 @@ import prompts from 'prompts';
 
 import { ALIASES } from './legacyTemplates';
 import { Log } from './log';
+import { formatSelfCommand } from './resolvePackageManager';
 import { env } from './utils/env';
 import { splitNpmNameAndTag } from './utils/npm';
 
 const debug = require('debug')('expo:init:sdk') as typeof console.log;
 
-/**
- * The Expo versions endpoint is the source of truth for SDK selection:
- * - `sdkVersions` entries with a `releaseNoteUrl` are considered released
- *   (anything without one is canary/in-development).
- * - The top-level `expoGoSdkVersion` field reports which SDK is currently
- *   shipping in the App Store / Play Store version of Expo Go. We treat that
- *   field as optional so older API responses just hide the "For beginners"
- *   choice instead of breaking the prompt.
- */
+// SDKs without a `releaseNoteUrl` are canary/in-development. The top-level
+// `expoGoSdkVersion` reports the SDK currently shipping in store Expo Go and
+// is treated as optional — when absent, the "For learning with Expo Go" choice
+// is hidden.
 const VERSIONS_URL = 'https://exp.host/--/api/v2/versions';
 
 type VersionsResponse = {
@@ -83,29 +79,47 @@ export async function applySdkVersionToTemplateAsync(
   template: string,
   { yes }: { yes: boolean }
 ): Promise<string> {
-  if (yes || env.CI || env.EXPO_BETA) {
+  if (env.EXPO_BETA) {
+    logCreatingProject(template);
     return template;
   }
 
   const [name, tag] = splitNpmNameAndTag(template);
   if (tag) {
+    logCreatingProject(template);
     return template;
   }
   if (!isKnownExpoTemplate(name)) {
+    logCreatingProject(template);
     return template;
   }
 
   const versions = await fetchSdkVersionsAsync();
   if (!versions) {
+    logCreatingProject(template);
     return template;
   }
 
-  const selectedSdk = await promptSdkVersionAsync(versions);
+  // Non-interactive runs use the latest released SDK rather than falling back
+  // to the npm `latest` dist-tag, which is pinned to the SDK currently shipping
+  // in the App Store / Play Store version of Expo Go.
+  if (yes || env.CI || !process.stdin.isTTY) {
+    const pinned = `${name}@sdk-${versions.latest}`;
+    logCreatingProject(pinned);
+    return pinned;
+  }
+
+  const selectedSdk = await promptSdkVersionAsync(versions, name);
   if (selectedSdk == null) {
+    logCreatingProject(template);
     return template;
   }
 
   return `${name}@sdk-${selectedSdk}`;
+}
+
+function logCreatingProject(template: string): void {
+  console.log(chalk`Creating an Expo project using the {cyan ${template}} template.\n`);
 }
 
 function isKnownExpoTemplate(name: string): boolean {
@@ -116,14 +130,30 @@ function isKnownExpoTemplate(name: string): boolean {
   return ALIASES.includes(`expo-template-${name}`);
 }
 
-async function promptSdkVersionAsync(versions: SdkVersionsSummary): Promise<number | null> {
+async function promptSdkVersionAsync(
+  versions: SdkVersionsSummary,
+  templateName: string
+): Promise<number | null> {
   const { latest, expoGoCompatible, available } = versions;
+
+  const friendly = templateName.replace(/^expo-template-/, '');
+  const cmd = formatSelfCommand();
+  console.log(
+    chalk`Creating a project using the {cyan ${friendly}} template. Alternatively:`
+  );
+  console.log(
+    `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--template')}  ${chalk.gray('to pick from other templates')}`
+  );
+  console.log(
+    `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--example')}   ${chalk.gray('to explore examples')}`
+  );
+  console.log();
 
   const choices: prompts.Choice[] = [
     {
       title: `Latest (SDK ${latest})`,
       value: latest,
-      description: 'recommended for most projects',
+      description: 'Recommended for most projects',
     },
   ];
 
@@ -140,7 +170,7 @@ async function promptSdkVersionAsync(versions: SdkVersionsSummary): Promise<numb
   const { answer } = await prompts({
     type: 'select',
     name: 'answer',
-    message: 'Choose an Expo SDK version:',
+    message: 'Select an Expo SDK version:',
     choices,
   });
 
@@ -157,7 +187,7 @@ async function promptSdkVersionAsync(versions: SdkVersionsSummary): Promise<numb
   const { sdkAnswer } = await prompts({
     type: 'select',
     name: 'sdkAnswer',
-    message: 'Choose an SDK version:',
+    message: 'Select an SDK version:',
     choices: available.slice(0, 4).map((sdk) => ({
       title: `SDK ${sdk}`,
       value: sdk,

--- a/packages/create-expo/src/promptSdkVersion.ts
+++ b/packages/create-expo/src/promptSdkVersion.ts
@@ -17,7 +17,7 @@ const VERSIONS_URL = 'https://exp.host/--/api/v2/versions';
 
 type VersionsResponse = {
   expoGoSdkVersion?: string;
-  sdkVersions?: Record<string, { releaseNoteUrl?: string; isDeprecated?: boolean; beta?: boolean }>;
+  sdkVersions?: Record<string, { releaseNoteUrl?: string; isDeprecated?: boolean }>;
 };
 
 type SdkVersionsSummary = {
@@ -45,7 +45,7 @@ export async function fetchSdkVersionsAsync(): Promise<SdkVersionsSummary | null
 
   const sdkVersions = json.sdkVersions ?? {};
   const available = Object.entries(sdkVersions)
-    .filter(([, info]) => !!info.releaseNoteUrl && !info.isDeprecated && !info.beta)
+    .filter(([, info]) => !!info.releaseNoteUrl && !info.isDeprecated)
     .map(([version]) => parseSdkMajor(version))
     .filter((major): major is number => major != null)
     .sort((a, b) => b - a);
@@ -98,8 +98,11 @@ export async function applySdkVersionToTemplateAsync(
     return template;
   }
 
-  // Non-interactive runs fall through to the template's npm `latest` dist-tag.
-  if (yes || env.CI || !process.stdin.isTTY) {
+  const nonInteractive = yes || env.CI || !process.stdin.isTTY;
+
+  // Non-interactive + user explicitly chose a template: fall through to that
+  // template's npm `latest` dist-tag. No need to fetch the versions endpoint.
+  if (nonInteractive && !showAlternatives) {
     logCreatingProject(template, projectName);
     return template;
   }
@@ -108,6 +111,13 @@ export async function applySdkVersionToTemplateAsync(
   if (!versions) {
     logCreatingProject(template, projectName);
     return template;
+  }
+
+  // Non-interactive + default template: pin to the actual latest released SDK.
+  if (nonInteractive) {
+    const pinned = `${name}@sdk-${versions.latest}`;
+    logCreatingProject(pinned, projectName);
+    return pinned;
   }
 
   const selectedSdk = await promptSdkVersionAsync(versions, name, showAlternatives, projectName);

--- a/packages/create-expo/src/promptSdkVersion.ts
+++ b/packages/create-expo/src/promptSdkVersion.ts
@@ -77,26 +77,30 @@ function parseSdkMajor(version: string | undefined): number | null {
  */
 export async function applySdkVersionToTemplateAsync(
   template: string,
-  { yes }: { yes: boolean }
+  {
+    yes,
+    showAlternatives = true,
+    projectName,
+  }: { yes: boolean; showAlternatives?: boolean; projectName?: string }
 ): Promise<string> {
   if (env.EXPO_BETA) {
-    logCreatingProject(template);
+    logCreatingProject(template, projectName);
     return template;
   }
 
   const [name, tag] = splitNpmNameAndTag(template);
   if (tag) {
-    logCreatingProject(template);
+    logCreatingProject(template, projectName);
     return template;
   }
   if (!isKnownExpoTemplate(name)) {
-    logCreatingProject(template);
+    logCreatingProject(template, projectName);
     return template;
   }
 
   const versions = await fetchSdkVersionsAsync();
   if (!versions) {
-    logCreatingProject(template);
+    logCreatingProject(template, projectName);
     return template;
   }
 
@@ -105,21 +109,22 @@ export async function applySdkVersionToTemplateAsync(
   // in the App Store / Play Store version of Expo Go.
   if (yes || env.CI || !process.stdin.isTTY) {
     const pinned = `${name}@sdk-${versions.latest}`;
-    logCreatingProject(pinned);
+    logCreatingProject(pinned, projectName);
     return pinned;
   }
 
-  const selectedSdk = await promptSdkVersionAsync(versions, name);
+  const selectedSdk = await promptSdkVersionAsync(versions, name, showAlternatives, projectName);
   if (selectedSdk == null) {
-    logCreatingProject(template);
+    logCreatingProject(template, projectName);
     return template;
   }
 
   return `${name}@sdk-${selectedSdk}`;
 }
 
-function logCreatingProject(template: string): void {
-  console.log(chalk`Creating an Expo project using the {cyan ${template}} template.\n`);
+function logCreatingProject(template: string, projectName: string | undefined): void {
+  const subject = projectName ? chalk.cyan(projectName) : 'a project';
+  console.log(chalk`Creating ${subject} using the {cyan ${template}} template.\n`);
 }
 
 function isKnownExpoTemplate(name: string): boolean {
@@ -132,22 +137,11 @@ function isKnownExpoTemplate(name: string): boolean {
 
 async function promptSdkVersionAsync(
   versions: SdkVersionsSummary,
-  templateName: string
+  templateName: string,
+  showAlternatives: boolean,
+  projectName: string | undefined
 ): Promise<number | null> {
   const { latest, expoGoCompatible, available } = versions;
-
-  const friendly = templateName.replace(/^expo-template-/, '');
-  const cmd = formatSelfCommand();
-  console.log(
-    chalk`Creating a project using the {cyan ${friendly}} template. Alternatively:`
-  );
-  console.log(
-    `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--template')}  ${chalk.gray('to pick from other templates')}`
-  );
-  console.log(
-    `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--example')}   ${chalk.gray('to explore examples')}`
-  );
-  console.log();
 
   const choices: prompts.Choice[] = [
     {
@@ -180,25 +174,43 @@ async function promptSdkVersionAsync(
     process.exit(1);
   }
 
+  let resolved: number;
   if (answer !== 'other') {
-    return answer as number;
+    resolved = answer as number;
+  } else {
+    const { sdkAnswer } = await prompts({
+      type: 'select',
+      name: 'sdkAnswer',
+      message: 'Select an SDK version:',
+      choices: available.slice(0, 4).map((sdk) => ({
+        title: `SDK ${sdk}`,
+        value: sdk,
+      })),
+    });
+
+    if (sdkAnswer == null) {
+      Log.log();
+      Log.log(chalk`Specify the SDK version, example: {cyan --template default@${latest}}`);
+      process.exit(1);
+    }
+    resolved = sdkAnswer as number;
   }
 
-  const { sdkAnswer } = await prompts({
-    type: 'select',
-    name: 'sdkAnswer',
-    message: 'Select an SDK version:',
-    choices: available.slice(0, 4).map((sdk) => ({
-      title: `SDK ${sdk}`,
-      value: sdk,
-    })),
-  });
-
-  if (sdkAnswer == null) {
-    Log.log();
-    Log.log(chalk`Specify the SDK version, example: {cyan --template default@${latest}}`);
-    process.exit(1);
+  const friendly = templateName.replace(/^expo-template-/, '');
+  const subject = projectName ? chalk.cyan(projectName) : 'a project';
+  console.log(chalk`Creating ${subject} using the {cyan ${friendly}} template.`);
+  if (showAlternatives) {
+    const cmd = formatSelfCommand();
+    console.log();
+    console.log(chalk.gray('Tip:'));
+    console.log(
+      `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--template')}  ${chalk.gray('to pick from other templates')}`
+    );
+    console.log(
+      `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--example')}   ${chalk.gray('to explore examples')}`
+    );
   }
+  console.log();
 
-  return sdkAnswer as number;
+  return resolved;
 }

--- a/packages/create-expo/src/promptSdkVersion.ts
+++ b/packages/create-expo/src/promptSdkVersion.ts
@@ -204,7 +204,7 @@ async function promptSdkVersionAsync(
       `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--template')}  ${chalk.gray('to pick from other templates')}`
     );
     console.log(
-      `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--example')}   ${chalk.gray('to explore examples')}`
+      `  ${chalk.gray('•')} ${chalk.gray(cmd)} ${chalk.cyan('--example')}   ${chalk.gray('to explore')} ${chalk.gray.underline('https://github.com/expo/examples')}`
     );
   }
   console.log();


### PR DESCRIPTION
Adds an SDK version selection prompt to `create-expo`.

<img width="1288" height="864" alt="image" src="https://github.com/user-attachments/assets/3c97d34f-58ac-4400-b218-f73ac9444208" />

<img width="1288" height="864" alt="image" src="https://github.com/user-attachments/assets/7824039e-3450-4a85-bfd9-a86bc8ee7927" />

<img width="1288" height="864" alt="image" src="https://github.com/user-attachments/assets/efcb4fde-89ef-4dfb-bf3c-16e5d35aeb96" />

# How

- Prompt options are pulled from the versions endpoint.  I added a new top-level `expoGoSdkVersion` field on that endpoint for the "For learning with Expo Go" option. Omitting the field hides that option.
- For a short period of time the default selected option in the prompt (SDK 55) will not be aligned with the default `latest` version on npm. We can update the `latest` tag for templates on npm after we roll this out. I am calling this out because I changed `create-expo my-app --yes` to default to the latest SDK, not just the `latest` tag -- in my opinion, passing in `--yes` is equivalent to saying "just hit return in the prompt" - so that is what this does. I apply this same logic in CI. I do not, however, change the existing behavior for `--template <name>` -- if you pass in this flag, since that maps to an npm package I use the `latest` tag. So that will briefly be slightly out of sync.
- While here, I also did a bit of cleanup on some of the copy to make it slightly nicer to read.

# Test Plan

Run the command:

- with no args
- with app name
- with `--template`
- with `--example`
- with `--template default`
- with `--template default@sdk-55`
- with `--yes`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)