### PR TITLE
[tools] Update lock file during publish

### DIFF
--- a/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
+++ b/tools/src/publish-packages/tasks/publishPackagesPipeline.ts
@@ -14,6 +14,7 @@ import { loadRequestedParcels } from './loadRequestedParcels';
 import { publishAndroidArtifacts } from './publishAndroidPackages';
 import { publishPackages } from './publishPackages';
 import { pushCommittedChanges } from './pushCommittedChanges';
+import { refreshPnpmLockfile } from './refreshPnpmLockfile';
 import { selectPackagesToPublish } from './selectPackagesToPublish';
 import { updateAndroidProjects } from './updateAndroidProjects';
 import { updateBundledNativeModulesFile } from './updateBundledNativeModulesFile';
@@ -91,6 +92,7 @@ export const publishPackagesPipeline = new Task<TaskArgs>(
       updateIosProjects,
       addTemplateTarball,
       cutOffChangelogs,
+      refreshPnpmLockfile,
       commitStagedChanges,
       pushCommittedChanges,
       publishAndroidArtifacts,

--- a/tools/src/publish-packages/tasks/refreshPnpmLockfile.ts
+++ b/tools/src/publish-packages/tasks/refreshPnpmLockfile.ts
@@ -1,0 +1,35 @@
+import { updateWorkspaceProjects } from './updateWorkspaceProjects';
+import { EXPO_DIR } from '../../Constants';
+import logger from '../../Logger';
+import { Task } from '../../TasksRunner';
+import { spawnAsync } from '../../Utils';
+import { CommandOptions, Parcel, TaskArgs } from '../types';
+
+/**
+ * Refreshes `pnpm-lock.yaml` after the `package.json` bumps so that
+ * `pnpm install --frozen-lockfile` on the publish commit doesn't fail.
+ */
+export const refreshPnpmLockfile = new Task<TaskArgs>(
+  {
+    name: 'refreshPnpmLockfile',
+    dependsOn: [updateWorkspaceProjects],
+    filesToStage: ['pnpm-lock.yaml'],
+  },
+  async (_parcels: Parcel[], options: CommandOptions) => {
+    if (options.templatesOnly) {
+      logger.info('\n🔒 Skipping lockfile refresh (templates-only).');
+      return;
+    }
+
+    logger.info('\n🔒 Refreshing pnpm-lock.yaml...');
+
+    await spawnAsync('pnpm', ['install', '--lockfile-only'], {
+      cwd: EXPO_DIR,
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        EXPO_NONINTERACTIVE: '1',
+      },
+    });
+  }
+);


### PR DESCRIPTION
# Why
Every publish leaves `pnpm-lock.yaml` stale, this causes the CI jobs on the publish commit to fail.

# How
New `refreshPnpmLockfile` task runs `pnpm install --lockfile-only` between `cutOffChangelogs` and `commitStagedChanges` so this gets included in the publish commit. 

# Test Plan
et publish-packages --dry -f expo-haptics
