### PR TITLE
fix(precomile) reduce output on CI

### DIFF
--- a/tools/src/Logger.ts
+++ b/tools/src/Logger.ts
@@ -9,25 +9,27 @@ const CONSOLE_RESOLVER: LoggerResolver = (level: LogLevel, color: Chalk | null, 
   return console[level](...(color ? args.map((arg) => color(arg)) : args));
 };
 
+// Process-wide verbose flag. All Logger instances (including LoggerBatch)
+// share this — verbosity is a property of the run, not of a logger object.
 let _verbose = false;
-
-/**
- * Enables or disables verbose logging globally. When `false` (default),
- * `logger.verbose(...)` calls are silently dropped.
- */
-export function setVerbose(value: boolean): void {
-  _verbose = value;
-}
-
-export function isVerbose(): boolean {
-  return _verbose;
-}
 
 /**
  * Basic logger just for simple console logging with colored output.
  */
 export class Logger {
   constructor(readonly resolver: LoggerResolver = CONSOLE_RESOLVER) {}
+
+  /**
+   * Enables or disables verbose logging globally. When `false` (default),
+   * `logger.verbose(...)` calls are silently dropped.
+   */
+  setVerbose(value: boolean): void {
+    _verbose = value;
+  }
+
+  isVerbose(): boolean {
+    return _verbose;
+  }
 
   /**
    * Emits a low-priority detail line. No-op unless `setVerbose(true)` has

--- a/tools/src/Logger.ts
+++ b/tools/src/Logger.ts
@@ -9,13 +9,33 @@ const CONSOLE_RESOLVER: LoggerResolver = (level: LogLevel, color: Chalk | null, 
   return console[level](...(color ? args.map((arg) => color(arg)) : args));
 };
 
+let _verbose = false;
+
+/**
+ * Enables or disables verbose logging globally. When `false` (default),
+ * `logger.verbose(...)` calls are silently dropped.
+ */
+export function setVerbose(value: boolean): void {
+  _verbose = value;
+}
+
+export function isVerbose(): boolean {
+  return _verbose;
+}
+
 /**
  * Basic logger just for simple console logging with colored output.
  */
 export class Logger {
   constructor(readonly resolver: LoggerResolver = CONSOLE_RESOLVER) {}
 
+  /**
+   * Emits a low-priority detail line. No-op unless `setVerbose(true)` has
+   * been called — used for progress chatter that buries signal in CI logs
+   * (per-step "Cleaning ...", "Generating ...", subprocess line streams, etc).
+   */
   verbose(...args: any[]): void {
+    if (!_verbose) return;
     this.resolver('debug', chalk.dim, args);
   }
 

--- a/tools/src/commands/PrebuildPackages.ts
+++ b/tools/src/commands/PrebuildPackages.ts
@@ -35,7 +35,11 @@ export default (program: Command) => {
       'Generates `.xcframework` artifacts for iOS packages. If no package names are provided, discovers all packages with spm.config.json.'
     )
     .alias('prebuild')
-    .option('-v, --verbose', 'Enable verbose output (full build logs instead of spinners).', false)
+    .option(
+      '-v, --verbose',
+      'Print every build step and the full xcodebuild line stream. Off by default; in CI only success/failure lines, compile warnings/errors, and the run summary are printed.',
+      false
+    )
     .option(
       '--react-native-version <version>',
       'Provides the current React Native version. Auto-detected from bare-expo if not set.'

--- a/tools/src/prebuilds/Dependencies.ts
+++ b/tools/src/prebuilds/Dependencies.ts
@@ -90,7 +90,7 @@ export const Dependencies = {
    * @returns Whether downloading artifacts should be skipped.
    */
   cleanArtifactsAsync: async (artifactsPath: string): Promise<void> => {
-    logger.info(
+    logger.verbose(
       `🧹 Clearing artifacts folder: ${chalk.gray(path.relative(process.cwd(), artifactsPath))}`
     );
     await fs.remove(artifactsPath);
@@ -122,7 +122,7 @@ export const Dependencies = {
       react: `${currentVersions.reactNativeVersion}-${currentVersions.buildFlavor}`,
     };
 
-    logger.info(`🧹 Pruning unused cache entries from ${chalk.gray(cachePath)}...`);
+    logger.verbose(`🧹 Pruning unused cache entries from ${chalk.gray(cachePath)}...`);
 
     // Iterate through artifact directories (hermes, react-native-dependencies, react)
     const artifactDirs = await fs.readdir(cachePath, { withFileTypes: true });
@@ -153,12 +153,12 @@ export const Dependencies = {
         if (versionDir.name === currentVersion) {
           // This is the current version - keep it
           keptCount++;
-          logger.info(
+          logger.verbose(
             `  ✓ Keeping ${chalk.green(artifactDir.name)}/${chalk.cyan(versionDir.name)}`
           );
         } else {
           // Old version - remove it
-          logger.info(
+          logger.verbose(
             `  🗑  Removing ${chalk.yellow(artifactDir.name)}/${chalk.gray(versionDir.name)}`
           );
           await fs.remove(versionPath);
@@ -168,9 +168,9 @@ export const Dependencies = {
     }
 
     if (removed.length > 0) {
-      logger.info(`🧹 Pruned ${chalk.yellow(removed.length)} old cache entries`);
+      logger.verbose(`🧹 Pruned ${chalk.yellow(removed.length)} old cache entries`);
     } else {
-      logger.info(`🧹 Cache is clean - no old entries to prune`);
+      logger.verbose(`🧹 Cache is clean - no old entries to prune`);
     }
 
     return { removed, keptCount };
@@ -196,7 +196,7 @@ export const Dependencies = {
       skipArtifacts,
     } = options;
 
-    logger.info(
+    logger.verbose(
       `⬇️  ${options.skipArtifacts ? 'Verifying' : 'Preparing'} centralized cache at ${chalk.gray(path.relative(process.cwd(), cachePath))}...`
     );
 
@@ -250,7 +250,7 @@ export const Dependencies = {
     const reactNativeSourcePath = resolvePackagePath('react-native');
     const xcframeworkPath = path.join(reactNativePath, 'React.xcframework');
     if (fs.existsSync(xcframeworkPath) && !isVFSGenerated(reactNativePath, reactNativeSourcePath)) {
-      logger.info('🔄 Generating VFS overlay for stock React.xcframework...');
+      logger.verbose('🔄 Generating VFS overlay for stock React.xcframework...');
       await transformReactXCFrameworkAsync({
         outputPath: reactNativePath,
         reactNativePath: reactNativeSourcePath,
@@ -287,7 +287,7 @@ export const Dependencies = {
     depsDestinationPath: string,
     copyDependencies: boolean
   ): Promise<void> => {
-    logger.info(
+    logger.verbose(
       `📋 ${copyDependencies ? 'Syncing' : 'Checking'} package dependencies for ${chalk.green(pkg.packageName)}`
     );
 
@@ -349,7 +349,7 @@ export const Dependencies = {
    * @param pkg Package
    */
   cleanDependenciesFolderAsync: async (pkg: SPMPackageSource): Promise<void> => {
-    logger.info(`🧹 Cleaning dependencies folder for package ${chalk.green(pkg.packageName)}...`);
+    logger.verbose(`🧹 Cleaning dependencies folder for package ${chalk.green(pkg.packageName)}...`);
     const buildFolderToClean = Dependencies.getPackageDependenciesPath(pkg);
     await fs.remove(buildFolderToClean);
   },
@@ -367,7 +367,7 @@ export const Dependencies = {
     const outputPath = path.join(pkg.buildPath, 'output', flavor.toLowerCase());
 
     if (fs.existsSync(outputPath)) {
-      logger.info(
+      logger.verbose(
         `🧹 Cleaning output folder for package ${chalk.green(pkg.packageName)}/${flavor}...`
       );
       await fs.remove(outputPath);
@@ -382,7 +382,7 @@ export const Dependencies = {
   cleanGeneratedFolderAsync: async (pkg: SPMPackageSource): Promise<void> => {
     const generatedPath = path.join(pkg.path, '.generated');
     if (fs.existsSync(generatedPath)) {
-      logger.info(`🧹 Cleaning generated folder for package ${chalk.green(pkg.packageName)}...`);
+      logger.verbose(`🧹 Cleaning generated folder for package ${chalk.green(pkg.packageName)}...`);
       await fs.remove(generatedPath);
     }
   },

--- a/tools/src/prebuilds/Dependencies.ts
+++ b/tools/src/prebuilds/Dependencies.ts
@@ -349,7 +349,9 @@ export const Dependencies = {
    * @param pkg Package
    */
   cleanDependenciesFolderAsync: async (pkg: SPMPackageSource): Promise<void> => {
-    logger.verbose(`🧹 Cleaning dependencies folder for package ${chalk.green(pkg.packageName)}...`);
+    logger.verbose(
+      `🧹 Cleaning dependencies folder for package ${chalk.green(pkg.packageName)}...`
+    );
     const buildFolderToClean = Dependencies.getPackageDependenciesPath(pkg);
     await fs.remove(buildFolderToClean);
   },

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -41,7 +41,7 @@ const signXCFramework = (
   identity: string,
   useTimestamp: boolean = true
 ): void => {
-  logger.info(`🔏 Signing XCFramework with identity "${identity}"...`);
+  logger.verbose(`🔏 Signing XCFramework with identity "${identity}"...`);
 
   const timestampFlag = useTimestamp ? '--timestamp' : '';
   const command = `codesign ${timestampFlag} --sign "${identity}" "${xcframeworkPath}"`.trim();
@@ -74,7 +74,7 @@ export const Frameworks = {
   ): Promise<void> => {
     const spmConfig = pkg.getSwiftPMConfiguration();
 
-    logger.info(
+    logger.verbose(
       `🧩 Composing XCFramework for ${chalk.green(pkg.packageName) + '/' + chalk.green(product.name)}...`
     );
 
@@ -484,7 +484,7 @@ const copySPMDependencyXCFrameworksAsync = async (
 
       const sharedPath = Frameworks.getSharedSPMDepFrameworkPath(productName, buildType);
       const destPath = path.join(outputDir, `${productName}.xcframework`);
-      logger.info(
+      logger.verbose(
         `📦 Copying shared SPM dep ${chalk.cyan(productName)} from shared location → ${path.relative(pkg.path, destPath)}`
       );
       await fs.remove(destPath);
@@ -552,7 +552,7 @@ const copySPMDependencyXCFrameworksAsync = async (
       const sourceXCFrameworkPath = path.join(artifactsDir, xcframeworkName);
 
       if (await fs.pathExists(sourceXCFrameworkPath)) {
-        logger.info(
+        logger.verbose(
           `📦 Copying SPM dependency ${chalk.cyan(xcframeworkName)} → ${path.relative(pkg.path, destXCFrameworkPath)}`
         );
         await fs.remove(destXCFrameworkPath);
@@ -569,7 +569,7 @@ const copySPMDependencyXCFrameworksAsync = async (
     }
 
     // Compose the dependency xcframework with only the relevant slices
-    logger.info(
+    logger.verbose(
       `📦 Composing SPM dependency ${chalk.cyan(xcframeworkName)} → ${path.relative(pkg.path, destXCFrameworkPath)}`
     );
     await fs.remove(destXCFrameworkPath);
@@ -648,7 +648,7 @@ const createProductTarballAsync = async (
     }
   }
 
-  logger.info(
+  logger.verbose(
     `📦 Creating tarball for ${chalk.green(product.name)} (${buildType}): ${xcframeworkEntries.join(', ')}`
   );
 

--- a/tools/src/prebuilds/SPMBuild.ts
+++ b/tools/src/prebuilds/SPMBuild.ts
@@ -34,7 +34,7 @@ export const SPMBuild = {
     platform?: BuildPlatform,
     hermesIncludeDirs?: string[]
   ): Promise<void> => {
-    logger.info(
+    logger.verbose(
       `🏗  Build Package.swift for ${chalk.green(pkg.packageName)}/${chalk.green(product.name)} [${buildType.toLowerCase()}]`
     );
 
@@ -69,7 +69,7 @@ export const SPMBuild = {
       );
     }
 
-    logger.info(`🏗  Swift package successfully built.`);
+    logger.verbose(`🏗  Swift package successfully built.`);
   },
 
   /**
@@ -84,7 +84,7 @@ export const SPMBuild = {
     buildType: BuildFlavor
   ): Promise<void> => {
     const buildFolderToClean = SPMBuild.getPackageBuildPath(pkg, product, buildType);
-    logger.info(
+    logger.verbose(
       `🧹 Cleaning build folder ${chalk.green(path.relative(pkg.buildPath, buildFolderToClean))}...`
     );
     await fs.remove(buildFolderToClean);
@@ -414,7 +414,7 @@ async function resolveSPMDependenciesAndPatch(packageDir: string): Promise<void>
         'public typealias NetworkUnreachable = (_ReachabilityRef) -> ()'
       );
       fs.writeFileSync(reachabilitySource, content, 'utf8');
-      logger.info('🩹 Patched Reachability.swift (library evolution typealias fix)');
+      logger.verbose('🩹 Patched Reachability.swift (library evolution typealias fix)');
     }
   }
 }
@@ -854,7 +854,7 @@ export async function buildSharedSPMDependencyAsync(
     return;
   }
 
-  logger.info(
+  logger.verbose(
     `🔨 Building shared SPM dependency ${chalk.cyan(productName)} [${buildType.toLowerCase()}]...`
   );
 
@@ -890,7 +890,7 @@ export async function buildSharedSPMDependencyAsync(
     // Package.swift changed or first run — resolve from scratch
     await resolveSPMDependenciesAndPatch(buildDir);
   } else {
-    logger.info(`   ⏭️  SPM dependencies already resolved (Package.swift unchanged)`);
+    logger.verbose(`   ⏭️  SPM dependencies already resolved (Package.swift unchanged)`);
   }
 
   // Build from the dependency's own checkout so we get a framework with the correct
@@ -973,7 +973,7 @@ export async function buildSharedSPMDependencyAsync(
     const externalInterDeps = interDeps.filter((d) => d !== productName);
 
     if (externalInterDeps.length > 0) {
-      logger.info(
+      logger.verbose(
         `   🔗 ${productName} depends on shared deps: ${externalInterDeps.map((d) => chalk.cyan(d)).join(', ')}`
       );
 
@@ -981,7 +981,7 @@ export async function buildSharedSPMDependencyAsync(
       for (const interDepName of externalInterDeps) {
         const interDep = allSharedDeps.get(interDepName);
         if (interDep && !Frameworks.hasSharedSPMDepFramework(interDepName, buildType)) {
-          logger.info(`   ↳ Building dependency ${chalk.cyan(interDepName)} first...`);
+          logger.verbose(`   ↳ Building dependency ${chalk.cyan(interDepName)} first...`);
           await buildSharedSPMDependencyAsync(interDep, buildType, allSharedDeps, platforms);
         }
       }

--- a/tools/src/prebuilds/SPMGenerator.ts
+++ b/tools/src/prebuilds/SPMGenerator.ts
@@ -3,13 +3,13 @@ import fs from 'fs-extra';
 import { glob } from 'glob';
 import path from 'path';
 
+import logger from '../Logger';
 import type { DownloadedDependencies } from './Artifacts.types';
 import type { SPMPackageSource } from './ExternalPackage';
 import { BuildFlavor } from './Prebuilder.types';
 import { SPMProduct, SPMTarget } from './SPMConfig.types';
 import { SPMPackage } from './SPMPackage';
 import { createAsyncSpinner, hasFileContentChanged } from './Utils';
-import logger from '../Logger';
 
 /**
  * Writes content to file only if it differs from existing content.
@@ -42,7 +42,7 @@ export const SPMGenerator = {
     buildType: BuildFlavor,
     artifacts?: DownloadedDependencies
   ): Promise<void> => {
-    logger.info(
+    logger.verbose(
       `📦 Generating Package.swift for ${chalk.green(pkg.packageName)}/${chalk.green(product.name)}...`
     );
     // Use SPMPackage to generate Package.swift
@@ -73,7 +73,7 @@ export const SPMGenerator = {
    */
   generateIsolatedSourcesForTargetsAsync: async (pkg: SPMPackageSource, product: SPMProduct) => {
     const loggerTitle = `${chalk.green(pkg.packageName)}/${chalk.green(product.name)}`;
-    logger.info(`📂 Generating files for ${loggerTitle}`);
+    logger.verbose(`📂 Generating files for ${loggerTitle}`);
 
     // Walk through all targets for the product and collect source files to copy into spm code structure
     for (const target of product.targets) {
@@ -357,7 +357,7 @@ ${allImports.join('\n')}
     pkg: SPMPackageSource,
     product: SPMProduct
   ): Promise<void> => {
-    logger.info(
+    logger.verbose(
       `🧹 Cleaning generated source code for ${chalk.green(pkg.packageName)}/${chalk.green(product.name)}...`
     );
 

--- a/tools/src/prebuilds/TransformReactXCFramework.ts
+++ b/tools/src/prebuilds/TransformReactXCFramework.ts
@@ -52,7 +52,7 @@ export async function transformReactXCFrameworkAsync(options: TransformOptions):
   // When present, use it directly instead of generating our own.
   const bundledTemplatePath = path.join(xcframeworkPath, 'React-VFS-template.yaml');
   if (fs.existsSync(bundledTemplatePath)) {
-    logger.info('  Using bundled React-VFS-template.yaml from xcframework (RN 0.85+)');
+    logger.verbose('  Using bundled React-VFS-template.yaml from xcframework (RN 0.85+)');
 
     // Copy bundled template to expected location (where resolveVFSOverlayTemplate reads it)
     fs.copyFileSync(bundledTemplatePath, path.join(outputPath, 'React-VFS-template.yaml'));
@@ -61,7 +61,7 @@ export async function transformReactXCFrameworkAsync(options: TransformOptions):
     const stagingDir = path.join(outputPath, 'React-extra-headers');
     if (fs.existsSync(stagingDir)) {
       fs.removeSync(stagingDir);
-      logger.info('  Removed stale React-extra-headers/ directory');
+      logger.verbose('  Removed stale React-extra-headers/ directory');
     }
 
     // Write version stamp for cache invalidation
@@ -70,23 +70,23 @@ export async function transformReactXCFrameworkAsync(options: TransformOptions):
     ).version;
     VersionStamp.write(outputPath, { reactNativeVersion: rnVersion }, VFS_STAMP_FILENAME);
 
-    logger.info('  VFS overlay setup complete (using bundled template).');
+    logger.verbose('  VFS overlay setup complete (using bundled template).');
     return;
   }
 
-  logger.info('  Collecting header mappings from podspecs...');
+  logger.verbose('  Collecting header mappings from podspecs...');
   const headerMappings = getHeaderFilesFromPodspecs(reactNativePath);
 
-  logger.info('  Inventorying stock xcframework headers...');
+  logger.verbose('  Inventorying stock xcframework headers...');
   const stockHeaders = inventoryStockHeaders(xcframeworkPath);
 
-  logger.info('  Detecting duplicate header basenames...');
+  logger.verbose('  Detecting duplicate header basenames...');
   const duplicateBasenames = findDuplicateBasenames(headerMappings);
 
-  logger.info('  Staging missing headers to React-extra-headers/...');
+  logger.verbose('  Staging missing headers to React-extra-headers/...');
   await stageMissingHeadersAsync(outputPath, headerMappings, stockHeaders, duplicateBasenames);
 
-  logger.info('  Generating VFS overlay template...');
+  logger.verbose('  Generating VFS overlay template...');
   const vfsYaml = createVFSOverlay(reactNativePath, stockHeaders, duplicateBasenames);
   fs.writeFileSync(path.join(outputPath, 'React-VFS-template.yaml'), vfsYaml);
 
@@ -96,7 +96,7 @@ export async function transformReactXCFrameworkAsync(options: TransformOptions):
   ).version;
   VersionStamp.write(outputPath, { reactNativeVersion: rnVersion }, VFS_STAMP_FILENAME);
 
-  logger.info('  VFS overlay generation complete (xcframework untouched).');
+  logger.verbose('  VFS overlay generation complete (xcframework untouched).');
 }
 
 /**
@@ -214,7 +214,7 @@ async function stageMissingHeadersAsync(
     }
   }
 
-  logger.info(`  Staged ${stagedCount} missing headers to React-extra-headers/`);
+  logger.verbose(`  Staged ${stagedCount} missing headers to React-extra-headers/`);
 }
 
 const VFS_STAMP_FILENAME = '.vfs-version-stamp';

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -5,7 +5,7 @@ import { glob } from 'glob';
 import ora from 'ora';
 import path from 'path';
 
-import logger from '../Logger';
+import logger, { isVerbose } from '../Logger';
 import { getListOfPackagesAsync, getPackageByName, Package } from '../Packages';
 import {
   discoverExternalPackagesAsync,
@@ -38,6 +38,7 @@ export function isNonInteractive(): boolean {
 export function setForceNonInteractive(value: boolean): void {
   _forceNonInteractive = value;
 }
+
 
 const _logPrefixStorage = new AsyncLocalStorage<string>();
 
@@ -546,6 +547,7 @@ export const createAsyncSpinner = (
         logger.log(`${Prefix} ${chalk.yellow('⚠')} ${effectivePrefix(chalk.yellow)}${text ?? ''}`);
       },
       info: (text?: string) => {
+        if (!isVerbose()) return;
         logger.log(`${Prefix} ${chalk.blue('ℹ')} ${effectivePrefix(chalk.green)}${text ?? ''}`);
       },
     };

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -5,7 +5,7 @@ import { glob } from 'glob';
 import ora from 'ora';
 import path from 'path';
 
-import logger, { isVerbose } from '../Logger';
+import logger from '../Logger';
 import { getListOfPackagesAsync, getPackageByName, Package } from '../Packages';
 import {
   discoverExternalPackagesAsync,
@@ -546,7 +546,7 @@ export const createAsyncSpinner = (
         logger.log(`${Prefix} ${chalk.yellow('⚠')} ${effectivePrefix(chalk.yellow)}${text ?? ''}`);
       },
       info: (text?: string) => {
-        if (!isVerbose()) return;
+        if (!logger.isVerbose()) return;
         logger.log(`${Prefix} ${chalk.blue('ℹ')} ${effectivePrefix(chalk.green)}${text ?? ''}`);
       },
     };

--- a/tools/src/prebuilds/Utils.ts
+++ b/tools/src/prebuilds/Utils.ts
@@ -39,7 +39,6 @@ export function setForceNonInteractive(value: boolean): void {
   _forceNonInteractive = value;
 }
 
-
 const _logPrefixStorage = new AsyncLocalStorage<string>();
 
 /**

--- a/tools/src/prebuilds/Verifier.ts
+++ b/tools/src/prebuilds/Verifier.ts
@@ -35,7 +35,7 @@ export const FrameworkVerifier = {
     buildFlavor: BuildFlavor,
     options?: XCFrameworkVerifyOptions
   ): Promise<Map<string, XCFrameworkVerificationReport>> => {
-    logger.info(
+    logger.verbose(
       `🔍 Verifying xcframework for ${chalk.green(pkg.packageName)}/${chalk.green(product.name)} [${buildFlavor.toLowerCase()}]`
     );
 
@@ -246,7 +246,7 @@ export const FrameworkVerifier = {
               `  ${chalk.red('✗')} Resource bundle ${chalk.cyan(bundleName)} missing from slices: ${missingSlices.join(', ')}`
             );
           } else {
-            logger.info(
+            logger.verbose(
               `  ${chalk.green('✓')} Resource bundle ${chalk.cyan(bundleName)} present in all slices (${foundSlices.join(', ')})`
             );
           }

--- a/tools/src/prebuilds/XCodeRunner.ts
+++ b/tools/src/prebuilds/XCodeRunner.ts
@@ -75,50 +75,63 @@ export async function spawnXcodeBuildWithSpinner(
         const statusText = `${spinnerText} ${summary.trim()}${warningText}`;
         if (hasWarnings) {
           spinner.warn(statusText);
+          // Surface the actual warnings even on success — without this, CI
+          // logs only see the count and have no way to triage what changed.
+          printDiagnostics(formatter.warnings, []);
         } else {
           spinner.succeed(statusText);
         }
       } else {
         spinner.fail(`${spinnerText} failed with code ${code}`);
         summary && logger.error('\n' + summary.trim() + '\n');
-
-        // On failure, show warnings first (consistent with FrameworkVerifier)
-        if (hasWarnings) {
-          logger.log(chalk.gray('      Warnings:'));
-          formatter.warnings
-            .slice(0, 10)
-            .forEach((warn) => logger.log(chalk.gray(`        ${warn}`)));
-          if (warningCount > 10) {
-            logger.log(chalk.gray(`        ... and ${warningCount - 10} more warnings`));
-          }
-        }
-
-        // Show errors (consistent with FrameworkVerifier style)
-        if (formatter.errors.length > 0) {
-          logger.log(chalk.gray('      Errors:'));
-          formatter.errors
-            .slice(0, 10)
-            .forEach((err) => logger.log(chalk.gray(`        ${err.trim()}`)));
-          if (formatter.errors.length > 10) {
-            logger.log(chalk.gray(`        ... and ${formatter.errors.length - 10} more errors`));
-          }
-        }
-
-        // If formatter didn't capture any errors, fall back to showing raw output
+        printDiagnostics(formatter.warnings, formatter.errors);
         if (formatter.errors.length === 0) {
-          const rawErrors = extractRawCompileErrors(results);
-          if (rawErrors.length > 0) {
-            logger.log(chalk.gray('      Raw errors:'));
-            rawErrors.slice(0, 10).forEach((err) => logger.log(chalk.gray(`        ${err}`)));
-          } else if (error) {
-            logger.log(chalk.gray(error));
-          }
+          printRawErrorFallback(results, error);
         }
       }
 
       resolve({ code, results, error });
     });
   });
+}
+
+/**
+ * Print formatted compile warnings and errors. Used on both success-with-
+ * warnings and failure, so CI always surfaces diagnostics regardless of
+ * overall build status.
+ */
+function printDiagnostics(warnings: string[], errors: string[]): void {
+  const MAX = 10;
+
+  if (warnings.length > 0) {
+    logger.log(chalk.gray('      Warnings:'));
+    warnings.slice(0, MAX).forEach((warn) => logger.log(chalk.gray(`        ${warn}`)));
+    if (warnings.length > MAX) {
+      logger.log(chalk.gray(`        ... and ${warnings.length - MAX} more warnings`));
+    }
+  }
+
+  if (errors.length > 0) {
+    logger.log(chalk.gray('      Errors:'));
+    errors.slice(0, MAX).forEach((err) => logger.log(chalk.gray(`        ${err.trim()}`)));
+    if (errors.length > MAX) {
+      logger.log(chalk.gray(`        ... and ${errors.length - MAX} more errors`));
+    }
+  }
+}
+
+/**
+ * Print fallback raw errors when the xcodebuild failed but the formatter
+ * didn't capture structured errors. Called only on failure.
+ */
+function printRawErrorFallback(rawOutput: string, stderr: string): void {
+  const rawErrors = extractRawCompileErrors(rawOutput);
+  if (rawErrors.length > 0) {
+    logger.log(chalk.gray('      Raw errors:'));
+    rawErrors.slice(0, 10).forEach((err) => logger.log(chalk.gray(`        ${err}`)));
+  } else if (stderr) {
+    logger.log(chalk.gray(stderr));
+  }
 }
 
 /**

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -14,7 +14,7 @@ import path from 'path';
 
 import { PACKAGES_DIR } from '../../Constants';
 import { getPrecompileDir } from '../../Directories';
-import logger from '../../Logger';
+import logger, { setVerbose } from '../../Logger';
 import { getPackageByName } from '../../Packages';
 import { Artifacts } from '../Artifacts';
 import { Dependencies } from '../Dependencies';
@@ -382,10 +382,14 @@ export const prepareInputsStep: Step<PrebuildContext> = {
   async run(ctx) {
     const { request } = ctx;
 
-    // Enable verbose output (full build logs instead of spinners).
-    // Also force non-interactive when building in parallel — ora spinners
-    // from concurrent packages would overwrite each other's terminal lines.
-    if (request.verbose || request.concurrency > 1) {
+    // Verbose widens what gets logged but doesn't change interactive vs.
+    // non-interactive — TTY users can opt into the full per-step trace and
+    // still see spinners. CI is non-interactive on its own.
+    setVerbose(request.verbose);
+
+    // Force non-interactive when building in parallel — ora spinners from
+    // concurrent packages would overwrite each other's terminal lines.
+    if (request.concurrency > 1) {
       setForceNonInteractive(true);
     }
 

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -14,7 +14,7 @@ import path from 'path';
 
 import { PACKAGES_DIR } from '../../Constants';
 import { getPrecompileDir } from '../../Directories';
-import logger, { setVerbose } from '../../Logger';
+import logger from '../../Logger';
 import { getPackageByName } from '../../Packages';
 import { Artifacts } from '../Artifacts';
 import { Dependencies } from '../Dependencies';
@@ -385,7 +385,7 @@ export const prepareInputsStep: Step<PrebuildContext> = {
     // Verbose widens what gets logged but doesn't change interactive vs.
     // non-interactive — TTY users can opt into the full per-step trace and
     // still see spinners. CI is non-interactive on its own.
-    setVerbose(request.verbose);
+    logger.setVerbose(request.verbose);
 
     // Force non-interactive when building in parallel — ora spinners from
     // concurrent packages would overwrite each other's terminal lines.


### PR DESCRIPTION
# Why

When building our precompiled XCFrameworks we get a lot of log output - a lot of it is not necessary.

# How

This PR fixes it by moving most of the trivial log output to a verbose option.

This reduces the output when build from around 30.000 to 3000 lines with/without verbose.

# Test-plan

✅ Ran both with/without `--verbose` option to verify that it still precompiles and displays warnings correctly.

