### PR TITLE
fix(cli): Tweak dependency check message and placement

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Bump to `@expo/xcpretty@^4.4.4` ([#45473](https://github.com/expo/expo/pull/45473) by [@EvanBacon](https://github.com/EvanBacon))
+- Tweak dependency check message and placement on `expo start` ([#45487](https://github.com/expo/expo/pull/45487) by [@kitten](https://github.com/kitten))
 
 ## 56.0.5 — 2026-05-06
 

--- a/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
+++ b/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
@@ -4,16 +4,21 @@ import chalk from 'chalk';
 import * as Log from '../log';
 import { getVersionedDependenciesAsync } from './doctor/dependencies/validateDependenciesVersions';
 
-export type DependencyCheckResult = {
+export interface DependencyCheckResult {
   expo?: { actualVersion: string; expectedVersionOrRange: string };
   otherCount: number;
-};
+}
+
+export interface DependencyCheckRef {
+  result: DependencyCheckResult | null;
+  promise: Promise<DependencyCheckResult | null>;
+}
 
 /**
  * Fetch dependency version check results.
  * Returns null if everything is up-to-date.
  */
-export async function checkDependenciesAsync(
+async function checkDependenciesAsync(
   projectRoot: string,
   exp: Pick<ExpoConfig, 'sdkVersion'>,
   pkg: PackageJSONConfig
@@ -37,18 +42,55 @@ export async function checkDependenciesAsync(
   };
 }
 
+let _checkDependenciesRef: DependencyCheckRef | undefined;
+
+export function checkDependencies(
+  projectRoot: string,
+  exp: Pick<ExpoConfig, 'sdkVersion'>,
+  pkg: PackageJSONConfig
+) {
+  if (_checkDependenciesRef) {
+    return _checkDependenciesRef;
+  }
+
+  const ref: DependencyCheckRef = {
+    result: null,
+    promise: Promise.resolve(null),
+  };
+
+  ref.promise = checkDependenciesAsync(projectRoot, exp, pkg).then(
+    (result) => {
+      ref.result = result;
+      return result;
+    },
+    (_error) => null
+  );
+
+  _checkDependenciesRef = ref;
+  return ref;
+}
+
+/** Print the condensed dependency check messages to the terminal. */
+export function getDependencyCheckMessage(
+  result: DependencyCheckResult | null | undefined
+): string[] {
+  if (result?.expo) {
+    return [
+      chalk.yellow`An update for {bold expo} is available: {red ${result.expo.actualVersion}} {dim →} {green ${result.expo.expectedVersionOrRange}}`,
+      chalk.yellow`${result.otherCount} other package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`,
+    ];
+  } else if (result?.otherCount) {
+    return [
+      chalk.yellow`${result.otherCount} package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`,
+    ];
+  } else {
+    return [];
+  }
+}
+
 /** Print the condensed dependency check messages to the terminal. */
 export function printDependencyCheckResult(result: DependencyCheckResult): void {
-  if (result.expo) {
-    Log.warn(
-      chalk`An update for {bold expo} is available: {red ${result.expo.actualVersion}} {dim →} {green ${result.expo.expectedVersionOrRange}}`
-    );
-    Log.warn(
-      chalk`${result.otherCount} other package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`
-    );
-  } else if (result.otherCount > 0) {
-    Log.warn(
-      chalk`${result.otherCount} package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`
-    );
+  for (const line of getDependencyCheckMessage(result)) {
+    Log.log(line);
   }
 }

--- a/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
+++ b/packages/@expo/cli/src/start/checkDependenciesOnStart.ts
@@ -43,10 +43,12 @@ export function printDependencyCheckResult(result: DependencyCheckResult): void 
     Log.warn(
       chalk`An update for {bold expo} is available: {red ${result.expo.actualVersion}} {dim →} {green ${result.expo.expectedVersionOrRange}}`
     );
-  }
-  if (result.otherCount > 0) {
     Log.warn(
       chalk`${result.otherCount} other package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`
+    );
+  } else if (result.otherCount > 0) {
+    Log.warn(
+      chalk`${result.otherCount} package${result.otherCount === 1 ? '' : 's'} may need updating. Run {bold npx expo install --check} for details.`
     );
   }
 }

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import wrapAnsi from 'wrap-ansi';
 
 import * as Log from '../../log';
-import type { DependencyCheckResult } from '../checkDependenciesOnStart';
+import type { DependencyCheckRef } from '../checkDependenciesOnStart';
 import type { McpServer } from '../server/MCP';
 
 // Approximately how many rows apart from the commands table (usage guide on `expo start`)
@@ -21,7 +21,7 @@ export type StartOptions = {
   maxWorkers?: number;
   platforms?: ExpoConfig['platforms'];
   mcpServer?: McpServer;
-  dependencyCheckPromise?: Promise<DependencyCheckResult | null>;
+  dependencyCheckRef?: DependencyCheckRef;
 };
 
 export const printHelp = (): void => {

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -9,6 +9,7 @@ import { learnMore } from '../../utils/link';
 import type { ExpoChoice } from '../../utils/prompts';
 import { selectAsync } from '../../utils/prompts';
 import { printQRCode } from '../../utils/qr';
+import { getDependencyCheckMessage } from '../checkDependenciesOnStart';
 import type { DevServerManager } from '../server/DevServerManager';
 import {
   openJsInspector,
@@ -30,7 +31,10 @@ export class DevServerManagerActions {
   ) {}
 
   printDevServerInfo(
-    options: Pick<StartOptions, 'devClient' | 'isWebSocketsEnabled' | 'platforms'>
+    options: Pick<
+      StartOptions,
+      'devClient' | 'isWebSocketsEnabled' | 'platforms' | 'dependencyCheckRef'
+    >
   ) {
     // Keep track of approximately how much space we have to print our usage guide
     let rows = process.stdout.rows || Infinity;
@@ -100,9 +104,16 @@ export class DevServerManagerActions {
       }
     }
 
+    const dependencyCheckLines = getDependencyCheckMessage(options.dependencyCheckRef?.result);
+    rows -= dependencyCheckLines.length;
+
     printUsage(options, { verbose: false, rows });
     printHelp();
     Log.log();
+
+    for (const line of dependencyCheckLines) {
+      Log.log(line);
+    }
   }
 
   async openJsInspectorAsync() {

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -10,8 +10,6 @@ import { AbortCommandError } from '../../utils/errors';
 import { getAllSpinners, ora } from '../../utils/ora';
 import { getProgressBar, setProgressBar } from '../../utils/progress';
 import { addInteractionListener, pauseInteractions } from '../../utils/prompts';
-import type { DependencyCheckResult } from '../checkDependenciesOnStart';
-import { printDependencyCheckResult } from '../checkDependenciesOnStart';
 import { WebSupportProjectPrerequisite } from '../doctor/web/WebSupportProjectPrerequisite';
 import type { DevServerManager } from '../server/DevServerManager';
 
@@ -39,45 +37,22 @@ const PLATFORM_SETTINGS: Record<
 
 export async function startInterfaceAsync(
   devServerManager: DevServerManager,
-  options: Pick<StartOptions, 'devClient' | 'platforms' | 'mcpServer' | 'dependencyCheckPromise'>
+  options: Pick<StartOptions, 'devClient' | 'platforms' | 'mcpServer' | 'dependencyCheckRef'>
 ) {
+  // Spend one-tick waiting for the dependency check result
+  if (options.dependencyCheckRef) {
+    await Promise.race([options.dependencyCheckRef.promise, Promise.resolve(null)]);
+  }
+
   const actions = new DevServerManagerActions(devServerManager, options);
-
   const isWebSocketsEnabled = devServerManager.getDefaultDevServer()?.isTargetingNative();
-
   const usageOptions = {
     isWebSocketsEnabled,
     devClient: devServerManager.options.devClient,
     ...options,
   };
 
-  // Print the dependency check if it completed (it runs in the background since early startup).
-  // With a warm fetch cache this resolves near-instantly, so we defer by a tick
-  // On cold starts it may not be ready, in which case it will appear on the next reprint or restart
-  let dependencyCheckResult: DependencyCheckResult | null | undefined;
-  if (options.dependencyCheckPromise) {
-    dependencyCheckResult = await Promise.race([
-      options.dependencyCheckPromise,
-      Promise.resolve(null),
-    ]);
-    if (!dependencyCheckResult) {
-      // Not ready yet — capture once resolved for display on next reprint
-      options.dependencyCheckPromise.then((result) => {
-        if (result) {
-          dependencyCheckResult = result;
-        }
-      });
-    }
-  }
-
-  const printDependencyCheckIfAvailable = () => {
-    if (dependencyCheckResult) {
-      printDependencyCheckResult(dependencyCheckResult);
-    }
-  };
-
   actions.printDevServerInfo(usageOptions);
-  printDependencyCheckIfAvailable();
 
   const onPressAsync = async (key: string) => {
     // Auxillary commands all escape.
@@ -173,7 +148,6 @@ export async function startInterfaceAsync(
         if (await devServerManager.toggleRuntimeMode()) {
           usageOptions.devClient = devServerManager.options.devClient;
           actions.printDevServerInfo(usageOptions);
-          printDependencyCheckIfAvailable();
           return;
         }
         break;
@@ -219,7 +193,6 @@ export async function startInterfaceAsync(
       case 'c':
         Log.clear();
         actions.printDevServerInfo(usageOptions);
-        printDependencyCheckIfAvailable();
         return;
       case 'j':
         return actions.openJsInspectorAsync();

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -2,8 +2,11 @@ import { getConfig } from '@expo/config';
 import chalk from 'chalk';
 
 import { getLogFile, shouldReduceLogs } from '../events';
-import type { DependencyCheckResult } from './checkDependenciesOnStart';
-import { checkDependenciesAsync, printDependencyCheckResult } from './checkDependenciesOnStart';
+import {
+  checkDependencies,
+  printDependencyCheckResult,
+  type DependencyCheckRef,
+} from './checkDependenciesOnStart';
 import { SimulatorAppPrerequisite } from './doctor/apple/SimulatorAppPrerequisite';
 import { getXcodeVersionAsync } from './doctor/apple/XcodePrerequisite';
 import { WebSupportProjectPrerequisite } from './doctor/web/WebSupportProjectPrerequisite';
@@ -84,9 +87,9 @@ export async function startAsync(
 
   // Start dependency version check in the background as early as possible (non-blocking).
   // The result will be displayed in the TUI once it resolves.
-  let dependencyCheckPromise: Promise<DependencyCheckResult | null> | undefined;
+  let dependencyCheckRef: DependencyCheckRef | undefined;
   if (!env.EXPO_OFFLINE && !env.EXPO_NO_DEPENDENCY_VALIDATION && !settings.webOnly) {
-    dependencyCheckPromise = checkDependenciesAsync(projectRoot, exp, pkg).catch(() => null);
+    dependencyCheckRef = checkDependencies(projectRoot, exp, pkg);
   }
 
   if (exp.platforms?.includes('ios') && process.platform !== 'win32') {
@@ -140,7 +143,7 @@ export async function startAsync(
     await profile(startInterfaceAsync)(devServerManager, {
       platforms: exp.platforms ?? ['ios', 'android', 'web'],
       mcpServer,
-      dependencyCheckPromise,
+      dependencyCheckRef,
     });
   } else {
     // Display the server location in CI...
@@ -151,10 +154,9 @@ export async function startAsync(
       }
       Log.log(chalk`Waiting on {underline ${defaultServerUrl}}`);
     }
-    // In non-interactive mode, await the check and print if available.
-    const result = await dependencyCheckPromise;
-    if (result) {
-      printDependencyCheckResult(result);
+    // In non-interactive mode, print the check outside of an interface, if it's available
+    if (dependencyCheckRef?.result) {
+      printDependencyCheckResult(dependencyCheckRef.result);
     }
   }
 


### PR DESCRIPTION
# Summary

- Drop "other" from message if there's no `expo` update
- Wrap result in a ref to have access to raw result early
- Don't await result in non-interactive mode
- Place result message below commands table and adjust rows fitment

# Test Plan

- Tested manually in `apps/router-e2e`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
