### PR TITLE
[tools] Update npm commands to pnpm

### DIFF
--- a/tools/src/Npm.ts
+++ b/tools/src/Npm.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import { glob } from 'glob';
+import path from 'path';
 
 import { spawnAsync, spawnJSONCommandAsync, SpawnOptions } from './Utils';
 
@@ -41,23 +42,13 @@ export type ProfileType = null | {
 };
 
 /**
- * Represents an object returned by `npm pack --json`.
+ * Represents an object returned by `pnpm pack --json`.
  */
 export type PackResult = {
-  id: string;
   name: string;
   version: string;
-  size: number;
-  unpackedSize: number;
-  shasum: string;
-  integrity: string;
   filename: string;
-  files: {
-    path: string;
-    size: number;
-    mode: number;
-  }[];
-  entryCount: number;
+  files: { path: string }[];
 };
 
 /**
@@ -111,18 +102,28 @@ export async function downloadPackageTarballAsync(
 
 /**
  * Creates a tarball from a package.
+ *
+ * We deliberately don't use `pnpm pack --json` here: pnpm prefixes the JSON
+ * output with `prepack`/`prepare` lifecycle script stdout, which breaks
+ * `JSON.parse` for packages that define those scripts. Instead we let `pnpm pack` write the
+ * tarball to the package directory and discover the produced file via glob,
+ * matching what is done by `downloadPackageTarballAsync` above.
  */
 export async function packToTarballAsync(packageDir: string): Promise<PackResult> {
-  const [result] = await spawnJSONCommandAsync<PackResult[]>(
-    'npm',
-    ['pack', '--json', '--foreground-scripts=false'],
-    {
-      cwd: packageDir,
-      // Prevent expo-module-scripts from auto-adding --watch during lifecycle scripts
-      env: { ...process.env, EXPO_NONINTERACTIVE: '1' },
-    }
-  );
-  return result;
+  await spawnAsync('pnpm', ['pack'], {
+    cwd: packageDir,
+    stdio: 'ignore',
+    // Prevent expo-module-scripts from auto-adding --watch during lifecycle scripts
+    env: { ...process.env, EXPO_NONINTERACTIVE: '1' },
+  });
+
+  const tarballs = await glob('*.tgz', { cwd: packageDir });
+  if (tarballs.length === 0) {
+    throw new Error(`pnpm pack did not produce a tarball in ${packageDir}`);
+  }
+
+  const { name, version } = require(path.join(packageDir, 'package.json'));
+  return { name, version, filename: tarballs[0], files: [] };
 }
 
 type PublishOptions = {
@@ -142,18 +143,19 @@ export async function publishPackageAsync(
   const args = [
     'publish',
     options.source ?? '.',
-    // omitting the tag parameter, will make npm publish and mark the as "latest"
+    // omitting the tag parameter, will make pnpm publish and mark the as "latest"
     '--tag',
     options.tagName ?? 'latest',
     '--access',
     'public',
+    '--no-git-checks',
   ];
 
   if (options.dryRun) {
     args.push('--dry-run');
   }
   args.push(...maybeNpmOtpFlag());
-  await spawnAsync('npm', args, {
+  await spawnAsync('pnpm', args, {
     cwd: packageDir,
     // Prevent expo-module-scripts from auto-adding --watch during lifecycle scripts
     env: { ...process.env, EXPO_NONINTERACTIVE: '1' },
@@ -180,7 +182,7 @@ export async function addTagAsync(
   spawnOptions?: SpawnOptions
 ): Promise<void> {
   await spawnAsync(
-    'npm',
+    'pnpm',
     ['dist-tag', 'add', `${packageName}@${version}`, tagName, ...maybeNpmOtpFlag()],
     spawnOptions
   );
@@ -196,7 +198,7 @@ export async function removeTagAsync(
 ): Promise<void> {
   try {
     await spawnAsync(
-      'npm',
+      'pnpm',
       ['dist-tag', 'rm', packageName, tagName, ...maybeNpmOtpFlag()],
       spawnOptions
     );


### PR DESCRIPTION
# Why

A recent publish shipped with `workspace:*` strings embedded in several published `package.json`'s . Each shipped because `npm pack` doesn't understand pnpm's workspace protocol and serializes the literal string into the tarball. I patched around it once with a `resolveWorkspaceSpecs` task (reverted) and won't attempt that again.

# How

`tools/src/Npm.ts`'s shell-outs migrate from `npm` to `pnpm` for the publish-path operations:

- `publishPackageAsync:` `pnpm publish`. Adds `--no-git-checks` since we already enforce via
`checkRepositoryStatus`.
- `packToTarballAsync:` `pnpm pack`resolves `workspace:` specs to concrete
versions at pack time.
- `addTagAsync` / `removeTagAsync` — `pnpm dist-tag. Added for consistency,`delegates to npm.

# Test Plan

- `pnpm pack` an expo workspace package locally and confirm the tarball's
`package.json` has no `"workspace:` substrings
- `pnpm publish --dry-run` runs `prepublishOnly`

