### PR TITLE
[JSI] Optimize runtime.execute and verify it doesn't block the JS thread

### DIFF
--- a/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
+++ b/apps/bare-expo/modules/benchmarking/ios/BenchmarkingExpoModule.swift
@@ -1,4 +1,5 @@
 import ExpoModulesCore
+import ExpoModulesJSI
 
 struct Point: Record {
   @Field
@@ -78,6 +79,84 @@ public final class BenchmarkingExpoModule: Module {
 
       Property("y") { (point: SharedPoint) in
         return point.y
+      }
+    }
+
+    // MARK: - runtime.execute() benchmarks
+    //
+    // Each benchmark times `iterations` round-trips of one of the four
+    // `JavaScriptRuntime.execute(...)` overloads from a non-JS thread, returning
+    // elapsed milliseconds. AsyncFunction bodies already run off the JS thread,
+    // so calling `execute` here exercises the cross-thread scheduling + wakeup
+    // path.
+    //
+    // The two non-async closures dispatch onto the GCD queue shared by Expo
+    // Modules; the two async closures dispatch onto a Swift Concurrency
+    // executor. Both call the same `RuntimeScheduler` underneath, but the
+    // caller side differs.
+
+    // Caller: GCD queue. Closure: sync.
+    AsyncFunction("executeBlockingSync") { (iterations: Int) throws -> Double in
+      let runtime = try self.appContext!.runtime
+      let start = DispatchTime.now()
+      for _ in 0..<iterations {
+        try runtime.execute { () -> Void in
+          _ = runtime.global().hasProperty("Math")
+        }
+      }
+      return Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+    }
+
+    // Caller: GCD queue. Closure: async.
+    AsyncFunction("executeBlockingAsync") { (iterations: Int) throws -> Double in
+      let runtime = try self.appContext!.runtime
+      let start = DispatchTime.now()
+      for _ in 0..<iterations {
+        try runtime.execute { @JavaScriptActor () async -> Void in
+          _ = runtime.global().hasProperty("Math")
+        }
+      }
+      return Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+    }
+
+    // Caller: Swift Concurrency (detached Task). Closure: sync.
+    // The detached Task runs on the cooperative pool — off the JS thread — so
+    // each `await runtime.execute(...)` exercises the cross-thread scheduling
+    // path instead of the same-thread fast path.
+    AsyncFunction("executeAsyncSync") { (iterations: Int, promise: Promise) in
+      let runtime = try self.appContext!.runtime
+      Task.detached {
+        do {
+          let start = DispatchTime.now()
+          for _ in 0..<iterations {
+            try await runtime.execute { () -> Void in
+              _ = runtime.global().hasProperty("Math")
+            }
+          }
+          let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+          promise.resolve(elapsedMs)
+        } catch {
+          promise.reject(error)
+        }
+      }
+    }
+
+    // Caller: Swift Concurrency (detached Task). Closure: async.
+    AsyncFunction("executeAsyncAsync") { (iterations: Int, promise: Promise) in
+      let runtime = try self.appContext!.runtime
+      Task.detached {
+        do {
+          let start = DispatchTime.now()
+          for _ in 0..<iterations {
+            try await runtime.execute { @JavaScriptActor () async -> Void in
+              _ = runtime.global().hasProperty("Math")
+            }
+          }
+          let elapsedMs = Double(DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds) / 1_000_000
+          promise.resolve(elapsedMs)
+        } catch {
+          promise.reject(error)
+        }
       }
     }
   }

--- a/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
+++ b/apps/bare-expo/modules/benchmarking/src/BenchmarkingExpoModule.ts
@@ -21,6 +21,14 @@ declare class BenchmarkingExpoModule extends NativeModule {
   SharedPoint: typeof SharedPoint;
   addNumbersAsync(a: number, b: number): Promise<number>;
   addNumbersAsyncOptimized(a: number, b: number): Promise<number>;
+  /** iOS only — measures blocking `runtime.execute` with a sync closure. */
+  executeBlockingSync(iterations: number): Promise<number>;
+  /** iOS only — measures blocking `runtime.execute` with an async closure. */
+  executeBlockingAsync(iterations: number): Promise<number>;
+  /** iOS only — measures async `runtime.execute` with a sync closure. */
+  executeAsyncSync(iterations: number): Promise<number>;
+  /** iOS only — measures async `runtime.execute` with an async closure. */
+  executeAsyncAsync(iterations: number): Promise<number>;
 }
 
 export default requireNativeModule<BenchmarkingExpoModule>('BenchmarkingExpoModule');

