### PR TITLE
[expo-router] pin screens version to exact beta.1

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Pin `react-native-screens` to exact version ([#45421](https://github.com/expo/expo/pull/45421) by [@Ubax](https://github.com/Ubax))
+
 ### 💡 Others
 
 ## 56.0.1 — 2026-05-05

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -100,7 +100,7 @@
     "react-native-gesture-handler": "*",
     "react-native-reanimated": "*",
     "react-native-safe-area-context": ">= 5.4.0",
-    "react-native-screens": "~4.25.0-beta.1",
+    "react-native-screens": "4.25.0-beta.1",
     "react-native-web": "*",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
@@ -141,7 +141,7 @@
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "~4.3.0",
     "react-native-safe-area-context": "~5.6.2",
-    "react-native-screens": "~4.25.0-beta.1",
+    "react-native-screens": "4.25.0-beta.1",
     "react-native-web": "~0.21.0",
     "react-server-dom-webpack": "~19.0.4",
     "tsd": "^0.33.0"
@@ -171,7 +171,7 @@
     "react-fast-compare": "^3.2.2",
     "react-is": "^19.1.0",
     "react-native-drawer-layout": "^4.2.2",
-    "react-native-screens": "~4.25.0-beta.1",
+    "react-native-screens": "4.25.0-beta.1",
     "server-only": "^0.0.1",
     "sf-symbols-typescript": "^2.1.0",
     "shallowequal": "^1.1.0",

--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -107,7 +107,7 @@
   "react-native-pager-view": "8.0.1",
   "react-native-worklets": "0.8.3",
   "react-native-reanimated": "4.3.0",
-  "react-native-screens": "~4.25.0-beta.1",
+  "react-native-screens": "4.25.0-beta.1",
   "react-native-safe-area-context": "~5.7.0",
   "react-native-svg": "15.15.4",
   "react-native-view-shot": "4.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5158,7 +5158,7 @@ importers:
         specifier: ^4.2.2
         version: 4.2.2(91ff31fb95915589425baaf56c831ef8)
       react-native-screens:
-        specifier: ~4.25.0-beta.1
+        specifier: 4.25.0-beta.1
         version: 4.25.0-beta.1(react-native@0.85.2(@babel/core@7.29.0)(@react-native/jest-preset@0.85.2(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       server-only:
         specifier: ^0.0.1

--- a/tools/src/check-packages/checkDependenciesAsync.ts
+++ b/tools/src/check-packages/checkDependenciesAsync.ts
@@ -261,8 +261,9 @@ function createExternalImportValidator(pkg: Package) {
         }
         // NOTE: Loose check to see if a dependency is pinned
         const isLoose = /[~|^><=](\s*\d+\.)/.test(versionRange) || versionRange === '*';
+        const isPrerelease = versionRange.includes('-');
         const isPinned = /^\d+\.\d+\.\d+$/.test(versionRange);
-        return !isLoose || isPinned;
+        return !isPrerelease && (!isLoose || isPinned);
       }
       return null;
     },


### PR DESCRIPTION
# Why

`"react-native-screens": "~4.25.0-beta.1"` resolves to both beta and all the nightly versions `4.25.0-nightly-*`. Additionally there may be breaking changes between screens beta versions

# How

Pin the dependency to be exact version.

# Test Plan

1. Test in local project

**Note**: if user has a different `react-native-screens` version specified in their `package.json`, two versions of screens may be installed. However expo-doctor should detect this problem and display a warning

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
