### PR TITLE
[docs][router] Wrap app.json snippets in expo object on installation page

### DIFF
--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -90,9 +90,11 @@ Add a deep linking `scheme` and enable [typed routes](/router/reference/typed-ro
 
 ```json app.json
 {
-  "scheme": "your-app-scheme",
-  "experiments": {
-    "typedRoutes": true
+  "expo": {
+    "scheme": "your-app-scheme",
+    "experiments": {
+      "typedRoutes": true
+    }
   }
 }
 ```
@@ -105,8 +107,10 @@ Then, enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro)
 
 ```json app.json
 {
-  "web": {
-    "bundler": "metro"
+  "expo": {
+    "web": {
+      "bundler": "metro"
+    }
   }
 }
 ```


### PR DESCRIPTION
## Why

The two `app.json` snippets in Step 3 of the Expo Router manual installation guide omit the top-level `"expo"` wrapper that all `app.json` config must live under. A first-time reader who copies the snippet verbatim ends up with a root-level `scheme` / `experiments` / `web` key that Expo silently ignores, so deep linking and typed routes appear to "not work."

This is also inconsistent with other `app.json` examples in the same `docs/pages/router/` tree (e.g. `async-routes.mdx`, `advanced/native-tabs.mdx`), which all include the `"expo"` wrapper.

## How

Wrap both snippets in `"expo": { ... }`. No content changes beyond the wrapper.

## Test Plan

- Docs-only change, no code paths affected.
- Verified the surrounding snippets (`package.json`, `babel.config.js`, `tsconfig.json`) are untouched.

## Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no impact).