--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
@@ -63,6 +63,43 @@ async function timeAsync(
   return performance.now() - start;
 }
 
+const TICK_INTERVAL_MS = 16;
+
+// Wraps a benchmark to log JS-thread responsiveness during the run. Schedules a
+// `setInterval` tick and compares the actual tick count against the expected
+// count for the elapsed wall time. Ratio ≈ 1.0 means the JS thread stayed
+// responsive; lower means it was blocked.
+function withResponsiveness(
+  label: string,
+  run: (iterations: number) => Promise<number>
+): (iterations: number) => Promise<number> {
+  return async (iterations) => {
+    let ticks = 0;
+    const handle = setInterval(() => {
+      ticks++;
+    }, TICK_INTERVAL_MS);
+    const start = performance.now();
+    try {
+      const elapsed = await run(iterations);
+      const expectedTicks = (performance.now() - start) / TICK_INTERVAL_MS;
+
+      if (expectedTicks < 5) {
+        console.log(
+          `[benchmark: ${label}] JS responsiveness: skipped (run too short, ${expectedTicks.toFixed(1)} expected ticks)`
+        );
+      } else {
+        const ratio = ticks / expectedTicks;
+        console.log(
+          `[benchmark: ${label}] JS responsiveness: ${ratio.toFixed(2)} (${ticks}/${expectedTicks.toFixed(0)} ticks)`
+        );
+      }
+      return elapsed;
+    } finally {
+      clearInterval(handle);
+    }
+  };
+}
+
 export const GROUPS: Group[] = [
   {
     id: 'nothing',
@@ -402,6 +439,48 @@ export const GROUPS: Group[] = [
             BridgeModule.foldArray(numbers);
           });
         },
+      },
+    ],
+  },
+  {
+    id: 'runtimeExecute',
+    title: 'runtime.execute() — iOS',
+    iterations: DEFAULT_ASYNC_ITERATIONS,
+    description:
+      'Round-trips `runtime.execute(...)` from a non-JS caller, calling `runtime.global().hasProperty("Math")` inside the closure.\n' +
+      'The JS thread should stay responsive across all four overloads (ratio logged to the console).',
+    benchmarks: [
+      {
+        id: 'blocking-sync',
+        label: 'blocking caller, sync closure',
+        available: ExpoModule?.executeBlockingSync != null,
+        run: withResponsiveness('executeBlockingSync', (iterations) =>
+          ExpoModule.executeBlockingSync(iterations)
+        ),
+      },
+      {
+        id: 'blocking-async',
+        label: 'blocking caller, async closure',
+        available: ExpoModule?.executeBlockingAsync != null,
+        run: withResponsiveness('executeBlockingAsync', (iterations) =>
+          ExpoModule.executeBlockingAsync(iterations)
+        ),
+      },
+      {
+        id: 'async-sync',
+        label: 'async caller, sync closure',
+        available: ExpoModule?.executeAsyncSync != null,
+        run: withResponsiveness('executeAsyncSync', (iterations) =>
+          ExpoModule.executeAsyncSync(iterations)
+        ),
+      },
+      {
+        id: 'async-async',
+        label: 'async caller, async closure',
+        available: ExpoModule?.executeAsyncAsync != null,
+        run: withResponsiveness('executeAsyncAsync', (iterations) =>
+          ExpoModule.executeAsyncAsync(iterations)
+        ),
       },
     ],
   },

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -33,6 +33,17 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   internal let scheduler: expo.RuntimeScheduler
 
   /**
+   Thread ID of the JavaScript thread, captured at construction time. Used by `isOnJavaScriptThread()`
+   for a fast integer comparison instead of `Thread.current.name == "..."`.
+   Assumes runtime initializers always run on the JS thread.
+   */
+  private let jsThreadID: UInt64 = {
+    var id: UInt64 = 0
+    pthread_threadid_np(nil, &id)
+    return id
+  }()
+
+  /**
    Actor for running runtime work.
    */
   lazy var runtimeActor: JavaScriptRuntimeActor = JavaScriptRuntimeActor(runtime: self)
@@ -319,7 +330,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
       let argumentsRef = arguments.copy().ref()
 
       // Switch to asynchronous context.
