### PR TITLE
fix(expo-sensors): guard CMAltimeter stop calls to prevent TCC crash on iOS 26

### DIFF
--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed TCC crash on iOS 26 during Metro reload when `motionPermission: false` — `CMAltimeter.stopRelativeAltitudeUpdates()` now only runs if updates were started. ([#45396](https://github.com/expo/expo/pull/45396) by [@JustinFay01](https://github.com/JustinFay01))
+
 ### 💡 Others
 
 ## 55.0.8 — 2026-02-25

--- a/packages/expo-sensors/ios/BarometerModule.swift
+++ b/packages/expo-sensors/ios/BarometerModule.swift
@@ -8,6 +8,7 @@ private let EVENT_BAROMETER_DID_UPDATE = "barometerDidUpdate"
 public final class BarometerModule: Module {
   private lazy var altimeter = CMAltimeter()
   private lazy var operationQueue = OperationQueue()
+  private var isObserving = false
 
   public func definition() -> ModuleDefinition {
     Name("ExpoBarometer")
@@ -31,6 +32,7 @@ public final class BarometerModule: Module {
         }
       }
 
+      isObserving = true
       altimeter.startRelativeAltitudeUpdates(to: operationQueue) { [weak self] data, _ in
         guard let data else {
           return
@@ -45,10 +47,14 @@ public final class BarometerModule: Module {
     }
 
     OnStopObserving {
+      guard isObserving else { return }
+      isObserving = false
       altimeter.stopRelativeAltitudeUpdates()
     }
 
     OnDestroy {
+      guard isObserving else { return }
+      isObserving = false
       altimeter.stopRelativeAltitudeUpdates()
     }
   }


### PR DESCRIPTION
# Why

Fixes #45386

On iOS 26.3.1(a), apps using `expo-sensors` with `motionPermission: false` are killed by TCC (`domain:tcc(11)`) on Metro reload. This is a regression caused by new TCC enforcement in iOS 26 around `CMAltimeter`.

# How

`BarometerModule.OnDestroy` unconditionally calls `altimeter.stopRelativeAltitudeUpdates()`. Since `altimeter` is a `lazy var` that is typically never initialized (no JS subscriber triggers `OnStartObserving`), `OnDestroy` creates a fresh `CMAltimeter` instance during teardown and immediately calls stop. On iOS 26, `CMAltimeter.stopRelativeAltitudeUpdates()` triggers a TCC authorization check even on a never-started altimeter — and with no `NSMotionUsageDescription` in the plist, TCC kills the process.

The fix adds an `isObserving` flag so stop calls only execute if `startRelativeAltitudeUpdates` was actually called. This is the same defensive pattern already used by `PedometerModule` (which guards via `watchHandler != nil`).

Note: `CMMotionManager.stop*Updates()` does **not** exhibit this behavior — only `CMAltimeter` triggers TCC on stop when never started.

# Test Plan

- Reproduced crash on iOS 26.3.1(a) / iPhone 17 with `motionPermission: false` and Metro reload
- Verified fix prevents crash — reload works without TCC kill
- Verified barometer updates still function correctly when JS subscribes (guard allows stop after start)
- Systematic bisection documented in [issue comment](https://github.com/expo/expo/issues/45386#issuecomment-4379767728)

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)