### PR TITLE
fix(cli): prevent Metro progress bars from corrupting terminal output

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix Metro progress bars appearing as permanent output due to cursor corruption from stderr writes and stale status snapshots. ([#45523](https://github.com/expo/expo/pull/XXXX) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent Metro loading indicator from showing broken states in headless runs. ([#45513](https://github.com/expo/expo/pull/45513) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `--port 0` exiting silently in `expo start` when the port is busy. ([#45513](https://github.com/expo/expo/pull/45513) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix Metro progress bars appearing as permanent output due to cursor corruption from stderr writes and stale status snapshots. ([#45523](https://github.com/expo/expo/pull/XXXX) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix Metro progress bars appearing as permanent output due to cursor corruption from stderr writes and stale status snapshots. ([#45523](https://github.com/expo/expo/pull/45523) by [@EvanBacon](https://github.com/EvanBacon))
 - Prevent Metro loading indicator from showing broken states in headless runs. ([#45513](https://github.com/expo/expo/pull/45513) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `--port 0` exiting silently in `expo start` when the port is busy. ([#45513](https://github.com/expo/expo/pull/45513) by [@EvanBacon](https://github.com/EvanBacon))
 

--- a/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
+++ b/packages/@expo/cli/src/start/server/metro/TerminalReporter.ts
@@ -59,6 +59,29 @@ export class TerminalReporter extends XTerminalReporter implements TerminalRepor
   /** Keep track of bundle processes that should not be logged. */
   _hiddenBundleEvents: Set<string> = new Set();
 
+  /**
+   * Override Metro's update() to clear the status before _log() runs.
+   *
+   * Metro's Terminal.#update() is async and snapshots #nextStatusStr at the start.
+   * When _log() calls terminal.log(), Terminal starts #update() which captures
+   * whatever status is currently set — often a stale progress bar. This progress bar
+   * gets written as permanent output between log lines because the next #update()
+   * cycle (which would clear it) runs 33ms later.
+   *
+   * By clearing the status to empty before _log(), Terminal's #update() captures
+   * an empty status and doesn't write any progress bars alongside log lines.
+   * The correct status is then restored by terminal.status() at the end.
+   */
+  update(event: TerminalReportableEvent): void {
+    if (
+      event.type !== 'bundle_transform_progressed' &&
+      event.type !== ('bundle_transform_progressed_throttled' as string)
+    ) {
+      this.terminal.status('');
+    }
+    super.update(event);
+  }
+
   _log(event: TerminalReportableEvent): void {
     switch (event.type) {
       case 'transform_cache_reset':

--- a/packages/@expo/cli/src/start/server/metro/__tests__/MetroTerminalReporter-test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/MetroTerminalReporter-test.ts
@@ -27,6 +27,11 @@ const LIGHT_BLOCK_CHAR = '\u2591';
 
 jest.useFakeTimers();
 
+const mockIsInteractive = jest.fn(() => false);
+jest.mock('../../../../utils/interactive', () => ({
+  isInteractive: () => mockIsInteractive(),
+}));
+
 jest.mock('../../serverLogLikeMetro', () => {
   const original = jest.requireActual('../../serverLogLikeMetro');
   return {
@@ -579,6 +584,153 @@ describe('non-interactive terminal output', () => {
     // In non-interactive mode, _getStatusMessage() should return empty
     // since status lines can't be overwritten and would produce permanent noise.
     expect(reporter._getStatusMessage()).toBe('');
+  });
+});
+
+describe('status cleared before log lines', () => {
+  beforeEach(() => mockIsInteractive.mockReturnValue(true));
+  afterEach(() => mockIsInteractive.mockReturnValue(false));
+
+  /**
+   * Metro's Terminal.#update() is async and snapshots #nextStatusStr when it starts.
+   * When _log() calls terminal.log(), Terminal starts #update() which captures
+   * whatever status is currently set. If it's a progress bar, that progress bar
+   * gets written as permanent output between log lines (it can't be reliably
+   * cleared before more output arrives).
+   *
+   * The fix: update() clears the status to empty before _log() runs, so Terminal's
+   * #update() captures an empty status and writes no progress bars alongside log lines.
+   */
+
+  const buildID1 = 'build-1';
+  const buildID2 = 'build-2';
+  const entryFile = 'node_modules/expo-router/entry.js';
+  const serverEntry = 'packages/@expo/router-server/node/render.js';
+  const webDetails = asBundleDetails({
+    entryFile,
+    platform: 'web',
+    bundleType: 'bundle',
+  });
+  const serverDetails = asBundleDetails({
+    entryFile: serverEntry,
+    platform: 'web',
+    bundleType: 'bundle',
+    customTransformOptions: { environment: 'node' },
+  });
+
+  function createReporter() {
+    const callOrder: { type: 'log' | 'status'; content: string }[] = [];
+
+    const terminal = {
+      log: jest.fn((...args: any[]) => {
+        const content = stripAnsi(args.join(' '));
+        callOrder.push({ type: 'log', content });
+      }),
+      persistStatus: jest.fn(),
+      status: jest.fn((...args: any[]) => {
+        const content = stripAnsi(args.join(' '));
+        callOrder.push({ type: 'status', content });
+      }),
+      flush: jest.fn(),
+    } satisfies Partial<Terminal>;
+
+    const reporter = new MetroTerminalReporter('/', terminal as any);
+    reporter._getElapsedTime = jest.fn(() => BigInt(100_000_000));
+    return { reporter, terminal, callOrder };
+  }
+
+  it('clears status before any log call during bundle_build_done', () => {
+    const { reporter, callOrder } = createReporter();
+
+    // Start a bundle and add progress
+    reporter.update({
+      type: 'bundle_build_started',
+      buildID: buildID1,
+      bundleDetails: { ...webDetails, buildID: buildID1 },
+      isPrefetch: false,
+    } as any);
+    reporter.update({
+      type: 'bundle_transform_progressed_throttled',
+      buildID: buildID1,
+      transformedFileCount: 50,
+      totalFileCount: 100,
+    } as any);
+
+    callOrder.length = 0;
+
+    // Bundle completes
+    reporter.update({
+      type: 'bundle_build_done',
+      buildID: buildID1,
+      bundleDetails: { ...webDetails, buildID: buildID1 },
+    } as any);
+
+    // The FIRST call should be status('') to clear progress bars
+    expect(callOrder[0]).toEqual({ type: 'status', content: '' });
+
+    // The log should come after the clear
+    const bundledLog = callOrder.find((c) => c.type === 'log' && c.content.includes('Bundled'));
+    expect(bundledLog).toBeDefined();
+  });
+
+  it('clears status before server log warnings', () => {
+    const { reporter, callOrder } = createReporter();
+
+    // Start a bundle (web) and add progress
+    reporter.update({
+      type: 'bundle_build_started',
+      buildID: buildID1,
+      bundleDetails: { ...webDetails, buildID: buildID1 },
+      isPrefetch: false,
+    } as any);
+    reporter.update({
+      type: 'bundle_transform_progressed_throttled',
+      buildID: buildID1,
+      transformedFileCount: 883,
+      totalFileCount: 886,
+    } as any);
+
+    callOrder.length = 0;
+
+    // A server log (WARN) comes in while web bundle is still active
+    reporter.update({
+      type: 'unstable_server_log',
+      level: 'warn',
+      data: ['Deep imports from react-native are deprecated'],
+    } as any);
+
+    // The FIRST call should be status('') to clear the web progress bar
+    expect(callOrder[0]).toEqual({ type: 'status', content: '' });
+
+    // Status should be restored at the end (web bundle still active)
+    const lastStatus = [...callOrder].reverse().find((c) => c.type === 'status');
+    expect(lastStatus?.content).toContain(entryFile);
+  });
+
+  it('does not clear status for progress events', () => {
+    const { reporter, callOrder } = createReporter();
+
+    // Start a bundle
+    reporter.update({
+      type: 'bundle_build_started',
+      buildID: buildID1,
+      bundleDetails: { ...webDetails, buildID: buildID1 },
+      isPrefetch: false,
+    } as any);
+
+    callOrder.length = 0;
+
+    // Progress event should NOT clear the status
+    reporter.update({
+      type: 'bundle_transform_progressed_throttled',
+      buildID: buildID1,
+      transformedFileCount: 50,
+      totalFileCount: 100,
+    } as any);
+
+    // Should not start with a clear
+    const firstStatus = callOrder.find((c) => c.type === 'status');
+    expect(firstStatus?.content).not.toBe('');
   });
 });
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -84,8 +84,20 @@ function asWritable<T>(input: T): { -readonly [K in keyof T]: T[K] } {
   return input;
 }
 
-// Wrap terminal and polyfill console.log so we can log during bundling without breaking the indicator.
+/**
+ * Extends Metro's Terminal to intercept all console methods so they don't
+ * corrupt the progress bar status lines.
+ *
+ * console.log/info are routed through terminal.log() (stdout, managed).
+ * console.warn/error are routed through logStderr() which clears the
+ * status from stdout before writing to stderr, then restores it.
+ * Without this, unmanaged stderr writes shift the cursor and cause
+ * progress bars to get stuck as permanent output.
+ */
 class LogRespectingTerminal extends Terminal {
+  #stderrQueue: string[] = [];
+  #drainingStderr = false;
+
   constructor(stream: import('node:net').Socket | import('node:stream').Writable) {
     super(stream, { ttyPrint: true });
 
@@ -100,8 +112,53 @@ class LogRespectingTerminal extends Terminal {
       this.flush();
     };
 
+    const sendStderr = (...msg: any[]) => {
+      if (!msg.length) {
+        this.logStderr('');
+      } else {
+        const [format, ...args] = msg;
+        this.logStderr(require('util').format(format, ...args));
+      }
+    };
+
     console.log = sendLog;
     console.info = sendLog;
+    console.warn = sendStderr;
+    console.error = sendStderr;
+  }
+
+  /**
+   * Write to stderr without corrupting Terminal's cursor tracking.
+   * Uses Terminal's public API: status() to clear/restore progress bars,
+   * and flush() to ensure the clear is applied before the stderr write.
+   */
+  logStderr(line: string): void {
+    if (!(process.stdout as any).isTTY) {
+      process.stderr.write(line + '\n');
+      return;
+    }
+    this.#stderrQueue.push(line);
+    this.#drainStderr();
+  }
+
+  async #drainStderr(): Promise<void> {
+    if (this.#drainingStderr) return;
+    this.#drainingStderr = true;
+
+    while (this.#stderrQueue.length > 0) {
+      // Clear status, flush to ensure it's removed from screen
+      const prev = this.status('');
+      await this.flush();
+
+      // Write to stderr while status is cleared
+      const lines = this.#stderrQueue.splice(0);
+      process.stderr.write(lines.join('\n') + '\n');
+
+      // Restore status
+      this.status(prev);
+    }
+
+    this.#drainingStderr = false;
   }
 }
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -127,11 +127,7 @@ class LogRespectingTerminal extends Terminal {
     console.error = sendStderr;
   }
 
-  /**
-   * Write to stderr without corrupting Terminal's cursor tracking.
-   * Uses Terminal's public API: status() to clear/restore progress bars,
-   * and flush() to ensure the clear is applied before the stderr write.
-   */
+  /** Write to stderr without corrupting Terminal's cursor tracking. */
   logStderr(line: string): void {
     if (!(process.stdout as any).isTTY) {
       process.stderr.write(line + '\n');


### PR DESCRIPTION
# Why

Metro's Terminal class manages progress bar status lines on stdout using cursor movement. Two issues caused progress bars to appear as permanent, stuck output:

1. **Stale status snapshots**: Terminal's `#update()` is async and captures `#nextStatusStr` at the start. When `_log()` calls `terminal.log()`, the async update captures whatever status is currently set (often a stale progress bar) before `terminal.status()` can update it.

2. **Stderr cursor corruption**: `console.warn()` and `console.error()` during server bundle evaluation write directly to stderr, which shifts the terminal cursor without Terminal's knowledge. When Terminal tries to clear status lines via cursor movement on stdout, the positions are wrong.

# How

**Status clearing** (`TerminalReporter.update()`): Clears `terminal.status('')` before `_log()` runs for non-progress events. This way Terminal's async `#update()` captures an empty status and writes no progress bars alongside log lines. The correct status is restored by `terminal.status()` at the end of `update()`.

**Non-interactive suppression** (`MetroTerminalReporter._getStatusMessage()`): Returns empty string in non-TTY mode since status lines can't be overwritten and just create noise. "Bundled Xms" completion messages still appear (they use `terminal.log()`).

**Stderr coordination** (`LogRespectingTerminal.logStderr()`): Intercepts `console.warn`/`console.error` and routes them through a `logStderr()` method that uses Terminal's public API (`status()` + `flush()`) to clear progress bars before the stderr write and restore them after.

# Test Plan

- Unit tests for status clearing behavior, non-interactive suppression, and progress event passthrough
- Manual testing with `expo start` on a project that triggers server bundle warnings during bundling
- Verified with debug logging that all event types flow through the `update()` override