### PR TITLE
[Help wanted] [expo-modules-core][ios][SDK 53] Candidate fix for Hermes Hades GC race in ExpoBridgeModule.setBridge: please sanity-check

### DIFF
--- a/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
+++ b/packages/expo-modules-core/ios/Core/ExpoBridgeModule.mm
@@ -46,7 +46,20 @@ RCT_EXPORT_MODULE(ExpoModulesCore);
   _appContext.reactBridge = bridge;
 
 #if !__has_include(<ReactCommon/RCTRuntimeExecutor.h>)
-  _appContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:bridge];
+  // Hop the runtime install (and the prepareRuntime() chain it triggers via
+  // _runtime.didSet) onto RCTJSThread. The original line ran synchronously
+  // on whatever thread called setBridge: — typically the main thread — and
+  // raced JSIExecutor::initializeRuntime() on the JS thread, corrupting
+  // Hermes' Hades GC (HadesGC::writeBarrierSlow EXC_BAD_ACCESS).
+  __weak EXAppContext *weakAppContext = _appContext;
+  __weak RCTBridge *weakBridge = bridge;
+  [bridge dispatchBlock:^{
+    EXAppContext *strongAppContext = weakAppContext;
+    RCTBridge *strongBridge = weakBridge;
+    if (strongAppContext != nil && strongBridge != nil && strongAppContext._runtime == nil) {
+      strongAppContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:strongBridge];
+    }
+  } queue:RCTJSThread];
 #endif // React Native <0.74
 }
 


### PR DESCRIPTION
### Context

We've been chasing a recurring App Store Connect crash for a while. We previously reported it upstream and haven't gotten a response:

