### PR TITLE
[docs] Prefer top-level path for components reachable via multiple aliases

### DIFF
--- a/docs/components/plugins/api/APISectionCompoundNames.test.ts
+++ b/docs/components/plugins/api/APISectionCompoundNames.test.ts
@@ -63,6 +63,26 @@ describe('buildCompoundNameByComponent', () => {
       Tab: 'Tabs.Tab',
     });
   });
+
+  test('prefers depth-2 path over deeper alias for the same component', () => {
+    const stackTitle = makeComponent('StackTitle', 'StackTitleProps');
+    const stackScreen = makeComponent('StackScreen', 'StackScreenProps', [
+      makeProp('Title', makeComponentType('StackTitleProps')),
+    ]);
+    const stack = makeComponent('Stack', 'StackProps', [
+      makeProp('Screen', makeComponentType('StackScreenProps')),
+      makeProp('Title', makeComponentType('StackTitleProps')),
+    ]);
+
+    const result = Object.fromEntries(
+      buildCompoundNameByComponent([stack, stackScreen, stackTitle])
+    );
+
+    expect(result).toEqual({
+      StackScreen: 'Stack.Screen',
+      StackTitle: 'Stack.Title',
+    });
+  });
 });
 
 describe('deriveComponentsFromProps', () => {

--- a/docs/components/plugins/api/APISectionCompoundNames.ts
+++ b/docs/components/plugins/api/APISectionCompoundNames.ts
@@ -129,11 +129,22 @@ export const buildCompoundNameByComponent = (components: GeneratedData[]) => {
   const { componentNameByPropsType, propertiesByEntry, baseNameByEntry } =
     collectComponentMetadata(components);
 
+  const targetNames = new Set<string>();
+  components.forEach(entry => {
+    const properties = propertiesByEntry.get(entry) ?? [];
+    properties.forEach(property => {
+      const target = resolveComponentTargetFromProperty(property, componentNameByPropsType);
+      if (target) {
+        targetNames.add(target);
+      }
+    });
+  });
+
   const directMap = new Map<string, string>();
 
   components.forEach(entry => {
     const parentName = baseNameByEntry.get(entry);
-    if (!parentName) {
+    if (!parentName || targetNames.has(parentName)) {
       return;
     }
     const properties = propertiesByEntry.get(entry) ?? [];
@@ -143,6 +154,9 @@ export const buildCompoundNameByComponent = (components: GeneratedData[]) => {
       }
       const target = resolveComponentTargetFromProperty(property, componentNameByPropsType);
       if (!target) {
+        return;
+      }
+      if (directMap.has(target)) {
         return;
       }
       directMap.set(target, `${parentName}.${property.name}`);
@@ -167,6 +181,9 @@ export const buildCompoundNameByComponent = (components: GeneratedData[]) => {
       }
       const target = resolveComponentTargetFromProperty(property, componentNameByPropsType);
       if (!target) {
+        return;
+      }
+      if (directMap.has(target)) {
         return;
       }
       compoundMap.set(target, `${parentAlias}.${property.name}`);


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/45334

The `expo-router` rename of `Stack.Screen.Title` to `Stack.Title` keeps the old path as a deprecated alias, so the same `StackTitle` component is reachable via two paths in the TypeDoc tree. The compound-name builder picked the deeper path, so the unversioned and v56 API page rendered `Stack.Screen.Title` as the component heading even though the canonical export is `Stack.Title` and the example code on the same page uses `<Stack.Title>`.

# How

Updated `buildCompoundNameByComponent` in `docs/components/plugins/api/APISectionCompoundNames.ts` to precompute a `targetNames` set, restrict the first pass to root components, and guard both passes against overwriting an existing `directMap` entry. When a component is reachable from a root and from a deeper alias, the shorter top-level name wins; components reachable only via a deeper path keep their chained name unchanged. Older SDK versions (v53, v54, v55) only expose the depth-3 path, so the guards never fire and rendering is identical to before.

# Test Plan

**Unversioned**

<img width="4094" height="2480" alt="CleanShot 2026-05-05 at 20 00 27@2x" src="https://github.com/user-attachments/assets/053e7901-ffeb-4235-95ab-3d77b722b968" />

**SDK 55 and older**

<img width="4112" height="2478" alt="CleanShot 2026-05-05 at 20 00 18@2x" src="https://github.com/user-attachments/assets/50bf979e-9a74-4db5-aa9c-4dc4c572dbfe" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
```