### PR TITLE
test(create-expo-module): Fix minimumReleaseAge applying to create-expo-module test

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 
-import os from 'os';
-
 import {
   createFakeProject,
   createTestPath,

--- a/packages/create-expo-module/e2e/__tests__/utils.ts
+++ b/packages/create-expo-module/e2e/__tests__/utils.ts
@@ -42,6 +42,8 @@ export function execute(args: string[], { env = {}, cwd = projectRoot }: SpawnOp
     cwd: cwdPath,
     env: {
       ...process.env,
+      // NOTE(@kitten): pnpm currently passes on and consumes all its workspace configs, which breaks isolation
+      npm_config_minimum_release_age: '0',
       // Force non-interactive mode for CI
       CI: '1',
       // Disable telemetry


### PR DESCRIPTION
# Why

This currently fails "Create Expo Module" tests quite often.

# How

- Override env arg for minimum release age

We can also choose not to pass `...process.env` and either only forward `PATH` or provide the absolute path to the `node` binary, but for now, overriding this one env var should be good enough.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
