### PR TITLE
[tools] Drop remaining yarn and npm refs

### DIFF
--- a/tools/src/Workspace.ts
+++ b/tools/src/Workspace.ts
@@ -136,8 +136,11 @@ async function listWorkspaceProjectsAsync(): Promise<PnpmProjectListing[]> {
   ]);
 }
 
+/**
+ * Runs `pnpm install` in the root workspace directory.
+ */
 export async function installAsync(): Promise<void> {
-  await spawnAsync('yarn');
+  await spawnAsync('pnpm', ['install']);
 }
 
 export function getNativeApps(): Package[] {

--- a/tools/src/commands/CheckPackages.ts
+++ b/tools/src/commands/CheckPackages.ts
@@ -22,7 +22,7 @@ export default (program: Command) => {
     .option('--no-build', 'Whether to skip `pnpm build` check.', false)
     .option('--no-test', 'Whether to skip `pnpm test` check.', false)
     .option('--no-lint', 'Whether to skip `pnpm lint` check.', false)
-    .option('--fix-lint', 'Whether to run `pnpm lint --fix` instead of `yarn lint`.', false)
+    .option('--fix-lint', 'Whether to run `pnpm lint --fix` instead of `pnpm lint`.', false)
     .option(
       '--no-uniformity-check',
       'Whether to check the uniformity of committed and generated build files.',

--- a/tools/src/commands/GenerateBareApp.ts
+++ b/tools/src/commands/GenerateBareApp.ts
@@ -258,7 +258,7 @@ async function runExpoPrebuild({
   if (useLocalTemplate) {
     const pathToBareTemplate = path.resolve(EXPO_DIR, 'templates', 'expo-template-bare-minimum');
     const templateVersion = require(path.join(pathToBareTemplate, 'package.json')).version;
-    await spawnAsync('npm', ['pack', '--pack-destination', projectDir], {
+    await spawnAsync('pnpm', ['pack', '--pack-destination', projectDir], {
       cwd: pathToBareTemplate,
       stdio: 'ignore',
     });

--- a/tools/src/commands/SetupReactNativeNightly.ts
+++ b/tools/src/commands/SetupReactNativeNightly.ts
@@ -48,7 +48,7 @@ async function main() {
   };
   await addPinnedPackagesAsync(pinnedPackages);
 
-  logger.info('Yarning...');
+  logger.info('Installing...');
   await workspaceInstallAsync();
 
   const patches = [
@@ -100,7 +100,7 @@ async function addBareExpoOptionalPackagesAsync() {
     logger.log('  ', pkg);
   }
 
-  await spawnAsync('yarn', ['add', ...installPackages], { cwd: bareExpoRoot });
+  await spawnAsync('pnpm', ['add', ...installPackages], { cwd: bareExpoRoot });
 }
 
 async function addPinnedPackagesAsync(packages: Record<string, string>) {

--- a/tools/src/prebuilds/ExternalPackage.ts
+++ b/tools/src/prebuilds/ExternalPackage.ts
@@ -114,7 +114,7 @@ export class ExternalPackage implements SPMPackageSource {
     if (!fs.existsSync(this.path)) {
       throw new Error(
         `External package "${packageName}" not found in node_modules. ` +
-          `Expected at: ${this.path}. Please run yarn install.`
+          `Expected at: ${this.path}. Please run pnpm install.`
       );
     }
 


### PR DESCRIPTION
# Why

Cleanup pass after the main pnpm migration in `Workspace.ts` and `Npm.ts`removing  yarn/npm references in tooling and one error message.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Grepped for and removed remiaing references to yarn/npm

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan