### PR TITLE
[docs] Replace plain Yes/No table cells with YesIcon and NoIcon

### DIFF
--- a/docs/pages/brownfield/overview.mdx
+++ b/docs/pages/brownfield/overview.mdx
@@ -8,6 +8,7 @@ description: An overview of how you can integrate Expo tools into existing nativ
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 An existing native app that was built using another technology, whose main entry point is _not_ a React Native view, is commonly referred to as a "brownfield" app. For example, if your app was built using UIKit and Swift, and you want to use React Native for a single screen then that is considered an "existing native app" and "brownfield".
 
@@ -23,14 +24,14 @@ Expo is primarily built with greenfield apps in mind, but we are increasingly in
 
 | Tool/Service                                                                                         | Supports brownfield? |
 | ---------------------------------------------------------------------------------------------------- | -------------------- |
-| [Expo SDK](/versions/latest/) - an extended standard library for React Native                        | Yes                  |
-| [Expo Modules API](/modules/overview/) - build native extensions using an idiomatic Swift/Kotlin API | Yes                  |
-| [Expo Router](/router/introduction/) - file-based routing and navigation                             | Yes                  |
-| [Expo CLI](/more/expo-cli/) - tools to run and develop your app from your terminal                   | Yes                  |
-| [Expo Dev Client](/versions/latest/sdk/dev-client/) - adds in-app developer tooling to Debug builds  | No                   |
-| [EAS Build](/build/introduction/) - a CI/CD service built specifically for Expo/React Native         | Yes                  |
-| [EAS Submit](/submit/introduction/) - a hosted service that uploads your app to stores               | Yes                  |
-| [EAS Update](/eas-update/introduction/) - instant updates of your app JavaScript and assets          | Yes                  |
+| [Expo SDK](/versions/latest/) - an extended standard library for React Native                        | <YesIcon />          |
+| [Expo Modules API](/modules/overview/) - build native extensions using an idiomatic Swift/Kotlin API | <YesIcon />          |
+| [Expo Router](/router/introduction/) - file-based routing and navigation                             | <YesIcon />          |
+| [Expo CLI](/more/expo-cli/) - tools to run and develop your app from your terminal                   | <YesIcon />          |
+| [Expo Dev Client](/versions/latest/sdk/dev-client/) - adds in-app developer tooling to Debug builds  | <NoIcon />           |
+| [EAS Build](/build/introduction/) - a CI/CD service built specifically for Expo/React Native         | <YesIcon />          |
+| [EAS Submit](/submit/introduction/) - a hosted service that uploads your app to stores               | <YesIcon />          |
+| [EAS Update](/eas-update/introduction/) - instant updates of your app JavaScript and assets          | <YesIcon />          |
 
 ## Integrated vs Isolated approaches
 

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -8,6 +8,7 @@ maxHeadingDepth: 5
 import { GithubIcon } from '@expo/styleguide-icons/custom/GithubIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
 
@@ -311,13 +312,13 @@ on:
     # @end #
 ```
 
-| Property      | Type       | Required                 | Description                                                                 |
-| ------------- | ---------- | ------------------------ | --------------------------------------------------------------------------- |
-| `type`        | `string`   | Yes                      | The input type (`string`, `boolean`, `number`, `choice`, or `environment`). |
-| `description` | `string`   | No                       | Description for the input.                                                  |
-| `required`    | `boolean`  | No                       | Whether the input is required. Defaults to `false`.                         |
-| `default`     | varies     | No                       | Default value for the input. Must match the input type.                     |
-| `options`     | `string[]` | Yes (for `type: choice`) | Available options for choice inputs.                                        |
+| Property      | Type       | Required                         | Description                                                                 |
+| ------------- | ---------- | -------------------------------- | --------------------------------------------------------------------------- |
+| `type`        | `string`   | <YesIcon />                      | The input type (`string`, `boolean`, `number`, `choice`, or `environment`). |
+| `description` | `string`   | <NoIcon />                       | Description for the input.                                                  |
+| `required`    | `boolean`  | <NoIcon />                       | Whether the input is required. Defaults to `false`.                         |
+| `default`     | varies     | <NoIcon />                       | Default value for the input. Must match the input type.                     |
+| `options`     | `string[]` | <YesIcon /> (for `type: choice`) | Available options for choice inputs.                                        |
 
 #### Providing inputs
 
@@ -1621,10 +1622,10 @@ jobs:
           extensions: [apk, aab, ipa, app] # Optional. List of file extensions to look for. Defaults to ["apk", "aab", "ipa", "app"].
 ```
 
