### PR TITLE
[tools] Fix cascade

### DIFF
--- a/tools/src/publish-packages/tasks/loadRequestedParcels.ts
+++ b/tools/src/publish-packages/tasks/loadRequestedParcels.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 
 import * as Changelogs from '../../Changelogs';
 import Git from '../../Git';
-import { getListOfPackagesAsync, Package } from '../../Packages';
+import { DependencyKind, getListOfPackagesAsync, Package } from '../../Packages';
 import { Task } from '../../TasksRunner';
 import { runWithSpinner } from '../../Utils';
 import { PackagesGraph, PackagesGraphNode } from '../../packages-graph';
@@ -122,8 +122,9 @@ export async function createParcelsForDependenciesOf(parcels: Set<Parcel>): Prom
   const allDependencies = new Set<Parcel>();
 
   for (const parcel of parcels) {
-    // Add all dependencies of the current package.
-    const dependencies = await createParcelsForGraphNodes(parcel.graphNode.getAllDependencies());
+    const dependencies = await createParcelsForGraphNodes(
+      parcel.graphNode.getAllDependencies([DependencyKind.Normal, DependencyKind.Optional])
+    );
 
     for (const dependencyParcel of dependencies) {
       parcel.dependencies.add(dependencyParcel);


### PR DESCRIPTION
# Why
`et publish-packages` was offering to publish unrelated packages with a misleading "Dependency of: pkg" label.
`expo-camera` prompted to publish `expo-dev-menu` because the transitive walk hopped through devDep edges

expo-camera     → expo            [devDep, peerDep]
expo            → expo-updates    [devDep]
expo-updates    → expo-dev-client [devDep, peerDep]
expo-dev-client → expo-dev-menu   [dep]

This happened because #44043, added the missing `expo-updates` devDep to the expo package. That edge didn't exist before, so the dev-dep chain wasn't reachable.

# How
`createParcelsForDependenciesOf` calls `parcel.graphNode.getAllDependencies()` to walk a requested package's transitive deps and offer them as additional publish candidates. Pass `[DependencyKind.Normal, DependencyKind.Optional]` explicitly so the walk skips devDep and peerDep edges. 

# Test Plan
`et publish-packages expo-camera` no longer suggests `expo-dev-menu` / `expo-updates` / `expo-dev-client` etc/

