### PR TITLE
[ncl] Fix AssetScreen 

### DIFF
--- a/apps/native-component-list/src/screens/MediaLibrary@Next/AddAssetToAlbumScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary@Next/AddAssetToAlbumScreen.tsx
@@ -52,7 +52,7 @@ const AddAssetToAlbumScreen = () => {
     const url =
       type === 'image'
         ? 'https://picsum.photos/200/300'
-        : 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4';
+        : 'https://expo-test-media.com/big_buck_bunny/bbb_720p.mp4';
     await File.downloadFileAsync(url, file, { idempotent: true });
     return file;
   };

--- a/apps/native-component-list/src/screens/MediaLibrary@Next/AssetScreen.tsx
+++ b/apps/native-component-list/src/screens/MediaLibrary@Next/AssetScreen.tsx
@@ -74,18 +74,18 @@ const AssetScreen = () => {
 
   const loadAssetState = async (selectedAsset: Asset) => {
     const info = await selectedAsset.getInfo();
-    const subtypes = await selectedAsset.getMediaSubtypes();
     if (Platform.OS === 'ios') {
-      const [orient, networkAsset, pairedVideo] = await Promise.all([
+      const [orient, networkAsset, pairedVideo, subtypes] = await Promise.all([
         selectedAsset.getOrientation(),
         selectedAsset.getIsInCloud(),
         selectedAsset.getLivePhotoVideoUri(),
+        selectedAsset.getMediaSubtypes(),
       ]);
+      setMediaSubtypes(subtypes);
       setOrientation(orient);
       setIsNetworkAsset(networkAsset);
       setPairedVideoUri(pairedVideo);
     }
-    setMediaSubtypes(subtypes);
     setAsset(selectedAsset);
     setAssetInfo(info);
     setTestState(TestState.FINISHED);
@@ -166,8 +166,7 @@ const AssetScreen = () => {
         }
         case 'video': {
           const videoFile = new File(dir, `${screenName}.mp4`);
-          const videoUrl =
-            'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4';
+          const videoUrl = 'https://expo-test-media.com/big_buck_bunny/bbb_720p.mp4';
           await File.downloadFileAsync(videoUrl, videoFile, { idempotent: true });
           return videoFile;
         }


### PR DESCRIPTION
# Why
- An exception was thrown when entering the screen because getMediaSubtypes is an iOS-only function.
- The video source was not available, replaced it with the one from expo-test-media-com
# How
- Move getMediaSubtypes into an iOS if statement
- Changed the video url 

# Test Plan
✅ BareExpo 