### PR TITLE
[sharing] Fix shareAsync promise leak on share cancellation

### DIFF
--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `shareAsync` promise leaking when the user picks an activity and then cancels its follow-up dialog (e.g. taps Print, then cancels the print dialog). The completion handler now resolves unconditionally on dismissal. ([@Elehiggle](https://github.com/Elehiggle))
+
 ### 💡 Others
 
 ## 56.0.1 — 2026-05-06

--- a/packages/expo-sharing/ios/SharingModule.swift
+++ b/packages/expo-sharing/ios/SharingModule.swift
@@ -21,16 +21,14 @@ public final class SharingModule: Module {
       let activityController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
       activityController.title = options.dialogTitle
 
-      activityController.completionWithItemsHandler = { type, completed, _, _ in
-        // user shared an item
-        if type != nil && completed {
-          promise.resolve(nil)
-        }
-
-        // dismissed without action
-        if type == nil && !completed {
-          promise.resolve(nil)
-        }
+      activityController.completionWithItemsHandler = { _, _, _, _ in
+        // Resolve unconditionally. UIActivityViewController invokes this once
+        // on dismissal for every (activityType, completed) permutation. The
+        // previous implementation only resolved two of four cases, leaking
+        // the promise when the user picked an activity and then cancelled
+        // its follow-up dialog (e.g. tapped Print, then cancelled the print
+        // dialog: activityType != nil, completed == false).
+        promise.resolve(nil)
       }
 
       guard let currentViewcontroller = appContext?.utilities?.currentViewController() else {


### PR DESCRIPTION
# Why

`Sharing.shareAsync` on iOS leaks its promise when the user picks an activity in the share sheet and then cancels the follow-up dialog. Easiest reproduction: present a share sheet with a PDF, tap **Print**, then tap **Cancel** in the print dialog. The promise never resolves, and any caller-side state guarded by `await Sharing.shareAsync(...)` (busy flags, ref-based sheet tracking) stays stuck and blocks subsequent calls.

The current `completionWithItemsHandler` in `packages/expo-sharing/ios/SharingModule.swift` only resolves two of four `(activityType, completed)` permutations:

```swift
activityController.completionWithItemsHandler = { type, completed, _, _ in
  if type != nil && completed { promise.resolve(nil) }
  if type == nil && !completed { promise.resolve(nil) }
}
```

When the user picks an activity and cancels its follow-up dialog, iOS calls the handler with `type != nil, completed == false`. Neither branch matches.

`UIActivityViewController` invokes `completionWithItemsHandler` exactly once on dismissal for every permutation, so all four cases are terminal and should settle the promise. Apple docs: https://developer.apple.com/documentation/uikit/uiactivityviewcontroller/completionwithitemshandler.

Related long-standing reports closed without a fix: #8218, #20567, #21418, #35835.

# How

Resolve unconditionally inside the handler. `shareAsync` returns `Promise<void>`, there is no result shape that depends on which branch fires, and the handler runs at most once per controller lifecycle, so no double-resolve risk.

```swift
activityController.completionWithItemsHandler = { _, _, _, _ in
  promise.resolve(nil)
}
```

# Test Plan

Verified on iOS with `expo-sharing@55.0.18` (same code as `main`), patched locally via `pnpm patch` and rebuilt.

| Flow | Before | After |
| --- | --- | --- |
| Tap Print in share sheet, then Cancel in print dialog | Promise never resolves, subsequent `shareAsync` calls hang | Resolves on dismissal |
| Tap Print, then Print in print dialog | Resolves | Resolves |
| Dismiss share sheet without picking an activity | Resolves | Resolves |
| Tap an activity, then cancel its compose dialog (Mail, Messages, etc.) | Same root cause as Print, expected to leak | Resolves on dismissal |

No JS API change. Behavior for callers that already resolved successfully is unchanged.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)