### PR TITLE
[docs] Add TabsGroup in Clerk guide source file

### DIFF
--- a/docs/pages/guides/using-clerk.mdx
+++ b/docs/pages/guides/using-clerk.mdx
@@ -9,8 +9,10 @@ import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
-import { Tabs, Tab } from '~/ui/components/Tabs';
+import { TabsGroup, Tabs, Tab } from '~/ui/components/Tabs';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
+
+<TabsGroup>
 
 [Clerk](https://clerk.com/expo-authentication) is an authentication and user management platform that provides sign-up, sign-in, multi-factor authentication, social sign-in, organizations, and a hosted user database. The [`@clerk/expo`](https://www.npmjs.com/package/@clerk/expo) SDK gives you React hooks, control components, and prebuilt native UI components that render with Jetpack Compose on Android and SwiftUI on iOS.
 
@@ -444,3 +446,5 @@ For the JavaScript-only approach, run the following command and open the project
   href="https://clerk.com/docs/guides/development/deployment/expo"
   Icon={BookOpen02Icon}
 />
+
+</TabsGroup>

--- a/docs/pages/guides/using-clerk.mdx
+++ b/docs/pages/guides/using-clerk.mdx
@@ -139,7 +139,7 @@ In Core 3, `publishableKey` is required on `<ClerkProvider>` for Expo apps. Envi
 
 The next step depends on which approach you chose. The tabs below show the minimum code for each.
 
-<Tabs tabs={['Native UI components', 'JavaScript with native sign-in', 'JavaScript only (Expo Go)']}>
+<Tabs tabs={['Native UI components', 'JavaScript with native sign-in', 'JavaScript-only (Expo Go)']}>
 
 <Tab>
 


### PR DESCRIPTION
# Why

The Clerk guide has two separate `<Tabs>` blocks (integration approach and platform-specific setup) that each track their own selected index. A reader who picks "JavaScript only (Expo Go)" in the first tab set has to re-select the matching tab further down the page, which is easy to miss and can lead them through the wrong steps.

# How

Wrap the page contents in `<TabsGroup>` from `~/ui/components/Tabs` so both `<Tabs>` instances share the same selected index via `SharedTabsContext`.

# Test Plan

Open `/guides/using-clerk` locally, switch the first tab set between "Native UI components", "JavaScript with native sign-in", and "JavaScript only (Expo Go)", and confirm the platform setup tabs further down the page move in lockstep. Reload the page and verify the default tab still renders.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).