### PR TITLE
[app-metrics][ios] Fix NetworkPathMonitor tests

### DIFF
--- a/packages/expo-app-metrics/ios/Network/NetworkPathMonitor.swift
+++ b/packages/expo-app-metrics/ios/Network/NetworkPathMonitor.swift
@@ -31,7 +31,8 @@ final class NetworkPathMonitor: NetworkPathObserverDelegate, Sendable {
    */
   private var firstPathContinuations: [CheckedContinuation<Void, Never>] = []
 
-  private init() {}
+  /** Internal so tests can construct dedicated instances; production code uses `shared`. */
+  init() {}
 
   /**
    Idempotent. Constructs the observer on the first call; later calls are
@@ -56,19 +57,28 @@ final class NetworkPathMonitor: NetworkPathObserverDelegate, Sendable {
     return currentPath
   }
 
+  /**
+   Caches `path` and resumes any callers awaiting the first path. Tests on
+   `AppMetricsActor` can call this directly to avoid the async hop in
+   `onNetworkPathUpdate(_:)`.
+   */
+  func apply(_ path: NetworkPath) {
+    let wasFirst = currentPath == nil
+    currentPath = path
+    if wasFirst {
+      let pending = firstPathContinuations
+      firstPathContinuations.removeAll()
+      for continuation in pending {
+        continuation.resume()
+      }
+    }
+  }
+
   // MARK: - NetworkPathObserverDelegate
 
   nonisolated func onNetworkPathUpdate(_ path: NetworkPath) {
     AppMetricsActor.isolated { [self] in
-      let wasFirst = currentPath == nil
-      currentPath = path
-      if wasFirst {
-        let pending = firstPathContinuations
-        firstPathContinuations.removeAll()
-        for continuation in pending {
-          continuation.resume()
-        }
-      }
+      apply(path)
     }
   }
 }

--- a/packages/expo-app-metrics/ios/Tests/NetworkPathTests.swift
+++ b/packages/expo-app-metrics/ios/Tests/NetworkPathTests.swift
@@ -66,8 +66,8 @@ struct NetworkPathTests {
 @Suite("NetworkPathMonitor")
 struct NetworkPathMonitorTests {
   @Test
-  func `caches the last received path`() async throws {
-    let monitor = NetworkPathMonitor.shared
+  func `caches the last received path`() {
+    let monitor = NetworkPathMonitor()
     let path = NetworkPath(
       status: .satisfied,
       interfaceType: .wifi,
@@ -76,16 +76,13 @@ struct NetworkPathMonitorTests {
       unsatisfiedReason: nil,
       timestamp: 1.0
     )
-    monitor.onNetworkPathUpdate(path)
-    // `onNetworkPathUpdate` dispatches via `AppMetricsActor.isolated { ... }`,
-    // so we yield to let the cache update before asserting.
-    try await Task.sleep(for: .milliseconds(10))
+    monitor.apply(path)
     #expect(monitor.currentPath == path)
   }
 
   @Test
-  func `overwrites the cached path on subsequent updates`() async throws {
-    let monitor = NetworkPathMonitor.shared
+  func `overwrites the cached path on subsequent updates`() {
+    let monitor = NetworkPathMonitor()
     let first = NetworkPath(
       status: .satisfied,
       interfaceType: .wifi,
@@ -102,15 +99,14 @@ struct NetworkPathMonitorTests {
       unsatisfiedReason: .notAvailable,
       timestamp: 2.0
     )
-    monitor.onNetworkPathUpdate(first)
-    monitor.onNetworkPathUpdate(second)
-    try await Task.sleep(for: .milliseconds(10))
+    monitor.apply(first)
+    monitor.apply(second)
     #expect(monitor.currentPath == second)
   }
 
   @Test
   func `waitForFirstPath returns immediately when a path is already cached`() async {
-    let monitor = NetworkPathMonitor.shared
+    let monitor = NetworkPathMonitor()
     let path = NetworkPath(
       status: .satisfied,
       interfaceType: .wifi,
@@ -119,7 +115,7 @@ struct NetworkPathMonitorTests {
       unsatisfiedReason: nil,
       timestamp: 1.0
     )
-    monitor.onNetworkPathUpdate(path)
+    monitor.apply(path)
     let result = await monitor.waitForFirstPath()
     #expect(result == path)
   }


### PR DESCRIPTION
# Why

The `NetworkPathMonitor` tests on `main` were flaky and order-dependent: they reused the `shared` singleton (so cached state leaked between tests) and slept 10ms after each `onNetworkPathUpdate(_:)` to wait for the `AppMetricsActor.isolated { ... }` hop.

# How

- Drop `private` from `NetworkPathMonitor.init()` so tests can construct dedicated instances.
- Extract the actor-isolated cache update into a synchronous `apply(_:)` method. `onNetworkPathUpdate(_:)` still hops onto `AppMetricsActor` and calls `apply`; tests already on the actor call `apply` directly and assert without sleeping.
- Update `NetworkPathTests` to use per-test instances and the synchronous path.

<!-- disable:changelog-checks -->