### PR TITLE
[tools] Switch to pod update

### DIFF
--- a/tools/src/CocoaPods.ts
+++ b/tools/src/CocoaPods.ts
@@ -46,13 +46,16 @@ type PodInstallOptions = Partial<{
 }>;
 
 /**
- * Installs pods under given project path.
+ * Re-resolves the given pods under the project path,
+ * respecting the existing lockfile for all other pods. Equivalent to
+ * `pod update <names> --no-repo-update`.
  */
-export async function podInstallAsync(
+export async function podUpdateAsync(
   projectPath: string,
+  podNames: string[],
   options: PodInstallOptions = { noRepoUpdate: false, stdio: 'pipe' }
 ): Promise<void> {
-  const args = ['install'];
+  const args = ['update', ...podNames];
 
   if (options.noRepoUpdate) {
     args.push('--no-repo-update');

--- a/tools/src/publish-packages/tasks/updateIosProjects.ts
+++ b/tools/src/publish-packages/tasks/updateIosProjects.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
-import { podInstallAsync } from '../../CocoaPods';
+import { podUpdateAsync } from '../../CocoaPods';
 import logger from '../../Logger';
 import { Task } from '../../TasksRunner';
 import { filterAsync } from '../../Utils';
@@ -46,10 +46,14 @@ export const updateIosProjects = new Task<TaskArgs>(
 
         logger.log('  ', `${green(nativeApp.packageName)}: Reinstalling pods...`);
 
-        // `pod install` sometimes fails, but it's not needed to properly
-        // publish packages, so let's just continue if that happens.
+        // Use `pod update`: we just bumped these pods' versions, and precompiled modules
+        // register them as `:podspec =>` sources, which trip CocoaPods' strict version-drift check on
+        // `pod install`. `pod update <names>` re-resolves only the bumped
+        // pods and is correct in source mode too. Failures are non-fatal.
         try {
-          await podInstallAsync(path.join(nativeApp.path, 'ios'), { noRepoUpdate: true });
+          await podUpdateAsync(path.join(nativeApp.path, 'ios'), podspecNames, {
+            noRepoUpdate: true,
+          });
         } catch (e) {
           logger.debug(e.stderr || e.stdout);
           logger.error('🍎 Failed to install pods in', green(nativeApp.packageName));


### PR DESCRIPTION
# Why
After turning on precompiled modules in bare expo, pod install fails when publishing the packages. This is because of CocoaPods strict version check. Precompiled mode registers each pod as `:podspec => ...` instead of `:path => ...`. CocoaPods' resolver has a strict version-drift check that fires only when both the locked and current external sources are `:podspec`. Because of this we have to delete the pods and lock file manually and commit after a publish. 

# How
We can get around it by switching to `pod update <bumped-pods>  --no-repo-update`. This bypasses the check.

# Test Plan
During a publish, the lock file is correctly updated.