### PR TITLE
[image-picker][ios] Fix crop bounds

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix broken bounds when cropping images when launching with `launchCameraAsync`. ([#45554](https://github.com/expo/expo/pull/45554) by [@behenate](https://github.com/behenate))
+
 ### 💡 Others
 
 - [Web] Drop dependency on `expo-modules-core` `Platform` in favor of inline `window`/`document` checks. ([#45923](https://github.com/expo/expo/pull/45923) by [@EvanBacon](https://github.com/EvanBacon))

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -106,7 +106,7 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     // Only the camera flow's edit screen needs this workaround. The library
     // picker hosts its editor in a separate system process via `_UISceneHostingView`,
     // so the fix is not applicable.
-    if sourceType == .camera {
+    if sourceType == .camera && options.allowsEditing {
       picker.fixCannotMoveEditingBox()
     }
 

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -104,9 +104,8 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     let picker = UIImagePickerController()
 
     // Only the camera flow's edit screen needs this workaround. The library
-    // picker on modern iOS hosts its editor in a separate system process via
-    // `_UISceneHostingView`, so we can't reach its scroll view from our
-    // address space.
+    // picker hosts its editor in a separate system process via `_UISceneHostingView`,
+    // so the fix is not applicable.
     if sourceType == .camera {
       picker.fixCannotMoveEditingBox()
     }

--- a/packages/expo-image-picker/ios/ImagePickerModule.swift
+++ b/packages/expo-image-picker/ios/ImagePickerModule.swift
@@ -102,7 +102,14 @@ public class ImagePickerModule: Module, OnMediaPickingResultHandler {
     let options = pickingContext.options
 
     let picker = UIImagePickerController()
-    picker.fixCannotMoveEditingBox()
+
+    // Only the camera flow's edit screen needs this workaround. The library
+    // picker on modern iOS hosts its editor in a separate system process via
+    // `_UISceneHostingView`, so we can't reach its scroll view from our
+    // address space.
+    if sourceType == .camera {
+      picker.fixCannotMoveEditingBox()
+    }
 
     if sourceType == .camera {
       picker.sourceType = .camera

--- a/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
+++ b/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
@@ -21,13 +21,11 @@ extension UIImagePickerController {
     }
   }
 
-  internal func applyCropFix() {
-    guard let cropView,
-      let scrollView,
-      let scrollSuperview = scrollView.superview,
+  internal func applyCropFix(cropView: UIView, scrollView: UIScrollView, isFirstApply: Bool) -> Bool {
+    guard let scrollSuperview = scrollView.superview,
       scrollView.contentSize.width > 0,
       scrollView.contentSize.height > 0 else {
-      return
+      return false
     }
 
     let cropFrame = cropView.convert(cropView.bounds, to: scrollSuperview)
@@ -36,6 +34,12 @@ extension UIImagePickerController {
     let baseWidth = scrollView.contentSize.width / scrollView.zoomScale
     let baseHeight = scrollView.contentSize.height / scrollView.zoomScale
     let minZoomForFill = max(cropSize.width / baseWidth, cropSize.height / baseHeight)
+    let needsFix = scrollView.zoomScale < minZoomForFill - 0.001
+
+    if scrollView.isZooming || scrollView.isZoomBouncing || !(isFirstApply || needsFix) {
+      return false
+    }
+
     let edgeInset = UIEdgeInsets(
       top: max(0, cropFrame.minY - scrollFrame.minY),
       left: max(0, cropFrame.minX - scrollFrame.minX),
@@ -43,16 +47,8 @@ extension UIImagePickerController {
       right: max(0, scrollFrame.maxX - cropFrame.maxX)
     )
 
-    let isInitialLayout = scrollView.contentOffset.y == 0 || scrollView.contentInset == .zero
-    let needsFix = scrollView.zoomScale < minZoomForFill - 0.001
-
-    if scrollView.isZooming || scrollView.isZoomBouncing || !(isInitialLayout || needsFix) {
-      return
-    }
-
     UIView.performWithoutAnimation {
       let previousOffset = scrollView.contentOffset
-      let shouldCenterContent = scrollView.contentInset == .zero
 
       if scrollView.zoomScale < minZoomForFill {
         scrollView.minimumZoomScale = minZoomForFill
@@ -60,7 +56,7 @@ extension UIImagePickerController {
       }
 
       scrollView.contentInset = edgeInset
-      if shouldCenterContent {
+      if isFirstApply {
         scrollView.contentOffset = CGPoint(
           x: -edgeInset.left + max(0, scrollView.contentSize.width - cropSize.width) / 2,
           y: -edgeInset.top + max(0, scrollView.contentSize.height - cropSize.height) / 2
@@ -77,6 +73,7 @@ extension UIImagePickerController {
         )
       }
     }
+    return true
   }
 
   var cropView: UIView? {
@@ -87,8 +84,9 @@ extension UIImagePickerController {
     return findScrollView(from: self.view)
   }
 
+  //TODO: @behenate check iPad behaviour
   func findCropView(from view: UIView) -> UIView? {
-    let shorterEdge = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height)
+    let shorterEdge = min(self.view.bounds.width, self.view.bounds.height)
     let size = view.bounds.size
     let tolerance = 1 / UIScreen.main.scale
     if abs(shorterEdge - size.width) <= tolerance, abs(shorterEdge - size.height) <= tolerance {
@@ -105,14 +103,30 @@ extension UIImagePickerController {
   }
 }
 
+private final class CropFixDriverProxy: NSObject {
+  weak var driver: CropFixDriver?
+
+  init(_ driver: CropFixDriver) {
+    self.driver = driver
+  }
+
+  @objc func tick() {
+    driver?.tick()
+  }
+}
+
 private final class CropFixDriver: NSObject {
   private weak var picker: UIImagePickerController?
   private var displayLink: CADisplayLink?
+  private weak var cachedCropView: UIView?
+  private weak var cachedScrollView: UIScrollView?
+  private var hasBeenApplied = false
 
   init(picker: UIImagePickerController) {
     self.picker = picker
     super.init()
-    let link = CADisplayLink(target: self, selector: #selector(tick))
+    let proxy = CropFixDriverProxy(self)
+    let link = CADisplayLink(target: proxy, selector: #selector(CropFixDriverProxy.tick))
     link.add(to: .main, forMode: .common)
     self.displayLink = link
   }
@@ -121,7 +135,22 @@ private final class CropFixDriver: NSObject {
     displayLink?.invalidate()
   }
 
-  @objc private func tick() {
-    picker?.applyCropFix()
+  fileprivate func tick() {
+    guard let picker = picker else {
+      return
+    }
+
+    if cachedScrollView?.window == nil || cachedCropView?.window == nil {
+      cachedScrollView = picker.scrollView
+      cachedCropView = picker.cropView
+      hasBeenApplied = false
+    }
+
+    guard let scrollView = cachedScrollView, let cropView = cachedCropView else {
+      return
+    }
+    if picker.applyCropFix(cropView: cropView, scrollView: scrollView, isFirstApply: !hasBeenApplied) {
+      hasBeenApplied = true
+    }
   }
 }

--- a/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
+++ b/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
@@ -22,21 +22,27 @@ extension UIImagePickerController {
   }
 
   internal func applyCropFix(cropView: UIView, scrollView: UIScrollView, isFirstApply: Bool) -> Bool {
-    guard let scrollSuperview = scrollView.superview,
-      scrollView.contentSize.width > 0,
-      scrollView.contentSize.height > 0 else {
+    guard scrollView.contentSize.width > 0,
+      scrollView.contentSize.height > 0,
+      let scrollSuperview = scrollView.superview else {
       return false
     }
 
     let cropFrame = cropView.convert(cropView.bounds, to: scrollSuperview)
     let scrollFrame = scrollView.frame
-    let cropSize = cropFrame.size
+    let cropSide = min(cropFrame.width, cropFrame.height)
     let baseWidth = scrollView.contentSize.width / scrollView.zoomScale
     let baseHeight = scrollView.contentSize.height / scrollView.zoomScale
-    let minZoomForFill = max(cropSize.width / baseWidth, cropSize.height / baseHeight)
-    let needsFix = scrollView.zoomScale < minZoomForFill - 0.001
+    let imageShortSide = min(baseWidth, baseHeight)
+    guard imageShortSide > 0 else {
+      return false
+    }
 
-    if scrollView.isZooming || scrollView.isZoomBouncing || !(isFirstApply || needsFix) {
+    let minZoomForFill = cropSide / imageShortSide
+    let needsFix = scrollView.zoomScale < minZoomForFill - 0.001
+    let needsMinimumZoomUpdate = abs(scrollView.minimumZoomScale - minZoomForFill) > 0.001
+
+    if scrollView.isZooming || scrollView.isZoomBouncing || !(isFirstApply || needsFix || needsMinimumZoomUpdate) {
       return false
     }
 
@@ -50,17 +56,18 @@ extension UIImagePickerController {
     UIView.performWithoutAnimation {
       let previousOffset = scrollView.contentOffset
 
-      if scrollView.zoomScale < minZoomForFill {
-        scrollView.minimumZoomScale = minZoomForFill
+      scrollView.minimumZoomScale = minZoomForFill
+      if isFirstApply || scrollView.zoomScale < minZoomForFill {
         scrollView.zoomScale = minZoomForFill
       }
 
       scrollView.contentInset = edgeInset
       if isFirstApply {
         scrollView.contentOffset = CGPoint(
-          x: -edgeInset.left + max(0, scrollView.contentSize.width - cropSize.width) / 2,
-          y: -edgeInset.top + max(0, scrollView.contentSize.height - cropSize.height) / 2
+          x: -edgeInset.left + max(0, scrollView.contentSize.width - cropSide) / 2,
+          y: -edgeInset.top + max(0, scrollView.contentSize.height - cropSide) / 2
         )
+        scrollView.layoutIfNeeded()
       } else {
         let minOffset = CGPoint(x: -edgeInset.left, y: -edgeInset.top)
         let maxOffset = CGPoint(
@@ -76,30 +83,21 @@ extension UIImagePickerController {
     return true
   }
 
-  var cropView: UIView? {
-    return findCropView(from: self.view)
-  }
-
   var scrollView: UIScrollView? {
-    return findScrollView(from: self.view)
+    return findView(named: "PLImageScrollView", from: view) as? UIScrollView
   }
 
-  //TODO: @behenate check iPad behaviour
-  func findCropView(from view: UIView) -> UIView? {
-    let shorterEdge = min(self.view.bounds.width, self.view.bounds.height)
-    let size = view.bounds.size
-    let tolerance = 1 / UIScreen.main.scale
-    if abs(shorterEdge - size.width) <= tolerance, abs(shorterEdge - size.height) <= tolerance {
+  var cropView: UIView? {
+    return findView(named: "PLCropOverlayCropView", from: view)?
+      .subviews
+      .first(where: { $0.bounds.isSquare })
+  }
+
+  private func findView(named className: String, from view: UIView) -> UIView? {
+    if NSStringFromClass(type(of: view)) == className {
       return view
     }
-    return view.subviews.lazy.compactMap { self.findCropView(from: $0) }.first
-  }
-
-  func findScrollView(from view: UIView) -> UIScrollView? {
-    if let scrollView = view as? UIScrollView {
-      return scrollView
-    }
-    return view.subviews.lazy.compactMap { self.findScrollView(from: $0) }.first
+    return view.subviews.lazy.compactMap { self.findView(named: className, from: $0) }.first
   }
 }
 
@@ -118,8 +116,8 @@ private final class CropFixDriverProxy: NSObject {
 private final class CropFixDriver: NSObject {
   private weak var picker: UIImagePickerController?
   private var displayLink: CADisplayLink?
-  private weak var cachedCropView: UIView?
   private weak var cachedScrollView: UIScrollView?
+  private var cachedCropFrame = CGRect.null
   private var hasBeenApplied = false
 
   init(picker: UIImagePickerController) {
@@ -140,17 +138,39 @@ private final class CropFixDriver: NSObject {
       return
     }
 
-    if cachedScrollView?.window == nil || cachedCropView?.window == nil {
-      cachedScrollView = picker.scrollView
-      cachedCropView = picker.cropView
+    guard let scrollView = picker.scrollView,
+      let scrollSuperview = scrollView.superview,
+      let cropView = picker.cropView else {
+      cachedScrollView = nil
+      cachedCropFrame = .null
+      hasBeenApplied = false
+      return
+    }
+
+    let cropFrame = cropView.convert(cropView.bounds, to: scrollSuperview)
+    if cachedScrollView !== scrollView ||
+      !cachedCropFrame.isApproximatelyEqual(to: cropFrame) {
+      cachedScrollView = scrollView
+      cachedCropFrame = cropFrame
       hasBeenApplied = false
     }
 
-    guard let scrollView = cachedScrollView, let cropView = cachedCropView else {
-      return
-    }
     if picker.applyCropFix(cropView: cropView, scrollView: scrollView, isFirstApply: !hasBeenApplied) {
       hasBeenApplied = true
     }
+  }
+}
+
+private extension CGRect {
+  var isSquare: Bool {
+    let tolerance = 2 / UIScreen.main.scale
+    return width >= 44 && abs(width - height) <= tolerance
+  }
+
+  func isApproximatelyEqual(to other: CGRect, tolerance: CGFloat = 1) -> Bool {
+    return abs(origin.x - other.origin.x) <= tolerance &&
+      abs(origin.y - other.origin.y) <= tolerance &&
+      abs(size.width - other.size.width) <= tolerance &&
+      abs(size.height - other.size.height) <= tolerance
   }
 }

--- a/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
+++ b/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
@@ -1,15 +1,29 @@
 // Copyright 2016-present 650 Industries. All rights reserved.
 
-extension UIImagePickerController {
-  func fixCannotMoveEditingBox() {
-    defer {
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self] in
-        self?.fixCannotMoveEditingBox()
-      }
-    }
+import ObjectiveC.runtime
 
-    guard let cropView = cropView,
-      let scrollView = scrollView,
+private var cropFixDriverKey: UInt8 = 0
+
+extension UIImagePickerController {
+  // Attaches a `CADisplayLink` to the picker that calls `applyCropFix` on
+  // every screen refresh while the picker is alive. UIImagePickerController
+  // exposes no callback for "the editor mounted" or "the image loaded," and
+  // its internal scroll view is rebuilt at points we can't observe, so we
+  // re-run the fix per frame until the picker deallocates.
+  func fixCannotMoveEditingBox() {
+    if objc_getAssociatedObject(self, &cropFixDriverKey) == nil {
+      objc_setAssociatedObject(
+        self,
+        &cropFixDriverKey,
+        CropFixDriver(picker: self),
+        .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+      )
+    }
+  }
+
+  internal func applyCropFix() {
+    guard let cropView,
+      let scrollView,
       let scrollSuperview = scrollView.superview,
       scrollView.contentSize.width > 0,
       scrollView.contentSize.height > 0 else {
@@ -88,5 +102,26 @@ extension UIImagePickerController {
       return scrollView
     }
     return view.subviews.lazy.compactMap { self.findScrollView(from: $0) }.first
+  }
+}
+
+private final class CropFixDriver: NSObject {
+  private weak var picker: UIImagePickerController?
+  private var displayLink: CADisplayLink?
+
+  init(picker: UIImagePickerController) {
+    self.picker = picker
+    super.init()
+    let link = CADisplayLink(target: self, selector: #selector(tick))
+    link.add(to: .main, forMode: .common)
+    self.displayLink = link
+  }
+
+  deinit {
+    displayLink?.invalidate()
+  }
+
+  @objc private func tick() {
+    picker?.applyCropFix()
   }
 }

--- a/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
+++ b/packages/expo-image-picker/ios/UIImagePickerControllerExtentsion.swift
@@ -2,22 +2,66 @@
 
 extension UIImagePickerController {
   func fixCannotMoveEditingBox() {
-    if let cropView = cropView,
-      let scrollView = scrollView,
-      scrollView.contentOffset.y == 0 {
-      let top = cropView.frame.minY + self.view.safeAreaInsets.top
-      let bottom = scrollView.frame.height - cropView.frame.height - top
-      scrollView.contentInset = UIEdgeInsets(top: top, left: 0, bottom: bottom, right: 0)
-
-      var offset: CGFloat = 0
-      if scrollView.contentSize.height > scrollView.contentSize.width {
-        offset = 0.5 * (scrollView.contentSize.height - scrollView.contentSize.width)
+    defer {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) { [weak self] in
+        self?.fixCannotMoveEditingBox()
       }
-      scrollView.contentOffset = CGPoint(x: 0, y: -top + offset)
     }
 
-    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-      self?.fixCannotMoveEditingBox()
+    guard let cropView = cropView,
+      let scrollView = scrollView,
+      let scrollSuperview = scrollView.superview,
+      scrollView.contentSize.width > 0,
+      scrollView.contentSize.height > 0 else {
+      return
+    }
+
+    let cropFrame = cropView.convert(cropView.bounds, to: scrollSuperview)
+    let scrollFrame = scrollView.frame
+    let cropSize = cropFrame.size
+    let baseWidth = scrollView.contentSize.width / scrollView.zoomScale
+    let baseHeight = scrollView.contentSize.height / scrollView.zoomScale
+    let minZoomForFill = max(cropSize.width / baseWidth, cropSize.height / baseHeight)
+    let edgeInset = UIEdgeInsets(
+      top: max(0, cropFrame.minY - scrollFrame.minY),
+      left: max(0, cropFrame.minX - scrollFrame.minX),
+      bottom: max(0, scrollFrame.maxY - cropFrame.maxY),
+      right: max(0, scrollFrame.maxX - cropFrame.maxX)
+    )
+
+    let isInitialLayout = scrollView.contentOffset.y == 0 || scrollView.contentInset == .zero
+    let needsFix = scrollView.zoomScale < minZoomForFill - 0.001
+
+    if scrollView.isZooming || scrollView.isZoomBouncing || !(isInitialLayout || needsFix) {
+      return
+    }
+
+    UIView.performWithoutAnimation {
+      let previousOffset = scrollView.contentOffset
+      let shouldCenterContent = scrollView.contentInset == .zero
+
+      if scrollView.zoomScale < minZoomForFill {
+        scrollView.minimumZoomScale = minZoomForFill
+        scrollView.zoomScale = minZoomForFill
+      }
+
+      scrollView.contentInset = edgeInset
+      if shouldCenterContent {
+        scrollView.contentOffset = CGPoint(
+          x: -edgeInset.left + max(0, scrollView.contentSize.width - cropSize.width) / 2,
+          y: -edgeInset.top + max(0, scrollView.contentSize.height - cropSize.height) / 2
+        )
+      } else {
+        let minOffset = CGPoint(x: -edgeInset.left, y: -edgeInset.top)
+        let maxOffset = CGPoint(
+          x: max(minOffset.x, scrollView.contentSize.width - scrollView.bounds.width + edgeInset.right),
+          y: max(minOffset.y, scrollView.contentSize.height - scrollView.bounds.height + edgeInset.bottom)
+        )
+        scrollView.contentOffset = CGPoint(
+          x: min(max(previousOffset.x, minOffset.x), maxOffset.x),
+          y: min(max(previousOffset.y, minOffset.y), maxOffset.y)
+        )
+      }
     }
   }
 
@@ -30,28 +74,19 @@ extension UIImagePickerController {
   }
 
   func findCropView(from view: UIView) -> UIView? {
-    let width = UIScreen.main.bounds.width
+    let shorterEdge = min(UIScreen.main.bounds.width, UIScreen.main.bounds.height)
     let size = view.bounds.size
-    if width == size.height, width == size.height {
+    let tolerance = 1 / UIScreen.main.scale
+    if abs(shorterEdge - size.width) <= tolerance, abs(shorterEdge - size.height) <= tolerance {
       return view
     }
-    for view in view.subviews {
-      if let cropView = findCropView(from: view) {
-        return cropView
-      }
-    }
-    return nil
+    return view.subviews.lazy.compactMap { self.findCropView(from: $0) }.first
   }
 
   func findScrollView(from view: UIView) -> UIScrollView? {
     if let scrollView = view as? UIScrollView {
       return scrollView
     }
-    for view in view.subviews {
-      if let scrollView = findScrollView(from: view) {
-        return scrollView
-      }
-    }
-    return nil
+    return view.subviews.lazy.compactMap { self.findScrollView(from: $0) }.first
   }
 }

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix broken bounds when cropping images.
+
 ### 💡 Others
 
 ## 56.1.2 — 2026-05-21

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### 🐛 Bug fixes
 
-- [ios] Fix broken bounds when cropping images.
-
 ### 💡 Others
 
 ## 56.1.2 — 2026-05-21


### PR DESCRIPTION
# Why

Fixes https://github.com/expo/expo/issues/41125

The bounds in the cropping area are incorrect, currently block from moving the crop area to parts of the image and add a black bar to the image.

# How

Re-create `fixCannotMoveEditingBox` logic to fix the issue and work correctly in all device orientations (previously there would also be bugs when rotating the phone during cropping etc.)

Now the cropper is effectively in `fill` `contentFit`, same as Android

# Test Plan

Tested in BareExpo on iOS 18