### PR TITLE
Fix pnpm-lock for observe-tester

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1320,7 +1320,7 @@ importers:
   apps/observe-tester:
     dependencies:
       '@expo/html-elements':
-        specifier: ^56.0.0
+        specifier: ^56.0.1
         version: link:../../packages/html-elements
       '@expo/styleguide-base':
         specifier: ^1.0.1


### PR DESCRIPTION
# Why

CI is failing due to outdated pnpm-lock for observe-tester

# How

Run `pnpm i`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
