### PR TITLE
[create-expo-module] Fix flaky e2e tests

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -298,6 +298,8 @@ describe('non-interactive module creation', () => {
     await executePassing([
       projectName,
       '--no-example',
+      '--source',
+      localTemplatePath,
       '--name',
       'TestModule',
       '--description',
@@ -345,6 +347,8 @@ describe('non-interactive module creation', () => {
     const result = await executePassing([
       projectName,
       '--no-example',
+      '--source',
+      localTemplatePath,
       '--name',
       'NonEmpty',
       '--package',


### PR DESCRIPTION
# Why

The e2e test uses the published module template, instead of the local one. Due to limitations if the package was published less than 24 hours ago the `Install dependencies` step fails.

# How

Use the local `expo-module-template`

# Test Plan

Tested by running the tests locally