-| Property     | Type     | Required | Default                        | Description                                                                |
-| ------------ | -------- | -------- | ------------------------------ | -------------------------------------------------------------------------- |
-| `build_id`   | string   | Yes      | –                              | The ID of the build to download. Must be a valid UUID.                     |
-| `extensions` | string[] | No       | `["apk", "aab", "ipa", "app"]` | List of file extensions to look for in the downloaded artifact or archive. |
+| Property     | Type     | Required    | Default                        | Description                                                                |
+| ------------ | -------- | ----------- | ------------------------------ | -------------------------------------------------------------------------- |
+| `build_id`   | string   | <YesIcon /> | –                              | The ID of the build to download. Must be a valid UUID.                     |
+| `extensions` | string[] | <NoIcon />  | `["apk", "aab", "ipa", "app"]` | List of file extensions to look for in the downloaded artifact or archive. |
 
 **Outputs:**
 
@@ -1737,11 +1738,11 @@ jobs:
       # @end #
 ```
 
-| Property       | Type     | Required | Description                                                                                                                                              |
-| -------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `key`          | `string` | Yes      | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |
-| `restore_keys` | `string` | No       | A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix. |
-| `path`         | `string` | Yes      | The path where the cache should be restored. This should match the path used when saving the cache.                                                      |
+| Property       | Type     | Required    | Description                                                                                                                                              |
+| -------------- | -------- | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `key`          | `string` | <YesIcon /> | The cache key to restore. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes.              |
+| `restore_keys` | `string` | <NoIcon />  | A fallback key or prefix to use if the exact key is not found. If provided, the cache system will look for any cache entry that starts with this prefix. |
+| `path`         | `string` | <YesIcon /> | The path where the cache should be restored. This should match the path used when saving the cache.                                                      |
 
 <BoxLink
   title="eas/restore_cache source code"
@@ -1775,10 +1776,10 @@ jobs:
       # @end #
 ```
 
-| Property | Type     | Required | Description                                                                                                                                                                                                       |
-| -------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `key`    | `string` | Yes      | The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
-| `path`   | `string` | Yes      | The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                               |
+| Property | Type     | Required    | Description                                                                                                                                                                                                       |
+| -------- | -------- | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `key`    | `string` | <YesIcon /> | The cache key to save the cache under. You can use expressions like `${{ hashFiles('package-lock.json') }}` to create dynamic keys based on file hashes. This should match the key used when restoring the cache. |
+| `path`   | `string` | <YesIcon /> | The path to the directory or files that should be cached. This should match the path used when restoring the cache.                                                                                               |
 
 <BoxLink
   title="eas/save_cache source code"
@@ -1862,10 +1863,10 @@ jobs:
 
 ##### Properties
 
-| Property      | Type   | Required | Description                                                                      |
-| ------------- | ------ | -------- | -------------------------------------------------------------------------------- |
-| `name`        | string | No       | The name of the artifact to download. Required if `artifact_id` is not provided. |
-| `artifact_id` | string | No       | The ID of the artifact to download. Required if `name` is not provided.          |
+| Property      | Type   | Required   | Description                                                                      |
+| ------------- | ------ | ---------- | -------------------------------------------------------------------------------- |
+| `name`        | string | <NoIcon /> | The name of the artifact to download. Required if `artifact_id` is not provided. |
+| `artifact_id` | string | <NoIcon /> | The ID of the artifact to download. Required if `name` is not provided.          |
 
 ##### Outputs
 

--- a/docs/pages/more/qr-codes.mdx
+++ b/docs/pages/more/qr-codes.mdx
@@ -4,6 +4,7 @@ description: Reference for the QR code generator at qr.expo.dev.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 qr.expo.dev is a cloud function that generates Expo-branded QR codes. This function creates QR codes for [EAS Update](/eas-update/introduction/), which are used to preview updates in [development builds](/develop/development-builds/introduction/) and Expo Go.
 
@@ -39,22 +40,22 @@ The following parameters apply to the `/eas-update` endpoint.
 
 The following base query parameters can be included with any request to `/eas-update`.
 
