### PR TITLE
[file-system][android] Improve SAF file creation error messages

### DIFF
--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemDirectory.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemDirectory.kt
@@ -51,13 +51,13 @@ class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
   }
 
   fun create(options: CreateOptions = CreateOptions()) {
+    if (uri.isContentUri) {
+      throw UnableToCreateException("Directory.create function does not work with SAF content:// uris, use `Directory.createDirectory` instead")
+    }
     validateType()
     validatePermission(FilePermissionService.Permission.WRITE)
     if (!needsCreation(options)) {
       return
-    }
-    if (uri.isContentUri) {
-      throw UnableToCreateException("create function does not work with SAF Uris, use `createDirectory` and `createFile` instead")
     }
     validateCanCreate(options)
     if (options.overwrite && file.exists()) {

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -36,12 +36,12 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
   }
 
   fun create(options: CreateOptions = CreateOptions()) {
+    if (uri.isContentUri) {
+      throw UnableToCreateException("File.create function does not work with SAF content:// uris, use `Directory.createFile` instead")
+    }
     validateType()
     validatePermission(FilePermissionService.Permission.WRITE)
     validateCanCreate(options)
-    if (uri.isContentUri) {
-      throw UnableToCreateException("create function does not work with SAF Uris, use `createDirectory` and `createFile` instead")
-    }
     if (options.overwrite && exists) {
       javaFile.delete()
     }

--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
@@ -1,0 +1,28 @@
+package expo.modules.filesystem
+
+import android.net.Uri
+import android.os.Build
+import org.junit.Assert.assertThrows
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class FileSystemFileTest {
+  @Test
+  fun createRejectsContentUriBeforeResolvingFileType() {
+    val file = FileSystemFile(Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADownload"))
+
+    val exception = assertThrows(UnableToCreateException::class.java) {
+      file.create()
+    }
+
+    assertTrue(
+      exception.message?.contains("File.create") == true &&
+        exception.message?.contains("Directory.createFile") == true
+    )
+  }
+}


### PR DESCRIPTION
# Why

Fix misleading error messages when using `File.create` for Android SAF URIs

Mentioned [here](https://github.com/expo/expo/issues/41717#issuecomment-3671449731)

# How

Moved the URI check to the top so it fails first with meaningful error

# Test Plan

Tried `File.create` for SAF URI

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
