### PR TITLE
[docs] Fix Algolia crawler record limit on EAS CLI reference

### DIFF
--- a/docs/ui/components/EASCLIReference/index.tsx
+++ b/docs/ui/components/EASCLIReference/index.tsx
@@ -28,7 +28,7 @@ type EasCliReferenceData = {
 };
 
 const SubsectionLabel = ({ children }: { children: ReactNode }) => (
-  <p className="text-base font-semibold leading-relaxed tracking-[-0.011rem] mt-0 mb-2">
+  <p className="mt-0 mb-2 text-base leading-relaxed font-semibold tracking-[-0.011rem]">
     {children}
   </p>
 );
@@ -96,9 +96,7 @@ const CommandSection = ({ command }: { command: CommandData }) => {
 
       {argumentsList.length > 0 && (
         <div className="mb-6">
-          <SubsectionLabel>
-            {argumentsList.length === 1 ? 'Argument' : 'Arguments'}
-          </SubsectionLabel>
+          <SubsectionLabel>{argumentsList.length === 1 ? 'Argument' : 'Arguments'}</SubsectionLabel>
           <ListSection entries={argumentsList} />
         </div>
       )}

--- a/docs/ui/components/EASCLIReference/index.tsx
+++ b/docs/ui/components/EASCLIReference/index.tsx
@@ -1,5 +1,7 @@
+import { type ReactNode } from 'react';
+
 import { Terminal } from '~/ui/components/Snippet';
-import { CODE, H3, H4, LI, P, UL } from '~/ui/components/Text';
+import { CODE, H3, LI, P, UL } from '~/ui/components/Text';
 
 import easCliData from './data/eas-cli-commands.json';
 import {
@@ -24,6 +26,12 @@ type CommandData = {
 type EasCliReferenceData = {
   commands: CommandData[];
 };
+
+const SubsectionLabel = ({ children }: { children: ReactNode }) => (
+  <p className="text-base font-semibold leading-relaxed tracking-[-0.011rem] mt-0 mb-2">
+    {children}
+  </p>
+);
 
 const ListSection = ({ entries }: { entries: ListEntry[] }) => {
   if (entries.length === 0) {
@@ -81,41 +89,39 @@ const CommandSection = ({ command }: { command: CommandData }) => {
 
       {sections.usage && (
         <div className="mb-6">
-          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">Usage</H4>
+          <SubsectionLabel>Usage</SubsectionLabel>
           <Terminal cmd={toTerminalLines(sections.usage)} />
         </div>
       )}
 
       {argumentsList.length > 0 && (
         <div className="mb-6">
-          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">
+          <SubsectionLabel>
             {argumentsList.length === 1 ? 'Argument' : 'Arguments'}
-          </H4>
+          </SubsectionLabel>
           <ListSection entries={argumentsList} />
         </div>
       )}
 
       {flagsList.length > 0 && (
         <div className="mb-6">
-          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">
-            {flagsList.length === 1 ? 'Flag' : 'Flags'}
-          </H4>
+          <SubsectionLabel>{flagsList.length === 1 ? 'Flag' : 'Flags'}</SubsectionLabel>
           <ListSection entries={flagsList} />
         </div>
       )}
 
       {sections.aliases && (
         <div className="mb-6">
-          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">
+          <SubsectionLabel>
             {countNonEmptyLines(sections.aliases) === 1 ? 'Alias' : 'Aliases'}
-          </H4>
+          </SubsectionLabel>
           <Terminal cmd={toTerminalLines(sections.aliases)} />
         </div>
       )}
 
       {sections.examples && (
         <div className="mb-4">
-          <H4 className="mt-0 mb-2 translate-y-[2px] self-center">Examples</H4>
+          <SubsectionLabel>Examples</SubsectionLabel>
           <Terminal cmd={toTerminalLines(sections.examples)} />
         </div>
       )}


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21084

The Algolia crawler fails to index `https://docs.expo.dev/eas/cli/` with `Extractors returned too many records` (784 records, max 750). The page renders 114 commands, each with up to five `<H4>` subsection labels, which together exceed the per-URL record ceiling. 

Similar in spirit to #41905, where redundant heading-equivalent elements were trimmed from the App Config schema.

# How

In `EASCLIReference/index.tsx`, the `Usage`, `Argument(s)`, `Flag(s)`, `Alias(es)`, and `Examples` labels inside `CommandSection` are now rendered through a small `SubsectionLabel` component that emits a styled `<p>` instead of `<H4>`. 

Visual styling matches the previous heading (semibold, base size, tight tracking), but the elements no longer produce heading records, removing roughly 570 records and putting the page comfortably under the limit. The `<H3>` per command is preserved, so command anchors and Algolia sub-section grouping are unchanged.

# Test Plan

Run the docs locally and confirm `/eas/cli/` looks identical, that each command still has a working `#command-slug` anchor, and that the right-rail TOC continues to list commands. 

After deploy, I'll re-crawl the page in the Algolia dashboard and verify the URL inspector reports a successful index with records under 750.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).