### PR TITLE
fix(cli): Remove remaining startup delay from `DevelopmentSession` and deps check grace period

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Run `DevelopmentSession` API call and dependencies check without any startup delays ([#45417](https://github.com/expo/expo/pull/45417) by [@kitten](https://github.com/kitten))
+
 ## 56.0.2 — 2026-05-05
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/src/api/updateDevelopmentSession.ts
+++ b/packages/@expo/cli/src/api/updateDevelopmentSession.ts
@@ -39,11 +39,13 @@ export async function updateDevelopmentSessionAsync({
   exp,
   runtime,
   url,
+  signal,
 }: {
   deviceIds: string[];
   exp: Pick<ExpoConfig, 'name' | 'description' | 'slug' | 'primaryColor'>;
   runtime: 'native' | 'web';
   url: string;
+  signal?: AbortSignal;
 }) {
   const searchParams = new URLSearchParams();
   deviceIds.forEach((id) => {
@@ -51,6 +53,7 @@ export async function updateDevelopmentSessionAsync({
   });
 
   const results = await fetchAsync('development-sessions/notify-alive', {
+    signal,
     searchParams,
     method: 'POST',
     body: JSON.stringify({

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -51,14 +51,14 @@ export async function startInterfaceAsync(
     ...options,
   };
 
-  // Wait briefly for the dependency check to resolve (it runs in the background since early startup).
-  // With a warm fetch cache this resolves near-instantly; on cold starts it may not be ready,
-  // in which case it will appear on the next TUI re-print (e.g. pressing 'c').
+  // Print the dependency check if it completed (it runs in the background since early startup).
+  // With a warm fetch cache this resolves near-instantly, so we defer by a tick
+  // On cold starts it may not be ready, in which case it will appear on the next reprint or restart
   let dependencyCheckResult: DependencyCheckResult | null | undefined;
   if (options.dependencyCheckPromise) {
     dependencyCheckResult = await Promise.race([
       options.dependencyCheckPromise,
-      new Promise<undefined>((resolve) => setTimeout(resolve, 100)),
+      Promise.resolve(null),
     ]);
     if (!dependencyCheckResult) {
       // Not ready yet — capture once resolved for display on next reprint

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -37,38 +37,44 @@ export class DevelopmentSession {
     exp?: Pick<ExpoConfig, 'name' | 'description' | 'slug' | 'primaryColor'>;
     runtime: 'native' | 'web';
   }): Promise<void> {
-    try {
-      if (env.CI || env.EXPO_OFFLINE) {
-        debug(
-          env.CI
-            ? 'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in CI.'
-            : 'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in offline-mode.'
-        );
-        return;
-      }
-
-      const deviceIds = await this.getDeviceInstallationIdsAsync();
-
-      if (!hasCredentials() && !deviceIds?.length) {
-        debug(
-          'Development session will not ping because the user is not authenticated and there are no devices.'
-        );
-        return;
-      }
-
-      if (this.url) {
-        debug(`Development session ping (runtime: ${runtime}, url: ${this.url})`);
-        await updateDevelopmentSessionAsync({
-          url: this.url,
-          runtime,
-          exp,
-          deviceIds,
-        });
-        this.hasActiveSession = true;
-      }
-    } catch (error: any) {
-      debug(`Error updating development session API: ${error}`);
+    if (env.CI || env.EXPO_OFFLINE) {
+      debug(
+        env.CI
+          ? 'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in CI.'
+          : 'This project will not be suggested in Expo Go or Dev Clients because Expo CLI is running in offline-mode.'
+      );
+      return;
     }
+
+    const fireAndForget = async () => {
+      try {
+        const deviceIds = await this.getDeviceInstallationIdsAsync();
+
+        if (!hasCredentials() && !deviceIds?.length) {
+          debug(
+            'Development session will not ping because the user is not authenticated and there are no devices.'
+          );
+          return;
+        }
+
+        if (this.url) {
+          debug(`Development session ping (runtime: ${runtime}, url: ${this.url})`);
+          await updateDevelopmentSessionAsync({
+            url: this.url,
+            runtime,
+            exp,
+            deviceIds,
+          });
+          this.hasActiveSession = true;
+        }
+      } catch (error: any) {
+        debug(`Error updating development session API: ${error}`);
+      }
+    };
+
+    // NOTE(@kitten): We never want to wait for this call, as it's not essential to the CLI startup
+    // But we do add a tick delay, for testing
+    await Promise.race([fireAndForget(), Promise.resolve()]);
   }
 
   /** Get all recent devices for the project. */

--- a/packages/@expo/cli/src/start/server/DevelopmentSession.ts
+++ b/packages/@expo/cli/src/start/server/DevelopmentSession.ts
@@ -15,6 +15,8 @@ export class DevelopmentSession {
   /** If the `startAsync` was successfully called */
   private hasActiveSession = false;
 
+  private abortController: AbortController | undefined;
+
   constructor(
     /** Project root directory. */
     private projectRoot: string,
@@ -59,16 +61,20 @@ export class DevelopmentSession {
 
         if (this.url) {
           debug(`Development session ping (runtime: ${runtime}, url: ${this.url})`);
+          this.abortController = new AbortController();
           await updateDevelopmentSessionAsync({
             url: this.url,
             runtime,
             exp,
             deviceIds,
+            signal: this.abortController.signal,
           });
           this.hasActiveSession = true;
         }
       } catch (error: any) {
         debug(`Error updating development session API: ${error}`);
+      } finally {
+        this.abortController = undefined;
       }
     };
 
@@ -85,7 +91,12 @@ export class DevelopmentSession {
 
   /** Try to close any pending development sessions, but always resolve */
   public async closeAsync(): Promise<boolean> {
-    if (env.CI || env.EXPO_OFFLINE || !this.hasActiveSession) {
+    if (env.CI || env.EXPO_OFFLINE) {
+      return false;
+    } else if (this.abortController) {
+      this.abortController.abort();
+      return false;
+    } else if (!this.hasActiveSession) {
       return false;
     }
 

--- a/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
@@ -11,6 +11,10 @@ jest.mock('../../../api/user/user');
 
 const originalEnvCI = process.env.CI;
 
+afterEach(() => {
+  nock.cleanAll();
+});
+
 describe(`startAsync`, () => {
   beforeEach(() => {
     delete process.env.CI;
@@ -47,6 +51,9 @@ describe(`startAsync`, () => {
       exp,
       runtime,
     });
+
+    // Flush the fire-and-forget promise chain from startAsync
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
     await session.closeAsync();
 


### PR DESCRIPTION
# Why

We're awaiting the `DevelopmentSession` ping call on startup, which isn't strictly necessary, as we're not relying on it being instant as the CLI starts up (all UIs displaying its data don't treat that data as highly accurate, as far as I know)

We can also remove the grace period of the two API calls on start up entirely, down to a tick, since that's only relevant for testing.

# How

- Remove `await` on `DevelopmentSession` and instead run it as a fire-and-forget
- Add cancellation for concurrent start/stop on `DevelopmentSession`
- Remove 100ms grace period for install check and instead just wait a single tick

# Test Plan

- CI should pass unchanged / manually tested with `expo start`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
