### PR TITLE
fix(publish-packages): pin Xcode to 26.2 for SDK 55 iOS XCFrameworks

### DIFF
--- a/guides/releasing/Release Workflow.md
+++ b/guides/releasing/Release Workflow.md
@@ -74,6 +74,7 @@ We use our fork of React Native for building Expo Go, but it is not used otherwi
 **How:**
 
 - Run `et publish-packages`. Talk to @tsapeta for more details/information.
+  - This requires Xcode 26.2 (the lowest Xcode supported by EAS Build for SDK 55) so that emitted `.swiftinterface` files remain parseable by all consumer toolchains. Install it from https://developer.apple.com/download/all/ — it can coexist with newer versions of Xcode, and `et publish-packages` will switch `DEVELOPER_DIR` automatically.
 - Run `et sync-bundled-native-modules` to sync the `bundledNativeModules.json` file with www.
 
 ## 0.7. Merge and cutoff changelogs

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.test.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  ensureSupportedToolchainAsync,
+  parseXcodeVersion,
+  SUPPORTED_XCODE_VERSION,
+} from './bundleIOSPrebuilds';
+
+describe('parseXcodeVersion', () => {
+  it('parses a normal `xcodebuild -version` output', () => {
+    assert.equal(parseXcodeVersion('Xcode 26.2\nBuild version 17C52\n'), '26.2.0');
+  });
+
+  it('parses an Xcode version with a patch component', () => {
+    assert.equal(parseXcodeVersion('Xcode 26.4.1\nBuild version 16A5318g\n'), '26.4.1');
+  });
+
+  it('returns null when the expected prefix is missing', () => {
+    assert.equal(parseXcodeVersion('something else entirely'), null);
+  });
+});
+
+describe('ensureSupportedToolchainAsync', () => {
+  let previousDeveloperDir: string | undefined;
+
+  beforeEach(() => {
+    previousDeveloperDir = process.env.DEVELOPER_DIR;
+  });
+
+  afterEach(() => {
+    if (previousDeveloperDir === undefined) {
+      delete process.env.DEVELOPER_DIR;
+    } else {
+      process.env.DEVELOPER_DIR = previousDeveloperDir;
+    }
+  });
+
+  it('does not touch DEVELOPER_DIR when active toolchain matches', async () => {
+    delete process.env.DEVELOPER_DIR;
+    const restore = await ensureSupportedToolchainAsync(
+      async () => SUPPORTED_XCODE_VERSION,
+      async () => []
+    );
+    assert.equal(process.env.DEVELOPER_DIR, undefined);
+    restore();
+    assert.equal(process.env.DEVELOPER_DIR, undefined);
+  });
+
+  it('sets DEVELOPER_DIR when switching, and unsets it on restore', async () => {
+    delete process.env.DEVELOPER_DIR;
+    const restore = await ensureSupportedToolchainAsync(
+      async () => '26.0.0',
+      async () => [
+        {
+          developerDir: '/Applications/Xcode_26.2.app/Contents/Developer',
+          xcode: SUPPORTED_XCODE_VERSION,
+        },
+      ]
+    );
+    assert.equal(process.env.DEVELOPER_DIR, '/Applications/Xcode_26.2.app/Contents/Developer');
+    restore();
+    assert.equal(process.env.DEVELOPER_DIR, undefined);
+  });
+
+  it('preserves a prior DEVELOPER_DIR value across switch + restore', async () => {
+    const prior = '/Applications/Xcode_27.0.app/Contents/Developer';
+    process.env.DEVELOPER_DIR = prior;
+    const restore = await ensureSupportedToolchainAsync(
+      async () => '27.0.0',
+      async () => [
+        {
+          developerDir: '/Applications/Xcode_26.2.app/Contents/Developer',
+          xcode: SUPPORTED_XCODE_VERSION,
+        },
+      ]
+    );
+    assert.equal(process.env.DEVELOPER_DIR, '/Applications/Xcode_26.2.app/Contents/Developer');
+    restore();
+    assert.equal(process.env.DEVELOPER_DIR, prior);
+  });
+
+  it('throws with a what/why/how message when no supported toolchain is available', async () => {
+    delete process.env.DEVELOPER_DIR;
+    await assert.rejects(
+      ensureSupportedToolchainAsync(
+        async () => '26.0.0',
+        async () => []
+      ),
+      (err: Error) => {
+        assert.match(err.message, /Active toolchain is Xcode 26\.0/);
+        assert.match(err.message, /must be built with Xcode 26\.2/);
+        assert.match(err.message, /No Xcode-shaped apps found in \/Applications/);
+        assert.match(err.message, /developer\.apple\.com/);
+        return true;
+      }
+    );
+    assert.equal(process.env.DEVELOPER_DIR, undefined);
+  });
+
+  it('lists discovered Xcodes in the throw message when none match', async () => {
+    delete process.env.DEVELOPER_DIR;
+    await assert.rejects(
+      ensureSupportedToolchainAsync(
+        async () => '26.0.0',
+        async () => [
+          {
+            developerDir: '/Applications/Xcode_26.0.app/Contents/Developer',
+            xcode: '26.0.0',
+          },
+          {
+            developerDir: '/Applications/Xcode_15.4.app/Contents/Developer',
+            xcode: '15.4.0',
+          },
+        ]
+      ),
+      (err: Error) => {
+        assert.match(err.message, /Found in \/Applications/);
+        assert.match(err.message, /Xcode 26\.0 at \/Applications\/Xcode_26\.0\.app/);
+        assert.match(err.message, /Xcode 15\.4 at \/Applications\/Xcode_15\.4\.app/);
+        return true;
+      }
+    );
+  });
+});

