### PR TITLE
[tools] Fix canary publishing

### DIFF
--- a/tools/src/publish-packages/tasks/publishCanary.ts
+++ b/tools/src/publish-packages/tasks/publishCanary.ts
@@ -4,7 +4,6 @@ import semver from 'semver';
 import { checkEnvironmentTask } from './checkEnvironmentTask';
 import { checkPackageAccess } from './checkPackageAccess';
 import { loadRequestedParcels } from './loadRequestedParcels';
-import { packPackageToTarball } from './packPackageToTarball';
 import { publishAndroidArtifacts } from './publishAndroidPackages';
 import { publishPackages } from './publishPackages';
 import { updateBundledNativeModulesFile } from './updateBundledNativeModulesFile';
@@ -139,7 +138,6 @@ export const publishCanaryPipeline = new Task<TaskArgs>(
       publishAndroidArtifacts,
       addTemplateTarball,
       bundleIOSPrebuilds,
-      packPackageToTarball,
       publishPackages,
       cleanWorkingTree,
     ],

--- a/tools/src/publish-packages/tasks/publishPackages.ts
+++ b/tools/src/publish-packages/tasks/publishPackages.ts
@@ -1,6 +1,5 @@
 import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
-import fs from 'fs-extra';
 import inquirer from 'inquirer';
 import path from 'path';
 import semver from 'semver';
@@ -11,7 +10,6 @@ import Git from '../../Git';
 import logger from '../../Logger';
 import * as Npm from '../../Npm';
 import { promptOtp, withOtpRetry } from '../../NpmOtp';
-import { Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import { sleepAsync } from '../../Utils';
 import { CommandOptions, Parcel, TaskArgs } from '../types';
@@ -49,20 +47,21 @@ export const publishPackages = new Task<TaskArgs>(
         `${green(pkg.packageName)} version ${cyan(releaseVersion)} as ${yellow(options.tag)}`
       );
 
-      // If there is a tarball already built, use it instead of packing it again
-      const packageSource = await findPackageSource(pkg, state.packageTarballFilename);
-
       // Update `gitHead` property so it will be available to read using `npm view --json`.
       // Next publish will depend on this to properly get changes made after that.
       if (!pkg.isTemplate()) {
         await JsonFile.setAsync(packageJsonPath, 'gitHead', gitHead);
       }
 
-      // Publish the package.
+      // Publish the package directly from its directory. pnpm publish handles
+      // pack-and-publish atomically and resolves `workspace:` specs at pack
+      // time. We deliberately don't pass a pre-packed tarball: when the
+      // directory contains multiple .tgz files (e.g. the embedded
+      // template.tgz inside packages/expo/), pnpm picks the wrong one
+      // (pnpm/pnpm#7950 and variants), causing publishes to be misdirected.
       try {
         await withOtpRetry(() =>
           Npm.publishPackageAsync(pkg.path, {
-            source: packageSource,
             tagName: options.tag,
             dryRun: options.dry,
           })
@@ -104,18 +103,3 @@ export const publishPackages = new Task<TaskArgs>(
     }
   }
 );
-
-/**
- * Finds the package source to publish from. If the tarball filename is provided and the file exists, it's returned.
- * Otherwise the source is the current directory.
- */
-async function findPackageSource(pkg: Package, tarballFilename?: string): Promise<string> {
-  if (tarballFilename) {
-    const tarballPath = path.join(pkg.path, tarballFilename);
-
-    if (await fs.pathExists(tarballPath)) {
-      return tarballFilename;
-    }
-  }
-  return '.';
-}


### PR DESCRIPTION
# Why
Attempt to fix canary publishing.  Publishing canaries pre-packed every parcel and then runs `pnpm publish <tarball>`. Because we also package a version of the template inside the expo package, we ended up with two tarballs, which seems to trigger a variant of https://github.com/pnpm/pnpm/issues/7950: `pnpm publish <tarball>` picks the wrong file from the directory.

# How
- Drop `packPackageToTarball` from the canary pipeline.
- Drop the `findPackageSource` helper and `state.packageTarballFilename` lookup from `publishPackages`.

# Test Plan
Tests are passing but I need to run the publish canaries job to fully verify
