### PR TITLE
[publish] Mark iOS build scripts as executable

### DIFF
--- a/packages/expo-constants/package.json
+++ b/packages/expo-constants/package.json
@@ -54,5 +54,11 @@
   "peerDependencies": {
     "expo": "*",
     "react-native": "*"
+  },
+  "publishConfig": {
+    "executableFiles": [
+      "./scripts/get-app-config-ios.sh",
+      "./scripts/with-node.sh"
+    ]
   }
 }

--- a/packages/expo-modules-jsi/package.json
+++ b/packages/expo-modules-jsi/package.json
@@ -36,5 +36,13 @@
   "devDependencies": {},
   "peerDependencies": {
     "react-native": "*"
+  },
+  "publishConfig": {
+    "executableFiles": [
+      "./apple/scripts/build-xcframework.sh",
+      "./apple/scripts/create-stub-xcframework.sh",
+      "./apple/scripts/generate-modulemap.sh",
+      "./apple/scripts/test.sh"
+    ]
   }
 }

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -85,5 +85,11 @@
     "expo-dev-client": {
       "optional": true
     }
+  },
+  "publishConfig": {
+    "executableFiles": [
+      "./scripts/create-updates-resources-ios.sh",
+      "./scripts/with-node.sh"
+    ]
   }
 }

--- a/packages/expo-widgets/package.json
+++ b/packages/expo-widgets/package.json
@@ -47,5 +47,11 @@
     "expo": "*",
     "react": "*",
     "react-native": "*"
+  },
+  "publishConfig": {
+    "executableFiles": [
+      "./scripts/with-node.sh",
+      "./scripts/xcode-build-bundle.sh"
+    ]
   }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -142,7 +142,9 @@
     "executableFiles": [
       "./scripts/node-binary.sh",
       "./scripts/react-native-xcode.sh",
-      "./scripts/xcode/with-environment.sh"
+      "./scripts/xcode/with-environment.sh",
+      "./scripts/compose-source-maps.js",
+      "scripts/resolveAppEntry.js"
     ]
   }
 }

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -137,5 +137,12 @@
     "react-native-webview": {
       "optional": true
     }
+  },
+  "publishConfig": {
+    "executableFiles": [
+      "./scripts/node-binary.sh",
+      "./scripts/react-native-xcode.sh",
+      "./scripts/xcode/with-environment.sh"
+    ]
   }
 }

--- a/templates/expo-template-bare-minimum/package.json
+++ b/templates/expo-template-bare-minimum/package.json
@@ -15,5 +15,10 @@
     "expo-status-bar": "~56.0.3",
     "react": "19.2.3",
     "react-native": "0.85.3"
+  },
+  "publishConfig": {
+    "executableFiles": [
+      "./android/gradlew"
+    ]
   }
 }


### PR DESCRIPTION
# Why
`pnpm pack` hardcodes tarball file mode based purely on whether a path appears in `bin` or `publishConfig.executableFiles` — see [pnpm/pnpm#6285](https://github.com/pnpm/pnpm/issues/6285). Anything else ships with `644`, regardless of the on-disk executable bit.

This causes iOS builds to fail with `Permission denied` the first time Xcode tries to run one

# How
Add `publishConfig.executableFiles` to each affected package's `package.json`

# Test Plan
Run `pnpm pack` on the 5 packages and confirm `.sh` entries show `-rwxr-xr-x` in the tarball.

