### PR TITLE
[app-metrics][android] Persist and dispatch log events

### DIFF
--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/AppMetricsModule.kt
@@ -2,8 +2,15 @@ package expo.modules.appmetrics
 
 import android.content.Context
 import expo.modules.appmetrics.appstartup.AppStartupManager
+import expo.modules.appmetrics.logevents.LogEventOptions
+import expo.modules.appmetrics.logevents.Severity
+import expo.modules.appmetrics.logevents.attributesToJsonObject
+import expo.modules.appmetrics.logevents.sanitizeLogEventAttributes
+import expo.modules.appmetrics.logevents.validateEventBody
+import expo.modules.appmetrics.logevents.validateEventName
 import expo.modules.appmetrics.memory.MemoryMetricsManager
 import expo.modules.appmetrics.storage.JsSession
+import expo.modules.appmetrics.storage.LogRecord
 import expo.modules.appmetrics.storage.Metric
 import expo.modules.appmetrics.storage.SessionManager
 import expo.modules.appmetrics.updates.UpdatesMonitoring
@@ -67,6 +74,35 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
 
         scope.launch {
           saveStartupMetricsIfNotSaved()
+        }
+      }
+
+      Function("logEvent") { name: String, options: LogEventOptions? ->
+        val validatedName = validateEventName(name) ?: return@Function
+        val validatedBody = validateEventBody(options?.body)
+        val sanitized = sanitizeLogEventAttributes(options?.attributes)
+        val severity = options?.severity ?: Severity.INFO
+
+        scope.launch {
+          // Attach any pending startup metrics first so the session has them
+          // alongside whatever's being logged. The session row itself is
+          // already persisted eagerly in `OnCreate`, so this is purely about
+          // ordering startup-metric writes ahead of caller-driven log events.
+          saveStartupMetricsIfNotSaved()
+          sessionManager.addLogs(
+            listOf(
+              LogRecord(
+                sessionId = appSessionId,
+                timestamp = TimeUtils.getCurrentTimestampInISOFormat(),
+                name = validatedName,
+                body = validatedBody,
+                severity = severity.rawValue,
+                attributes = sanitized.attributes?.let { Json.encodeToString(attributesToJsonObject(it)) },
+                droppedAttributesCount = sanitized.droppedCount
+              )
+            ),
+            sessionId = appSessionId
+          )
         }
       }
 
