### PR TITLE
[expo-cli] Fix @react-navigation/core rewrite to expo-router/react-navigation

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Prevent Metro loading indicator from showing broken states in headless runs. ([#45513](https://github.com/expo/expo/pull/45513) by [@EvanBacon](https://github.com/EvanBacon))
 - Fix `--port 0` exiting silently in `expo start` when the port is busy. ([#45513](https://github.com/expo/expo/pull/45513) by [@EvanBacon](https://github.com/EvanBacon))
 - Apply printf-style format substitution for web client logs forwarded from the browser. ([#45516](https://github.com/expo/expo/pull/45516) by [@EvanBacon](https://github.com/EvanBacon))
+- Fix @react-navigation/core rewrite to expo-router/react-navigation ([#45543](https://github.com/expo/expo/pull/45543) by [@Ubax](https://github.com/Ubax))
+
 ### 💡 Others
 
 - Replace deprecated `url.parse()` with WHATWG `URL` API in Metro dev server. ([#45524](https://github.com/expo/expo/pull/45524) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -640,7 +640,7 @@ export function withExtendedResolver(
           }
           if (moduleName === '@react-navigation/core') {
             // We already checked if expo-router resolves
-            return doResolve('expo-router');
+            return doResolve('expo-router/react-navigation');
           }
         }
       }


### PR DESCRIPTION
# Why

After https://github.com/expo/expo/pull/45241 was merged, I forgot to adjust the rewrite in the metro plugin.
At the moment it incorrectly rewrites `@react-navigation/core` imports to `expo-router` instead of `expo-router/react-navigation`

# How

Change `return doResolve('expo-router');` to `return doResolve('expo-router/react-navigation');`

# Test Plan

Local project with `react-native-screens-transition` (or any other third-party navigator) installed

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
