### PR TITLE
chore: Upgrade to metro@0.84.4 (`@expo/metro@~56.0.0` bump)

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Add `@expo/metro-file-map` fork ([#45373](https://github.com/expo/expo/pull/45373) by [@kitten](https://github.com/kitten))
 - Disable watchman by default ([#45378](https://github.com/expo/expo/pull/45378) by [@kitten](https://github.com/kitten))
 - Defer version check output to command table, and prefetch on start, to prevent it blocking/slowing down startup ([#45400](https://github.com/expo/expo/pull/45400) by [@kitten](https://github.com/kitten))
+- Bump to `@expo/metro@56.0.0` and `metro@0.84.4` ([#45404](https://github.com/expo/expo/pull/45404) by [@kitten](https://github.com/kitten))
 
 ## 55.0.12 — 2026-02-25
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -58,7 +58,7 @@
     "@expo/inline-modules": "workspace:0.0.1",
     "@expo/json-file": "workspace:^10.0.12",
     "@expo/log-box": "workspace:55.0.7",
-    "@expo/metro": "56.0.0-rc.2",
+    "@expo/metro": "~56.0.0",
     "@expo/metro-config": "workspace:~55.0.9",
     "@expo/metro-file-map": "workspace:55.0.0-0",
     "@expo/osascript": "workspace:^2.4.2",

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add more stringent Babel config detection that disables redundant Babel config/rc file crawling, and support more Babel config filenames by default ([#45254](https://github.com/expo/expo/pull/45254) by [@kitten](https://github.com/kitten))
 - Use Babel config path hint to Expo Metro transformer and add `loadPartialConfigSync` cache key to invalidate Babel transform cache more granularly ([#45260](https://github.com/expo/expo/pull/45260) by [@kitten](https://github.com/kitten))
 - Skip `generateImportNames` traversal/phase when live bindings import/export support is enabled ([#45349](https://github.com/expo/expo/pull/45349) by [@kitten](https://github.com/kitten))
+- Bump to `@expo/metro@56.0.0` and `metro@0.84.4` ([#45404](https://github.com/expo/expo/pull/45404) by [@kitten](https://github.com/kitten))
 
 ## 55.0.9 — 2026-02-25
 

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -68,7 +68,7 @@
     "@expo/config": "workspace:~55.0.8",
     "@expo/env": "workspace:~2.1.1",
     "@expo/json-file": "workspace:~10.0.12",
-    "@expo/metro": "56.0.0-rc.2",
+    "@expo/metro": "~56.0.0",
     "@expo/spawn-async": "^1.7.2",
     "browserslist": "^4.25.0",
     "chalk": "^4.1.0",

--- a/packages/@expo/metro-file-map/package.json
+++ b/packages/@expo/metro-file-map/package.json
@@ -39,7 +39,7 @@
     "walker": "^1.0.8"
   },
   "devDependencies": {
-    "@expo/metro": "56.0.0-rc.2",
+    "@expo/metro": "~56.0.0",
     "@types/debug": "^4.1.7",
     "@types/fb-watchman": "^2.0.6",
     "@types/invariant": "^2.2.37",

--- a/packages/babel-preset-expo/package.json
+++ b/packages/babel-preset-expo/package.json
@@ -101,7 +101,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
-    "@expo/metro": "56.0.0-rc.2",
+    "@expo/metro": "~56.0.0",
     "@expo/metro-config": "workspace:*",
     "@types/babel__core": "^7.20.5",
     "@types/babel__generator": "^7.27.0",

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -39,7 +39,7 @@
     "@expo/config": "workspace:*",
     "@expo/env": "workspace:*",
     "@expo/json-file": "workspace:*",
-    "@expo/metro": "56.0.0-rc.2",
+    "@expo/metro": "~56.0.0",
     "@expo/schemer": "workspace:*",
     "@expo/spawn-async": "^1.7.2",
     "@types/debug": "^4.1.8",

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -88,7 +88,7 @@
     "ts-jest": "~29.4.7"
   },
   "devDependencies": {
-    "@expo/metro": "56.0.0-rc.2",
+    "@expo/metro": "~56.0.0",
     "@babel/core": "^7.26.0"
   }
 }

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [iOS] Remove `RCTHostRuntimeDelegate` usage now that it's merged into `RCTHostDelegate`. ([#43838](https://github.com/expo/expo/pull/43838) by [@zoontek](https://github.com/zoontek))
 - Bumped project templates to TypeScript v6 ([#45091](https://github.com/expo/expo/pull/45091) by [@hassankhan](https://github.com/hassankhan))
 - [dom] Added opt-out `unstable_useExpoModulesBridge` flag. ([#45223](https://github.com/expo/expo/pull/45223) by [@kudo](https://github.com/kudo))
+- Bump to `@expo/metro@56.0.0` and `metro@0.84.4` ([#45404](https://github.com/expo/expo/pull/45404) by [@kitten](https://github.com/kitten))
 
 ### ⚠️ Notices
 

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -83,7 +83,7 @@
     "@expo/fingerprint": "workspace:0.16.5",
     "@expo/local-build-cache-provider": "workspace:55.0.6",
     "@expo/log-box": "workspace:55.0.7",
-    "@expo/metro": "56.0.0-rc.2",
+    "@expo/metro": "~56.0.0",
     "@expo/metro-config": "workspace:55.0.9",
     "@expo/vector-icons": "^15.0.2",
     "@ungap/structured-clone": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1804,8 +1804,8 @@ importers:
         specifier: workspace:55.0.7
         version: link:../log-box
       '@expo/metro':
-        specifier: 56.0.0-rc.2
-        version: 56.0.0-rc.2
+        specifier: ~56.0.0
+        version: 56.0.0
       '@expo/metro-config':
         specifier: workspace:~55.0.9
         version: link:../metro-config
@@ -2533,8 +2533,8 @@ importers:
         specifier: workspace:~10.0.12
         version: link:../json-file
       '@expo/metro':
-        specifier: 56.0.0-rc.2
-        version: 56.0.0-rc.2
+        specifier: ~56.0.0
+        version: 56.0.0
       '@expo/spawn-async':
         specifier: ^1.7.2
         version: 1.7.2
@@ -2628,8 +2628,8 @@ importers:
         version: 1.0.8
     devDependencies:
       '@expo/metro':
-        specifier: 56.0.0-rc.2
-        version: 56.0.0-rc.2
+        specifier: ~56.0.0
+        version: 56.0.0
       '@types/debug':
         specifier: ^4.1.7
         version: 4.1.12
@@ -3097,8 +3097,8 @@ importers:
         specifier: ^7.26.0
         version: 7.29.0
       '@expo/metro':
-        specifier: 56.0.0-rc.2
-        version: 56.0.0-rc.2
+        specifier: ~56.0.0
+        version: 56.0.0
       '@expo/metro-config':
         specifier: workspace:*
         version: link:../@expo/metro-config
@@ -3452,8 +3452,8 @@ importers:
         specifier: workspace:55.0.7
         version: link:../@expo/log-box
       '@expo/metro':
-        specifier: 56.0.0-rc.2
-        version: 56.0.0-rc.2
+        specifier: ~56.0.0
+        version: 56.0.0
       '@expo/metro-config':
         specifier: workspace:55.0.9
         version: link:../@expo/metro-config
@@ -4208,8 +4208,8 @@ importers:
         specifier: workspace:*
         version: link:../@expo/json-file
       '@expo/metro':
-        specifier: 56.0.0-rc.2
-        version: 56.0.0-rc.2
+        specifier: ~56.0.0
+        version: 56.0.0
       '@expo/schemer':
         specifier: workspace:*
         version: link:../@expo/schemer
@@ -4835,8 +4835,8 @@ importers:
         specifier: ^7.26.0
         version: 7.29.0
       '@expo/metro':
-        specifier: 56.0.0-rc.2
-        version: 56.0.0-rc.2
+        specifier: ~56.0.0
+        version: 56.0.0
 
   packages/expo-module-template:
     devDependencies:
@@ -7494,8 +7494,8 @@ packages:
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.26.0
 
-  '@expo/metro@56.0.0-rc.2':
-    resolution: {integrity: sha512-VgEkAshU/uVkOXux199M1i5in5rXw3PMOEHlTkl0Zi1BLP1zOL6mOIRXHG/8ZQ/6qDTJtpYgComI4/v42JOqFg==}
+  '@expo/metro@56.0.0':
+    resolution: {integrity: sha512-5gIgQHtEpjjvsjKfVtIv23a98LLRV0/y07PDShEwYSytAMlE3FSF8RHXqtHc1sUJL6dn7hnuIBpIbrLXXuVi0A==}
 
   '@expo/multipart-body-parser@1.1.0':
     resolution: {integrity: sha512-XOaS79wFIJgx0J7oUzRb+kZsnZmFqGpisu0r8RPO3b0wjbW7xpWgiXmRR4RavKeGiVAPauZOi4vad7cJ3KCspg==}
@@ -17367,7 +17367,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@expo/metro@56.0.0-rc.2':
+  '@expo/metro@56.0.0':
     dependencies:
       metro: 0.84.4
       metro-babel-transformer: 0.84.4


### PR DESCRIPTION
# Summary

**No changes in the actual transitive dependencies. This just bumps us to the release version (just published) and switches the prerelease ranges back.**

Changes within range (compared to sdk-55 w/o metro patch releases that were backported): https://github.com/facebook/metro/compare/v0.83.4...v0.84.4

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