@@ -180,9 +216,9 @@ class AppMetricsModule : Module(), UpdatesStateChangeListener {
     if (UpdatesStateEvent.fromMap(event)?.type == UpdatesStateEvent.EventType.DownloadCompleteWithUpdate) {
       updatesMonitoring.downloadTimeMetric(subscription)?.let { metric ->
         scope.launch {
-          // Ensure the session row exists before inserting the metric,
-          // since the session may not have been saved yet if the download
-          // completes before markInteractive or app backgrounding.
+          // Attach any pending startup metrics first so the download-time
+          // metric lands alongside them. The session row itself is already
+          // persisted eagerly in `OnCreate`.
           saveStartupMetricsIfNotSaved()
           sessionManager.addMetrics(listOf(metric), sessionId = appSessionId)
         }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/AttributeValidation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/AttributeValidation.kt
@@ -1,0 +1,148 @@
+package expo.modules.appmetrics.logevents
+
+import android.util.Log
+import expo.modules.appmetrics.TAG
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+/**
+ * Patterns that match attribute keys reserved by the SDK. Caller-provided
+ * attributes whose key matches any of these are dropped:
+ *
+ * - The `expo.*` namespace, owned entirely by the SDK (e.g. `expo.app.name`,
+ *   `expo.eas_client.id`).
+ * - Specific OTel Semantic Convention keys the SDK sets on every record
+ *   (e.g. `session.id`, `event.name`). Letting callers set these would
+ *   produce duplicate-attribute errors on the collector.
+ */
+private val RESERVED_ATTRIBUTE_PATTERNS: List<Regex> = listOf(
+  Regex("^expo\\..+"),
+  Regex("^session\\.id$"),
+  Regex("^event\\.name$")
+)
+
+/**
+ * Maximum number of attributes accepted per log record. Mirrors the OTel SDK
+ * default — collectors and backends start to push back well before this limit,
+ * so we cap eagerly and surface the overflow via `droppedAttributesCount`.
+ */
+private const val MAX_ATTRIBUTE_COUNT = 128
+
+/**
+ * Result of sanitizing caller-provided log-event attributes.
+ *
+ * - `attributes`: the attributes that survived validation, or `null` when the
+ *   input was `null` or every entry was dropped.
+ * - `droppedCount`: number of attributes that were dropped during validation.
+ *   Surfaced on the OTel wire as `droppedAttributesCount` so backends know the
+ *   record was filtered.
+ */
+data class SanitizedLogAttributes(
+  val attributes: Map<String, Any?>?,
+  val droppedCount: Int
+)
+
+/**
+ * Filters caller-provided log-event attributes. Drops:
+ *
+ * - keys that are empty after trimming whitespace,
+ * - keys under the reserved `expo.*` namespace or matching SDK-set keys,
+ * - everything past the per-record attribute count cap.
+ *
+ * Each rule warns with its own message so the developer can tell at a glance
+ * which rule fired.
+ */
+internal fun sanitizeLogEventAttributes(attributes: Map<String, Any?>?): SanitizedLogAttributes {
+  if (attributes == null) {
+    return SanitizedLogAttributes(attributes = null, droppedCount = 0)
+  }
+
+  val sanitized = LinkedHashMap<String, Any?>()
+  var emptyKeyDrops = 0
+  val reservedKeyDrops = mutableListOf<String>()
+
+  for ((key, value) in attributes) {
+    val trimmedKey = key.trim()
+    if (trimmedKey.isEmpty()) {
+      emptyKeyDrops += 1
+      continue
+    }
+    if (RESERVED_ATTRIBUTE_PATTERNS.any { it.matches(trimmedKey) }) {
+      reservedKeyDrops += key
+      continue
+    }
+    sanitized[trimmedKey] = value
+  }
+
+  // Apply the per-record cap last so the count reflects every other rule first.
+  // Sort by key for a stable choice of which entries survive the cap; otherwise
+  // map iteration order would make this nondeterministic. Note this biases
+  // retention toward alphabetically-earlier keys when the cap is hit —
+  // acceptable for accidental-overflow cases (loop bug, typo); a caller that
+  // genuinely needs >128 attributes should split them across multiple events.
+  var overflowDrops = 0
+  if (sanitized.size > MAX_ATTRIBUTE_COUNT) {
+    val keptKeys = sanitized.keys.sorted().take(MAX_ATTRIBUTE_COUNT).toSet()
+    overflowDrops = sanitized.size - MAX_ATTRIBUTE_COUNT
+    sanitized.keys.toList().forEach { k -> if (k !in keptKeys) sanitized.remove(k) }
+  }
+
+  if (emptyKeyDrops > 0) {
+    Log.w(
+      TAG,
+      "[AppMetrics] logEvent dropped $emptyKeyDrops attribute(s) with empty or whitespace-only keys."
+    )
+  }
+  if (reservedKeyDrops.isNotEmpty()) {
+    val formattedKeys = reservedKeyDrops.sorted().joinToString(", ") { "`$it`" }
+    Log.w(
+      TAG,
+      "[AppMetrics] logEvent dropped attributes that overlap SDK-set keys or use the reserved `expo.` namespace: $formattedKeys."
+    )
+  }
+  if (overflowDrops > 0) {
+    Log.w(
+      TAG,
+      "[AppMetrics] logEvent dropped $overflowDrops attribute(s) past the $MAX_ATTRIBUTE_COUNT-attribute per-record cap."
+    )
+  }
+
+  return SanitizedLogAttributes(
+    attributes = if (sanitized.isEmpty()) null else sanitized,
+    droppedCount = emptyKeyDrops + reservedKeyDrops.size + overflowDrops
+  )
+}
+
+/**
+ * Converts a sanitized attribute map to a `JsonObject` for storage. Values
+ * whose type cannot be represented in OTLP (e.g. `Date`, NaN/Infinity doubles)
+ * are encoded as JSON `null` here; the typed-attribute encoder at dispatch
+ * time will skip them and add to `droppedAttributesCount` accordingly.
+ */
+internal fun attributesToJsonObject(attributes: Map<String, Any?>): JsonObject {
+  return JsonObject(attributes.mapValues { (_, value) -> anyToJsonElement(value) })
+}
+
+private fun anyToJsonElement(value: Any?): JsonElement {
+  return when (value) {
+    null -> JsonNull
+    is Boolean -> JsonPrimitive(value)
+    is Int -> JsonPrimitive(value)
+    is Long -> JsonPrimitive(value)
+    is Double -> if (value.isFinite()) JsonPrimitive(value) else JsonNull
+    is Float -> if (value.isFinite()) JsonPrimitive(value.toDouble()) else JsonNull
+    is Number -> JsonPrimitive(value.toDouble())
+    is String -> JsonPrimitive(value)
+    is Map<*, *> -> JsonObject(
+      value.entries
+        .filter { it.key is String }
+        .associate { (k, v) -> (k as String) to anyToJsonElement(v) }
+    )
+    is List<*> -> JsonArray(value.map { anyToJsonElement(it) })
+    is Array<*> -> JsonArray(value.map { anyToJsonElement(it) })
+    else -> JsonNull
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/AttributeValidation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/AttributeValidation.kt
@@ -2,11 +2,8 @@ package expo.modules.appmetrics.logevents
 
 import android.util.Log
 import expo.modules.appmetrics.TAG
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
+import expo.modules.appmetrics.utils.JsonAny
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 
 /**
  * Patterns that match attribute keys reserved by the SDK. Caller-provided
@@ -26,8 +23,11 @@ private val RESERVED_ATTRIBUTE_PATTERNS: List<Regex> = listOf(
 
 /**
  * Maximum number of attributes accepted per log record. Mirrors the OTel SDK
- * default — collectors and backends start to push back well before this limit,
- * so we cap eagerly and surface the overflow via `droppedAttributesCount`.
+ * default (`OTEL_LOGRECORD_ATTRIBUTE_COUNT_LIMIT`) — collectors and backends
+ * start to push back well before this limit, so we cap eagerly and surface the
+ * overflow via `droppedAttributesCount`.
+ *
+ * Spec: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#logrecord-limits
  */
 private const val MAX_ATTRIBUTE_COUNT = 128
 
@@ -60,7 +60,7 @@ internal fun sanitizeLogEventAttributes(attributes: Map<String, Any?>?): Sanitiz
     return SanitizedLogAttributes(attributes = null, droppedCount = 0)
   }
 
-  val sanitized = LinkedHashMap<String, Any?>()
+  val sanitized = mutableMapOf<String, Any?>()
   var emptyKeyDrops = 0
   val reservedKeyDrops = mutableListOf<String>()
 
@@ -85,9 +85,9 @@ internal fun sanitizeLogEventAttributes(attributes: Map<String, Any?>?): Sanitiz
   // genuinely needs >128 attributes should split them across multiple events.
   var overflowDrops = 0
   if (sanitized.size > MAX_ATTRIBUTE_COUNT) {
-    val keptKeys = sanitized.keys.sorted().take(MAX_ATTRIBUTE_COUNT).toSet()
-    overflowDrops = sanitized.size - MAX_ATTRIBUTE_COUNT
-    sanitized.keys.toList().forEach { k -> if (k !in keptKeys) sanitized.remove(k) }
+    val droppedKeys = sanitized.keys.sorted().drop(MAX_ATTRIBUTE_COUNT).toSet()
+    overflowDrops = droppedKeys.size
+    sanitized.keys.removeAll(droppedKeys)
   }
 
   if (emptyKeyDrops > 0) {
@@ -123,26 +123,5 @@ internal fun sanitizeLogEventAttributes(attributes: Map<String, Any?>?): Sanitiz
  * time will skip them and add to `droppedAttributesCount` accordingly.
  */
 internal fun attributesToJsonObject(attributes: Map<String, Any?>): JsonObject {
-  return JsonObject(attributes.mapValues { (_, value) -> anyToJsonElement(value) })
-}
-
-private fun anyToJsonElement(value: Any?): JsonElement {
-  return when (value) {
-    null -> JsonNull
-    is Boolean -> JsonPrimitive(value)
-    is Int -> JsonPrimitive(value)
-    is Long -> JsonPrimitive(value)
-    is Double -> if (value.isFinite()) JsonPrimitive(value) else JsonNull
-    is Float -> if (value.isFinite()) JsonPrimitive(value.toDouble()) else JsonNull
-    is Number -> JsonPrimitive(value.toDouble())
-    is String -> JsonPrimitive(value)
-    is Map<*, *> -> JsonObject(
-      value.entries
-        .filter { it.key is String }
-        .associate { (k, v) -> (k as String) to anyToJsonElement(v) }
-    )
-    is List<*> -> JsonArray(value.map { anyToJsonElement(it) })
-    is Array<*> -> JsonArray(value.map { anyToJsonElement(it) })
-    else -> JsonNull
-  }
+  return JsonObject(attributes.mapValues { (_, value) -> JsonAny.toElement(value) })
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/EventBodyValidation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/EventBodyValidation.kt
@@ -1,0 +1,38 @@
+package expo.modules.appmetrics.logevents
+
+import android.util.Log
+import expo.modules.appmetrics.TAG
+
+/**
+ * Maximum length of a log event body in characters. Bodies longer than this are
+ * truncated rather than dropped, preserving the prefix (most useful for "what
+ * happened") and appending an ellipsis suffix so consumers can tell the value
+ * was cut. Mirrors the OTel `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` default.
+ */
+private const val MAX_EVENT_BODY_LENGTH = 4096
+
+/**
+ * Suffix appended to truncated bodies. Single character so the prefix stays
+ * close to the original length budget.
+ */
+private const val TRUNCATION_SUFFIX = "…"
+
+/**
+ * Truncates a caller-provided log event body to `MAX_EVENT_BODY_LENGTH` characters,
+ * logging a warning when truncation happens. Returns `null` for `null` input so
+ * the call site can pass the result through unchanged.
+ */
+internal fun validateEventBody(body: String?): String? {
+  if (body == null) {
+    return null
+  }
+  if (body.length <= MAX_EVENT_BODY_LENGTH) {
+    return body
+  }
+  val truncated = body.substring(0, MAX_EVENT_BODY_LENGTH - TRUNCATION_SUFFIX.length) + TRUNCATION_SUFFIX
+  Log.w(
+    TAG,
+    "[AppMetrics] logEvent truncated body from ${body.length} characters to the $MAX_EVENT_BODY_LENGTH-character limit."
+  )
+  return truncated
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/EventBodyValidation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/EventBodyValidation.kt
@@ -4,10 +4,15 @@ import android.util.Log
 import expo.modules.appmetrics.TAG
 
 /**
- * Maximum length of a log event body in characters. Bodies longer than this are
- * truncated rather than dropped, preserving the prefix (most useful for "what
- * happened") and appending an ellipsis suffix so consumers can tell the value
- * was cut. Mirrors the OTel `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` default.
+ * Maximum length of a log event body, measured in UTF-16 code units (Kotlin
+ * `String.length`). Bodies longer than this are truncated rather than dropped,
+ * preserving the prefix (most useful for "what happened") and appending an
+ * ellipsis suffix so consumers can tell the value was cut.
+ *
+ * The OTel spec leaves the equivalent log-record body limit unset by default
+ * (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/configuration/sdk-environment-variables.md#logrecord-limits);
+ * 4096 is our own cap, chosen to match the SDK's default
+ * `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT` for symmetry with attribute values.
  */
 private const val MAX_EVENT_BODY_LENGTH = 4096
 

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/EventNameValidation.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/EventNameValidation.kt
@@ -1,0 +1,47 @@
+package expo.modules.appmetrics.logevents
+
+import android.util.Log
+import expo.modules.appmetrics.TAG
+
+/**
+ * Prefix reserved for internal Expo event names. Callers cannot use it so SDK-emitted
+ * events stay distinguishable from app-emitted ones in the backend.
+ */
+private const val RESERVED_EVENT_NAME_PREFIX = "expo."
+
+/**
+ * Maximum length of a log event name in characters. Names beyond this length are
+ * dropped with a warning — most log backends balk on very long names and a runaway
+ * template literal can easily blow past a few hundred characters by accident.
+ */
+private const val MAX_EVENT_NAME_LENGTH = 256
+
+/**
+ * Validates and normalizes a caller-provided log event name.
+ *
+ * Returns the trimmed name on success, or `null` when the name should be rejected.
+ * In the rejection case, a warning is logged explaining why so the developer can
+ * fix the call site without the app crashing over a telemetry concern.
+ */
+internal fun validateEventName(name: String): String? {
+  val trimmedName = name.trim()
+  if (trimmedName.isEmpty()) {
+    Log.w(TAG, "[AppMetrics] logEvent dropped: event name must not be empty.")
+    return null
+  }
+  if (trimmedName.startsWith(RESERVED_EVENT_NAME_PREFIX)) {
+    Log.w(
+      TAG,
+      "[AppMetrics] logEvent dropped: event name `$trimmedName` uses the reserved `expo.` prefix."
+    )
+    return null
+  }
+  if (trimmedName.length > MAX_EVENT_NAME_LENGTH) {
+    Log.w(
+      TAG,
+      "[AppMetrics] logEvent dropped: event name is ${trimmedName.length} characters long, exceeding the $MAX_EVENT_NAME_LENGTH-character limit."
+    )
+    return null
+  }
+  return trimmedName
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/LogEventOptions.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/LogEventOptions.kt
@@ -1,0 +1,15 @@
+package expo.modules.appmetrics.logevents
+
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+
+/**
+ * Options accepted by the `logEvent` module function. The event name is
+ * passed as a separate positional argument and is therefore not part of this
+ * record.
+ */
+data class LogEventOptions(
+  @Field val body: String? = null,
+  @Field val attributes: Map<String, Any?>? = null,
+  @Field val severity: Severity? = null
+) : Record

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/Severity.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/Severity.kt
@@ -3,20 +3,31 @@ package expo.modules.appmetrics.logevents
 import expo.modules.kotlin.types.Enumerable
 
 /**
- * Severity of a log event. Each case carries its OpenTelemetry severity number
- * (see https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber)
- * and is sent as `severityText` (uppercased `rawValue`) on the wire.
- *
- * The `rawValue: String` constructor parameter is required by Expo's
- * `Enumerable` converter — it matches incoming JS strings against this value.
+ * Severity of a log event. The `rawValue: String` constructor parameter is the
+ * single field Expo's `Enumerable` converter inspects when coercing an incoming
+ * JS string, so it must stay the only primary-constructor argument. The
+ * matching OpenTelemetry severity number
+ * (https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber)
+ * is exposed via the `severityNumber` extension property below.
  */
-enum class Severity(val rawValue: String, val severityNumber: Int) : Enumerable {
-  TRACE("trace", 1),
-  DEBUG("debug", 5),
-  INFO("info", 9),
-  WARN("warn", 13),
-  ERROR("error", 17),
-  FATAL("fatal", 21);
+enum class Severity(val rawValue: String) : Enumerable {
+  TRACE("trace"),
+  DEBUG("debug"),
+  INFO("info"),
+  WARN("warn"),
+  ERROR("error"),
+  FATAL("fatal");
+
+  /** OpenTelemetry `severityNumber` value for this case. */
+  val severityNumber: Int
+    get() = when (this) {
+      TRACE -> 1
+      DEBUG -> 5
+      INFO -> 9
+      WARN -> 13
+      ERROR -> 17
+      FATAL -> 21
+    }
 
   /** Severity text suitable for the OpenTelemetry `severityText` field. */
   val severityText: String

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/Severity.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/Severity.kt
@@ -1,0 +1,42 @@
+package expo.modules.appmetrics.logevents
+
+import expo.modules.kotlin.types.Enumerable
+
+/**
+ * Severity of a log event. Each case carries its OpenTelemetry severity number
+ * via `severityNumber` and is sent as `severityText` (uppercased) on the wire.
+ *
+ * The single `rawValue: String` constructor parameter is required by Expo's
+ * `Enumerable` converter — it matches incoming JS strings against this value.
+ */
+enum class Severity(val rawValue: String) : Enumerable {
+  TRACE("trace"),
+  DEBUG("debug"),
+  INFO("info"),
+  WARN("warn"),
+  ERROR("error"),
+  FATAL("fatal");
+
+  /**
+   * OpenTelemetry severity number that matches this case.
+   * See https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber.
+   */
+  val severityNumber: Int
+    get() = when (this) {
+      TRACE -> 1
+      DEBUG -> 5
+      INFO -> 9
+      WARN -> 13
+      ERROR -> 17
+      FATAL -> 21
+    }
+
+  /** Severity text suitable for the OpenTelemetry `severityText` field. */
+  val severityText: String
+    get() = rawValue.uppercase()
+
+  companion object {
+    fun fromRawValue(value: String?): Severity? =
+      value?.let { raw -> entries.firstOrNull { it.rawValue == raw } }
+  }
+}

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/Severity.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/logevents/Severity.kt
@@ -4,32 +4,19 @@ import expo.modules.kotlin.types.Enumerable
 
 /**
  * Severity of a log event. Each case carries its OpenTelemetry severity number
- * via `severityNumber` and is sent as `severityText` (uppercased) on the wire.
+ * (see https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber)
+ * and is sent as `severityText` (uppercased `rawValue`) on the wire.
  *
- * The single `rawValue: String` constructor parameter is required by Expo's
+ * The `rawValue: String` constructor parameter is required by Expo's
  * `Enumerable` converter — it matches incoming JS strings against this value.
  */
-enum class Severity(val rawValue: String) : Enumerable {
-  TRACE("trace"),
-  DEBUG("debug"),
-  INFO("info"),
-  WARN("warn"),
-  ERROR("error"),
-  FATAL("fatal");
-
-  /**
-   * OpenTelemetry severity number that matches this case.
-   * See https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber.
-   */
-  val severityNumber: Int
-    get() = when (this) {
-      TRACE -> 1
-      DEBUG -> 5
-      INFO -> 9
-      WARN -> 13
-      ERROR -> 17
-      FATAL -> 21
-    }
+enum class Severity(val rawValue: String, val severityNumber: Int) : Enumerable {
+  TRACE("trace", 1),
+  DEBUG("debug", 5),
+  INFO("info", 9),
+  WARN("warn", 13),
+  ERROR("error", 17),
+  FATAL("fatal", 21);
 
   /** Severity text suitable for the OpenTelemetry `severityText` field. */
   val severityText: String

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -146,18 +146,18 @@ data class SessionWithMetrics(
 )
 @Serializable
 data class LogRecord(
-  @PrimaryKey val logId: String = UUID.randomUUID().toString(),
-  val sessionId: String,
+  @PrimaryKey @Field val logId: String = UUID.randomUUID().toString(),
+  @Field val sessionId: String,
   // ISO 8601 date string
-  val timestamp: String,
-  val name: String,
-  val body: String? = null,
+  @Field val timestamp: String,
+  @Field val name: String,
+  @Field val body: String? = null,
   // Lowercase severity case name (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).
-  val severity: String,
+  @Field val severity: String,
   // JSON string. Typed encoding happens at OTel time, not at storage time.
-  val attributes: String? = null,
-  val droppedAttributesCount: Int = 0
-)
+  @Field val attributes: String? = null,
+  @Field val droppedAttributesCount: Int = 0
+) : Record
 
 data class SessionWithLogs(
   @Embedded val session: Session,

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -146,27 +146,27 @@ data class SessionWithMetrics(
 )
 @Serializable
 data class LogRecord(
-  @PrimaryKey @Field val logId: String = UUID.randomUUID().toString(),
-  @Field val sessionId: String,
+  @PrimaryKey val logId: String = UUID.randomUUID().toString(),
+  val sessionId: String,
   // ISO 8601 date string
-  @Field val timestamp: String,
-  @Field val name: String,
-  @Field val body: String? = null,
+  val timestamp: String,
+  val name: String,
+  val body: String? = null,
   // Lowercase severity case name (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).
-  @Field val severity: String,
+  val severity: String,
   // JSON string. Typed encoding happens at OTel time, not at storage time.
-  @Field val attributes: String? = null,
-  @Field val droppedAttributesCount: Int = 0
-) : Record
+  val attributes: String? = null,
+  val droppedAttributesCount: Int = 0
+)
 
 data class SessionWithLogs(
-  @Field @Embedded val session: Session,
+  @Embedded val session: Session,
   @Relation(
     parentColumn = "id",
     entityColumn = "sessionId"
   )
-  @Field val logs: List<LogRecord>
-) : Record
+  val logs: List<LogRecord>
+)
 
 @Dao
 interface MetricDao {

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/MetricsDatabase.kt
@@ -25,12 +25,14 @@ object MetricsConstants {
 }
 
 @Database(
-  entities = [Metric::class, Session::class],
-  version = 14,
+  entities = [Metric::class, LogRecord::class, Session::class],
+  version = 15,
   exportSchema = false
 )
 abstract class MetricsDatabase : RoomDatabase() {
   abstract fun metricDao(): MetricDao
+
+  abstract fun logDao(): LogDao
 
   abstract fun sessionDao(): SessionDao
 
@@ -122,7 +124,48 @@ data class SessionWithMetrics(
     parentColumn = "id",
     entityColumn = "sessionId"
   )
-  @Field val metrics: List<Metric>
+  @Field val metrics: List<Metric>,
+  @Relation(
+    parentColumn = "id",
+    entityColumn = "sessionId"
+  )
+  @Field val logs: List<LogRecord> = emptyList()
+) : Record
+
+@Entity(
+  tableName = "logs",
+  indices = [Index("sessionId")],
+  foreignKeys = [
+    ForeignKey(
+      entity = Session::class,
+      parentColumns = ["id"],
+      childColumns = ["sessionId"],
+      onDelete = ForeignKey.CASCADE
+    )
+  ]
+)
+@Serializable
+data class LogRecord(
+  @PrimaryKey @Field val logId: String = UUID.randomUUID().toString(),
+  @Field val sessionId: String,
+  // ISO 8601 date string
+  @Field val timestamp: String,
+  @Field val name: String,
+  @Field val body: String? = null,
+  // Lowercase severity case name (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).
+  @Field val severity: String,
+  // JSON string. Typed encoding happens at OTel time, not at storage time.
+  @Field val attributes: String? = null,
+  @Field val droppedAttributesCount: Int = 0
+) : Record
+
+data class SessionWithLogs(
+  @Field @Embedded val session: Session,
+  @Relation(
+    parentColumn = "id",
+    entityColumn = "sessionId"
+  )
+  @Field val logs: List<LogRecord>
 ) : Record
 
 @Dao
@@ -135,6 +178,18 @@ interface MetricDao {
 
   @Delete
   suspend fun delete(metrics: List<Metric>)
+}
+
+@Dao
+interface LogDao {
+  @Insert(onConflict = OnConflictStrategy.IGNORE)
+  suspend fun insertAll(logs: List<LogRecord>)
+
+  @Delete
+  suspend fun delete(logs: List<LogRecord>)
+
+  @Query("DELETE FROM logs WHERE timestamp < :cutoffTimestamp")
+  suspend fun deleteLogsOlderThan(cutoffTimestamp: String)
 }
 
 @Dao
@@ -194,4 +249,8 @@ interface SessionDao {
   @Transaction
   @Query("SELECT DISTINCT s.* FROM sessions s INNER JOIN metrics m ON s.id = m.sessionId WHERE m.metricId IN (:metricIds)")
   suspend fun getSessionsWithMetricsByMetricIds(metricIds: List<String>): List<SessionWithMetrics>
+
+  @Transaction
+  @Query("SELECT DISTINCT s.* FROM sessions s INNER JOIN logs l ON s.id = l.sessionId WHERE l.logId IN (:logIds)")
+  suspend fun getSessionsWithLogsByLogIds(logIds: List<String>): List<SessionWithLogs>
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionManager.kt
@@ -25,7 +25,12 @@ class SessionManager(
     suspend fun onMetricsInserted(metricIds: List<String>)
   }
 
+  fun interface LogsInsertListener {
+    suspend fun onLogsInserted(logIds: List<String>)
+  }
+
   private val metricsInsertListeners = CopyOnWriteArrayList<MetricsInsertListener>()
+  private val logsInsertListeners = CopyOnWriteArrayList<LogsInsertListener>()
 
   fun addMetricsInsertListener(listener: MetricsInsertListener) {
     metricsInsertListeners.add(listener)
@@ -33,6 +38,14 @@ class SessionManager(
 
   fun removeMetricsInsertListener(listener: MetricsInsertListener) {
     metricsInsertListeners.remove(listener)
+  }
+
+  fun addLogsInsertListener(listener: LogsInsertListener) {
+    logsInsertListeners.add(listener)
+  }
+
+  fun removeLogsInsertListener(listener: LogsInsertListener) {
+    logsInsertListeners.remove(listener)
   }
 
   fun createSessionId(): String = UUID.randomUUID().toString()
@@ -139,6 +152,27 @@ class SessionManager(
     database.sessionDao().deleteSessionsOlderThan(cutoffTimestamp)
   }
 
+  suspend fun addLogs(
+    logs: List<LogRecord>,
+    sessionId: String
+  ) {
+    val logsWithSession = logs.map { it.copy(sessionId = sessionId) }
+    database.logDao().insertAll(logsWithSession)
+    val logIds = logsWithSession.map { it.logId }
+    logsInsertListeners.forEach { listener ->
+      try {
+        listener.onLogsInserted(logIds)
+      } catch (e: Exception) {
+        Log.e(TAG, "LogsInsertListener failed", e)
+      }
+    }
+  }
+
+  suspend fun cleanupOldLogs() {
+    val cutoffTimestamp = TimeUtils.getTimestampInISOFormatFromPast(MetricsConstants.SECONDS_TO_REMOVE_OLD_METRICS)
+    database.logDao().deleteLogsOlderThan(cutoffTimestamp)
+  }
+
   suspend fun updateEnvironmentForActiveSessions(environment: String) {
     database.sessionDao().updateEnvironmentForActiveSessions(environment)
   }
@@ -163,6 +197,30 @@ class SessionManager(
             .flatMap { it.metrics }
             .distinctBy { it.metricId }
             .filter { it.metricId in metricIdSet }
+        )
+      }
+  }
+
+  suspend fun getSessionsWithLogs(logIds: List<String>): List<SessionWithLogs> {
+    val logIdSet = logIds.toSet()
+    if (logIds.size <= SQLITE_MAX_BIND_VARIABLES) {
+      return database.sessionDao().getSessionsWithLogsByLogIds(logIds).map { sessionWithLogs ->
+        sessionWithLogs.copy(logs = sessionWithLogs.logs.filter { it.logId in logIdSet })
+      }
+    }
+
+    val allResults = logIds.chunked(SQLITE_MAX_BIND_VARIABLES).flatMap { chunk ->
+      database.sessionDao().getSessionsWithLogsByLogIds(chunk)
+    }
+    return allResults
+      .groupBy { it.session.id }
+      .map { (_, sessions) ->
+        SessionWithLogs(
+          session = sessions.first().session,
+          logs = sessions
+            .flatMap { it.logs }
+            .distinctBy { it.logId }
+            .filter { it.logId in logIdSet }
         )
       }
   }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
@@ -74,17 +74,17 @@ data class JsMetric(
  * JS-facing shape of a log event. Mirrors the TypeScript `LogRecord` type and
  * decodes the storage-only JSON `attributes` column into a typed map.
  *
- * `logId` and `sessionId` are storage-only — JS consumers see the record under
- * its parent `Session.logs`, so the parent ID is implicit and the row's
- * primary key isn't useful.
+ * `logId`, `sessionId`, and `droppedAttributesCount` are storage- and
+ * dispatch-side concerns: JS consumers see the record under its parent
+ * `Session.logs` (so the parent ID is implicit), and the dropped-attribute
+ * bookkeeping is only meaningful on the OTel wire payload.
  */
 data class JsLogRecord(
   @Field val timestamp: String,
   @Field val name: String,
   @Field val body: String?,
   @Field val severity: String,
-  @Field val attributes: Map<String, Any?>?,
-  @Field val droppedAttributesCount: Int
+  @Field val attributes: Map<String, Any?>?
 ) : Record {
   companion object {
     fun fromLogRecord(log: LogRecord): JsLogRecord =
@@ -93,8 +93,7 @@ data class JsLogRecord(
         name = log.name,
         body = log.body,
         severity = log.severity,
-        attributes = decodeJsonObject(log.attributes),
-        droppedAttributesCount = log.droppedAttributesCount
+        attributes = decodeJsonObject(log.attributes)
       )
   }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
@@ -28,9 +28,7 @@ data class JsSession(
   @Field val startDate: String,
   @Field val endDate: String?,
   @Field val metrics: List<JsMetric>,
-  // Android doesn't collect log events yet; emitted as an empty list so
-  // consumers can rely on the same shape iOS produces.
-  @Field val logs: List<Any> = emptyList()
+  @Field val logs: List<JsLogRecord>
 ) : Record {
   companion object {
     fun fromSessionWithMetrics(value: SessionWithMetrics): JsSession =
@@ -39,7 +37,8 @@ data class JsSession(
         type = "main",
         startDate = value.session.startTimestamp,
         endDate = value.session.endTimestamp,
-        metrics = value.metrics.map { JsMetric.fromMetric(it) }
+        metrics = value.metrics.map { JsMetric.fromMetric(it) },
+        logs = value.logs.map { JsLogRecord.fromLogRecord(it) }
       )
   }
 }
@@ -67,6 +66,35 @@ data class JsMetric(
         routeName = metric.routeName,
         updateId = metric.updateId,
         params = decodeJsonObject(metric.params)
+      )
+  }
+}
+
+/**
+ * JS-facing shape of a log event. Mirrors the TypeScript `LogRecord` type and
+ * decodes the storage-only JSON `attributes` column into a typed map.
+ */
+data class JsLogRecord(
+  @Field val logId: String,
+  @Field val sessionId: String,
+  @Field val timestamp: String,
+  @Field val name: String,
+  @Field val body: String?,
+  @Field val severity: String,
+  @Field val attributes: Map<String, Any?>?,
+  @Field val droppedAttributesCount: Int
+) : Record {
+  companion object {
+    fun fromLogRecord(log: LogRecord): JsLogRecord =
+      JsLogRecord(
+        logId = log.logId,
+        sessionId = log.sessionId,
+        timestamp = log.timestamp,
+        name = log.name,
+        body = log.body,
+        severity = log.severity,
+        attributes = decodeJsonObject(log.attributes),
+        droppedAttributesCount = log.droppedAttributesCount
       )
   }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
@@ -1,16 +1,11 @@
 package expo.modules.appmetrics.storage
 
+import expo.modules.appmetrics.utils.JsonAny
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.doubleOrNull
-import kotlinx.serialization.json.longOrNull
 
 /**
  * JS-facing shape of a session. Field names mirror the TypeScript `Session`
@@ -113,22 +108,6 @@ private fun decodeJsonObject(jsonString: String?): Map<String, Any?>? {
     if (element !is JsonObject) {
       return@runCatching null
     }
-    element.mapValues { (_, v) -> jsonElementToAny(v) }
+    element.mapValues { (_, v) -> JsonAny.fromElement(v) }
   }.getOrNull()
-}
-
-private fun jsonElementToAny(element: JsonElement): Any? {
-  return when (element) {
-    is JsonNull -> null
-    is JsonPrimitive -> when {
-      element.isString -> element.content
-      else ->
-        element.booleanOrNull
-          ?: element.longOrNull
-          ?: element.doubleOrNull
-          ?: element.content
-    }
-    is JsonObject -> element.mapValues { (_, v) -> jsonElementToAny(v) }
-    is JsonArray -> element.map { jsonElementToAny(it) }
-  }
 }

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/storage/SessionMappers.kt
@@ -73,10 +73,12 @@ data class JsMetric(
 /**
  * JS-facing shape of a log event. Mirrors the TypeScript `LogRecord` type and
  * decodes the storage-only JSON `attributes` column into a typed map.
+ *
+ * `logId` and `sessionId` are storage-only — JS consumers see the record under
+ * its parent `Session.logs`, so the parent ID is implicit and the row's
+ * primary key isn't useful.
  */
 data class JsLogRecord(
-  @Field val logId: String,
-  @Field val sessionId: String,
   @Field val timestamp: String,
   @Field val name: String,
   @Field val body: String?,
@@ -87,8 +89,6 @@ data class JsLogRecord(
   companion object {
     fun fromLogRecord(log: LogRecord): JsLogRecord =
       JsLogRecord(
-        logId = log.logId,
-        sessionId = log.sessionId,
         timestamp = log.timestamp,
         name = log.name,
         body = log.body,

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/JsonAny.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/utils/JsonAny.kt
@@ -1,0 +1,59 @@
+package expo.modules.appmetrics.utils
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * Bidirectional converters between caller-supplied `Map<String, Any?>` (typed
+ * Kotlin primitives) and `JsonElement` (storage form). The two operations
+ * are inverses; keeping them together prevents the encode/decode rules from
+ * drifting apart.
+ *
+ * Decode is best-effort — values whose type cannot be represented in the OTLP
+ * `AnyValue` shape (e.g. `Date`, NaN/Infinity doubles) are encoded as JSON
+ * `null`, and the dispatch-time encoder folds them into
+ * `droppedAttributesCount`.
+ */
+object JsonAny {
+  fun toElement(value: Any?): JsonElement {
+    return when (value) {
+      null -> JsonNull
+      is Boolean -> JsonPrimitive(value)
+      is Int -> JsonPrimitive(value)
+      is Long -> JsonPrimitive(value)
+      is Double -> if (value.isFinite()) JsonPrimitive(value) else JsonNull
+      is Float -> if (value.isFinite()) JsonPrimitive(value.toDouble()) else JsonNull
+      is Number -> JsonPrimitive(value.toDouble())
+      is String -> JsonPrimitive(value)
+      is Map<*, *> -> JsonObject(
+        value.entries
+          .filter { it.key is String }
+          .associate { (k, v) -> (k as String) to toElement(v) }
+      )
+      is List<*> -> JsonArray(value.map { toElement(it) })
+      is Array<*> -> JsonArray(value.map { toElement(it) })
+      else -> JsonNull
+    }
+  }
+
+  fun fromElement(element: JsonElement): Any? {
+    return when (element) {
+      is JsonNull -> null
+      is JsonPrimitive -> when {
+        element.isString -> element.content
+        else -> element.booleanOrNull
+          ?: element.longOrNull
+          ?: element.doubleOrNull
+          ?: element.content
+      }
+      is JsonObject -> element.mapValues { (_, v) -> fromElement(v) }
+      is JsonArray -> element.map { fromElement(it) }
+    }
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/AttributeValidationTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/AttributeValidationTest.kt
@@ -1,0 +1,151 @@
+package expo.modules.appmetrics.logevents
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class AttributeValidationTest {
+  @Test
+  fun `returns null when input is null`() {
+    val result = sanitizeLogEventAttributes(null)
+    assertNull(result.attributes)
+    assertEquals(0, result.droppedCount)
+  }
+
+  @Test
+  fun `passes through normal attributes unchanged`() {
+    val result = sanitizeLogEventAttributes(mapOf("userId" to "u_42", "attempt" to 2))
+    assertEquals(0, result.droppedCount)
+    val attributes = result.attributes!!
+    assertEquals(2, attributes.size)
+    assertEquals("u_42", attributes["userId"])
+    assertEquals(2, attributes["attempt"])
+  }
+
+  @Test
+  fun `trims whitespace from valid keys`() {
+    val result = sanitizeLogEventAttributes(mapOf("  userId  " to "u_42"))
+    assertEquals(0, result.droppedCount)
+    val attributes = result.attributes!!
+    assertEquals("u_42", attributes["userId"])
+    assertNull(attributes["  userId  "])
+  }
+
+  @Test
+  fun `drops empty and whitespace-only keys`() {
+    val result = sanitizeLogEventAttributes(
+      mapOf("" to "x", "   " to "y", "valid" to "z")
+    )
+    assertEquals(2, result.droppedCount)
+    val attributes = result.attributes!!
+    assertEquals(1, attributes.size)
+    assertEquals("z", attributes["valid"])
+  }
+
+  @Test
+  fun `drops keys under the reserved expo namespace`() {
+    val result = sanitizeLogEventAttributes(
+      mapOf(
+        "expo.app.name" to "spoofed",
+        "expo.eas_client.id" to "spoofed",
+        "userId" to "u_42"
+      )
+    )
+    assertEquals(2, result.droppedCount)
+    val attributes = result.attributes!!
+    assertEquals(1, attributes.size)
+    assertEquals("u_42", attributes["userId"])
+  }
+
+  @Test
+  fun `drops SDK-set OTel keys (event_name and session_id)`() {
+    val result = sanitizeLogEventAttributes(
+      mapOf(
+        "event.name" to "spoofed",
+        "session.id" to "spoofed",
+        "ok" to true
+      )
+    )
+    assertEquals(2, result.droppedCount)
+    val attributes = result.attributes!!
+    assertEquals(1, attributes.size)
+    assertEquals(true, attributes["ok"])
+  }
+
+  @Test
+  fun `applies reserved-prefix check after trimming whitespace`() {
+    val result = sanitizeLogEventAttributes(mapOf("  expo.foo  " to "x"))
+    assertEquals(1, result.droppedCount)
+    assertNull(result.attributes)
+  }
+
+  @Test
+  fun `applies SDK-set check after trimming whitespace`() {
+    val result = sanitizeLogEventAttributes(mapOf("  event.name  " to "x"))
+    assertEquals(1, result.droppedCount)
+    assertNull(result.attributes)
+  }
+
+  @Test
+  fun `does not match keys that merely start with a reserved word but aren't the namespace`() {
+    val result = sanitizeLogEventAttributes(
+      mapOf(
+        "expoFoo" to "ok",
+        "expo" to "ok",
+        "session.idx" to "ok",
+        "event.name.extra" to "ok"
+      )
+    )
+    assertEquals(0, result.droppedCount)
+    val attributes = result.attributes!!
+    assertEquals(4, attributes.size)
+  }
+
+  @Test
+  fun `caps attributes at 128 entries and reports the overflow`() {
+    val input = LinkedHashMap<String, Any?>()
+    for (i in 0 until 200) {
+      // Pad keys so sort order is deterministic and predictable.
+      input[String.format("k%03d", i)] = i
+    }
+    val result = sanitizeLogEventAttributes(input)
+    assertEquals(72, result.droppedCount)
+    val attributes = result.attributes!!
+    assertEquals(128, attributes.size)
+    // Sorted-ascending kept set means the first 128 keys (k000…k127) survive.
+    assertEquals(0, attributes["k000"])
+    assertEquals(127, attributes["k127"])
+    assertNull(attributes["k128"])
+  }
+
+  @Test
+  fun `returns null attributes when every entry is dropped`() {
+    val result = sanitizeLogEventAttributes(
+      mapOf("expo.foo" to "x", "expo.bar" to "y")
+    )
+    assertNull(result.attributes)
+    assertEquals(2, result.droppedCount)
+  }
+
+  @Test
+  fun `combines multiple drop categories in the count`() {
+    val result = sanitizeLogEventAttributes(
+      mapOf(
+        "" to "empty-key-drop",
+        "expo.foo" to "namespace-drop",
+        "session.id" to "sdk-drop",
+        "valid" to "ok"
+      )
+    )
+    assertEquals(3, result.droppedCount)
+    val attributes = result.attributes!!
+    assertEquals(1, attributes.size)
+    assertEquals("ok", attributes["valid"])
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/EventBodyValidationTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/EventBodyValidationTest.kt
@@ -1,0 +1,52 @@
+package expo.modules.appmetrics.logevents
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class EventBodyValidationTest {
+  @Test
+  fun `returns null when input is null`() {
+    assertNull(validateEventBody(null))
+  }
+
+  @Test
+  fun `passes through a short body unchanged`() {
+    assertEquals("hello", validateEventBody("hello"))
+  }
+
+  @Test
+  fun `passes through a body exactly at the cap`() {
+    val atLimit = "a".repeat(4096)
+    assertEquals(atLimit, validateEventBody(atLimit))
+  }
+
+  @Test
+  fun `truncates a body just past the cap`() {
+    val oversized = "a".repeat(4097)
+    val result = validateEventBody(oversized)!!
+    assertEquals(4096, result.length)
+    assertTrue(result.endsWith("…"))
+  }
+
+  @Test
+  fun `truncates a long body and appends the ellipsis`() {
+    val oversized = "x".repeat(10_000)
+    val result = validateEventBody(oversized)!!
+    assertEquals(4096, result.length)
+    assertTrue(result.endsWith("…"))
+    // Prefix is preserved (start of the original body survives).
+    assertTrue(result.startsWith("xxxx"))
+  }
+
+  @Test
+  fun `passes through an empty body`() {
+    assertEquals("", validateEventBody(""))
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/EventNameValidationTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/logevents/EventNameValidationTest.kt
@@ -1,0 +1,56 @@
+package expo.modules.appmetrics.logevents
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class EventNameValidationTest {
+  @Test
+  fun `accepts a regular name and returns it unchanged`() {
+    assertEquals("auth.login_failed", validateEventName("auth.login_failed"))
+  }
+
+  @Test
+  fun `trims surrounding whitespace`() {
+    assertEquals("user.signed_in", validateEventName("  user.signed_in\n"))
+  }
+
+  @Test
+  fun `rejects an empty name`() {
+    assertNull(validateEventName(""))
+  }
+
+  @Test
+  fun `rejects a whitespace-only name`() {
+    assertNull(validateEventName("   \t\n"))
+  }
+
+  @Test
+  fun `rejects names that use the reserved expo prefix`() {
+    assertNull(validateEventName("expo.app_startup.tti"))
+    assertNull(validateEventName("expo.something"))
+  }
+
+  @Test
+  fun `accepts names containing 'expo' as long as it isn't the prefix`() {
+    assertEquals("my_expo.event", validateEventName("my_expo.event"))
+    assertEquals("app.expo.thing", validateEventName("app.expo.thing"))
+  }
+
+  @Test
+  fun `rejects names longer than the cap`() {
+    val oversized = "a".repeat(257)
+    assertNull(validateEventName(oversized))
+  }
+
+  @Test
+  fun `accepts names exactly at the cap`() {
+    val atLimit = "a".repeat(256)
+    assertEquals(atLimit, validateEventName(atLimit))
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionManagerTest.kt
@@ -599,6 +599,32 @@ class SessionManagerTest {
       assertEquals(600, s2.metrics.size)
     }
 
+  @Test
+  fun `getSessionsWithMetrics yields empty logs from the chunked merger path`() =
+    runTest {
+      // Arrange — the chunked-merger branch in `getSessionsWithMetrics`
+      // constructs `SessionWithMetrics(...)` without passing logs and relies on
+      // the `= emptyList()` default. The session DOES have logs in storage,
+      // but the merger projects metrics-only. This test fails loudly if the
+      // default is removed or the merger ever needs to surface logs too.
+      val sessionId = "session-with-logs"
+      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
+
+      val metricIds = (1..1100).map { "metric-$it" }
+      metricIds.chunked(500).forEach { chunk ->
+        database.metricDao().insertAll(chunk.map { createMetric(it, sessionId) })
+      }
+      // Also insert logs so an accidental relation-load would surface them.
+      database.logDao().insertAll(listOf(createLog("log-a", sessionId)))
+
+      // Act — 1100 IDs forces the chunked path
+      val result = sessionManager.getSessionsWithMetrics(metricIds)
+
+      // Assert
+      assertEquals(1, result.size)
+      assertEquals(emptyList<LogRecord>(), result[0].logs)
+    }
+
   // endregion
 
   // region Data Cleanup Tests
@@ -694,6 +720,56 @@ class SessionManagerTest {
       assertTrue("fresh stopped session should be preserved", remaining.contains(freshStoppedId))
     }
 
+  @Test
+  fun `getAllSessions populates the logs relation alongside metrics`() =
+    runTest {
+      // Arrange — exercises the Room `@Relation` for `LogRecord` end-to-end.
+      // Unit-level mapper tests construct `SessionWithMetrics` directly and
+      // never hit the DAO, so this is the only path that catches a schema or
+      // foreign-key misconfiguration.
+      val sessionId = "session-with-mixed-events"
+      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
+      database.metricDao().insertAll(
+        listOf(
+          createMetric("metric-a", sessionId),
+          createMetric("metric-b", sessionId)
+        )
+      )
+      database.logDao().insertAll(
+        listOf(
+          createLog("log-a", sessionId, name = "auth.login_failed", severity = "warn"),
+          createLog("log-b", sessionId, name = "user.signed_in", severity = "info"),
+          createLog("log-c", sessionId, name = "cache.miss", severity = "debug")
+        )
+      )
+
+      // Act
+      val sessions = sessionManager.getAllSessions()
+
+      // Assert
+      val session = sessions.single { it.session.id == sessionId }
+      assertEquals(2, session.metrics.size)
+      assertEquals(3, session.logs.size)
+      assertEquals(setOf("log-a", "log-b", "log-c"), session.logs.map { it.logId }.toSet())
+    }
+
+  @Test
+  fun `getAllSessions yields an empty logs list when no logs exist for the session`() =
+    runTest {
+      // Arrange — a session with metrics but no logs. The relation should
+      // populate as an empty list, not null.
+      val sessionId = "session-no-logs"
+      sessionManager.startSessionWithIdAt(sessionId, "2025-01-01T00:00:00.000Z")
+      database.metricDao().insertAll(listOf(createMetric("metric-1", sessionId)))
+
+      // Act
+      val sessions = sessionManager.getAllSessions()
+
+      // Assert
+      val session = sessions.single { it.session.id == sessionId }
+      assertEquals(emptyList<LogRecord>(), session.logs)
+    }
+
   // endregion
 
   // region Helper Methods
@@ -714,6 +790,24 @@ class SessionManagerTest {
       value = value,
       routeName = null,
       params = null
+    )
+
+  private fun createLog(
+    logId: String,
+    sessionId: String,
+    name: String = "test.event",
+    severity: String = "info",
+    attributes: String? = null
+  ): LogRecord =
+    LogRecord(
+      logId = logId,
+      sessionId = sessionId,
+      timestamp = "2025-01-01T00:00:00.000Z",
+      name = name,
+      body = null,
+      severity = severity,
+      attributes = attributes,
+      droppedAttributesCount = 0
     )
 
   private fun createTestMetadata(

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
@@ -39,8 +39,7 @@ class SessionMappersTest {
     logId: String = "log-1",
     sessionId: String = "session-1",
     name: String = "auth.login_failed",
-    attributes: String? = null,
-    droppedAttributesCount: Int = 0
+    attributes: String? = null
   ): LogRecord = LogRecord(
     logId = logId,
     sessionId = sessionId,
@@ -48,8 +47,7 @@ class SessionMappersTest {
     name = name,
     body = "invalid_credentials",
     severity = "warn",
-    attributes = attributes,
-    droppedAttributesCount = droppedAttributesCount
+    attributes = attributes
   )
 
   @Test
@@ -164,13 +162,12 @@ class SessionMappersTest {
 
   @Test
   fun `JsLogRecord_fromLogRecord copies scalar fields verbatim`() {
-    val js = JsLogRecord.fromLogRecord(makeLog(droppedAttributesCount = 3))
+    val js = JsLogRecord.fromLogRecord(makeLog())
 
     assertEquals("auth.login_failed", js.name)
     assertEquals("invalid_credentials", js.body)
     assertEquals("warn", js.severity)
     assertEquals("2025-01-01T00:00:02.000Z", js.timestamp)
-    assertEquals(3, js.droppedAttributesCount)
   }
 
   @Test

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
@@ -38,13 +38,14 @@ class SessionMappersTest {
   private fun makeLog(
     logId: String = "log-1",
     sessionId: String = "session-1",
+    name: String = "auth.login_failed",
     attributes: String? = null,
     droppedAttributesCount: Int = 0
   ): LogRecord = LogRecord(
     logId = logId,
     sessionId = sessionId,
     timestamp = "2025-01-01T00:00:02.000Z",
-    name = "auth.login_failed",
+    name = name,
     body = "invalid_credentials",
     severity = "warn",
     attributes = attributes,
@@ -123,16 +124,16 @@ class SessionMappersTest {
       session = makeSession(),
       metrics = emptyList(),
       logs = listOf(
-        makeLog(logId = "l-1"),
-        makeLog(logId = "l-2")
+        makeLog(logId = "l-1", name = "first.event"),
+        makeLog(logId = "l-2", name = "second.event")
       )
     )
 
     val js = JsSession.fromSessionWithMetrics(swm)
 
     assertEquals(2, js.logs.size)
-    assertEquals("l-1", js.logs[0].logId)
-    assertEquals("l-2", js.logs[1].logId)
+    assertEquals("first.event", js.logs[0].name)
+    assertEquals("second.event", js.logs[1].name)
   }
 
   @Test
@@ -163,10 +164,8 @@ class SessionMappersTest {
 
   @Test
   fun `JsLogRecord_fromLogRecord copies scalar fields verbatim`() {
-    val js = JsLogRecord.fromLogRecord(makeLog(logId = "l-42", droppedAttributesCount = 3))
+    val js = JsLogRecord.fromLogRecord(makeLog(droppedAttributesCount = 3))
 
-    assertEquals("l-42", js.logId)
-    assertEquals("session-1", js.sessionId)
     assertEquals("auth.login_failed", js.name)
     assertEquals("invalid_credentials", js.body)
     assertEquals("warn", js.severity)

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/storage/SessionMappersTest.kt
@@ -35,6 +35,22 @@ class SessionMappersTest {
     params = params
   )
 
+  private fun makeLog(
+    logId: String = "log-1",
+    sessionId: String = "session-1",
+    attributes: String? = null,
+    droppedAttributesCount: Int = 0
+  ): LogRecord = LogRecord(
+    logId = logId,
+    sessionId = sessionId,
+    timestamp = "2025-01-01T00:00:02.000Z",
+    name = "auth.login_failed",
+    body = "invalid_credentials",
+    severity = "warn",
+    attributes = attributes,
+    droppedAttributesCount = droppedAttributesCount
+  )
+
   @Test
   fun `JsSession_fromSessionWithMetrics exposes the JS-facing field names`() {
     val swm = SessionWithMetrics(
@@ -99,5 +115,89 @@ class SessionMappersTest {
     assertEquals("timeToInteractive", js.name)
     assertEquals(1.5, js.value, 0.0)
     assertEquals("2025-01-01T00:00:01.000Z", js.timestamp)
+  }
+
+  @Test
+  fun `JsSession_fromSessionWithMetrics surfaces stored logs`() {
+    val swm = SessionWithMetrics(
+      session = makeSession(),
+      metrics = emptyList(),
+      logs = listOf(
+        makeLog(logId = "l-1"),
+        makeLog(logId = "l-2")
+      )
+    )
+
+    val js = JsSession.fromSessionWithMetrics(swm)
+
+    assertEquals(2, js.logs.size)
+    assertEquals("l-1", js.logs[0].logId)
+    assertEquals("l-2", js.logs[1].logId)
+  }
+
+  @Test
+  fun `JsLogRecord_fromLogRecord decodes attributes from JSON`() {
+    val log = makeLog(attributes = """{"userId":"u_42","attempt":2,"retry":true}""")
+
+    val js = JsLogRecord.fromLogRecord(log)
+
+    val attributes = js.attributes
+    assertEquals("u_42", attributes?.get("userId"))
+    assertEquals(2L, attributes?.get("attempt"))
+    assertEquals(true, attributes?.get("retry"))
+  }
+
+  @Test
+  fun `JsLogRecord_fromLogRecord yields null attributes when storage column is null`() {
+    val js = JsLogRecord.fromLogRecord(makeLog(attributes = null))
+
+    assertNull(js.attributes)
+  }
+
+  @Test
+  fun `JsLogRecord_fromLogRecord yields null attributes when storage column is malformed JSON`() {
+    val js = JsLogRecord.fromLogRecord(makeLog(attributes = "{ this is not valid json"))
+
+    assertNull(js.attributes)
+  }
+
+  @Test
+  fun `JsLogRecord_fromLogRecord copies scalar fields verbatim`() {
+    val js = JsLogRecord.fromLogRecord(makeLog(logId = "l-42", droppedAttributesCount = 3))
+
+    assertEquals("l-42", js.logId)
+    assertEquals("session-1", js.sessionId)
+    assertEquals("auth.login_failed", js.name)
+    assertEquals("invalid_credentials", js.body)
+    assertEquals("warn", js.severity)
+    assertEquals("2025-01-01T00:00:02.000Z", js.timestamp)
+    assertEquals(3, js.droppedAttributesCount)
+  }
+
+  @Test
+  fun `JsLogRecord and JsMetric decode nested JSON objects identically`() {
+    // The shared `decodeJsonObject` helper handles both `params` and
+    // `attributes`. This test pins down behavior for a non-trivial nested
+    // payload so the two callers can't quietly drift.
+    val payload = """{"user":{"id":"u_42","prefs":{"theme":"dark"}},"tags":["a","b"]}"""
+
+    val metricResult = JsMetric.fromMetric(makeMetric(params = payload)).params
+    val logResult = JsLogRecord.fromLogRecord(makeLog(attributes = payload)).attributes
+
+    // Both should decode the nested user object the same way.
+    @Suppress("UNCHECKED_CAST")
+    val metricUser = metricResult?.get("user") as? Map<String, Any?>
+    @Suppress("UNCHECKED_CAST")
+    val logUser = logResult?.get("user") as? Map<String, Any?>
+    assertEquals(metricUser, logUser)
+    assertEquals("u_42", metricUser?.get("id"))
+
+    @Suppress("UNCHECKED_CAST")
+    val prefs = metricUser?.get("prefs") as? Map<String, Any?>
+    assertEquals("dark", prefs?.get("theme"))
+
+    // And arrays decode identically too.
+    assertEquals(listOf("a", "b"), metricResult?.get("tags"))
+    assertEquals(metricResult?.get("tags"), logResult?.get("tags"))
   }
 }

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -165,12 +165,6 @@ export type LogRecord = {
    * Severity of the event.
    */
   severity: LogSeverity;
-  /**
-   * Number of attributes the SDK dropped while accepting this record (caller
-   * tried to use a reserved key, exceeded the per-record cap, etc.). `0` when
-   * nothing was dropped.
-   */
-  droppedAttributesCount: number;
 };
 
 /**

--- a/packages/expo-app-metrics/src/types.ts
+++ b/packages/expo-app-metrics/src/types.ts
@@ -165,6 +165,12 @@ export type LogRecord = {
    * Severity of the event.
    */
   severity: LogSeverity;
+  /**
+   * Number of attributes the SDK dropped while accepting this record (caller
+   * tried to use a reserved key, exceeded the per-record cap, etc.). `0` when
+   * nothing was dropped.
+   */
+  droppedAttributesCount: number;
 };
 
 /**

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/Event.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/Event.kt
@@ -1,5 +1,6 @@
 package expo.modules.observe
 
+import expo.modules.appmetrics.storage.LogRecord
 import expo.modules.appmetrics.storage.Metric
 import expo.modules.appmetrics.storage.Session
 import kotlinx.serialization.Serializable
@@ -105,7 +106,36 @@ data class EASMetric(
 }
 
 @Serializable
+data class EASLogRecord(
+  val sessionId: String,
+  val timestamp: String,
+  val name: String,
+  val body: String? = null,
+  val severity: String,
+  val attributes: JsonObject? = null,
+  val droppedAttributesCount: Int = 0
+) {
+  companion object {
+    fun fromLogRecord(log: LogRecord): EASLogRecord =
+      EASLogRecord(
+        sessionId = log.sessionId,
+        timestamp = log.timestamp,
+        name = log.name,
+        body = log.body,
+        severity = log.severity,
+        // Stored as a JSON string; parse defensively, falling back to no
+        // attributes if the blob is somehow malformed.
+        attributes = log.attributes?.let {
+          runCatching { Json.decodeFromString<JsonObject>(it) }.getOrNull()
+        },
+        droppedAttributesCount = log.droppedAttributesCount
+      )
+  }
+}
+
+@Serializable
 data class Event(
   val metadata: Metadata,
-  val metrics: List<EASMetric>
+  val metrics: List<EASMetric>,
+  val logs: List<EASLogRecord> = emptyList()
 )

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/Event.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/Event.kt
@@ -105,8 +105,14 @@ data class EASMetric(
   }
 }
 
+/**
+ * Wire shape of a log event ready for dispatch. Distinct from the storage-side
+ * `LogRecord`: this form has the JSON `attributes` blob already parsed back
+ * into a structured object (so the OTel encoder can map values to typed
+ * `OTAnyValue`s) and drops storage-only columns like `logId`.
+ */
 @Serializable
-data class EASLogRecord(
+data class LogEvent(
   val sessionId: String,
   val timestamp: String,
   val name: String,
@@ -116,8 +122,8 @@ data class EASLogRecord(
   val droppedAttributesCount: Int = 0
 ) {
   companion object {
-    fun fromLogRecord(log: LogRecord): EASLogRecord =
-      EASLogRecord(
+    fun fromLogRecord(log: LogRecord): LogEvent =
+      LogEvent(
         sessionId = log.sessionId,
         timestamp = log.timestamp,
         name = log.name,
@@ -137,5 +143,5 @@ data class EASLogRecord(
 data class Event(
   val metadata: Metadata,
   val metrics: List<EASMetric>,
-  val logs: List<EASLogRecord> = emptyList()
+  val logs: List<LogEvent> = emptyList()
 )

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -68,16 +68,11 @@ class EventDispatcher(
     }
 
   /**
-   * Dispatches log records to `{baseUrl}/{projectId}/v1/logs`. Only meaningful
-   * in OpenTelemetry mode — there's no legacy logs endpoint, so non-OTel mode
-   * short-circuits to `false`.
+   * Dispatches log records to `{baseUrl}/{projectId}/v1/logs`. Always uses the
+   * OTLP wire shape — there is no legacy logs endpoint.
    */
   suspend fun dispatchLogs(events: List<Event>): Boolean =
     suspendCancellableCoroutine { continuation ->
-      if (!useOpenTelemetry) {
-        continuation.resume(false)
-        return@suspendCancellableCoroutine Unit
-      }
       val easId = EASClientID(context).uuid.toString()
       val resourceLogs = events
         .filter { it.logs.isNotEmpty() }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -21,15 +21,18 @@ class EventDispatcher(
   private val useOpenTelemetry: Boolean = false,
   private val httpClient: OkHttpClient = OkHttpClient()
 ) {
-  private fun endpointUrl(): String {
-    val base = when (baseUrl.endsWith("/")) {
+  private val baseProjectUrl: String
+    get() = when (baseUrl.endsWith("/")) {
       true -> "${baseUrl}$projectId"
       else -> "$baseUrl/$projectId"
     }
-    return if (useOpenTelemetry) "$base/v1/metrics" else base
-  }
 
-  suspend fun dispatch(events: List<Event>) =
+  private fun metricsEndpointUrl(): String =
+    if (useOpenTelemetry) "$baseProjectUrl/v1/metrics" else baseProjectUrl
+
+  private fun logsEndpointUrl(): String = "$baseProjectUrl/v1/logs"
+
+  suspend fun dispatch(events: List<Event>): Boolean =
     suspendCancellableCoroutine { continuation ->
       if (events.isEmpty()) {
         continuation.resume(false)
@@ -54,28 +57,7 @@ class EventDispatcher(
           json.encodeToString(Payload.serializer(), payload)
         }
 
-        val endpointUrl = endpointUrl()
-
-        Log.d(TAG, "Sending events to $endpointUrl")
-
-        val request = Request
-          .Builder()
-          .url(endpointUrl)
-          .post(body.toRequestBody("application/json".toMediaType()))
-          .build()
-
-        Log.d(TAG, body)
-
-        val call = httpClient.newCall(request)
-
-        continuation.invokeOnCancellation {
-          call.cancel()
-        }
-
-        val response = call.execute()
-        Log.d(TAG, "Server responded with: ${response.body?.string()}")
-
-        continuation.resume(response.code in 200..299)
+        executePost(continuation, metricsEndpointUrl(), body)
       } catch (e: Exception) {
         Log.w(
           TAG,
@@ -84,6 +66,63 @@ class EventDispatcher(
         continuation.resumeWithException(e)
       }
     }
+
+  /**
+   * Dispatches log records to `{baseUrl}/{projectId}/v1/logs`. Only meaningful
+   * in OpenTelemetry mode — there's no legacy logs endpoint, so non-OTel mode
+   * short-circuits to `false`.
+   */
+  suspend fun dispatchLogs(events: List<Event>): Boolean =
+    suspendCancellableCoroutine { continuation ->
+      if (!useOpenTelemetry) {
+        continuation.resume(false)
+        return@suspendCancellableCoroutine Unit
+      }
+      val resourceLogs = events
+        .filter { it.logs.isNotEmpty() }
+        .map { it.toOTResourceLogs(EASClientID(context).uuid.toString()) }
+      if (resourceLogs.isEmpty()) {
+        continuation.resume(false)
+        return@suspendCancellableCoroutine Unit
+      }
+      try {
+        val body = OTLogsRequestBody(resourceLogs = resourceLogs).toJson(prettyPrint = true)
+        executePost(continuation, logsEndpointUrl(), body)
+      } catch (e: Exception) {
+        Log.w(
+          TAG,
+          "Dispatching the logs has thrown an error: ${e.message}"
+        )
+        continuation.resumeWithException(e)
+      }
+    }
+
+  private fun executePost(
+    continuation: kotlinx.coroutines.CancellableContinuation<Boolean>,
+    endpointUrl: String,
+    body: String
+  ) {
+    Log.d(TAG, "Sending events to $endpointUrl")
+
+    val request = Request
+      .Builder()
+      .url(endpointUrl)
+      .post(body.toRequestBody("application/json".toMediaType()))
+      .build()
+
+    Log.d(TAG, body)
+
+    val call = httpClient.newCall(request)
+
+    continuation.invokeOnCancellation {
+      call.cancel()
+    }
+
+    val response = call.execute()
+    Log.d(TAG, "Server responded with: ${response.body?.string()}")
+
+    continuation.resume(response.code in 200..299)
+  }
 
   companion object {
     private const val TAG = "EasObserve"

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/EventDispatcher.kt
@@ -78,9 +78,10 @@ class EventDispatcher(
         continuation.resume(false)
         return@suspendCancellableCoroutine Unit
       }
+      val easId = EASClientID(context).uuid.toString()
       val resourceLogs = events
         .filter { it.logs.isNotEmpty() }
-        .map { it.toOTResourceLogs(EASClientID(context).uuid.toString()) }
+        .map { it.toOTResourceLogs(easId) }
       if (resourceLogs.isEmpty()) {
         continuation.resume(false)
         return@suspendCancellableCoroutine Unit

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/OTAnyValueSerializer.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/OTAnyValueSerializer.kt
@@ -1,0 +1,111 @@
+package expo.modules.observe
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
+
+/**
+ * Custom serializer that emits the OTLP-correct wire shape for `OTAnyValue`.
+ * Each variant becomes a single-key JSON object:
+ *   - Str   -> {"stringValue": "..."}
+ *   - Int64 -> {"intValue": "42"}        (string per OTLP int64 mapping)
+ *   - Dbl   -> {"doubleValue": 3.14}
+ *   - Bln   -> {"boolValue": true}
+ *   - Arr   -> {"arrayValue": {"values": [...]}}
+ *   - KvList -> {"kvlistValue": {"values": [{"key": "...", "value": ...}]}}
+ */
+internal object OTAnyValueSerializer : KSerializer<OTAnyValue> {
+  override val descriptor: SerialDescriptor =
+    buildClassSerialDescriptor("expo.modules.observe.OTAnyValue")
+
+  override fun serialize(encoder: Encoder, value: OTAnyValue) {
+    val jsonEncoder = encoder as? JsonEncoder
+      ?: error("OTAnyValue is only serializable to JSON (got ${encoder::class}).")
+
+    val element: JsonElement = when (value) {
+      is OTAnyValue.Str -> buildJsonObject { put("stringValue", JsonPrimitive(value.value)) }
+      is OTAnyValue.Int64 -> buildJsonObject { put("intValue", JsonPrimitive(value.value.toString())) }
+      is OTAnyValue.Dbl -> buildJsonObject { put("doubleValue", JsonPrimitive(value.value)) }
+      is OTAnyValue.Bln -> buildJsonObject { put("boolValue", JsonPrimitive(value.value)) }
+      is OTAnyValue.Arr -> buildJsonObject {
+        put(
+          "arrayValue",
+          buildJsonObject {
+            put(
+              "values",
+              jsonEncoder.json.encodeToJsonElement(
+                ListSerializer(OTAnyValueSerializer),
+                value.values
+              )
+            )
+          }
+        )
+      }
+      is OTAnyValue.KvList -> buildJsonObject {
+        put(
+          "kvlistValue",
+          buildJsonObject {
+            put(
+              "values",
+              jsonEncoder.json.encodeToJsonElement(
+                ListSerializer(OTKeyValue.serializer()),
+                value.values
+              )
+            )
+          }
+        )
+      }
+    }
+
+    jsonEncoder.encodeJsonElement(element)
+  }
+
+  override fun deserialize(decoder: Decoder): OTAnyValue {
+    val jsonDecoder = decoder as? JsonDecoder
+      ?: error("OTAnyValue is only deserializable from JSON (got ${decoder::class}).")
+    val obj = jsonDecoder.decodeJsonElement().jsonObject
+
+    obj["stringValue"]?.let {
+      return OTAnyValue.Str(it.jsonPrimitive.contentOrNull ?: "")
+    }
+    obj["intValue"]?.let {
+      val parsed = it.jsonPrimitive.contentOrNull?.toLongOrNull()
+        ?: it.jsonPrimitive.longOrNull
+        ?: error("OTAnyValue.intValue could not be parsed as Long: $it")
+      return OTAnyValue.Int64(parsed)
+    }
+    obj["doubleValue"]?.let {
+      return OTAnyValue.Dbl(it.jsonPrimitive.doubleOrNull ?: error("OTAnyValue.doubleValue not a number: $it"))
+    }
+    obj["boolValue"]?.let {
+      return OTAnyValue.Bln(it.jsonPrimitive.booleanOrNull ?: it.jsonPrimitive.boolean)
+    }
+    obj["arrayValue"]?.let { arr ->
+      val values = arr.jsonObject["values"]?.jsonArray
+        ?: error("OTAnyValue.arrayValue is missing `values`")
+      return OTAnyValue.Arr(values.map { jsonDecoder.json.decodeFromJsonElement(OTAnyValueSerializer, it) })
+    }
+    obj["kvlistValue"]?.let { kv ->
+      val values = kv.jsonObject["values"]?.jsonArray
+        ?: error("OTAnyValue.kvlistValue is missing `values`")
+      return OTAnyValue.KvList(values.map { jsonDecoder.json.decodeFromJsonElement(OTKeyValue.serializer(), it) })
+    }
+    error("OTAnyValue has no recognized variant: $obj")
+  }
+}

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityBackgroundWorker.kt
@@ -15,6 +15,7 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import expo.modules.observe.storage.PendingLogsManager
 import expo.modules.observe.storage.PendingMetricsManager
 import expo.modules.appmetrics.storage.SessionManager
 
@@ -43,12 +44,14 @@ class ObservabilityBackgroundWorker(
     )
 
     val pendingMetricsManager = PendingMetricsManager(context)
+    val pendingLogsManager = PendingLogsManager(context)
 
     BaseObservabilityManager(
       context = context,
       projectId = projectId,
       sessionManager = sessionManager,
       pendingMetricsManager = pendingMetricsManager,
+      pendingLogsManager = pendingLogsManager,
       baseUrl = baseUrl,
       isDebugBuild = BuildConfig.DEBUG,
       useOpenTelemetry = useOpenTelemetry
@@ -81,7 +84,8 @@ class ObservabilityBackgroundWorker(
       // This also adds a side benefit of cleaning up even if dispatch fails
       observabilityManager.cleanup()
       observabilityManager.dispatchUnsentMetrics()
-      Log.d(OBSERVE_TAG, "Successfully dispatched unsent metrics")
+      observabilityManager.dispatchUnsentLogs()
+      Log.d(OBSERVE_TAG, "Successfully dispatched unsent metrics and logs")
       Result.success()
     } catch (e: Exception) {
       Log.e(OBSERVE_TAG, "Failed to dispatch metrics", e)

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -2,6 +2,7 @@ package expo.modules.observe
 
 import android.content.Context
 import expo.modules.easclient.EASClientID
+import expo.modules.observe.storage.PendingLogsManager
 import expo.modules.observe.storage.PendingMetricsManager
 import expo.modules.appmetrics.storage.SessionManager
 import expo.modules.interfaces.constants.ConstantsInterface
@@ -30,11 +31,13 @@ class ObservabilityManager(
     useOpenTelemetry = manifest.useOpenTelemetry
 
     val pendingMetricsManager = PendingMetricsManager(context)
+    val pendingLogsManager = PendingLogsManager(context)
 
     baseManager = BaseObservabilityManager(
       context = context,
       sessionManager = sessionManager,
       pendingMetricsManager = pendingMetricsManager,
+      pendingLogsManager = pendingLogsManager,
       projectId = projectId,
       baseUrl = baseUrl,
       isDebugBuild = BuildConfig.DEBUG,
@@ -44,10 +47,22 @@ class ObservabilityManager(
     sessionManager.addMetricsInsertListener { metricIds ->
       pendingMetricsManager.addPendingMetrics(metricIds)
     }
+    // Logs are only dispatched in OpenTelemetry mode (no legacy logs endpoint
+    // exists). Skip the pending-table tracking entirely on non-OTel installs
+    // so rows don't accumulate with no path to drain them.
+    if (useOpenTelemetry) {
+      sessionManager.addLogsInsertListener { logIds ->
+        pendingLogsManager.addPendingLogs(logIds)
+      }
+    }
   }
 
   suspend fun dispatchUnsentMetrics() {
     baseManager.dispatchUnsentMetrics()
+  }
+
+  suspend fun dispatchUnsentLogs() {
+    baseManager.dispatchUnsentLogs()
   }
 
   fun scheduleBackgroundDispatch() {
@@ -64,6 +79,7 @@ class BaseObservabilityManager(
   private val context: Context,
   private val sessionManager: SessionManager,
   private val pendingMetricsManager: PendingMetricsManager,
+  private val pendingLogsManager: PendingLogsManager,
   val projectId: String,
   val baseUrl: String,
   private val isDebugBuild: Boolean = false,
@@ -116,6 +132,50 @@ class BaseObservabilityManager(
     }
   }
 
+  /**
+   * Dispatches log events to `/v1/logs`. Independent from the metrics path —
+   * a logs failure doesn't affect the metrics pending table and vice versa.
+   * Logs are only sent in OpenTelemetry mode (the dispatcher short-circuits
+   * otherwise), so non-OTel installs accumulate nothing on this path.
+   */
+  suspend fun dispatchUnsentLogs() {
+    val pendingIds = pendingLogsManager.getAllPendingLogIds()
+    if (pendingIds.isEmpty()) {
+      return
+    }
+
+    if (!shouldDispatch()) {
+      pendingLogsManager.removePendingLogs(pendingIds)
+      return
+    }
+
+    val sessionsWithPendingLogs = sessionManager.getSessionsWithLogs(pendingIds)
+
+    // Clean up orphaned pending IDs (logs deleted from MetricsDatabase but still in pending table).
+    val resolvedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }.toSet()
+    val orphanedIds = pendingIds.filter { it !in resolvedLogIds }
+    if (orphanedIds.isNotEmpty()) {
+      pendingLogsManager.removePendingLogs(orphanedIds)
+    }
+
+    if (sessionsWithPendingLogs.isEmpty()) {
+      return
+    }
+
+    val events = sessionsWithPendingLogs.map { sessionWithLogs ->
+      Event(
+        metadata = Metadata.fromSessionMetadata(sessionWithLogs.session),
+        metrics = emptyList(),
+        logs = sessionWithLogs.logs.map { EASLogRecord.fromLogRecord(it) }
+      )
+    }
+
+    if (eventDispatcher.dispatchLogs(events)) {
+      val dispatchedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }
+      pendingLogsManager.removePendingLogs(dispatchedLogIds)
+    }
+  }
+
   private fun isInSample(): Boolean {
     val rate = ObservePreferences.getConfig(context)?.sampleRate ?: return true
     val clamped = rate.coerceIn(0.0, 1.0)
@@ -136,7 +196,9 @@ class BaseObservabilityManager(
 
   suspend fun cleanup() {
     pendingMetricsManager.cleanupOldPendingMetrics()
+    pendingLogsManager.cleanupOldPendingLogs()
     // TODO(@ubax): Move sessionManager.cleanupOldSessions out of eas observe
     sessionManager.cleanupOldSessions()
+    sessionManager.cleanupOldLogs()
   }
 }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -135,10 +135,16 @@ class BaseObservabilityManager(
   /**
    * Dispatches log events to `/v1/logs`. Independent from the metrics path —
    * a logs failure doesn't affect the metrics pending table and vice versa.
-   * Logs are only sent in OpenTelemetry mode (the dispatcher short-circuits
-   * otherwise), so non-OTel installs accumulate nothing on this path.
+   * Logs are only sent in OpenTelemetry mode (no legacy logs endpoint exists);
+   * skip the work entirely in non-OTel mode so any leftover `pending_logs`
+   * rows from an earlier OTel-enabled run don't trigger a wasted session join
+   * + event build every dispatch cycle.
    */
   suspend fun dispatchUnsentLogs() {
+    if (!useOpenTelemetry) {
+      return
+    }
+
     val pendingIds = pendingLogsManager.getAllPendingLogIds()
     if (pendingIds.isEmpty()) {
       return
@@ -151,7 +157,8 @@ class BaseObservabilityManager(
 
     val sessionsWithPendingLogs = sessionManager.getSessionsWithLogs(pendingIds)
 
-    // Clean up orphaned pending IDs (logs deleted from MetricsDatabase but still in pending table).
+    // Clean up orphaned pending IDs (logs deleted from the `logs` table but
+    // still tracked in `pending_logs`).
     val resolvedLogIds = sessionsWithPendingLogs.flatMap { it.logs }.map { it.logId }.toSet()
     val orphanedIds = pendingIds.filter { it !in resolvedLogIds }
     if (orphanedIds.isNotEmpty()) {
@@ -166,7 +173,7 @@ class BaseObservabilityManager(
       Event(
         metadata = Metadata.fromSessionMetadata(sessionWithLogs.session),
         metrics = emptyList(),
-        logs = sessionWithLogs.logs.map { EASLogRecord.fromLogRecord(it) }
+        logs = sessionWithLogs.logs.map { LogEvent.fromLogRecord(it) }
       )
     }
 

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObservabilityManager.kt
@@ -47,13 +47,8 @@ class ObservabilityManager(
     sessionManager.addMetricsInsertListener { metricIds ->
       pendingMetricsManager.addPendingMetrics(metricIds)
     }
-    // Logs are only dispatched in OpenTelemetry mode (no legacy logs endpoint
-    // exists). Skip the pending-table tracking entirely on non-OTel installs
-    // so rows don't accumulate with no path to drain them.
-    if (useOpenTelemetry) {
-      sessionManager.addLogsInsertListener { logIds ->
-        pendingLogsManager.addPendingLogs(logIds)
-      }
+    sessionManager.addLogsInsertListener { logIds ->
+      pendingLogsManager.addPendingLogs(logIds)
     }
   }
 
@@ -135,16 +130,8 @@ class BaseObservabilityManager(
   /**
    * Dispatches log events to `/v1/logs`. Independent from the metrics path —
    * a logs failure doesn't affect the metrics pending table and vice versa.
-   * Logs are only sent in OpenTelemetry mode (no legacy logs endpoint exists);
-   * skip the work entirely in non-OTel mode so any leftover `pending_logs`
-   * rows from an earlier OTel-enabled run don't trigger a wasted session join
-   * + event build every dispatch cycle.
    */
   suspend fun dispatchUnsentLogs() {
-    if (!useOpenTelemetry) {
-      return
-    }
-
     val pendingIds = pendingLogsManager.getAllPendingLogIds()
     if (pendingIds.isEmpty()) {
       return

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/ObserveModule.kt
@@ -50,7 +50,10 @@ class ObserveModule : Module() {
         observabilityManager.scheduleBackgroundDispatch()
       }
 
-      AsyncFunction("dispatchEvents") Coroutine { -> observabilityManager.dispatchUnsentMetrics() }
+      AsyncFunction("dispatchEvents") Coroutine { ->
+        observabilityManager.dispatchUnsentMetrics()
+        observabilityManager.dispatchUnsentLogs()
+      }
 
       Function("configure") { config: Config ->
         ObservePreferences.setConfig(

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
@@ -3,25 +3,168 @@ package expo.modules.observe
 import expo.modules.appmetrics.AppStartupMetric
 import expo.modules.appmetrics.MetricCategory
 import expo.modules.appmetrics.utils.TimeUtils.timestampToDateNS
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.descriptors.buildClassSerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonEncoder
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.longOrNull
 
 // MARK: -- Open Telemetry data classes
 
+/**
+ * Wire shape for the OTel `body` field on `LogRecord` — always carries a string.
+ * Kept distinct from `OTAnyValue.Str` because the body field on the log record
+ * is positional in OTLP (no `stringValue` wrapper key on the value side).
+ */
 @Serializable
 data class OTStringValue(
   val stringValue: String
 )
 
+/**
+ * Tagged union mirroring the OTLP `AnyValue` shape — encodes as a JSON object
+ * with exactly one of `stringValue` / `intValue` / `doubleValue` / `boolValue` /
+ * `arrayValue` / `kvlistValue`, depending on the variant.
+ *
+ * OTLP encodes 64-bit integers as JSON strings to avoid precision loss; we follow
+ * that convention so collectors that rely on the protobuf-JSON mapping accept the
+ * payload.
+ */
+@Serializable(with = OTAnyValueSerializer::class)
+sealed class OTAnyValue {
+  data class Str(val value: String) : OTAnyValue()
+  data class Int64(val value: Long) : OTAnyValue()
+  data class Dbl(val value: Double) : OTAnyValue()
+  data class Bln(val value: Boolean) : OTAnyValue()
+  data class Arr(val values: List<OTAnyValue>) : OTAnyValue()
+  data class KvList(val values: List<OTKeyValue>) : OTAnyValue()
+}
+
+/**
+ * Custom serializer that emits the OTLP-correct wire shape for `OTAnyValue`.
+ * Each variant becomes a single-key JSON object:
+ *   - Str   -> {"stringValue": "..."}
+ *   - Int64 -> {"intValue": "42"}        (string per OTLP int64 mapping)
+ *   - Dbl   -> {"doubleValue": 3.14}
+ *   - Bln   -> {"boolValue": true}
+ *   - Arr   -> {"arrayValue": {"values": [...]}}
+ *   - KvList -> {"kvlistValue": {"values": [{"key": "...", "value": ...}]}}
+ */
+internal object OTAnyValueSerializer : KSerializer<OTAnyValue> {
+  override val descriptor: SerialDescriptor =
+    buildClassSerialDescriptor("expo.modules.observe.OTAnyValue")
+
+  override fun serialize(encoder: Encoder, value: OTAnyValue) {
+    val jsonEncoder = encoder as? JsonEncoder
+      ?: error("OTAnyValue is only serializable to JSON (got ${encoder::class}).")
+
+    val element: JsonElement = when (value) {
+      is OTAnyValue.Str -> buildJsonObject { put("stringValue", JsonPrimitive(value.value)) }
+      is OTAnyValue.Int64 -> buildJsonObject { put("intValue", JsonPrimitive(value.value.toString())) }
+      is OTAnyValue.Dbl -> buildJsonObject { put("doubleValue", JsonPrimitive(value.value)) }
+      is OTAnyValue.Bln -> buildJsonObject { put("boolValue", JsonPrimitive(value.value)) }
+      is OTAnyValue.Arr -> buildJsonObject {
+        put(
+          "arrayValue",
+          buildJsonObject {
+            put(
+              "values",
+              jsonEncoder.json.encodeToJsonElement(
+                kotlinx.serialization.builtins.ListSerializer(OTAnyValueSerializer),
+                value.values
+              )
+            )
+          }
+        )
+      }
+      is OTAnyValue.KvList -> buildJsonObject {
+        put(
+          "kvlistValue",
+          buildJsonObject {
+            put(
+              "values",
+              jsonEncoder.json.encodeToJsonElement(
+                kotlinx.serialization.builtins.ListSerializer(OTKeyValue.serializer()),
+                value.values
+              )
+            )
+          }
+        )
+      }
+    }
+
+    jsonEncoder.encodeJsonElement(element)
+  }
+
+  override fun deserialize(decoder: Decoder): OTAnyValue {
+    val jsonDecoder = decoder as? JsonDecoder
+      ?: error("OTAnyValue is only deserializable from JSON (got ${decoder::class}).")
+    val obj = jsonDecoder.decodeJsonElement().jsonObject
+
+    obj["stringValue"]?.let {
+      return OTAnyValue.Str(it.jsonPrimitive.contentOrNull ?: "")
+    }
+    obj["intValue"]?.let {
+      val parsed = it.jsonPrimitive.contentOrNull?.toLongOrNull()
+        ?: it.jsonPrimitive.longOrNull
+        ?: error("OTAnyValue.intValue could not be parsed as Long: $it")
+      return OTAnyValue.Int64(parsed)
+    }
+    obj["doubleValue"]?.let {
+      return OTAnyValue.Dbl(it.jsonPrimitive.doubleOrNull ?: error("OTAnyValue.doubleValue not a number: $it"))
+    }
+    obj["boolValue"]?.let {
+      return OTAnyValue.Bln(it.jsonPrimitive.booleanOrNull ?: it.jsonPrimitive.boolean)
+    }
+    obj["arrayValue"]?.let { arr ->
+      val values = arr.jsonObject["values"]?.jsonArray
+        ?: error("OTAnyValue.arrayValue is missing `values`")
+      return OTAnyValue.Arr(values.map { jsonDecoder.json.decodeFromJsonElement(OTAnyValueSerializer, it) })
+    }
+    obj["kvlistValue"]?.let { kv ->
+      val values = kv.jsonObject["values"]?.jsonArray
+        ?: error("OTAnyValue.kvlistValue is missing `values`")
+      return OTAnyValue.KvList(values.map { jsonDecoder.json.decodeFromJsonElement(OTKeyValue.serializer(), it) })
+    }
+    error("OTAnyValue has no recognized variant: $obj")
+  }
+}
+
+/**
+ * Key/value pair used inside `kvlistValue` (and at the top level for span
+ * attributes). Same shape as `OTAttribute` but split out for the recursive case.
+ */
+@Serializable
+data class OTKeyValue(
+  val key: String,
+  val value: OTAnyValue
+)
+
 @Serializable
 data class OTAttribute(
   val key: String,
-  val value: OTStringValue
+  val value: OTAnyValue
 ) {
   companion object {
     fun of(key: String, rawValue: String) = OTAttribute(
       key = key,
-      value = OTStringValue(stringValue = rawValue)
+      value = OTAnyValue.Str(rawValue)
     )
   }
 }
@@ -65,7 +208,32 @@ data class OTScopeMetrics(
 @Serializable
 data class OTEvent(
   val resource: OTMetadata,
-  val scopeMetrics: List<OTScopeMetrics>
+  val scopeMetrics: List<OTScopeMetrics>,
+  val schemaUrl: String
+)
+
+@Serializable
+data class OTLogRecord(
+  val timeUnixNano: Long,
+  val observedTimeUnixNano: Long,
+  val severityNumber: Int,
+  val severityText: String,
+  val body: OTStringValue,
+  val attributes: List<OTAttribute>,
+  val droppedAttributesCount: Int? = null
+)
+
+@Serializable
+data class OTScopeLogs(
+  val scope: OTScope,
+  val logRecords: List<OTLogRecord>
+)
+
+@Serializable
+data class OTResourceLogs(
+  val resource: OTMetadata,
+  val scopeLogs: List<OTScopeLogs>,
+  val schemaUrl: String
 )
 
 // MARK: -- Request body for Open Telemetry events
@@ -81,6 +249,30 @@ data class OTRequestBody(
     return json.encodeToString(serializer(), this)
   }
 }
+
+@Serializable
+data class OTLogsRequestBody(
+  val resourceLogs: List<OTResourceLogs>
+) {
+  fun toJson(prettyPrint: Boolean = false): String {
+    val json = Json {
+      this.prettyPrint = prettyPrint
+    }
+    return json.encodeToString(serializer(), this)
+  }
+}
+
+/**
+ * OpenTelemetry Semantic Conventions schema URL referenced by the resource on
+ * every dispatched payload. Bumping this constant signals that our attribute
+ * names follow a newer revision of the conventions.
+ *
+ * Before bumping, audit the attribute keys we set in `toOTMetadata` and
+ * `toOTLogRecord` against the SemConv changelog at
+ * https://github.com/open-telemetry/semantic-conventions/blob/main/CHANGELOG.md
+ * — a renamed key would silently mismatch the declared schema otherwise.
+ */
+internal const val SEMCONV_SCHEMA_URL = "https://opentelemetry.io/schemas/1.27.0"
 
 // This must be kept in sync with the INTERNAL_TO_OTEL map in universe
 // https://github.com/expo/universe/blob/main/server/www/src/middleware/easObserveRoutes.ts#L209
@@ -199,6 +391,126 @@ fun Event.toOTEvent(easClientId: String): OTEvent {
         scope = OTScope(name = "expo-observe", version = BuildConfig.EXPO_OBSERVE_VERSION),
         metrics = metrics.map { it.toOTMetric() }
       )
-    )
+    ),
+    schemaUrl = SEMCONV_SCHEMA_URL
   )
+}
+
+/**
+ * Maps a caller-supplied JSON attribute object (values stored after the JSON
+ * roundtrip) to typed `OTAttribute`s. Returns the mapped attributes plus a
+ * count of entries that could not be represented (a value type we don't
+ * support, or a deeply unrepresentable nested structure) so callers can fold
+ * the count into the OTel `droppedAttributesCount`.
+ */
+internal fun otAttributesFromJsonObject(
+  obj: JsonObject
+): Pair<List<OTAttribute>, Int> {
+  val attributes = mutableListOf<OTAttribute>()
+  var droppedCount = 0
+  for ((key, element) in obj) {
+    val mapped = otAnyValueFromJsonElement(element)
+    if (mapped != null) {
+      attributes.add(OTAttribute(key = key, value = mapped))
+    } else {
+      droppedCount += 1
+    }
+  }
+  return attributes to droppedCount
+}
+
+/**
+ * Converts a `JsonElement` (the storage form of a caller attribute value) into
+ * a typed `OTAnyValue`. Returns `null` for `JsonNull` and for any element we
+ * cannot represent, so the caller can fold it into `droppedAttributesCount`.
+ */
+fun EASLogRecord.toOTLogRecord(): OTLogRecord {
+  val attributes = mutableListOf(
+    OTAttribute.of(key = "session.id", rawValue = sessionId),
+    OTAttribute.of(key = "event.name", rawValue = name)
+  )
+
+  var encodeTimeDrops = 0
+  this.attributes?.let { attrs ->
+    val (typed, dropped) = otAttributesFromJsonObject(attrs)
+    attributes.addAll(typed)
+    encodeTimeDrops = dropped
+  }
+
+  val totalDrops = droppedAttributesCount + encodeTimeDrops
+  val timeNs = timestampToDateNS(timestamp)
+  val severityNumber = severityNumberForRaw(severity)
+  return OTLogRecord(
+    timeUnixNano = timeNs,
+    observedTimeUnixNano = timeNs,
+    severityNumber = severityNumber,
+    severityText = severity.uppercase(),
+    body = OTStringValue(stringValue = body ?: ""),
+    attributes = attributes,
+    droppedAttributesCount = if (totalDrops > 0) totalDrops else null
+  )
+}
+
+fun Event.toOTResourceLogs(easClientId: String): OTResourceLogs {
+  return OTResourceLogs(
+    resource = toOTMetadata(easClientId),
+    scopeLogs = listOf(
+      OTScopeLogs(
+        scope = OTScope(name = "expo-observe", version = BuildConfig.EXPO_OBSERVE_VERSION),
+        logRecords = logs.map { it.toOTLogRecord() }
+      )
+    ),
+    schemaUrl = SEMCONV_SCHEMA_URL
+  )
+}
+
+/**
+ * Maps a stored severity rawValue (lowercase: `trace`, `debug`, …) to the
+ * matching OpenTelemetry severity number. Falls back to `INFO` (9) for
+ * unrecognized values so a future enum case isn't a hard failure.
+ */
+private fun severityNumberForRaw(raw: String): Int {
+  return when (raw) {
+    "trace" -> 1
+    "debug" -> 5
+    "info" -> 9
+    "warn" -> 13
+    "error" -> 17
+    "fatal" -> 21
+    else -> 9
+  }
+}
+
+internal fun otAnyValueFromJsonElement(element: JsonElement): OTAnyValue? {
+  if (element is kotlinx.serialization.json.JsonNull) {
+    return null
+  }
+  return when (element) {
+    is JsonPrimitive -> {
+      // Booleans first — JsonPrimitive.booleanOrNull only matches `true`/`false`,
+      // not numeric primitives, so order isn't strictly load-bearing, but matching
+      // the iOS ordering keeps the ports symmetric.
+      element.booleanOrNull?.let { return OTAnyValue.Bln(it) }
+      // `isString` distinguishes "42" (string) from 42 (number) since the JSON
+      // primitive representation is the same string-of-digits.
+      if (element.isString) {
+        return OTAnyValue.Str(element.content)
+      }
+      element.longOrNull?.let { return OTAnyValue.Int64(it) }
+      element.doubleOrNull?.let { return if (it.isFinite()) OTAnyValue.Dbl(it) else null }
+      null
+    }
+    is JsonObject -> {
+      val pairs = mutableListOf<OTKeyValue>()
+      for ((k, v) in element) {
+        val mapped = otAnyValueFromJsonElement(v) ?: return null
+        pairs.add(OTKeyValue(key = k, value = mapped))
+      }
+      OTAnyValue.KvList(pairs)
+    }
+    is kotlinx.serialization.json.JsonArray -> {
+      val mapped = element.map { otAnyValueFromJsonElement(it) ?: return null }
+      OTAnyValue.Arr(mapped)
+    }
+  }
 }

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
@@ -2,6 +2,7 @@ package expo.modules.observe
 
 import expo.modules.appmetrics.AppStartupMetric
 import expo.modules.appmetrics.MetricCategory
+import expo.modules.appmetrics.logevents.Severity
 import expo.modules.appmetrics.utils.TimeUtils.timestampToDateNS
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -424,7 +425,7 @@ internal fun otAttributesFromJsonObject(
  * a typed `OTAnyValue`. Returns `null` for `JsonNull` and for any element we
  * cannot represent, so the caller can fold it into `droppedAttributesCount`.
  */
-fun EASLogRecord.toOTLogRecord(): OTLogRecord {
+fun LogEvent.toOTLogRecord(): OTLogRecord {
   val attributes = mutableListOf(
     OTAttribute.of(key = "session.id", rawValue = sessionId),
     OTAttribute.of(key = "event.name", rawValue = name)
@@ -439,12 +440,16 @@ fun EASLogRecord.toOTLogRecord(): OTLogRecord {
 
   val totalDrops = droppedAttributesCount + encodeTimeDrops
   val timeNs = timestampToDateNS(timestamp)
-  val severityNumber = severityNumberForRaw(severity)
+  // Both `severityNumber` and `severityText` come off the same enum case so
+  // they can't disagree. Unknown raw values (e.g. a future case shipped on JS
+  // ahead of the native side) fall back to INFO rather than producing an
+  // internally-inconsistent OTel record.
+  val resolvedSeverity = Severity.fromRawValue(severity) ?: Severity.INFO
   return OTLogRecord(
     timeUnixNano = timeNs,
     observedTimeUnixNano = timeNs,
-    severityNumber = severityNumber,
-    severityText = severity.uppercase(),
+    severityNumber = resolvedSeverity.severityNumber,
+    severityText = resolvedSeverity.severityText,
     body = OTStringValue(stringValue = body ?: ""),
     attributes = attributes,
     droppedAttributesCount = if (totalDrops > 0) totalDrops else null
@@ -462,23 +467,6 @@ fun Event.toOTResourceLogs(easClientId: String): OTResourceLogs {
     ),
     schemaUrl = SEMCONV_SCHEMA_URL
   )
-}
-
-/**
- * Maps a stored severity rawValue (lowercase: `trace`, `debug`, …) to the
- * matching OpenTelemetry severity number. Falls back to `INFO` (9) for
- * unrecognized values so a future enum case isn't a hard failure.
- */
-private fun severityNumberForRaw(raw: String): Int {
-  return when (raw) {
-    "trace" -> 1
-    "debug" -> 5
-    "info" -> 9
-    "warn" -> 13
-    "error" -> 17
-    "fatal" -> 21
-    else -> 9
-  }
 }
 
 internal fun otAnyValueFromJsonElement(element: JsonElement): OTAnyValue? {

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/OpenTelemetry.kt
@@ -4,26 +4,13 @@ import expo.modules.appmetrics.AppStartupMetric
 import expo.modules.appmetrics.MetricCategory
 import expo.modules.appmetrics.logevents.Severity
 import expo.modules.appmetrics.utils.TimeUtils.timestampToDateNS
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonDecoder
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonEncoder
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.boolean
 import kotlinx.serialization.json.booleanOrNull
-import kotlinx.serialization.json.buildJsonObject
-import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.doubleOrNull
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.longOrNull
 
 // MARK: -- Open Telemetry data classes
@@ -55,96 +42,6 @@ sealed class OTAnyValue {
   data class Bln(val value: Boolean) : OTAnyValue()
   data class Arr(val values: List<OTAnyValue>) : OTAnyValue()
   data class KvList(val values: List<OTKeyValue>) : OTAnyValue()
-}
-
-/**
- * Custom serializer that emits the OTLP-correct wire shape for `OTAnyValue`.
- * Each variant becomes a single-key JSON object:
- *   - Str   -> {"stringValue": "..."}
- *   - Int64 -> {"intValue": "42"}        (string per OTLP int64 mapping)
- *   - Dbl   -> {"doubleValue": 3.14}
- *   - Bln   -> {"boolValue": true}
- *   - Arr   -> {"arrayValue": {"values": [...]}}
- *   - KvList -> {"kvlistValue": {"values": [{"key": "...", "value": ...}]}}
- */
-internal object OTAnyValueSerializer : KSerializer<OTAnyValue> {
-  override val descriptor: SerialDescriptor =
-    buildClassSerialDescriptor("expo.modules.observe.OTAnyValue")
-
-  override fun serialize(encoder: Encoder, value: OTAnyValue) {
-    val jsonEncoder = encoder as? JsonEncoder
-      ?: error("OTAnyValue is only serializable to JSON (got ${encoder::class}).")
-
-    val element: JsonElement = when (value) {
-      is OTAnyValue.Str -> buildJsonObject { put("stringValue", JsonPrimitive(value.value)) }
-      is OTAnyValue.Int64 -> buildJsonObject { put("intValue", JsonPrimitive(value.value.toString())) }
-      is OTAnyValue.Dbl -> buildJsonObject { put("doubleValue", JsonPrimitive(value.value)) }
-      is OTAnyValue.Bln -> buildJsonObject { put("boolValue", JsonPrimitive(value.value)) }
-      is OTAnyValue.Arr -> buildJsonObject {
-        put(
-          "arrayValue",
-          buildJsonObject {
-            put(
-              "values",
-              jsonEncoder.json.encodeToJsonElement(
-                kotlinx.serialization.builtins.ListSerializer(OTAnyValueSerializer),
-                value.values
-              )
-            )
-          }
-        )
-      }
-      is OTAnyValue.KvList -> buildJsonObject {
-        put(
-          "kvlistValue",
-          buildJsonObject {
-            put(
-              "values",
-              jsonEncoder.json.encodeToJsonElement(
-                kotlinx.serialization.builtins.ListSerializer(OTKeyValue.serializer()),
-                value.values
-              )
-            )
-          }
-        )
-      }
-    }
-
-    jsonEncoder.encodeJsonElement(element)
-  }
-
-  override fun deserialize(decoder: Decoder): OTAnyValue {
-    val jsonDecoder = decoder as? JsonDecoder
-      ?: error("OTAnyValue is only deserializable from JSON (got ${decoder::class}).")
-    val obj = jsonDecoder.decodeJsonElement().jsonObject
-
-    obj["stringValue"]?.let {
-      return OTAnyValue.Str(it.jsonPrimitive.contentOrNull ?: "")
-    }
-    obj["intValue"]?.let {
-      val parsed = it.jsonPrimitive.contentOrNull?.toLongOrNull()
-        ?: it.jsonPrimitive.longOrNull
-        ?: error("OTAnyValue.intValue could not be parsed as Long: $it")
-      return OTAnyValue.Int64(parsed)
-    }
-    obj["doubleValue"]?.let {
-      return OTAnyValue.Dbl(it.jsonPrimitive.doubleOrNull ?: error("OTAnyValue.doubleValue not a number: $it"))
-    }
-    obj["boolValue"]?.let {
-      return OTAnyValue.Bln(it.jsonPrimitive.booleanOrNull ?: it.jsonPrimitive.boolean)
-    }
-    obj["arrayValue"]?.let { arr ->
-      val values = arr.jsonObject["values"]?.jsonArray
-        ?: error("OTAnyValue.arrayValue is missing `values`")
-      return OTAnyValue.Arr(values.map { jsonDecoder.json.decodeFromJsonElement(OTAnyValueSerializer, it) })
-    }
-    obj["kvlistValue"]?.let { kv ->
-      val values = kv.jsonObject["values"]?.jsonArray
-        ?: error("OTAnyValue.kvlistValue is missing `values`")
-      return OTAnyValue.KvList(values.map { jsonDecoder.json.decodeFromJsonElement(OTKeyValue.serializer(), it) })
-    }
-    error("OTAnyValue has no recognized variant: $obj")
-  }
 }
 
 /**

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/ObserveDatabase.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/ObserveDatabase.kt
@@ -18,6 +18,13 @@ data class PendingMetric(
   val addedAt: String
 )
 
+@Entity(tableName = "pending_logs")
+data class PendingLog(
+  @PrimaryKey val logId: String,
+  // ISO 8601 timestamp
+  val addedAt: String
+)
+
 @Dao
 interface PendingMetricDao {
   @Insert(onConflict = OnConflictStrategy.IGNORE)
@@ -33,9 +40,26 @@ interface PendingMetricDao {
   suspend fun deleteOlderThan(cutoffTimestamp: String)
 }
 
-@Database(entities = [PendingMetric::class], version = 1, exportSchema = false)
+@Dao
+interface PendingLogDao {
+  @Insert(onConflict = OnConflictStrategy.IGNORE)
+  suspend fun insertAll(logs: List<PendingLog>)
+
+  @Query("SELECT logId FROM pending_logs")
+  suspend fun getAllLogIds(): List<String>
+
+  @Query("DELETE FROM pending_logs WHERE logId IN (:logIds)")
+  suspend fun deleteByIds(logIds: List<String>)
+
+  @Query("DELETE FROM pending_logs WHERE addedAt < :cutoffTimestamp")
+  suspend fun deleteOlderThan(cutoffTimestamp: String)
+}
+
+@Database(entities = [PendingMetric::class, PendingLog::class], version = 2, exportSchema = false)
 abstract class ObserveDatabase : RoomDatabase() {
   abstract fun pendingMetricDao(): PendingMetricDao
+
+  abstract fun pendingLogDao(): PendingLogDao
 
   companion object {
     @Volatile

--- a/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/PendingLogsManager.kt
+++ b/packages/expo-observe/android/src/main/java/expo/modules/observe/storage/PendingLogsManager.kt
@@ -1,0 +1,38 @@
+package expo.modules.observe.storage
+
+import android.content.Context
+import androidx.room.withTransaction
+import expo.modules.appmetrics.utils.TimeUtils
+import expo.modules.observe.SQLITE_MAX_BIND_VARIABLES
+
+class PendingLogsManager(
+  context: Context,
+  database: ObserveDatabase? = null
+) {
+  private val database: ObserveDatabase = database ?: ObserveDatabase.getDatabase(context)
+
+  suspend fun addPendingLogs(logIds: List<String>) {
+    val now = TimeUtils.getCurrentTimestampInISOFormat()
+    val pendingLogs = logIds.map { PendingLog(logId = it, addedAt = now) }
+    database.pendingLogDao().insertAll(pendingLogs)
+  }
+
+  suspend fun getAllPendingLogIds(): List<String> = database.pendingLogDao().getAllLogIds()
+
+  suspend fun removePendingLogs(logIds: List<String>) {
+    database.withTransaction {
+      logIds.chunked(SQLITE_MAX_BIND_VARIABLES).forEach { chunk ->
+        database.pendingLogDao().deleteByIds(chunk)
+      }
+    }
+  }
+
+  suspend fun cleanupOldPendingLogs() {
+    val cutoffTimestamp = TimeUtils.getTimestampInISOFormatFromPast(SECONDS_TO_REMOVE_OLD_PENDING_LOGS)
+    database.pendingLogDao().deleteOlderThan(cutoffTimestamp)
+  }
+
+  companion object {
+    private const val SECONDS_TO_REMOVE_OLD_PENDING_LOGS: Long = 7 * 24 * 60 * 60 // 7 days in seconds
+  }
+}

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/BaseObservabilityManagerTest.kt
@@ -25,6 +25,7 @@ class BaseObservabilityManagerTest {
   private lateinit var mockSessionManager: SessionManager
   private lateinit var mockEventDispatcher: EventDispatcher
   private lateinit var mockPendingMetricsManager: PendingMetricsManager
+  private lateinit var mockPendingLogsManager: expo.modules.observe.storage.PendingLogsManager
 
   private val testProjectId = "test-project-123"
   private val testBaseUrl = "https://test.example.com/"
@@ -35,6 +36,7 @@ class BaseObservabilityManagerTest {
     mockSessionManager = mockk(relaxed = true)
     mockEventDispatcher = mockk(relaxed = true)
     mockPendingMetricsManager = mockk(relaxed = true)
+    mockPendingLogsManager = mockk(relaxed = true)
 
     // Default to enabled so existing tests aren't short-circuited
     mockkObject(ObservePreferences)
@@ -753,7 +755,7 @@ class BaseObservabilityManagerTest {
   // region Cleanup tests
 
   @Test
-  fun `cleanup prunes pending metrics and stale sessions`() =
+  fun `cleanup prunes pending metrics, pending logs, stale sessions, and stale logs`() =
     runTest {
       // Arrange
       val manager = createManager()
@@ -763,7 +765,9 @@ class BaseObservabilityManagerTest {
 
       // Assert
       coVerify(exactly = 1) { mockPendingMetricsManager.cleanupOldPendingMetrics() }
+      coVerify(exactly = 1) { mockPendingLogsManager.cleanupOldPendingLogs() }
       coVerify(exactly = 1) { mockSessionManager.cleanupOldSessions() }
+      coVerify(exactly = 1) { mockSessionManager.cleanupOldLogs() }
     }
 
   // endregion
@@ -1009,6 +1013,7 @@ class BaseObservabilityManagerTest {
       context = mockContext,
       sessionManager = mockSessionManager,
       pendingMetricsManager = mockPendingMetricsManager,
+      pendingLogsManager = mockPendingLogsManager,
       projectId = testProjectId,
       baseUrl = testBaseUrl,
       isDebugBuild = isDebugBuild,

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/OTAnyValueTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/OTAnyValueTest.kt
@@ -1,0 +1,177 @@
+package expo.modules.observe
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.double
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class OTAnyValueCodableTest {
+  private val json = Json
+
+  private fun encode(value: OTAnyValue): JsonObject {
+    return json.encodeToJsonElement(OTAnyValueSerializer, value).jsonObject
+  }
+
+  @Test
+  fun `encodes Str under stringValue`() {
+    val obj = encode(OTAnyValue.Str("hello"))
+    assertEquals(1, obj.size)
+    assertEquals("hello", obj["stringValue"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `encodes Int64 under intValue as a string`() {
+    val obj = encode(OTAnyValue.Int64(42))
+    assertEquals(1, obj.size)
+    // OTLP encodes int64 as a JSON string to avoid JS-number precision loss.
+    assertEquals("42", obj["intValue"]!!.jsonPrimitive.content)
+    assertTrue(obj["intValue"]!!.jsonPrimitive.isString)
+  }
+
+  @Test
+  fun `encodes Dbl under doubleValue as a JSON number`() {
+    val obj = encode(OTAnyValue.Dbl(3.14))
+    assertEquals(1, obj.size)
+    assertEquals(3.14, obj["doubleValue"]!!.jsonPrimitive.double, 0.0)
+  }
+
+  @Test
+  fun `encodes Bln under boolValue`() {
+    val obj = encode(OTAnyValue.Bln(true))
+    assertEquals(1, obj.size)
+    assertEquals(true, obj["boolValue"]!!.jsonPrimitive.boolean)
+  }
+
+  @Test
+  fun `encodes Arr as arrayValue with values list`() {
+    val obj = encode(OTAnyValue.Arr(listOf(OTAnyValue.Int64(1), OTAnyValue.Str("x"))))
+    assertEquals(1, obj.size)
+    val values = obj["arrayValue"]!!.jsonObject["values"]!!.jsonArray
+    assertEquals(2, values.size)
+    assertEquals("1", values[0].jsonObject["intValue"]!!.jsonPrimitive.content)
+    assertEquals("x", values[1].jsonObject["stringValue"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `encodes KvList as kvlistValue with key value pairs`() {
+    val obj = encode(
+      OTAnyValue.KvList(
+        listOf(
+          OTKeyValue(key = "a", value = OTAnyValue.Int64(1)),
+          OTKeyValue(key = "b", value = OTAnyValue.Str("x"))
+        )
+      )
+    )
+    assertEquals(1, obj.size)
+    val values = obj["kvlistValue"]!!.jsonObject["values"]!!.jsonArray
+    assertEquals(2, values.size)
+    assertEquals("a", values[0].jsonObject["key"]!!.jsonPrimitive.content)
+    assertEquals("1", values[0].jsonObject["value"]!!.jsonObject["intValue"]!!.jsonPrimitive.content)
+  }
+
+  @Test
+  fun `roundtrips through serialization`() {
+    val original: OTAnyValue = OTAnyValue.KvList(
+      listOf(
+        OTKeyValue(key = "name", value = OTAnyValue.Str("hello")),
+        OTKeyValue(key = "count", value = OTAnyValue.Int64(3)),
+        OTKeyValue(key = "ratio", value = OTAnyValue.Dbl(0.5)),
+        OTKeyValue(key = "ok", value = OTAnyValue.Bln(true)),
+        OTKeyValue(
+          key = "tags",
+          value = OTAnyValue.Arr(listOf(OTAnyValue.Str("a"), OTAnyValue.Str("b")))
+        )
+      )
+    )
+    val encoded = json.encodeToString(OTAnyValueSerializer, original)
+    val decoded = json.decodeFromString(OTAnyValueSerializer, encoded)
+    require(decoded is OTAnyValue.KvList)
+    assertEquals(5, decoded.values.size)
+  }
+}
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class OTAnyValueConversionTest {
+  private fun jsonObj(block: kotlinx.serialization.json.JsonObjectBuilder.() -> Unit) =
+    buildJsonObject(block)
+
+  @Test
+  fun `maps a JSON boolean to Bln`() {
+    val value = otAnyValueFromJsonElement(JsonPrimitive(true))
+    assertTrue(value is OTAnyValue.Bln)
+    assertEquals(true, (value as OTAnyValue.Bln).value)
+  }
+
+  @Test
+  fun `maps a JSON integer to Int64`() {
+    val value = otAnyValueFromJsonElement(JsonPrimitive(42))
+    assertTrue(value is OTAnyValue.Int64)
+    assertEquals(42L, (value as OTAnyValue.Int64).value)
+  }
+
+  @Test
+  fun `maps a JSON double to Dbl`() {
+    val value = otAnyValueFromJsonElement(JsonPrimitive(3.14))
+    assertTrue(value is OTAnyValue.Dbl)
+    assertEquals(3.14, (value as OTAnyValue.Dbl).value, 0.0)
+  }
+
+  @Test
+  fun `maps a JSON string to Str`() {
+    val value = otAnyValueFromJsonElement(JsonPrimitive("hello"))
+    assertTrue(value is OTAnyValue.Str)
+    assertEquals("hello", (value as OTAnyValue.Str).value)
+  }
+
+  @Test
+  fun `drops a JSON non-finite double`() {
+    // JSON cannot encode NaN/Infinity directly; validate the code path that
+    // checks `isFinite` against a manually-constructed primitive.
+    assertNull(otAnyValueFromJsonElement(JsonPrimitive(Double.NaN)))
+    assertNull(otAnyValueFromJsonElement(JsonPrimitive(Double.POSITIVE_INFINITY)))
+    assertNull(otAnyValueFromJsonElement(JsonPrimitive(Double.NEGATIVE_INFINITY)))
+  }
+
+  @Test
+  fun `maps a JSON array to Arr`() {
+    val element = buildJsonArray {
+      add(JsonPrimitive(1))
+      add(JsonPrimitive("x"))
+    }
+    val value = otAnyValueFromJsonElement(element)
+    assertTrue(value is OTAnyValue.Arr)
+    assertEquals(2, (value as OTAnyValue.Arr).values.size)
+  }
+
+  @Test
+  fun `maps a JSON object to KvList`() {
+    val element = jsonObj {
+      put("a", JsonPrimitive(1))
+      put("b", JsonPrimitive("x"))
+    }
+    val value = otAnyValueFromJsonElement(element)
+    assertTrue(value is OTAnyValue.KvList)
+    assertEquals(2, (value as OTAnyValue.KvList).values.size)
+  }
+
+  @Test
+  fun `drops a JSON null value`() {
+    assertNull(otAnyValueFromJsonElement(kotlinx.serialization.json.JsonNull))
+  }
+}

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/OpenTelemetryTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/OpenTelemetryTest.kt
@@ -476,3 +476,12 @@ class OpenTelemetryTest {
     assertEquals(testSessionId, sessionAttr["value"]!!.jsonObject["stringValue"]!!.jsonPrimitive.content)
   }
 }
+
+/**
+ * Test-only convenience for pulling the inner string out of an [OTAnyValue].
+ * Returns `null` for non-string variants — the metric tests in this file only
+ * produce string-valued attributes, so a null result is a real assertion
+ * failure.
+ */
+internal val OTAnyValue.stringValue: String?
+  get() = (this as? OTAnyValue.Str)?.value

--- a/packages/expo-observe/android/src/test/java/expo/modules/observe/OpenTelemetryTest.kt
+++ b/packages/expo-observe/android/src/test/java/expo/modules/observe/OpenTelemetryTest.kt
@@ -485,3 +485,39 @@ class OpenTelemetryTest {
  */
 internal val OTAnyValue.stringValue: String?
   get() = (this as? OTAnyValue.Str)?.value
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class LogEventToOTLogRecordTest {
+  private fun makeLog(severity: String): LogEvent =
+    LogEvent(
+      sessionId = "session-1",
+      timestamp = "2025-01-01T00:00:00.000Z",
+      name = "auth.login_failed",
+      body = "invalid_credentials",
+      severity = severity,
+      attributes = null,
+      droppedAttributesCount = 0
+    )
+
+  @Test
+  fun `renders severityText and severityNumber consistently for known cases`() {
+    val warn = makeLog(severity = "warn").toOTLogRecord()
+    assertEquals("WARN", warn.severityText)
+    assertEquals(13, warn.severityNumber)
+
+    val error = makeLog(severity = "error").toOTLogRecord()
+    assertEquals("ERROR", error.severityText)
+    assertEquals(17, error.severityNumber)
+  }
+
+  @Test
+  fun `falls back to INFO consistently for an unknown severity string`() {
+    // The previous code uppercased the raw value verbatim while the number
+    // path fell back to 9, producing internally-inconsistent records like
+    // (severityText="FROBNICATE", severityNumber=9). This pins the fix.
+    val ot = makeLog(severity = "frobnicate").toOTLogRecord()
+    assertEquals("INFO", ot.severityText)
+    assertEquals(9, ot.severityNumber)
+  }
+}


### PR DESCRIPTION
## Why

Brings Android to parity with the iOS log-events path: a JS-callable `logEvent` API that records validated log records alongside metrics and ships them to OTel `/v1/logs`.

## How

**`expo-app-metrics`**
- New `logEvent(name, options)` JS function on `AppMetricsModule` that validates the event name, body, and attributes (with sanitization + dropped-attribute counting) before persisting.
- New `logevents` package: `EventNameValidation`, `EventBodyValidation`, `AttributeValidation`, `Severity`, `LogEventOptions`.
- Room schema bumped to v15: new `logs` table (with FK + cascade on `sessions.id`), `LogRecord` entity, `LogDao`, `SessionWithLogs` projection, and `SessionManager.addLogs` / `getSessionsWithLogs` / `cleanupOldLogs`.

**`expo-observe`**
- `PendingLogsManager` (mirrors `PendingMetricsManager`) tracks unsent log IDs in `ObserveDatabase`.
- `ObservabilityManager.dispatchUnsentLogs()` runs independently of the metrics path: a logs failure doesn't affect metrics and vice versa. Logs are only sent in OTel mode (the dispatcher and the manager both short-circuit otherwise).
- `EventDispatcher.dispatchLogs` posts to `/v1/logs`; `OpenTelemetry` gains conversion of log records (severity, body, attributes via `OTAnyValue`). Severity is resolved through the `Severity` enum so `severityNumber` and `severityText` can't disagree on an unknown raw value.
- Background worker and `cleanup()` extended to cover the logs side.

## Test Plan

- `./gradlew :expo-app-metrics:testDebugUnitTest :expo-observe:testDebugUnitTest` — green (new `AttributeValidationTest`, `EventBodyValidationTest`, `EventNameValidationTest`, `OTAnyValueTest`, `LogEventToOTLogRecordTest`, plus extensions to existing observe tests).
- Note: release-variant unit tests will fail until #45548 lands; that PR makes the existing environment tests build-variant aware.