### PR TITLE
fix(precompile) fixed react-native-skia prebuild failing

### DIFF
--- a/tools/src/Packages.test.ts
+++ b/tools/src/Packages.test.ts
@@ -27,4 +27,9 @@ describe('getPackageByName', () => {
   it('returns null for an unknown package name', () => {
     assert.equal(getPackageByName('definitely-not-a-real-package'), null);
   });
+
+  it('returns null for third-party scoped packages installed only under node_modules', () => {
+    // @babel/core is reachable via the node_modules walk-up but is not a workspace package.
+    assert.equal(getPackageByName('@babel/core'), null);
+  });
 });

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -487,7 +487,13 @@ function readExpoModuleConfigJson(expoModuleConfigJsonPath: string) {
 function pathToLocalPackageJson(packageName: string): string {
   if (packageName.startsWith('@')) {
     try {
-      return require.resolve(`${packageName}/package.json`, { paths: [PACKAGES_DIR] });
+      const resolved = require.resolve(`${packageName}/package.json`, { paths: [PACKAGES_DIR] });
+      // require.resolve walks up node_modules/. Reject realpaths outside PACKAGES_DIR
+      // so third-party scoped installs (e.g. @babel/core) fall through to the cache lookup.
+      const rel = path.relative(PACKAGES_DIR, fs.realpathSync(resolved));
+      if (!rel.startsWith('..') && !path.isAbsolute(rel)) {
+        return resolved;
+      }
     } catch {
       // Fall through — caller's cachedPackages fallback still applies.
     }

--- a/tools/src/prebuilds/SPMGenerator.hardlinkRefresh.test.ts
+++ b/tools/src/prebuilds/SPMGenerator.hardlinkRefresh.test.ts
@@ -1,0 +1,52 @@
+import fs from 'fs-extra';
+import assert from 'node:assert/strict';
+import os from 'node:os';
+import { describe, it } from 'node:test';
+import path from 'path';
+
+import { refreshHardlinkIfNeeded } from './SPMGenerator';
+
+describe('refreshHardlinkIfNeeded', () => {
+  it('relinks when the source inode changed even though content is identical', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'spm-hardlink-'));
+    try {
+      const src = path.join(tmp, 'src.h');
+      const dest = path.join(tmp, 'staging', 'dest.h');
+      const content = '#pragma once\nint X = 1;\n';
+      await fs.outputFile(src, content);
+
+      assert.equal(await refreshHardlinkIfNeeded(src, dest), true);
+      const inodeBefore = (await fs.stat(dest)).ino;
+      assert.equal(inodeBefore, (await fs.stat(src)).ino);
+
+      // Simulate pnpm reinstall: same bytes, fresh inode.
+      await fs.remove(src);
+      await fs.outputFile(src, content);
+      const newSrcInode = (await fs.stat(src)).ino;
+      assert.notEqual(newSrcInode, inodeBefore);
+      assert.equal((await fs.stat(dest)).ino, inodeBefore);
+
+      assert.equal(await refreshHardlinkIfNeeded(src, dest), true);
+      assert.equal((await fs.stat(dest)).ino, newSrcInode);
+    } finally {
+      await fs.remove(tmp);
+    }
+  });
+
+  it('is a no-op when source and dest already share an inode', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'spm-hardlink-'));
+    try {
+      const src = path.join(tmp, 'src.h');
+      const dest = path.join(tmp, 'staging', 'dest.h');
+      await fs.outputFile(src, 'x');
+
+      assert.equal(await refreshHardlinkIfNeeded(src, dest), true);
+      const ctimeAfterFirst = (await fs.stat(dest)).ctimeMs;
+
+      assert.equal(await refreshHardlinkIfNeeded(src, dest), false);
+      assert.equal((await fs.stat(dest)).ctimeMs, ctimeAfterFirst);
+    } finally {
+      await fs.remove(tmp);
+    }
+  });
+});

