### PR TITLE
[app-metrics][android] Make environment unit tests build-variant aware

### DIFF
--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/AppMetricsPreferencesTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/AppMetricsPreferencesTest.kt
@@ -26,8 +26,8 @@ class AppMetricsPreferencesTest {
 
   @Test
   fun `getEnvironment returns default environment when nothing saved`() {
-    // Robolectric apps are debuggable by default
-    assertEquals("development", AppMetricsPreferences.getEnvironment(context))
+    val expected = if (BuildConfig.DEBUG) "development" else null
+    assertEquals(expected, AppMetricsPreferences.getEnvironment(context))
   }
 
   @Test
@@ -43,8 +43,8 @@ class AppMetricsPreferencesTest {
   }
 
   @Test
-  fun `getDefaultEnvironment returns development in debug builds`() {
-    // testDebugUnitTest has BuildConfig.DEBUG = true
-    assertEquals("development", AppMetricsPreferences.getDefaultEnvironment())
+  fun `getDefaultEnvironment matches build variant`() {
+    val expected = if (BuildConfig.DEBUG) "development" else null
+    assertEquals(expected, AppMetricsPreferences.getDefaultEnvironment())
   }
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
@@ -5,6 +5,7 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import expo.modules.appmetrics.AppMetadata
 import expo.modules.appmetrics.AppUpdatesInfo
+import expo.modules.appmetrics.BuildConfig
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.*
@@ -173,15 +174,15 @@ class SessionManagerTest {
   @Test
   fun `startSessionWithIdAt falls back to preferences environment`() =
     runTest {
-      // Arrange — Robolectric apps are debuggable, so default is "development"
       val sessionId = "test-session"
+      val expected = if (BuildConfig.DEBUG) "development" else null
 
       // Act
       sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
 
       // Assert
       val sessions = sessionManager.getAllSessions()
-      assertEquals("development", sessions[0].session.environment)
+      assertEquals(expected, sessions[0].session.environment)
     }
 
   @Test


### PR DESCRIPTION
## Why

`AppMetricsPreferences.getDefaultEnvironment()` returns `"development"` when `BuildConfig.DEBUG` is true and `null` otherwise. Three unit tests hardcoded `"development"` in their assertions, so they passed under `testDebugUnitTest` but failed under `testReleaseUnitTest`:

- `AppMetricsPreferencesTest.getEnvironment returns default environment when nothing saved`
- `AppMetricsPreferencesTest.getDefaultEnvironment returns development in debug builds`
- `SessionManagerTest.startSessionWithIdAt falls back to preferences environment`

## How

Derive the expected value from `BuildConfig.DEBUG` in each test so both build variants pass. Renamed `getDefaultEnvironment returns development in debug builds` → `getDefaultEnvironment matches build variant` since it now covers both cases.

## Test Plan

- `./gradlew :expo-app-metrics:testDebugUnitTest :expo-app-metrics:testReleaseUnitTest` — both green.

<!-- disable:changelog-checks -->