### PR TITLE
[docs] fine tune dom component usage

### DIFF
--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -18,7 +18,7 @@ While the Expo native runtime generally does not support elements like `<div>` o
   <Requirement title="Expo SDK 55 and earlier: react-native-webview">
     <Tabs>
       <Tab label="SDK 56 and later">
-        DOM components use [`@expo/dom-webview`](https://www.npmjs.com/package/@expo/dom-webview) by default and no additional install is required.
+        DOM components use [`@expo/dom-webview`](https://www.npmjs.com/package/@expo/dom-webview) by default and no additional installation is required.
 
         <Collapsible summary="How to opt out of @expo/dom-webview and use react-native-webview instead?">
         If you want to use `react-native-webview` instead, install it and opt out via the `dom` prop:

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -15,6 +15,33 @@ Expo offers a novel approach to work with modern web code directly in a native a
 While the Expo native runtime generally does not support elements like `<div>` or `<img>`, there may be instances where you need to quickly incorporate web components. In such cases, DOM components provide a useful solution.
 
 <Prerequisites>
+  <Requirement title="Expo SDK 55 and earlier: react-native-webview">
+    <Tabs>
+      <Tab label="SDK 56 and later">
+        DOM components use [`@expo/dom-webview`](https://www.npmjs.com/package/@expo/dom-webview) by default and no additional install is required.
+
+        <Collapsible summary="How to opt out of @expo/dom-webview and use react-native-webview instead?">
+        If you want to use `react-native-webview` instead, install it and opt out via the `dom` prop:
+
+        <Terminal cmd={['$ npx expo install react-native-webview']} />
+
+        ```tsx App.tsx (native)
+        import DOMComponent from './my-component';
+
+        export default function App() {
+          return <DOMComponent dom={{ useExpoDOMWebView: false }} />;
+        }
+        ```
+        </Collapsible>
+
+      </Tab>
+      <Tab label="SDK 55 and earlier">
+        Install `react-native-webview` in your project:
+        <Terminal cmd={['$ npx expo install react-native-webview']} />
+      </Tab>
+    </Tabs>
+
+  </Requirement>
   <Requirement title="Expo CLI and the Expo Metro Config">
     If you already run your project with `npx expo [command]` (for example, if you created it with `npx create-expo-app`), you're all set.
 
@@ -34,36 +61,6 @@ While the Expo native runtime generally does not support elements like `<div>` o
 </Prerequisites>
 
 ## Usage
-
-<Tabs>
-
-<Tab label="SDK 56 and later">
-
-DOM components use [`@expo/dom-webview`](https://www.npmjs.com/package/@expo/dom-webview) by default and no additional install is required.
-
-If you want to use `react-native-webview` instead, install it and opt out via the `dom` prop:
-
-<Terminal cmd={['$ npx expo install react-native-webview']} />
-
-```tsx App.tsx (native)
-import DOMComponent from './my-component';
-
-export default function App() {
-  return <DOMComponent dom={{ useExpoDOMWebView: false }} />;
-}
-```
-
-</Tab>
-
-<Tab label="SDK 55 and earlier">
-
-Install `react-native-webview` in your project:
-
-<Terminal cmd={['$ npx expo install react-native-webview']} />
-
-</Tab>
-
-</Tabs>
 
 To render a React component to the DOM, add the `'use dom'` directive to the top of the web component file:
 


### PR DESCRIPTION
# Why

i feel that the usage guide for dom component is confusing. we should hide react-native-webview more, otherwise it feels react-native-webview installation is still required.

# How

merge react-native-webview into prerequisites

### Before

<img width="1080" height="946" alt="Screenshot 2026-05-07 at 3 51 36 PM" src="https://github.com/user-attachments/assets/1e45dfdf-4499-4cc7-a624-727d0675554a" />

### After

<img width="1094" height="460" alt="Screenshot 2026-05-07 at 3 52 00 PM" src="https://github.com/user-attachments/assets/c708aaca-f7dd-4fa5-af0c-097ec1b7f264" />

#### after opening prerequisites toggle

<img width="1081" height="325" alt="Screenshot 2026-05-07 at 3 52 09 PM" src="https://github.com/user-attachments/assets/e7ea05eb-f636-40e0-9ae2-766ded33720f" />

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