-| Param                    | Required | Default    | Description                                                                                                                                                       |
-| ------------------------ | -------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `slug`                   | No       | exp        | Use [`slug`](/versions/latest/config/app/#slug) from [app config](/workflow/configuration/) to target a development build. Otherwise use "exp" to target Expo Go. |
-| `appScheme` (deprecated) | No       | exp        | Replaced by `slug`. Use `slug` instead.                                                                                                                           |
-| `host`                   | No       | u.expo.dev | The hostname of the server that handles update requests.                                                                                                          |
-| `format`                 | No       | svg        | Endpoints respond with SVGs by default. To receive a plain text URL, use `url`.                                                                                   |
+| Param                    | Required   | Default    | Description                                                                                                                                                       |
+| ------------------------ | ---------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slug`                   | <NoIcon /> | exp        | Use [`slug`](/versions/latest/config/app/#slug) from [app config](/workflow/configuration/) to target a development build. Otherwise use "exp" to target Expo Go. |
+| `appScheme` (deprecated) | <NoIcon /> | exp        | Replaced by `slug`. Use `slug` instead.                                                                                                                           |
+| `host`                   | <NoIcon /> | u.expo.dev | The hostname of the server that handles update requests.                                                                                                          |
+| `format`                 | <NoIcon /> | svg        | Endpoints respond with SVGs by default. To receive a plain text URL, use `url`.                                                                                   |
 
 ### Update by device traits
 
 Preview and production builds make requests to the EAS Update service with `runtimeVersion` and `channel` properties. You can emulate this behavior with the following query parameters:
 
-| Param            | Required | Description                                                       |
-| ---------------- | -------- | ----------------------------------------------------------------- |
-| `projectId`      | Yes      | The ID of the project                                             |
-| `runtimeVersion` | Yes      | The [runtime version](/eas-update/runtime-versions/) of the build |
-| `channel`        | Yes      | The channel name of the build                                     |
+| Param            | Required    | Description                                                       |
+| ---------------- | ----------- | ----------------------------------------------------------------- |
+| `projectId`      | <YesIcon /> | The ID of the project                                             |
+| `runtimeVersion` | <YesIcon /> | The [runtime version](/eas-update/runtime-versions/) of the build |
+| `channel`        | <YesIcon /> | The channel name of the build                                     |
 
 #### Example
 
@@ -66,9 +67,9 @@ https://qr.expo.dev/eas-update?projectId=your-project-id&runtimeVersion=your-run
 
 You can create a QR code for a specific update given its platform-specific ID.
 
-| Param      | Required | Description          |
-| ---------- | -------- | -------------------- |
-| `updateId` | Yes      | The ID of the update |
+| Param      | Required    | Description          |
+| ---------- | ----------- | -------------------- |
+| `updateId` | <YesIcon /> | The ID of the update |
 
 #### Example
 
@@ -80,10 +81,10 @@ https://qr.expo.dev/eas-update?updateId=your-update-id
 
 You can create a QR code for an update group given the update's group ID.
 
-| Param       | Required | Description                |
-| ----------- | -------- | -------------------------- |
-| `projectId` | Yes      | The ID of the project      |
-| `groupId`   | Yes      | The ID of the update group |
+| Param       | Required    | Description                |
+| ----------- | ----------- | -------------------------- |
+| `projectId` | <YesIcon /> | The ID of the project      |
+| `groupId`   | <YesIcon /> | The ID of the update group |
 
 #### Example
 
@@ -95,10 +96,10 @@ https://qr.expo.dev/eas-update?projectId=your-project-id&groupId=your-update-id
 
 You can create a QR code with a branch's ID, which will return the latest update available on that branch.
 
-| Param       | Required | Description           |
-| ----------- | -------- | --------------------- |
-| `projectId` | Yes      | The ID of the project |
-| `branchId`  | Yes      | The ID of the branch  |
+| Param       | Required    | Description           |
+| ----------- | ----------- | --------------------- |
+| `projectId` | <YesIcon /> | The ID of the project |
+| `branchId`  | <YesIcon /> | The ID of the branch  |
 
 #### Example
 
@@ -110,10 +111,10 @@ https://qr.expo.dev/eas-update?projectId=your-project-id&branchId=your-branch-id
 
 You can create a QR code with a channel's ID, which will return the latest update available on the branch or branches that are mapped to that channel.
 
-| Param       | Required | Description           |
-| ----------- | -------- | --------------------- |
-| `projectId` | Yes      | The ID of the project |
-| `channelId` | Yes      | The ID of the channel |
+| Param       | Required    | Description           |
+| ----------- | ----------- | --------------------- |
+| `projectId` | <YesIcon /> | The ID of the project |
+| `channelId` | <YesIcon /> | The ID of the channel |
 
 #### Example
 

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -5,6 +5,7 @@ isAlpha: true
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
 import { FileTree } from '~/ui/components/FileTree';
 import { Terminal } from '~/ui/components/Snippet';
@@ -232,7 +233,7 @@ EAS Hosting supports server rendering out of the box. Export your app and deploy
 | Configuration      |     | `web.output: 'static'`                                                                | `web.output: 'server'`          |
 | Dynamic routes     |     | Requires [`generateStaticParams`](/router/web/static-rendering/#generatestaticparams) | Works automatically             |
 | Metadata           |     | [`<Head>`](/versions/latest/sdk/router/#head) component                               | [`generateMetadata`](#metadata) |
-| Server required    |     | No                                                                                    | Yes                             |
+| Server required    |     | <NoIcon />                                                                            | <YesIcon />                     |
 | Time to First Byte |     | Fastest (cached)                                                                      | Slower (rendered per request)   |
 | Hosting            |     | Any static host                                                                       | Server runtime required         |
 

--- a/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/drop-in-replacements/bottomsheet.mdx
@@ -8,6 +8,7 @@ platforms: ['android', 'ios', 'web', 'expo-go']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 A `BottomSheet` component with an API compatible with `@gorhom/bottom-sheet`. It wraps the platform-specific `@expo/ui` primitives: [Jetpack Compose ModalBottomSheet](../jetpack-compose/bottomsheet) on Android and [SwiftUI BottomSheet](../swift-ui/bottomsheet) on iOS. On web, it uses a [vaul](https://github.com/emilkowalski/vaul) drawer.
 
@@ -137,20 +138,20 @@ This difference is intentional. `@gorhom/bottom-sheet` owns the gesture and anim
 
 ## Supported exports
 
-| Export                     | Supported | Notes                                                     |
-| -------------------------- | --------- | --------------------------------------------------------- |
-| `BottomSheet`              | Yes       | Modal on Android and iOS, drawer on web                   |
-| `BottomSheetModal`         | Yes       | Starts closed and opens with `present()`                  |
-| `BottomSheetModalProvider` | Yes       | Renders children directly for compatibility               |
-| `BottomSheetView`          | Yes       | Wraps sheet content                                       |
-| `BottomSheetScrollView`    | Yes       | Re-export of React Native `ScrollView`                    |
-| `BottomSheetFlatList`      | Yes       | Re-export of React Native `FlatList`                      |
-| `BottomSheetSectionList`   | Yes       | Re-export of React Native `SectionList`                   |
-| `BottomSheetTextInput`     | Yes       | Re-export of React Native `TextInput`                     |
-| `useBottomSheet`           | Yes       | Returns the sheet ref methods from context                |
-| `BottomSheetBackdrop`      | No        | The native sheet or web drawer handles the backdrop       |
-| `BottomSheetHandle`        | No        | The native sheet or web drawer handles the drag indicator |
-| `BottomSheetFooter`        | No        | No equivalent in this implementation                      |
+| Export                     | Supported   | Notes                                                     |
+| -------------------------- | ----------- | --------------------------------------------------------- |
+| `BottomSheet`              | <YesIcon /> | Modal on Android and iOS, drawer on web                   |
+| `BottomSheetModal`         | <YesIcon /> | Starts closed and opens with `present()`                  |
+| `BottomSheetModalProvider` | <YesIcon /> | Renders children directly for compatibility               |
+| `BottomSheetView`          | <YesIcon /> | Wraps sheet content                                       |
+| `BottomSheetScrollView`    | <YesIcon /> | Re-export of React Native `ScrollView`                    |
+| `BottomSheetFlatList`      | <YesIcon /> | Re-export of React Native `FlatList`                      |
+| `BottomSheetSectionList`   | <YesIcon /> | Re-export of React Native `SectionList`                   |
+| `BottomSheetTextInput`     | <YesIcon /> | Re-export of React Native `TextInput`                     |
+| `useBottomSheet`           | <YesIcon /> | Returns the sheet ref methods from context                |
+| `BottomSheetBackdrop`      | <NoIcon />  | The native sheet or web drawer handles the backdrop       |
+| `BottomSheetHandle`        | <NoIcon />  | The native sheet or web drawer handles the drag indicator |
+| `BottomSheetFooter`        | <NoIcon />  | No equivalent in this implementation                      |
 
 ## Compatibility notes
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/drop-in-replacements/bottomsheet.mdx
@@ -8,6 +8,7 @@ platforms: ['android', 'ios', 'web', 'expo-go']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { YesIcon, NoIcon } from '~/ui/components/DocIcons';
 
 A `BottomSheet` component with an API compatible with `@gorhom/bottom-sheet`. It wraps the platform-specific `@expo/ui` primitives: [Jetpack Compose ModalBottomSheet](../jetpack-compose/bottomsheet) on Android and [SwiftUI BottomSheet](../swift-ui/bottomsheet) on iOS. On web, it uses a [vaul](https://github.com/emilkowalski/vaul) drawer.
 
@@ -137,20 +138,20 @@ This difference is intentional. `@gorhom/bottom-sheet` owns the gesture and anim
 
 ## Supported exports
 
-| Export                     | Supported | Notes                                                     |
-| -------------------------- | --------- | --------------------------------------------------------- |
-| `BottomSheet`              | Yes       | Modal on Android and iOS, drawer on web                   |
-| `BottomSheetModal`         | Yes       | Starts closed and opens with `present()`                  |
-| `BottomSheetModalProvider` | Yes       | Renders children directly for compatibility               |
-| `BottomSheetView`          | Yes       | Wraps sheet content                                       |
-| `BottomSheetScrollView`    | Yes       | Re-export of React Native `ScrollView`                    |
-| `BottomSheetFlatList`      | Yes       | Re-export of React Native `FlatList`                      |
-| `BottomSheetSectionList`   | Yes       | Re-export of React Native `SectionList`                   |
-| `BottomSheetTextInput`     | Yes       | Re-export of React Native `TextInput`                     |
-| `useBottomSheet`           | Yes       | Returns the sheet ref methods from context                |
-| `BottomSheetBackdrop`      | No        | The native sheet or web drawer handles the backdrop       |
-| `BottomSheetHandle`        | No        | The native sheet or web drawer handles the drag indicator |
-| `BottomSheetFooter`        | No        | No equivalent in this implementation                      |
+| Export                     | Supported   | Notes                                                     |
+| -------------------------- | ----------- | --------------------------------------------------------- |
+| `BottomSheet`              | <YesIcon /> | Modal on Android and iOS, drawer on web                   |
+| `BottomSheetModal`         | <YesIcon /> | Starts closed and opens with `present()`                  |
+| `BottomSheetModalProvider` | <YesIcon /> | Renders children directly for compatibility               |
+| `BottomSheetView`          | <YesIcon /> | Wraps sheet content                                       |
+| `BottomSheetScrollView`    | <YesIcon /> | Re-export of React Native `ScrollView`                    |
+| `BottomSheetFlatList`      | <YesIcon /> | Re-export of React Native `FlatList`                      |
+| `BottomSheetSectionList`   | <YesIcon /> | Re-export of React Native `SectionList`                   |
+| `BottomSheetTextInput`     | <YesIcon /> | Re-export of React Native `TextInput`                     |
+| `useBottomSheet`           | <YesIcon /> | Returns the sheet ref methods from context                |
+| `BottomSheetBackdrop`      | <NoIcon />  | The native sheet or web drawer handles the backdrop       |
+| `BottomSheetHandle`        | <NoIcon />  | The native sheet or web drawer handles the drag indicator |
+| `BottomSheetFooter`        | <NoIcon />  | No equivalent in this implementation                      |
 
 ## Compatibility notes
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Replace plain Yes/No table cells with YesIcon and NoIcon in multiple pages.

# How

<!--
How did you build this feature or fix this bug and why?
-->

 Imported `YesIcon` and `NoIcon` from `~/ui/components/DocIcons` in the affected pages and replaced every `Yes`/`No` status cell with the corresponding component.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Example preview from `BottomSheet` page:

<img width="2456" height="1614" alt="CleanShot 2026-05-08 at 22 33 45@2x" src="https://github.com/user-attachments/assets/d926a301-018b-4302-a7ea-1d9191b483ed" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
