### PR TITLE
[linear-gradient] Add macOS support

### DIFF
--- a/packages/expo-linear-gradient/CHANGELOG.md
+++ b/packages/expo-linear-gradient/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add macOS support ([#45448](https://github.com/expo/expo/pull/45448) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-linear-gradient/ios/ExpoLinearGradient.podspec
+++ b/packages/expo-linear-gradient/ios/ExpoLinearGradient.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.platforms      = {
     :ios => '16.4',
     :tvos => '16.4'
+    :osx => '13.4'
   }
   s.swift_version  = '5.9'
   s.source         = { git: 'https://github.com/expo/expo.git' }

--- a/packages/expo-linear-gradient/ios/ExpoLinearGradient.podspec
+++ b/packages/expo-linear-gradient/ios/ExpoLinearGradient.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.homepage       = package['homepage']
   s.platforms      = {
     :ios => '16.4',
-    :tvos => '16.4'
+    :tvos => '16.4',
     :osx => '13.4'
   }
   s.swift_version  = '5.9'

--- a/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
@@ -60,7 +60,15 @@ final class LinearGradientLayer: CALayer {
       return result || color.cgColor.alpha < 1.0
     }
 
-    #if !os(macOS)
+    #if os(macOS)
+    setLayerContentsMacOS(hasAlpha: hasAlpha)
+    #else
+    setLayerContents(hasAlpha: hasAlpha)
+    #endif
+  }
+
+  #if !os(macOS)
+  private func setLayerContents(hasAlpha: Bool) {
     UIGraphicsBeginImageContextWithOptions(bounds.size, !hasAlpha, 0.0)
 
     guard let contextRef = UIGraphicsGetCurrentContext() else {
@@ -77,7 +85,9 @@ final class LinearGradientLayer: CALayer {
     self.contentsScale = image.scale
 
     UIGraphicsEndImageContext()
-    #else
+  }
+  #else
+  private func setLayerContentsMacOS(hasAlpha: Bool) {
     let scale = contentsScale > 0 ? contentsScale : (NSScreen.main?.backingScaleFactor ?? 2.0)
     let pixelWidth = Int(bounds.size.width * scale)
     let pixelHeight = Int(bounds.size.height * scale)
@@ -103,8 +113,8 @@ final class LinearGradientLayer: CALayer {
     draw(in: ctx)
     self.contents = ctx.makeImage()
     self.contentsScale = scale
-    #endif
   }
+  #endif
 
   override func draw(in ctx: CGContext) {
     super.draw(in: ctx)

--- a/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientLayer.swift
@@ -2,6 +2,7 @@
 
 import QuartzCore
 import CoreGraphics
+import ExpoModulesCore
 
 var defaultStartPoint = CGPoint(x: 0.5, y: 0.0)
 var defaultEndPoint = CGPoint(x: 0.5, y: 1.0)
@@ -59,6 +60,7 @@ final class LinearGradientLayer: CALayer {
       return result || color.cgColor.alpha < 1.0
     }
 
+    #if !os(macOS)
     UIGraphicsBeginImageContextWithOptions(bounds.size, !hasAlpha, 0.0)
 
     guard let contextRef = UIGraphicsGetCurrentContext() else {
@@ -75,6 +77,33 @@ final class LinearGradientLayer: CALayer {
     self.contentsScale = image.scale
 
     UIGraphicsEndImageContext()
+    #else
+    let scale = contentsScale > 0 ? contentsScale : (NSScreen.main?.backingScaleFactor ?? 2.0)
+    let pixelWidth = Int(bounds.size.width * scale)
+    let pixelHeight = Int(bounds.size.height * scale)
+    if pixelWidth == 0 || pixelHeight == 0 {
+      return
+    }
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let bitmapInfo: UInt32 = hasAlpha
+      ? CGImageAlphaInfo.premultipliedLast.rawValue
+      : CGImageAlphaInfo.noneSkipLast.rawValue
+    guard let ctx = CGContext(
+      data: nil,
+      width: pixelWidth,
+      height: pixelHeight,
+      bitsPerComponent: 8,
+      bytesPerRow: 0,
+      space: colorSpace,
+      bitmapInfo: bitmapInfo
+    ) else {
+      return
+    }
+    ctx.scaleBy(x: scale, y: scale)
+    draw(in: ctx)
+    self.contents = ctx.makeImage()
+    self.contentsScale = scale
+    #endif
   }
 
   override func draw(in ctx: CGContext) {

--- a/packages/expo-linear-gradient/ios/LinearGradientView.swift
+++ b/packages/expo-linear-gradient/ios/LinearGradientView.swift
@@ -1,19 +1,34 @@
 // Copyright 2021-present 650 Industries. All rights reserved.
 
+#if !os(macOS)
 import UIKit
+#endif
 import ExpoModulesCore
 
 final class LinearGradientView: ExpoView {
+  #if !os(macOS)
   override class var layerClass: AnyClass {
     return LinearGradientLayer.self
   }
+  #else
+  override func makeBackingLayer() -> CALayer {
+    return LinearGradientLayer()
+  }
+  #endif
 
   public var gradientLayer: LinearGradientLayer {
     return layer as! LinearGradientLayer
   }
 
+  #if !os(macOS)
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
     super.traitCollectionDidChange(previousTraitCollection)
     layer.setNeedsDisplay()
   }
+  #else
+  override func viewDidChangeEffectiveAppearance() {
+    super.viewDidChangeEffectiveAppearance()
+    layer?.setNeedsDisplay()
+  }
+  #endif
 }


### PR DESCRIPTION
# Why

We should slowly add macOS support to more libraries, and we plan on using expo-linear-gradient in Expo Orbit

# How

Add macOS support to linear-gradient, most of the code was already compatible  

# Test Plan

Run BareExpo macos locally 

<img width="1522" height="1664" alt="image" src="https://github.com/user-attachments/assets/ef5e604c-105f-4faf-a330-82fa97c6467e" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
