### PR TITLE
[core][Android] Use CT reflection to convert Records to JS in legacy converter

### DIFF
--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverter.kt
@@ -3,7 +3,6 @@ package expo.modules.kotlin.types
 import android.net.Uri
 import android.os.Bundle
 import expo.modules.kotlin.jni.ReturnType
-import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.formatters.FormattedRecord
 import expo.modules.kotlin.typedarray.RawTypedArrayHolder
@@ -121,7 +120,7 @@ interface JSTypeConverter<T> {
   object RecordConverter : JSTypeConverter<Record> {
     override fun convertToJS(value: Any?): Any? {
       enforceType<Record?>(value)
-      return value?.toJSValueExperimental()
+      return value?.toJSValueExperimental(null)
     }
 
     override val returnType: ReturnType
@@ -129,49 +128,11 @@ interface JSTypeConverter<T> {
   }
 
   class IntrospectableRecordConverter(
-    introspectableData: PIntrospectionData<Record>
+    private val introspectableData: PIntrospectionData<Record>
   ) : JSTypeConverter<Record> {
-    data class Property(
-      val key: String,
-      val getter: (Record) -> Any?
-    )
-
-    private val properties = introspectableData
-      .properties
-      .mapNotNull { property ->
-        val fieldAnnotation = property
-          .annotations
-          .firstOrNull { annotation -> annotation.jClass == Field::class.java }
-          ?: return@mapNotNull null
-
-        val propertyName = (
-          fieldAnnotation
-            .arguments
-            .getOrDefault("key", property.name) as String
-          )
-          .ifEmpty { property.name }
-
-        Property(
-          propertyName,
-          property::get
-        )
-      }
-
     override fun convertToJS(value: Any?): Any? {
-      if (value == null) {
-        return null
-      }
-
-      enforceType<Record>(value)
-      val result = mutableMapOf<String, Any?>()
-
-      properties.forEach { property ->
-        val propValue = property.getter(value)
-        val convertedValue = JSTypeConverterProvider.convertToJSValue(propValue, useExperimentalConverter = true)
-        result[property.key] = convertedValue
-      }
-
-      return result
+      enforceType<Record?>(value)
+      return value?.toJSValueExperimental(introspectableData)
     }
 
     override val returnType: ReturnType

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverterHelper.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/types/JSTypeConverterHelper.kt
@@ -10,6 +10,9 @@ import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import expo.modules.kotlin.records.formatters.FormattedRecord
 import expo.modules.kotlin.records.formatters.ValueOrSkip
+import io.github.lukmccall.pika.PIntrospectionData
+import io.github.lukmccall.pika.PIntrospectionProvider
+import io.github.lukmccall.pika.PProperty
 import java.io.File
 import java.net.URI
 import java.net.URL
@@ -20,22 +23,63 @@ import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.jvm.isAccessible
 
-fun Record.toJSValueExperimental(): Map<String, Any?> {
+/**
+ * Returns field key if property is annotated with [Field]
+ */
+private fun PProperty<Record, *>.asFieldKey(): String? {
+  val fieldAnnotation = annotations
+    .firstOrNull { annotation -> annotation.jClass == Field::class.java }
+    ?: return null
+
+  val propertyName = (
+    fieldAnnotation
+      .arguments
+      .getOrDefault("key", name) as String
+    )
+    .ifEmpty { name }
+
+  return propertyName
+}
+
+private fun Record.getIntrospectionData(): PIntrospectionData<Record>? {
+  return if (this is PIntrospectionProvider) {
+    @Suppress("UNCHECKED_CAST")
+    getIntrospectionData() as? PIntrospectionData<Record>
+  } else {
+    null
+  }
+}
+
+fun Record.toJSValueExperimental(
+  introspectionData: PIntrospectionData<Record>? = this.getIntrospectionData()
+): Map<String, Any?> {
   val result = mutableMapOf<String, Any?>()
 
-  javaClass
-    .kotlin
-    .memberProperties
-    .forEach { property ->
-      val fieldInformation = property.findAnnotation<Field>() ?: return@forEach
-      val jsKey = fieldInformation.key.takeUnless { it == "" } ?: property.name
+  if (introspectionData == null) {
+    javaClass
+      .kotlin
+      .memberProperties
+      .forEach { property ->
+        val fieldInformation = property.findAnnotation<Field>() ?: return@forEach
+        val jsKey = fieldInformation.key.takeUnless { it == "" } ?: property.name
 
-      property.isAccessible = true
+        property.isAccessible = true
 
-      val value = property.get(this)
-      val convertedValue = JSTypeConverterProvider.convertToJSValue(value, useExperimentalConverter = true)
-      result[jsKey] = convertedValue
-    }
+        val value = property.get(this)
+        val convertedValue = JSTypeConverterProvider.convertToJSValue(value, useExperimentalConverter = true)
+        result[jsKey] = convertedValue
+      }
+  } else {
+    introspectionData
+      .properties
+      .forEach { property ->
+        val propertyKey = property.asFieldKey() ?: return@forEach
+
+        val propValue = property.get(this)
+        val convertedValue = JSTypeConverterProvider.convertToJSValue(propValue, useExperimentalConverter = true)
+        result[propertyKey] = convertedValue
+      }
+  }
 
   return result
 }
@@ -74,21 +118,37 @@ fun FormattedRecord<*>.toJSValueExperimental(): Map<String, Any?> {
   return result
 }
 
-fun Record.toJSValue(containerProvider: JSTypeConverterProvider.ContainerProvider): WritableMap {
+fun Record.toJSValue(
+  containerProvider: JSTypeConverterProvider.ContainerProvider,
+  introspectionData: PIntrospectionData<Record>? = this.getIntrospectionData()
+): WritableMap {
   val result = containerProvider.createMap()
 
-  javaClass
-    .kotlin
-    .memberProperties.map { property ->
-      val fieldInformation = property.findAnnotation<Field>() ?: return@map
-      val jsKey = fieldInformation.key.takeUnless { it == "" } ?: property.name
+  if (introspectionData == null) {
+    javaClass
+      .kotlin
+      .memberProperties
+      .forEach { property ->
+        val fieldInformation = property.findAnnotation<Field>() ?: return@forEach
+        val jsKey = fieldInformation.key.takeUnless { it == "" } ?: property.name
 
-      property.isAccessible = true
+        property.isAccessible = true
 
-      val value = property.get(this)
-      val convertedValue = JSTypeConverterProvider.legacyConvertToJSValue(value, containerProvider)
-      result.putGeneric(jsKey, convertedValue)
-    }
+        val value = property.get(this)
+        val convertedValue = JSTypeConverterProvider.legacyConvertToJSValue(value, containerProvider)
+        result.putGeneric(jsKey, convertedValue)
+      }
+  } else {
+    introspectionData
+      .properties
+      .forEach { property ->
+        val propertyKey = property.asFieldKey() ?: return@forEach
+
+        val value = property.get(this)
+        val convertedValue = JSTypeConverterProvider.legacyConvertToJSValue(value, containerProvider)
+        result.putGeneric(propertyKey, convertedValue)
+      }
+  }
 
   return result
 }


### PR DESCRIPTION
# Why

Uses CT reflection to convert Records to JS in the legacy converter.
A follow-up to https://github.com/expo/expo/pull/45415.
The new conversion is ~1.3X faster. 

# Test Plan

Before:
<img width="1272" height="1168" alt="image" src="https://github.com/user-attachments/assets/3f069d86-30a4-4bfd-adf2-554628fd077f" />

After:
<img width="1270" height="1187" alt="image" src="https://github.com/user-attachments/assets/5a2b597a-8c3a-4975-9de4-51ac04a48307" />
