### PR TITLE
feat(create-expo): Drop automatic `node-linker=hoisted` for pnpm

### DIFF
--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Drop automatically setting `node-linker=hoisted` for pnpm ([#45491](https://github.com/expo/expo/pull/45491) by [@kitten](https://github.com/kitten))
+
 ## 3.7.2 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/create-expo/e2e/__tests__/index-test.ts
+++ b/packages/create-expo/e2e/__tests__/index-test.ts
@@ -93,12 +93,6 @@ it('uses pnpm', async () => {
   expectFileExists(projectName, '.gitignore');
   // Check if it skipped install
   expectFileNotExists(projectName, 'node_modules');
-
-  // Check if `pnpm` node linker is set
-  const { stdout } = expectExecutePassing(
-    await spawnAsync('pnpm', ['config', 'get', 'node-linker'], { cwd: getTestPath(projectName) })
-  );
-  expect(stdout).toContain('hoisted');
 });
 
 it('uses Bun', async () => {

--- a/packages/create-expo/src/resolvePackageManager.ts
+++ b/packages/create-expo/src/resolvePackageManager.ts
@@ -105,10 +105,6 @@ export async function configurePackageManager(
 ) {
   const manager = createPackageManager(packageManager, { cwd: projectRoot, ...flags });
   switch (manager.name) {
-    case 'pnpm':
-      await manager.runAsync(['config', '--location', 'project', 'set', 'node-linker', 'hoisted']);
-      break;
-
     case 'yarn': {
       const yarnVersion = await manager.versionAsync();
       const majorVersion = parseInt(yarnVersion.split('.')[0] ?? '', 10);


### PR DESCRIPTION
# Why

Bun is already defaulting to the isolated install, and since we support this well now (and have for a while), and are using pnpm ourselves now, we should drop this for newly created projects.

# How

- Drop setting `node-linker=hoisted` when creating projects with pnpm

**Note:** I didn't mark this as a feature or breaking. It feels natural to just put it in "Others", since it's for new projects (so technically not breaking), and isn't a feature but a removal.

# Test Plan

- Manually tested

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
