### PR TITLE
[docs] Add migration guides for Calendar, MediaLibrary, Contacts

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
+++ b/docs/.vale/writing-styles/expo-docs/HeadingCase.yml
@@ -82,6 +82,7 @@ exceptions:
   - '.*EAS Insights.*'
   - '.*Element Inspector.*'
   - '.*Environment Variables.*'
+  - '.*EXIF.*'
   - '.*ESLint.*'
   - '.*Expo.*'
   - '.*ExpoKit.*'

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -380,6 +380,11 @@ export const general = [
     'More',
     [
       makePage('workflow/upgrading-expo-sdk-walkthrough.mdx'),
+      makeSection('SDK libraries migration', [
+        makePage('guides/sdk-libraries-migration/media-library.mdx'),
+        makePage('guides/sdk-libraries-migration/calendar.mdx'),
+        makePage('guides/sdk-libraries-migration/contacts.mdx'),
+      ]),
       makeSection('Assorted', [
         makePage('guides/authentication.mdx'),
         makePage('guides/using-hermes.mdx'),

--- a/docs/pages/guides/sdk-libraries-migration/calendar.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/calendar.mdx
@@ -11,7 +11,6 @@ The new API replaces free functions that accepted ids with methods on class inst
 - Operations on calendars, events, reminders, and attendees are now methods on the corresponding instance instead of free functions that accept an id.
 - `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string ids.
 
-
 ## Importing the new API
 
 Import from `expo-calendar/next`:

--- a/docs/pages/guides/sdk-libraries-migration/calendar.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/calendar.mdx
@@ -11,7 +11,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 The `expo-calendar/next` API is now stable. The legacy `expo-calendar` module is deprecated. Migrate to `expo-calendar/next` to benefit from the new API and future fixes.
 
-The new API replaces free functions that accepted IDs with methods on class instances. Calendars, events, reminders, and attendees are now represented as class instances that hold only the ID of the native object. Key changes:
+The new API replaces free functions that accepted IDs with methods on class instances. Calendars, events, reminders, and attendees are now represented as class instances with their own methods. Key changes:
 
 - Operations on calendars, events, reminders, and attendees are now methods on the corresponding instance instead of free functions that accept an ID.
 - `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string IDs.

--- a/docs/pages/guides/sdk-libraries-migration/calendar.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/calendar.mdx
@@ -356,7 +356,7 @@ await getRemindersPermissions();
 
 - Calendars, events, reminders, and attendees are now class instances. Operations are methods on the instance instead of free functions that accept an ID. Use the corresponding `.get(id)` static method to obtain an instance if you only have an ID.
 - `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string IDs.
-- The `Async` suffix is dropped. The majority of the library is asynchronous &mdash; only synchronous functions use a `Sync` suffix (e.g., `getDefaultCalendarSync`, `getSourcesSync`, `getOccurrenceSync`).
+- The `Async` suffix is dropped. The majority of the library is asynchronous &mdash; only synchronous functions use a `Sync` suffix (for example, `getDefaultCalendarSync`, `getSourcesSync`, `getOccurrenceSync`).
 - `getSourcesAsync` is replaced by the synchronous `getSourcesSync`. Fetching a single source by ID has no direct equivalent.
 - `createEventInCalendarAsync` is renamed to `calendar.addEventWithForm`.
 - `openEventInCalendar` (the fire-and-forget sync variant) is removed. Use `event.openInCalendar()` instead.

--- a/docs/pages/guides/sdk-libraries-migration/calendar.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/calendar.mdx
@@ -1,15 +1,26 @@
 ---
-title: Migrate to Calendar@Next
-sidebar_title: Calendar@Next
-description: Migrate from the legacy expo-calendar API to the new class-based @Next API with ExpoCalendar, ExpoCalendarEvent, and hooks.
+title: Migrate to expo-calendar/next
+sidebar_title: expo-calendar/next
+description: Migrate from the legacy expo-calendar API to the new class-based expo-calendar/next API with ExpoCalendar, ExpoCalendarEvent, and hooks.
 ---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Terminal } from '~/ui/components/Snippet';
 
 The `expo-calendar/next` API is now stable. The legacy `expo-calendar` module is deprecated. Migrate to `expo-calendar/next` to benefit from the new API and future fixes.
 
-The new API replaces free functions that accepted ids with methods on class instances. Calendars, events, reminders, and attendees are now represented as class instances that hold only the id of the native object. Key changes:
+The new API replaces free functions that accepted IDs with methods on class instances. Calendars, events, reminders, and attendees are now represented as class instances that hold only the ID of the native object. Key changes:
 
-- Operations on calendars, events, reminders, and attendees are now methods on the corresponding instance instead of free functions that accept an id.
-- `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string ids.
+- Operations on calendars, events, reminders, and attendees are now methods on the corresponding instance instead of free functions that accept an ID.
+- `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string IDs.
+
+## Installation
+
+Install the SDK-compatible package that includes `expo-calendar/next`:
+
+<Terminal cmd={['$ npx expo install expo-calendar']} />
 
 ## Importing the new API
 
@@ -31,7 +42,7 @@ const calendarId = await Calendar.createCalendarAsync({ title: 'My Calendar', co
 const calendar = await createCalendar({ title: 'My Calendar', color: '#ff0000' });
 ```
 
-`createCalendar` returns an `ExpoCalendar` instance, not just an id.
+`createCalendar` returns an `ExpoCalendar` instance, not just an ID.
 
 ### List calendars
 
@@ -96,7 +107,7 @@ if (calendar) {
 }
 ```
 
-`presentPicker` returns `null` if the user dismisses the picker without selecting a calendar.
+`presentPicker` returns `null` if the app user dismisses the picker without selecting a calendar.
 
 ## Events
 
@@ -114,7 +125,7 @@ const eventId = await Calendar.createEventAsync(calendarId, {
 const event = await calendar.createEvent({ title: 'Lunch', startDate, endDate });
 ```
 
-`createEvent` returns an `ExpoCalendarEvent` instance, not just an id.
+`createEvent` returns an `ExpoCalendarEvent` instance, not just an ID.
 
 ### List events in a calendar
 
@@ -156,7 +167,7 @@ await Calendar.updateEventAsync(eventId, { title: 'Lunch with Alex' });
 await event.update({ title: 'Lunch with Alex' });
 ```
 
-The legacy `updateEventAsync` accepted `recurringEventOptions` (iOS only) to target a single occurrence or future occurrences of a recurring event. This is not supported in the new API — `update()` always modifies the entire recurring event series.
+The legacy `updateEventAsync` accepted `recurringEventOptions` (iOS only) to target a single occurrence or future occurrences of a recurring event. This is not supported in the new API &mdash; `update()` always modifies the entire recurring event series.
 
 ### Delete an event
 
@@ -168,7 +179,7 @@ await Calendar.deleteEventAsync(eventId);
 await event.delete();
 ```
 
-The legacy `deleteEventAsync` accepted `recurringEventOptions` (iOS only) to target a single occurrence or future occurrences of a recurring event. This is not supported in the new API — `delete()` always deletes the entire recurring event series.
+The legacy `deleteEventAsync` accepted `recurringEventOptions` (iOS only) to target a single occurrence or future occurrences of a recurring event. This is not supported in the new API &mdash; `delete()` always deletes the entire recurring event series.
 
 ### Open event in calendar
 
@@ -180,7 +191,7 @@ await Calendar.openEventInCalendarAsync(params);
 await event.openInCalendar(params);
 ```
 
-The `id` field is no longer part of params — it comes from the event instance. Presentation options (`allowsEditing`, `allowsCalendarPreview`, `startNewActivityTask`) are now passed in the same params object instead of as a separate argument.
+The `id` field is no longer part of params &mdash; it comes from the event instance. Presentation options (`allowsEditing`, `allowsCalendarPreview`, `startNewActivityTask`) are now passed in the same params object instead of as a separate argument.
 
 ### Edit event with native form
 
@@ -196,7 +207,7 @@ await event.editInCalendar(params);
 await calendar.addEventWithForm({ title, startDate, endDate });
 ```
 
-The `id` field is no longer part of params — it comes from the event instance. Presentation options (`startNewActivityTask`) are now passed in the same params object instead of as a separate argument.
+The `id` field is no longer part of params &mdash; it comes from the event instance. Presentation options (`startNewActivityTask`) are now passed in the same params object instead of as a separate argument.
 
 ### Get recurring event occurrence
 
@@ -269,7 +280,7 @@ const reminderId = await Calendar.createReminderAsync(calendarId, { title: 'Buy 
 const reminder = await calendar.createReminder({ title: 'Buy milk' });
 ```
 
-`createReminder` returns an `ExpoCalendarReminder` instance, not just an id.
+`createReminder` returns an `ExpoCalendarReminder` instance, not just an ID.
 
 ### List reminders
 
@@ -343,14 +354,19 @@ await getRemindersPermissions();
 
 ## Breaking semantic changes
 
-- Calendars, events, reminders, and attendees are now class instances. Operations are methods on the instance instead of free functions that accept an id. Use the corresponding `.get(id)` static method to obtain an instance if you only have an id.
-- `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string ids.
-- The `Async` suffix is dropped. The majority of the library is asynchronous — only synchronous functions use a `Sync` suffix (e.g., `getDefaultCalendarSync`, `getSourcesSync`, `getOccurrenceSync`).
-- `getSourcesAsync` is replaced by the synchronous `getSourcesSync`. Fetching a single source by id has no direct equivalent.
+- Calendars, events, reminders, and attendees are now class instances. Operations are methods on the instance instead of free functions that accept an ID. Use the corresponding `.get(id)` static method to obtain an instance if you only have an ID.
+- `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string IDs.
+- The `Async` suffix is dropped. The majority of the library is asynchronous &mdash; only synchronous functions use a `Sync` suffix (e.g., `getDefaultCalendarSync`, `getSourcesSync`, `getOccurrenceSync`).
+- `getSourcesAsync` is replaced by the synchronous `getSourcesSync`. Fetching a single source by ID has no direct equivalent.
 - `createEventInCalendarAsync` is renamed to `calendar.addEventWithForm`.
 - `openEventInCalendar` (the fire-and-forget sync variant) is removed. Use `event.openInCalendar()` instead.
 - Attendee operations are now instance methods: creating an attendee is done via `event.createAttendee()` on an `ExpoCalendarEvent` instance; updating and deleting are methods on the resulting `ExpoCalendarAttendee` instance.
 
 ## Reference
 
-See the full API at [Calendar (next)](/versions/latest/sdk/calendar-next/).
+<BoxLink
+  title="Calendar (next)"
+  description="See the full API reference for expo-calendar/next."
+  href="/versions/latest/sdk/calendar-next/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/guides/sdk-libraries-migration/calendar.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/calendar.mdx
@@ -1,0 +1,357 @@
+---
+title: Migrate to Calendar@Next
+sidebar_title: Calendar@Next
+description: Migrate from the legacy expo-calendar API to the new class-based @Next API with ExpoCalendar, ExpoCalendarEvent, and hooks.
+---
+
+The `expo-calendar/next` API is now stable. The legacy `expo-calendar` module is deprecated. Migrate to `expo-calendar/next` to benefit from the new API and future fixes.
+
+The new API replaces free functions that accepted ids with methods on class instances. Calendars, events, reminders, and attendees are now represented as class instances that hold only the id of the native object. Key changes:
+
+- Operations on calendars, events, reminders, and attendees are now methods on the corresponding instance instead of free functions that accept an id.
+- `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string ids.
+
+
+## Importing the new API
+
+Import from `expo-calendar/next`:
+
+```ts
+import { ExpoCalendar, ExpoCalendarEvent } from 'expo-calendar/next';
+```
+
+## Calendars
+
+### Create a calendar
+
+```ts
+// Before
+const calendarId = await Calendar.createCalendarAsync({ title: 'My Calendar', color: '#ff0000' });
+
+// After
+const calendar = await createCalendar({ title: 'My Calendar', color: '#ff0000' });
+```
+
+`createCalendar` returns an `ExpoCalendar` instance, not just an id.
+
+### List calendars
+
+```ts
+// Before
+const calendars = await Calendar.getCalendarsAsync(Calendar.EntityTypes.EVENT);
+
+// After
+const calendars = await getCalendars(EntityTypes.EVENT);
+```
+
+### Get a calendar by ID
+
+```ts
+// Before
+// No direct equivalent, had to filter from getCalendarsAsync
+
+// After
+const calendar = await ExpoCalendar.get(calendarId);
+```
+
+### Update a calendar
+
+```ts
+// Before
+await Calendar.updateCalendarAsync(calendarId, { title: 'Renamed' });
+
+// After
+await calendar.update({ title: 'Renamed' });
+```
+
+### Delete a calendar
+
+```ts
+// Before
+await Calendar.deleteCalendarAsync(calendarId);
+
+// After
+await calendar.delete();
+```
+
+### Get default calendar (iOS only)
+
+```ts
+// Before
+const calendar = await Calendar.getDefaultCalendarAsync();
+
+// After
+const calendar = getDefaultCalendarSync();
+```
+
+### Show a calendar picker (iOS only)
+
+```ts
+// Before
+// No equivalent
+
+// After
+const calendar = await presentPicker();
+if (calendar) {
+  // user selected a calendar
+}
+```
+
+`presentPicker` returns `null` if the user dismisses the picker without selecting a calendar.
+
+## Events
+
+### Create an event
+
+```ts
+// Before
+const eventId = await Calendar.createEventAsync(calendarId, {
+  title: 'Lunch',
+  startDate,
+  endDate,
+});
+
+// After
+const event = await calendar.createEvent({ title: 'Lunch', startDate, endDate });
+```
+
+`createEvent` returns an `ExpoCalendarEvent` instance, not just an id.
+
+### List events in a calendar
+
+```ts
+// Before
+const events = await Calendar.getEventsAsync([calendarId], startDate, endDate);
+
+// After
+const events = await calendar.listEvents(startDate, endDate);
+```
+
+### List events across multiple calendars
+
+```ts
+// Before
+const events = await Calendar.getEventsAsync([id1, id2], startDate, endDate);
+
+// After
+const events = await listEvents([calendar1, calendar2], startDate, endDate);
+```
+
+### Get an event by ID
+
+```ts
+// Before
+const event = await Calendar.getEventAsync(eventId);
+
+// After
+const event = await ExpoCalendarEvent.get(eventId);
+```
+
+### Update an event
+
+```ts
+// Before
+await Calendar.updateEventAsync(eventId, { title: 'Lunch with Alex' });
+
+// After
+await event.update({ title: 'Lunch with Alex' });
+```
+
+The legacy `updateEventAsync` accepted `recurringEventOptions` (iOS only) to target a single occurrence or future occurrences of a recurring event. This is not supported in the new API — `update()` always modifies the entire recurring event series.
+
+### Delete an event
+
+```ts
+// Before
+await Calendar.deleteEventAsync(eventId);
+
+// After
+await event.delete();
+```
+
+The legacy `deleteEventAsync` accepted `recurringEventOptions` (iOS only) to target a single occurrence or future occurrences of a recurring event. This is not supported in the new API — `delete()` always deletes the entire recurring event series.
+
+### Open event in calendar
+
+```ts
+// Before
+await Calendar.openEventInCalendarAsync(params);
+
+// After
+await event.openInCalendar(params);
+```
+
+The `id` field is no longer part of params — it comes from the event instance. Presentation options (`allowsEditing`, `allowsCalendarPreview`, `startNewActivityTask`) are now passed in the same params object instead of as a separate argument.
+
+### Edit event with native form
+
+```ts
+// Before
+await Calendar.editEventInCalendarAsync(params);
+// or, to create a new event with form
+await Calendar.createEventInCalendarAsync({ title, startDate, endDate });
+
+// After
+await event.editInCalendar(params);
+// or, to create a new event with form
+await calendar.addEventWithForm({ title, startDate, endDate });
+```
+
+The `id` field is no longer part of params — it comes from the event instance. Presentation options (`startNewActivityTask`) are now passed in the same params object instead of as a separate argument.
+
+### Get recurring event occurrence
+
+```ts
+// Before
+const event = await Calendar.getEventAsync(eventId, { instanceStartDate });
+
+// After
+const event = await ExpoCalendarEvent.get(eventId);
+const occurrence = event.getOccurrenceSync({ instanceStartDate });
+```
+
+## Attendees
+
+### Get attendees of an event
+
+```ts
+// Before
+const attendees = await Calendar.getAttendeesForEventAsync(eventId);
+
+// After
+const attendees = await event.getAttendees();
+```
+
+### Add an attendee
+
+```ts
+// Before
+const attendeeId = await Calendar.createAttendeeAsync(eventId, {
+  email: 'alex@example.com',
+  name: 'Alex',
+  role: Calendar.AttendeeRole.ATTENDEE,
+  type: Calendar.AttendeeType.PERSON,
+  status: Calendar.AttendeeStatus.ACCEPTED,
+});
+
+// After
+const attendee = await event.createAttendee({ email: 'alex@example.com', name: 'Alex' });
+```
+
+### Update an attendee (Android only)
+
+```ts
+// Before
+await Calendar.updateAttendeeAsync(attendeeId, { name: 'Alexander' });
+
+// After
+await attendee.update({ name: 'Alexander' });
+```
+
+### Delete an attendee (Android only)
+
+```ts
+// Before
+await Calendar.deleteAttendeeAsync(attendeeId);
+
+// After
+await attendee.delete();
+```
+
+## Reminders (iOS only)
+
+### Create a reminder
+
+```ts
+// Before
+const reminderId = await Calendar.createReminderAsync(calendarId, { title: 'Buy milk' });
+
+// After
+const reminder = await calendar.createReminder({ title: 'Buy milk' });
+```
+
+`createReminder` returns an `ExpoCalendarReminder` instance, not just an id.
+
+### List reminders
+
+```ts
+// Before
+const reminders = await Calendar.getRemindersAsync([calendarId], status, startDate, endDate);
+
+// After
+const reminders = await calendar.listReminders(startDate, endDate, status);
+```
+
+### Get a reminder by ID
+
+```ts
+// Before
+const reminder = await Calendar.getReminderAsync(reminderId);
+
+// After
+const reminder = await ExpoCalendarReminder.get(reminderId);
+```
+
+### Update a reminder
+
+```ts
+// Before
+await Calendar.updateReminderAsync(reminderId, { title: 'Buy oat milk' });
+
+// After
+await reminder.update({ title: 'Buy oat milk' });
+```
+
+### Delete a reminder
+
+```ts
+// Before
+await Calendar.deleteReminderAsync(reminderId);
+
+// After
+await reminder.delete();
+```
+
+## Sources
+
+```ts
+// Before
+const sources = await Calendar.getSourcesAsync();
+
+// After
+const sources = getSourcesSync();
+```
+
+`getSourcesAsync` is replaced by the synchronous `getSourcesSync`. Fetching a single source by ID has no direct equivalent in the new API.
+
+## Permissions
+
+```ts
+// Before
+await Calendar.requestCalendarPermissionsAsync();
+await Calendar.getCalendarPermissionsAsync();
+await Calendar.requestRemindersPermissionsAsync();
+await Calendar.getRemindersPermissionsAsync();
+
+// After
+await requestCalendarPermissions();
+await getCalendarPermissions();
+await requestRemindersPermissions();
+await getRemindersPermissions();
+```
+
+`useCalendarPermissions` and `useRemindersPermissions` hooks are unchanged.
+
+## Breaking semantic changes
+
+- Calendars, events, reminders, and attendees are now class instances. Operations are methods on the instance instead of free functions that accept an id. Use the corresponding `.get(id)` static method to obtain an instance if you only have an id.
+- `createCalendar`, `createEvent`, and `createReminder` return class instances instead of string ids.
+- The `Async` suffix is dropped. The majority of the library is asynchronous — only synchronous functions use a `Sync` suffix (e.g., `getDefaultCalendarSync`, `getSourcesSync`, `getOccurrenceSync`).
+- `getSourcesAsync` is replaced by the synchronous `getSourcesSync`. Fetching a single source by id has no direct equivalent.
+- `createEventInCalendarAsync` is renamed to `calendar.addEventWithForm`.
+- `openEventInCalendar` (the fire-and-forget sync variant) is removed. Use `event.openInCalendar()` instead.
+- Attendee operations are now instance methods: creating an attendee is done via `event.createAttendee()` on an `ExpoCalendarEvent` instance; updating and deleting are methods on the resulting `ExpoCalendarAttendee` instance.
+
+## Reference
+
+See the full API at [Calendar (next)](/versions/latest/sdk/calendar-next/).

--- a/docs/pages/guides/sdk-libraries-migration/contacts.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/contacts.mdx
@@ -13,7 +13,7 @@ The `expo-contacts/next` API is now stable. The legacy `expo-contacts` module is
 
 The new API replaces the function-based API with a `Contact` class. Contacts are represented as class instances that hold only the ID of the native contact. Key changes:
 
-- Contact properties (name, company, birthday, etc.) are async getters and setters instead of plain object properties.
+- Contact properties (name, company, birthday, and more) are async getters and setters instead of plain object properties.
 - Sub-records (phones, emails, addresses, ...) are managed via dedicated `add*`/`get*`/`update*`/`delete*` methods instead of re-writing the entire array.
 - Two update methods are now available: `patch` for partial updates and `update` for full replacement.
 

--- a/docs/pages/guides/sdk-libraries-migration/contacts.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/contacts.mdx
@@ -1,16 +1,27 @@
 ---
-title: Migrate to Contacts@Next
-sidebar_title: Contacts@Next
-description: Migrate from the legacy expo-contacts API to the new class-based @Next API.
+title: Migrate to expo-contacts/next
+sidebar_title: expo-contacts/next
+description: Migrate from the legacy expo-contacts API to the new class-based expo-contacts/next API.
 ---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Terminal } from '~/ui/components/Snippet';
 
 The `expo-contacts/next` API is now stable. The legacy `expo-contacts` module is deprecated. Migrate to `expo-contacts/next` to benefit from the new API and future fixes.
 
-The new API replaces the function-based API with a `Contact` class. Contacts are represented as class instances that hold only the id of the native contact. Key changes:
+The new API replaces the function-based API with a `Contact` class. Contacts are represented as class instances that hold only the ID of the native contact. Key changes:
 
 - Contact properties (name, company, birthday, etc.) are async getters and setters instead of plain object properties.
 - Sub-records (phones, emails, addresses, ...) are managed via dedicated `add*`/`get*`/`update*`/`delete*` methods instead of re-writing the entire array.
 - Two update methods are now available: `patch` for partial updates and `update` for full replacement.
+
+## Installation
+
+Install the SDK-compatible package that includes `expo-contacts/next`:
+
+<Terminal cmd={['$ npx expo install expo-contacts']} />
 
 ## Importing the new API
 
@@ -32,7 +43,7 @@ const id = await Contacts.addContactAsync({ firstName: 'John', lastName: 'Doe' }
 const contact = await Contact.create({ givenName: 'John', familyName: 'Doe' });
 ```
 
-`Contact.create` returns a `Contact` instance, not just an id.
+`Contact.create` returns a `Contact` instance, not just an ID.
 
 ### Get all contacts
 
@@ -63,7 +74,7 @@ const contacts = await Contact.getAllDetails([ContactField.FULL_NAME, ContactFie
 
 ### Get a contact by ID
 
-Results from `getAllDetails` include the contact id. If you want to call methods on a contact returned from `getAllDetails`, wrap it in a `Contact` instance using the constructor:
+Results from `getAllDetails` include the contact ID. If you want to call methods on a contact returned from `getAllDetails`, wrap it in a `Contact` instance using the constructor:
 
 ```ts
 const results = await Contact.getAllDetails([ContactField.FULL_NAME, ContactField.PHONES]);
@@ -93,7 +104,7 @@ await Contacts.updateContactAsync({ ...contact, firstName: 'Andrew' });
 // After, partial update (only changes provided fields)
 await contact.patch({ givenName: 'Andrew' });
 
-// After, full replacement — all fields not provided will be cleared
+// After, full replacement - all fields not provided will be cleared
 await contact.update({
   givenName: 'John',
   familyName: 'Doe',
@@ -297,4 +308,9 @@ removeAllContactsChangeListeners();
 
 ## Reference
 
-See the full API at [Contacts (next)](/versions/latest/sdk/contacts-next/).
+<BoxLink
+  title="Contacts (next)"
+  description="See the full API reference for expo-contacts/next."
+  href="/versions/latest/sdk/contacts-next/"
+  Icon={BookOpen02Icon}
+/>

--- a/docs/pages/guides/sdk-libraries-migration/contacts.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/contacts.mdx
@@ -46,13 +46,17 @@ const { data } = await Contacts.getContactsAsync({
 });
 
 // After, instance objects
-const contacts = await Contact.getAll({ limit: 20, offset: 10, sortOrder: ContactsSortOrder.GivenName });
+const contacts = await Contact.getAll({
+  limit: 20,
+  offset: 10,
+  sortOrder: ContactsSortOrder.GivenName,
+});
 
 // After, typed field projection
-const contacts = await Contact.getAllDetails(
-  [ContactField.FULL_NAME, ContactField.PHONES],
-  { limit: 20, offset: 10 }
-);
+const contacts = await Contact.getAllDetails([ContactField.FULL_NAME, ContactField.PHONES], {
+  limit: 20,
+  offset: 10,
+});
 ```
 
 `getAllDetails` returns a strongly typed projection narrowed to the requested fields.
@@ -90,7 +94,11 @@ await Contacts.updateContactAsync({ ...contact, firstName: 'Andrew' });
 await contact.patch({ givenName: 'Andrew' });
 
 // After, full replacement — all fields not provided will be cleared
-await contact.update({ givenName: 'John', familyName: 'Doe', phones: [{ label: 'mobile', number: '+12123456789' }] });
+await contact.update({
+  givenName: 'John',
+  familyName: 'Doe',
+  phones: [{ label: 'mobile', number: '+12123456789' }],
+});
 ```
 
 ### Delete a contact
@@ -107,25 +115,25 @@ await contact.delete();
 
 All scalar contact properties are now async getters and setters. Use `get*` to read and `set*` to write. You can also retrieve multiple fields at once using `contact.getDetails()`.
 
-| Field | Getter | Setter |
-|---|---|---|
-| Given name | `getGivenName` | `setGivenName` |
-| Family name | `getFamilyName` | `setFamilyName` |
-| Middle name | `getMiddleName` | `setMiddleName` |
-| Full name | `getFullName` | — |
-| Nickname (iOS only) | `getNickname` | `setNickname` |
-| Prefix | `getPrefix` | `setPrefix` |
-| Suffix | `getSuffix` | `setSuffix` |
-| Phonetic given name | `getPhoneticGivenName` | `setPhoneticGivenName` |
-| Phonetic family name | `getPhoneticFamilyName` | `setPhoneticFamilyName` |
-| Company | `getCompany` | `setCompany` |
-| Job title | `getJobTitle` | `setJobTitle` |
-| Department | `getDepartment` | `setDepartment` |
-| Birthday (iOS only) | `getBirthday` | `setBirthday` |
-| Note | `getNote` | `setNote` |
-| Image | `getImage` | `setImage` |
-| Thumbnail | `getThumbnail` | — |
-| Favourite (Android only) | `getIsFavourite` | `setIsFavourite` |
+| Field                    | Getter                  | Setter                  |
+| ------------------------ | ----------------------- | ----------------------- |
+| Given name               | `getGivenName`          | `setGivenName`          |
+| Family name              | `getFamilyName`         | `setFamilyName`         |
+| Middle name              | `getMiddleName`         | `setMiddleName`         |
+| Full name                | `getFullName`           | —                       |
+| Nickname (iOS only)      | `getNickname`           | `setNickname`           |
+| Prefix                   | `getPrefix`             | `setPrefix`             |
+| Suffix                   | `getSuffix`             | `setSuffix`             |
+| Phonetic given name      | `getPhoneticGivenName`  | `setPhoneticGivenName`  |
+| Phonetic family name     | `getPhoneticFamilyName` | `setPhoneticFamilyName` |
+| Company                  | `getCompany`            | `setCompany`            |
+| Job title                | `getJobTitle`           | `setJobTitle`           |
+| Department               | `getDepartment`         | `setDepartment`         |
+| Birthday (iOS only)      | `getBirthday`           | `setBirthday`           |
+| Note                     | `getNote`               | `setNote`               |
+| Image                    | `getImage`              | `setImage`              |
+| Thumbnail                | `getThumbnail`          | —                       |
+| Favourite (Android only) | `getIsFavourite`        | `setIsFavourite`        |
 
 ### Name
 
@@ -150,16 +158,16 @@ await contact.setMiddleName('Michael');
 
 Sub-records are no longer managed by re-writing the entire array with `updateContactAsync`. Each type has dedicated `add*`, `get*`, `update*`, and `delete*` methods:
 
-| Sub-record | Methods |
-|---|---|
-| Phone numbers | `addPhone`, `getPhones`, `updatePhone`, `deletePhone` |
-| Emails | `addEmail`, `getEmails`, `updateEmail`, `deleteEmail` |
-| Addresses | `addAddress`, `getAddresses`, `updateAddress`, `deleteAddress` |
-| URLs | `addUrlAddress`, `getUrlAddresses`, `updateUrlAddress`, `deleteUrlAddress` |
-| Social profiles | `addSocialProfile`, `getSocialProfiles`, `updateSocialProfile`, `deleteSocialProfile` |
-| IM addresses | `addImAddress`, `getImAddresses`, `updateImAddress`, `deleteImAddress` |
-| Dates | `addDate`, `getDates`, `updateDate`, `deleteDate` |
-| Extra names (Android only) | `addExtraName`, `getExtraNames`, `updateExtraName`, `deleteExtraName` |
+| Sub-record                 | Methods                                                                               |
+| -------------------------- | ------------------------------------------------------------------------------------- |
+| Phone numbers              | `addPhone`, `getPhones`, `updatePhone`, `deletePhone`                                 |
+| Emails                     | `addEmail`, `getEmails`, `updateEmail`, `deleteEmail`                                 |
+| Addresses                  | `addAddress`, `getAddresses`, `updateAddress`, `deleteAddress`                        |
+| URLs                       | `addUrlAddress`, `getUrlAddresses`, `updateUrlAddress`, `deleteUrlAddress`            |
+| Social profiles            | `addSocialProfile`, `getSocialProfiles`, `updateSocialProfile`, `deleteSocialProfile` |
+| IM addresses               | `addImAddress`, `getImAddresses`, `updateImAddress`, `deleteImAddress`                |
+| Dates                      | `addDate`, `getDates`, `updateDate`, `deleteDate`                                     |
+| Extra names (Android only) | `addExtraName`, `getExtraNames`, `updateExtraName`, `deleteExtraName`                 |
 
 The following examples use phone numbers.
 

--- a/docs/pages/guides/sdk-libraries-migration/contacts.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/contacts.mdx
@@ -1,0 +1,292 @@
+---
+title: Migrate to Contacts@Next
+sidebar_title: Contacts@Next
+description: Migrate from the legacy expo-contacts API to the new class-based @Next API.
+---
+
+The `expo-contacts/next` API is now stable. The legacy `expo-contacts` module is deprecated. Migrate to `expo-contacts/next` to benefit from the new API and future fixes.
+
+The new API replaces the function-based API with a `Contact` class. Contacts are represented as class instances that hold only the id of the native contact. Key changes:
+
+- Contact properties (name, company, birthday, etc.) are async getters and setters instead of plain object properties.
+- Sub-records (phones, emails, addresses, ...) are managed via dedicated `add*`/`get*`/`update*`/`delete*` methods instead of re-writing the entire array.
+- Two update methods are now available: `patch` for partial updates and `update` for full replacement.
+
+## Importing the new API
+
+Import from `expo-contacts/next`:
+
+```ts
+import { Contact } from 'expo-contacts/next';
+```
+
+## Contacts
+
+### Create a contact
+
+```ts
+// Before
+const id = await Contacts.addContactAsync({ firstName: 'John', lastName: 'Doe' });
+
+// After
+const contact = await Contact.create({ givenName: 'John', familyName: 'Doe' });
+```
+
+`Contact.create` returns a `Contact` instance, not just an id.
+
+### Get all contacts
+
+```ts
+// Before
+const { data } = await Contacts.getContactsAsync({
+  fields: [Contacts.Fields.Name, Contacts.Fields.PhoneNumbers],
+  pageSize: 20,
+  pageOffset: 10,
+  sort: Contacts.SortTypes.FirstName,
+});
+
+// After, instance objects
+const contacts = await Contact.getAll({ limit: 20, offset: 10, sortOrder: ContactsSortOrder.GivenName });
+
+// After, typed field projection
+const contacts = await Contact.getAllDetails(
+  [ContactField.FULL_NAME, ContactField.PHONES],
+  { limit: 20, offset: 10 }
+);
+```
+
+`getAllDetails` returns a strongly typed projection narrowed to the requested fields.
+
+### Get a contact by ID
+
+Results from `getAllDetails` include the contact id. If you want to call methods on a contact returned from `getAllDetails`, wrap it in a `Contact` instance using the constructor:
+
+```ts
+const results = await Contact.getAllDetails([ContactField.FULL_NAME, ContactField.PHONES]);
+const contact = new Contact(results[0].id);
+await contact.addPhone({ label: 'work', number: '+12345678912' });
+```
+
+### Count contacts
+
+```ts
+// Before
+const hasAny = await Contacts.hasContactsAsync();
+
+// After
+const hasAny = await Contact.hasAny();
+
+// After, no direct equivalent before
+const count = await Contact.getCount();
+```
+
+### Update a contact
+
+```ts
+// Before, re-write the whole contact
+await Contacts.updateContactAsync({ ...contact, firstName: 'Andrew' });
+
+// After, partial update (only changes provided fields)
+await contact.patch({ givenName: 'Andrew' });
+
+// After, full replacement — all fields not provided will be cleared
+await contact.update({ givenName: 'John', familyName: 'Doe', phones: [{ label: 'mobile', number: '+12123456789' }] });
+```
+
+### Delete a contact
+
+```ts
+// Before
+await Contacts.removeContactAsync(id);
+
+// After
+await contact.delete();
+```
+
+## Scalar fields
+
+All scalar contact properties are now async getters and setters. Use `get*` to read and `set*` to write. You can also retrieve multiple fields at once using `contact.getDetails()`.
+
+| Field | Getter | Setter |
+|---|---|---|
+| Given name | `getGivenName` | `setGivenName` |
+| Family name | `getFamilyName` | `setFamilyName` |
+| Middle name | `getMiddleName` | `setMiddleName` |
+| Full name | `getFullName` | — |
+| Nickname (iOS only) | `getNickname` | `setNickname` |
+| Prefix | `getPrefix` | `setPrefix` |
+| Suffix | `getSuffix` | `setSuffix` |
+| Phonetic given name | `getPhoneticGivenName` | `setPhoneticGivenName` |
+| Phonetic family name | `getPhoneticFamilyName` | `setPhoneticFamilyName` |
+| Company | `getCompany` | `setCompany` |
+| Job title | `getJobTitle` | `setJobTitle` |
+| Department | `getDepartment` | `setDepartment` |
+| Birthday (iOS only) | `getBirthday` | `setBirthday` |
+| Note | `getNote` | `setNote` |
+| Image | `getImage` | `setImage` |
+| Thumbnail | `getThumbnail` | — |
+| Favourite (Android only) | `getIsFavourite` | `setIsFavourite` |
+
+### Name
+
+```ts
+// Before, contact fetched via getContactByIdAsync
+const contact = await Contacts.getContactByIdAsync(id);
+console.log(contact.firstName, contact.lastName);
+
+// After, individual async getters
+const givenName = await contact.getGivenName();
+const familyName = await contact.getFamilyName();
+
+// After, full name object via getDetails()
+const details = await contact.getDetails([ContactField.FULL_NAME]);
+
+await contact.setGivenName('John');
+await contact.setFamilyName('Doe');
+await contact.setMiddleName('Michael');
+```
+
+## Sub-records
+
+Sub-records are no longer managed by re-writing the entire array with `updateContactAsync`. Each type has dedicated `add*`, `get*`, `update*`, and `delete*` methods:
+
+| Sub-record | Methods |
+|---|---|
+| Phone numbers | `addPhone`, `getPhones`, `updatePhone`, `deletePhone` |
+| Emails | `addEmail`, `getEmails`, `updateEmail`, `deleteEmail` |
+| Addresses | `addAddress`, `getAddresses`, `updateAddress`, `deleteAddress` |
+| URLs | `addUrlAddress`, `getUrlAddresses`, `updateUrlAddress`, `deleteUrlAddress` |
+| Social profiles | `addSocialProfile`, `getSocialProfiles`, `updateSocialProfile`, `deleteSocialProfile` |
+| IM addresses | `addImAddress`, `getImAddresses`, `updateImAddress`, `deleteImAddress` |
+| Dates | `addDate`, `getDates`, `updateDate`, `deleteDate` |
+| Extra names (Android only) | `addExtraName`, `getExtraNames`, `updateExtraName`, `deleteExtraName` |
+
+The following examples use phone numbers.
+
+```ts
+// Before, re-write the whole array
+await Contacts.updateContactAsync({
+  ...contact,
+  phoneNumbers: [...existing, { label: 'work', number: '+12345678912' }],
+});
+
+// After, add
+await contact.addPhone({ label: 'work', number: '+12345678912' });
+
+// After, get
+const phones = await contact.getPhones();
+
+// After, update
+await contact.updatePhone(existingPhone);
+
+// After, delete
+await contact.deletePhone(existingPhone);
+```
+
+## Native UI
+
+```ts
+// Before
+const contact = await Contacts.presentContactPickerAsync();
+await Contacts.presentFormAsync(null, contactData, { isNew: true });
+await Contacts.presentFormAsync(contactId);
+
+// After
+const contact = await Contact.presentPicker();
+if (contact) {
+  // user selected a contact
+}
+const created = await Contact.presentCreateForm(contactData);
+await contact.editWithForm();
+```
+
+### Access picker (iOS 18+ only)
+
+```ts
+// Before
+const contactIds = await Contacts.presentAccessPickerAsync();
+
+// After
+const selectedContacts = await Contact.presentAccessPicker();
+```
+
+## Groups (iOS only)
+
+```ts
+// Before
+const groups = await Contacts.getGroupsAsync({});
+await Contacts.createGroupAsync('Family');
+await Contacts.addExistingContactToGroupAsync(contactId, groupId);
+await Contacts.removeContactFromGroupAsync(contactId, groupId);
+
+// After
+const groups = await Group.getAll();
+const group = await Group.create('Family');
+await group.addContact(contact);
+await group.removeContact(contact);
+const contacts = await group.getContacts();
+const name = await group.getName();
+await group.setName('Close Friends');
+await group.delete();
+```
+
+## Containers (iOS only)
+
+```ts
+// Before
+const containers = await Contacts.getContainersAsync({});
+const defaultId = await Contacts.getDefaultContainerIdAsync();
+
+// After
+const containers = await Container.getAll();
+const defaultContainer = await Container.getDefault(); // may be null
+const name = await container.getName();
+const type = await container.getType();
+const groups = await container.getGroups();
+const contacts = await container.getContacts();
+```
+
+## Permissions
+
+```ts
+// Before
+const { status } = await Contacts.requestPermissionsAsync();
+const { status } = await Contacts.getPermissionsAsync();
+
+// After
+const { status } = await requestPermissionsAsync();
+const { status } = await getPermissionsAsync();
+```
+
+## Listening for changes
+
+```ts
+// Before
+const subscription = Contacts.addContactsChangeListener(() => {
+  // contacts changed
+});
+subscription.remove();
+
+// After
+const subscription = addContactsChangeListener(() => {
+  // contacts changed
+});
+subscription.remove();
+
+// Remove all listeners at once
+removeAllContactsChangeListeners();
+```
+
+## Breaking semantic changes
+
+- Field names follow the platform convention. For example, `firstName`/`lastName` become `givenName`/`familyName`.
+- Field selection uses the typed `ContactField` enum. The result type of `getAllDetails` is narrowed to the requested fields.
+- The `Async` suffix is dropped. The entire library is asynchronous.
+- Contact properties are now async getters and setters instead of plain properties on the contact object. Use `contact.getDetails()` to retrieve multiple fields at once.
+- Sub-records (phones, emails, addresses, ...) are managed via dedicated `add*`/`get*`/`update*`/`delete*` methods instead of re-writing the entire array with `updateContactAsync`.
+- Two update methods replace `updateContactAsync`: `patch` applies partial changes, `update` replaces the entire contact.
+- `shareContactAsync` and `writeContactToFileAsync` are removed with no replacement. You can safely delete any calls to these functions.
+
+## Reference
+
+See the full API at [Contacts (next)](/versions/latest/sdk/contacts-next/).

--- a/docs/pages/guides/sdk-libraries-migration/media-library.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/media-library.mdx
@@ -1,0 +1,229 @@
+---
+title: Migrate to MediaLibrary@Next
+sidebar_title: MediaLibrary@Next
+description: Migrate from the legacy expo-media-library API to the new class-based @Next API with Asset, Album, and Query.
+---
+
+The `expo-media-library/next` API is now stable. The legacy `expo-media-library` module is deprecated. Migrate to `expo-media-library/next` to benefit from the new API and future fixes.
+
+The new API replaces the function-based `MediaLibrary.getAssetsAsync({ ... })` style with `Asset`, `Album`, and `Query` classes. Albums and assets are now represented as class instances that hold only the id of the native asset. Asset properties are async getters instead of pre-fetched fields. `Query` replaces the `getAssetsAsync` function with a chainable builder pattern.
+
+## Importing the new API
+
+Import from `expo-media-library/next`:
+
+```ts
+import { Asset, Album, Query } from 'expo-media-library/next';
+```
+
+## Assets
+
+### Create an asset from a file
+
+```ts
+// Before
+await MediaLibrary.saveToLibraryAsync(localUri);
+// or, to get a reference back:
+const asset = await MediaLibrary.createAssetAsync(localUri);
+
+// After
+const asset = await Asset.create(localUri);
+```
+
+`saveToLibraryAsync` is not available in the new API. Use `Asset.create`, which saves the file to the library and returns an `Asset` instance.
+
+### Query assets
+
+```ts
+// Before
+const { assets } = await MediaLibrary.getAssetsAsync({
+  mediaType: MediaLibrary.MediaType.photo,
+  first: 20,
+  sortBy: [['creationTime', false]],
+});
+
+// After
+const assets = await new Query()
+  .eq(AssetField.MEDIA_TYPE, MediaType.IMAGE)
+  .limit(20)
+  .orderBy({ key: AssetField.CREATION_TIME, ascending: false })
+  .exe();
+```
+
+`Query` returns an array of `Asset` instances directly. There is no `assets` wrapper or `endCursor`. Pagination is handled by chaining `.limit()` and `.offset()`.
+
+### Read asset properties
+
+```ts
+// Before
+const info = await MediaLibrary.getAssetInfoAsync(asset);
+console.log(info.filename, info.width, info.height);
+
+// After, individual getters
+const filename = await asset.getFilename();
+const width = await asset.getWidth();
+const height = await asset.getHeight();
+const mediaType = await asset.getMediaType();
+
+// After, all properties at once
+const info = await asset.getInfo();
+```
+
+Properties are accessed through async getters instead of pre-fetched fields. Use `getInfo()` to retrieve all properties at once as an `AssetInfo` object.
+
+### Read EXIF data
+
+```ts
+// Before
+const info = await MediaLibrary.getAssetInfoAsync(asset);
+const exif = info.exif;
+
+// After
+const exif = await asset.getExif();
+```
+
+### Delete assets
+
+```ts
+// Before
+await MediaLibrary.deleteAssetsAsync([asset]);
+
+// After, single asset
+await asset.delete();
+
+// After, multiple assets
+await Asset.delete([asset1, asset2]);
+```
+
+## Albums
+
+### Get an album by name
+
+```ts
+// Before
+const album = await MediaLibrary.getAlbumAsync('MyAlbum');
+
+// After
+const album = await Album.get('MyAlbum');
+if (album) {
+  // album found
+}
+```
+
+### Get all albums
+
+```ts
+// Before
+const albums = await MediaLibrary.getAlbumsAsync();
+
+// After
+const albums = await Album.getAll();
+```
+
+### Create an album
+
+```ts
+// Before
+const album = await MediaLibrary.createAlbumAsync('MyNewAlbum', asset, false);
+
+// After
+const album = await Album.create('MyNewAlbum', [asset]);
+```
+
+### Get all assets in an album
+
+```ts
+// Before
+const { assets } = await MediaLibrary.getAssetsAsync({ album: album.id });
+
+// After
+const assets = await album.getAssets();
+```
+
+### Get album title
+
+```ts
+// Before, title was a synchronous property but required fetching the full album object first
+const album = await MediaLibrary.getAlbumAsync('MyAlbum');
+console.log(album.title);
+
+// After
+const title = await album.getTitle();
+```
+
+### Add assets to an album
+
+```ts
+// Before
+await MediaLibrary.addAssetsToAlbumAsync([asset], album, false);
+
+// After
+await album.add([asset]);
+```
+
+### Remove assets from an album (iOS only)
+
+```ts
+// Before
+await MediaLibrary.removeAssetsFromAlbumAsync(assets, album);
+
+// After
+await album.removeAssets(assets);
+```
+
+### Delete an album
+
+```ts
+// Before
+await MediaLibrary.deleteAlbumsAsync([album], false);
+
+// After, single album
+await album.delete();
+
+// After, multiple albums
+await Album.delete([album1, album2]);
+```
+
+## Permissions
+
+The permission hooks and functions are available under the same names. The only change is that `presentPermissionsPickerAsync` was renamed to `presentPermissionsPicker`.
+
+```ts
+// Before
+await MediaLibrary.presentPermissionsPickerAsync(mediaTypes);
+
+// After
+await presentPermissionsPicker(mediaTypes);
+```
+
+`requestPermissionsAsync`, `getPermissionsAsync`, and `usePermissions` are unchanged.
+
+## Listening for changes
+
+```ts
+// Before
+const subscription = MediaLibrary.addListener(event => { ... });
+subscription.remove();
+
+// After
+const subscription = addListener(event => { ... });
+subscription.remove();
+
+// Remove all listeners at once
+removeAllListeners();
+```
+
+The listener event shape is unchanged.
+
+## Breaking semantic changes
+
+- Asset properties are now async getters (`getFilename()`, `getWidth()`, ...) instead of synchronous fields on a result object. Use `asset.getInfo()` to retrieve all properties at once.
+- The `Async` suffix is dropped. The entire library is asynchronous.
+- `Query` replaces the `getAssetsAsync` options bag. There is no `endCursor`/`hasNextPage`. Use `.limit()` and `.offset()` for pagination.
+- Operations on albums and assets are now methods on `Album` and `Asset` instances instead of free functions that accept an id or reference.
+- `saveToLibraryAsync` is replaced by `Asset.create`, which returns an `Asset` instance.
+- `getMomentsAsync`, `albumNeedsMigrationAsync`, and `migrateAlbumIfNeededAsync` are removed with no replacement. You can safely delete any calls to these functions.
+
+## Reference
+
+See the full API at [MediaLibrary (next)](/versions/latest/sdk/media-library-next/).

--- a/docs/pages/guides/sdk-libraries-migration/media-library.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/media-library.mdx
@@ -1,12 +1,23 @@
 ---
-title: Migrate to MediaLibrary@Next
-sidebar_title: MediaLibrary@Next
-description: Migrate from the legacy expo-media-library API to the new class-based @Next API with Asset, Album, and Query.
+title: Migrate to expo-media-library/next
+sidebar_title: expo-media-library/next
+description: Migrate from the legacy expo-media-library API to the new class-based expo-media-library/next API with Asset, Album, and Query.
 ---
+
+import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+import { Terminal } from '~/ui/components/Snippet';
 
 The `expo-media-library/next` API is now stable. The legacy `expo-media-library` module is deprecated. Migrate to `expo-media-library/next` to benefit from the new API and future fixes.
 
-The new API replaces the function-based `MediaLibrary.getAssetsAsync({ ... })` style with `Asset`, `Album`, and `Query` classes. Albums and assets are now represented as class instances that hold only the id of the native asset. Asset properties are async getters instead of pre-fetched fields. `Query` replaces the `getAssetsAsync` function with a chainable builder pattern.
+The new API replaces the function-based `MediaLibrary.getAssetsAsync({ ... })` style with `Asset`, `Album`, and `Query` classes. Albums and assets are now represented as class instances that hold only the ID of the native asset. Asset properties are async getters instead of pre-fetched fields. `Query` replaces the `getAssetsAsync` function with a chainable builder pattern.
+
+## Installation
+
+Install the SDK-compatible package that includes `expo-media-library/next`:
+
+<Terminal cmd={['$ npx expo install expo-media-library']} />
 
 ## Importing the new API
 
@@ -220,10 +231,15 @@ The listener event shape is unchanged.
 - Asset properties are now async getters (`getFilename()`, `getWidth()`, ...) instead of synchronous fields on a result object. Use `asset.getInfo()` to retrieve all properties at once.
 - The `Async` suffix is dropped. The entire library is asynchronous.
 - `Query` replaces the `getAssetsAsync` options bag. There is no `endCursor`/`hasNextPage`. Use `.limit()` and `.offset()` for pagination.
-- Operations on albums and assets are now methods on `Album` and `Asset` instances instead of free functions that accept an id or reference.
+- Operations on albums and assets are now methods on `Album` and `Asset` instances instead of free functions that accept an ID or reference.
 - `saveToLibraryAsync` is replaced by `Asset.create`, which returns an `Asset` instance.
 - `getMomentsAsync`, `albumNeedsMigrationAsync`, and `migrateAlbumIfNeededAsync` are removed with no replacement. You can safely delete any calls to these functions.
 
 ## Reference
 
-See the full API at [MediaLibrary (next)](/versions/latest/sdk/media-library-next/).
+<BoxLink
+  title="MediaLibrary (next)"
+  description="See the full API reference for expo-media-library/next."
+  href="/versions/latest/sdk/media-library-next/"
+  Icon={BookOpen02Icon}
+/>


### PR DESCRIPTION
# Why
Adds migration guides for the next versions of the calendar, contacts, and media-library packages, as they are now stable in SDK 56.

# How
Adds new guide pages, as a separate tab in the "More" section.

# Test Plan
Docs Preview