### PR TITLE
[app-metrics][ios] Add long-lived NetworkPathMonitor

### DIFF
--- a/packages/expo-app-metrics/ios/AppMetricsAppDelegateSubscriber.swift
+++ b/packages/expo-app-metrics/ios/AppMetricsAppDelegateSubscriber.swift
@@ -3,6 +3,9 @@ import ExpoModulesCore
 public class AppMetricsAppDelegateSubscriber: ExpoAppDelegateSubscriber {
   public func appDelegateWillBeginInitialization() {
     AppMetrics.mainSession.appStartupMonitor.markMain()
+    AppMetricsActor.isolated {
+      NetworkPathMonitor.shared.start()
+    }
   }
 
   public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {

--- a/packages/expo-app-metrics/ios/AppStartup/AppStartupMonitoring.swift
+++ b/packages/expo-app-metrics/ios/AppStartup/AppStartupMonitoring.swift
@@ -112,7 +112,7 @@ final class AppStartupMonitoring: MetricReporter, @unchecked Sendable {
         for (key, value) in await DeviceConditions.deviceParams() {
           params[key] = value
         }
-        for (key, value) in DeviceConditions.networkParams() {
+        for (key, value) in await DeviceConditions.networkParams() {
           params[key] = value
         }
         let metric = Metric(

--- a/packages/expo-app-metrics/ios/Network/NetworkPath.swift
+++ b/packages/expo-app-metrics/ios/Network/NetworkPath.swift
@@ -1,0 +1,125 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Foundation
+import Network
+
+/**
+ A `Sendable` snapshot of `NWPath` distilled to the fields we care about. We
+ don't pass `NWPath` itself across actor boundaries because it isn't
+ `Sendable`, and a stable typed surface decouples downstream code from the
+ OS API.
+ */
+struct NetworkPath: Sendable, Equatable {
+  enum Status: String, Sendable {
+    case satisfied
+    case unsatisfied
+    case requiresConnection
+    case unknown
+  }
+
+  enum InterfaceType: String, Sendable {
+    case wifi
+    case cellular
+    case ethernet
+    case other
+    case none
+  }
+
+  enum UnsatisfiedReason: String, Sendable {
+    case notAvailable
+    case cellularDenied
+    case wifiDenied
+    case localNetworkDenied
+    case vpnInactive
+    case unknown
+  }
+
+  let status: Status
+  let interfaceType: InterfaceType
+  let isExpensive: Bool
+  let isConstrained: Bool
+  /**
+   Populated only when `status != .satisfied`. Distinguishes "no usable path"
+   from "user denied cellular/wifi for this app" from "VPN configured but down."
+   */
+  let unsatisfiedReason: UnsatisfiedReason?
+  /**
+   `CACurrentMediaTime` of the snapshot. Useful for transition timing once the
+   recorder lands.
+   */
+  let timestamp: TimeInterval
+}
+
+extension NetworkPath {
+  /**
+   Builds a snapshot from an `NWPath`. The current implementation reads the
+   primary interface type via `usesInterfaceType(_:)` predicates because
+   `NWPath` doesn't expose a single "preferred type" field.
+   */
+  static func from(_ path: NWPath, at timestamp: TimeInterval) -> NetworkPath {
+    return NetworkPath(
+      status: Status.from(path.status),
+      interfaceType: InterfaceType.from(path),
+      isExpensive: path.isExpensive,
+      isConstrained: path.isConstrained,
+      unsatisfiedReason: path.status == .satisfied ? nil : UnsatisfiedReason.from(path.unsatisfiedReason),
+      timestamp: timestamp
+    )
+  }
+}
+
+private extension NetworkPath.Status {
+  static func from(_ status: NWPath.Status) -> Self {
+    switch status {
+    case .satisfied:
+      return .satisfied
+    case .unsatisfied:
+      return .unsatisfied
+    case .requiresConnection:
+      return .requiresConnection
+    @unknown default:
+      return .unknown
+    }
+  }
+}
+
+private extension NetworkPath.InterfaceType {
+  static func from(_ path: NWPath) -> Self {
+    if path.status != .satisfied {
+      return .none
+    }
+    if path.usesInterfaceType(.wifi) {
+      return .wifi
+    }
+    if path.usesInterfaceType(.cellular) {
+      return .cellular
+    }
+    if path.usesInterfaceType(.wiredEthernet) {
+      return .ethernet
+    }
+    // `.loopback` folds into `other` since the OS only reports it as primary
+    // when no real network is up — already handled by the `.satisfied` check
+    // above — or in unusual simulator configurations. Keeps the value set
+    // aligned with Android.
+    return .other
+  }
+}
+
+private extension NetworkPath.UnsatisfiedReason {
+  static func from(_ reason: NWPath.UnsatisfiedReason) -> Self {
+    switch reason {
+    case .notAvailable:
+      return .notAvailable
+    case .cellularDenied:
+      return .cellularDenied
+    case .wifiDenied:
+      return .wifiDenied
+    case .localNetworkDenied:
+      return .localNetworkDenied
+    case .vpnInactive:
+      return .vpnInactive
+    @unknown default:
+      return .unknown
+    }
+  }
+}

--- a/packages/expo-app-metrics/ios/Network/NetworkPathMonitor.swift
+++ b/packages/expo-app-metrics/ios/Network/NetworkPathMonitor.swift
@@ -1,0 +1,74 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+/**
+ A singleton that owns the long-lived `NetworkPathObserver` and caches the
+ most recent `NetworkPath` snapshot.
+
+ The observer is started eagerly at app launch (see
+ `AppMetricsAppDelegateSubscriber.appDelegateWillBeginInitialization`) so the
+ cache is warm by the time `markInteractive` reads it. `NWPathMonitor` is
+ event-driven and cheap, so there's no benefit to deferring the start.
+
+ Readers can either grab the cached `currentPath` synchronously, or `await
+ waitForFirstPath()` if they specifically need the first OS-delivered path
+ (and don't mind suspending for it). The latter is what TTI param collection
+ uses — the TTI value itself is captured from the synchronously-recorded
+ `markers.timeToInteractive` timestamp, so awaiting the first path here only
+ delays the local-storage write, not the metric measurement.
+ */
+@AppMetricsActor
+final class NetworkPathMonitor: NetworkPathObserverDelegate, Sendable {
+  static let shared = NetworkPathMonitor()
+
+  private var observer: NetworkPathObserver?
+  private(set) var currentPath: NetworkPath?
+
+  /**
+   All resumed at once when the first path is delivered. An array (rather
+   than a single optional) means concurrent callers don't clobber each
+   other's continuations — useful if a future metric joins the TTI metric in
+   awaiting the first path.
+   */
+  private var firstPathContinuations: [CheckedContinuation<Void, Never>] = []
+
+  private init() {}
+
+  /**
+   Idempotent. Constructs the observer on the first call; later calls are
+   no-ops. The observer runs for the app lifetime.
+   */
+  func start() {
+    if observer != nil {
+      return
+    }
+    observer = NetworkPathObserver(delegate: self)
+  }
+
+  /**
+   Suspends until the first path delivery, then returns the latest cached
+   path. Returns immediately if a path has already been received.
+   */
+  func waitForFirstPath() async -> NetworkPath? {
+    if currentPath != nil {
+      return currentPath
+    }
+    await withCheckedContinuation { firstPathContinuations.append($0) }
+    return currentPath
+  }
+
+  // MARK: - NetworkPathObserverDelegate
+
+  nonisolated func onNetworkPathUpdate(_ path: NetworkPath) {
+    AppMetricsActor.isolated { [self] in
+      let wasFirst = currentPath == nil
+      currentPath = path
+      if wasFirst {
+        let pending = firstPathContinuations
+        firstPathContinuations.removeAll()
+        for continuation in pending {
+          continuation.resume()
+        }
+      }
+    }
+  }
+}

--- a/packages/expo-app-metrics/ios/Network/NetworkPathObserver.swift
+++ b/packages/expo-app-metrics/ios/Network/NetworkPathObserver.swift
@@ -1,0 +1,37 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Network
+import QuartzCore
+
+protocol NetworkPathObserverDelegate: AnyObject, Sendable {
+  func onNetworkPathUpdate(_ path: NetworkPath)
+}
+
+/**
+ Owns one long-lived `NWPathMonitor` and converts each delivered `NWPath`
+ into a `Sendable` `NetworkPath` snapshot before handing it off to the
+ delegate. The monitor runs for the app lifetime — `NWPathMonitor` is cheap
+ (event-driven, no polling, no radios woken) so there's no benefit to
+ starting and stopping it around recording windows.
+ */
+final class NetworkPathObserver: Sendable {
+  private let monitor = NWPathMonitor()
+  private weak let delegate: NetworkPathObserverDelegate?
+  private let queue = DispatchQueue(label: "expo.appmetrics.networkPath")
+
+  init(delegate: NetworkPathObserverDelegate) {
+    self.delegate = delegate
+    monitor.pathUpdateHandler = { [weak self] path in
+      guard let self else {
+        return
+      }
+      let snapshot = NetworkPath.from(path, at: CACurrentMediaTime())
+      self.delegate?.onNetworkPathUpdate(snapshot)
+    }
+    monitor.start(queue: queue)
+  }
+
+  deinit {
+    monitor.cancel()
+  }
+}

--- a/packages/expo-app-metrics/ios/Tests/AppStartupMonitoringTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/AppStartupMonitoringTests.swift
@@ -26,6 +26,16 @@ struct AppStartupMonitoringTests {
     monitoring.launchType = .cold
     monitoring.markers.finishedLaunching = 0
     monitoring.addReceiver(receiver)
+    // Seed `NetworkPathMonitor.shared` so `markInteractive` doesn't suspend
+    // forever waiting for the OS to deliver a real path in the test process.
+    NetworkPathMonitor.shared.onNetworkPathUpdate(NetworkPath(
+      status: .satisfied,
+      interfaceType: .wifi,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: nil,
+      timestamp: 0
+    ))
     return monitoring
   }
 

--- a/packages/expo-app-metrics/ios/Tests/NetworkPathTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkPathTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Testing
+
+@testable import ExpoAppMetrics
+
+@Suite("NetworkPath")
+struct NetworkPathTests {
+  @Test
+  func `interface type defaults to none when not satisfied`() {
+    let path = NetworkPath(
+      status: .unsatisfied,
+      interfaceType: .none,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: .notAvailable,
+      timestamp: 0
+    )
+    #expect(path.interfaceType == .none)
+  }
+
+  @Test
+  func `equatable on identical values`() {
+    let now: TimeInterval = 1.0
+    let lhs = NetworkPath(
+      status: .satisfied,
+      interfaceType: .wifi,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: nil,
+      timestamp: now
+    )
+    let rhs = NetworkPath(
+      status: .satisfied,
+      interfaceType: .wifi,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: nil,
+      timestamp: now
+    )
+    #expect(lhs == rhs)
+  }
+
+  @Test
+  func `equatable distinguishes interface type`() {
+    let wifi = NetworkPath(
+      status: .satisfied,
+      interfaceType: .wifi,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: nil,
+      timestamp: 0
+    )
+    let cellular = NetworkPath(
+      status: .satisfied,
+      interfaceType: .cellular,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: nil,
+      timestamp: 0
+    )
+    #expect(wifi != cellular)
+  }
+}
+
+@AppMetricsActor
+@Suite("NetworkPathMonitor")
+struct NetworkPathMonitorTests {
+  @Test
+  func `caches the last received path`() async throws {
+    let monitor = NetworkPathMonitor.shared
+    let path = NetworkPath(
+      status: .satisfied,
+      interfaceType: .wifi,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: nil,
+      timestamp: 1.0
+    )
+    monitor.onNetworkPathUpdate(path)
+    // `onNetworkPathUpdate` dispatches via `AppMetricsActor.isolated { ... }`,
+    // so we yield to let the cache update before asserting.
+    try await Task.sleep(for: .milliseconds(10))
+    #expect(monitor.currentPath == path)
+  }
+
+  @Test
+  func `overwrites the cached path on subsequent updates`() async throws {
+    let monitor = NetworkPathMonitor.shared
+    let first = NetworkPath(
+      status: .satisfied,
+      interfaceType: .wifi,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: nil,
+      timestamp: 1.0
+    )
+    let second = NetworkPath(
+      status: .unsatisfied,
+      interfaceType: .none,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: .notAvailable,
+      timestamp: 2.0
+    )
+    monitor.onNetworkPathUpdate(first)
+    monitor.onNetworkPathUpdate(second)
+    try await Task.sleep(for: .milliseconds(10))
+    #expect(monitor.currentPath == second)
+  }
+
+  @Test
+  func `waitForFirstPath returns immediately when a path is already cached`() async {
+    let monitor = NetworkPathMonitor.shared
+    let path = NetworkPath(
+      status: .satisfied,
+      interfaceType: .wifi,
+      isExpensive: false,
+      isConstrained: false,
+      unsatisfiedReason: nil,
+      timestamp: 1.0
+    )
+    monitor.onNetworkPathUpdate(path)
+    let result = await monitor.waitForFirstPath()
+    #expect(result == path)
+  }
+}

--- a/packages/expo-app-metrics/ios/Utils/DeviceConditions.swift
+++ b/packages/expo-app-metrics/ios/Utils/DeviceConditions.swift
@@ -1,7 +1,6 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
-import Network
 
 /**
  Snapshots of the device's environment (power, thermals, connectivity) attached
@@ -64,38 +63,19 @@ enum DeviceConditions {
   }
 
   /**
-   Reads the current network path synchronously via a short-lived `NWPathMonitor`
-   and returns `expo.network.connected` and `expo.network.type`. The monitor is
-   cancelled before returning so the helper holds no system resources.
+   Reads `expo.network.connected` and `expo.network.type` from the snapshot
+   maintained by `NetworkPathMonitor`. Awaits the monitor's first path
+   delivery if it hasn't arrived yet — the TTI value is captured from a
+   synchronously-recorded timestamp before we get here, so the await only
+   delays the local-storage write, not the metric itself.
    */
-  static func networkParams() -> [String: any Sendable] {
-    let path = currentNetworkPath()
-    var params: [String: any Sendable] = [
-      "expo.network.connected": path?.status == .satisfied
+  @AppMetricsActor
+  static func networkParams() async -> [String: any Sendable] {
+    let path = await NetworkPathMonitor.shared.waitForFirstPath()
+    return [
+      "expo.network.connected": path?.status == .satisfied,
+      "expo.network.type": networkTypeString(path)
     ]
-    params["expo.network.type"] = networkTypeString(path)
-    return params
-  }
-
-  private static func currentNetworkPath() -> NWPath? {
-    let monitor = NWPathMonitor()
-    let semaphore = DispatchSemaphore(value: 0)
-    let queue = DispatchQueue(label: "expo.appmetrics.networkSnapshot")
-    nonisolated(unsafe) var snapshot: NWPath?
-    monitor.pathUpdateHandler = { path in
-      snapshot = path
-      semaphore.signal()
-    }
-    monitor.start(queue: queue)
-    // NWPathMonitor delivers the initial path almost immediately (typically
-    // sub-millisecond). 5ms is a generous upper bound that still keeps TTI
-    // reporting on a tight budget.
-    // TODO: Replace this short-lived monitor with a long-lived one started at
-    // module init so the snapshot read is free and we don't block a
-    // cooperative-pool thread.
-    _ = semaphore.wait(timeout: .now() + .milliseconds(5))
-    monitor.cancel()
-    return snapshot
   }
 
   private static func thermalStateString(_ state: ProcessInfo.ThermalState) -> String {
@@ -113,27 +93,22 @@ enum DeviceConditions {
     }
   }
 
-  private static func networkTypeString(_ path: NWPath?) -> String {
+  private static func networkTypeString(_ path: NetworkPath?) -> String {
     guard let path else {
       return "unknown"
     }
     if path.status != .satisfied {
       return "none"
     }
-    if path.usesInterfaceType(.wifi) {
+    switch path.interfaceType {
+    case .wifi:
       return "wifi"
-    }
-    if path.usesInterfaceType(.cellular) {
+    case .cellular:
       return "cellular"
-    }
-    if path.usesInterfaceType(.wiredEthernet) {
+    case .ethernet:
       return "ethernet"
+    case .other, .none:
+      return "other"
     }
-    // `.loopback` is folded into `other`. The OS only reports loopback as the
-    // primary interface when no real network is up (in which case the path is
-    // already `.unsatisfied` above and we returned `none`) or in unusual
-    // simulator configurations — neither case is operationally meaningful for
-    // TTI, and dropping the value keeps the platform enums aligned.
-    return "other"
   }
 }


### PR DESCRIPTION
## Why

Followup to #45414. That PR added `expo.network.connected` and `expo.network.type` to the TTI metric using a short-lived `NWPathMonitor` + 5ms semaphore wait — pragmatic but with a self-review TODO calling out that it blocks a cooperative-pool thread for the duration of the wait.

This replaces it with a long-lived monitor started at app launch, so the snapshot read is free.

## What

- New `NetworkPath` Sendable value type — distilled from `NWPath` (which isn't `Sendable`) so the snapshot can cross actor boundaries safely.
- New `NetworkPathObserver` — owns the OS-level `NWPathMonitor` on a private dispatch queue, converts each `NWPath` into a `NetworkPath` snapshot, hands it to the delegate.
- New `NetworkPathMonitor` singleton — `@AppMetricsActor`-isolated. Caches the latest path. Started eagerly at `appDelegateWillBeginInitialization` so the cache is warm by the time `markInteractive` reads it.
- `DeviceConditions.networkParams()` is now `async` and awaits the first path delivery via `waitForFirstPath()`. The TTI value itself is captured from the synchronously-recorded `markers.timeToInteractive` timestamp before this runs, so awaiting the first path here only delays the local-storage write — not the metric measurement.

The 5ms semaphore wait, the `Network` import in `DeviceConditions`, and the inline `currentNetworkPath()` helper are gone. The TODO is gone.

## Implementation notes

- `waitForFirstPath()` uses an array of `CheckedContinuation`s rather than a single optional, so concurrent callers don't clobber each other's continuations. Useful if a future metric joins TTI in awaiting the first path.
- `NetworkPathObserver`'s `delegate` is `weak let` (Swift 6.2+).
- Tests seed `NetworkPathMonitor.shared` directly so they don't hang waiting for the OS to deliver a real path in the test process.

## Test plan

- [x] Unit tests for `NetworkPath` value type (interface-type defaults, equatable).
- [x] Unit tests for `NetworkPathMonitor` (caching, overwrites, immediate-return when cached).
- [x] Existing `AppStartupMonitoring` tests updated to seed the monitor; pass.
- [x] Manual: launch observe-tester, verify TTI metric still gets `expo.network.connected` and `expo.network.type` populated correctly across wifi / cellular / airplane mode.
- [x] Manual: confirm there's no observable startup-time regression from running the monitor app-wide.