### PR TITLE
fix(cli): Prevent timeouts/intervals or own timeout from preventing force exit

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevent dangling timeouts (e.g. set in Metro config) from hanging `expo export` ([#45445](https://github.com/expo/expo/pull/45445) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Run `DevelopmentSession` API call and dependencies check without any startup delays ([#45417](https://github.com/expo/expo/pull/45417) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/utils/__tests__/exit-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/exit-test.ts
@@ -46,6 +46,25 @@ describe(ensureProcessExitsAfterDelay, () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it("force-exits when a ref'd timer is leaked", async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
+
+    // Simulate a library leaking a ref'd timer (e.g. during static rendering).
+    // getActiveResourcesInfo() only reports ref'd timers, so this should be
+    // detected as a blocking resource and eventually force-exited.
+    const leaked = setTimeout(() => {}, 60_000);
+
+    ensureProcessExitsAfterDelay(200);
+
+    // Wait longer than the exit timer
+    await timers.setTimeout(1000);
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    clearTimeout(leaked);
+    exitSpy.mockRestore();
+  });
+
   it('detects and logs unexpected active child processes and force exits', async () => {
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
 

--- a/packages/@expo/cli/src/utils/__tests__/exit-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/exit-test.ts
@@ -1,5 +1,4 @@
-import { fork } from 'node:child_process';
-import path from 'node:path';
+import { spawn } from 'node:child_process';
 import timers from 'node:timers/promises';
 
 import { warn } from '../../log';
@@ -50,23 +49,18 @@ describe(ensureProcessExitsAfterDelay, () => {
   it('detects and logs unexpected active child processes and force exits', async () => {
     const exitSpy = jest.spyOn(process, 'exit').mockImplementation();
 
-    // Get the file path to the process that will go on indefinitely
-    const processFile = path.join(__dirname, './fixtures/exit-indefinite-process.js');
-    // Start a process that will go on indefinitely
-    const pending = fork(processFile, { stdio: 'inherit' });
+    // Start a child process with piped stdio so the handles remain visible in getActiveResourcesInfo
+    const pending = spawn('sleep', ['60'], { stdio: 'pipe' });
     // Test if the process is force-exited after 0.2 seconds
     ensureProcessExitsAfterDelay(200);
 
-    // Wait longer than the exit timer (0.5s)
-    await timers.setTimeout(500);
+    // Wait longer than the exit timer (1s to account for nextTick delays in polling)
+    await timers.setTimeout(1000);
 
     // Ensure `process.exit` was called
     expect(exitSpy).toHaveBeenCalledWith(0);
-    // Ensure a warning was logged
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining(processFile));
-    expect(warn).toHaveBeenCalledWith(
-      'Detected 1 process preventing Expo from exiting, forcefully exiting now.'
-    );
+    // Ensure a warning was logged about the active process
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/preventing Expo from exiting/));
 
     exitSpy.mockReset();
     pending.kill();

--- a/packages/@expo/cli/src/utils/exit.ts
+++ b/packages/@expo/cli/src/utils/exit.ts
@@ -136,10 +136,9 @@ export function ensureProcessExitsAfterDelay(waitUntilExitMs = 10000, startedAtM
   }
 
   const timeoutId = setTimeout(() => {
-    // Ensure the timeout is cleared before checking the active resources
-    clearTimeout(timeoutId);
-    // Check if the process can exit
-    ensureProcessExitsAfterDelay(waitUntilExitMs, startedAtMs);
+    // Delay the next check by one tick so the current timer is fully cleaned up
+    // and doesn't appear in the active resources list.
+    process.nextTick(() => ensureProcessExitsAfterDelay(waitUntilExitMs, startedAtMs));
 
     // setTimeout is using the global definitions from React Native which is missing the unref method in Node.js.
   }, 100) as unknown as NodeJS.Timeout;

--- a/packages/@expo/cli/src/utils/exit.ts
+++ b/packages/@expo/cli/src/utils/exit.ts
@@ -107,25 +107,27 @@ export function ensureProcessExitsAfterDelay(waitUntilExitMs = 10000, startedAtM
     return true;
   });
 
-  // Check if only Timeouts remain (no blocking resources like ProcessWrap/PipeWrap)
+  // Check if there are any resources that block the process from exiting.
+  // CloseReq is always transient and completes on its own.
+  // NOTE: Timeout is NOT excluded — getActiveResourcesInfo() only reports ref'd timers,
+  // so any Timeout in this list will keep the event loop alive indefinitely.
   const hasBlockingResources = unexpectedActiveResources.some(
-    (resource) => resource !== 'Timeout' && resource !== 'CloseReq'
+    (resource) => resource !== 'CloseReq'
   );
 
-  const canExitProcess = !unexpectedActiveResources.length || !hasBlockingResources;
-  if (canExitProcess) {
-    if (unexpectedActiveResources.length && !hasBlockingResources) {
-      debug('only non-blocking resources remain (Timeout/CloseReq), process can safely exit');
-    } else {
-      debug('no active resources detected, process can safely exit');
-    }
-    return;
-  } else {
+  if (!hasBlockingResources) {
     debug(
-      `process is trying to exit, but is stuck on unexpected active resources:`,
-      unexpectedActiveResources
+      unexpectedActiveResources.length
+        ? 'only transient resources remain (CloseReq), process can safely exit'
+        : 'no active resources detected, process can safely exit'
     );
+    return;
   }
+
+  debug(
+    `process is trying to exit, but is stuck on unexpected active resources:`,
+    unexpectedActiveResources
+  );
 
   // Check if the process needs to be force-closed
   const elapsedTime = Date.now() - startedAtMs;

--- a/packages/@expo/cli/src/utils/exit.ts
+++ b/packages/@expo/cli/src/utils/exit.ts
@@ -86,7 +86,7 @@ function attachMasterListener() {
  *
  * @see https://nodejs.org/docs/latest-v18.x/api/process.html#processgetactiveresourcesinfo
  */
-export function ensureProcessExitsAfterDelay(waitUntilExitMs = 10000, startedAtMs = Date.now()) {
+export function ensureProcessExitsAfterDelay(waitUntilExitMs = 4_000, startedAtMs = Date.now()) {
   // Create a list of the expected active resources before exiting.
   // Note, the order is undeterministic
   const expectedResources = [


### PR DESCRIPTION
# Why

Supersedes #44837

The current exit guard may still have its own timeout included in the exit guard, and we need to wait a tick for our own timeout to drop. We can then include timeouts in the active resources check, and hence detect spurious timeouts and intervals properly.

# How

- Remove `Timeout` filter from active resources
- Delay next `ensureProcessExitsAfterDelay` check by a tick, so active resources from the same tick (like the handler's own timeout) drop
- Reduce default timeout to 4s

# Test Plan

- Manually verified with `expo export` and a `setInterval` in a Metro config

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
