### PR TITLE
[core][Android] Remove `KType` from `SharedObjectTypeConverter`

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObjectTypeConverter.kt
@@ -3,15 +3,11 @@ package expo.modules.kotlin.sharedobjects
 import com.facebook.react.bridge.Dynamic
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.IncorrectRefTypeException
-import expo.modules.kotlin.fastIsSupperClassOf
 import expo.modules.kotlin.jni.CppType
 import expo.modules.kotlin.jni.ExpectedType
 import expo.modules.kotlin.toStrongReference
 import expo.modules.kotlin.types.NonNullableTypeConverter
 import expo.modules.kotlin.types.descriptors.TypeDescriptor
-import kotlin.reflect.KClass
-import kotlin.reflect.KType
-import kotlin.reflect.KTypeProjection
 
 class SharedObjectTypeConverter<T : SharedObject>(
   val typeDescriptor: TypeDescriptor
@@ -41,47 +37,29 @@ class SharedRefTypeConverter<T : SharedRef<*>>(
 ) : NonNullableTypeConverter<T>() {
   private val sharedObjectTypeConverter = SharedObjectTypeConverter<T>(typeDescriptor)
 
-  val sharedRefType: KType? by lazy {
-    // TODO(@lukmccall): Remove KType and KClass usage
-    var currentClass: KClass<*>? = typeDescriptor.jClass.kotlin
-    var currentType: KType? = typeDescriptor.kType
-    while (currentClass != null) {
-      if (currentClass == SharedRef::class) {
-        val firstArgument = currentType?.arguments?.first()
-        // If someone uses `SharedRef<*>` we can't determine the type.
-        // In that case, the API will allow to pass any shared ref.
-        if (firstArgument == KTypeProjection.STAR) {
-          return@lazy null
-        }
-
-        return@lazy requireNotNull(firstArgument?.type) {
-          "The $sharedRefType type should contain the type of the inner ref"
-        }
-      }
-      currentType = currentClass.supertypes.firstOrNull()
-      currentClass = currentType?.classifier as? KClass<*>
-    }
-
-    return@lazy null
-  }
-
   override fun convertNonNullable(value: Any, context: AppContext?, forceConversion: Boolean): T {
     val sharedObject = sharedObjectTypeConverter.convert(value, context, forceConversion)
 
-    @Suppress("UNCHECKED_CAST")
-    return checkInnerRef(sharedObject) as T
-  }
-
-  private fun checkInnerRef(sharedRef: SharedRef<*>): SharedRef<*> {
-    val ref = sharedRef.ref ?: return sharedRef
-    val sharedRefClass = sharedRefType?.classifier as? KClass<*>
-      ?: return sharedRef
-
-    if (sharedRefClass.fastIsSupperClassOf(ref.javaClass)) {
-      return sharedRef
+    if (!checkType(sharedObject)) {
+      throw IncorrectRefTypeException(typeDescriptor, sharedObject::class.java)
     }
 
-    throw IncorrectRefTypeException(typeDescriptor, sharedRef.javaClass)
+    return sharedObject
+  }
+
+  private fun checkType(sharedRef: SharedRef<*>): Boolean {
+    if (typeDescriptor.jClass == SharedRef::class.java) {
+      val param = typeDescriptor.params.first()
+      // If someone uses `SharedRef<*>` we can't determine the type.
+      // In that case, the API will allow to pass any shared ref.
+      if (param.isStar) {
+        return true
+      }
+
+      return param.jClass.isAssignableFrom(sharedRef.ref::class.java)
+    }
+
+    return typeDescriptor.jClass.isAssignableFrom(sharedRef::class.java)
   }
 
   override fun getCppRequiredTypes() = sharedObjectTypeConverter.getCppRequiredTypes()

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/TypeDescriptor.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/TypeDescriptor.kt
@@ -21,6 +21,12 @@ sealed interface RawTypeDescriptor {
     override val introspection: PIntrospectionData<*>?,
     val params: List<RawTypeDescriptor>
   ) : RawTypeDescriptor
+
+  object Star : RawTypeDescriptor {
+    override val jClass: Class<*> = Any::class.java
+    override val isNullable: Boolean = true
+    override val introspection: PIntrospectionData<*>? = null
+  }
 }
 
 class TypeDescriptor(
@@ -42,6 +48,9 @@ class TypeDescriptor(
   inline val jClass: Class<*>
     get() = typeInfo.jClass
 
+  inline val isStar
+    get() = typeInfo == RawTypeDescriptor.Star
+
   inline val params: List<TypeDescriptor>
     get() = when (typeInfo) {
       is RawTypeDescriptor.Simple -> emptyList()
@@ -51,6 +60,8 @@ class TypeDescriptor(
           kTypeProvider = { kType.arguments[index].type ?: error("Type argument is missing") }
         )
       }
+
+      RawTypeDescriptor.Star -> emptyList()
     }
 
   override fun toString(): String {
@@ -68,14 +79,29 @@ fun KType.toTypeDescriptor(): TypeDescriptor {
   val classifier = this.classifier as? KClass<*> ?: error("Unsupported type: $this")
   val isNullable = this.isMarkedNullable
   val params = this.arguments.map { arg ->
-    val argType = arg.type ?: error("Type argument is missing for $this")
-    argType.toTypeDescriptor()
+    if (arg.variance == null) {
+      TypeDescriptor(
+        RawTypeDescriptor.Star
+      ) { error("Star projection doesn't have type") }
+    } else {
+      val argType = arg.type ?: error("Type argument is missing for $this")
+      argType.toTypeDescriptor()
+    }
   }
 
   val rawTypeDescriptor = if (params.isEmpty()) {
-    RawTypeDescriptor.Simple(classifier.java, isNullable, null)
+    RawTypeDescriptor.Simple(
+      classifier.java,
+      isNullable,
+      null
+    )
   } else {
-    RawTypeDescriptor.Parameterized(classifier.java, isNullable, null, params.map { it.typeInfo })
+    RawTypeDescriptor.Parameterized(
+      classifier.java,
+      isNullable,
+      null,
+      params.map { it.typeInfo }
+    )
   }
 
   return TypeDescriptor(

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/typeDescriptorOf.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/descriptors/typeDescriptorOf.kt
@@ -24,7 +24,7 @@ internal fun PTypeDescriptor.toRawTypeDescriptor(): RawTypeDescriptor {
       }
     }
 
-    PTypeDescriptor.Star -> error("Star projections are not supported")
+    PTypeDescriptor.Star -> RawTypeDescriptor.Star
   }
 }
 


### PR DESCRIPTION
# Why

Removes `KType` from `SharedObjectTypeConverter`

# How

Replaces Kotlin with Java reflection

# Test Plan

- unit test ✅ 
- bare-expo ✅ 