- [original issue raised on expo](https://github.com/expo/expo/issues/43003)

After a lot of digging (with AI help), my current working theory is that this is a **race condition between three concurrent paths during bridge startup**, and that it lines up with code that has already been refactored away in newer Expo:

We're stuck on **SDK 53** for now, so we need a **backport-style fix**. We can upgrade to 54, however from what I see the possible culprit file is **deleted in latest SDK 55**, so upgrading to 54 won't help us much either. PR ref: expo/expo#44351

### Suspected root cause (please verify)

This is my reading of the code paths — **I could be wrong about specifics; corrections very welcome.**

1. **`EXNativeModulesProxy` doesn't override `+requiresMainQueueSetup`**, so it defaults to `YES`. `RCTCxxBridge` therefore initializes it on the main thread via `RCTUnsafeExecuteOnMainQueueSync`.
2. Inside that flow, `EXNativeModulesProxy.setBridge:` calls `[bridge moduleForClass:ExpoBridgeModule.class]`, which lazily loads `ExpoBridgeModule` **on the caller thread (the main thread here)**.
3. As far as I can tell, React Native's lazy load path (`moduleForName:lazilyLoadIfNecessary:` → `setUpInstanceAndBridge:`) **does not respect `+requiresMainQueueSetup`**, so `ExpoBridgeModule.requiresMainQueueSetup = NO` is effectively ignored in this path.
4. `ExpoBridgeModule.setBridge:` then runs this line **on the main thread**:

   ```objc
   _appContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:bridge];
   ```

   That assignment fires Swift's `didSet` on `_runtime`, which **synchronously calls `prepareRuntime()`** — i.e. JSI mutations on the main thread.
5. Concurrently, the **JS thread is already inside `JSIExecutor::initializeRuntime()`** doing its own JSI mutations (right around `setProperty(global, "nativeModuleProxy", …)`).

Two threads mutating the same Hermes runtime → Hades GC's write barrier sees an inconsistent pointer → **`EXC_BAD_ACCESS` in `HadesGC::writeBarrierSlow`**.

If any of the above is wrong, I'd really appreciate being corrected — **that directly changes whether the fix below is in the right place.**

### Reproduction

The production trace is non-deterministic; I couldn't hit it naturally. I forced it with a deterministic harness:

- Inside `JSIExecutor::initializeRuntime()`, paused the JS thread with `usleep(200ms)` gated by a shared `dispatch_semaphore_t`, right before `setProperty(global, "nativeModuleProxy", …)`.
- Concurrently, ran `_appContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:bridge]` on the main thread.
- This **reliably crashes with a Hermes-side stack nearly identical to production.**

### Production stack trace

```
0   hermes  hermes::vm::HadesGC::writeBarrierSlow(...)               (HadesGC.cpp:1975)
1   hermes  hermes::vm::HiddenClass::addToPropertyMap(...)           (HiddenClass.cpp:833)
2   hermes  hermes::vm::HiddenClass::addProperty(...)                (HiddenClass.cpp:404)
3   hermes  hermes::vm::JSObject::addOwnPropertyImpl(...)            (JSObject.cpp:2755)
4   hermes  hermes::vm::JSObject::addOwnProperty(...)                (JSObject.cpp:2731)
5   hermes  hermes::vm::JSObject::putComputedWithReceiver_RJS(...)   (JSObject.cpp:1846)
6   hermes  HermesRuntimeImpl::setPropertyValue(...)                 (hermes.cpp:2174)
7   Quince  <deduplicated_symbol> + 92
8   Quince  <deduplicated_symbol> + 92
9   Quince  facebook::react::JSIExecutor::initializeRuntime() + 156  (JSIExecutor.cpp:87)
10  Quince  facebook::react::NativeToJsBridge::runOnExecutorQueue(...)::$_0
...
21  Quince  facebook::react::RCTMessageThread::tryFunc(...)          (RCTMessageThread.mm:68)
24  Quince  invocation function for block in RCTMessageThread::runAsync(...)
29  Quince  +[RCTCxxBridge runRunLoop] + 212                          (RCTCxxBridge.mm:347)
30  Foundation _NSThread__start_ + 732
```

**Frame 9 is the JS thread mid-`initializeRuntime()`**; my hypothesis is that the Hades crash at frame 0 happens because **the main thread is concurrently mutating the same runtime via `prepareRuntime()`**.

### The candidate fix in this PR

**Hop the runtime install (and the `prepareRuntime()` chain it triggers via `_runtime.didSet`) onto `RCTJSThread`**, so all JSI mutation happens on the JS thread:

```objc
#if !__has_include(<ReactCommon/RCTRuntimeExecutor.h>)
  __weak EXAppContext *weakAppContext = _appContext;
  __weak RCTBridge *weakBridge = bridge;
  [bridge dispatchBlock:^{
    EXAppContext *strongAppContext = weakAppContext;
    RCTBridge *strongBridge = weakBridge;
    if (strongAppContext != nil && strongBridge != nil && strongAppContext._runtime == nil) {
      strongAppContext._runtime = [EXJavaScriptRuntimeManager runtimeFromBridge:strongBridge];
    }
  } queue:RCTJSThread];
#endif // React Native <0.74
```

Notes on the shape (again, **AI-assisted reasoning — please push back if any of this is wrong**):

- **Weak captures** so the block doesn't extend the lifetime of `_appContext` / `bridge` past their natural owners.
- **`_runtime == nil` guard** so we don't double-install if the synchronous path in `RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(installModules)` got there first (that path also lazily creates the runtime if missing).
- **Only the RN <0.74 branch is changed.** RN ≥0.74 already routes through `setRuntimeExecutor:` and, as far as I can tell, isn't affected by this race in the same way.

### Why this *might* be the right shape

- **`RCTJSThread` looks like the canonical thread for JSI mutation**; `JSIExecutor::initializeRuntime()` and downstream RN module setup already happen there.
- Moving `prepareRuntime()` onto the same thread should **serialize our mutation with RN's own runtime setup, eliminating the data race** instead of papering over it with a lock.
- Upstream's larger refactor (#44351) seems (to me) to move toward the same property — `setBridge:` no longer inheriting the caller's thread for runtime install — just via deletion of the offending file rather than a hop.

That said, **I'm not confident this is the *cleanest* fix**; it's just the smallest one that I could reason about end-to-end and that holds up under the forced-race repro.

### Risk / what could go wrong

- **The runtime install is now async w.r.t. `setBridge:` returning.** `installModules` (the blocking sync method) already handles the "runtime not yet installed" case by creating it on demand, so the first JS-side `installModules` call should still get a runtime synchronously even if our dispatched block hasn't run yet. The `== nil` guard prevents the double-install. (**I'd love confirmation that this reasoning is correct.**)
- `dispatchBlock:queue:` is the **legacy bridge API** — used here only because we're inside the `!__has_include(<ReactCommon/RCTRuntimeExecutor.h>)` (RN <0.74) branch where it's still supported.
- Anyone subclassing `ExpoBridgeModule` and reading `_appContext._runtime` synchronously from `setBridge:` would now **see `nil`**. I don't *think* anyone does this in our app or in standard Expo modules, but it's the one observable behavior change and worth flagging.

### Asks for the Expo team

I'd really appreciate a sanity check from someone who actually owns this code:

1. **Direction check**: does hopping the install to `RCTJSThread` look like the right SDK-53-era fix to you, or would you prefer a different shape (e.g. fixing it in `EXJavaScriptRuntimeManager` / Swift `didSet`, making `EXNativeModulesProxy` honor `+requiresMainQueueSetup`, or something else entirely)?
2. **Confirmation of root cause**: does the three-path analysis above match your mental model of how `setBridge:` is reached during startup on the legacy bridge? I'm not confident I've got the RN lazy-load behavior exactly right.
3. **Backport viability**: is there appetite to land an equivalent fix in an SDK 53 patch release of `expo-modules-core`, since #44351 only helps newer SDKs?
4. **Anything I'd be breaking**: any internal Expo module that reads `_appContext._runtime` synchronously from inside a `setBridge:` chain on the main thread? That's the one observable behavior change here.

Refs:
- expo/expo#43003 (original report, no response yet)
- expo/expo#44351 (upstream refactor that deletes the offending path)

---

> **I'm not an Expo or React Native internals expert.** I dug through this with **heavy AI assistance** to form a working theory and a candidate fix. The analysis above is my best understanding, **not authoritative** — the whole point of opening this is to ask the Expo team to sanity-check it. **This patch touches the very critical `prepareRuntime()` path in `expo-modules-core`**, so I'd rather get it wrong loudly than land something silently broken. See "Asks for the Expo team" above.