### PR TITLE
fix(log-box): fix error overlay footer overlapping content

### DIFF
--- a/packages/@expo/log-box/CHANGELOG.md
+++ b/packages/@expo/log-box/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix error overlay footer overlapping content by using fixed positioning and adding bottom padding. ([#45526](https://github.com/expo/expo/pull/45526) by [@EvanBacon](https://github.com/EvanBacon))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-07

--- a/packages/@expo/log-box/src/overlay/Overlay.module.css
+++ b/packages/@expo/log-box/src/overlay/Overlay.module.css
@@ -150,7 +150,7 @@
 }
 
 .footer {
-  position: absolute;
+  position: fixed;
   bottom: 0;
   left: 0;
   right: 0;

--- a/packages/@expo/log-box/src/overlay/Overlay.tsx
+++ b/packages/@expo/log-box/src/overlay/Overlay.tsx
@@ -293,7 +293,8 @@ function LogBoxContent({
         />
 
         {
-          <div style={{ padding: '0 1rem', gap: 10, display: 'flex', flexDirection: 'column' }}>
+          <div
+            style={{ padding: '0 1rem 3.5rem', gap: 10, display: 'flex', flexDirection: 'column' }}>
             {codeFrames.map(([key, codeFrame]) => {
               // If no frame from a stack is expanded, likely no frame is from user code, let's not show the code snippet.
               // This avoid cluttering the overlay with irrelevant code frames of node_modules and internals.


### PR DESCRIPTION
# Why

The error overlay footer (with reload/dismiss buttons) uses `position: absolute`, which causes it to overlap the code frame content when scrolling. Users can't see the bottom of the code frames because the footer covers them.

# How

- Changed the footer from `position: absolute` to `position: fixed` so it stays anchored to the viewport bottom regardless of scroll position
- Added `3.5rem` bottom padding to the code frames container to prevent content from being hidden behind the fixed footer

# Test Plan

- Open an app with a runtime error that shows a code frame in the error overlay
- Verify the footer stays at the bottom of the screen
- Verify the code frame content is fully visible and not obscured by the footer
- Verify scrolling behavior works correctly