### PR TITLE
[docs] Fix indentations in the tutorial code piece

### DIFF
--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -346,17 +346,17 @@ type Props = PropsWithChildren<{
 export default function EmojiPicker({ isVisible, children, onClose }: Props) {
   return (
     <View>
-    <Modal animationType="slide" transparent={true} visible={isVisible}>
-      <View style={styles.modalContent}>
-        <View style={styles.titleContainer}>
-          <Text style={styles.title}>Choose a sticker</Text>
-          <Pressable onPress={onClose}>
-            <MaterialIcons name="close" color="#fff" size={22} />
-          </Pressable>
+      <Modal animationType="slide" transparent={true} visible={isVisible}>
+        <View style={styles.modalContent}>
+          <View style={styles.titleContainer}>
+            <Text style={styles.title}>Choose a sticker</Text>
+            <Pressable onPress={onClose}>
+              <MaterialIcons name="close" color="#fff" size={22} />
+            </Pressable>
+          </View>
+          {children}
         </View>
-        {children}
-      </View>
-    </Modal>
+      </Modal>
     </View>
   );
 }


### PR DESCRIPTION
# Why

When I was going through the tutorial, I noticed indentation in [`components/EmojiPicker.tsx`](https://docs.expo.dev/tutorial/create-a-modal/#create-an-emoji-picker-modal) code block is off.

# How

Added missing indentation to everything inside `<View />`

# Test Plan

I visually tested by running the docs locally

| Before | After |
| - | - |
| <img width="1148" height="686" alt="Screenshot 2026-05-06 at 14 22 21" src="https://github.com/user-attachments/assets/5190877b-fb20-4692-9656-92fdbd6f25f6" /> | <img width="1150" height="682" alt="Screenshot 2026-05-06 at 14 22 37" src="https://github.com/user-attachments/assets/ad073558-7b7a-45a2-af78-d460333a25c0" /> |

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
