### PR TITLE
perf(metro-file-map): Reduce crawl time by optimizing more ignore checks

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,6 +16,7 @@ on:
       - packages/@expo/prebuild-config/src/**
       - packages/@expo/router-server/**
       - packages/@expo/log-box/**
+      - packages/@expo/metro-file-map/**
       - packages/create-expo/**
       - packages/eslint-config-expo/**
       - packages/eslint-plugin-expo/**
@@ -37,6 +38,7 @@ on:
       - packages/@expo/prebuild-config/src/**
       - packages/@expo/router-server/**
       - packages/@expo/log-box/**
+      - packages/@expo/metro-file-map/**
       - packages/create-expo/**
       - packages/eslint-config-expo/**
       - packages/eslint-plugin-expo/**

--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Reduce crawl time further by embedding VCS check and reducing redundant checks ([#45550](https://github.com/expo/expo/pull/45550) by [@kitten](https://github.com/kitten))
+
 ## 56.0.0-2 — 2026-05-06
 
 ### 🎉 New features

--- a/packages/@expo/metro-file-map/build/Watcher.d.ts
+++ b/packages/@expo/metro-file-map/build/Watcher.d.ts
@@ -14,9 +14,9 @@ interface WatcherOptions {
     extensions: readonly string[];
     /** @deprecated */
     forceNodeFilesystemAPI?: boolean;
-    healthCheckFilePrefix: string;
+    healthCheckFilePrefix: string | null;
     ignoreForCrawl: (filePath: string) => boolean;
-    ignorePatternForWatch: RegExp;
+    ignorePatternForWatch: RegExp | null;
     previousState: CrawlerOptions['previousState'];
     perfLogger: PerfLogger | undefined | null;
     roots: readonly string[];

