### PR TITLE
[test-suite] Fix contacts get/set tests

### DIFF
--- a/apps/test-suite/tests/ContactsNext.ts
+++ b/apps/test-suite/tests/ContactsNext.ts
@@ -769,7 +769,7 @@ export async function test(t) {
   t.describe('Set, Get properties', () => {
     let contact: Contact;
 
-    t.beforeAll(async () => {
+    t.beforeEach(async () => {
       const contactDetails = {
         givenName: 'Name',
         familyName: 'Tester',
@@ -778,7 +778,7 @@ export async function test(t) {
       t.expect(contact.id).toBeDefined();
     });
 
-    t.afterAll(async () => {
+    t.afterEach(async () => {
       await contact.delete();
     });
 


### PR DESCRIPTION
# Why

All the get/set tests shared the same contact which led to a problem where setting given and family name to null removed the contact on some devices and the rest of tests failed

# How

Changed before/afterAll to beforeAfterEach


# Test Plan
BareExpo ✅