### PR TITLE
feat(cli): Update `expo start`'s check version output, prefetch it, and defer it to the commands table

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Provide Babel config path hint to Expo Metro transformer ([#45260](https://github.com/expo/expo/pull/45260) by [@kitten](https://github.com/kitten))
 - Add `@expo/metro-file-map` fork ([#45373](https://github.com/expo/expo/pull/45373) by [@kitten](https://github.com/kitten))
 - Disable watchman by default ([#45378](https://github.com/expo/expo/pull/45378) by [@kitten](https://github.com/kitten))
+- Defer version check output to command table, and prefetch on start, to prevent it blocking/slowing down startup ([#45400](https://github.com/expo/expo/pull/45400) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
+++ b/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
@@ -1,8 +1,8 @@
 import type { ExpoConfig, PackageJSONConfig } from '@expo/config';
 import chalk from 'chalk';
 
-import { getVersionedDependenciesAsync } from './doctor/dependencies/validateDependenciesVersions';
 import * as Log from '../log';
+import { getVersionedDependenciesAsync } from './doctor/dependencies/validateDependenciesVersions';
 
 export type DependencyCheckResult = {
   expo?: { actualVersion: string; expectedVersionOrRange: string };
@@ -28,7 +28,10 @@ export async function checkDependenciesAsync(
 
   return {
     expo: expoDep
-      ? { actualVersion: expoDep.actualVersion, expectedVersionOrRange: expoDep.expectedVersionOrRange }
+      ? {
+          actualVersion: expoDep.actualVersion,
+          expectedVersionOrRange: expoDep.expectedVersionOrRange,
+        }
       : undefined,
     otherCount,
   };

--- a/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
+++ b/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
@@ -4,27 +4,46 @@ import chalk from 'chalk';
 import { getVersionedDependenciesAsync } from './doctor/dependencies/validateDependenciesVersions';
 import * as Log from '../log';
 
+export type DependencyCheckResult = {
+  expo?: { actualVersion: string; expectedVersionOrRange: string };
+  otherCount: number;
+};
+
 /**
- * Check dependency versions and print a condensed summary for the start command.
- * Shows a specific hint for `expo` if out-of-range, and a one-line summary for all others.
+ * Fetch dependency version check results.
+ * Returns null if everything is up-to-date.
  */
-export async function checkDependenciesOnStartAsync(
+export async function checkDependenciesAsync(
   projectRoot: string,
   exp: Pick<ExpoConfig, 'sdkVersion'>,
   pkg: PackageJSONConfig
-): Promise<void> {
+): Promise<DependencyCheckResult | null> {
   const incorrectDeps = await getVersionedDependenciesAsync(projectRoot, exp, pkg);
-  const expoDep = incorrectDeps.find((dep) => dep.packageName === 'expo');
-  const otherDeps = incorrectDeps.filter((dep) => dep.packageName !== 'expo');
+  if (incorrectDeps.length === 0) {
+    return null;
+  }
 
-  if (expoDep) {
+  const expoDep = incorrectDeps.find((dep) => dep.packageName === 'expo');
+  const otherCount = incorrectDeps.filter((dep) => dep.packageName !== 'expo').length;
+
+  return {
+    expo: expoDep
+      ? { actualVersion: expoDep.actualVersion, expectedVersionOrRange: expoDep.expectedVersionOrRange }
+      : undefined,
+    otherCount,
+  };
+}
+
+/** Print the condensed dependency check messages to the terminal. */
+export function printDependencyCheckResult(result: DependencyCheckResult): void {
+  if (result.expo) {
     Log.warn(
-      chalk`An update for {bold expo} is available: {red ${expoDep.actualVersion}} {dim →} {green ${expoDep.expectedVersionOrRange}}`
+      chalk`An update for {bold expo} is available: {red ${result.expo.actualVersion}} {dim →} {green ${result.expo.expectedVersionOrRange}}`
     );
   }
-  if (otherDeps.length > 0) {
+  if (result.otherCount > 0) {
     Log.warn(
-      chalk`${otherDeps.length} other package${otherDeps.length === 1 ? '' : 's'} should be updated. Run {bold npx expo install --check} for details.`
+      chalk`${result.otherCount} other package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`
     );
   }
 }

--- a/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
+++ b/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
@@ -1,0 +1,30 @@
+import type { ExpoConfig, PackageJSONConfig } from '@expo/config';
+import chalk from 'chalk';
+
+import { getVersionedDependenciesAsync } from './doctor/dependencies/validateDependenciesVersions';
+import * as Log from '../log';
+
+/**
+ * Check dependency versions and print a condensed summary for the start command.
+ * Shows a specific hint for `expo` if out-of-range, and a one-line summary for all others.
+ */
+export async function checkDependenciesOnStartAsync(
+  projectRoot: string,
+  exp: Pick<ExpoConfig, 'sdkVersion'>,
+  pkg: PackageJSONConfig
+): Promise<void> {
+  const incorrectDeps = await getVersionedDependenciesAsync(projectRoot, exp, pkg);
+  const expoDep = incorrectDeps.find((dep) => dep.packageName === 'expo');
+  const otherDeps = incorrectDeps.filter((dep) => dep.packageName !== 'expo');
+
+  if (expoDep) {
+    Log.warn(
+      chalk`An update for {bold expo} is available: {red ${expoDep.actualVersion}} {dim →} {green ${expoDep.expectedVersionOrRange}}`
+    );
+  }
+  if (otherDeps.length > 0) {
+    Log.warn(
+      chalk`${otherDeps.length} other package${otherDeps.length === 1 ? '' : 's'} should be updated. Run {bold npx expo install --check} for details.`
+    );
+  }
+}

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import wrapAnsi from 'wrap-ansi';
 
 import * as Log from '../../log';
+import type { DependencyCheckResult } from '../checkDependenciesOnStart';
 import type { McpServer } from '../server/MCP';
 
 // Approximately how many rows apart from the commands table (usage guide on `expo start`)
@@ -20,6 +21,7 @@ export type StartOptions = {
   maxWorkers?: number;
   platforms?: ExpoConfig['platforms'];
   mcpServer?: McpServer;
+  dependencyCheckPromise?: Promise<DependencyCheckResult | null>;
 };
 
 export const printHelp = (): void => {

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -10,6 +10,8 @@ import { AbortCommandError } from '../../utils/errors';
 import { getAllSpinners, ora } from '../../utils/ora';
 import { getProgressBar, setProgressBar } from '../../utils/progress';
 import { addInteractionListener, pauseInteractions } from '../../utils/prompts';
+import type { DependencyCheckResult } from '../checkDependenciesOnStart';
+import { printDependencyCheckResult } from '../checkDependenciesOnStart';
 import { WebSupportProjectPrerequisite } from '../doctor/web/WebSupportProjectPrerequisite';
 import type { DevServerManager } from '../server/DevServerManager';
 
@@ -37,7 +39,7 @@ const PLATFORM_SETTINGS: Record<
 
 export async function startInterfaceAsync(
   devServerManager: DevServerManager,
-  options: Pick<StartOptions, 'devClient' | 'platforms' | 'mcpServer'>
+  options: Pick<StartOptions, 'devClient' | 'platforms' | 'mcpServer' | 'dependencyCheckPromise'>
 ) {
   const actions = new DevServerManagerActions(devServerManager, options);
 
@@ -49,7 +51,33 @@ export async function startInterfaceAsync(
     ...options,
   };
 
+  // Wait briefly for the dependency check to resolve (it runs in the background since early startup).
+  // With a warm fetch cache this resolves near-instantly; on cold starts it may not be ready,
+  // in which case it will appear on the next TUI re-print (e.g. pressing 'c').
+  let dependencyCheckResult: DependencyCheckResult | null | undefined;
+  if (options.dependencyCheckPromise) {
+    dependencyCheckResult = await Promise.race([
+      options.dependencyCheckPromise,
+      new Promise<undefined>((resolve) => setTimeout(resolve, 100)),
+    ]);
+    if (!dependencyCheckResult) {
+      // Not ready yet — capture once resolved for display on next reprint
+      options.dependencyCheckPromise.then((result) => {
+        if (result) {
+          dependencyCheckResult = result;
+        }
+      });
+    }
+  }
+
+  const printDependencyCheckIfAvailable = () => {
+    if (dependencyCheckResult) {
+      printDependencyCheckResult(dependencyCheckResult);
+    }
+  };
+
   actions.printDevServerInfo(usageOptions);
+  printDependencyCheckIfAvailable();
 
   const onPressAsync = async (key: string) => {
     // Auxillary commands all escape.
@@ -144,7 +172,9 @@ export async function startInterfaceAsync(
         Log.clear();
         if (await devServerManager.toggleRuntimeMode()) {
           usageOptions.devClient = devServerManager.options.devClient;
-          return actions.printDevServerInfo(usageOptions);
+          actions.printDevServerInfo(usageOptions);
+          printDependencyCheckIfAvailable();
+          return;
         }
         break;
       }
@@ -188,7 +218,9 @@ export async function startInterfaceAsync(
       }
       case 'c':
         Log.clear();
-        return actions.printDevServerInfo(usageOptions);
+        actions.printDevServerInfo(usageOptions);
+        printDependencyCheckIfAvailable();
+        return;
       case 'j':
         return actions.openJsInspectorAsync();
       case 'r':

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -2,7 +2,8 @@ import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 
 import { getLogFile, shouldReduceLogs } from '../events';
-import { checkDependenciesOnStartAsync } from './checkDependenciesOnStart';
+import type { DependencyCheckResult } from './checkDependenciesOnStart';
+import { checkDependenciesAsync, printDependencyCheckResult } from './checkDependenciesOnStart';
 import { SimulatorAppPrerequisite } from './doctor/apple/SimulatorAppPrerequisite';
 import { getXcodeVersionAsync } from './doctor/apple/XcodePrerequisite';
 import { WebSupportProjectPrerequisite } from './doctor/web/WebSupportProjectPrerequisite';
@@ -81,6 +82,13 @@ export async function startAsync(
 
   const { exp, pkg } = profile(getConfig)(projectRoot);
 
+  // Start dependency version check in the background as early as possible (non-blocking).
+  // The result will be displayed in the TUI once it resolves.
+  let dependencyCheckPromise: Promise<DependencyCheckResult | null> | undefined;
+  if (!env.EXPO_OFFLINE && !env.EXPO_NO_DEPENDENCY_VALIDATION && !settings.webOnly) {
+    dependencyCheckPromise = checkDependenciesAsync(projectRoot, exp, pkg).catch(() => null);
+  }
+
   if (exp.platforms?.includes('ios') && process.platform !== 'win32') {
     // If Xcode could potentially be used, then we should eagerly perform the
     // assertions since they can take a while on cold boots.
@@ -117,15 +125,6 @@ export async function startAsync(
     await devServerManager.bootstrapTypeScriptAsync();
   }
 
-  if (!env.EXPO_OFFLINE && !env.EXPO_NO_DEPENDENCY_VALIDATION && !settings.webOnly) {
-    try {
-      await profile(checkDependenciesOnStartAsync)(projectRoot, exp, pkg);
-    } catch {
-      // We don't show the dependency validation error, since it's non-essential
-      // for the user to know it ran or failed
-    }
-  }
-
   // Open project on devices.
   await profile(openPlatformsAsync)(devServerManager, options);
 
@@ -141,6 +140,7 @@ export async function startAsync(
     await profile(startInterfaceAsync)(devServerManager, {
       platforms: exp.platforms ?? ['ios', 'android', 'web'],
       mcpServer,
+      dependencyCheckPromise,
     });
   } else {
     // Display the server location in CI...
@@ -150,6 +150,11 @@ export async function startAsync(
         console.info(`[__EXPO_E2E_TEST:server] ${JSON.stringify({ url: defaultServerUrl })}`);
       }
       Log.log(chalk`Waiting on {underline ${defaultServerUrl}}`);
+    }
+    // In non-interactive mode, await the check and print if available.
+    const result = await dependencyCheckPromise;
+    if (result) {
+      printDependencyCheckResult(result);
     }
   }
 

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -2,9 +2,9 @@ import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 
 import { getLogFile, shouldReduceLogs } from '../events';
+import { checkDependenciesOnStartAsync } from './checkDependenciesOnStart';
 import { SimulatorAppPrerequisite } from './doctor/apple/SimulatorAppPrerequisite';
 import { getXcodeVersionAsync } from './doctor/apple/XcodePrerequisite';
-import { validateDependenciesVersionsAsync } from './doctor/dependencies/validateDependenciesVersions';
 import { WebSupportProjectPrerequisite } from './doctor/web/WebSupportProjectPrerequisite';
 import { startInterfaceAsync } from './interface/startInterface';
 import type { Options } from './resolveOptions';
@@ -13,13 +13,13 @@ import * as Log from '../log';
 import type { BundlerStartOptions } from './server/BundlerDevServer';
 import type { MultiBundlerStartOptions } from './server/DevServerManager';
 import { DevServerManager } from './server/DevServerManager';
+import { maybeCreateMCPServerAsync } from './server/MCP';
 import { openPlatformsAsync } from './server/openPlatforms';
 import type { PlatformBundlers } from './server/platformBundlers';
 import { getPlatformBundlers } from './server/platformBundlers';
 import { env } from '../utils/env';
 import { isInteractive } from '../utils/interactive';
 import { profile } from '../utils/profile';
-import { maybeCreateMCPServerAsync } from './server/MCP';
 import { addMcpCapabilities } from './server/MCPDevToolsPluginCLIExtensions';
 
 async function getMultiBundlerStartOptions(
@@ -117,9 +117,9 @@ export async function startAsync(
     await devServerManager.bootstrapTypeScriptAsync();
   }
 
-  if (!env.EXPO_NO_DEPENDENCY_VALIDATION && !settings.webOnly && !options.devClient) {
+  if (!env.EXPO_OFFLINE && !env.EXPO_NO_DEPENDENCY_VALIDATION && !settings.webOnly) {
     try {
-      await profile(validateDependenciesVersionsAsync)(projectRoot, exp, pkg);
+      await profile(checkDependenciesOnStartAsync)(projectRoot, exp, pkg);
     } catch {
       // We don't show the dependency validation error, since it's non-essential
       // for the user to know it ran or failed


### PR DESCRIPTION
# Why

Currently, when we run the versions check it blocks `expo start` and unnecessarily slows down the CLI's startup. Instead, we can prefetch it during the startup, and display it in the commands table, if it fetched in time. If it doesn't fetch in time to be displayed in the commands table, we instead rely on the result being cached, which means it'd be displayed on the next `expo start` run or when/if the commands table is re-printed.

# How

- Refactor version check output to be shorter and tell users to run `npx expo install --check`
- Prefetch version check output and display it (if it's available) in the commands table

# Test Plan

- Tested manually against `apps/router-e2e`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
