### PR TITLE
fix(precompile) transitive dep resolution for scoped slug-mismatched packages

### DIFF
--- a/tools/src/Packages.test.ts
+++ b/tools/src/Packages.test.ts
@@ -1,13 +1,9 @@
 import assert from 'node:assert/strict';
-import { before, describe, it } from 'node:test';
+import { describe, it } from 'node:test';
 
-import { getListOfPackagesAsync, getPackageByName } from './Packages';
+import { getPackageByName } from './Packages';
 
 describe('getPackageByName', () => {
-  before(async () => {
-    await getListOfPackagesAsync();
-  });
-
   it('resolves packages whose directory matches their name', () => {
     const pkg = getPackageByName('expo-router');
     assert.ok(pkg);

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -485,5 +485,12 @@ function readExpoModuleConfigJson(expoModuleConfigJsonPath: string) {
 }
 
 function pathToLocalPackageJson(packageName: string): string {
+  if (packageName.startsWith('@')) {
+    try {
+      return require.resolve(`${packageName}/package.json`, { paths: [PACKAGES_DIR] });
+    } catch {
+      // Fall through — caller's cachedPackages fallback still applies.
+    }
+  }
   return path.join(PACKAGES_DIR, packageName, 'package.json');
 }


### PR DESCRIPTION
# Why

Getting errors when precompiling Expo Widgets:

```
[2026-05-06T15:55:59.083Z] :x: [expo-widgets/ExpoWidgets] Generate sources failed: Could not find xcframework for external dependency @expo/ui/ExpoUI at expected path: /Users/expo/workingdir/build/packages/precompile/.build/@expo/ui/output/debug/xcframeworks/ExpoUI.xcframework
```

`@expo/ui` lives at `packages/expo-ui/`, a slug that differs from the npm name

# How

`tools/src/Packages.ts`: for scoped names, `pathToLocalPackageJson` now
uses `require.resolve('@scope/name/package.json', { paths: [PACKAGES_DIR] })`.

Workspace symlinks point at the real on-disk location regardless of the slug, so this works for both standard layouts (`@expo/cli`) and slug-mismatched ones (`@expo/ui`). The non-scoped fast path is untouched.

# Test-plan

✅ run `et prebuild expo-widgets` to verify.

