### PR TITLE
fix(precompile): fix log warning being treated as error in pod install

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Avoid logging the precompiled modules React Native fallback as a CocoaPods warning.
+- [iOS] Avoid logging the precompiled modules React Native fallback as a CocoaPods warning. ([#45431](https://github.com/expo/expo/pull/45431) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Avoid logging the precompiled modules React Native fallback as a CocoaPods warning.
+
 ### 💡 Others
 
 ## 56.0.0 — 2026-05-05

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -101,14 +101,14 @@ module Expo
       # Precompiled module xcframeworks are linked against the prebuilt
       # React.xcframework, so they also require RCT_USE_PREBUILT_RNCORE=1. If
       # the user opted in to precompiled modules but React Native is still set
-      # to build from source, fall back to source-built modules and warn once.
+      # to build from source, fall back to source-built modules and print once.
       def enabled?
         return false unless ENV[ENV_VAR] == '1'
         return true if prebuilt_react_active?
 
         unless @warned_no_prebuilt_react
           @warned_no_prebuilt_react = true
-          Pod::UI.warn "[Expo] EXPO_USE_PRECOMPILED_MODULES=1 was set, but React Native is configured to build from source (RCT_USE_PREBUILT_RNCORE is not 1). Precompiled Expo modules require the prebuilt React.xcframework, so every Expo module will be built from source for this install. To use precompiled modules, ensure `ios.buildReactNativeFromSource` is not `true` in the `expo-build-properties` plugin (the default uses the prebuilt framework), or export RCT_USE_PREBUILT_RNCORE=1 before running `pod install`."
+          Pod::UI.puts "[Expo] EXPO_USE_PRECOMPILED_MODULES=1 was set, but React Native is configured to build from source (RCT_USE_PREBUILT_RNCORE is not 1). Precompiled Expo modules require the prebuilt React.xcframework, so every Expo module will be built from source for this install. To use precompiled modules, ensure `ios.buildReactNativeFromSource` is not `true` in the `expo-build-properties` plugin (the default uses the prebuilt framework), or export RCT_USE_PREBUILT_RNCORE=1 before running `pod install`.".yellow
         end
         false
       end


### PR DESCRIPTION
## Why

When running pod install with `EXPO_USE_PRECOMPILED_MODULES=1` with React Native built from source, a warning about falling back to source build for the Expo Modules is picked up as an error in EAS build logs:

```
[!] [Expo] EXPO_USE_PRECOMPILED_MODULES=1 was set, but React Native is configured to build from source (RCT_USE_PREBUILT_RNCORE is not 1). Precompiled Expo modules require the prebuilt React.xcframework, so every Expo module will be built from source for this install. To use precompiled modules, ensure `ios.buildReactNativeFromSource` is not `true` in the `expo-build-properties` plugin (the default uses the prebuilt framework), or export RCT_USE_PREBUILT_RNCORE=1 before running `pod install`.
```

This looks like the source of the error, but is actually not.

## How

This PR fixes this by changing the log from using `Pod::UI.warn` to `Pod::UI.puts`.

## Test-plan

✅ Run builds with `EXPO_USE_PRECOMPILED_MODULES=1` and `buildReactNativeFromSource`.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
