### PR TITLE
chore(config-types,cli): Regenerate `config-types` and update CLI

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 - Replace deprecated `url.parse()` with WHATWG `URL` API in Metro dev server. ([#45524](https://github.com/expo/expo/pull/45524) by [@EvanBacon](https://github.com/EvanBacon))
 - Remove pinned dependencies ([#45520](https://github.com/expo/expo/pull/45520) by [@kitten](https://githun.com/kitten))
+- Adopt `experiments.onDemandFilesystem` on `@expo/config-types` ([#45555](https://github.com/expo/expo/pull/45555) by [@kitten](https://github.com/kitten))
 
 ## 56.0.6 — 2026-05-07
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -248,7 +248,7 @@ export async function loadMetroConfigAsync(
 
   // On-Demand Filesystem is enabled by default
   // TODO(@kitten): Add to config-types JSON schema
-  const onDemandFilesystem = (exp.experiments as any)?.onDemandFilesystem ?? true;
+  const onDemandFilesystem = exp.experiments?.onDemandFilesystem ?? true;
   asWritable(config.resolver).unstable_onDemandFilesystem = onDemandFilesystem;
 
   // NOTE(@kitten): `useWatchman` is currently enabled by default, but it also disables `forceNodeFilesystemAPI`.

--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -206,6 +206,10 @@ export interface ExpoConfig {
      */
     experiments?: {
         /**
+         * Enables Expo's On-Demand Filesystem allowing Metro bundling outside of the watchFolders and with package manager global virtual stores.
+         */
+        onDemandFilesystem?: boolean;
+        /**
          * Apply Expo Autolinking's search results to Metro's module resolution. This forces your project's dependencies on `react`, `react-dom`, and `react-native`, and the autolinked versions of any Expo and React Native modules to be resolved when bundling your app. This prevents version misalignment and is useful for monorepos and to prevent conflicts.
          */
         autolinkingModuleResolution?: boolean;
@@ -226,10 +230,6 @@ export interface ExpoConfig {
          * If true, indicates that this project does not support tablets or handsets, and only supports Apple TV and Android TV
          */
         supportsTVOnly?: boolean;
-        /**
-         * Enable React-based CSS support for native platforms. Only supports a subset of CSS properties, class names selectors, and has no cascading.
-         */
-        functionalCSS?: boolean;
         /**
          * Enable tsconfig/jsconfig `compilerOptions.paths` and `compilerOptions.baseUrl` support for import aliases in Metro.
          */

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -212,6 +212,10 @@ export interface ExpoConfig {
    */
   experiments?: {
     /**
+     * Enables Expo's On-Demand Filesystem allowing Metro bundling outside of the watchFolders and with package manager global virtual stores.
+     */
+    onDemandFilesystem?: boolean;
+    /**
      * Apply Expo Autolinking's search results to Metro's module resolution. This forces your project's dependencies on `react`, `react-dom`, and `react-native`, and the autolinked versions of any Expo and React Native modules to be resolved when bundling your app. This prevents version misalignment and is useful for monorepos and to prevent conflicts.
      */
     autolinkingModuleResolution?: boolean;
@@ -234,10 +238,6 @@ export interface ExpoConfig {
      * If true, indicates that this project does not support tablets or handsets, and only supports Apple TV and Android TV
      */
     supportsTVOnly?: boolean;
-    /**
-     * Enable React-based CSS support for native platforms. Only supports a subset of CSS properties, class names selectors, and has no cascading.
-     */
-    functionalCSS?: boolean;
     /**
      * Enable tsconfig/jsconfig `compilerOptions.paths` and `compilerOptions.baseUrl` support for import aliases in Metro.
      */


### PR DESCRIPTION
# Summary

- Adds `experiments.onDemandFilesystem`

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