-      self.schedule(taskName: "[JS] Async function \(name)") {
+      self.schedule {
         // Invoke the asynchronous function and resolve/reject the promise.
         do {
           let result = try await function(this, argumentsRef.take())
@@ -356,11 +367,10 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
   public func schedule(
     priority: SchedulerPriority = .normal,
-    taskName: String? = "[JS] runtime.schedule (\(#function))",
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () async throws -> Void
   ) -> Void {
     schedule(priority: priority) {
-      Task.immediate_polyfill(name: taskName) {
+      Task.immediate_polyfill {
         try await closure()
       }
     }
@@ -371,8 +381,14 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    Not available in async contexts to prevent blocking the cooperative thread pool.
    */
   @available(*, noasync)
+  @discardableResult
   public func execute<R: Sendable>(@_implicitSelfCapture _ closure: @escaping @JavaScriptActor () throws -> R) throws -> sending R {
+    if isOnJavaScriptThread() {
+      return try JavaScriptActor.assumeIsolated(closure)
+    }
+
     var result: Result<R, any Error>!
+    nonisolated(unsafe) let callerRunLoop = CFRunLoopGetCurrent()
 
     scheduler.scheduleTask(.ImmediatePriority) {
       do {
@@ -380,12 +396,23 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
       } catch {
         result = .failure(error)
       }
+      // Wake the caller's run loop so its `CFRunLoopRunInMode(...)` returns immediately
+      // instead of waiting out the timeout backstop.
+      CFRunLoopPerformBlock(callerRunLoop, CFRunLoopMode.commonModes.rawValue) {}
+      CFRunLoopWakeUp(callerRunLoop)
     }
 
-    // Use RunLoop to wait for the task to finish. As opposed to DispatchSemaphore or DispatchGroup,
-    // this solution lets the current run loop to process other events in the meantime.
+    // Pump the caller's run loop until the task finishes. As opposed to DispatchSemaphore
+    // or DispatchGroup, this lets the run loop continue to process other events in the meantime,
+    // and the spin is also faster than a real kernel-mediated context switch when the JS work
+    // is short (the common case). The 100ms timeout is a backstop in case the wakeup is missed;
+    // the common path is woken by `CFRunLoopWakeUp` from the scheduled block above.
+    //
+    // `CFRunLoopRunInMode` is the C API rather than `RunLoop.current.run(mode:before:)` to
+    // avoid the per-iteration `+[NSRunLoop currentRunLoop]` autorelease push and `Date()`
+    // allocation that dominated the caller-thread profile otherwise.
     while result == nil {
-      RunLoop.current.run(mode: .common, before: Date().addingTimeInterval(0.001))
+      CFRunLoopRunInMode(.commonModes, 0.1, false)
     }
     return try result.get()
   }
@@ -395,26 +422,40 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    Not available in async contexts to prevent blocking the cooperative thread pool.
    */
   @available(*, noasync)
+  @discardableResult
   public func execute<R: Sendable>(
-    taskName: String? = "[JS] runtime.execute (\(#function))",
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () async throws -> R
   ) throws -> sending R {
     let result = NonisolatedUnsafeVar<Result<R, any Error>>()
+    let runInline = isOnJavaScriptThread()
+    // Wrapped in `NonisolatedUnsafeVar` instead of `nonisolated(unsafe) let`
+    // to work around a Swift 6.2.3 compiler bug.
+    let callerRunLoop = NonisolatedUnsafeVar(CFRunLoopGetCurrent())
 
-    scheduler.scheduleTask(.ImmediatePriority) {
-      Task.immediate_polyfill(name: taskName, priority: .high) {
+    func body() -> Void {
+      Task.immediate_polyfill(priority: .high) {
         do {
           result.value = .success(try await closure())
         } catch {
           result.value = .failure(error)
         }
+        // Wake the caller's run loop so its `CFRunLoopRunInMode(...)` returns immediately
+        // instead of waiting out the timeout backstop.
+        CFRunLoopPerformBlock(callerRunLoop.value, CFRunLoopMode.commonModes.rawValue) {}
+        CFRunLoopWakeUp(callerRunLoop.value)
       }
     }
+    if runInline {
+      body()
+    } else {
+      scheduler.scheduleTask(.ImmediatePriority, body)
+    }
 
-    // Use RunLoop to wait for the task to finish. As opposed to DispatchSemaphore or DispatchGroup,
-    // this solution lets the current run loop to process other events in the meantime.
+    // Pump the caller's run loop until the task finishes. See the sync overload above for
+    // the rationale on `CFRunLoopRunInMode` vs. `RunLoop.current.run(...)` and on pumping
+    // the run loop instead of blocking on a semaphore.
     while result.value == nil {
-      RunLoop.current.run(mode: .common, before: Date().addingTimeInterval(0.001))
+      CFRunLoopRunInMode(.commonModes, 0.1, false)
     }
     return try result.value.get()
   }
@@ -422,9 +463,13 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   /**
    Asynchronously executes a sync closure on the JavaScript runtime thread, awaiting its completion without blocking.
    */
+  @discardableResult
   public func execute<R: Sendable>(
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () throws -> R
   ) async throws -> sending R {
+    if isOnJavaScriptThread() {
+      return try JavaScriptActor.assumeIsolated(closure)
+    }
     return try await withUnsafeThrowingContinuation { continuation in
       scheduler.scheduleTask(.ImmediatePriority) {
         do {
@@ -439,13 +484,16 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   /**
    Asynchronously executes an async closure on the JavaScript runtime thread, awaiting its completion without blocking.
    */
+  @discardableResult
   public func execute<R: Sendable>(
-    taskName: String? = "[JS] runtime.execute (async \(#function))",
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () async throws -> R
   ) async throws -> sending R {
+    if isOnJavaScriptThread() {
+      return try await Task.immediate_polyfill(priority: .high, operation: closure).value
+    }
     return try await withUnsafeThrowingContinuation { continuation in
       scheduler.scheduleTask(.ImmediatePriority) {
-        Task.immediate_polyfill(name: taskName, priority: .high) { @JavaScriptActor in
+        Task.immediate_polyfill(priority: .high) { @JavaScriptActor in
           do {
             continuation.resume(returning: try await closure())
           } catch {
@@ -459,14 +507,18 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   /**
    Checks whether the function is called on the JavaScript thread.
    */
-  public func isOnJavaScriptThread() -> Bool {
-    return Thread.current.name == "com.facebook.react.runtime.JavaScript"
+  @inline(__always)
+  public final func isOnJavaScriptThread() -> Bool {
+    var current: UInt64 = 0
+    pthread_threadid_np(nil, &current)
+    return current == jsThreadID
   }
 
   /**
    Asserts whether we are on the JavaScript thread. Helpful for debugging threading issues.
    */
-  public func assertThread(file: String = #file, function: String = #function, line: Int = #line) {
+  @inline(__always)
+  public final func assertThread(file: String = #file, function: String = #function, line: Int = #line) {
     assert(isOnJavaScriptThread(), "Function '\(function)' is not run on the JavaScript thread (\(file):\(line))")
   }
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -118,6 +118,47 @@ struct JavaScriptRuntimeTests {
     #expect(result == 100)
   }
 
+  // The execute<R> overloads have a same-thread fast path and a cross-thread path that
+  // schedules the closure onto the JS thread and pumps the caller's run loop until it
+  // completes. The tests above run on `@JavaScriptActor` (the JS thread), so they only
+  // exercise the fast path. The next three hop off the JS thread first to cover the
+  // cross-thread scheduling + run-loop pump.
+
+  @Test
+  func `execute sync from off-thread caller`() async throws {
+    let runtime = self.runtime
+    let result = try await Task.detached { @Sendable in
+      try runtime.execute { @JavaScriptActor in
+        runtime.global().hasProperty("Object") ? 1 : 0
+      }
+    }.value
+    #expect(result == 1)
+  }
+
+  @Test
+  func `execute blocking-async from off-thread caller`() async throws {
+    let runtime = self.runtime
+    let result = try await Task.detached { @Sendable in
+      try runtime.execute { @JavaScriptActor () async in
+        await Task.yield()
+        return runtime.global().hasProperty("Object") ? 1 : 0
+      }
+    }.value
+    #expect(result == 1)
+  }
+
+  @Test
+  func `execute sync rethrows from off-thread caller`() async throws {
+    let runtime = self.runtime
+    await #expect(throws: ScriptEvaluationError.self) {
+      try await Task.detached { @Sendable in
+        try runtime.execute { @JavaScriptActor in
+          try runtime.eval("invalid syntax +++")
+        }
+      }.value
+    }
+  }
+
   // MARK: - Host objects
 
   @Test


### PR DESCRIPTION
## Summary

Refines the four `JavaScriptRuntime.execute(...)` overloads on iOS and adds benchmarks that exercise both the cross-thread scheduling path and the JS-thread responsiveness it preserves.

- Cache the JS thread ID at runtime construction time and switch `isOnJavaScriptThread()` to a `pthread_threadid_np` integer comparison instead of a `Thread.current.name` string compare. Marked `@inline(__always) public final` so callers see the inlined fast path.
- For the two blocking overloads (sync caller), the cross-thread wait is now an event-driven pump:
  - The JS-thread side calls `CFRunLoopWakeUp` (with a no-op `CFRunLoopPerformBlock` to ensure the wake is delivered) when the task completes, instead of the caller polling on a fixed interval.
  - The caller pumps via `CFRunLoopRunInMode(.commonModes, 0.1, false)` rather than `RunLoop.current.run(mode: .common, before: Date()...)`. The Swift wrapper allocated a fresh autorelease pool (`+[NSRunLoop currentRunLoop]`) and a `Date` (with `clock_gettime`) every iteration, both of which dominated caller-thread CPU in profiling. The C API takes a `CFTimeInterval` directly. This also fixes a silent mode mismatch — the Swift wrapper internally used default mode regardless of the `.common` argument it was passed, while the wake side posts on common modes.
  - The 100 ms timeout is a backstop in case the wake is missed; the common path returns immediately on the wake.
- Mark all four `execute(...)` overloads `@discardableResult` so callers don't need `_ = try ...` for fire-and-forget use.

- Adds four benchmarks, one per overload:

| Benchmark | Caller | Closure |
|---|---|---|
| `executeBlockingSync` | sync (GCD queue) | sync |
| `executeBlockingAsync` | sync (GCD queue) | async |
| `executeAsyncSync` | async (detached `Task`) | sync |
| `executeAsyncAsync` | async (detached `Task`) | async |

Each loops natively for `iterations` round-trips, calling `runtime.global().hasProperty("Math")` inside the closure (a typical native→JS interaction without parser overhead), and returns the elapsed milliseconds. Closures return `Void` so the per-call cost reflects `execute(...)`'s machinery rather than the value-witness traffic Swift's generic `Result<R, any Error>` would emit for a `Bool`-returning closure.

- Adds a `runtime.execute() — iOS` group driving the four benchmarks at 100k iterations. Each benchmark is wrapped in `withResponsiveness(...)`, which schedules a `setInterval(16ms)` tick and logs the ratio of actual ticks to expected ticks while the benchmark runs. The ratio is the diagnostic that confirms the JS thread stayed responsive — it lands at ~0.94–0.95 across all four overloads on a Release iPhone 16 Pro build, confirming the wait strategy doesn't starve JS.

### Numbers

100k iterations on iPhone 16 Pro (Release):

| Variant | Total | Per call | JS responsiveness |
|---|---|---|---|
| Blocking caller, sync closure | 497 ms | 4.97 µs | 0.94 |
| Async caller, sync closure | 735 ms | 7.35 µs | 0.95 |
| Async caller, async closure | 695 ms | 6.95 µs | 0.95 |
| Blocking caller, async closure | 711 ms | 7.11 µs | 0.95 |

The ordering reflects the underlying machinery cost:

- **Blocking-sync** is the floor at ~5 µs: one scheduler hop + run-loop wakeup, no Task allocation, no continuation.
- **Blocking-async / async-sync / async-async** all land in the 7 µs range. Each adds one extra piece of machinery on top of the floor — a Task for the async closure body, or a continuation suspension for the async caller — and the costs are roughly fungible.

### Tests

The existing `JavaScriptRuntimeTests` suite is `@JavaScriptActor`-isolated, so every test runs *on* the JS thread and only exercises the same-thread fast path inside `execute(...)`. Adds three tests that hop off via `Task.detached` first to cover the cross-thread scheduling + run-loop pump:

- `execute sync from off-thread caller`
- `execute blocking-async from off-thread caller`
- `execute sync rethrows from off-thread caller`

<!-- disable:changelog-checks -->

## Test plan

- [x] Run the JSI test suite (`pnpm test` in `packages/expo-modules-jsi`); the three new off-thread tests should pass alongside the existing `@JavaScriptActor` ones.
- [x] Open native-component-list, scroll to the `runtime.execute() — iOS` group, run all four benchmarks. Verify per-call costs land in the 5–15 µs range and the responsiveness ratios logged to the console are above 0.9.