--- a/packages/@expo/metro-file-map/build/Watcher.js
+++ b/packages/@expo/metro-file-map/build/Watcher.js
@@ -60,8 +60,23 @@ class Watcher extends events_1.default {
     async #crawl(crawlOptions) {
         const options = this.#options;
         const { useWatchman, subpath } = crawlOptions;
-        const ignoreForCrawl = (filePath) => options.ignoreForCrawl(filePath) ||
-            path_1.default.basename(filePath).startsWith(this.#options.healthCheckFilePrefix);
+        const ignoreForCrawl = (() => {
+            if (options.ignoreForCrawl && options.healthCheckFilePrefix) {
+                const baseIgnore = options.ignoreForCrawl;
+                const prefix = options.healthCheckFilePrefix;
+                return (filePath) => baseIgnore(filePath) || filePath.startsWith(prefix, filePath.lastIndexOf(path_1.default.sep) + 1);
+            }
+            else if (options.ignoreForCrawl) {
+                return options.ignoreForCrawl;
+            }
+            else if (options.healthCheckFilePrefix) {
+                const prefix = options.healthCheckFilePrefix;
+                return (filePath) => filePath.startsWith(prefix, filePath.lastIndexOf(path_1.default.sep) + 1);
+            }
+            else {
+                return () => false;
+            }
+        })();
         const crawl = useWatchman ? watchman_1.default : node_1.default;
         let crawler = crawl === watchman_1.default ? 'watchman' : 'node';
         options.abortSignal.throwIfAborted();
@@ -146,14 +161,17 @@ class Watcher extends events_1.default {
             const watcher = new WatcherImpl(root, watcherOptions);
             return new Promise(async (resolve, reject) => {
                 const rejectTimeout = setTimeout(() => reject(new Error('Failed to start watch mode.')), MAX_WAIT_TIME);
+                const healthCheckFilePrefix = this.#options.healthCheckFilePrefix;
                 watcher.onFileEvent((change) => {
-                    const basename = path_1.default.basename(change.relativePath);
-                    if (basename.startsWith(this.#options.healthCheckFilePrefix)) {
-                        if (change.event === common_1.TOUCH_EVENT) {
-                            debug('Observed possible health check cookie: %s in %s', change.relativePath, root);
-                            this.#handleHealthCheckObservation(basename);
+                    if (healthCheckFilePrefix) {
+                        const isHealthCheckFile = change.relativePath.startsWith(healthCheckFilePrefix, change.relativePath.lastIndexOf(path_1.default.sep) + 1);
+                        if (isHealthCheckFile) {
+                            if (change.event === common_1.TOUCH_EVENT) {
+                                debug('Observed possible health check cookie: %s in %s', change.relativePath, root);
+                                this.#handleHealthCheckObservation(path_1.default.basename(change.relativePath));
+                            }
+                            return;
                         }
-                        return;
                     }
                     // Watchman handles recrawls internally - receiving a recrawl event
                     // when using Watchman would indicate a bug. Log an error and ignore.

--- a/packages/@expo/metro-file-map/build/crawlers/node/fallback.js
+++ b/packages/@expo/metro-file-map/build/crawlers/node/fallback.js
@@ -67,7 +67,8 @@ function createFallbackFilesystem(opts) {
                 continue;
             }
             if (entry.isDirectory()) {
-                if (!result.has(name)) {
+                // NOTE(@kitten): ".git" and ".hg" check replace the VCS_DIRECTORIES ignore pattern
+                if (!result.has(name) && name !== '.git' && name !== '.hg') {
                     const childDir = new Map();
                     markDir(childDir, FallbackFlag.VISITED);
                     result.set(name, childDir);

--- a/packages/@expo/metro-file-map/build/crawlers/node/index.js
+++ b/packages/@expo/metro-file-map/build/crawlers/node/index.js
@@ -63,7 +63,12 @@ function find(roots, extensions, ignore, includeSymlinks, rootDir, console, prev
             else {
                 for (let idx = 0; idx < entries.length; idx++) {
                     const entry = entries[idx];
-                    const name = entry.name.toString();
+                    const name = entry.name;
+                    // NOTE(@kitten): This replaces the VCS_DIRECTORIES ignore pattern
+                    const isDirectory = entry.isDirectory();
+                    if (isDirectory && (name === '.git' || name === '.hg')) {
+                        continue;
+                    }
                     const file = directory + path.sep + name;
                     const isSymbolicLink = entry.isSymbolicLink();
                     if (ignore(file) || (!includeSymlinks && isSymbolicLink)) {
@@ -77,7 +82,7 @@ function find(roots, extensions, ignore, includeSymlinks, rootDir, console, prev
                         : dirNormal === ''
                             ? name
                             : dirNormal + path.sep + name;
-                    if (entry.isDirectory()) {
+                    if (isDirectory) {
                         // NOTE(@kitten): We'd like to be able to apply excludes to directories selectively based
                         // on their normal paths, so we can exclude using `^...`
                         if (!ignore(childNormal)) {

--- a/packages/@expo/metro-file-map/build/crawlers/watchman/index.js
+++ b/packages/@expo/metro-file-map/build/crawlers/watchman/index.js
@@ -49,6 +49,7 @@ const path = __importStar(require("path"));
 const perf_hooks_1 = require("perf_hooks");
 const planQuery_1 = require("./planQuery");
 const RootPathUtils_1 = require("../../lib/RootPathUtils");
+const isVcsPath_1 = __importDefault(require("../../lib/isVcsPath"));
 const normalizePathSeparatorsToPosix_1 = __importDefault(require("../../lib/normalizePathSeparatorsToPosix"));
 const normalizePathSeparatorsToSystem_1 = __importDefault(require("../../lib/normalizePathSeparatorsToSystem"));
 const WATCHMAN_WARNING_INITIAL_DELAY_MILLISECONDS = 10000;
@@ -247,7 +248,7 @@ async function watchmanCrawl({ abortSignal, computeSha1, extensions, ignore, inc
                 // Whether watchman can return exists: false in a fresh instance
                 // response is unknown, but there's nothing we need to do in that case.
             }
-            else if (!ignore(filePath)) {
+            else if (!(0, isVcsPath_1.default)(fileData.name) && !ignore(filePath)) {
                 const { mtime_ms, size } = fileData;
                 (0, invariant_1.default)(mtime_ms != null && size != null, 'missing file data in watchman response');
                 const mtime = typeof mtime_ms === 'number' ? mtime_ms : mtime_ms.toNumber();

--- a/packages/@expo/metro-file-map/build/index.js
+++ b/packages/@expo/metro-file-map/build/index.js
@@ -77,7 +77,6 @@ Object.defineProperty(exports, "HastePlugin", { enumerable: true, get: function 
 const CACHE_BREAKER = '12';
 const CHANGE_INTERVAL = 30;
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
-const VCS_DIRECTORIES = /[/\\]\.(git|hg)[/\\]/.source;
 const WATCHMAN_REQUIRED_CAPABILITIES = [
     'field-content.sha1hex',
     'relative_root',
@@ -189,19 +188,9 @@ class FileMap extends events_1.default {
             this.#startupPerfLogger = options.perfLoggerFactory?.('START_UP').subSpan('fileMap') ?? null;
             this.#startupPerfLogger?.point('constructor_start');
         }
-        // Add VCS_DIRECTORIES to provided ignorePattern
-        let ignorePattern;
-        if (options.ignorePattern) {
-            const inputIgnorePattern = options.ignorePattern;
-            if (inputIgnorePattern instanceof RegExp) {
-                ignorePattern = new RegExp(inputIgnorePattern.source.concat('|' + VCS_DIRECTORIES), inputIgnorePattern.flags);
-            }
-            else {
-                throw new Error('metro-file-map: the `ignorePattern` option must be a RegExp');
-            }
-        }
-        else {
-            ignorePattern = new RegExp(VCS_DIRECTORIES);
+        const ignorePattern = options.ignorePattern ?? null;
+        if (ignorePattern && !(ignorePattern instanceof RegExp)) {
+            throw new Error('metro-file-map: the `ignorePattern` option must be a RegExp');
         }
         this.#console = options.console || globalThis.console;
         let dataSlot = constants_1.default.PLUGINDATA;
@@ -279,6 +268,7 @@ class FileMap extends events_1.default {
                     debug('Cache loaded (%d clock(s))', initialData.clocks.size);
                 }
                 const rootDir = this.#options.rootDir;
+                const ignorePattern = this.#options.ignorePattern;
                 this.#startupPerfLogger?.point('constructFileSystem_start');
                 const processFile = async (normalPath, metadata, opts) => {
                     const result = await this.#fileProcessor.processRegularFile(normalPath, metadata, {
@@ -294,7 +284,7 @@ class FileMap extends events_1.default {
                     ? (0, fallback_1.default)({
                         rootPathUtils: this.#pathUtils,
                         extensions: this.#options.extensions,
-                        ignore: (filePath) => this.#options.ignorePattern.test(filePath),
+                        ignore: ignorePattern ? (filePath) => ignorePattern.test(filePath) : () => false,
                         includeSymlinks: this.#options.enableSymlinks,
                     })
                     : null;
@@ -395,6 +385,20 @@ class FileMap extends events_1.default {
     async #buildFileDelta(previousState) {
         this.#startupPerfLogger?.point('buildFileDelta_start');
         const { computeSha1, enableSymlinks, extensions, forceNodeFilesystemAPI, ignorePattern, retainAllFiles, roots, rootDir, watch, watchmanDeferStates, } = this.#options;
+        const ignoreForCrawl = (() => {
+            if (ignorePattern && !retainAllFiles) {
+                return (filePath) => ignorePattern.test(filePath) || filePath.includes(NODE_MODULES);
+            }
+            else if (ignorePattern) {
+                return (filePath) => ignorePattern.test(filePath);
+            }
+            else if (!retainAllFiles) {
+                return (filePath) => filePath.includes(NODE_MODULES);
+            }
+            else {
+                return () => false;
+            }
+        })();
         this.#watcher = new Watcher_1.Watcher({
             abortSignal: this.#crawlerAbortController.signal,
             computeSha1,
@@ -402,12 +406,10 @@ class FileMap extends events_1.default {
             enableSymlinks,
             extensions,
             forceNodeFilesystemAPI,
-            healthCheckFilePrefix: this.#options.healthCheck.filePrefix,
-            // TODO: Refactor out the two different ignore strategies here.
-            ignoreForCrawl: (filePath) => {
-                const ignoreMatched = ignorePattern.test(filePath);
-                return ignoreMatched || (!retainAllFiles && filePath.includes(NODE_MODULES));
-            },
+            healthCheckFilePrefix: this.#options.healthCheck.enabled
+                ? this.#options.healthCheck.filePrefix
+                : null,
+            ignoreForCrawl,
             ignorePatternForWatch: ignorePattern,
             perfLogger: this.#startupPerfLogger,
             previousState,
@@ -630,7 +632,8 @@ class FileMap extends events_1.default {
             const absoluteFilePath = path.join(change.root, (0, normalizePathSeparatorsToSystem_1.default)(change.relativePath));
             // Ignore files (including symlinks) whose path matches ignorePattern
             // (we don't ignore node_modules in watch mode)
-            if (this.#options.ignorePattern.test(absoluteFilePath)) {
+            // TODO(@kitten): Can be dropped, assuming that regexes aren't violating constraints
+            if (this.#options.ignorePattern?.test(absoluteFilePath) === true) {
                 return;
             }
             const relativeFilePath = this.#pathUtils.absoluteToNormal(absoluteFilePath);

--- a/packages/@expo/metro-file-map/build/lib/TreeFS.js
+++ b/packages/@expo/metro-file-map/build/lib/TreeFS.js
@@ -787,8 +787,8 @@ class TreeFS {
         }
         return null;
     }
-    *metadataIterator(opts) {
-        yield* this.#metadataIterator(this.#rootNode, opts);
+    metadataIterator(opts) {
+        return this.#metadataIterator(this.#rootNode, opts);
     }
     *#metadataIterator(rootNode, opts, prefix = '') {
         for (const [name, node] of rootNode) {

--- a/packages/@expo/metro-file-map/build/lib/isVcsPath.d.ts
+++ b/packages/@expo/metro-file-map/build/lib/isVcsPath.d.ts
@@ -1,0 +1,1 @@
+export default function isVcsPath(filePath: string): boolean;

--- a/packages/@expo/metro-file-map/build/lib/isVcsPath.js
+++ b/packages/@expo/metro-file-map/build/lib/isVcsPath.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = isVcsPath;
+const VCS_DIR_SEGMENT = /(?:^|[/\\])\.(?:git|hg)[/\\]/;
+function isVcsPath(filePath) {
+    return VCS_DIR_SEGMENT.test(filePath);
+}

--- a/packages/@expo/metro-file-map/build/lib/rootRelativeCacheKeys.js
+++ b/packages/@expo/metro-file-map/build/lib/rootRelativeCacheKeys.js
@@ -32,7 +32,7 @@ function rootRelativeCacheKeys(buildParameters) {
             case 'retainAllFiles':
                 return buildParameters[key] ?? null;
             case 'ignorePattern':
-                return buildParameters[key].toString();
+                return buildParameters[key]?.toString() ?? null;
             case 'forceNodeFilesystemAPI':
                 return null;
             default:

--- a/packages/@expo/metro-file-map/build/types.d.ts
+++ b/packages/@expo/metro-file-map/build/types.d.ts
@@ -14,7 +14,7 @@ export interface BuildParameters {
     readonly extensions: readonly string[];
     /** @deprecated */
     readonly forceNodeFilesystemAPI?: boolean;
-    readonly ignorePattern: RegExp;
+    readonly ignorePattern: RegExp | null;
     readonly plugins: readonly InputFileMapPlugin[];
     readonly retainAllFiles: boolean;
     readonly rootDir: string;

--- a/packages/@expo/metro-file-map/build/watchers/AbstractWatcher.js
+++ b/packages/@expo/metro-file-map/build/watchers/AbstractWatcher.js
@@ -45,6 +45,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.AbstractWatcher = void 0;
 const events_1 = __importDefault(require("events"));
 const path = __importStar(require("path"));
+const isVcsPath_1 = __importDefault(require("../lib/isVcsPath"));
 const common_1 = require("./common");
 class AbstractWatcher {
     root;
@@ -59,8 +60,8 @@ class AbstractWatcher {
         this.ignored = ignored;
         this.globs = globs;
         this.doIgnore = ignored
-            ? (filePath) => (0, common_1.posixPathMatchesPattern)(ignored, filePath)
-            : () => false;
+            ? (filePath) => (0, isVcsPath_1.default)(filePath) || (0, common_1.posixPathMatchesPattern)(ignored, filePath)
+            : isVcsPath_1.default;
         this.root = path.resolve(dir);
     }
     onFileEvent(listener) {

--- a/packages/@expo/metro-file-map/src/Watcher.ts
+++ b/packages/@expo/metro-file-map/src/Watcher.ts
@@ -48,7 +48,7 @@ interface WatcherOptions {
   forceNodeFilesystemAPI?: boolean;
   healthCheckFilePrefix: string;
   ignoreForCrawl: (filePath: string) => boolean;
-  ignorePatternForWatch: RegExp;
+  ignorePatternForWatch: RegExp | null;
   previousState: CrawlerOptions['previousState'];
   perfLogger: PerfLogger | undefined | null;
   roots: readonly string[];
@@ -122,9 +122,11 @@ export class Watcher extends EventEmitter {
     const options = this.#options;
     const { useWatchman, subpath } = crawlOptions;
 
+    const baseIgnoreForCrawl = options.ignoreForCrawl;
+    const healthCheckFilePrefix = options.healthCheckFilePrefix;
     const ignoreForCrawl = (filePath: string) =>
-      options.ignoreForCrawl(filePath) ||
-      path.basename(filePath).startsWith(this.#options.healthCheckFilePrefix);
+      baseIgnoreForCrawl(filePath) ||
+      filePath.startsWith(healthCheckFilePrefix, filePath.lastIndexOf(path.sep) + 1);
     const crawl = useWatchman ? watchmanCrawl : nodeCrawl;
     let crawler = crawl === watchmanCrawl ? 'watchman' : 'node';
 

--- a/packages/@expo/metro-file-map/src/Watcher.ts
+++ b/packages/@expo/metro-file-map/src/Watcher.ts
@@ -46,7 +46,7 @@ interface WatcherOptions {
   extensions: readonly string[];
   /** @deprecated */
   forceNodeFilesystemAPI?: boolean;
-  healthCheckFilePrefix: string;
+  healthCheckFilePrefix: string | null;
   ignoreForCrawl: (filePath: string) => boolean;
   ignorePatternForWatch: RegExp | null;
   previousState: CrawlerOptions['previousState'];
@@ -122,11 +122,23 @@ export class Watcher extends EventEmitter {
     const options = this.#options;
     const { useWatchman, subpath } = crawlOptions;
 
-    const baseIgnoreForCrawl = options.ignoreForCrawl;
-    const healthCheckFilePrefix = options.healthCheckFilePrefix;
-    const ignoreForCrawl = (filePath: string) =>
-      baseIgnoreForCrawl(filePath) ||
-      filePath.startsWith(healthCheckFilePrefix, filePath.lastIndexOf(path.sep) + 1);
+    const ignoreForCrawl = (() => {
+      if (options.ignoreForCrawl && options.healthCheckFilePrefix) {
+        const baseIgnore = options.ignoreForCrawl;
+        const prefix = options.healthCheckFilePrefix;
+        return (filePath: string) =>
+          baseIgnore(filePath) || filePath.startsWith(prefix, filePath.lastIndexOf(path.sep) + 1);
+      } else if (options.ignoreForCrawl) {
+        return options.ignoreForCrawl;
+      } else if (options.healthCheckFilePrefix) {
+        const prefix = options.healthCheckFilePrefix;
+        return (filePath: string) =>
+          filePath.startsWith(prefix, filePath.lastIndexOf(path.sep) + 1);
+      } else {
+        return () => false;
+      }
+    })();
+
     const crawl = useWatchman ? watchmanCrawl : nodeCrawl;
     let crawler = crawl === watchmanCrawl ? 'watchman' : 'node';
 
@@ -235,15 +247,22 @@ export class Watcher extends EventEmitter {
           MAX_WAIT_TIME
         );
 
+        const healthCheckFilePrefix = this.#options.healthCheckFilePrefix;
         watcher.onFileEvent((change) => {
-          const basename = path.basename(change.relativePath);
-          if (basename.startsWith(this.#options.healthCheckFilePrefix)) {
-            if (change.event === TOUCH_EVENT) {
-              debug('Observed possible health check cookie: %s in %s', change.relativePath, root);
-              this.#handleHealthCheckObservation(basename);
+          if (healthCheckFilePrefix) {
+            const isHealthCheckFile = change.relativePath.startsWith(
+              healthCheckFilePrefix,
+              change.relativePath.lastIndexOf(path.sep) + 1
+            );
+            if (isHealthCheckFile) {
+              if (change.event === TOUCH_EVENT) {
+                debug('Observed possible health check cookie: %s in %s', change.relativePath, root);
+                this.#handleHealthCheckObservation(path.basename(change.relativePath));
+              }
+              return;
             }
-            return;
           }
+
           // Watchman handles recrawls internally - receiving a recrawl event
           // when using Watchman would indicate a bug. Log an error and ignore.
           if (change.event === 'recrawl' && useWatchman) {

--- a/packages/@expo/metro-file-map/src/__tests__/Watcher.test.ts
+++ b/packages/@expo/metro-file-map/src/__tests__/Watcher.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 650 Industries, Inc. (Expo).
+ */
+
+import { vol } from 'memfs';
+
+import { Watcher } from '../Watcher';
+import TreeFS from '../lib/TreeFS';
+import type { CrawlerOptions, FileData } from '../types';
+
+const rootDir = '/project';
+const processFile = async () => null;
+
+function makeTreeFS(files?: FileData): TreeFS {
+  return new TreeFS({ rootDir, files, processFile });
+}
+
+function makeWatcher(
+  overrides: {
+    ignoreForCrawl?: (filePath: string) => boolean;
+    healthCheckFilePrefix?: string | null;
+    roots?: readonly string[];
+  } = {}
+) {
+  return new Watcher({
+    abortSignal: new AbortController().signal,
+    computeSha1: false,
+    console,
+    enableSymlinks: false,
+    extensions: ['js'],
+    forceNodeFilesystemAPI: true,
+    healthCheckFilePrefix: overrides.healthCheckFilePrefix ?? null,
+    ignoreForCrawl: overrides.ignoreForCrawl ?? (() => false),
+    ignorePatternForWatch: null,
+    perfLogger: null,
+    previousState: {
+      fileSystem: makeTreeFS(),
+      clocks: new Map(),
+    } as CrawlerOptions['previousState'],
+    rootDir,
+    roots: overrides.roots ?? [rootDir],
+    useWatchman: false,
+    watch: false,
+    watchmanDeferStates: [],
+  });
+}
+
+function sorted(iter: IterableIterator<string>): string[] {
+  return Array.from(iter).sort();
+}
+
+describe('Watcher.crawl ignoreForCrawl composition', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  test('filters health-check-prefixed files when prefix is set', async () => {
+    vol.fromJSON({
+      '/project/a.js': 'a',
+      '/project/.metro-health-check-1.js': 'hc',
+      '/project/sub/.metro-health-check-2.js': 'hc',
+      '/project/sub/b.js': 'b',
+    });
+
+    const { changedFiles } = await makeWatcher({
+      healthCheckFilePrefix: '.metro-health-check',
+    }).crawl();
+
+    expect(sorted(changedFiles.keys())).toEqual(['a.js', 'sub/b.js']);
+  });
+
+  test('does not filter health-check files when prefix is null (default)', async () => {
+    vol.fromJSON({
+      '/project/a.js': 'a',
+      '/project/.metro-health-check-1.js': 'hc',
+    });
+
+    const { changedFiles } = await makeWatcher({
+      healthCheckFilePrefix: null,
+    }).crawl();
+
+    expect(sorted(changedFiles.keys())).toEqual(['.metro-health-check-1.js', 'a.js']);
+  });
+
+  test('applies user ignoreForCrawl alongside health-check filter', async () => {
+    vol.fromJSON({
+      '/project/keep.js': 'k',
+      '/project/blocked.js': 'b',
+      '/project/.metro-health-check.js': 'hc',
+    });
+
+    const { changedFiles } = await makeWatcher({
+      ignoreForCrawl: (filePath) => filePath.includes('blocked'),
+      healthCheckFilePrefix: '.metro-health-check',
+    }).crawl();
+
+    expect(sorted(changedFiles.keys())).toEqual(['keep.js']);
+  });
+
+  test('only matches the prefix at the start of the basename', async () => {
+    vol.fromJSON({
+      // The prefix string appears mid-basename — must NOT be filtered, since
+      // we only match when the basename *starts with* the prefix.
+      '/project/x.metro-health-check.js': 'a',
+      '/project/sub/y.metro-health-check.js': 'b',
+    });
+
+    const { changedFiles } = await makeWatcher({
+      healthCheckFilePrefix: '.metro-health-check',
+    }).crawl();
+
+    expect(sorted(changedFiles.keys())).toEqual([
+      'sub/y.metro-health-check.js',
+      'x.metro-health-check.js',
+    ]);
+  });
+
+  test('matches a basename-only path (no separator) against the prefix', async () => {
+    vol.fromJSON({
+      '/project/.metro-health-check.js': 'hc',
+      '/project/other.js': 'o',
+    });
+
+    const { changedFiles } = await makeWatcher({
+      healthCheckFilePrefix: '.metro-health-check',
+    }).crawl();
+
+    expect(sorted(changedFiles.keys())).toEqual(['other.js']);
+  });
+
+  test('user ignoreForCrawl alone suffices when prefix is null', async () => {
+    vol.fromJSON({
+      '/project/keep.js': 'k',
+      '/project/blocked.js': 'b',
+    });
+
+    const { changedFiles } = await makeWatcher({
+      ignoreForCrawl: (filePath) => filePath.includes('blocked'),
+      healthCheckFilePrefix: null,
+    }).crawl();
+
+    expect(sorted(changedFiles.keys())).toEqual(['keep.js']);
+  });
+});

--- a/packages/@expo/metro-file-map/src/crawlers/node/__tests__/fallback.test.ts
+++ b/packages/@expo/metro-file-map/src/crawlers/node/__tests__/fallback.test.ts
@@ -216,6 +216,32 @@ describe('createFallbackFilesystem', () => {
 
       expect(result!.get('file.js')?.[0]).toBe(999); // preserved
     });
+
+    test('skips .git and .hg directories', () => {
+      vol.fromJSON({
+        '/project/src/keep.js': 'a',
+        '/project/src/.git/HEAD': 'ref',
+        '/project/src/.hg/store/data': 'binary',
+      });
+      const fallback = createFallback();
+      const result = fallback.readdir('src', '/project/src', undefined);
+
+      expect(result).toBeInstanceOf(Map);
+      expect(result!.has('keep.js')).toBe(true);
+      expect(result!.has('.git')).toBe(false);
+      expect(result!.has('.hg')).toBe(false);
+    });
+
+    test('skips .git and .hg even when ignore would not match them', () => {
+      vol.fromJSON({
+        '/project/src/.git/HEAD': 'ref',
+        '/project/src/keep.js': 'a',
+      });
+      const fallback = createFallback({ ignore: () => false });
+      const result = fallback.readdir('src', '/project/src', undefined);
+
+      expect(result!.has('.git')).toBe(false);
+    });
   });
 
   describe('directory marking (isFallbackDir)', () => {

--- a/packages/@expo/metro-file-map/src/crawlers/node/__tests__/index.test.ts
+++ b/packages/@expo/metro-file-map/src/crawlers/node/__tests__/index.test.ts
@@ -375,6 +375,58 @@ describe('node crawler', () => {
     expect(sorted(changedFiles.keys())).toEqual(['fruits/apple.js', 'fruits/tropical.js']);
   });
 
+  describe('VCS directories', () => {
+    test('skips .git and .hg directories without consulting ignore', async () => {
+      const ignore = jest.fn(() => false);
+
+      vol.fromJSON({
+        '/project/fruits/apple.js': 'a',
+        '/project/fruits/.git/HEAD': 'ref',
+        '/project/fruits/.git/objects/abc': 'binary',
+        '/project/fruits/.hg/store/data': 'binary',
+      });
+
+      const { changedFiles } = await crawl({ ignore });
+
+      expect(sorted(changedFiles.keys())).toEqual(['fruits/apple.js']);
+      // The early-skip happens before any `ignore()` call for the .git/.hg
+      // directory entries, so the matcher is never asked about those paths.
+      const seenPaths = ignore.mock.calls.map((args) => args[0] as string);
+      expect(seenPaths.some((p) => p.includes('.git'))).toBe(false);
+      expect(seenPaths.some((p) => p.includes('.hg'))).toBe(false);
+    });
+
+    test('skips .git directory even when ignore would otherwise allow it', async () => {
+      vol.fromJSON({
+        '/project/fruits/apple.js': 'a',
+        '/project/fruits/.git/HEAD': 'ref',
+      });
+
+      const { changedFiles } = await crawl({
+        // ignore returns false for everything, including .git contents
+        ignore: () => false,
+      });
+
+      expect(sorted(changedFiles.keys())).toEqual(['fruits/apple.js']);
+    });
+
+    test('does not skip files merely named .git or .hg', async () => {
+      // A *file* named `.git` (e.g. a git submodule pointer file) matches the
+      // basename equality but `entry.isDirectory()` is false, so it falls
+      // through to the regular ignore/extension pipeline.
+      vol.fromJSON({
+        '/project/fruits/apple.js': 'a',
+        '/project/fruits/.git': 'gitdir: ../.git/modules/fruits',
+      });
+
+      const { changedFiles } = await crawl({ extensions: ['js'] });
+
+      // The `.git` file has no matching extension, so it isn't included; but
+      // the directory traversal didn't bail out either.
+      expect(sorted(changedFiles.keys())).toEqual(['fruits/apple.js']);
+    });
+  });
+
   describe('abort signal', () => {
     test('aborts on pre-aborted signal', async () => {
       const err = new Error('aborted for test');

--- a/packages/@expo/metro-file-map/src/crawlers/node/fallback.ts
+++ b/packages/@expo/metro-file-map/src/crawlers/node/fallback.ts
@@ -91,7 +91,8 @@ export default function createFallbackFilesystem(
       }
 
       if (entry.isDirectory()) {
-        if (!result.has(name)) {
+        // NOTE(@kitten): ".git" and ".hg" check replace the VCS_DIRECTORIES ignore pattern
+        if (!result.has(name) && name !== '.git' && name !== '.hg') {
           const childDir = new Map();
           markDir(childDir, FallbackFlag.VISITED);
           result.set(name, childDir);

--- a/packages/@expo/metro-file-map/src/crawlers/node/index.ts
+++ b/packages/@expo/metro-file-map/src/crawlers/node/index.ts
@@ -55,9 +55,15 @@ function find(
       } else {
         for (let idx = 0; idx < entries.length; idx++) {
           const entry = entries[idx]!;
-          const name = entry.name.toString();
-          const file = directory + path.sep + name;
+          const name = entry.name;
 
+          // NOTE(@kitten): This replaces the VCS_DIRECTORIES ignore pattern
+          const isDirectory = entry.isDirectory();
+          if (isDirectory && (name === '.git' || name === '.hg')) {
+            continue;
+          }
+
+          const file = directory + path.sep + name;
           const isSymbolicLink = entry.isSymbolicLink();
           if (ignore(file) || (!includeSymlinks && isSymbolicLink)) {
             continue;
@@ -72,7 +78,7 @@ function find(
               ? name
               : dirNormal + path.sep + name;
 
-          if (entry.isDirectory()) {
+          if (isDirectory) {
             // NOTE(@kitten): We'd like to be able to apply excludes to directories selectively based
             // on their normal paths, so we can exclude using `^...`
             if (!ignore(childNormal)) {

--- a/packages/@expo/metro-file-map/src/crawlers/watchman/index.ts
+++ b/packages/@expo/metro-file-map/src/crawlers/watchman/index.ts
@@ -13,6 +13,7 @@ import { performance } from 'perf_hooks';
 
 import { planQuery } from './planQuery';
 import { RootPathUtils } from '../../lib/RootPathUtils';
+import isVcsPath from '../../lib/isVcsPath';
 import normalizePathSeparatorsToPosix from '../../lib/normalizePathSeparatorsToPosix';
 import normalizePathSeparatorsToSystem from '../../lib/normalizePathSeparatorsToSystem';
 import type {
@@ -292,7 +293,7 @@ export default async function watchmanCrawl({
         }
         // Whether watchman can return exists: false in a fresh instance
         // response is unknown, but there's nothing we need to do in that case.
-      } else if (!ignore(filePath)) {
+      } else if (!isVcsPath(fileData.name) && !ignore(filePath)) {
         const { mtime_ms, size } = fileData;
         invariant(mtime_ms != null && size != null, 'missing file data in watchman response');
         const mtime = typeof mtime_ms === 'number' ? mtime_ms : mtime_ms.toNumber();

--- a/packages/@expo/metro-file-map/src/index.ts
+++ b/packages/@expo/metro-file-map/src/index.ts
@@ -538,7 +538,9 @@ export default class FileMap extends EventEmitter {
       enableSymlinks,
       extensions,
       forceNodeFilesystemAPI,
-      healthCheckFilePrefix: this.#options.healthCheck.filePrefix,
+      healthCheckFilePrefix: this.#options.healthCheck.enabled
+        ? this.#options.healthCheck.filePrefix
+        : null,
       ignoreForCrawl,
       ignorePatternForWatch: ignorePattern,
       perfLogger: this.#startupPerfLogger,

--- a/packages/@expo/metro-file-map/src/index.ts
+++ b/packages/@expo/metro-file-map/src/index.ts
@@ -160,7 +160,6 @@ const CACHE_BREAKER = '12';
 const CHANGE_INTERVAL = 30;
 
 const NODE_MODULES = path.sep + 'node_modules' + path.sep;
-const VCS_DIRECTORIES = /[/\\]\.(git|hg)[/\\]/.source;
 const WATCHMAN_REQUIRED_CAPABILITIES = [
   'field-content.sha1hex',
   'relative_root',
@@ -278,20 +277,13 @@ export default class FileMap extends EventEmitter {
       this.#startupPerfLogger?.point('constructor_start');
     }
 
-    // Add VCS_DIRECTORIES to provided ignorePattern
-    let ignorePattern;
+    let ignorePattern: RegExp | null = null;
     if (options.ignorePattern) {
-      const inputIgnorePattern = options.ignorePattern;
-      if (inputIgnorePattern instanceof RegExp) {
-        ignorePattern = new RegExp(
-          inputIgnorePattern.source.concat('|' + VCS_DIRECTORIES),
-          inputIgnorePattern.flags
-        );
+      if (options.ignorePattern instanceof RegExp) {
+        ignorePattern = options.ignorePattern;
       } else {
         throw new Error('metro-file-map: the `ignorePattern` option must be a RegExp');
       }
-    } else {
-      ignorePattern = new RegExp(VCS_DIRECTORIES);
     }
 
     this.#console = options.console || globalThis.console;
@@ -379,6 +371,7 @@ export default class FileMap extends EventEmitter {
         }
 
         const rootDir = this.#options.rootDir;
+        const ignorePattern = this.#options.ignorePattern;
         this.#startupPerfLogger?.point('constructFileSystem_start');
         const processFile: ProcessFileFunction = async (normalPath, metadata, opts) => {
           const result = await this.#fileProcessor.processRegularFile(normalPath, metadata, {
@@ -394,7 +387,7 @@ export default class FileMap extends EventEmitter {
           ? createFallbackFilesystem({
               rootPathUtils: this.#pathUtils,
               extensions: this.#options.extensions,
-              ignore: (filePath) => this.#options.ignorePattern.test(filePath),
+              ignore: ignorePattern ? (filePath) => ignorePattern.test(filePath) : () => false,
               includeSymlinks: this.#options.enableSymlinks,
             })
           : null;
@@ -525,6 +518,19 @@ export default class FileMap extends EventEmitter {
       watchmanDeferStates,
     } = this.#options;
 
+    const ignoreForCrawl = (() => {
+      if (ignorePattern && !retainAllFiles) {
+        return (filePath: string) =>
+          ignorePattern.test(filePath) || filePath.includes(NODE_MODULES);
+      } else if (ignorePattern) {
+        return (filePath: string) => ignorePattern.test(filePath);
+      } else if (!retainAllFiles) {
+        return (filePath: string) => filePath.includes(NODE_MODULES);
+      } else {
+        return () => false;
+      }
+    })();
+
     this.#watcher = new Watcher({
       abortSignal: this.#crawlerAbortController.signal,
       computeSha1,
@@ -533,11 +539,7 @@ export default class FileMap extends EventEmitter {
       extensions,
       forceNodeFilesystemAPI,
       healthCheckFilePrefix: this.#options.healthCheck.filePrefix,
-      // TODO: Refactor out the two different ignore strategies here.
-      ignoreForCrawl: (filePath) => {
-        const ignoreMatched = ignorePattern.test(filePath);
-        return ignoreMatched || (!retainAllFiles && filePath.includes(NODE_MODULES));
-      },
+      ignoreForCrawl,
       ignorePatternForWatch: ignorePattern,
       perfLogger: this.#startupPerfLogger,
       previousState,
@@ -842,7 +844,8 @@ export default class FileMap extends EventEmitter {
 
       // Ignore files (including symlinks) whose path matches ignorePattern
       // (we don't ignore node_modules in watch mode)
-      if (this.#options.ignorePattern.test(absoluteFilePath)) {
+      // TODO(@kitten): Can be dropped, assuming that regexes aren't violating constraints
+      if (this.#options.ignorePattern?.test(absoluteFilePath) === true) {
         return;
       }
 

--- a/packages/@expo/metro-file-map/src/index.ts
+++ b/packages/@expo/metro-file-map/src/index.ts
@@ -277,13 +277,9 @@ export default class FileMap extends EventEmitter {
       this.#startupPerfLogger?.point('constructor_start');
     }
 
-    let ignorePattern: RegExp | null = null;
-    if (options.ignorePattern) {
-      if (options.ignorePattern instanceof RegExp) {
-        ignorePattern = options.ignorePattern;
-      } else {
-        throw new Error('metro-file-map: the `ignorePattern` option must be a RegExp');
-      }
+    const ignorePattern: RegExp | null = options.ignorePattern ?? null;
+    if (ignorePattern && !(ignorePattern instanceof RegExp)) {
+      throw new Error('metro-file-map: the `ignorePattern` option must be a RegExp');
     }
 
     this.#console = options.console || globalThis.console;

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -1109,12 +1109,12 @@ export default class TreeFS implements MutableFileSystem {
     return null;
   }
 
-  *metadataIterator(opts: MetadataIteratorOptions): Generator<{
+  metadataIterator(opts: MetadataIteratorOptions): Generator<{
     baseName: string;
     canonicalPath: string;
     metadata: FileMetadata;
   }> {
-    yield* this.#metadataIterator(this.#rootNode, opts);
+    return this.#metadataIterator(this.#rootNode, opts);
   }
 
   *#metadataIterator(

--- a/packages/@expo/metro-file-map/src/lib/__tests__/isVcsPath.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/isVcsPath.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 650 Industries, Inc. (Expo).
+ */
+
+import isVcsPath from '../isVcsPath';
+
+describe('isVcsPath', () => {
+  test('matches .git and .hg segments at the start of a relative path', () => {
+    expect(isVcsPath('.git/HEAD')).toBe(true);
+    expect(isVcsPath('.hg/store/data')).toBe(true);
+  });
+
+  test('matches .git and .hg segments in the middle of a path', () => {
+    expect(isVcsPath('foo/.git/HEAD')).toBe(true);
+    expect(isVcsPath('a/b/c/.hg/store')).toBe(true);
+  });
+
+  test('matches .git and .hg segments in absolute paths', () => {
+    expect(isVcsPath('/repo/.git/HEAD')).toBe(true);
+    expect(isVcsPath('/repo/.hg/store')).toBe(true);
+  });
+
+  test('matches with backslash separators (Windows)', () => {
+    expect(isVcsPath('C:\\repo\\.git\\HEAD')).toBe(true);
+    expect(isVcsPath('.git\\HEAD')).toBe(true);
+    expect(isVcsPath('foo\\.hg\\store')).toBe(true);
+  });
+
+  test('does not match files that merely contain .git or .hg in their name', () => {
+    expect(isVcsPath('foo.git')).toBe(false);
+    expect(isVcsPath('foo/bar.git')).toBe(false);
+    expect(isVcsPath('foo/my.git.txt')).toBe(false);
+    expect(isVcsPath('foo/.gitignore')).toBe(false);
+  });
+
+  test('does not match the bare .git or .hg basename without a trailing separator', () => {
+    // Preserves the original VCS_DIRECTORIES `[/\\]\.(git|hg)[/\\]` semantics:
+    // a path ending at the VCS directory itself (no trailing separator) is not
+    // matched. Crawlers and walkers handle the directory entry case via a
+    // dedicated basename string check.
+    expect(isVcsPath('/repo/.git')).toBe(false);
+    expect(isVcsPath('/repo/.hg')).toBe(false);
+    expect(isVcsPath('.git')).toBe(false);
+    expect(isVcsPath('.hg')).toBe(false);
+  });
+
+  test('does not match unrelated paths', () => {
+    expect(isVcsPath('src/index.ts')).toBe(false);
+    expect(isVcsPath('/repo/src/index.ts')).toBe(false);
+    expect(isVcsPath('node_modules/foo/index.js')).toBe(false);
+  });
+});

--- a/packages/@expo/metro-file-map/src/lib/isVcsPath.ts
+++ b/packages/@expo/metro-file-map/src/lib/isVcsPath.ts
@@ -1,0 +1,5 @@
+const VCS_DIR_SEGMENT = /(?:^|[/\\])\.(?:git|hg)[/\\]/;
+
+export default function isVcsPath(filePath: string): boolean {
+  return VCS_DIR_SEGMENT.test(filePath);
+}

--- a/packages/@expo/metro-file-map/src/lib/rootRelativeCacheKeys.ts
+++ b/packages/@expo/metro-file-map/src/lib/rootRelativeCacheKeys.ts
@@ -36,7 +36,7 @@ export default function rootRelativeCacheKeys(buildParameters: BuildParameters):
         case 'retainAllFiles':
           return buildParameters[key] ?? null;
         case 'ignorePattern':
-          return buildParameters[key].toString();
+          return buildParameters[key]?.toString() ?? null;
         case 'forceNodeFilesystemAPI':
           return null;
         default:

--- a/packages/@expo/metro-file-map/src/types.ts
+++ b/packages/@expo/metro-file-map/src/types.ts
@@ -21,7 +21,7 @@ export interface BuildParameters {
   readonly extensions: readonly string[];
   /** @deprecated */
   readonly forceNodeFilesystemAPI?: boolean;
-  readonly ignorePattern: RegExp;
+  readonly ignorePattern: RegExp | null;
   readonly plugins: readonly InputFileMapPlugin[];
   readonly retainAllFiles: boolean;
   readonly rootDir: string;

--- a/packages/@expo/metro-file-map/src/watchers/AbstractWatcher.ts
+++ b/packages/@expo/metro-file-map/src/watchers/AbstractWatcher.ts
@@ -8,6 +8,7 @@
 import EventEmitter from 'events';
 import * as path from 'path';
 
+import isVcsPath from '../lib/isVcsPath';
 import type { WatcherBackend, WatcherBackendChangeEvent, WatcherBackendOptions } from '../types';
 import { posixPathMatchesPattern } from './common';
 
@@ -35,8 +36,8 @@ export class AbstractWatcher implements WatcherBackend {
     this.ignored = ignored;
     this.globs = globs;
     this.doIgnore = ignored
-      ? (filePath: string) => posixPathMatchesPattern(ignored, filePath)
-      : () => false;
+      ? (filePath: string) => isVcsPath(filePath) || posixPathMatchesPattern(ignored, filePath)
+      : isVcsPath;
 
     this.root = path.resolve(dir);
   }

--- a/packages/@expo/metro-file-map/src/watchers/__tests__/AbstractWatcher.test.ts
+++ b/packages/@expo/metro-file-map/src/watchers/__tests__/AbstractWatcher.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 650 Industries, Inc. (Expo).
+ */
+
+import { AbstractWatcher } from '../AbstractWatcher';
+
+describe('AbstractWatcher.doIgnore', () => {
+  test('rejects .git and .hg path segments without a user pattern', () => {
+    const watcher = new AbstractWatcher('/project', {
+      dot: true,
+      globs: [],
+      ignored: null,
+      watchmanDeferStates: [],
+    });
+
+    expect(watcher.doIgnore('.git/HEAD')).toBe(true);
+    expect(watcher.doIgnore('foo/.git/HEAD')).toBe(true);
+    expect(watcher.doIgnore('.hg/store/data')).toBe(true);
+    expect(watcher.doIgnore('foo/.hg/data')).toBe(true);
+  });
+
+  test('passes non-VCS paths through when no user pattern is set', () => {
+    const watcher = new AbstractWatcher('/project', {
+      dot: true,
+      globs: [],
+      ignored: null,
+      watchmanDeferStates: [],
+    });
+
+    expect(watcher.doIgnore('src/index.ts')).toBe(false);
+    expect(watcher.doIgnore('node_modules/foo/index.js')).toBe(false);
+  });
+
+  test('rejects VCS paths even when user pattern would not match', () => {
+    const watcher = new AbstractWatcher('/project', {
+      dot: true,
+      globs: [],
+      ignored: /never-matches-anything-xyz/,
+      watchmanDeferStates: [],
+    });
+
+    expect(watcher.doIgnore('foo/.git/HEAD')).toBe(true);
+  });
+
+  test('still applies the user pattern alongside the VCS check', () => {
+    const watcher = new AbstractWatcher('/project', {
+      dot: true,
+      globs: [],
+      ignored: /__tests__\//,
+      watchmanDeferStates: [],
+    });
+
+    expect(watcher.doIgnore('src/__tests__/foo.test.js')).toBe(true);
+    expect(watcher.doIgnore('src/index.ts')).toBe(false);
+  });
+});


### PR DESCRIPTION
# Why

The `VCS_DIRECTORIES` check was embedded in `ignorePattern` and is often redundant or redundantly applied, given that it's a fixed pattern that can be applied as needed. Especially in the Node crawler's hot path, it's a check we can just inline, since we have all necessary data already.

Some checks were performed unnecessarily, instead of constructing smaller, fixed predicates once. This also applied to the "health check file prefix" check (for health checking the watcher), which isn't enabled by default and hence entirely redundant.

# How

- Embed and localize VCS directory checks, as possible/needed, and remove regex modification 
- Make health-file check conditional and remove its use of `path.basename` 

# Test Plan

- Unit tests added to capture changes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)