### PR TITLE
[updates] Add runtime version header to asset requests

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add runtime version header to asset requests. ([#45465](https://github.com/expo/expo/pull/45465) by [@douglowder](https://github.com/douglowder))
+
 ## 56.0.5 — 2026-05-07
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add runtime version header to asset requests. ([#45465](https://github.com/expo/expo/pull/45465) by [@douglowder](https://github.com/douglowder))
+
 ## 56.0.4 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/loader/FileDownloader.kt
@@ -787,6 +787,10 @@ class FileDownloader(
       } else {
         removeHeader(A_IM_HEADER)
       }
+      val runtimeVersion = configuration.runtimeVersionRaw
+      if (!runtimeVersion.isNullOrEmpty()) {
+        header("Expo-Runtime-Version", runtimeVersion)
+      }
     }
     .apply {
       for ((key, value) in configuration.requestHeaders) {

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/basic_checkRequestHeaders.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/basic_checkRequestHeaders.yml
@@ -13,7 +13,17 @@ onFlowStart:
     label: Assert update string is from embedded bundle
 - assertTrue:
     condition:  ${output.api.lastRequestHeaders().host == 'localhost:' + MAESTRO_UPDATES_SERVER_PORT}
-    label: Check that request contains correct headers
+    label: Check that request contains correct host header
+    env:
+      MAESTRO_UPDATES_SERVER_PORT: ${MAESTRO_UPDATES_SERVER_PORT}
+- assertTrue:
+    condition:  ${output.api.lastRequestHeaders()['expo-channel-name'] == 'default'}
+    label: Check that request contains correct channel name header 
+    env:
+      MAESTRO_UPDATES_SERVER_PORT: ${MAESTRO_UPDATES_SERVER_PORT}
+- assertTrue:
+    condition:  ${output.api.lastRequestHeaders()['expo-runtime-version'] == '1.0.0'}
+    label: Check that request contains correct runtime version header
     env:
       MAESTRO_UPDATES_SERVER_PORT: ${MAESTRO_UPDATES_SERVER_PORT}
 - stopApp

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/basic_updateMultipleAssets.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/basic_updateMultipleAssets.yml
@@ -30,4 +30,19 @@ onFlowStart:
 - assertTrue:
     condition: ${maestro.copiedText == "test-update-2"}
     label: Assert update string is from downloaded update
+- assertTrue:
+    condition:  ${output.api.lastAssetRequestHeaders().host == 'localhost:' + MAESTRO_UPDATES_SERVER_PORT}
+    label: Check that asset request contains correct host header
+    env:
+      MAESTRO_UPDATES_SERVER_PORT: ${MAESTRO_UPDATES_SERVER_PORT}
+- assertTrue:
+    condition:  ${output.api.lastAssetRequestHeaders()['expo-channel-name'] == 'default'}
+    label: Check that asset request contains correct channel name header 
+    env:
+      MAESTRO_UPDATES_SERVER_PORT: ${MAESTRO_UPDATES_SERVER_PORT}
+- assertTrue:
+    condition:  ${output.api.lastAssetRequestHeaders()['expo-runtime-version'] == '1.0.0'}
+    label: Check that asset request contains correct runtime version header
+    env:
+      MAESTRO_UPDATES_SERVER_PORT: ${MAESTRO_UPDATES_SERVER_PORT}
 - stopApp

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/maestroUpdatesApi.js
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/maestroUpdatesApi.js
@@ -18,6 +18,12 @@ function lastRequestHeaders() {
   return JSON.parse(response.body);
 }
 
+function lastAssetRequestHeaders() {
+  var requestString = `${serverBaseUrl}/last-asset-request-headers`;
+  const response = http.get(requestString);
+  return JSON.parse(response.body);
+}
+
 function stopUpdatesServer() {
   http.get(`${serverBaseUrl}/stop-server`);
 }
@@ -69,6 +75,7 @@ output.api = {
   installClient: installClient,
   uninstallClient: uninstallClient,
   lastRequestHeaders: lastRequestHeaders,
+  lastAssetRequestHeaders: lastAssetRequestHeaders,
   logEntries: logEntries,
   restartUpdatesServer: restartUpdatesServer,
   serveManifest: serveManifest,

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/updates-server/server.ts
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/updates-server/server.ts
@@ -38,6 +38,7 @@ let messages: any[] = [];
 let responsesToServe: any[] = [];
 
 let updateRequest: Request | null = null;
+let assetRequest: Request | null = null;
 
 let manifestToServe: null = null;
 let manifestHeadersToServe: { [x: string]: any } | null = null;
@@ -82,6 +83,7 @@ function stop() {
   messages = [];
   responsesToServe = [];
   updateRequest = null;
+  assetRequest = null;
   manifestToServe = null;
   manifestHeadersToServe = null;
   serveChannel = null;
@@ -104,10 +106,12 @@ app.use(express.json({ limit: '200kb' }));
 app.use(
   '/static',
   (
-    req: { url: string; headers: Record<string, string | undefined> },
+    req: any,
     res: any,
     next: () => void
   ) => {
+    console.log('Requested static file: ', JSON.stringify(req.headers, null, 2));
+    assetRequest = req;
     requestedStaticFiles.push(path.basename(req.url));
     next();
   }
@@ -465,6 +469,15 @@ app.get('/last-request-headers', (_: Request, res: Response) => {
     return;
   }
   res.status(200).json(updateRequest.headers).end();
+  return;
+});
+
+app.get('/last-asset-request-headers', (_: Request, res: Response) => {
+  if (!assetRequest) {
+    res.status(404).send('No asset request');
+    return;
+  }
+  res.status(200).json(assetRequest.headers).end();
   return;
 });
 

--- a/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
+++ b/packages/expo-updates/ios/EXUpdates/AppLoader/FileDownloader.swift
@@ -440,6 +440,7 @@ public final class FileDownloader {
     request.setValue("1", forHTTPHeaderField: "Expo-API-Version")
     request.setValue("BARE", forHTTPHeaderField: "Expo-Updates-Environment")
     request.setValue(EASClientID.uuid().uuidString, forHTTPHeaderField: "EAS-Client-ID")
+    request.setValue(config.runtimeVersion, forHTTPHeaderField: "Expo-Runtime-Version")
 
     for (key, value) in config.requestHeaders {
       request.setValue(value, forHTTPHeaderField: key)


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

For enrichment of the updates dashboard in EAS, it would be helpful to have channel and runtime version headers in all asset requests for updates.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Inspection of the code indicates that the channel is already included in the headers for asset requests, but runtime version was only added for the full update requests. The runtime version headers are now added for assets in both iOS and Android versions of the FileDownloader class.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Tests for the presence of the correct headers are added to the Updates E2E (enabled) CI.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)