### PR TITLE
perf(cli): Pre-optimize `ignorePattern` passed to `@expo/metro-file-map`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### 💡 Others
 
+- Slightly optimize `ignorePattern` passed to `@expo/metro-file-map` ([#45552](https://github.com/expo/expo/pull/45552) by [@kitten](https://github.com/kitten))
 - Replace deprecated `url.parse()` with WHATWG `URL` API in Metro dev server. ([#45524](https://github.com/expo/expo/pull/45524) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove pinned dependencies ([#45520](https://github.com/expo/expo/pull/45520) by [@kitten](https://githun.com/kitten))
 - Adopt `experiments.onDemandFilesystem` on `@expo/config-types` ([#45555](https://github.com/expo/expo/pull/45555) by [@kitten](https://github.com/kitten))

--- a/packages/@expo/cli/src/start/server/metro/createFileMap-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/createFileMap-fork.ts
@@ -10,35 +10,11 @@ import FileMap, { DependencyPlugin, DiskCacheManager, HastePlugin } from '@expo/
 import ciInfo from 'ci-info';
 import path from 'node:path';
 
+import { composeMetroIgnorePatterns } from '../../../utils/composeMetroIgnorePatterns';
+
 function getIgnorePattern(config: ConfigT): RegExp {
   const { blockList, blacklistRE } = config.resolver;
-  const ignorePattern = blacklistRE || blockList;
-  if (!ignorePattern) {
-    return / ^/;
-  }
-  const combine = (regexes: RegExp[]) =>
-    new RegExp(
-      regexes
-        .map((regex, index) => {
-          if (regex.flags !== regexes[0]!.flags) {
-            throw new Error(
-              'Cannot combine blockList patterns, because they have different flags:\n' +
-                ' - Pattern 0: ' +
-                regexes[0]!.toString() +
-                '\n' +
-                ` - Pattern ${index}: ` +
-                regexes[index]!.toString()
-            );
-          }
-          return '(' + regex.source + ')';
-        })
-        .join('|'),
-      regexes[0]?.flags ?? ''
-    );
-  if (Array.isArray(ignorePattern)) {
-    return combine(ignorePattern);
-  }
-  return ignorePattern;
+  return composeMetroIgnorePatterns(blacklistRE || blockList);
 }
 
 interface CreateFileMapOptions {

--- a/packages/@expo/cli/src/utils/__tests__/composeMetroIgnorePatterns-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/composeMetroIgnorePatterns-test.ts
@@ -1,0 +1,122 @@
+import { composeMetroIgnorePatterns } from '../composeMetroIgnorePatterns';
+
+describe(composeMetroIgnorePatterns, () => {
+  it.each([[null], [undefined], [[]]])('returns a never-matching regex for %p', (input) => {
+    expect(composeMetroIgnorePatterns(input).test('foo')).toBe(false);
+    expect(composeMetroIgnorePatterns(input).test('')).toBe(false);
+  });
+
+  it('returns an equivalent regex for a single regex input', () => {
+    const composed = composeMetroIgnorePatterns(/foo/);
+    expect(composed.test('xfoox')).toBe(true);
+    expect(composed.test('bar')).toBe(false);
+  });
+
+  it('unwraps a single-element array', () => {
+    const composed = composeMetroIgnorePatterns([/foo/]);
+    expect(composed.test('xfoox')).toBe(true);
+    expect(composed.test('bar')).toBe(false);
+  });
+
+  it('matches the union of multiple patterns', () => {
+    const composed = composeMetroIgnorePatterns([/foo/, /bar/, /^baz/]);
+    expect(composed.test('xfoox')).toBe(true);
+    expect(composed.test('xbarx')).toBe(true);
+    expect(composed.test('baz123')).toBe(true);
+    expect(composed.test('123baz')).toBe(false);
+    expect(composed.test('quux')).toBe(false);
+  });
+
+  it('uses non-capturing groups when composing', () => {
+    expect(composeMetroIgnorePatterns([/foo/, /bar/]).source).toMatchInlineSnapshot(
+      `"(?:foo)|(?:bar)"`
+    );
+  });
+
+  it('throws when patterns have different flags', () => {
+    expect(() => composeMetroIgnorePatterns([/foo/i, /bar/])).toThrow(/different flags/);
+  });
+
+  it('preserves shared flags', () => {
+    const composed = composeMetroIgnorePatterns([/foo/i, /bar/i]);
+    expect(composed.flags).toBe('i');
+    expect(composed.test('FOO')).toBe(true);
+    expect(composed.test('BAR')).toBe(true);
+  });
+
+  describe('decoration stripping', () => {
+    it.each<[RegExp, string]>([
+      [/.*foo/, 'foo'],
+      [/.*?foo/, 'foo'],
+      [/^.*foo/, 'foo'],
+      [/^.*?foo/, 'foo'],
+      [/[\s\S]*foo/, 'foo'],
+      [/[\s\S]*?foo/, 'foo'],
+      [/foo.*/, 'foo'],
+      [/foo.*?/, 'foo'],
+      [/foo.*$/, 'foo'],
+      [/foo.*?$/, 'foo'],
+      [/foo[\s\S]*/, 'foo'],
+      [/foo[\s\S]*?$/, 'foo'],
+      [/.*foo.*/, 'foo'],
+      [/^.*foo.*$/, 'foo'],
+      [/[\s\S]*foo[\s\S]*/, 'foo'],
+    ])('strips redundant decoration: %p -> %p', (input, expected) => {
+      expect(composeMetroIgnorePatterns(input).source).toBe(expected);
+    });
+
+    it.each<[RegExp, string]>([
+      [/foo\.*/, 'foo\\.*'],
+      [/foo\\.*/, 'foo\\\\'],
+      [/foo[a-z*]/, 'foo[a-z*]'],
+    ])('respects escapes and character classes: %p -> %p', (input, expected) => {
+      expect(composeMetroIgnorePatterns(input).source).toBe(expected);
+    });
+
+    it.each<[RegExp]>([[/^.*$/], [/.*/], [/^.*/], [/.*$/]])(
+      'returns the original source when stripping would be degenerate: %p',
+      (input) => {
+        expect(composeMetroIgnorePatterns(input).source).toBe(input.source);
+      }
+    );
+
+    it('produces a regex semantically equivalent to the original', () => {
+      const before = /.*bare-expo\/e2e.*/;
+      const after = composeMetroIgnorePatterns(before);
+      const inputs = [
+        'apps/bare-expo/e2e/test.js',
+        'apps/bare-expo/e2e',
+        'apps/other/file.js',
+        '',
+        'bare-expo/e2e',
+      ];
+      for (const input of inputs) {
+        expect(after.test(input)).toBe(before.test(input));
+      }
+    });
+
+    it('preserves union semantics across the array after stripping', () => {
+      const inputs = [/.*foo.*/, /^bar/, /baz\/.*$/];
+      const composed = composeMetroIgnorePatterns(inputs);
+      const samples = ['xfoox', 'bar123', '123bar', 'baz/x', 'baz', 'qux', 'foo'];
+      for (const sample of samples) {
+        const expected = inputs.some((re) => re.test(sample));
+        expect(composed.test(sample)).toBe(expected);
+      }
+    });
+  });
+
+  describe('ordering', () => {
+    it('places start-anchored alternatives first', () => {
+      expect(composeMetroIgnorePatterns([/foo/, /^bar/, /baz/]).source).toMatchInlineSnapshot(
+        `"(?:^bar)|(?:foo)|(?:baz)"`
+      );
+    });
+
+    it('places leading-wildcard alternatives last when they cannot be stripped', () => {
+      expect(composeMetroIgnorePatterns([/.*$/, /^bar/, /baz/]).source).toMatchInlineSnapshot(
+        `"(?:^bar)|(?:baz)|(?:.*$)"`
+      );
+    });
+  });
+});

--- a/packages/@expo/cli/src/utils/composeMetroIgnorePatterns.ts
+++ b/packages/@expo/cli/src/utils/composeMetroIgnorePatterns.ts
@@ -1,0 +1,81 @@
+const NEVER_MATCHES = /(?!)/;
+
+function isEscapedAt(source: string, dotIdx: number): boolean {
+  let backslashes = 0;
+  for (let i = dotIdx - 1; i >= 0 && source.charCodeAt(i) === 92; i--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+}
+
+function stripUnanchoredDecoration(source: string): string {
+  let s = source;
+
+  if (s.startsWith('^.*?')) s = s.slice(4);
+  else if (s.startsWith('^.*')) s = s.slice(3);
+  else if (s.startsWith('^[\\s\\S]*?')) s = s.slice(9);
+  else if (s.startsWith('^[\\s\\S]*')) s = s.slice(8);
+  else if (s.startsWith('.*?')) s = s.slice(3);
+  else if (s.startsWith('.*')) s = s.slice(2);
+  else if (s.startsWith('[\\s\\S]*?')) s = s.slice(8);
+  else if (s.startsWith('[\\s\\S]*')) s = s.slice(7);
+
+  if (s.endsWith('.*?$') && !isEscapedAt(s, s.length - 4)) s = s.slice(0, -4);
+  else if (s.endsWith('.*$') && !isEscapedAt(s, s.length - 3)) s = s.slice(0, -3);
+  else if (s.endsWith('[\\s\\S]*?$')) s = s.slice(0, -9);
+  else if (s.endsWith('[\\s\\S]*$')) s = s.slice(0, -8);
+  else if (s.endsWith('.*?') && !isEscapedAt(s, s.length - 3)) s = s.slice(0, -3);
+  else if (s.endsWith('.*') && !isEscapedAt(s, s.length - 2)) s = s.slice(0, -2);
+  else if (s.endsWith('[\\s\\S]*?')) s = s.slice(0, -8);
+  else if (s.endsWith('[\\s\\S]*')) s = s.slice(0, -7);
+
+  if (s === '' || s === '^' || s === '$' || s === '^$') return source;
+  return s;
+}
+
+function rankForOrdering(source: string): number {
+  if (source.startsWith('^')) return 0;
+  if (source.startsWith('.*') || source.startsWith('.*?') || source.startsWith('[\\s\\S]*')) {
+    return 2;
+  }
+  return 1;
+}
+
+/**
+ * Composes Metro `blockList` regexes into a single ignore pattern, normalizing
+ * leading/trailing `.*` decoration so V8 can extract a literal prefilter from
+ * each alternative.
+ */
+export function composeMetroIgnorePatterns(
+  input: RegExp | readonly RegExp[] | null | undefined
+): RegExp {
+  if (!input) return NEVER_MATCHES;
+  if (!Array.isArray(input)) {
+    const regex = input as RegExp;
+    return new RegExp(stripUnanchoredDecoration(regex.source), regex.flags);
+  }
+
+  const patterns = input as readonly RegExp[];
+  if (patterns.length === 0) return NEVER_MATCHES;
+  if (patterns.length === 1) {
+    const regex = patterns[0]!;
+    return new RegExp(stripUnanchoredDecoration(regex.source), regex.flags);
+  }
+
+  const flags = patterns[0]!.flags;
+  for (let i = 1; i < patterns.length; i++) {
+    if (patterns[i]!.flags !== flags) {
+      throw new Error(
+        'Cannot combine blockList patterns, because they have different flags:\n' +
+          ` - Pattern 0: ${patterns[0]!.toString()}\n` +
+          ` - Pattern ${i}: ${patterns[i]!.toString()}`
+      );
+    }
+  }
+
+  const sources = patterns
+    .map((regex) => stripUnanchoredDecoration(regex.source))
+    .sort((a, b) => rankForOrdering(a) - rankForOrdering(b))
+    .map((s) => '(?:' + s + ')');
+  return new RegExp(sources.join('|'), flags);
+}


### PR DESCRIPTION
# Why

#45463 has demonstrated that `resolver.blockList` can easily become a footgun since it's not well documented what happens to these regular expressions. Also patterns such as `.*` explicitly become un-anchored, defeating some of Irregexp's optimizations.

# How

We can do slightly bettern by stripping out anti-patterns that don't alter the match e.g. leading and trailing `.*` and the likes, and pre-sorting the regular expression.

**Note:** This is largely LLM-generated with slight instructions on how Irregexp functions and what we'd like to strip out.

# Test Plan

- Captures snapshots of patterns of what RegExp patterns can be optimized

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
