### PR TITLE
[tools] Refresh embedded versions in workspace:<exact> specs

### DIFF
--- a/apps/observe-tester/package.json
+++ b/apps/observe-tester/package.json
@@ -14,7 +14,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/html-elements": "^56.0.1",
+    "@expo/html-elements": "workspace:*",
     "@expo/styleguide-base": "^1.0.1",
     "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.15.5",

--- a/apps/observe-tester/package.json
+++ b/apps/observe-tester/package.json
@@ -14,7 +14,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/html-elements": "^56.0.2",
+    "@expo/html-elements": "^56.0.1",
     "@expo/styleguide-base": "^1.0.1",
     "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.15.5",

--- a/apps/observe-tester/package.json
+++ b/apps/observe-tester/package.json
@@ -14,7 +14,7 @@
     "lint": "expo lint"
   },
   "dependencies": {
-    "@expo/html-elements": "^56.0.1",
+    "@expo/html-elements": "^56.0.2",
     "@expo/styleguide-base": "^1.0.1",
     "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.15.5",

--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -25,6 +25,7 @@
     "stacktrace-parser": "^0.1.10"
   },
   "devDependencies": {
+    "@expo/cli": "workspace:*",
     "@expo/spawn-async": "^1.7.2",
     "@types/react": "~19.2.0",
     "@types/react-dom": "^19.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1317,7 +1317,7 @@ importers:
   apps/observe-tester:
     dependencies:
       '@expo/html-elements':
-        specifier: ^56.0.1
+        specifier: workspace:*
         version: link:../../packages/html-elements
       '@expo/styleguide-base':
         specifier: ^1.0.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2469,6 +2469,9 @@ importers:
         specifier: ^0.1.10
         version: 0.1.11
     devDependencies:
+      '@expo/cli':
+        specifier: workspace:*
+        version: link:../cli
       '@expo/spawn-async':
         specifier: ^1.7.2
         version: 1.7.2

--- a/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
+++ b/tools/src/publish-packages/tasks/updateWorkspaceProjects.ts
@@ -102,9 +102,17 @@ export const updateWorkspaceProjects = new Task<TaskArgs>(
             }
 
             // Leave tilde and caret as they are, just replace the version.
+            // For workspace: forms with an embedded version, preserve the
+            // workspace: prefix and any caret/tilde modifier so the source
+            // continues to declare the workspace protocol.
             const newVersionRange = options.canary
               ? state.releaseVersion
-              : currentVersionRange.replace(/([\^~]?).*/, `$1${state.releaseVersion}`);
+              : currentVersionRange.startsWith('workspace:')
+                ? currentVersionRange.replace(
+                    /^workspace:([\^~]?).*/,
+                    `workspace:$1${state.releaseVersion}`
+                  )
+                : currentVersionRange.replace(/([\^~]?).*/, `$1${state.releaseVersion}`);
 
             dependenciesObject[pkg.packageName] = newVersionRange;
 
@@ -146,12 +154,20 @@ function shouldUpdateDependencyVersion(context: {
     return false;
   }
 
-  // Skip workspace: specs entirely. pnpm resolves them to concrete versions
-  // at pack time, so the published artifact gets the right version while the
-  // source stays as the workspace-protocol declaration. Rewriting source
-  // would flush the prefix and propagate concrete pins back into the repo.
+  // For workspace: specs, distinguish between auto-resolving forms (no
+  // embedded version — pnpm pack picks the local version at pack time) and
+  // embedded-version forms (workspace:1.2.3, workspace:^1.2.3 — pnpm pack
+  // ships the embedded version verbatim). Auto-resolving forms must NOT be
+  // mutated in source, otherwise the workspace: protocol gets flushed.
+  // Embedded-version forms DO need refreshing when their target is in the
+  // current parcel set, otherwise expo and similar packages keep pointing at
+  // stale versions of their workspace deps.
   if (context.currentVersionRange.startsWith('workspace:')) {
-    return false;
+    const rest = context.currentVersionRange.slice('workspace:'.length);
+    if (rest === '*' || rest === '' || rest === '^' || rest === '~') {
+      return false;
+    }
+    return true;
   }
 
   // Only update the peerDependencies & optionalDependencies, where the version is `*`, during canary releases


### PR DESCRIPTION
# Why

Distinguishes auto-resolving workspace forms (workspace:*, workspace:^, workspace:~, workspace:) from embedded-version forms (workspace:1.2.3, workspace:^1.2.3, workspace:~1.2.3). The former resolve from the local workspace package at pack time and must not be mutated in source. The latter ship the embedded version verbatim and DO need refreshing when their target is being republished — otherwise expo's pin to e.g. @expo/log-box: workspace:56.0.1 stays stale even after log-box bumps to 56.0.2 in the same parcel set, causing "incorrect peer dependency" warnings on installs.

# How

`shouldUpdateDependencyVersion` now distinguishes the two classes:

- `workspace:*`, `workspace:`, `workspace:^`, `workspace:~` → return false (no embedded version; pnpm resolves at pack time)
- `workspace:1.2.3`, `workspace:^1.2.3`, `workspace:~1.2.3` → return true (embedded version needs refreshing when target is in the parcel set)

# Test Plan
Tools tests are passing

