### PR TITLE
[widgets] Add widget RedBox

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -19,7 +19,7 @@
 - Support `PlatformColor`. ([#44193](https://github.com/expo/expo/pull/44193) by [@jakex7](https://github.com/jakex7))
 - [plugin] Make incremental prebuilds work ([#45157](https://github.com/expo/expo/pull/45157) by [@jakex7](https://github.com/jakex7))
 - [android] Add stub methods. ([#45335](https://github.com/expo/expo/pull/45335) by [@jakex7](https://github.com/jakex7))
-- Add widget RedBox.
+- Add widget RedBox. ([#45402](https://github.com/expo/expo/pull/45402) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Support `PlatformColor`. ([#44193](https://github.com/expo/expo/pull/44193) by [@jakex7](https://github.com/jakex7))
 - [plugin] Make incremental prebuilds work ([#45157](https://github.com/expo/expo/pull/45157) by [@jakex7](https://github.com/jakex7))
 - [android] Add stub methods. ([#45335](https://github.com/expo/expo/pull/45335) by [@jakex7](https://github.com/jakex7))
+- Add widget RedBox.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/ios/Widgets/AppIntent.swift
+++ b/packages/expo-widgets/ios/Widgets/AppIntent.swift
@@ -1,6 +1,28 @@
 import AppIntents
 import WidgetKit
 
+struct WidgetReload: AppIntent {
+  // title is not used for non-discoverable intents, but it is required
+  static var title: LocalizedStringResource = "Reload widget"
+  static var isDiscoverable: Bool = false
+  @Parameter(title: "source")
+  var source: String?
+
+  init() {}
+  init(source: String?) {
+    self.source = source
+  }
+
+  func perform() async throws -> some IntentResult {
+    guard let source else {
+      return .result()
+    }
+
+    WidgetCenter.shared.reloadTimelines(ofKind: source)
+    return .result()
+  }
+}
+
 @available(iOS 16.0, *)
 struct WidgetUserInteraction: AppIntent {
   // title is not used for non-discoverable intents, but it is required

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -104,11 +104,18 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
       render(FragmentView.self, FragmentProps.self, updateProps: updateChildren)
     case "LinkView":
       render(LinkView.self, LinkViewProps.self, updateProps: updateChildren)
+#if DEBUG
+    case "RedBoxView":
+      render(RedBoxView.self, RedBoxViewProps.self)
     default:
       ZStack {
         Color.red.opacity(0.5)
         Text("Unable to get the view for: \(node["type"] as? String ?? "undefined")")
       }
+#else
+    default:
+      EmptyView()
+#endif
     }
   }
 

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -106,7 +106,7 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
       render(LinkView.self, LinkViewProps.self, updateProps: updateChildren)
 #if DEBUG
     case "RedBoxView":
-      render(RedBoxView.self, RedBoxViewProps.self)
+      render(RedBoxView.self, RedBoxViewProps.self) { $0.source = name }
     default:
       ZStack {
         Color.red.opacity(0.5)

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -106,7 +106,10 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
       render(LinkView.self, LinkViewProps.self, updateProps: updateChildren)
 #if DEBUG
     case "RedBoxView":
-      render(RedBoxView.self, RedBoxViewProps.self) { $0.source = name }
+      render(RedBoxView.self, RedBoxViewProps.self) { redBoxProps in
+        redBoxProps.source = name
+        redBoxProps.kind = kind
+      }
     default:
       ZStack {
         Color.red.opacity(0.5)

--- a/packages/expo-widgets/ios/Widgets/RedBoxView.swift
+++ b/packages/expo-widgets/ios/Widgets/RedBoxView.swift
@@ -6,6 +6,7 @@ public final class RedBoxViewProps: UIBaseViewProps {
   @Field var message: String
   @Field var source: String?
   @Field var stack: String?
+  var kind: WidgetsKind = .widget
 }
 
 public struct RedBoxView: ExpoSwiftUI.View {
@@ -16,7 +17,7 @@ public struct RedBoxView: ExpoSwiftUI.View {
   }
 
   public var body: some View {
-    FullSizeZStack {
+    FullSizeZStack(kind: props.kind) {
       Color.red
       VStack(alignment: .leading, spacing: 2) {
         HStack(spacing: 6) {
@@ -64,21 +65,19 @@ private struct RedBoxBody: ViewModifier {
 }
 
 public struct FullSizeZStack<Content: View>: View {
+  let kind: WidgetsKind
   let content: Content
 
-  init(@ViewBuilder _ content: () -> Content) {
+  init(kind: WidgetsKind = .widget, @ViewBuilder _ content: () -> Content) {
+    self.kind = kind
     self.content = content()
   }
 
   public var body: some View {
-    if #available(iOS 17.0, *) {
-      ZStack {
-        content
-      }.containerRelativeFrame([.horizontal, .vertical])
+    if #available(iOS 17.0, *), kind == .widget {
+      ZStack { content }.containerRelativeFrame([.horizontal, .vertical])
     } else {
-      ZStack {
-        content
-      }
+      ZStack { content }.frame(maxWidth: .infinity)
     }
   }
 }

--- a/packages/expo-widgets/ios/Widgets/RedBoxView.swift
+++ b/packages/expo-widgets/ios/Widgets/RedBoxView.swift
@@ -1,0 +1,75 @@
+import ExpoModulesCore
+import SwiftUI
+import ExpoUI
+
+public final class RedBoxViewProps: UIBaseViewProps {
+  @Field var message: String
+  @Field var stack: String?
+}
+
+public struct RedBoxView: ExpoSwiftUI.View {
+  @ObservedObject public var props: RedBoxViewProps
+
+  public init(props: RedBoxViewProps) {
+    self.props = props
+  }
+
+  public var body: some View {
+    FullSizeZStack {
+      Color.red
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 6) {
+          Image(systemName: "exclamationmark.triangle.fill")
+          Text("Error").font(.headline)
+        }
+        .foregroundStyle(.white)
+
+        Text(props.message)
+          .font(.system(size: 14).bold().monospaced())
+          .foregroundStyle(.white.opacity(0.9))
+          .modifier(RedBoxBody())
+
+        if let stack = props.stack, !stack.isEmpty {
+          Text(stack)
+            .font(.system(size: 11).monospaced())
+            .foregroundStyle(.white.opacity(0.75))
+            .modifier(RedBoxBody())
+        }
+      }
+      .padding(12)
+      .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+  }
+}
+
+private struct RedBoxBody: ViewModifier {
+  @ViewBuilder
+  func body(content: Content) -> some View {
+    let base = content.lineLimit(nil).fixedSize(horizontal: false, vertical: true)
+    if #available(iOS 26.0, *) {
+      base.lineHeight(.tight)
+    } else {
+      base
+    }
+  }
+}
+
+public struct FullSizeZStack<Content: View>: View {
+  let content: Content
+
+  init(@ViewBuilder _ content: () -> Content) {
+    self.content = content()
+  }
+
+  public var body: some View {
+    if #available(iOS 17.0, *) {
+      ZStack {
+        content
+      }.containerRelativeFrame([.horizontal, .vertical])
+    } else {
+      ZStack {
+        content
+      }
+    }
+  }
+}

--- a/packages/expo-widgets/ios/Widgets/RedBoxView.swift
+++ b/packages/expo-widgets/ios/Widgets/RedBoxView.swift
@@ -4,6 +4,7 @@ import ExpoUI
 
 public final class RedBoxViewProps: UIBaseViewProps {
   @Field var message: String
+  @Field var source: String?
   @Field var stack: String?
 }
 
@@ -21,6 +22,14 @@ public struct RedBoxView: ExpoSwiftUI.View {
         HStack(spacing: 6) {
           Image(systemName: "exclamationmark.triangle.fill")
           Text("Error").font(.headline)
+          Spacer()
+          if #available(iOS 17.0, *) {
+            Button(intent: WidgetReload(source: props.source)) {
+              Image(systemName: "arrow.clockwise")
+            }
+              .buttonStyle(.plain)
+              .padding(4)
+          }
         }
         .foregroundStyle(.white)
 

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -20,6 +20,14 @@ func parseTimeline(identifier: String, name: String, family: WidgetFamily) -> [W
   return entries.compactMap(\.self)
 }
 
+func createRedBox(message: String, stack: String? = nil) -> [String: Any] {
+  var props: [String: Any] = ["message": message]
+  if let stack {
+    props["stack"] = stack
+  }
+  return ["type": "RedBoxView", "props": props]
+}
+
 func evaluateLayout(
   layout: String,
   props: [String: Any],
@@ -32,6 +40,10 @@ func evaluateLayout(
   let result = context.objectForKeyedSubscript("__expoWidgetRender")?.call(
     withArguments: [props, environment]
   )
+  if let exception = context.exception {
+    print("[ExpoWidgets] Layout evaluation failed: \(exception)")
+    return createRedBox(message: exception.toString())
+  }
   return result?.toObject() as? [String: Any]
 }
 
@@ -49,6 +61,12 @@ func getLiveActivityNodes(forName name: String, props: String = "{}", environmen
   let result = context.objectForKeyedSubscript("__expoWidgetRender")?.call(
     withArguments: [propsDict, environment]
   )
+
+  if let exception = context.exception {
+    print("[ExpoWidgets] Layout evaluation failed: \(exception)")
+    return createRedBox(message: exception.toString())
+  }
+
   return result?.toObject() as? [String: Any] ?? [:]
 }
 

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -64,7 +64,7 @@ func getLiveActivityNodes(forName name: String, props: String = "{}", environmen
 
   if let exception = context.exception {
     print("[ExpoWidgets] Layout evaluation failed: \(exception)")
-    return createRedBox(message: exception.toString())
+    return ["banner": createRedBox(message: exception.toString())]
   }
 
   return result?.toObject() as? [String: Any] ?? [:]

--- a/packages/expo-widgets/ios/Widgets/WidgetContext.swift
+++ b/packages/expo-widgets/ios/Widgets/WidgetContext.swift
@@ -6,12 +6,6 @@ func createWidgetContext(layout: String) -> JSContext? {
     return nil
   }
 
-  context.exceptionHandler = { _, exception in
-    if let exception {
-      print("[ExpoWidgets] Layout evaluation failed: \(exception)")
-    }
-  }
-
   // Inject ExpoUI bundle
   guard let bundleURL = Bundle.main.url(forResource: "ExpoWidgets", withExtension: "bundle"),
         let bundle = Bundle(url: bundleURL),


### PR DESCRIPTION
# Why

It's hard to debug widgets without access to native logs from different target.

# How

In debug, create a RedBox view with the error message gathered from JSC execution

## Widgets
<img width="300" alt="image" src="https://github.com/user-attachments/assets/c3210b38-fe43-4e53-b817-918e46e97054" />

## Live Activities
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e2d2cef9-2c09-400e-8217-cf8897d81cb1" />

# Test Plan

Make invalid widget

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
