### PR TITLE
[core][android] Fix unsetting border width on views with border radius causing images to disappear

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix unsetting border width on views with border radius causing views to disappear ([#45467](https://github.com/expo/expo/pull/45467) by [@fractalbeauty](https://github.com/fractalbeauty))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/decorators/CSSProps.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/decorators/CSSProps.kt
@@ -64,7 +64,7 @@ private fun <T : View> ViewDefinitionBuilder<T>.UseBorderWidthProps() {
     BackgroundStyleApplicator.setBorderWidth(
       view,
       edge,
-      width ?: Float.NaN
+      width
     )
   }
 }


### PR DESCRIPTION
# Why

When using `expo-image`'s `Image` component with a border radius and conditional border width, the image disappears when the border width is removed. [Minimal reproduction Snack](https://snack.expo.dev/@fractalbeauty/expo-image-removing-borderwidth?platform=android)

# How

This is caused by coercing `null` to `NaN` when calling `BackgroundStyleApplicator.setBorderWidth` in `expo-modules-core` `CSSProps.kt`. `setBorderWidth` now has a [doc comment](https://github.com/facebook/react-native/blob/7ae9b664e9001e0467647506913b417967ed2c4f/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt#L127) that says to pass `null` to remove the style, and width is typed as `Float?`, so passing null is likely more correct than passing `NaN`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

This can be tested using the code from the [Snack](https://snack.expo.dev/@fractalbeauty/expo-image-removing-borderwidth?platform=android), using locally-built `expo-image` and the fixed `expo-modules-core`. This issue might apply to more than `expo-image` but I've only tested with `<Image>`.

Before:

<img width="222" height="436" alt="border width before" src="https://github.com/user-attachments/assets/9dfcbf43-00bb-4482-b33b-9520cba3ff73" />

After:

<img width="375" height="723" alt="border width after" src="https://github.com/user-attachments/assets/034f1472-b1fb-410c-80c3-aaaf28349127" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
