### PR TITLE
[test-suite] fix android e2e

### DIFF
--- a/apps/test-suite/components/Suites.tsx
+++ b/apps/test-suite/components/Suites.tsx
@@ -163,13 +163,13 @@ export default function Suites({
     }
     const totalCount = passedCount + failedCount;
 
-    // Maestro E2E assertions wait for test_suite_text_results to appear and contain "All tests passed!" text
+    // Maestro E2E asserts visibility of test_suite_summary_result_text after the FlatList
+    // auto-scrolls to the bottom, so that text lives in the bottom footer block below.
     return (
       <View
         testID="test_suite_text_results"
         style={[styles.summary, { borderTopColor: theme.border.secondary }]}>
         <Text
-          testID="test_suite_summary_result_text"
           style={[
             styles.summaryTitle,
             { color: failedCount > 0 ? theme.text.danger : theme.text.success },
@@ -233,6 +233,18 @@ export default function Suites({
             <Text style={[styles.actionText, { color: theme.text.link }]}>Replay all</Text>
           </TouchableOpacity>
           {failedCount > 0 && failures != null && <CopyFailuresButton failures={failures} />}
+        </View>
+        <View style={[styles.resultFooter, { borderTopColor: theme.border.secondary }]}>
+          <Text style={[styles.resultFooterLabel, { color: theme.text.secondary }]}>Result</Text>
+          <Text
+            testID="test_suite_summary_result_text"
+            style={[
+              styles.summaryTitle,
+              styles.resultFooterTitle,
+              { color: failedCount > 0 ? theme.text.danger : theme.text.success },
+            ]}>
+            {failedCount > 0 ? 'Some tests failed!' : 'All tests passed!'}
+          </Text>
         </View>
       </View>
     );
@@ -352,5 +364,20 @@ const styles = StyleSheet.create({
   actionText: {
     fontSize: 16,
     fontWeight: '600',
+  },
+  resultFooter: {
+    marginTop: 16,
+    paddingTop: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+  },
+  resultFooterLabel: {
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 1,
+    marginBottom: 4,
+  },
+  resultFooterTitle: {
+    marginBottom: 0,
   },
 });


### PR DESCRIPTION
# Why

fix failure of test suite e2e android

# How

sqlite test-suite has longer content so the "All tests passed!" is outside of viewport. this pr tries to add a second anchor result at the footer

# Test Plan

test suite e2e passed. ios build failed at unrelated point. will fix in a separate pr

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
