### PR TITLE
feat(metro-file-map): Allow on-demand filesystem to follow symlinks out of scope

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Allow the on-demand filesystem to follow symlinks out of `watchFolders` to their targets ([#45460](https://github.com/expo/expo/pull/45460) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/metro-file-map/build/crawlers/node/fallback.d.ts
+++ b/packages/@expo/metro-file-map/build/crawlers/node/fallback.d.ts
@@ -7,6 +7,13 @@ type FallbackFilesystemOptions = {
     includeSymlinks: boolean;
 };
 /**
+ * Whether a directory node was created or populated by the fallback filesystem.
+ * Used by TreeFS to determine if a directory outside the fallback boundary was
+ * reached legitimately (e.g., via symlink traversal) and should allow further
+ * fallback lookups.
+ */
+export declare function isFallbackDir(dirNode: any): boolean;
+/**
  * Create a FallbackFilesystem that synchronously queries the real filesystem.
  *
  * - `lookup` uses lstatSync to check a single path (for traversal).

--- a/packages/@expo/metro-file-map/build/crawlers/node/fallback.js
+++ b/packages/@expo/metro-file-map/build/crawlers/node/fallback.js
@@ -3,17 +3,32 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.isFallbackDir = isFallbackDir;
 exports.default = createFallbackFilesystem;
 exports.shouldFallbackCrawlDir = shouldFallbackCrawlDir;
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const normalizePathSeparatorsToPosix_1 = __importDefault(require("../../lib/normalizePathSeparatorsToPosix"));
-const readdirMarker = Symbol.for('fallbackDir');
-function markDir(dirNode) {
-    dirNode[readdirMarker] = true;
+const FALLBACK_DIR = Symbol.for('fallbackDir');
+var FallbackFlag;
+(function (FallbackFlag) {
+    FallbackFlag[FallbackFlag["VISITED"] = 0] = "VISITED";
+    FallbackFlag[FallbackFlag["CRAWLED"] = 1] = "CRAWLED";
+})(FallbackFlag || (FallbackFlag = {}));
+function markDir(dirNode, flag) {
+    dirNode[FALLBACK_DIR] = flag;
 }
-function isMarkedDir(dirNode) {
-    return !!dirNode[readdirMarker];
+function getDirFlag(dirNode) {
+    return dirNode[FALLBACK_DIR];
+}
+/**
+ * Whether a directory node was created or populated by the fallback filesystem.
+ * Used by TreeFS to determine if a directory outside the fallback boundary was
+ * reached legitimately (e.g., via symlink traversal) and should allow further
+ * fallback lookups.
+ */
+function isFallbackDir(dirNode) {
+    return dirNode[FALLBACK_DIR] != null;
 }
 function isDirectory(node) {
     return node instanceof Map;
@@ -34,7 +49,7 @@ function createFallbackFilesystem(opts) {
         return acc;
     }, {});
     function readdir(_normalPath, absolutePath, dirNode) {
-        if (dirNode != null && isMarkedDir(dirNode)) {
+        if (dirNode != null && getDirFlag(dirNode) === FallbackFlag.CRAWLED) {
             return dirNode;
         }
         let dirEntries;
@@ -53,7 +68,9 @@ function createFallbackFilesystem(opts) {
             }
             if (entry.isDirectory()) {
                 if (!result.has(name)) {
-                    result.set(name, new Map());
+                    const childDir = new Map();
+                    markDir(childDir, FallbackFlag.VISITED);
+                    result.set(name, childDir);
                 }
             }
             else if (entry.isSymbolicLink()) {
@@ -69,7 +86,7 @@ function createFallbackFilesystem(opts) {
                 }
             }
         }
-        markDir(result);
+        markDir(result, FallbackFlag.CRAWLED);
         return result;
     }
     return {
@@ -87,9 +104,15 @@ function createFallbackFilesystem(opts) {
             }
             if (stat.isDirectory()) {
                 const dirNode = isDirectory(prevNode) ? prevNode : null;
-                return shouldFallbackCrawlDir(absolutePath)
-                    ? readdir(normalPath, absolutePath, dirNode)
-                    : (dirNode ?? new Map());
+                if (shouldFallbackCrawlDir(absolutePath)) {
+                    return readdir(normalPath, absolutePath, dirNode);
+                }
+                if (dirNode != null) {
+                    return dirNode;
+                }
+                const newDir = new Map();
+                markDir(newDir, FallbackFlag.VISITED);
+                return newDir;
             }
             else if (stat.isSymbolicLink()) {
                 if (!includeSymlinks) {

--- a/packages/@expo/metro-file-map/build/lib/TreeFS.js
+++ b/packages/@expo/metro-file-map/build/lib/TreeFS.js
@@ -428,6 +428,9 @@ class TreeFS {
         let targetNormalPath = requestedNormalPath;
         // Lazy-initialised set of seen target paths, to detect symlink cycles.
         let seen;
+        // Set when a symlink is followed, to allow fallback population outside
+        // the boundary for paths reachable transitively through symlinks.
+        let followedSymlink = false;
         // Pointer to the first character of the current path segment in
         // targetNormalPath.
         let fromIdx = opts.start?.pathIdx ?? 0;
@@ -470,7 +473,7 @@ class TreeFS {
                             ? fromIdx - segmentName.length - 1
                             : fromIdx - segmentName.length - 2;
                         const parentCanonicalPath = parentEnd > 0 ? targetNormalPath.slice(0, parentEnd) : '';
-                        segmentNode = this.#populateFromFilesystem(parentNode, segmentName, parentCanonicalPath);
+                        segmentNode = this.#populateFromFilesystem(parentNode, segmentName, parentCanonicalPath, followedSymlink);
                         if (segmentNode != null) {
                             ancestorOfRootIdx = null;
                         }
@@ -496,8 +499,7 @@ class TreeFS {
                         }
                         parentNode.set(segmentName, segmentNode);
                     }
-                    else if (!opts.skipFallback &&
-                        this.#fallbackFilesystem != null) {
+                    else if (!opts.skipFallback && this.#fallbackFilesystem != null) {
                         parentNode.set(segmentName, segmentNode);
                     }
                 }
@@ -617,6 +619,7 @@ class TreeFS {
                     };
                 }
                 seen.add(targetNormalPath);
+                followedSymlink = true;
                 fromIdx = 0;
                 parentNode = this.#rootNode;
                 ancestorOfRootIdx = 0;
@@ -827,7 +830,7 @@ class TreeFS {
             !pathPrefix.endsWith(pathSep + '..')) {
             const canonicalRoot = opts.canonicalPathOfRoot;
             const rootCanonical = pathPrefix === '' ? canonicalRoot : canonicalRoot + path_1.default.sep + pathPrefix;
-            this.#populateDirFromFilesystem(iterationRootNode, rootCanonical, false);
+            this.#populateDirFromFilesystem(iterationRootNode, rootCanonical, false, false);
         }
         for (const [name, node] of this.#directoryNodeIterator(iterationRootNode, iterationRootParentNode, ancestorOfRootIdx)) {
             if (node == null) {
@@ -881,7 +884,7 @@ class TreeFS {
                     const canonicalPath = opts.canonicalPathOfRoot === ''
                         ? nodePathWithSystemSeparators
                         : opts.canonicalPathOfRoot + path_1.default.sep + nodePathWithSystemSeparators;
-                    this.#populateDirFromFilesystem(node, canonicalPath, false);
+                    this.#populateDirFromFilesystem(node, canonicalPath, false, false);
                 }
                 yield* this.#pathIterator(node, iterationRootParentNode, ancestorOfRootIdx != null && ancestorOfRootIdx > 0 ? ancestorOfRootIdx - 1 : null, opts, nodePath, followedLinks);
             }
@@ -942,7 +945,11 @@ class TreeFS {
         }
         return clone;
     }
-    #isOutsideFallbackBoundary(canonicalPath) {
+    #isOutsideFallbackBoundary(canonicalPath, dirNode) {
+        // We allow any directory that's already been crawled
+        if ((0, fallback_1.isFallbackDir)(dirNode)) {
+            return false;
+        }
         const maxDepth = this.#fallbackBoundaryDepth;
         return maxDepth != null && (0, RootPathUtils_1.getAncestorOfRootIdx)(canonicalPath) > maxDepth;
     }
@@ -951,20 +958,26 @@ class TreeFS {
      * fallback filesystem. The fallback returns tree-compatible nodes
      * (FileMetadata tuples or directory Maps) that are inserted directly.
      *
+     * Accepts `wasFollowing` to allow traversal on symlinks that were followed.
+     * If we're resolving a symlink target, we allow the lookup to escape the
+     * fallback scope.
+     *
      * Returns the newly created node, or null if the path doesn't exist on disk.
      */
-    #populateFromFilesystem(parentNode, segmentName, parentCanonicalPath) {
+    #populateFromFilesystem(parentNode, segmentName, parentCanonicalPath, wasFollowing) {
         const fallback = this.#fallbackFilesystem;
         if (fallback == null) {
             return null;
         }
+        // A symlink traversal (wasFollowing) or a parent created by the fallback
+        // (isFallbackDir) lets us skip the boundary check.
         const childCanonicalPath = parentCanonicalPath === '' ? segmentName : parentCanonicalPath + path_1.default.sep + segmentName;
         if (this.#rootPattern?.test(childCanonicalPath + path_1.default.sep) ||
-            this.#isOutsideFallbackBoundary(childCanonicalPath)) {
+            (!wasFollowing && this.#isOutsideFallbackBoundary(childCanonicalPath, parentNode))) {
             return null;
         }
         else if (parentCanonicalPath !== '' && (0, fallback_1.shouldFallbackCrawlDir)(parentCanonicalPath)) {
-            this.#populateDirFromFilesystem(parentNode, parentCanonicalPath, true);
+            this.#populateDirFromFilesystem(parentNode, parentCanonicalPath, true, wasFollowing);
             return parentNode.get(segmentName) ?? null;
         }
         else if (parentNode.has(segmentName)) {
@@ -984,12 +997,12 @@ class TreeFS {
      * iteration, and by #populateFromFilesystem for optimistic parent
      * population.
      */
-    #populateDirFromFilesystem(dirNode, canonicalPath, skipCheck) {
+    #populateDirFromFilesystem(dirNode, canonicalPath, skipCheck, wasFollowed) {
         const fallback = this.#fallbackFilesystem;
         if (fallback == null ||
             (!skipCheck &&
                 (this.#rootPattern?.test(canonicalPath + path_1.default.sep) ||
-                    this.#isOutsideFallbackBoundary(canonicalPath)))) {
+                    (!wasFollowed && this.#isOutsideFallbackBoundary(canonicalPath, dirNode))))) {
             return;
         }
         const absolutePath = this.#pathUtils.normalToAbsolute(canonicalPath);

--- a/packages/@expo/metro-file-map/src/crawlers/node/__tests__/fallback.test.ts
+++ b/packages/@expo/metro-file-map/src/crawlers/node/__tests__/fallback.test.ts
@@ -2,7 +2,7 @@ import { vol } from 'memfs';
 
 import { RootPathUtils } from '../../../lib/RootPathUtils';
 import type { FallbackFilesystem } from '../../../types';
-import createFallbackFilesystem from '../fallback';
+import createFallbackFilesystem, { isFallbackDir } from '../fallback';
 
 const rootDir = '/project';
 
@@ -215,6 +215,85 @@ describe('createFallbackFilesystem', () => {
       const result = fallback.readdir('src', '/project/src', existing);
 
       expect(result!.get('file.js')?.[0]).toBe(999); // preserved
+    });
+  });
+
+  describe('directory marking (isFallbackDir)', () => {
+    test('readdir result is marked as a fallback dir', () => {
+      vol.fromJSON({ '/project/src/a.js': 'a' });
+      const fallback = createFallback();
+      const result = fallback.readdir('src', '/project/src', undefined);
+
+      expect(isFallbackDir(result)).toBe(true);
+    });
+
+    test('readdir child directories are marked as fallback dirs', () => {
+      vol.fromJSON({ '/project/src/sub/file.js': 'content' });
+      const fallback = createFallback();
+      const result = fallback.readdir('src', '/project/src', undefined);
+
+      const sub = result!.get('sub');
+      expect(sub).toBeInstanceOf(Map);
+      expect(isFallbackDir(sub)).toBe(true);
+    });
+
+    test('lookup-returned directory (crawled) is marked as a fallback dir', () => {
+      vol.fromJSON({ '/project/dir/file.js': 'content' });
+      const fallback = createFallback();
+      const node = fallback.lookup('dir', '/project/dir', undefined);
+
+      expect(isFallbackDir(node)).toBe(true);
+    });
+
+    test('lookup-returned directory (non-crawled) is marked as a fallback dir', () => {
+      vol.fromJSON({ '/project/node_modules/pkg/index.js': 'content' });
+      const fallback = createFallback();
+      const node = fallback.lookup('node_modules', '/project/node_modules', undefined);
+
+      expect(node).toBeInstanceOf(Map);
+      expect((node as Map<string, any>).size).toBe(0);
+      expect(isFallbackDir(node)).toBe(true);
+    });
+
+    test('readdir skips CRAWLED dirs but not VISITED dirs', () => {
+      vol.fromJSON({
+        '/project/src/a.js': 'a',
+        '/project/src/sub/b.js': 'b',
+      });
+      const fallback = createFallback();
+
+      // First readdir returns the parent (CRAWLED) with child sub (VISITED)
+      const parent = fallback.readdir('src', '/project/src', undefined);
+      const sub = parent!.get('sub') as Map<string, any>;
+      expect(sub.size).toBe(0); // VISITED, not yet populated
+
+      // readdir on the VISITED child should populate it (not skip)
+      const populated = fallback.readdir('src/sub', '/project/src/sub', sub);
+      expect(populated).toBe(sub); // same reference, mutated in place
+      expect(sub.has('b.js')).toBe(true);
+
+      // readdir again on the now-CRAWLED child should skip
+      vol.fromJSON({
+        '/project/src/a.js': 'a',
+        '/project/src/sub/b.js': 'b',
+        '/project/src/sub/c.js': 'c',
+      });
+      const skipped = fallback.readdir('src/sub', '/project/src/sub', sub);
+      expect(skipped).toBe(sub);
+      expect(sub.has('c.js')).toBe(false); // not re-read
+    });
+
+    test('unmarked Maps are not fallback dirs', () => {
+      expect(isFallbackDir(new Map())).toBe(false);
+    });
+
+    test('non-directory lookup results are not marked', () => {
+      vol.fromJSON({ '/project/file.js': 'content' });
+      const fallback = createFallback();
+      const node = fallback.lookup('file.js', '/project/file.js', undefined);
+
+      expect(Array.isArray(node)).toBe(true);
+      expect(isFallbackDir(node)).toBe(false);
     });
   });
 });

--- a/packages/@expo/metro-file-map/src/crawlers/node/fallback.ts
+++ b/packages/@expo/metro-file-map/src/crawlers/node/fallback.ts
@@ -16,14 +16,29 @@ type FallbackFilesystemOptions = {
   includeSymlinks: boolean;
 };
 
-const readdirMarker = Symbol.for('fallbackDir');
+const FALLBACK_DIR = Symbol.for('fallbackDir');
 
-function markDir(dirNode: any) {
-  dirNode[readdirMarker] = true;
+const enum FallbackFlag {
+  VISITED = 0,
+  CRAWLED = 1,
 }
 
-function isMarkedDir(dirNode: any) {
-  return !!dirNode[readdirMarker];
+function markDir(dirNode: any, flag: FallbackFlag) {
+  dirNode[FALLBACK_DIR] = flag;
+}
+
+function getDirFlag(dirNode: any): FallbackFlag | undefined {
+  return dirNode[FALLBACK_DIR];
+}
+
+/**
+ * Whether a directory node was created or populated by the fallback filesystem.
+ * Used by TreeFS to determine if a directory outside the fallback boundary was
+ * reached legitimately (e.g., via symlink traversal) and should allow further
+ * fallback lookups.
+ */
+export function isFallbackDir(dirNode: any): boolean {
+  return dirNode[FALLBACK_DIR] != null;
 }
 
 function isDirectory(node: MixedNode | null | undefined): node is DirectoryNode {
@@ -57,7 +72,7 @@ export default function createFallbackFilesystem(
     absolutePath: string,
     dirNode: DirectoryNode | null | undefined
   ): DirectoryNode | null {
-    if (dirNode != null && isMarkedDir(dirNode)) {
+    if (dirNode != null && getDirFlag(dirNode) === FallbackFlag.CRAWLED) {
       return dirNode;
     }
     let dirEntries;
@@ -77,7 +92,9 @@ export default function createFallbackFilesystem(
 
       if (entry.isDirectory()) {
         if (!result.has(name)) {
-          result.set(name, new Map());
+          const childDir = new Map();
+          markDir(childDir, FallbackFlag.VISITED);
+          result.set(name, childDir);
         }
       } else if (entry.isSymbolicLink()) {
         // We can skip reading the symlink target here, since it'll be read lazily
@@ -91,7 +108,7 @@ export default function createFallbackFilesystem(
         }
       }
     }
-    markDir(result);
+    markDir(result, FallbackFlag.CRAWLED);
     return result;
   }
 
@@ -116,9 +133,15 @@ export default function createFallbackFilesystem(
 
       if (stat.isDirectory()) {
         const dirNode = isDirectory(prevNode) ? prevNode : null;
-        return shouldFallbackCrawlDir(absolutePath)
-          ? readdir(normalPath, absolutePath, dirNode)
-          : (dirNode ?? new Map());
+        if (shouldFallbackCrawlDir(absolutePath)) {
+          return readdir(normalPath, absolutePath, dirNode);
+        }
+        if (dirNode != null) {
+          return dirNode;
+        }
+        const newDir = new Map();
+        markDir(newDir, FallbackFlag.VISITED);
+        return newDir;
       } else if (stat.isSymbolicLink()) {
         if (!includeSymlinks) {
           return null;

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -12,7 +12,7 @@ import path from 'path';
 import H from '../constants';
 import normalizePathSeparatorsToPosix from './normalizePathSeparatorsToPosix';
 import normalizePathSeparatorsToSystem from './normalizePathSeparatorsToSystem';
-import { shouldFallbackCrawlDir } from '../crawlers/node/fallback';
+import { isFallbackDir, shouldFallbackCrawlDir } from '../crawlers/node/fallback';
 import type {
   CacheData,
   FallbackFilesystem,
@@ -638,6 +638,9 @@ export default class TreeFS implements MutableFileSystem {
     let targetNormalPath = requestedNormalPath;
     // Lazy-initialised set of seen target paths, to detect symlink cycles.
     let seen: Set<string> | undefined;
+    // Set when a symlink is followed, to allow fallback population outside
+    // the boundary for paths reachable transitively through symlinks.
+    let followedSymlink = false;
     // Pointer to the first character of the current path segment in
     // targetNormalPath.
     let fromIdx = opts.start?.pathIdx ?? 0;
@@ -689,7 +692,8 @@ export default class TreeFS implements MutableFileSystem {
             segmentNode = this.#populateFromFilesystem(
               parentNode,
               segmentName,
-              parentCanonicalPath
+              parentCanonicalPath,
+              followedSymlink
             );
             if (segmentNode != null) {
               ancestorOfRootIdx = null;
@@ -716,10 +720,7 @@ export default class TreeFS implements MutableFileSystem {
               changeListener.directoryAdded(canonicalPath);
             }
             parentNode.set(segmentName, segmentNode);
-          } else if (
-            !opts.skipFallback &&
-            this.#fallbackFilesystem != null
-          ) {
+          } else if (!opts.skipFallback && this.#fallbackFilesystem != null) {
             parentNode.set(segmentName, segmentNode);
           }
         }
@@ -858,6 +859,7 @@ export default class TreeFS implements MutableFileSystem {
           };
         }
         seen.add(targetNormalPath);
+        followedSymlink = true;
         fromIdx = 0;
         parentNode = this.#rootNode;
         ancestorOfRootIdx = 0;
@@ -1185,7 +1187,7 @@ export default class TreeFS implements MutableFileSystem {
       const canonicalRoot = opts.canonicalPathOfRoot;
       const rootCanonical =
         pathPrefix === '' ? canonicalRoot : canonicalRoot + path.sep + pathPrefix;
-      this.#populateDirFromFilesystem(iterationRootNode, rootCanonical, false);
+      this.#populateDirFromFilesystem(iterationRootNode, rootCanonical, false, false);
     }
 
     for (const [name, node] of this.#directoryNodeIterator(
@@ -1256,7 +1258,7 @@ export default class TreeFS implements MutableFileSystem {
             opts.canonicalPathOfRoot === ''
               ? nodePathWithSystemSeparators
               : opts.canonicalPathOfRoot + path.sep + nodePathWithSystemSeparators;
-          this.#populateDirFromFilesystem(node, canonicalPath, false);
+          this.#populateDirFromFilesystem(node, canonicalPath, false, false);
         }
         yield* this.#pathIterator(
           node,
@@ -1332,7 +1334,11 @@ export default class TreeFS implements MutableFileSystem {
     return clone;
   }
 
-  #isOutsideFallbackBoundary(canonicalPath: string): boolean {
+  #isOutsideFallbackBoundary(canonicalPath: string, dirNode: DirectoryNode): boolean {
+    // We allow any directory that's already been crawled
+    if (isFallbackDir(dirNode)) {
+      return false;
+    }
     const maxDepth = this.#fallbackBoundaryDepth;
     return maxDepth != null && getAncestorOfRootIdx(canonicalPath) > maxDepth;
   }
@@ -1342,26 +1348,33 @@ export default class TreeFS implements MutableFileSystem {
    * fallback filesystem. The fallback returns tree-compatible nodes
    * (FileMetadata tuples or directory Maps) that are inserted directly.
    *
+   * Accepts `wasFollowing` to allow traversal on symlinks that were followed.
+   * If we're resolving a symlink target, we allow the lookup to escape the
+   * fallback scope.
+   *
    * Returns the newly created node, or null if the path doesn't exist on disk.
    */
   #populateFromFilesystem(
     parentNode: DirectoryNode,
     segmentName: string,
-    parentCanonicalPath: string
+    parentCanonicalPath: string,
+    wasFollowing: boolean
   ): MixedNode | null {
     const fallback = this.#fallbackFilesystem;
     if (fallback == null) {
       return null;
     }
+    // A symlink traversal (wasFollowing) or a parent created by the fallback
+    // (isFallbackDir) lets us skip the boundary check.
     const childCanonicalPath =
       parentCanonicalPath === '' ? segmentName : parentCanonicalPath + path.sep + segmentName;
     if (
       this.#rootPattern?.test(childCanonicalPath + path.sep) ||
-      this.#isOutsideFallbackBoundary(childCanonicalPath)
+      (!wasFollowing && this.#isOutsideFallbackBoundary(childCanonicalPath, parentNode))
     ) {
       return null;
     } else if (parentCanonicalPath !== '' && shouldFallbackCrawlDir(parentCanonicalPath)) {
-      this.#populateDirFromFilesystem(parentNode, parentCanonicalPath, true);
+      this.#populateDirFromFilesystem(parentNode, parentCanonicalPath, true, wasFollowing);
       return parentNode.get(segmentName) ?? null;
     } else if (parentNode.has(segmentName)) {
       return parentNode.get(segmentName) ?? null;
@@ -1383,14 +1396,15 @@ export default class TreeFS implements MutableFileSystem {
   #populateDirFromFilesystem(
     dirNode: DirectoryNode,
     canonicalPath: string,
-    skipCheck: boolean
+    skipCheck: boolean,
+    wasFollowed: boolean
   ): void {
     const fallback = this.#fallbackFilesystem;
     if (
       fallback == null ||
       (!skipCheck &&
         (this.#rootPattern?.test(canonicalPath + path.sep) ||
-          this.#isOutsideFallbackBoundary(canonicalPath)))
+          (!wasFollowed && this.#isOutsideFallbackBoundary(canonicalPath, dirNode))))
     ) {
       return;
     }

--- a/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
@@ -1582,6 +1582,13 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
   });
 
   describe('fallback filesystem', () => {
+    const FALLBACK_DIR = Symbol.for('fallbackDir');
+
+    function markFallbackDir(dir: Map<string, any>, flag: 0 | 1 = 0): Map<string, any> {
+      (dir as any)[FALLBACK_DIR] = flag;
+      return dir;
+    }
+
     let mockFallback: {
       lookup: jest.Mock;
       readdir: jest.Mock;
@@ -1740,6 +1747,315 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
         // Even deeply nested parent access should work
         const result = fbTfs.lookup(p('/project/../../deep/file.js'));
         expect(result).toMatchObject({ exists: true });
+      });
+
+      test('allows fallback for symlink targets outside serverRoot boundary', () => {
+        const fbTfs = makeFallbackTfs({
+          serverRoot: p('/project'),
+          files: new Map([
+            [p('node_modules/pkg'), [0, 0, 0, null, '../../store/pkg', null] as any],
+          ]),
+        });
+
+        mockFallback.readdir.mockImplementation(
+          (normalPath: string, _absolutePath: string, dirNode: any) => {
+            const result = dirNode ?? new Map();
+            if (normalPath === p('../..')) {
+              if (!result.has('store')) {
+                result.set('store', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../store')) {
+              if (!result.has('pkg')) {
+                result.set('pkg', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../store/pkg')) {
+              result.set('index.js', [100, 5, 0, null, 0, null]);
+              return markFallbackDir(result, 1);
+            }
+            return dirNode;
+          }
+        );
+
+        const result = fbTfs.lookup(p('/project/node_modules/pkg/index.js'));
+        expect(result).toMatchObject({ exists: true, type: 'f' });
+      });
+
+      test('blocks direct fallback access outside serverRoot even with symlinks elsewhere', () => {
+        const fbTfs = makeFallbackTfs({
+          serverRoot: p('/project'),
+          files: new Map([
+            [p('node_modules/pkg'), [0, 0, 0, null, '../../store/pkg', null] as any],
+          ]),
+        });
+
+        mockFallback.readdir.mockImplementation(
+          (_normalPath: string, _absolutePath: string, dirNode: any) => {
+            const result = dirNode ?? new Map();
+            result.set('index.js', [100, 5, 0, null, 0, null]);
+            return markFallbackDir(result, 1);
+          }
+        );
+
+        const result = fbTfs.lookup(p('/project/../../store/pkg/index.js'));
+        expect(result).toMatchObject({ exists: false });
+      });
+
+      test('allows chained symlinks outside boundary', () => {
+        const fbTfs = makeFallbackTfs({
+          serverRoot: p('/project'),
+          files: new Map([[p('link-a'), [0, 0, 0, null, '../../external/hop', null] as any]]),
+        });
+
+        mockFallback.readdir.mockImplementation(
+          (normalPath: string, _absolutePath: string, dirNode: any) => {
+            const result = dirNode ?? new Map();
+            if (normalPath === p('../..')) {
+              if (!result.has('external')) {
+                result.set('external', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../external')) {
+              if (!result.has('hop')) {
+                result.set('hop', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../external/hop')) {
+              if (!result.has('link-b')) {
+                result.set('link-b', [0, 0, 0, null, '../../../other/final', null]);
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../..')) {
+              if (!result.has('other')) {
+                result.set('other', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../../other')) {
+              if (!result.has('final')) {
+                result.set('final', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../../other/final')) {
+              result.set('deep.js', [100, 5, 0, null, 0, null]);
+              return markFallbackDir(result, 1);
+            }
+            return dirNode;
+          }
+        );
+
+        const result = fbTfs.lookup(p('/project/link-a/link-b/deep.js'));
+        expect(result).toMatchObject({ exists: true, type: 'f' });
+      });
+
+      test('subsequent lookups via real path bypass boundary (pnpm relative import)', () => {
+        const fbTfs = makeFallbackTfs({
+          serverRoot: p('/project'),
+          files: new Map([[p('node_modules/pkg'), [0, 0, 0, null, '../store/pkg', null] as any]]),
+        });
+
+        mockFallback.readdir.mockImplementation(
+          (normalPath: string, _absolutePath: string, dirNode: any) => {
+            const result = dirNode ?? new Map();
+            if (normalPath === p('..')) {
+              if (!result.has('store')) {
+                result.set('store', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../store')) {
+              if (!result.has('pkg')) {
+                result.set('pkg', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../store/pkg')) {
+              if (!result.has('dist')) {
+                result.set('dist', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../store/pkg/dist')) {
+              if (!result.has('exports')) {
+                result.set('exports', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../store/pkg/dist/exports')) {
+              if (!result.has('AppRegistry')) {
+                result.set('AppRegistry', markFallbackDir(new Map()));
+              }
+              if (!result.has('unmountComponentAtNode')) {
+                result.set('unmountComponentAtNode', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../store/pkg/dist/exports/AppRegistry')) {
+              result.set('index.js', [100, 5, 0, null, 0, null]);
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../store/pkg/dist/exports/unmountComponentAtNode')) {
+              result.set('index.js', [100, 5, 0, null, 0, null]);
+              return markFallbackDir(result, 1);
+            }
+            return dirNode;
+          }
+        );
+
+        // Follow symlink to populate the store directories
+        const appResult = fbTfs.lookup(
+          p('/project/node_modules/pkg/dist/exports/AppRegistry/index.js')
+        );
+        expect(appResult).toMatchObject({ exists: true, type: 'f' });
+
+        // Look up a sibling via real path (no symlink traversal)
+        const realPath = mockPathModule.resolve(
+          p('/project'),
+          p('../store/pkg/dist/exports/unmountComponentAtNode/index.js')
+        );
+        const siblingResult = fbTfs.lookup(realPath);
+        expect(siblingResult).toMatchObject({ exists: true, type: 'f' });
+      });
+
+      test('dot-folder reached via symlink allows sibling lookups', () => {
+        // .store is a dot-folder — shouldFallbackCrawlDir skips readdir,
+        // so children are resolved individually via fallback.lookup.
+        const fbTfs = makeFallbackTfs({
+          serverRoot: p('/project'),
+          files: new Map([[p('node_modules/pkg'), [0, 0, 0, null, '../.store/pkg', null] as any]]),
+        });
+
+        mockFallback.readdir.mockImplementation(
+          (normalPath: string, _absolutePath: string, dirNode: any) => {
+            const result = dirNode ?? new Map();
+            if (normalPath === p('..')) {
+              if (!result.has('.store')) {
+                result.set('.store', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../.store/pkg')) {
+              if (!result.has('A.js')) {
+                result.set('A.js', [100, 5, 0, null, 0, null]);
+              }
+              if (!result.has('B.js')) {
+                result.set('B.js', [100, 5, 0, null, 0, null]);
+              }
+              return markFallbackDir(result, 1);
+            }
+            return dirNode;
+          }
+        );
+        mockFallback.lookup.mockImplementation((normalPath: string) => {
+          if (normalPath === p('../.store/pkg')) {
+            return markFallbackDir(new Map<string, any>());
+          }
+          return null;
+        });
+
+        const aResult = fbTfs.lookup(p('/project/node_modules/pkg/A.js'));
+        expect(aResult).toMatchObject({ exists: true, type: 'f' });
+
+        // Look up sibling B.js via real path (no symlink traversal)
+        const realPath = mockPathModule.resolve(p('/project'), p('../.store/pkg/B.js'));
+        const bResult = fbTfs.lookup(realPath);
+        expect(bResult).toMatchObject({ exists: true, type: 'f' });
+      });
+
+      test('hierarchicalLookup resolves subpath in symlink-reached directory', () => {
+        const fbTfs = makeFallbackTfs({
+          serverRoot: p('/project'),
+          files: new Map([
+            [p('node_modules/react'), [0, 0, 0, null, '../../.bun-cache/react', null] as any],
+          ]),
+        });
+
+        mockFallback.readdir.mockImplementation(
+          (normalPath: string, _absolutePath: string, dirNode: any) => {
+            const result = dirNode ?? new Map();
+            if (normalPath === p('../..')) {
+              if (!result.has('.bun-cache')) {
+                result.set('.bun-cache', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (
+              normalPath === p('../../.bun-cache/react') ||
+              normalPath === p('node_modules/react')
+            ) {
+              result.set('package.json', [100, 5, 0, null, 0, null]);
+              result.set('index.js', [100, 5, 0, null, 0, null]);
+              return markFallbackDir(result, 1);
+            }
+            return dirNode;
+          }
+        );
+        mockFallback.lookup.mockImplementation((normalPath: string) => {
+          if (normalPath === p('../../.bun-cache/react')) {
+            return markFallbackDir(new Map<string, any>());
+          }
+          return null;
+        });
+
+        fbTfs.lookup(p('/project/node_modules/react/index.js'));
+
+        const found = fbTfs.hierarchicalLookup(
+          p('/project/node_modules/react/index.js'),
+          'package.json',
+          { subpathType: 'f' }
+        );
+        expect(found).not.toBeNull();
+        expect(found?.absolutePath).toBe(
+          mockPathModule.resolve(p('/project'), p('../../.bun-cache/react/package.json'))
+        );
+      });
+
+      test('matchFiles follows symlink to out-of-boundary directory', () => {
+        const fbTfs = makeFallbackTfs({
+          serverRoot: p('/project'),
+          files: new Map([
+            [p('outside/dir-link'), [0, 0, 0, null, '../../store/real-dir', null] as any],
+          ]),
+        });
+
+        mockFallback.readdir.mockImplementation(
+          (normalPath: string, _absolutePath: string, dirNode: any) => {
+            const result = dirNode ?? new Map();
+            if (normalPath === p('../..')) {
+              if (!result.has('store')) {
+                result.set('store', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../store')) {
+              if (!result.has('real-dir')) {
+                result.set('real-dir', markFallbackDir(new Map()));
+              }
+              return markFallbackDir(result, 1);
+            }
+            if (normalPath === p('../../store/real-dir') || normalPath === p('outside/dir-link')) {
+              result.set('found.js', [100, 5, 0, null, 0, null]);
+              return markFallbackDir(result, 1);
+            }
+            return dirNode;
+          }
+        );
+
+        const matches = [
+          ...fbTfs.matchFiles({
+            rootDir: p('/project/outside'),
+            follow: true,
+            recursive: true,
+          }),
+        ];
+        expect(matches).toContain(p('/project/outside/dir-link/found.js'));
       });
     });
 


### PR DESCRIPTION
# Why

Currently, we enable `scopeFallback` out of an abundance of caution, which disallows the on-demand filesystem from leaving the defined server root. This has to be explicitly disabled in some cases, for example for package manager global stores (supported by [pnpm](https://pnpm.io/11.x/global-virtual-store) and [bun](https://bun.com/docs/pm/global-store)).

Global stores for package managers with isolated installations are pretty ideal for worktrees, and as such, we'd like to support them by default, which the on-demand filesystem allowed, provided `scopeFallback: false` was passed.

Instead, we can allow the on-demand filesystem to automatically follow symlinks out of the server root, trusting that symlinks in the server root are intended and safe. That assumption is usually safe and already made by different frameworks/bundlers that don't have a "server root" concept.

# How

- Mark directories discovered by on-demand filesystem with `VISITED | CRAWLED` flag, and mark all directories at least as `VISITED` if the crawler found them
- Pass on a symlink flag to the on-demand filesystem calls, and allow directories if they've either been reached by a symlink, or if they've been discovered by the on-demand filesystem

This effectively allows a symlink to first escape the server root, and then subsequent sub-directories are allowed to be discovered by Metro.

# Test Plan

- Unit tests added
- Tested in a fresh `expo/expo` worktree with `enableGlobalVirtualStore` enabled

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
