### PR TITLE
fix(precompile): reduce prominence of 3rd party fallback logs

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Reduce prominence of expected source-build fallback logs for missing external precompiled XCFrameworks.
+
 ## 56.0.0 — 2026-05-05
 
 ### 🎉 New features

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 💡 Others
 
-- [iOS] Reduce prominence of expected source-build fallback logs for missing external precompiled XCFrameworks.
+- [iOS] Reduce prominence of expected source-build fallback logs for missing external precompiled XCFrameworks. ([#45435](https://github.com/expo/expo/pull/45435) by [@chrfalch](https://github.com/chrfalch))
 
 ## 56.0.0 — 2026-05-05
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -1665,7 +1665,8 @@ module Expo
           unless has_prebuilt_xcframework?(pod_name)
             product_name = info[:product_name] || pod_name
             expected = File.join(info[:build_output_dir], build_flavor, 'xcframeworks', "#{product_name}.tar.gz")
-            Pod::UI.warn "[Expo-precompiled] #{pod_name}: prebuilt xcframework not found. Expected tarball at #{expected}"
+            Pod::UI.puts "#{'[Expo-precompiled] '.blue}#{"#{pod_name}: prebuilt xcframework unavailable; building from source".yellow}"
+            Pod::UI.puts "#{'[Expo-precompiled] '.blue}#{gray("  Expected tarball: #{expected}")}"
             next
           end
 


### PR DESCRIPTION
## Why

Missing external precompiled XCFrameworks are an expected source-build fallback when `EXPO_USE_PRECOMPILED_MODULES=1` is enabled without matching third-party prebuild artifacts. Reporting these as CocoaPods warnings makes successful installs look more concerning than they are.

## How

Changed the missing external prebuild message from `Pod::UI.warn` to `Pod::UI.puts`, while keeping the fallback notice and expected tarball path in the logs.

## Test-plan

✅ Run `EXPO_USE_PRECOMPILED_MODULES=1 pod-install` and verify that we see the messages about 3rd party frameworks like Reanimated, RNScreens etc is not found as XCFrameworks.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)