### PR TITLE
[video][android] Fix `PictureInPictureHelperFragment` crashes on restoration after process death

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `PictureInPictureHelperFragment` crashes on restoration after process death. ([#45426](https://github.com/expo/expo/pull/45426) by [@behenate](https://github.com/behenate) and [@dive](https://github.com/dive))
+
 ### 💡 Others
 
 ## 56.0.0 — 2026-05-05

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/PictureInPictureHelperFragment.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/PictureInPictureHelperFragment.kt
@@ -1,5 +1,6 @@
 package expo.modules.video
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import java.lang.ref.WeakReference
 import java.util.UUID
@@ -9,21 +10,40 @@ interface PictureInPictureFragmentListener {
   fun onPictureInPictureStop()
 }
 
-class PictureInPictureHelperFragment(listener: PictureInPictureFragmentListener) : Fragment() {
+// Keep this fragment restorable after Android process death.
+// https://github.com/expo/expo/issues/42878
+// Related PiP refactor: https://github.com/expo/expo/issues/40157
+class PictureInPictureHelperFragment() : Fragment() {
+  constructor(listener: PictureInPictureFragmentListener) : this() {
+    this.listener = WeakReference(listener)
+  }
+
   val id = "${PictureInPictureHelperFragment::class.java.simpleName}_${UUID.randomUUID()}"
-  private val listener = WeakReference(listener)
+  private var listener: WeakReference<PictureInPictureFragmentListener>? = null
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    if (listener == null) {
+      parentFragmentManager
+        .beginTransaction()
+        .remove(this)
+        .commitAllowingStateLoss()
+    }
+  }
 
   fun release() {
-    listener.clear()
+    listener?.clear()
+    listener = null
   }
 
   override fun onPictureInPictureModeChanged(isInPictureInPictureMode: Boolean) {
     super.onPictureInPictureModeChanged(isInPictureInPictureMode)
 
     if (isInPictureInPictureMode) {
-      listener.get()?.onPictureInPictureStart()
+      listener?.get()?.onPictureInPictureStart()
     } else {
-      listener.get()?.onPictureInPictureStop()
+      listener?.get()?.onPictureInPictureStop()
     }
   }
 }


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/45234

The default generated Expo MainActivity uses super.onCreate(null), which masks this issue by discarding Activity saved state. Apps that preserve Activity state restoration can hit the crash.

# How

Add a no-arg constructor (required for fragment restoration), and self-removethe restored zombie fragment in onCreate when no listener is attached.


# Test Plan

Tested in the provided repro app, by running the following commands:

```
adb shell input keyevent KEYCODE_HOME
adb shell dumpsys activity activities | grep -E "dev.expo.videopiprestoreissue/.MainActivity|mHaveState|mIcicle|state=STOPPED"
adb shell am kill dev.expo.videopiprestoreissue
adb shell am start -n dev.expo.videopiprestoreissue/.MainActivity -a android.intent.action.MAIN -c android.intent.category.LAUNCHER
```
