### PR TITLE
[core][Android] Bump pika to `0.3.2`

### DIFF
--- a/apps/test-suite/tests/Haptics.js
+++ b/apps/test-suite/tests/Haptics.js
@@ -3,13 +3,13 @@ import * as Haptics from 'expo-haptics';
 export const name = 'Haptics';
 
 export async function test(t) {
-  t.describe('Haptics', async () => {
+  t.describe('Haptics', () => {
     t.it('selectionAsync()', async () => {
       const result = await Haptics.selectionAsync();
       t.expect(result).toBeUndefined();
     });
 
-    t.describe('notificationAsync()', async () => {
+    t.describe('notificationAsync()', () => {
       t.it('success', async () => {
         const result = await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         t.expect(result).toBeUndefined();
@@ -26,7 +26,7 @@ export async function test(t) {
       });
     });
 
-    t.describe('impactAsync()', async () => {
+    t.describe('impactAsync()', () => {
       t.it('light', async () => {
         const result = await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
         t.expect(result).toBeUndefined();

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -230,7 +230,7 @@ dependencies {
     implementation workletsProject
   }
 
-  implementation("io.github.lukmccall.pika:pika-api:0.2.1-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-api:0.3.2")
 
   testImplementation 'androidx.test:core:1.7.0'
   testImplementation 'junit:junit:4.13.2'

--- a/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
   compileOnly("com.android.tools.build:gradle:8.5.0")
   implementation("com.facebook.react:react-native-gradle-plugin")
   implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
-  implementation("io.github.lukmccall.pika:pika-gradle:0.2.1-2.1.20")
+  implementation("io.github.lukmccall.pika:pika-gradle:0.3.2")
 
   if (isExpoAutolinkingSettingsPluginAvailable) {
     implementation("expo.modules:expo-autolinking-plugin-shared")


### PR DESCRIPTION
# Why

Bumps pika to `0.3.2`.
This version introduces a new release schema, allowing us to change the Kotlin version dynamically. This took a lot of time. Hopefully, it will work fine.

# Test Plan

- bare-expo ✅ 
- unit test ✅ 