### PR TITLE
[tools] Migrate to pnpm

### DIFF
--- a/tools/src/Workspace.test.ts
+++ b/tools/src/Workspace.test.ts
@@ -1,0 +1,195 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { EXPO_DIR } from './Constants';
+import { Package, PackageJson } from './Packages';
+import { buildWorkspacesInfo } from './Workspace';
+
+function makePackage(
+  packageName: string,
+  packageJson: Partial<PackageJson> & { version: string },
+  relPath?: string
+): Package {
+  // The directory name does NOT have to match the package name — that's the
+  // whole point of the regression these tests cover.
+  const dirName = relPath ?? packageName.replace(/^@[^/]+\//, '');
+  return new Package(path.join(EXPO_DIR, 'packages', dirName), {
+    name: packageName,
+    scripts: {},
+    ...packageJson,
+  } as PackageJson);
+}
+
+describe('buildWorkspacesInfo', () => {
+  it('returns empty info for an empty workspace', () => {
+    assert.deepEqual(buildWorkspacesInfo([]), {});
+  });
+
+  it('classifies regular dependencies that satisfy the local version', () => {
+    const expo = makePackage('expo', { version: '56.0.1' });
+    const consumer = makePackage('consumer', {
+      version: '1.0.0',
+      dependencies: { expo: '^56.0.0' },
+    });
+
+    const info = buildWorkspacesInfo([expo, consumer]);
+
+    assert.deepEqual(info.consumer.workspaceDependencies, ['expo']);
+    assert.deepEqual(info.consumer.mismatchedWorkspaceDependencies, []);
+  });
+
+  it('classifies regular dependencies whose range does not satisfy the local version as mismatched', () => {
+    const expo = makePackage('expo', { version: '56.0.1' });
+    const consumer = makePackage('consumer', {
+      version: '1.0.0',
+      dependencies: { expo: '~55.0.0' },
+    });
+
+    const info = buildWorkspacesInfo([expo, consumer]);
+
+    assert.deepEqual(info.consumer.workspaceDependencies, []);
+    assert.deepEqual(info.consumer.mismatchedWorkspaceDependencies, ['expo']);
+  });
+
+  it('treats workspace: protocol specs as always-satisfying (pnpm linkWorkspacePackages: deep)', () => {
+    const expo = makePackage('expo', { version: '56.0.1' });
+    const consumer = makePackage('consumer', {
+      version: '1.0.0',
+      dependencies: {
+        expo: 'workspace:*',
+      },
+      devDependencies: {
+        // Even an explicit workspace:~55 range still resolves locally under pnpm.
+        'expo-dev': 'workspace:~55.0.0',
+      },
+    });
+    const expoDev = makePackage('expo-dev', { version: '56.0.1' });
+
+    const info = buildWorkspacesInfo([expo, consumer, expoDev]);
+
+    assert.deepEqual(info.consumer.workspaceDependencies.sort(), ['expo', 'expo-dev']);
+    assert.deepEqual(info.consumer.mismatchedWorkspaceDependencies, []);
+  });
+
+  it('populates workspacePeerDependencies for peer-deps that point at workspace packages', () => {
+    const expo = makePackage('expo', { version: '56.0.1' });
+    // The directory differs from the package name — the previous yarn-based
+    // implementation silently dropped this case.
+    const ui = makePackage(
+      '@expo/ui',
+      {
+        version: '56.0.1',
+        peerDependencies: {
+          expo: 'workspace:*',
+          react: '*',
+        },
+      },
+      'expo-ui'
+    );
+
+    const info = buildWorkspacesInfo([expo, ui]);
+
+    assert.deepEqual(info['@expo/ui'].workspacePeerDependencies, ['expo']);
+    assert.deepEqual(info['@expo/ui'].mismatchedWorkspacePeerDependencies, []);
+    // `react` isn't a workspace package, so it's not classified as a workspace peer.
+    assert.ok(!info['@expo/ui'].workspacePeerDependencies.includes('react'));
+  });
+
+  it('flags peer pins whose range does not satisfy the local peer version', () => {
+    const expo = makePackage('expo', { version: '56.0.0-preview.2' });
+    const cli = makePackage('@expo/cli', {
+      version: '56.0.2',
+      peerDependencies: {
+        expo: '56.0.0-preview.1', // exact pin to an older expo
+      },
+    });
+
+    const info = buildWorkspacesInfo([expo, cli]);
+
+    assert.deepEqual(info['@expo/cli'].workspacePeerDependencies, ['expo']);
+    assert.deepEqual(info['@expo/cli'].mismatchedWorkspacePeerDependencies, ['expo']);
+  });
+
+  it('keeps mismatchedWorkspacePeerDependencies as a subset of workspacePeerDependencies', () => {
+    const expo = makePackage('expo', { version: '56.0.0-preview.2' });
+    const reanimated = makePackage('react-native-reanimated', { version: '4.3.0' });
+    const consumer = makePackage('consumer', {
+      version: '1.0.0',
+      peerDependencies: {
+        expo: '56.0.0-preview.1', // mismatched
+        'react-native-reanimated': 'workspace:*', // satisfied
+        react: '*', // not a workspace package
+      },
+    });
+
+    const info = buildWorkspacesInfo([expo, reanimated, consumer]);
+
+    assert.deepEqual(info.consumer.workspacePeerDependencies.sort(), [
+      'expo',
+      'react-native-reanimated',
+    ]);
+    assert.deepEqual(info.consumer.mismatchedWorkspacePeerDependencies, ['expo']);
+  });
+
+  it('populates workspaceOptionalDependencies separately from regular deps', () => {
+    const expo = makePackage('expo', { version: '56.0.1' });
+    const consumer = makePackage('consumer', {
+      version: '1.0.0',
+      optionalDependencies: { expo: 'workspace:*' },
+    });
+
+    const info = buildWorkspacesInfo([expo, consumer]);
+
+    assert.deepEqual(info.consumer.workspaceOptionalDependencies, ['expo']);
+    assert.deepEqual(info.consumer.workspaceDependencies, []);
+  });
+
+  it('ignores deps whose name does not match a workspace package', () => {
+    const expo = makePackage('expo', { version: '56.0.1' });
+    const consumer = makePackage('consumer', {
+      version: '1.0.0',
+      dependencies: {
+        expo: '^56.0.0',
+        'react-native': '0.85.2',
+      },
+    });
+
+    const info = buildWorkspacesInfo([expo, consumer]);
+
+    assert.deepEqual(info.consumer.workspaceDependencies, ['expo']);
+  });
+
+  it('records each project at its location relative to EXPO_DIR', () => {
+    const ui = makePackage('@expo/ui', { version: '56.0.1' }, 'expo-ui');
+
+    const info = buildWorkspacesInfo([ui]);
+
+    assert.equal(info['@expo/ui'].location, 'packages/expo-ui');
+  });
+
+  it('matches prerelease ranges that explicitly target the same prerelease line', () => {
+    const expo = makePackage('expo', { version: '56.0.0-preview.2' });
+    const tilde = makePackage('tilde-consumer', {
+      version: '1.0.0',
+      dependencies: { expo: '~56.0.0-preview.0' },
+    });
+
+    const info = buildWorkspacesInfo([expo, tilde]);
+
+    assert.deepEqual(info['tilde-consumer'].workspaceDependencies, ['expo']);
+  });
+
+  it('flags non-prerelease ranges against prerelease versions as mismatched', () => {
+    const expo = makePackage('expo', { version: '56.0.0-preview.2' });
+    const caret = makePackage('caret-consumer', {
+      version: '1.0.0',
+      dependencies: { expo: '^56.0.0' },
+    });
+
+    const info = buildWorkspacesInfo([expo, caret]);
+
+    assert.deepEqual(info['caret-consumer'].workspaceDependencies, []);
+    assert.deepEqual(info['caret-consumer'].mismatchedWorkspaceDependencies, ['expo']);
+  });
+});

--- a/tools/src/Workspace.ts
+++ b/tools/src/Workspace.ts
@@ -1,8 +1,9 @@
 import JsonFile from '@expo/json-file';
 import path from 'path';
+import * as semver from 'semver';
 
 import { EXPO_DIR, EXPO_GO_DIR } from './Constants';
-import { DependencyKind, getPackageByName, Package } from './Packages';
+import { DependencyKind, Package, PackageJson } from './Packages';
 import { spawnAsync, spawnJSONCommandAsync } from './Utils';
 
 const NATIVE_APPS_PATHS = [EXPO_GO_DIR, path.join(EXPO_DIR, 'apps/bare-expo')];
@@ -13,13 +14,15 @@ const NATIVE_APPS_PATHS = [EXPO_GO_DIR, path.join(EXPO_DIR, 'apps/bare-expo')];
 export type WorkspaceProjectInfo = {
   /** The relative location of the workspace within this monorepo */
   location: string;
-  /** All `dependencies` or `devDependencies` that points to workspaces, but use a different version which is downloaded from npm */
+  /** All `dependencies` or `devDependencies` that point to workspaces but use a version range that does not satisfy the local workspace package's version */
   mismatchedWorkspaceDependencies: string[];
-  /** All `dependencies` or `devDependencies` that points to other workspaces in this monorepo */
+  /** All `dependencies` or `devDependencies` that point to other workspaces in this monorepo */
   workspaceDependencies: string[];
-  /** All `peerDependencies` that points to other workspaces in this monorepo */
+  /** All `peerDependencies` that point to other workspaces in this monorepo */
   workspacePeerDependencies: string[];
-  /** All `optionalDependencies` that points to other workspaces in this monorepo */
+  /** Subset of `workspacePeerDependencies` where the declared peer range does not satisfy the local workspace package's version. Catches peer pins that have drifted past a peer's published version (e.g. `peer.expo: "56.0.0-preview.1"` after `expo` bumped to `56.0.0-preview.2`). */
+  mismatchedWorkspacePeerDependencies: string[];
+  /** All `optionalDependencies` that point to other workspaces in this monorepo */
   workspaceOptionalDependencies: string[];
 };
 
@@ -28,55 +31,115 @@ export type WorkspaceProjectInfo = {
  */
 export type WorkspacesInfo = Record<string, WorkspaceProjectInfo>;
 
+type PnpmProjectListing = {
+  name?: string;
+  version?: string;
+  path: string;
+  private?: boolean;
+};
+
 /**
  * Returns an object containing info for all projects in the workspace.
  */
 export async function getInfoAsync(): Promise<WorkspacesInfo> {
-  // This only lists workspace dependencies from `dependencies` and `devDependencies`.
-  const info = await spawnJSONCommandAsync<{ data: string }>('yarn', [
-    '--json',
-    'workspaces',
-    'info',
-  ]);
+  const projects = await listWorkspaceProjectsAsync();
+  const packages = projects
+    .filter((project) => path.resolve(project.path) !== path.resolve(EXPO_DIR))
+    .map((project) => {
+      const packageJsonPath = path.join(project.path, 'package.json');
+      const packageJson = require(packageJsonPath) as PackageJson;
+      return new Package(project.path, packageJson);
+    })
+    .filter((pkg) => !!pkg.packageName);
 
-  const workspaces = JSON.parse(info.data) as WorkspacesInfo;
+  return buildWorkspacesInfo(packages);
+}
 
-  for (const workspaceName in workspaces) {
-    const workspace = workspaces[workspaceName];
-    const workspacePackage = getPackageByName(workspaceName);
-
-    if (!workspacePackage) {
-      workspace.workspacePeerDependencies = [];
-      workspace.workspaceOptionalDependencies = [];
-      continue;
-    }
-
-    // Load all `peerDependencies` of the workspace
-    workspace.workspacePeerDependencies = workspacePackage
-      .getDependencies([DependencyKind.Peer])
-      .filter((dependency) => !!workspaces[dependency.name])
-      .map((dependency) => dependency.name);
-
-    // Load all `optionalDependencies` of the workspace
-    workspace.workspaceOptionalDependencies = workspacePackage
-      .getDependencies([DependencyKind.Optional])
-      .filter((dependency) => !!workspaces[dependency.name])
-      .map((dependency) => dependency.name);
+export function buildWorkspacesInfo(packages: Package[]): WorkspacesInfo {
+  const packagesByName = new Map<string, Package>();
+  for (const pkg of packages) {
+    packagesByName.set(pkg.packageName, pkg);
   }
 
-  return workspaces;
+  const result: WorkspacesInfo = {};
+  for (const pkg of packages) {
+    result[pkg.packageName] = {
+      location: path.relative(EXPO_DIR, pkg.path),
+      ...classifyDependencies(pkg, packagesByName),
+    };
+  }
+  return result;
+}
+
+function classifyDependencies(pkg: Package, byName: Map<string, Package>) {
+  const workspaceDependencies: string[] = [];
+  const mismatchedWorkspaceDependencies: string[] = [];
+
+  for (const dep of pkg.getDependencies([DependencyKind.Normal, DependencyKind.Dev])) {
+    const target = byName.get(dep.name);
+    if (!target) continue;
+    if (rangeSatisfies(dep.versionRange, target.packageJson.version)) {
+      workspaceDependencies.push(dep.name);
+    } else {
+      mismatchedWorkspaceDependencies.push(dep.name);
+    }
+  }
+
+  const workspacePeerDependencies: string[] = [];
+  const mismatchedWorkspacePeerDependencies: string[] = [];
+  for (const dep of pkg.getDependencies([DependencyKind.Peer])) {
+    const target = byName.get(dep.name);
+    if (!target) continue;
+    workspacePeerDependencies.push(dep.name);
+    if (!rangeSatisfies(dep.versionRange, target.packageJson.version)) {
+      mismatchedWorkspacePeerDependencies.push(dep.name);
+    }
+  }
+
+  const workspaceOptionalDependencies = pkg
+    .getDependencies([DependencyKind.Optional])
+    .filter((dep) => byName.has(dep.name))
+    .map((dep) => dep.name);
+
+  return {
+    workspaceDependencies,
+    mismatchedWorkspaceDependencies,
+    workspacePeerDependencies,
+    mismatchedWorkspacePeerDependencies,
+    workspaceOptionalDependencies,
+  };
 }
 
 /**
- * Runs yarn in the root workspace directory.
+ * Whether a dependency's declared range will resolve to the local workspace
+ * package's version. The pnpm `workspace:` protocol always links locally, so
+ * any `workspace:*`/`workspace:^`/etc. counts as a match regardless of the
+ * embedded range.
  */
+function rangeSatisfies(range: string, version: string): boolean {
+  if (range.startsWith('workspace:')) {
+    return true;
+  }
+  try {
+    return semver.satisfies(version, range, { includePrerelease: true });
+  } catch {
+    return false;
+  }
+}
+
+async function listWorkspaceProjectsAsync(): Promise<PnpmProjectListing[]> {
+  return await spawnJSONCommandAsync<PnpmProjectListing[]>('pnpm', [
+    '-r',
+    '--depth=-1',
+    'ls',
+    '--json',
+  ]);
+}
+
 export async function installAsync(): Promise<void> {
   await spawnAsync('yarn');
 }
 
-/**
- * Returns an array of workspace's native apps, like Expo Client or BareExpo.
- */
 export function getNativeApps(): Package[] {
   return NATIVE_APPS_PATHS.map((appPath) => new Package(appPath));
 }

--- a/tools/src/commands/ValidateWorkspaceDependencies.ts
+++ b/tools/src/commands/ValidateWorkspaceDependencies.ts
@@ -14,38 +14,82 @@ export default (program: Command) => {
 
 async function actionAsync() {
   const workspacePackages = await getWorkspacePackagesAsync();
+
   const workspacesMismatched = Object.values(workspacePackages).filter(
     (workspace) => workspace.mismatchedWorkspaceDependencies.length
   );
+  const workspacesWithMismatchedPeers = Object.values(workspacePackages).filter(
+    (workspace) => workspace.mismatchedWorkspacePeerDependencies.length
+  );
 
-  if (!workspacesMismatched.length) {
-    console.log(`✅  Verified that all workspace packages are symlinked.`);
+  if (!workspacesMismatched.length && !workspacesWithMismatchedPeers.length) {
+    console.log(
+      `✅  Verified that all workspace packages are symlinked and peer pins are in sync.`
+    );
     return;
   }
 
-  console.warn(
-    workspacesMismatched.length === 1
-      ? `⚠️  Found 1 workspace package installed from npm instead of this repository.`
-      : `⚠️  Found ${workspacesMismatched.length} workspace packages installed from npm instead of this repository.`
-  );
-
-  for (const workspace of workspacesMismatched) {
-    const mismatched = workspace.mismatchedWorkspaceDependencies;
-
-    console.warn();
+  if (workspacesMismatched.length) {
     console.warn(
-      mismatched.length === 1
-        ? `${workspace._name} has 1 workspace package that isn't symlinked:`
-        : `${workspace._name} has ${mismatched.length} workspace packages that aren't symlinked:`
+      workspacesMismatched.length === 1
+        ? `⚠️  Found 1 workspace package installed from npm instead of this repository.`
+        : `⚠️  Found ${workspacesMismatched.length} workspace packages installed from npm instead of this repository.`
     );
 
-    for (const dependency of mismatched) {
-      const workspaceVersion = workspacePackages[dependency]._version;
-      const installedVersion = await getResolvedVersionAsync(workspace._directory, dependency);
+    for (const workspace of workspacesMismatched) {
+      const mismatched = workspace.mismatchedWorkspaceDependencies;
 
+      console.warn();
       console.warn(
-        `- ${dependency}@${installedVersion} is installed, but workspace package is at ${workspaceVersion}`
+        mismatched.length === 1
+          ? `${workspace._name} has 1 workspace package that isn't symlinked:`
+          : `${workspace._name} has ${mismatched.length} workspace packages that aren't symlinked:`
       );
+
+      for (const dependency of mismatched) {
+        const workspaceVersion = workspacePackages[dependency]._version;
+        const installedVersion = await getResolvedVersionAsync(workspace._directory, dependency);
+
+        console.warn(
+          `- ${dependency}@${installedVersion} is installed, but workspace package is at ${workspaceVersion}`
+        );
+      }
+    }
+  }
+
+  if (workspacesWithMismatchedPeers.length) {
+    console.warn();
+    console.warn(
+      workspacesWithMismatchedPeers.length === 1
+        ? `⚠️  Found 1 workspace package with a stale peerDependency pin to another workspace package.`
+        : `⚠️  Found ${workspacesWithMismatchedPeers.length} workspace packages with stale peerDependency pins to other workspace packages.`
+    );
+    console.warn(
+      `   These pins ship to npm verbatim. After a peer's version bumps past the pinned range, every install of these packages emits "incorrect peer dependency" warnings until the dependent is republished.`
+    );
+
+    for (const workspace of workspacesWithMismatchedPeers) {
+      const mismatched = workspace.mismatchedWorkspacePeerDependencies;
+      const declaredPeers =
+        (require(path.join(workspace._directory, 'package.json')).peerDependencies as
+          | Record<string, string>
+          | undefined) ?? {};
+
+      console.warn();
+      console.warn(
+        mismatched.length === 1
+          ? `${workspace._name} has 1 stale peer pin:`
+          : `${workspace._name} has ${mismatched.length} stale peer pins:`
+      );
+
+      for (const dependency of mismatched) {
+        const peerVersion = workspacePackages[dependency]._version;
+        const declaredRange = declaredPeers[dependency];
+
+        console.warn(
+          `- peerDependencies.${dependency} declares "${declaredRange}", but workspace ${dependency} is at ${peerVersion}`
+        );
+      }
     }
   }
 

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -40,6 +40,7 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
           .map((dep) => dep.name),
         mismatchedWorkspaceDependencies: [],
         workspacePeerDependencies: [],
+        mismatchedWorkspacePeerDependencies: [],
         workspaceOptionalDependencies: [],
       };
     });
@@ -142,6 +143,14 @@ function shouldUpdateDependencyVersion(context: {
 }) {
   // Do not update the version if there is no current version range
   if (!context.currentVersionRange) {
+    return false;
+  }
+
+  // Skip workspace: specs entirely. pnpm resolves them to concrete versions
+  // at pack time, so the published artifact gets the right version while the
+  // source stays as the workspace-protocol declaration. Rewriting source
+  // would flush the prefix and propagate concrete pins back into the repo.
+  if (context.currentVersionRange.startsWith('workspace:')) {
     return false;
   }
 


### PR DESCRIPTION
## Why

`tools/src/Workspace.ts` shelled out to `yarn workspaces info` to enumerate the monorepo. The post-processing step relied on`getPackageByName`, which assumes a workspace package's directory name matches its `package.json` `name`. That assumption fails for scoped packages like `@expo/ui` (lives at `packages/expo-ui/`) and `@expo/app-integrity` — their `workspacePeerDependencies` came back empty, silently masking peer specs from `updateWorkspaceProjects` during publish.

That's why `@expo/ui@56.0.0` shipped to npm with `peerDependencies.expo = "workspace:*"` and broke installs.

## How
- Replace `yarn workspaces info` with `pnpm m ls --json --depth=-1` that constructs `WorkspacesInfo` directly from each package's `package.json`. Drops the `getPackageByName` lookup.
- Add `mismatchedWorkspacePeerDependencies` to `WorkspaceProjectInfo` (subset of`workspacePeerDependencies` whose declared range doesn't satisfy the local workspace version) and surface it in `et validate-workspace-dependencies` so stale peer pins get caught before they ship.
- New unit tests in `Workspace.test.ts` exercising the pure builder against fixture monorepos including the `@expo/ui`\-shaped dir-mismatch case.

## Test plan
`et validate-workspace-dependencies` passes
`et publish-packages --dry @expo/ui expo` produces a clean dry-run with
`peerDependencies.expo` rewritten to the new `expo` version