--- a/tools/src/prebuilds/SPMGenerator.ts
+++ b/tools/src/prebuilds/SPMGenerator.ts
@@ -12,6 +12,31 @@ import { createAsyncSpinner, hasFileContentChanged } from './Utils';
 import logger from '../Logger';
 
 /**
+ * Ensures `destPath` is a hardlink to `sourcePath`. For staged headers, inode equality
+ * is the source of truth — clang's `#pragma once` keys on inode, so a stale dest with
+ * identical bytes but a different inode is processed as a separate header within the
+ * same TU and produces redefinition errors. This is reachable when the package manager
+ * rewrites the source file with the same content but a fresh inode (pnpm reinstalls
+ * into a new content-addressed `.pnpm/` dir on patch-hash or version changes).
+ */
+export async function refreshHardlinkIfNeeded(
+  sourcePath: string,
+  destPath: string
+): Promise<boolean> {
+  const srcStat = await fs.stat(sourcePath);
+  const destStat = await fs.lstat(destPath).catch(() => null);
+  if (destStat && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev) {
+    return false;
+  }
+  if (destStat) {
+    await fs.remove(destPath);
+  }
+  await fs.ensureDir(path.dirname(destPath));
+  await fs.link(sourcePath, destPath);
+  return true;
+}
+
+/**
  * Writes content to file only if it differs from existing content.
  * Preserves mtime for Xcode incremental builds.
  * Returns true if file was written, false if unchanged.
@@ -243,16 +268,11 @@ export const SPMGenerator = {
               path.basename(file)
             );
 
-            await fs.ensureDir(path.dirname(destinationFilePath));
-            if (hasFileContentChanged(sourceFilePath, destinationFilePath)) {
+            const linked = await refreshHardlinkIfNeeded(sourceFilePath, destinationFilePath);
+            if (linked) {
               spinner.info(
                 `Linking header file for target ${chalk.green(target.name)} ${path.basename(file)}...`
               );
-              // Remove existing file before creating hardlink
-              if (await fs.pathExists(destinationFilePath)) {
-                await fs.remove(destinationFilePath);
-              }
-              await fs.link(sourceFilePath, destinationFilePath);
             }
           }
         }


### PR DESCRIPTION
# Why

When building 3rd party XCFrameworks, Skia failed locally when built without cleaning:

```
❌ cpp/api/CustomBlendModes.h:10:15
  > 10 | constexpr int kBlendModePlusDarker = 1001;
       |               ^ redefinition of 'kBlendModePlusDarker'
     ... redefinition of 'kBlendModePlusLighter', 'kPlusDarkerSkSL',
         'kPlusLighterSkSL', 'CustomBlenders', 'applyBlendMode'
  ❌ Build Swift package failed: xcodebuild failed with code 65
```

This was caused by a stale hardlink after pnpm reinstall.

# How

SPMGenerator.ts flattens all package headers into a staging dir using hardlinks, specifically so #pragma once works across include paths (clang dedupes by inode). The skip condition for the relink, however, was hasFileContentChanged(...) — content/size/mtime, not inode.

When pnpm reinstalled Skia (different patch hash → different content-addressed .pnpm/ dir → fresh inode for CustomBlendModes.h, identical bytes), the staged hardlink kept its old inode. Within a single TU, clang then saw the header via two different inodes (staged vs. -I source path) and processed it twice → redefinition errors for every symbol in it.

Confirmed empirically:
source (May 6 20:30): inode 1761296556
staged (Apr 21 14:08): inode 1738862996

Fix: new exported helper refreshHardlinkIfNeeded(src, dest) that keys on ino + dev and unlinks/relinks when stale. Replaces the inline content-comparison block. Test in SPMGenerator.hardlinkRefresh.test.ts simulates the same-content-new-inode case.

When running `et prebuild @shopify/react-native-skia` a small bug after fix to ExpoWidgets build (#45461) the `@` prefix fell through. A fix/test for this was also added by making `pathToLocalPackageJson` keep the `require.resolve` test so that 3rd party projects use the old path.join logic.

# Test-plan

✅ Run `et prebuild @shopify/react-native-skia` and verify that it works without failure.

