### PR TITLE
[iOS][camera] Frame preview at wide-angle equivalent on virtual multi-lens devices

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [iOS] Fix inconsistent barcode `type` value returned by ZXing fallback scanner (code39, pdf417, codabar) — it now returns the same format as the AVFoundation scanner (e.g. `"code39"` instead of `"org.iso.Code39"`). ([#44726](https://github.com/expo/expo/pull/44726) by [@jensdev](https://github.com/jensdev))
 - [iOS] Fix camera activity indicator remaining active after `CameraView.launchScanner` is interactively dismissed and the app is backgrounded/foregrounded. ([#45063](https://github.com/expo/expo/pull/45063) by [@alanjhughes](https://github.com/alanjhughes))
 - [Android] Remove `RECORD_AUDIO` from the manifest so `recordAudioAndroid` depends on the plugin. ([#45132](https://github.com/expo/expo/pull/45132) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Fix preview framing when `selectedLens` is a virtual multi-lens device (Triple Camera, Dual Wide Camera). `zoom: 0` previously pinned the device to its ultra-wide constituent (videoZoomFactor 1.0); it now uses the device's first reported `virtualDeviceSwitchOverVideoZoomFactors` value (typically 2.0), matching the system Camera app's default 1× framing. (by [@seanadkinson](https://github.com/seanadkinson))
 
 ### 💡 Others
 

--- a/packages/expo-camera/ios/Current/CameraSessionManager.swift
+++ b/packages/expo-camera/ios/Current/CameraSessionManager.swift
@@ -214,7 +214,21 @@ class CameraSessionManager: NSObject, DeviceDiscoveryDelegate {
     do {
       try device.lockForConfiguration()
       defer { device.unlockForConfiguration() }
-      let minZoom = 1.0
+      // For virtual devices that include both ultra-wide and wide constituents (Triple Camera,
+      // Dual Wide Camera), videoZoomFactor 1.0 corresponds to the ultra-wide lens. The system
+      // Camera app's "1×" view sits at the first switch-over factor (typically 2.0). Use that
+      // as our minimum so `zoom: 0` frames like the system camera — ultra-wide / macro is
+      // reached via auto-macro on close focus, or by selecting the ultra-wide lens explicitly.
+      let minZoom: CGFloat = {
+        let constituents = device.constituentDevices
+        let hasUltraWide = constituents.contains { $0.deviceType == .builtInUltraWideCamera }
+        let hasWide = constituents.contains { $0.deviceType == .builtInWideAngleCamera }
+        if hasUltraWide && hasWide,
+           let firstFactor = device.virtualDeviceSwitchOverVideoZoomFactors.first?.doubleValue {
+          return CGFloat(firstFactor)
+        }
+        return 1.0
+      }()
       device.videoZoomFactor = minZoom * pow(device.activeFormat.videoMaxZoomFactor / minZoom, delegate.zoom)
     } catch {
       log.info("\(#function): \(error.localizedDescription)")


### PR DESCRIPTION
# Why

When `selectedLens` selects a virtual `AVCaptureDevice` whose constituents include both an ultra-wide and a wide camera (`Back Triple Camera`, `Back Dual Wide Camera`), `videoZoomFactor = 1.0` pins the active lens to the **ultra-wide** constituent. The system Camera app's "1×" framing sits at the first switch-over factor — typically `2.0` on these devices — and exposes ultra-wide explicitly via the "0.5×" toggle plus auto-macro on close focus.

`CameraSessionManager.updateZoom()` currently hardcodes `let minZoom = 1.0` for all devices. With `zoom: 0` (the default), this produces a heavily distorted ultra-wide preview on these virtual devices that doesn't match user intuition or the behavior of the system Camera app. Users selecting `Back Triple Camera` to leverage iOS's automatic macro/lens-switching get a fisheye-looking preview instead of the expected 1× framing.

Related discussion: [#40489](https://github.com/expo/expo/issues/40489) (auto-closed without resolution; same root cause).

# How

In `updateZoom()`, derive `minZoom` from the device:

- If `device.constituentDevices` contains **both** `.builtInUltraWideCamera` and `.builtInWideAngleCamera`, use the first value of `device.virtualDeviceSwitchOverVideoZoomFactors` as `minZoom` (typically 2.0). This matches Camera.app's default 1× framing.
- Otherwise (physical devices, `Back Dual Camera` = wide + telephoto, etc.), keep `minZoom = 1.0` — unchanged.

The `zoom` prop's normalized 0–1 mapping is preserved; only the floor of the exponential range shifts on the affected virtual devices. Auto-macro continues to engage transparently when iOS detects close focus.

# Behavior change

| Active device | Before (`zoom: 0`) | After (`zoom: 0`) |
| --- | --- | --- |
| `Back Camera` (wide, physical) | 1.0× | 1.0× (unchanged) |
| `Back Ultra Wide Camera` (physical) | min × 1.0 | unchanged |
| `Back Triple Camera` (virtual, UW+W+T) | **0.5× equivalent (ultra-wide)** | **1.0× equivalent (wide)** |
| `Back Dual Wide Camera` (virtual, UW+W) | **0.5× equivalent (ultra-wide)** | **1.0× equivalent (wide)** |
| `Back Dual Camera` (virtual, W+T) | 1.0× (wide) | 1.0× (unchanged) |

Users who *want* the ultra-wide framing on a virtual device can either:
- Set `selectedLens` to the physical ultra-wide directly, or
- Rely on iOS auto-macro to engage on close focus

# Test Plan

Tested manually in a downstream app (using `pnpm patch` to apply the change to `expo-camera@55.0.16`):

- iPhone 15 Pro: setting `selectedLens="Back Triple Camera"` previously showed a heavily distorted ultra-wide preview at default zoom; now shows the standard wide-angle framing matching the iOS Camera app
- Physical-lens selections (`Back Camera`, `Back Ultra Wide Camera`) frame identically to before
- Auto-macro still engages when focusing on subjects within ~14 cm

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)