### PR TITLE
Add AbortSignal timeout and any polyfills

### DIFF
--- a/apps/test-suite/tests/Fetch.ts
+++ b/apps/test-suite/tests/Fetch.ts
@@ -342,6 +342,41 @@ export function test({ describe, expect, it, ...t }) {
       expect(error).not.toBeNull();
     });
 
+    it('should abort request with AbortSignal.timeout', async () => {
+      const signal = AbortSignal.timeout(500);
+      let error: Error | null = null;
+      try {
+        await fetch('https://httpbin.io/delay/3', {
+          signal,
+        });
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          error = e;
+        }
+      }
+      expect(error).not.toBeNull();
+      expect(signal.aborted).toBe(true);
+      expect(signal.reason.name).toBe('TimeoutError');
+    });
+
+    it('should abort request with AbortSignal.any', async () => {
+      const controller = new AbortController();
+      const signal = AbortSignal.any([controller.signal, AbortSignal.timeout(3000)]);
+      setTimeout(() => controller.abort(), 500);
+      let error: Error | null = null;
+      try {
+        await fetch('https://httpbin.io/delay/3', {
+          signal,
+        });
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          error = e;
+        }
+      }
+      expect(error).not.toBeNull();
+      expect(signal.aborted).toBe(true);
+    });
+
     it('should abort streaming request', async () => {
       const controller = new AbortController();
       setTimeout(() => controller.abort(), 5000);

--- a/apps/test-suite/tests/Fetch.ts
+++ b/apps/test-suite/tests/Fetch.ts
@@ -260,6 +260,41 @@ export function test({ describe, expect, it, ...t }) {
       expect(error).not.toBeNull();
     });
 
+    it('should abort request with AbortSignal.timeout', async () => {
+      const signal = AbortSignal.timeout(500);
+      let error: Error | null = null;
+      try {
+        await fetch('https://httpbin.io/delay/3', {
+          signal,
+        });
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          error = e;
+        }
+      }
+      expect(error).not.toBeNull();
+      expect(signal.aborted).toBe(true);
+      expect(signal.reason.name).toBe('TimeoutError');
+    });
+
+    it('should abort request with AbortSignal.any', async () => {
+      const controller = new AbortController();
+      const signal = AbortSignal.any([controller.signal, AbortSignal.timeout(3000)]);
+      setTimeout(() => controller.abort(), 500);
+      let error: Error | null = null;
+      try {
+        await fetch('https://httpbin.io/delay/3', {
+          signal,
+        });
+      } catch (e: unknown) {
+        if (e instanceof Error) {
+          error = e;
+        }
+      }
+      expect(error).not.toBeNull();
+      expect(signal.aborted).toBe(true);
+    });
+
     it('should abort streaming request', async () => {
       const controller = new AbortController();
       setTimeout(() => controller.abort(), 5000);

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `AbortSignal.timeout` and `AbortSignal.any` to the native Winter runtime.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `AbortSignal.timeout` and `AbortSignal.any` to the native Winter runtime.
+- Added `AbortSignal.timeout`, `AbortSignal.any`, and `DOMException` to the native runtime. ([#45441](https://github.com/expo/expo/pull/45441) by [@kudo](https://github.com/kudo))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo/build/winter/AbortSignal.d.ts
+++ b/packages/expo/build/winter/AbortSignal.d.ts
@@ -1,0 +1,4 @@
+type AbortSignalConstructor = typeof AbortSignal;
+export declare function installAbortSignalPatch(abortSignal: AbortSignalConstructor): AbortSignalConstructor;
+export {};
+//# sourceMappingURL=AbortSignal.d.ts.map

--- a/packages/expo/build/winter/AbortSignal.d.ts.map
+++ b/packages/expo/build/winter/AbortSignal.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"AbortSignal.d.ts","sourceRoot":"","sources":["../../src/winter/AbortSignal.ts"],"names":[],"mappings":"AAAA,KAAK,sBAAsB,GAAG,OAAO,WAAW,CAAC;AAKjD,wBAAgB,uBAAuB,CACrC,WAAW,EAAE,sBAAsB,GAClC,sBAAsB,CASxB"}

--- a/packages/expo/build/winter/DOMException.d.ts
+++ b/packages/expo/build/winter/DOMException.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright © 2026 650 Industries.
+ * Copyright © Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Fork of React Native's DOMException implementation
+ * https://github.com/facebook/react-native/blob/2fb7a63570429a85cd869b29e4a470b963234147/packages/react-native/src/private/webapis/errors/DOMException.js
+ */
+export declare class DOMException extends Error {
+    #private;
+    constructor(message?: string, name?: string);
+    get name(): string;
+    get code(): number;
+}
+//# sourceMappingURL=DOMException.d.ts.map

--- a/packages/expo/build/winter/DOMException.d.ts
+++ b/packages/expo/build/winter/DOMException.d.ts
@@ -5,8 +5,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * Fork of React Native's DOMException implementation
- * https://github.com/facebook/react-native/blob/2fb7a63570429a85cd869b29e4a470b963234147/packages/react-native/src/private/webapis/errors/DOMException.js
+ * Forked from React Native's DOMException implementation
+ * https://github.com/facebook/react-native/blob/f5bd86c31105bb6a994acb03c8149bd7ee03dac6/packages/react-native/src/private/webapis/errors/DOMException.js
  */
 export declare class DOMException extends Error {
     #private;

--- a/packages/expo/build/winter/DOMException.d.ts.map
+++ b/packages/expo/build/winter/DOMException.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"DOMException.d.ts","sourceRoot":"","sources":["../../src/winter/DOMException.ts"],"names":[],"mappings":"AAAA;;;;;;;;;GASG;AAuDH,qBAAa,YAAa,SAAQ,KAAK;;gBAIzB,OAAO,CAAC,EAAE,MAAM,EAAE,IAAI,CAAC,EAAE,MAAM;IAY3C,IAAa,IAAI,IAAI,MAAM,CAE1B;IAED,IAAI,IAAI,IAAI,MAAM,CAEjB;CACF"}

--- a/packages/expo/src/winter/AbortSignal.ts
+++ b/packages/expo/src/winter/AbortSignal.ts
@@ -1,0 +1,138 @@
+type AbortSignalConstructor = typeof AbortSignal;
+
+const MAX_TIMEOUT = Number.MAX_SAFE_INTEGER;
+const MAX_TIMER_DELAY = 2 ** 31 - 1;
+
+export function installAbortSignalPatch(
+  abortSignal: AbortSignalConstructor
+): AbortSignalConstructor {
+  if (abortSignal.timeout == null) {
+    defineAbortSignalStatic(abortSignal, 'timeout', timeout);
+  }
+  if (abortSignal.any == null) {
+    defineAbortSignalStatic(abortSignal, 'any', any);
+  }
+
+  return abortSignal;
+}
+
+function timeout(milliseconds: number): AbortSignal {
+  validateTimeout(milliseconds);
+
+  const controller = new AbortController();
+  const reason = createError('TimeoutError', 'The signal timed out.');
+  let remaining = milliseconds;
+
+  const schedule = () => {
+    const delay = Math.min(remaining, MAX_TIMER_DELAY);
+    remaining -= delay;
+    setTimeout(() => {
+      if (remaining > 0) {
+        schedule();
+      } else {
+        abortWithReason(controller, reason);
+      }
+    }, delay);
+  };
+
+  schedule();
+
+  return controller.signal;
+}
+
+function any(signals: Iterable<AbortSignal>): AbortSignal {
+  if (signals == null || typeof signals[Symbol.iterator] !== 'function') {
+    throw new TypeError('AbortSignal.any requires an iterable.');
+  }
+
+  const signalList = Array.from(signals);
+  const controller = new AbortController();
+  const cleanupFunctions: (() => void)[] = [];
+
+  for (const signal of signalList) {
+    validateAbortSignal(signal);
+
+    if (signal.aborted) {
+      abortWithReason(controller, getAbortReason(signal));
+      return controller.signal;
+    }
+  }
+
+  const abort = (signal: AbortSignal) => {
+    cleanupFunctions.forEach((cleanup) => cleanup());
+    abortWithReason(controller, getAbortReason(signal));
+  };
+
+  for (const signal of signalList) {
+    const listener = () => {
+      abort(signal);
+    };
+    signal.addEventListener('abort', listener);
+    cleanupFunctions.push(() => {
+      signal.removeEventListener('abort', listener);
+    });
+  }
+
+  return controller.signal;
+}
+
+function validateTimeout(milliseconds: number): void {
+  if (typeof milliseconds !== 'number') {
+    throw new TypeError('AbortSignal.timeout requires a number.');
+  }
+  if (!Number.isInteger(milliseconds) || milliseconds < 0 || milliseconds > MAX_TIMEOUT) {
+    throw new RangeError(
+      `AbortSignal.timeout requires a timeout between 0 and ${MAX_TIMEOUT} milliseconds.`
+    );
+  }
+}
+
+function validateAbortSignal(signal: AbortSignal): void {
+  if (
+    signal == null ||
+    typeof signal !== 'object' ||
+    typeof signal.aborted !== 'boolean' ||
+    typeof signal.addEventListener !== 'function' ||
+    typeof signal.removeEventListener !== 'function'
+  ) {
+    throw new TypeError('AbortSignal.any requires every item to be an AbortSignal.');
+  }
+}
+
+function getAbortReason(signal: AbortSignal): unknown {
+  return 'reason' in signal
+    ? signal.reason
+    : createError('AbortError', 'The operation was aborted.');
+}
+
+function abortWithReason(controller: AbortController, reason: unknown): void {
+  controller.abort(reason);
+
+  if (controller.signal.reason !== reason) {
+    try {
+      Object.defineProperty(controller.signal, 'reason', {
+        value: reason,
+        configurable: true,
+      });
+    } catch {}
+  }
+}
+
+function createError(name: string, message: string): Error {
+  const error = new Error(message);
+  error.name = name;
+  return error;
+}
+
+function defineAbortSignalStatic(
+  abortSignal: AbortSignalConstructor,
+  name: 'timeout' | 'any',
+  value: AbortSignalConstructor[typeof name]
+): void {
+  Object.defineProperty(abortSignal, name, {
+    value,
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+}

--- a/packages/expo/src/winter/AbortSignal.ts
+++ b/packages/expo/src/winter/AbortSignal.ts
@@ -20,7 +20,7 @@ function timeout(milliseconds: number): AbortSignal {
   validateTimeout(milliseconds);
 
   const controller = new AbortController();
-  const reason = createError('TimeoutError', 'The signal timed out.');
+  const reason = new DOMException('The signal timed out.', 'TimeoutError');
   let remaining = milliseconds;
 
   const schedule = () => {
@@ -102,7 +102,7 @@ function validateAbortSignal(signal: AbortSignal): void {
 function getAbortReason(signal: AbortSignal): unknown {
   return 'reason' in signal
     ? signal.reason
-    : createError('AbortError', 'The operation was aborted.');
+    : new DOMException('The operation was aborted.', 'AbortError');
 }
 
 function abortWithReason(controller: AbortController, reason: unknown): void {
@@ -116,12 +116,6 @@ function abortWithReason(controller: AbortController, reason: unknown): void {
       });
     } catch {}
   }
-}
-
-function createError(name: string, message: string): Error {
-  const error = new Error(message);
-  error.name = name;
-  return error;
 }
 
 function defineAbortSignalStatic(

--- a/packages/expo/src/winter/DOMException.ts
+++ b/packages/expo/src/winter/DOMException.ts
@@ -5,8 +5,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * Fork of React Native's DOMException implementation
- * https://github.com/facebook/react-native/blob/2fb7a63570429a85cd869b29e4a470b963234147/packages/react-native/src/private/webapis/errors/DOMException.js
+ * Forked from React Native's DOMException implementation
+ * https://github.com/facebook/react-native/blob/f5bd86c31105bb6a994acb03c8149bd7ee03dac6/packages/react-native/src/private/webapis/errors/DOMException.js
  */
 
 const ERROR_NAME_TO_ERROR_CODE_MAP: Record<string, number> = {

--- a/packages/expo/src/winter/DOMException.ts
+++ b/packages/expo/src/winter/DOMException.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright © 2026 650 Industries.
+ * Copyright © Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Fork of React Native's DOMException implementation
+ * https://github.com/facebook/react-native/blob/2fb7a63570429a85cd869b29e4a470b963234147/packages/react-native/src/private/webapis/errors/DOMException.js
+ */
+
+const ERROR_NAME_TO_ERROR_CODE_MAP: Record<string, number> = {
+  IndexSizeError: 1,
+  HierarchyRequestError: 3,
+  WrongDocumentError: 4,
+  InvalidCharacterError: 5,
+  NoModificationAllowedError: 7,
+  NotFoundError: 8,
+  NotSupportedError: 9,
+  InUseAttributeError: 10,
+  InvalidStateError: 11,
+  SyntaxError: 12,
+  InvalidModificationError: 13,
+  NamespaceError: 14,
+  InvalidAccessError: 15,
+  TypeMismatchError: 17,
+  SecurityError: 18,
+  NetworkError: 19,
+  AbortError: 20,
+  URLMismatchError: 21,
+  QuotaExceededError: 22,
+  TimeoutError: 23,
+  InvalidNodeTypeError: 24,
+  DataCloneError: 25,
+};
+
+const ERROR_CODES: Record<string, number> = {
+  INDEX_SIZE_ERR: 1,
+  DOMSTRING_SIZE_ERR: 2,
+  HIERARCHY_REQUEST_ERR: 3,
+  WRONG_DOCUMENT_ERR: 4,
+  INVALID_CHARACTER_ERR: 5,
+  NO_DATA_ALLOWED_ERR: 6,
+  NO_MODIFICATION_ALLOWED_ERR: 7,
+  NOT_FOUND_ERR: 8,
+  NOT_SUPPORTED_ERR: 9,
+  INUSE_ATTRIBUTE_ERR: 10,
+  INVALID_STATE_ERR: 11,
+  SYNTAX_ERR: 12,
+  INVALID_MODIFICATION_ERR: 13,
+  NAMESPACE_ERR: 14,
+  INVALID_ACCESS_ERR: 15,
+  VALIDATION_ERR: 16,
+  TYPE_MISMATCH_ERR: 17,
+  SECURITY_ERR: 18,
+  NETWORK_ERR: 19,
+  ABORT_ERR: 20,
+  URL_MISMATCH_ERR: 21,
+  QUOTA_EXCEEDED_ERR: 22,
+  TIMEOUT_ERR: 23,
+  INVALID_NODE_TYPE_ERR: 24,
+  DATA_CLONE_ERR: 25,
+};
+
+export class DOMException extends Error {
+  readonly #name: string;
+  readonly #code: number;
+
+  constructor(message?: string, name?: string) {
+    super(message);
+
+    if (typeof name === 'undefined') {
+      this.#name = 'Error';
+      this.#code = 0;
+    } else {
+      this.#name = String(name);
+      this.#code = ERROR_NAME_TO_ERROR_CODE_MAP[this.name] ?? 0;
+    }
+  }
+
+  override get name(): string {
+    return this.#name;
+  }
+
+  get code(): number {
+    return this.#code;
+  }
+}
+
+for (const code in ERROR_CODES) {
+  Object.defineProperty(DOMException, code, {
+    enumerable: true,
+    value: ERROR_CODES[code],
+  });
+
+  Object.defineProperty(DOMException.prototype, code, {
+    enumerable: true,
+    value: ERROR_CODES[code],
+  });
+}

--- a/packages/expo/src/winter/__tests__/AbortSignal.test.native.ts
+++ b/packages/expo/src/winter/__tests__/AbortSignal.test.native.ts
@@ -83,6 +83,7 @@ describe('AbortSignal patch', () => {
 
     expect(signal.aborted).toBe(true);
     expect(listener).toHaveBeenCalledTimes(1);
+    expect(signal.reason).toBeInstanceOf(DOMException);
     expect(signal.reason.name).toBe('TimeoutError');
   });
 

--- a/packages/expo/src/winter/__tests__/AbortSignal.test.native.ts
+++ b/packages/expo/src/winter/__tests__/AbortSignal.test.native.ts
@@ -1,0 +1,162 @@
+import { installAbortSignalPatch } from '../AbortSignal';
+
+const originalTimeout = AbortSignal.timeout;
+const originalAny = AbortSignal.any;
+
+function resetAbortSignalStatics() {
+  Object.defineProperty(AbortSignal, 'timeout', {
+    value: undefined,
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+  Object.defineProperty(AbortSignal, 'any', {
+    value: undefined,
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+}
+
+function restoreAbortSignalStatics() {
+  Object.defineProperty(AbortSignal, 'timeout', {
+    value: originalTimeout,
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+  Object.defineProperty(AbortSignal, 'any', {
+    value: originalAny,
+    configurable: true,
+    enumerable: false,
+    writable: true,
+  });
+}
+
+describe('AbortSignal patch', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetAbortSignalStatics();
+    installAbortSignalPatch(AbortSignal);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    restoreAbortSignalStatics();
+  });
+
+  it('should install timeout and any when missing', () => {
+    expect(AbortSignal.timeout).toEqual(expect.any(Function));
+    expect(AbortSignal.any).toEqual(expect.any(Function));
+  });
+
+  it('should not override native timeout or any implementations', () => {
+    const timeout = jest.fn();
+    const any = jest.fn();
+
+    Object.defineProperty(AbortSignal, 'timeout', {
+      value: timeout,
+      configurable: true,
+    });
+    Object.defineProperty(AbortSignal, 'any', {
+      value: any,
+      configurable: true,
+    });
+
+    installAbortSignalPatch(AbortSignal);
+
+    expect(AbortSignal.timeout).toBe(timeout);
+    expect(AbortSignal.any).toBe(any);
+  });
+
+  it('should abort timeout signal after delay with TimeoutError reason', () => {
+    const signal = AbortSignal.timeout(10);
+    const listener = jest.fn();
+
+    signal.addEventListener('abort', listener);
+    jest.advanceTimersByTime(9);
+
+    expect(signal.aborted).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+
+    expect(signal.aborted).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(signal.reason.name).toBe('TimeoutError');
+  });
+
+  it('should reject invalid timeout values', () => {
+    expect(() => AbortSignal.timeout(-1)).toThrow(RangeError);
+    expect(() => AbortSignal.timeout(1.5)).toThrow(RangeError);
+    expect(() => AbortSignal.timeout(Number.MAX_SAFE_INTEGER + 1)).toThrow(RangeError);
+    // @ts-expect-error: Testing invalid usage
+    expect(() => AbortSignal.timeout('1')).toThrow(TypeError);
+  });
+
+  it('should return non-aborted signal for empty any iterable', () => {
+    const signal = AbortSignal.any([]);
+
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('should abort any signal when source is already aborted', () => {
+    const reason = new Error('cancelled');
+    const controller = new AbortController();
+
+    controller.abort(reason);
+    const signal = AbortSignal.any([controller.signal]);
+
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBe(reason);
+  });
+
+  it('should abort any signal when any source aborts', () => {
+    const reason = new Error('second');
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const signal = AbortSignal.any([firstController.signal, secondController.signal]);
+    const listener = jest.fn();
+
+    signal.addEventListener('abort', listener);
+    secondController.abort(reason);
+
+    expect(signal.aborted).toBe(true);
+    expect(signal.reason).toBe(reason);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(firstController.signal.aborted).toBe(false);
+  });
+
+  it('should preserve first abort reason for any signal', () => {
+    const firstReason = new Error('first');
+    const secondReason = new Error('second');
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const signal = AbortSignal.any([firstController.signal, secondController.signal]);
+
+    secondController.abort(secondReason);
+    firstController.abort(firstReason);
+
+    expect(signal.reason).toBe(secondReason);
+  });
+
+  it('should remove source listeners after any signal aborts', () => {
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const removeFirstListener = jest.spyOn(firstController.signal, 'removeEventListener');
+    const removeSecondListener = jest.spyOn(secondController.signal, 'removeEventListener');
+
+    AbortSignal.any([firstController.signal, secondController.signal]);
+    firstController.abort();
+
+    expect(removeFirstListener).toHaveBeenCalledWith('abort', expect.any(Function));
+    expect(removeSecondListener).toHaveBeenCalledWith('abort', expect.any(Function));
+  });
+
+  it('should reject invalid any iterable values', () => {
+    // @ts-expect-error: Testing invalid usage
+    expect(() => AbortSignal.any(null)).toThrow(TypeError);
+    // @ts-expect-error: Testing invalid usage
+    expect(() => AbortSignal.any([{}])).toThrow(TypeError);
+  });
+});

--- a/packages/expo/src/winter/__tests__/DOMException.test.native.ts
+++ b/packages/expo/src/winter/__tests__/DOMException.test.native.ts
@@ -1,0 +1,98 @@
+describe('DOMException', () => {
+  const errorCodes = [
+    ['INDEX_SIZE_ERR', 1],
+    ['DOMSTRING_SIZE_ERR', 2],
+    ['HIERARCHY_REQUEST_ERR', 3],
+    ['WRONG_DOCUMENT_ERR', 4],
+    ['INVALID_CHARACTER_ERR', 5],
+    ['NO_DATA_ALLOWED_ERR', 6],
+    ['NO_MODIFICATION_ALLOWED_ERR', 7],
+    ['NOT_FOUND_ERR', 8],
+    ['NOT_SUPPORTED_ERR', 9],
+    ['INUSE_ATTRIBUTE_ERR', 10],
+    ['INVALID_STATE_ERR', 11],
+    ['SYNTAX_ERR', 12],
+    ['INVALID_MODIFICATION_ERR', 13],
+    ['NAMESPACE_ERR', 14],
+    ['INVALID_ACCESS_ERR', 15],
+    ['VALIDATION_ERR', 16],
+    ['TYPE_MISMATCH_ERR', 17],
+    ['SECURITY_ERR', 18],
+    ['NETWORK_ERR', 19],
+    ['ABORT_ERR', 20],
+    ['URL_MISMATCH_ERR', 21],
+    ['QUOTA_EXCEEDED_ERR', 22],
+    ['TIMEOUT_ERR', 23],
+    ['INVALID_NODE_TYPE_ERR', 24],
+    ['DATA_CLONE_ERR', 25],
+  ] as const;
+
+  const errorNameCodes = [
+    ['SomethingElse', 0],
+    ['IndexSizeError', DOMException.INDEX_SIZE_ERR],
+    ['HierarchyRequestError', DOMException.HIERARCHY_REQUEST_ERR],
+    ['WrongDocumentError', DOMException.WRONG_DOCUMENT_ERR],
+    ['InvalidCharacterError', DOMException.INVALID_CHARACTER_ERR],
+    ['NoModificationAllowedError', DOMException.NO_MODIFICATION_ALLOWED_ERR],
+    ['NotFoundError', DOMException.NOT_FOUND_ERR],
+    ['NotSupportedError', DOMException.NOT_SUPPORTED_ERR],
+    ['InUseAttributeError', DOMException.INUSE_ATTRIBUTE_ERR],
+    ['InvalidStateError', DOMException.INVALID_STATE_ERR],
+    ['SyntaxError', DOMException.SYNTAX_ERR],
+    ['InvalidModificationError', DOMException.INVALID_MODIFICATION_ERR],
+    ['NamespaceError', DOMException.NAMESPACE_ERR],
+    ['InvalidAccessError', DOMException.INVALID_ACCESS_ERR],
+    ['TypeMismatchError', DOMException.TYPE_MISMATCH_ERR],
+    ['SecurityError', DOMException.SECURITY_ERR],
+    ['NetworkError', DOMException.NETWORK_ERR],
+    ['AbortError', DOMException.ABORT_ERR],
+    ['URLMismatchError', DOMException.URL_MISMATCH_ERR],
+    ['QuotaExceededError', DOMException.QUOTA_EXCEEDED_ERR],
+    ['TimeoutError', DOMException.TIMEOUT_ERR],
+    ['InvalidNodeTypeError', DOMException.INVALID_NODE_TYPE_ERR],
+    ['DataCloneError', DOMException.DATA_CLONE_ERR],
+  ] as const;
+
+  it('should use the Expo built-in API', () => {
+    expect((DOMException as any)[Symbol.for('expo.builtin')]).toBe(true);
+  });
+
+  it('should provide error codes as static fields and instance fields', () => {
+    const exception = new DOMException();
+
+    for (const [name, code] of errorCodes) {
+      expect(DOMException[name]).toBe(code);
+      expect(exception[name]).toBe(code);
+    }
+  });
+
+  it('should create named exceptions with legacy codes', () => {
+    const exception = new DOMException('signal timed out', 'TimeoutError');
+
+    expect(exception).toBeInstanceOf(Error);
+    expect(exception.message).toBe('signal timed out');
+    expect(exception.name).toBe('TimeoutError');
+    expect(exception.code).toBe(DOMException.TIMEOUT_ERR);
+    expect(exception.code).toBe(23);
+  });
+
+  it('should default to Error with code 0', () => {
+    const exception = new DOMException('failed');
+
+    expect(exception.name).toBe('Error');
+    expect(exception.code).toBe(0);
+  });
+
+  it('should normalize names', () => {
+    expect(new DOMException(undefined, undefined).name).toBe('Error');
+    expect(new DOMException(undefined, '').name).toBe('');
+    expect(new DOMException(undefined, null as unknown as string).name).toBe('null');
+    expect(new DOMException(undefined, {} as string).name).toBe('[object Object]');
+  });
+
+  it('should assign the right code for the given name', () => {
+    for (const [name, code] of errorNameCodes) {
+      expect(new DOMException(undefined, name).code).toBe(code);
+    }
+  });
+});

--- a/packages/expo/src/winter/__tests__/DOMException.test.native.ts
+++ b/packages/expo/src/winter/__tests__/DOMException.test.native.ts
@@ -1,3 +1,8 @@
+/**
+ * Based on React Native's DOMException integration tests
+ * https://github.com/facebook/react-native/blob/f5bd86c31105bb6a994acb03c8149bd7ee03dac6/packages/react-native/src/private/webapis/errors/__tests__/DOMException-itest.js
+ */
+
 describe('DOMException', () => {
   const errorCodes = [
     ['INDEX_SIZE_ERR', 1],

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -17,6 +17,8 @@ install('TextEncoderStream', () => require('./TextDecoderStream').TextEncoderStr
 install('URL', () => require('./url').URL);
 // https://url.spec.whatwg.org/#urlsearchparams
 install('URLSearchParams', () => require('./url').URLSearchParams);
+// https://webidl.spec.whatwg.org/#idl-DOMException
+install('DOMException', () => require('./DOMException').DOMException);
 // https://streams.spec.whatwg.org/#rs
 // ReadableStream is injected by Metro as a global
 

--- a/packages/expo/src/winter/runtime.native.ts
+++ b/packages/expo/src/winter/runtime.native.ts
@@ -3,6 +3,7 @@
 
 import '../../types';
 
+import { installAbortSignalPatch } from './AbortSignal';
 import { installFormDataPatch } from './FormData';
 import { installGlobal as install } from './installGlobal';
 
@@ -25,6 +26,7 @@ install('__ExpoImportMetaRegistry', () => require('./ImportMetaRegistry').Import
 install('structuredClone', () => require('@ungap/structured-clone').default);
 
 installFormDataPatch(FormData);
+installAbortSignalPatch(AbortSignal);
 
 // Polyfill async iterator symbol for Hermes.
 // @ts-expect-error: readonly property only applies when the engine supports it


### PR DESCRIPTION
# Why

React Native's AbortSignal polyfill does not include `AbortSignal.timeout` or `AbortSignal.any`, which are needed for WinterTC-compatible fetch behavior.

close ENG-17748

# How

- Add a native Winter runtime patch that installs the missing static methods only when the platform does not already provide them.
- Add `DOMException`

# Test Plan

- `pnpm --filter expo exec jest --watchman=false --runTestsByPath src/winter/__tests__/AbortSignal.test.native.ts`
- `pnpm --filter expo exec jest --watchman=false packages/expo/src/winter/fetch`
- `pnpm --filter expo exec tsc --noEmit false --emitDeclarationOnly`
- `pnpm --filter expo exec eslint src/winter/AbortSignal.ts src/winter/runtime.native.ts src/winter/__tests__/AbortSignal.test.native.ts`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)