### PR TITLE
[docs] Update EmDash Vale rule

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/EmDash.yml
+++ b/docs/.vale/writing-styles/expo-docs/EmDash.yml
@@ -1,9 +1,11 @@
 extends: substitution
-message: "Instead of '-' or '--', use '&mdash;'. Markdown renders this nicely."
+message: "Use '%s' instead. Markdown renders this nicely."
 link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#use-mdash'
 level: suggestion
 scope: raw
-# Look for ' - ' (space, hyphen, space) or ' -- ' (space, two hyphens, space)
+nonword: true
+# Look for ' - ' (space, hyphen, space), ' -- ' (space, two hyphens, space), or '—' (Unicode em-dash, U+2014)
 swap:
   ' - ': ' &mdash; '
   ' -- ': ' &mdash; '
+  '—': '&mdash;'

--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -241,7 +241,7 @@ Only apply inline code formatting using back-ticks (``) on programming words and
 
 ### Use `&mdash;`
 
-In some scenarios, when you split two sentences and use `-` or `--`, instead use `&mdash;`. Markdown renders that em dash nicely instead of a hyphen (`-`).
+In some scenarios, when you split two sentences and use `-`, `--`, or a literal em-dash character (`—`, U+2014), instead use `&mdash;`. Markdown renders that em dash nicely instead of a hyphen (`-`). The literal `—` character is the most common variant inserted by AI-assisted writing, so watch for it during review.
 
 ### Referencing Keyboard shortcuts
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The existing rule only catches ASCII - and -- used as dash substitutes. It does not catch the Unicode em-dash character `—` (U+2014), which is what AI-generated text drops in. Update the EmDash Vale rule to catch this during PR review process.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update EmDash Vale rule file.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `pnpm lint-prose` and there should be no warnings or errors right now.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
