### PR TITLE
perf(cli): Reduce `withMetroErrorReportingResolver`'s memory pressure

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Bump to `@expo/xcpretty@^4.4.4` ([#45473](https://github.com/expo/expo/pull/45473) by [@EvanBacon](https://github.com/EvanBacon))
 - Tweak dependency check message and placement on `expo start` ([#45487](https://github.com/expo/expo/pull/45487) by [@kitten](https://github.com/kitten))
+- Reduce memory pressure/usage from `withMetroErrorReportingResolver` ([#45446](https://github.com/expo/expo/pull/45446) by [@kitten](https://github.com/kitten))
 
 ## 56.0.5 — 2026-05-06
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -23,6 +23,7 @@ _This version does not introduce any user-facing changes._
 ### 💡 Others
 
 - Run `DevelopmentSession` API call and dependencies check without any startup delays ([#45417](https://github.com/expo/expo/pull/45417) by [@kitten](https://github.com/kitten))
+- Reduce memory pressure/usage from `withMetroErrorReportingResolver` ([#45446](https://github.com/expo/expo/pull/45446) by [@kitten](https://github.com/kitten))
 
 ## 56.0.2 — 2026-05-05
 

--- a/packages/@expo/cli/src/start/server/metro/__tests__/withMetroErrorReportingResolver.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/withMetroErrorReportingResolver.test.ts
@@ -25,28 +25,9 @@ it('adds import stack to error', () => {
         [
           'ios', // platform
           new Map([
-            [
-              '/project/a.js',
-              new Set([
-                {
-                  path: '/project/b.js',
-                  request: 'b',
-                },
-              ]),
-            ],
-            [
-              '/project/b.js',
-              new Set([
-                {
-                  path: '/project/c.js',
-                  request: 'c',
-                },
-              ]),
-            ],
-            [
-              '/project/c.js', // unresolved module
-              new Set<{ path: string; request: string }>(),
-            ],
+            ['/project/a.js', new Map([['/project/b.js', 'b']])],
+            ['/project/b.js', new Map([['/project/c.js', 'c']])],
+            ['/project/c.js', new Map<string, string>()],
           ]),
         ],
       ]),
@@ -90,24 +71,8 @@ it('adds import stack with circular dependencies to error', () => {
         [
           'ios', // platform
           new Map([
-            [
-              '/project/foo.js',
-              new Set([
-                {
-                  path: '/project/bar.js',
-                  request: 'bar',
-                },
-              ]),
-            ],
-            [
-              '/project/bar.js',
-              new Set([
-                {
-                  path: '/project/foo.js',
-                  request: 'foo',
-                },
-              ]),
-            ],
+            ['/project/foo.js', new Map([['/project/bar.js', 'bar']])],
+            ['/project/bar.js', new Map([['/project/foo.js', 'foo']])],
           ]),
         ],
       ]),
@@ -155,37 +120,10 @@ it('adds import stack with stack depth limit to error', () => {
         [
           'ios', // platform
           new Map([
-            [
-              '/project/a.js',
-              new Set([
-                {
-                  path: '/project/b.js',
-                  request: 'b',
-                },
-              ]),
-            ],
-            [
-              '/project/b.js',
-              new Set([
-                {
-                  path: '/project/c.js',
-                  request: 'c',
-                },
-              ]),
-            ],
-            [
-              '/project/c.js',
-              new Set([
-                {
-                  path: '/project/d.js',
-                  request: 'd',
-                },
-              ]),
-            ],
-            [
-              '/project/d.js', // unresolved module
-              new Set<{ path: string; request: string }>(),
-            ],
+            ['/project/a.js', new Map([['/project/b.js', 'b']])],
+            ['/project/b.js', new Map([['/project/c.js', 'c']])],
+            ['/project/c.js', new Map([['/project/d.js', 'd']])],
+            ['/project/d.js', new Map<string, string>()],
           ]),
         ],
       ]),
@@ -230,37 +168,10 @@ it('adds import stack with stack count limit to error', () => {
         [
           'ios', // platform
           new Map([
-            [
-              '/project/node_modules/a.js',
-              new Set([
-                {
-                  path: '/project/b.js',
-                  request: 'b',
-                },
-              ]),
-            ],
-            [
-              '/project/a.js',
-              new Set([
-                {
-                  path: '/project/b.js',
-                  request: 'b',
-                },
-              ]),
-            ],
-            [
-              '/project/b.js',
-              new Set([
-                {
-                  path: '/project/c.js',
-                  request: 'c',
-                },
-              ]),
-            ],
-            [
-              '/project/c.js', // unresolved module
-              new Set<{ path: string; request: string }>(),
-            ],
+            ['/project/node_modules/a.js', new Map([['/project/b.js', 'b']])],
+            ['/project/a.js', new Map([['/project/b.js', 'b']])],
+            ['/project/b.js', new Map([['/project/c.js', 'c']])],
+            ['/project/c.js', new Map<string, string>()],
           ]),
         ],
       ]),
@@ -304,94 +215,24 @@ it('prioritizes project stack over node_modules, circular deps, and depth limite
           'ios', // platform
           new Map([
             // Node modules stack
-            [
-              '/project/node_modules/lib.js',
-              new Set([
-                {
-                  path: '/project/utils.js',
-                  request: 'utils',
-                },
-              ]),
-            ],
+            ['/project/node_modules/lib.js', new Map([['/project/utils.js', 'utils']])],
             // Circular dependency stack
-            [
-              '/project/circular1.js',
-              new Set([
-                {
-                  path: '/project/circular2.js',
-                  request: 'circular2',
-                },
-              ]),
-            ],
+            ['/project/circular1.js', new Map([['/project/circular2.js', 'circular2']])],
             [
               '/project/circular2.js',
-              new Set([
-                {
-                  path: '/project/circular1.js',
-                  request: 'circular1',
-                },
-                {
-                  path: '/project/utils.js',
-                  request: 'utils',
-                },
+              new Map([
+                ['/project/circular1.js', 'circular1'],
+                ['/project/utils.js', 'utils'],
               ]),
             ],
             // Deep stack that would hit depth limit
-            [
-              '/project/deep1.js',
-              new Set([
-                {
-                  path: '/project/deep2.js',
-                  request: 'deep2',
-                },
-              ]),
-            ],
-            [
-              '/project/deep2.js',
-              new Set([
-                {
-                  path: '/project/deep3.js',
-                  request: 'deep3',
-                },
-              ]),
-            ],
-            [
-              '/project/deep3.js',
-              new Set([
-                {
-                  path: '/project/deep4.js',
-                  request: 'deep4',
-                },
-              ]),
-            ],
-            [
-              '/project/deep4.js',
-              new Set([
-                {
-                  path: '/project/utils.js',
-                  request: 'utils',
-                },
-              ]),
-            ],
+            ['/project/deep1.js', new Map([['/project/deep2.js', 'deep2']])],
+            ['/project/deep2.js', new Map([['/project/deep3.js', 'deep3']])],
+            ['/project/deep3.js', new Map([['/project/deep4.js', 'deep4']])],
+            ['/project/deep4.js', new Map([['/project/utils.js', 'utils']])],
             // preferred project
-            [
-              '/project/app.js',
-              new Set([
-                {
-                  path: '/project/utils.js',
-                  request: 'utils',
-                },
-              ]),
-            ],
-            [
-              '/project/utils.js',
-              new Set([
-                {
-                  path: '/project/missing.js',
-                  request: 'missing',
-                },
-              ]),
-            ],
+            ['/project/app.js', new Map([['/project/utils.js', 'utils']])],
+            ['/project/utils.js', new Map([['/project/missing.js', 'missing']])],
           ]),
         ],
       ]),
@@ -435,33 +276,12 @@ it('prioritizes projectRoot stack over server root stack', () => {
           'ios', // platform
           new Map([
             // Server root stack
-            [
-              '/server-root/lib.js',
-              new Set([
-                {
-                  path: '/server-root/project/utils.js',
-                  request: 'utils',
-                },
-              ]),
-            ],
+            ['/server-root/lib.js', new Map([['/server-root/project/utils.js', 'utils']])],
             // Project root stack (should be preferred)
-            [
-              '/server-root/project/app.js',
-              new Set([
-                {
-                  path: '/server-root/project/utils.js',
-                  request: 'utils',
-                },
-              ]),
-            ],
+            ['/server-root/project/app.js', new Map([['/server-root/project/utils.js', 'utils']])],
             [
               '/server-root/project/utils.js',
-              new Set([
-                {
-                  path: '/server-root/project/missing.js',
-                  request: 'missing',
-                },
-              ]),
+              new Map([['/server-root/project/missing.js', 'missing']]),
             ],
           ]),
         ],

--- a/packages/@expo/cli/src/start/server/metro/withMetroErrorReportingResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroErrorReportingResolver.ts
@@ -25,6 +25,13 @@ export function withMetroErrorReportingResolver(config: MetroConfig): MetroConfi
 
   const mutateResolutionError = createMutateResolutionError(config, depGraph);
 
+  // Single-entry cache for the most recent (options, platform, origin) → deps map.
+  // Metro resolves depth-first, so the same origin repeats for consecutive calls.
+  let _prevOptions: Record<string, unknown> | null | undefined;
+  let _prevPlatform: string | undefined;
+  let _prevOrigin: string | undefined;
+  let _prevDeps: Map<string, string> | undefined;
+
   return {
     ...config,
     resolver: {
@@ -44,14 +51,29 @@ export function withMetroErrorReportingResolver(config: MetroConfig): MetroConfi
           const res = firstResolver(context, moduleName, platform);
 
           const inputPlatform = platform ?? 'null';
-          const key = optionsKeyForContext(context);
-          let mapByTarget = depGraph.get(key);
-          if (!mapByTarget) depGraph.set(key, (mapByTarget = new Map()));
-          let mapByPlatform = mapByTarget.get(inputPlatform);
-          if (!mapByPlatform) mapByTarget.set(inputPlatform, (mapByPlatform = new Map()));
-          let depsForModule = mapByPlatform.get(context.originModulePath);
-          if (!depsForModule)
-            mapByPlatform.set(context.originModulePath, (depsForModule = new Map()));
+          let depsForModule: Map<string, string> | undefined;
+
+          if (
+            context.customResolverOptions === _prevOptions &&
+            inputPlatform === _prevPlatform &&
+            context.originModulePath === _prevOrigin
+          ) {
+            depsForModule = _prevDeps!;
+          } else {
+            const key = optionsKeyForContext(context);
+            let mapByTarget = depGraph.get(key);
+            if (!mapByTarget) depGraph.set(key, (mapByTarget = new Map()));
+            let mapByPlatform = mapByTarget.get(inputPlatform);
+            if (!mapByPlatform) mapByTarget.set(inputPlatform, (mapByPlatform = new Map()));
+            depsForModule = mapByPlatform.get(context.originModulePath);
+            if (!depsForModule)
+              mapByPlatform.set(context.originModulePath, (depsForModule = new Map()));
+            _prevOptions = context.customResolverOptions;
+            _prevPlatform = inputPlatform;
+            _prevOrigin = context.originModulePath;
+            _prevDeps = depsForModule;
+          }
+
           const qualifiedModuleName = res?.type === 'sourceFile' ? res.filePath : moduleName;
           depsForModule.set(qualifiedModuleName, moduleName);
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroErrorReportingResolver.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroErrorReportingResolver.ts
@@ -1,10 +1,10 @@
 import type { ConfigT as MetroConfig } from '@expo/metro/metro-config';
+import canonicalize from '@expo/metro/metro-core/canonicalize';
 import type { ResolutionContext } from '@expo/metro/metro-resolver';
 import chalk from 'chalk';
 import path from 'path';
 import { stripVTControlCharacters } from 'util';
 
-import type { ExpoCustomMetroResolver } from './withMetroResolvers';
 import { isPathInside } from '../../../utils/dir';
 import { env } from '../../../utils/env';
 
@@ -30,22 +30,6 @@ export function withMetroErrorReportingResolver(config: MetroConfig): MetroConfi
     resolver: {
       ...config.resolver,
       resolveRequest(context, moduleName, platform) {
-        const storeResult = (res: NonNullable<ReturnType<ExpoCustomMetroResolver>>) => {
-          const inputPlatform = platform ?? 'null';
-
-          const key = optionsKeyForContext(context);
-          if (!depGraph.has(key)) depGraph.set(key, new Map());
-          const mapByTarget = depGraph.get(key);
-          if (!mapByTarget!.has(inputPlatform)) mapByTarget!.set(inputPlatform, new Map());
-          const mapByPlatform = mapByTarget!.get(inputPlatform);
-          if (!mapByPlatform!.has(context.originModulePath))
-            mapByPlatform!.set(context.originModulePath, new Set());
-          const setForModule = mapByPlatform!.get(context.originModulePath)!;
-
-          const qualifiedModuleName = res?.type === 'sourceFile' ? res.filePath : moduleName;
-          setForModule.add({ path: qualifiedModuleName, request: moduleName });
-        };
-
         // If the user defined a resolver, run it first and depend on the documented
         // chaining logic: https://facebook.github.io/metro/docs/resolution/#resolution-algorithm
         //
@@ -58,7 +42,19 @@ export function withMetroErrorReportingResolver(config: MetroConfig): MetroConfi
         try {
           const firstResolver = originalResolveRequest ?? context.resolveRequest;
           const res = firstResolver(context, moduleName, platform);
-          storeResult(res);
+
+          const inputPlatform = platform ?? 'null';
+          const key = optionsKeyForContext(context);
+          let mapByTarget = depGraph.get(key);
+          if (!mapByTarget) depGraph.set(key, (mapByTarget = new Map()));
+          let mapByPlatform = mapByTarget.get(inputPlatform);
+          if (!mapByPlatform) mapByTarget.set(inputPlatform, (mapByPlatform = new Map()));
+          let depsForModule = mapByPlatform.get(context.originModulePath);
+          if (!depsForModule)
+            mapByPlatform.set(context.originModulePath, (depsForModule = new Map()));
+          const qualifiedModuleName = res?.type === 'sourceFile' ? res.filePath : moduleName;
+          depsForModule.set(qualifiedModuleName, moduleName);
+
           return res;
         } catch (error: any) {
           throw mutateResolutionError(error, context, moduleName, platform);
@@ -77,21 +73,28 @@ export type DepGraph = Map<
     Map<
       // origin module name
       string,
-      Set<{
-        // required module name
-        path: string;
-        // This isn't entirely accurate since a module can be imported multiple times in a file,
-        // and use different names. But it's good enough for now.
-        request: string;
-      }>
+      // resolved path → import request
+      // This isn't entirely accurate since a module can be imported multiple times in a file,
+      // and use different names. But it's good enough for now.
+      Map<string, string>
     >
   >
 >;
 
-function optionsKeyForContext(context: ResolutionContext) {
-  const canonicalize: typeof import('@expo/metro/metro-core/canonicalize').default = require('@expo/metro/metro-core/canonicalize');
-  // Compound key for the resolver cache
-  return JSON.stringify(context.customResolverOptions ?? {}, canonicalize) ?? '';
+const optionsKeyCache = new WeakMap<Record<string, unknown>, string>();
+const EMPTY_OPTIONS_KEY = '{}';
+
+function optionsKeyForContext(context: ResolutionContext): string {
+  const options = context.customResolverOptions;
+  if (options == null) {
+    return EMPTY_OPTIONS_KEY;
+  }
+  let key = optionsKeyCache.get(options);
+  if (key == null) {
+    key = JSON.stringify(options, canonicalize) ?? EMPTY_OPTIONS_KEY;
+    optionsKeyCache.set(options, key);
+  }
+  return key;
 }
 
 interface ErrorWithExpoImportStack extends Error {
@@ -129,15 +132,13 @@ export const createMutateResolutionError =
         return inverseOrigin;
       }
 
-      for (const [originKey, mapByTarget] of mapByPlatform) {
-        // search comparing origin to path
-
-        const found = [...mapByTarget.values()].find((resolution) => resolution.path === origin);
-        if (found) {
+      for (const [originKey, depsMap] of mapByPlatform) {
+        const request = depsMap.get(origin);
+        if (request !== undefined) {
           inverseOrigin.push({
             origin,
             previous: originKey,
-            request: found.request,
+            request,
           });
         }
       }


### PR DESCRIPTION
# Why

The current data structure accumulates duplicates over time and doesn't merge well, which can cause excessive GC runs and an unbounded increase in memory over time.

# How

- Restructure data structure to shed `Set` and replace `{ request, path }` structure
  - **NOTE:** This had nothing to merge on before
- Reduce cost of `customResolverOptions` serialisation for keying
- Add memoisation for previous map structure as a micro-opt

# Test Plan

- Existing tests (with changes to adjust the data structure) should pass as-is

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
