### PR TITLE
fix(expo-router): Move `@jest/globals` to `devDependencies`

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Move `@jest/globals` to `devDependencies` ([#45469](https://github.com/expo/expo/pull/45469) by [@kitten](https://github.com/kitten))
+
 ## 56.0.4 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -125,6 +125,7 @@
     }
   },
   "devDependencies": {
+    "@jest/globals": "^29.7.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/react-native": "^13.3.0",
@@ -151,7 +152,6 @@
     "@expo/metro-runtime": "workspace:^56.0.4",
     "@expo/schema-utils": "workspace:^56.0.0",
     "@expo/ui": "workspace:^56.0.1",
-    "@jest/globals": "^29.7.0",
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-tabs": "^1.1.12",
     "@react-native-masked-view/masked-view": "^0.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5068,9 +5068,6 @@ importers:
       '@expo/ui':
         specifier: workspace:^56.0.1
         version: link:../expo-ui
-      '@jest/globals':
-        specifier: ^29.7.0
-        version: 29.7.0
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.4(@types/react@19.2.14)(react@19.2.3)
@@ -5162,6 +5159,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     devDependencies:
+      '@jest/globals':
+        specifier: ^29.7.0
+        version: 29.7.0
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.1


### PR DESCRIPTION
# Why

Unless I'm missing something, this was probably accidental from the pnpm migration.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
