### PR TITLE
[tools] Resolve scoped packages by name when directory differs

### DIFF
--- a/tools/src/Packages.test.ts
+++ b/tools/src/Packages.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { before, describe, it } from 'node:test';
+
+import { getListOfPackagesAsync, getPackageByName } from './Packages';
+
+describe('getPackageByName', () => {
+  before(async () => {
+    await getListOfPackagesAsync();
+  });
+
+  it('resolves packages whose directory matches their name', () => {
+    const pkg = getPackageByName('expo-router');
+    assert.ok(pkg);
+    assert.equal(pkg.packageName, 'expo-router');
+  });
+
+  it('resolves scoped packages whose directory matches their name', () => {
+    const pkg = getPackageByName('@expo/cli');
+    assert.ok(pkg);
+    assert.equal(pkg.packageName, '@expo/cli');
+  });
+
+  it('resolves scoped packages whose directory differs from their name', () => {
+    for (const name of ['@expo/ui', '@expo/app-integrity']) {
+      const pkg = getPackageByName(name);
+      assert.ok(pkg, `${name} should resolve`);
+      assert.equal(pkg.packageName, name);
+    }
+  });
+
+  it('returns null for an unknown package name', () => {
+    assert.equal(getPackageByName('definitely-not-a-real-package'), null);
+  });
+});

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -421,6 +421,7 @@ export class Package {
 
 /**
  * Resolves to a Package instance if the package with given name exists in the repository.
+ * Falls back to scanning the cached package list when the directory name doesn't match.
  */
 export function getPackageByName(packageName: string): Package | null {
   const packageJsonPath = pathToLocalPackageJson(packageName);
@@ -428,7 +429,7 @@ export function getPackageByName(packageName: string): Package | null {
     const packageJson = require(packageJsonPath);
     return new Package(path.dirname(packageJsonPath), packageJson);
   } catch {
-    return null;
+    return cachedPackages?.find((pkg) => pkg.packageName === packageName) ?? null;
   }
 }
 


### PR DESCRIPTION
Hit this trying to install `@expo/ui` after upgrading to canary expo per the [docs canary install instructions](https://docs.expo.dev/versions/unversioned/#canary-releases). Bun and npm error out. pnpm and yarn install canary `@expo/ui` linked against whatever stable `expo` was already there.

The canary tarballs are shipping `peerDependencies.expo: "workspace:*"` instead of the substituted canary version. Tracked it to `getPackageByName` doing a `packages/<name>/package.json` lookup, which misses for `@expo/ui` (lives at `packages/expo-ui/`) and `@expo/app-integrity` (at `packages/expo-app-integrity/`). When the lookup misses, `Workspace.getInfoAsync` records empty `workspacePeerDependencies` for those packages, so `updateWorkspaceProjects` never rewrites `workspace:*` to the canary version.

Same root cause as #44412, at a different call site the earlier fix didn't reach.

The fix keeps the existing path-based fast path and adds a fallback that scans `cachedPackages` by `name` field when the path lookup misses. The cache is already populated by `getListOfPackagesAsync` in `loadRequestedParcels` before `updateWorkspaceProjects` runs.

# Test Plan

- `pnpm build` in `tools`: clean
- `pnpm lint --fix` in `tools`: clean
- `pnpm test` in `tools`: 184/184 passing. Added `tools/src/Packages.test.ts` with four cases pinning the fast path and the new fallback. The scoped-mismatched-dir case (`@expo/ui`, `@expo/app-integrity`) fails on `main` and passes on this branch.

`Workspace.getInfoAsync()` output before and after the fix:

| Package | Before | After |
|---|---|---|
| `@expo/ui` | `[]` | `["expo"]` |
| `@expo/app-integrity` | `[]` | `["expo"]` |
| `expo-router`, `expo-image`, `expo-system-ui` | unchanged | unchanged |

Repro through the official canary install flow:

```bash
npx create-expo-app@latest repro --no-install --yes
cd repro
bun install
bun add expo@canary
bunx expo install @expo/ui

# under the hood:
> bun add @expo/ui@56.0.0-canary-20260501-15d3529
error: Workspace dependency "expo" not found
```

Same broken tarball under npm:

```bash
npm install @expo/ui@canary
# npm error code EUNSUPPORTEDPROTOCOL
# Unsupported URL Type "workspace:": workspace:*
```