### PR TITLE
[bare-expo][Android] Fix network security in debugOptimized

### DIFF
--- a/apps/bare-expo/android/app/src/debugOptimized/res/xml/network_security_config.xml
+++ b/apps/bare-expo/android/app/src/debugOptimized/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+  <base-config
+    cleartextTrafficPermitted="true"
+    tools:ignore="InsecureBaseConfiguration" />
+</network-security-config>

--- a/apps/bare-expo/plugins/withAndroidNetworkSecurityConfig.js
+++ b/apps/bare-expo/plugins/withAndroidNetworkSecurityConfig.js
@@ -39,10 +39,16 @@ const withAndroidNetworkSecurityConfigXml = (config) => {
 `
       );
 
-      await fs.mkdir(path.join(projectPath, 'app/src/debug/res/xml'), { recursive: true });
-      await fs.writeFile(
-        path.join(projectPath, 'app/src/debug/res/xml/network_security_config.xml'),
-        `\
+      for (const debuggableBuildTypes in ['debug', 'debugOptimized']) {
+        await fs.mkdir(path.join(projectPath, `app/src/${debuggableBuildTypes}/res/xml`), {
+          recursive: true,
+        });
+        await fs.writeFile(
+          path.join(
+            projectPath,
+            `app/src/${debuggableBuildTypes}/res/xml/network_security_config.xml`
+          ),
+          `\
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config xmlns:tools="http://schemas.android.com/tools">
   <base-config
@@ -50,7 +56,8 @@ const withAndroidNetworkSecurityConfigXml = (config) => {
     tools:ignore="InsecureBaseConfiguration" />
 </network-security-config>
 `
-      );
+        );
+      }
       return config;
     },
   ]);


### PR DESCRIPTION
# Why

Fixes network security in debugOptimized.
This change is only needed in bare-expo, as it has a different network policy. Not sure why we don't use the same one from the template. I'll check that later.

# Test Plan

- bare-expo ✅ 