### PR TITLE
[iOS][core] Fix double to UIColor conversion

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix double to UIColor conversion
+- [iOS] Fix double to UIColor conversion ([#45387](https://github.com/expo/expo/pull/45387) by [@Wenszel](https://github.com/Wenszel))
 - [iOS] Fix random crash when concurrent access of the same `Record` on `Field.options`. The set is now guarded by a per-field lock and accessed through a single `withOptions` API. ([#45072](https://github.com/expo/expo/pull/45072) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed converting `Enumerable` function results to JS values. ([#45168](https://github.com/expo/expo/pull/45168) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed prebuild dependencies for `ExpoModulesJSI` ([#45124](https://github.com/expo/expo/pull/45124) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix double to UIColor conversion
 - [iOS] Fix random crash when concurrent access of the same `Record` on `Field.options`. The set is now guarded by a per-field lock and accessed through a single `withOptions` API. ([#45072](https://github.com/expo/expo/pull/45072) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Fixed converting `Enumerable` function results to JS values. ([#45168](https://github.com/expo/expo/pull/45168) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Fixed prebuild dependencies for `ExpoModulesJSI` ([#45124](https://github.com/expo/expo/pull/45124) by [@chrfalch](https://github.com/chrfalch))

--- a/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
+++ b/packages/expo-modules-core/ios/Core/Convertibles/Convertibles+Color.swift
@@ -21,6 +21,9 @@ extension UIColor: Convertible {
     if let value = value as? Int {
       return try colorFromArgb(UInt64(value)) as! Self
     }
+    if let value = value as? Double {
+      return try colorFromArgb(UInt64(value)) as! Self
+    }
 
     // Handle `PlatformColor` and `DynamicColorIOS`
     if let opaqueValue = value as? [String: Any] {

--- a/packages/expo-modules-core/ios/Tests/ColorConvertiblesTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ColorConvertiblesTests.swift
@@ -45,6 +45,12 @@ struct ColorConvertiblesTests {
   }
 
   @Test
+  func `converts from ARGB double`() throws {
+    let color = try CGColor.convert(from: 4283143818.0, appContext: appContext)
+    testColorComponents(color, 0x4B, 0x96, 0x8A, 0xFF)
+  }
+
+  @Test
   func `converts from RGBA hex string`() throws {
     let color = try CGColor.convert(from: "47AC7F51", appContext: appContext)
     testColorComponents(color, 0x47, 0xAC, 0x7F, 0x51)


### PR DESCRIPTION
# Why
fixes the calendar@next errors from the QA:
```
[FAIL] Calendar@next Global functions listEvents() returns an array of events
Error: The 1st argument cannot be cast to type CalendarRecordNext
→ Caused by: Cannot cast '4283143818.0' for field 'color' of type Optional<UIColor>
→ Caused by: Cannot convert 'Optional(Optional(4283143818.0))' to UIColor
```


# How
Adds a conversion from double to UIColor to `Convertibles+Color.swift`

# Test Plan

Added a native test
