### PR TITLE
chore(bare-expo): Fix expensive regex

### DIFF
--- a/apps/bare-expo/metro.config.js
+++ b/apps/bare-expo/metro.config.js
@@ -22,7 +22,7 @@ config.resolver.resolveRequest = (context, moduleName, platform) => {
   return context.resolveRequest(context, moduleName, platform);
 };
 // writing a screenshot otherwise shows a metro refresh banner at the top of the screen which can interfere with another screenshot
-config.resolver.blockList.push(/.*bare-expo\/e2e.*/);
+config.resolver.blockList.push(/^e2e/);
 
 // When testing on MacOS we need to include the `react-native-macos/Libraries/Core/InitializeCore` as prepended global module
 const originalGetModulesRunBeforeMainModule = config.serializer.getModulesRunBeforeMainModule;


### PR DESCRIPTION
# Why

This regular expression is very expensive and slows down per-file checks to >3ms, which adds up very quickly. We can now replace it with a project-root relative check.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
