### PR TITLE
fix(metro-file-map): Fix snapshot not including relative roots

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix serialized snapshot not including relative roots ([#45462](https://github.com/expo/expo/pull/45462) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.0.0-1 — 2026-05-06

--- a/packages/@expo/metro-file-map/build/lib/TreeFS.js
+++ b/packages/@expo/metro-file-map/build/lib/TreeFS.js
@@ -79,6 +79,7 @@ class TreeFS {
     #processFile;
     #rootDir;
     #rootPattern;
+    #roots;
     #rootNode = new Map();
     constructor(opts) {
         const { rootDir, files, processFile, fallbackFilesystem, roots, serverRoot } = opts;
@@ -92,13 +93,15 @@ class TreeFS {
         else {
             this.#fallbackBoundaryDepth = null;
         }
+        const normalRoots = (roots ?? []).map((r) => this.#pathUtils.absoluteToNormal(r));
+        this.#roots = normalRoots;
         this.#rootPattern = (0, RootPathUtils_1.pathsToPattern)(roots ?? [], this.#pathUtils);
         if (files != null) {
             this.bulkAddOrModify(files);
         }
     }
     getSerializableSnapshot() {
-        return this.#cloneTree(this.#rootNode, '');
+        return this.#cloneTree(this.#rootNode);
     }
     static fromDeserializedSnapshot(args) {
         const { rootDir, fileSystemData, processFile, fallbackFilesystem, roots, serverRoot } = args;
@@ -496,8 +499,7 @@ class TreeFS {
                         }
                         parentNode.set(segmentName, segmentNode);
                     }
-                    else if (!opts.skipFallback &&
-                        this.#fallbackFilesystem != null) {
+                    else if (!opts.skipFallback && this.#fallbackFilesystem != null) {
                         parentNode.set(segmentName, segmentNode);
                     }
                 }
@@ -924,20 +926,61 @@ class TreeFS {
         }
         return result.node;
     }
-    #cloneTree(root, prefix) {
-        const clone = new Map();
-        for (const [name, node] of root) {
-            if (node == null) {
-                continue;
+    /**
+     * Return a filtered view of the tree containing only content under watched
+     * roots. Walk each root path from #rootNode, creating intermediate directory
+     * nodes as needed, and reference the subtree at each root endpoint directly.
+     * Since roots are non-overlapping, each contributes independently.
+     */
+    #cloneTree(rootNode) {
+        // NOTE(@kitten): The upstream version deeply clones this structure, but this
+        // isn't necessary since it's serialized right away by the DiskCacheManager.
+        // Even if it isn't, the intention is to store it faithfully, so we're okay
+        // with more modifications
+        function copyRootInto(normalRoot, source, clone) {
+            let currentSource = source;
+            let currentClone = clone;
+            let fromIdx = 0;
+            while (fromIdx < normalRoot.length) {
+                const nextSepIdx = normalRoot.indexOf(path_1.default.sep, fromIdx);
+                const isLastSegment = nextSepIdx === -1;
+                const seg = isLastSegment
+                    ? normalRoot.slice(fromIdx)
+                    : normalRoot.slice(fromIdx, nextSepIdx);
+                fromIdx = isLastSegment ? normalRoot.length : nextSepIdx + 1;
+                const sourceChild = currentSource.get(seg);
+                if (sourceChild == null || !isDirectory(sourceChild)) {
+                    return;
+                }
+                else if (isLastSegment || fromIdx >= normalRoot.length) {
+                    currentClone.set(seg, sourceChild);
+                }
+                else {
+                    let cloneChild = currentClone.get(seg);
+                    if (cloneChild == null || !isDirectory(cloneChild)) {
+                        cloneChild = new Map();
+                        currentClone.set(seg, cloneChild);
+                    }
+                    currentSource = sourceChild;
+                    currentClone = cloneChild;
+                }
             }
-            else if (isDirectory(node)) {
-                const childPath = prefix === '' ? name : prefix + path_1.default.sep + name;
-                if (this.#rootPattern == null || this.#rootPattern.test(childPath + path_1.default.sep)) {
-                    clone.set(name, this.#cloneTree(node, childPath));
+        }
+        if (this.#roots.length === 0) {
+            return rootNode;
+        }
+        const clone = new Map();
+        for (const normalRoot of this.#roots) {
+            if (normalRoot === '') {
+                // Root is rootDir itself — include everything except '..'
+                for (const [name, node] of rootNode) {
+                    if (node != null && name !== '..') {
+                        clone.set(name, node);
+                    }
                 }
             }
             else {
-                clone.set(name, [...node]);
+                copyRootInto(normalRoot, rootNode, clone);
             }
         }
         return clone;

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -133,6 +133,7 @@ export default class TreeFS implements MutableFileSystem {
   readonly #processFile: ProcessFileFunction;
   readonly #rootDir: Path;
   readonly #rootPattern: RegExp | null;
+  readonly #roots: readonly string[];
   #rootNode: DirectoryNode = new Map();
 
   constructor(opts: TreeFSOptions) {
@@ -148,6 +149,8 @@ export default class TreeFS implements MutableFileSystem {
     } else {
       this.#fallbackBoundaryDepth = null;
     }
+    const normalRoots = (roots ?? []).map((r) => this.#pathUtils.absoluteToNormal(r));
+    this.#roots = normalRoots;
     this.#rootPattern = pathsToPattern(roots ?? [], this.#pathUtils);
     if (files != null) {
       this.bulkAddOrModify(files);
@@ -155,7 +158,7 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   getSerializableSnapshot(): CacheData['fileSystemData'] {
-    return this.#cloneTree(this.#rootNode, '');
+    return this.#cloneTree(this.#rootNode);
   }
 
   static fromDeserializedSnapshot(args: DeserializedSnapshotInput): TreeFS {
@@ -716,10 +719,7 @@ export default class TreeFS implements MutableFileSystem {
               changeListener.directoryAdded(canonicalPath);
             }
             parentNode.set(segmentName, segmentNode);
-          } else if (
-            !opts.skipFallback &&
-            this.#fallbackFilesystem != null
-          ) {
+          } else if (!opts.skipFallback && this.#fallbackFilesystem != null) {
             parentNode.set(segmentName, segmentNode);
           }
         }
@@ -1315,18 +1315,62 @@ export default class TreeFS implements MutableFileSystem {
     return result.node;
   }
 
-  #cloneTree(root: DirectoryNode, prefix: string): DirectoryNode {
+  /**
+   * Return a filtered view of the tree containing only content under watched
+   * roots. Walk each root path from #rootNode, creating intermediate directory
+   * nodes as needed, and reference the subtree at each root endpoint directly.
+   * Since roots are non-overlapping, each contributes independently.
+   */
+  #cloneTree(rootNode: DirectoryNode): DirectoryNode {
+    // NOTE(@kitten): The upstream version deeply clones this structure, but this
+    // isn't necessary since it's serialized right away by the DiskCacheManager.
+    // Even if it isn't, the intention is to store it faithfully, so we're okay
+    // with more modifications
+
+    function copyRootInto(normalRoot: string, source: DirectoryNode, clone: DirectoryNode): void {
+      let currentSource = source;
+      let currentClone = clone;
+      let fromIdx = 0;
+
+      while (fromIdx < normalRoot.length) {
+        const nextSepIdx = normalRoot.indexOf(path.sep, fromIdx);
+        const isLastSegment = nextSepIdx === -1;
+        const seg = isLastSegment
+          ? normalRoot.slice(fromIdx)
+          : normalRoot.slice(fromIdx, nextSepIdx);
+        fromIdx = isLastSegment ? normalRoot.length : nextSepIdx + 1;
+
+        const sourceChild = currentSource.get(seg);
+        if (sourceChild == null || !isDirectory(sourceChild)) {
+          return;
+        } else if (isLastSegment || fromIdx >= normalRoot.length) {
+          currentClone.set(seg, sourceChild);
+        } else {
+          let cloneChild = currentClone.get(seg);
+          if (cloneChild == null || !isDirectory(cloneChild)) {
+            cloneChild = new Map();
+            currentClone.set(seg, cloneChild);
+          }
+          currentSource = sourceChild;
+          currentClone = cloneChild as DirectoryNode;
+        }
+      }
+    }
+
+    if (this.#roots.length === 0) {
+      return rootNode;
+    }
     const clone: DirectoryNode = new Map();
-    for (const [name, node] of root) {
-      if (node == null) {
-        continue;
-      } else if (isDirectory(node)) {
-        const childPath = prefix === '' ? name : prefix + path.sep + name;
-        if (this.#rootPattern == null || this.#rootPattern.test(childPath + path.sep)) {
-          clone.set(name, this.#cloneTree(node, childPath));
+    for (const normalRoot of this.#roots) {
+      if (normalRoot === '') {
+        // Root is rootDir itself — include everything except '..'
+        for (const [name, node] of rootNode) {
+          if (node != null && name !== '..') {
+            clone.set(name, node);
+          }
         }
       } else {
-        clone.set(name, [...node]);
+        copyRootInto(normalRoot, rootNode, clone);
       }
     }
     return clone;

--- a/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
@@ -1826,6 +1826,27 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
         expect(srcDir.has('a.js')).toBe(true);
         expect(srcDir.has('b.js')).toBe(true);
       });
+
+      test('includes roots above rootDir in snapshot', () => {
+        const files = new Map<CanonicalPath, FileMetadata>([
+          [p('src/app.js'), [100, 5, 0, null, 0, null]],
+          [p('../packages/expo/index.js'), [200, 3, 0, null, 0, null]],
+        ]);
+        const fbTfs = makeFallbackTfs({
+          files,
+          roots: [p('/project/src'), p('/packages/expo')],
+        });
+
+        const snapshot = fbTfs.getSerializableSnapshot() as Map<string, any>;
+        expect(snapshot.has('src')).toBe(true);
+        const dotdot = snapshot.get('..') as Map<string, any>;
+        expect(dotdot).toBeInstanceOf(Map);
+        const pkgs = dotdot.get('packages') as Map<string, any>;
+        expect(pkgs).toBeInstanceOf(Map);
+        const expo = pkgs.get('expo') as Map<string, any>;
+        expect(expo).toBeInstanceOf(Map);
+        expect(expo.has('index.js')).toBe(true);
+      });
     });
 
     describe('rootPattern consistency with trailing separator', () => {


### PR DESCRIPTION
# Why

There's a subtle issue with `#cloneTree`'s changes in #45391 — it's unable to include relative roots, since it's trying to apply the `#rootPattern` to partial root folders.

# How

Instead, we should re-traverse all `roots` and rebuild the tree starting from these roots, knowing that they'll be included in `watchFolders` that way.

This PR also removes the full clone of the tree, since it's not necessary and just increases memory pressure.

# Test Plan

- Unit test added

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
