### PR TITLE
[test-suite] Fix brightness tests

### DIFF
--- a/apps/test-suite/tests/Brightness.ts
+++ b/apps/test-suite/tests/Brightness.ts
@@ -5,7 +5,22 @@ import * as TestUtils from '../TestUtils';
 
 export const name = 'Brightness (device-only)';
 
-export const EPSILON = Math.pow(10, -5);
+// Android system brightness is stored as an integer in the [1, 255] range
+// This means the maximum error after mapping to the [0, 1] range can be half of the interval
+const ANDROID_EPSILON = 1 / 254 / 2;
+// Arbitrary precision, which compensates for floating-point inaccuracies
+const IOS_EPSILON = Math.pow(10, -5);
+const EPSILON = Platform.OS === 'android' ? ANDROID_EPSILON : IOS_EPSILON;
+// Arbitrary delay to give the system time to set the brightness
+const BRIGHTNESS_UPDATE_DELAY_MS = 400;
+
+function timeoutWrapper(fn: () => void | Promise<void>, time: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      Promise.resolve(fn()).then(resolve, reject);
+    }, time);
+  });
+}
 
 export async function test(t) {
   const shouldSkipTestsRequiringPermissions =
@@ -32,9 +47,11 @@ export async function test(t) {
         } catch {
           wasRejected = true;
         }
-        const obtainedValue = await Brightness.getBrightnessAsync();
-        t.expect(Math.abs(originalValue - obtainedValue)).toBeLessThan(EPSILON);
-        t.expect(wasRejected).toBe(false);
+        await timeoutWrapper(async () => {
+          const obtainedValue = await Brightness.getBrightnessAsync();
+          t.expect(Math.abs(originalValue - obtainedValue)).toBeLessThan(EPSILON);
+          t.expect(wasRejected).toBe(false);
+        }, BRIGHTNESS_UPDATE_DELAY_MS);
       });
 
       t.it(
@@ -47,9 +64,11 @@ export async function test(t) {
           } catch {
             wasRejected = true;
           }
-          const obtainedValue = await Brightness.getBrightnessAsync();
-          t.expect(Math.abs(0 - obtainedValue)).toBeLessThan(EPSILON);
-          t.expect(wasRejected).toBe(false);
+          await timeoutWrapper(async () => {
+            const obtainedValue = await Brightness.getBrightnessAsync();
+            t.expect(Math.abs(0 - obtainedValue)).toBeLessThan(EPSILON);
+            t.expect(wasRejected).toBe(false);
+          }, BRIGHTNESS_UPDATE_DELAY_MS);
         }
       );
 
@@ -63,9 +82,11 @@ export async function test(t) {
           } catch {
             wasRejected = true;
           }
-          const obtainedValue = await Brightness.getBrightnessAsync();
-          t.expect(Math.abs(1 - obtainedValue)).toBeLessThan(EPSILON);
-          t.expect(wasRejected).toBe(false);
+          await timeoutWrapper(async () => {
+            const obtainedValue = await Brightness.getBrightnessAsync();
+            t.expect(Math.abs(1 - obtainedValue)).toBeLessThan(EPSILON);
+            t.expect(wasRejected).toBe(false);
+          }, BRIGHTNESS_UPDATE_DELAY_MS);
         }
       );
 
@@ -110,9 +131,11 @@ export async function test(t) {
             } catch {
               wasRejected = true;
             }
-            const obtainedValue = await Brightness.getSystemBrightnessAsync();
-            t.expect(Math.abs(originalValue - obtainedValue)).toBeLessThan(EPSILON);
-            t.expect(wasRejected).toBe(false);
+            await timeoutWrapper(async () => {
+              const obtainedValue = await Brightness.getSystemBrightnessAsync();
+              t.expect(Math.abs(originalValue - obtainedValue)).toBeLessThan(EPSILON);
+              t.expect(wasRejected).toBe(false);
+            }, BRIGHTNESS_UPDATE_DELAY_MS);
           });
 
           t.it(
@@ -125,9 +148,11 @@ export async function test(t) {
               } catch {
                 wasRejected = true;
               }
-              const obtainedValue = await Brightness.getSystemBrightnessAsync();
-              t.expect(Math.abs(0 - obtainedValue)).toBeLessThan(EPSILON);
-              t.expect(wasRejected).toBe(false);
+              await timeoutWrapper(async () => {
+                const obtainedValue = await Brightness.getSystemBrightnessAsync();
+                t.expect(Math.abs(0 - obtainedValue)).toBeLessThan(EPSILON);
+                t.expect(wasRejected).toBe(false);
+              }, BRIGHTNESS_UPDATE_DELAY_MS);
             }
           );
 
@@ -141,9 +166,11 @@ export async function test(t) {
               } catch {
                 wasRejected = true;
               }
-              const obtainedValue = await Brightness.getSystemBrightnessAsync();
-              t.expect(Math.abs(1 - obtainedValue)).toBeLessThan(EPSILON);
-              t.expect(wasRejected).toBe(false);
+              await timeoutWrapper(async () => {
+                const obtainedValue = await Brightness.getSystemBrightnessAsync();
+                t.expect(Math.abs(1 - obtainedValue)).toBeLessThan(EPSILON);
+                t.expect(wasRejected).toBe(false);
+              }, BRIGHTNESS_UPDATE_DELAY_MS);
             }
           );
 
@@ -183,9 +210,11 @@ export async function test(t) {
           } catch {
             wasRejected = true;
           }
-          const obtainedValue = await Brightness.getBrightnessAsync();
-          t.expect(Math.abs(obtainedValue - systemValue)).toBeLessThan(EPSILON);
-          t.expect(wasRejected).toBe(false);
+          await timeoutWrapper(async () => {
+            const obtainedValue = await Brightness.getBrightnessAsync();
+            t.expect(Math.abs(obtainedValue - systemValue)).toBeLessThan(EPSILON);
+            t.expect(wasRejected).toBe(false);
+          }, BRIGHTNESS_UPDATE_DELAY_MS);
         });
 
         t.it(`is overridden by setting the app brightness`, async () => {
@@ -199,9 +228,11 @@ export async function test(t) {
           } catch {
             wasRejected = true;
           }
-          const obtainedValue = await Brightness.getBrightnessAsync();
-          t.expect(Math.abs(obtainedValue - appValue)).toBeLessThan(EPSILON);
-          t.expect(wasRejected).toBe(false);
+          await timeoutWrapper(async () => {
+            const obtainedValue = await Brightness.getBrightnessAsync();
+            t.expect(Math.abs(obtainedValue - appValue)).toBeLessThan(EPSILON);
+            t.expect(wasRejected).toBe(false);
+          }, BRIGHTNESS_UPDATE_DELAY_MS);
         });
       });
 


### PR DESCRIPTION
# Why
Fixes two main problems with the brightness test suite:
On iOS: The system didn't have time to update the brightness value, causing:
<img width="345" height="66" alt="Screenshot 2026-05-07 at 21 52 45" src="https://github.com/user-attachments/assets/ad1d2cf8-462e-4099-b121-31daff0f0828" />

On Android: There was a problem with the epsilon:
<img width="323" height="98" alt="Screenshot 2026-05-07 at 21 47 31" src="https://github.com/user-attachments/assets/fdb43a0b-e89c-4531-99b2-9f3761ab0c80" />


# How
- Added `timeoutWrapper`, to give the system time to update the brightness
- Added a correct epsilon for Android  

# Test Plan
BareExpo  ✅