### PR TITLE
[ui][docs] move Expo UI to a separate subsection

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -726,7 +726,7 @@ const versionsReference = VERSIONS.reduce(
         'Expo SDK',
         shiftEntryToFront(
           pagesFromDir(`versions/${version}/sdk`).filter(
-            entry => !entry.inExpoGo && entry.name !== 'Router' && entry.name !== 'UI'
+            entry => !entry.inExpoGo && !['Router', 'UI'].includes(entry.name)
           ),
           entry => entry.name === 'Expo'
         ),

--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -714,11 +714,19 @@ const versionsReference = VERSIONS.reduce(
             }),
           ]
         : []),
+      ...(fs.existsSync(path.resolve(PAGES_DIR, `versions/${version}/sdk/ui`))
+        ? [
+            makeSection('Expo UI', pagesFromDir(`versions/${version}/sdk/ui`), {
+              expanded: true,
+              hideIcon: true,
+            }),
+          ]
+        : []),
       makeSection(
         'Expo SDK',
         shiftEntryToFront(
           pagesFromDir(`versions/${version}/sdk`).filter(
-            entry => !entry.inExpoGo && entry.name !== 'Router'
+            entry => !entry.inExpoGo && entry.name !== 'Router' && entry.name !== 'UI'
           ),
           entry => entry.name === 'Expo'
         ),


### PR DESCRIPTION
# Why

Move Expo UI in a separate subsection similar to Expo Router

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Using `makeSection` util. I have placed it below Expo Router and above Expo SDK as Expo SDK is a big section and requires some scrolling, lmk if this ordering works.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

  <table>         
    <tr>
      <td><b>Before</b><br><img width="200" 
  src="https://github.com/user-attachments/assets/0d1c3add-9ab0-48bc-8a67-4996a81ebacf" /></td>                              
      <td><b>After</b><br><img width="200" 
  src="https://github.com/user-attachments/assets/6b7cd68e-1647-40a9-8e46-2a1bdf8fc288" /></td>                              
    </tr>         
  </table>      

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