--- a/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
+++ b/tools/src/publish-packages/tasks/bundleIOSPrebuilds.ts
@@ -5,9 +5,100 @@ import { loadRequestedParcels } from './loadRequestedParcels';
 import { PACKAGES_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
-import { runWithSpinner } from '../../Utils';
+import { runWithSpinner, spawnAsync } from '../../Utils';
 import { runPrebuildPackagesAsync } from '../../commands/PrebuildPackages';
 import { Parcel, TaskArgs } from '../types';
+
+/**
+ * Xcode version that prebuilds must be built with. Each Xcode bundles a specific Swift
+ * compiler, and `.swiftinterface` files emitted by a newer Swift cannot be parsed by an
+ * older one, which breaks consumers who haven't yet upgraded. Keep in sync with the CI
+ * workflows that publish artifacts (see .github/workflows/publish-canaries.yml).
+ */
+export const SUPPORTED_XCODE_VERSION = '26.2.0';
+
+type InstalledXcode = { developerDir: string; xcode: string | null };
+
+// Strip a trailing `.0` so '26.2.0' renders as '26.2' to match Apple's labeling.
+function displayVersion(v: string): string {
+  return v.replace(/\.0$/, '');
+}
+
+// Returns major.minor.patch (`Xcode 26.2` → `26.2.0`); `null` when the prefix isn't found.
+export function parseXcodeVersion(output: string): string | null {
+  const match = output.match(/Xcode\s+(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+  if (!match) return null;
+  return `${match[1]}.${match[2] ?? '0'}.${match[3] ?? '0'}`;
+}
+
+async function readXcodeVersionAsync(developerDir?: string): Promise<string | null> {
+  const env = developerDir ? { ...process.env, DEVELOPER_DIR: developerDir } : process.env;
+  try {
+    const { stdout } = await spawnAsync('xcodebuild', ['-version'], { env });
+    return parseXcodeVersion(stdout);
+  } catch {
+    return null;
+  }
+}
+
+async function listInstalledXcodesAsync(): Promise<InstalledXcode[]> {
+  const entries = await fs.promises.readdir('/Applications').catch(() => [] as string[]);
+  const xcodeApps = entries.filter((n) => /^Xcode.*\.app$/i.test(n));
+  return Promise.all(
+    xcodeApps.map(async (name) => {
+      const developerDir = path.join('/Applications', name, 'Contents', 'Developer');
+      const xcode = await readXcodeVersionAsync(developerDir);
+      return { developerDir, xcode };
+    })
+  );
+}
+
+// Returns a restorer that undoes any DEVELOPER_DIR mutation (no-op if none).
+// `readActive` / `listInstalled` are injection seams for tests.
+export async function ensureSupportedToolchainAsync(
+  readActive: () => Promise<string | null> = () => readXcodeVersionAsync(),
+  listInstalled: () => Promise<InstalledXcode[]> = listInstalledXcodesAsync
+): Promise<() => void> {
+  const active = await readActive();
+  if (active === SUPPORTED_XCODE_VERSION) {
+    logger.log(`   Using active toolchain: Xcode ${displayVersion(active)}`);
+    return () => {};
+  }
+
+  const installed = await listInstalled();
+  const match = installed.find((t) => t.xcode === SUPPORTED_XCODE_VERSION);
+  if (match) {
+    const previous = process.env.DEVELOPER_DIR;
+    process.env.DEVELOPER_DIR = match.developerDir;
+    logger.log(
+      `   Switched DEVELOPER_DIR to ${match.developerDir} for this run (will reset after).`
+    );
+    return () => {
+      if (previous === undefined) {
+        delete process.env.DEVELOPER_DIR;
+      } else {
+        process.env.DEVELOPER_DIR = previous;
+      }
+    };
+  }
+
+  const wanted = displayVersion(SUPPORTED_XCODE_VERSION);
+  const activeDescription = active
+    ? `Active toolchain is Xcode ${displayVersion(active)}`
+    : 'No active Xcode toolchain detected';
+  const found =
+    installed.length > 0
+      ? `Found in /Applications: ${installed
+          .map((t) => `Xcode ${t.xcode ? displayVersion(t.xcode) : '?'} at ${t.developerDir}`)
+          .join('; ')}.`
+      : `No Xcode-shaped apps found in /Applications.`;
+  throw new Error(
+    `${activeDescription}, but iOS prebuilds must be built with Xcode ${wanted}. ` +
+      `Newer Swift compilers emit module interfaces that older consumer toolchains cannot parse, which breaks compilation for downstream consumers. ` +
+      `${found} ` +
+      `Install Xcode ${wanted} from https://developer.apple.com/download/all/ (it can coexist with other Xcodes).`
+  );
+}
 
 /**
  * Packages whose iOS prebuilt xcframeworks should be bundled into the npm tarball.
@@ -54,79 +145,85 @@ export const bundleIOSPrebuilds = new Task<TaskArgs>(
       return;
     }
 
-    const result = await runPrebuildPackagesAsync(relevantParcels, {
-      clean: false,
-      cleanCache: false,
-      skipGenerate: false,
-      skipArtifacts: false,
-      skipBuild: false,
-      skipCompose: false,
-      skipVerify: false,
-      verbose: false,
-      bundleSharedDeps: true,
-    });
+    const restoreToolchain = await ensureSupportedToolchainAsync();
 
-    if (result.exitCode !== 0) {
-      logger.error(`iOS prebuild failed with exit code ${result.exitCode}`);
-      if (result.errorLogPath) {
-        logger.error(`Error log: ${result.errorLogPath}`);
+    try {
+      const result = await runPrebuildPackagesAsync(relevantParcels, {
+        clean: false,
+        cleanCache: false,
+        skipGenerate: false,
+        skipArtifacts: false,
+        skipBuild: false,
+        skipCompose: false,
+        skipVerify: false,
+        verbose: false,
+        bundleSharedDeps: true,
+      });
+
+      if (result.exitCode !== 0) {
+        logger.error(`iOS prebuild failed with exit code ${result.exitCode}`);
+        if (result.errorLogPath) {
+          logger.error(`Error log: ${result.errorLogPath}`);
+        }
+
+        const errorDetails = result.errors
+          .map((e) => `  - [${e.packageName}/${e.productName}] ${e.stage}: ${e.error.message}`)
+          .join('\n');
+        const errorMessage = errorDetails
+          ? `iOS prebuild pipeline failed:\n${errorDetails}`
+          : 'iOS prebuild pipeline failed';
+        throw new Error(errorMessage);
       }
 
-      const errorDetails = result.errors
-        .map((e) => `  - [${e.packageName}/${e.productName}] ${e.stage}: ${e.error.message}`)
-        .join('\n');
-      const errorMessage = errorDetails
-        ? `iOS prebuild pipeline failed:\n${errorDetails}`
-        : 'iOS prebuild pipeline failed';
-      throw new Error(errorMessage);
-    }
+      // Copy built tarballs into each package's prebuilds/ directory
+      for (const pkgName of IOS_PREBUILD_PACKAGES) {
+        const parcel = parcels.find(
+          (p) => p.pkg.packageName === pkgName || p.pkg.packageSlug === pkgName
+        );
+        if (!parcel) {
+          logger.warn(`Package ${pkgName} not found in parcels, skipping prebuild bundling`);
+          continue;
+        }
 
-    // Copy built tarballs into each package's prebuilds/ directory
-    for (const pkgName of IOS_PREBUILD_PACKAGES) {
-      const parcel = parcels.find(
-        (p) => p.pkg.packageName === pkgName || p.pkg.packageSlug === pkgName
-      );
-      if (!parcel) {
-        logger.warn(`Package ${pkgName} not found in parcels, skipping prebuild bundling`);
-        continue;
-      }
+        await runWithSpinner(
+          `Bundling iOS prebuilds into ${pkgName}`,
+          async () => {
+            for (const flavor of FLAVORS) {
+              const srcDir = path.join(
+                PRECOMPILE_BUILD_DIR,
+                pkgName,
+                'output',
+                flavor,
+                'xcframeworks'
+              );
+              const destDir = path.join(
+                parcel.pkg.path,
+                'prebuilds',
+                'output',
+                flavor,
+                'xcframeworks'
+              );
 
-      await runWithSpinner(
-        `Bundling iOS prebuilds into ${pkgName}`,
-        async () => {
-          for (const flavor of FLAVORS) {
-            const srcDir = path.join(
-              PRECOMPILE_BUILD_DIR,
-              pkgName,
-              'output',
-              flavor,
-              'xcframeworks'
-            );
-            const destDir = path.join(
-              parcel.pkg.path,
-              'prebuilds',
-              'output',
-              flavor,
-              'xcframeworks'
-            );
+              if (!fs.existsSync(srcDir)) {
+                logger.warn(`  No ${flavor} xcframeworks found at ${srcDir}`);
+                continue;
+              }
 
-            if (!fs.existsSync(srcDir)) {
-              logger.warn(`  No ${flavor} xcframeworks found at ${srcDir}`);
-              continue;
-            }
+              await fs.promises.mkdir(destDir, { recursive: true });
 
-            await fs.promises.mkdir(destDir, { recursive: true });
-
-            const files = await fs.promises.readdir(srcDir);
-            for (const file of files) {
-              if (file.endsWith('.tar.gz')) {
-                await fs.promises.copyFile(path.join(srcDir, file), path.join(destDir, file));
+              const files = await fs.promises.readdir(srcDir);
+              for (const file of files) {
+                if (file.endsWith('.tar.gz')) {
+                  await fs.promises.copyFile(path.join(srcDir, file), path.join(destDir, file));
+                }
               }
             }
-          }
-        },
-        `Bundled iOS prebuilds into ${pkgName}`
-      );
+          },
+          `Bundled iOS prebuilds into ${pkgName}`
+        );
+      }
+    } finally {
+      restoreToolchain();
     }
   }
 );


### PR DESCRIPTION
## Why

`et publish-packages` is often run on local dev machines, making the version of Xcode unclear. XCFrameworks are forwards-compatible with future Swift compiler versions, not backwards. Therefore we need to build using the lowest EAS Build Xcode when publishing — which is Xcode 26.2 for SDK 55.

## How

Updated `et publish-packages` to check and verify that Xcode 26.2 is installed, and to automatically set DEVELOPER_DIR to the correct Xcode path or fail when running publish-packages.

The Canaries and External XCFrameworks workflows on `sdk-55` already pin Xcode 26.2, so no workflow changes were needed.

## Test plan

- Added unit tests.
- Verified DEVELOPER_DIR is switched when active Xcode is not 26.2 but 26.2 is installed.
- Verified the error path when no Xcode 26.2 is found on the system.

(Using the app `Xcodes` to have multiple versions of Xcode installed for testing)

