### PR TITLE
[expo] remove dependency on @expo/vector-icons

### DIFF
--- a/apps/common/package.json
+++ b/apps/common/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@expo/styleguide-base": "^1.0.1",
+    "@expo/vector-icons": "^15.0.2",
     "react-native": "0.85.3",
     "react": "19.2.3"
   },

--- a/apps/notification-tester/package.json
+++ b/apps/notification-tester/package.json
@@ -22,6 +22,7 @@
     "@react-navigation/bottom-tabs": "^7.15.5",
     "@react-navigation/native": "^7.1.33",
     "@expo/ui": "workspace:*",
+    "@expo/vector-icons": "^15.0.2",
     "expo": "workspace:*",
     "expo-font": "workspace:*",
     "expo-linking": "workspace:*",

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- Removed `@expo/vector-icons` from the `expo` package's dependencies. Apps that list `@expo/vector-icons` in their own `package.json` are unaffected; this is flagged as breaking only for apps that relied on `expo` transitively pulling it in. ([#45563](https://github.com/expo/expo/pull/45563) by [@vonovak](https://github.com/vonovak))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -85,7 +85,6 @@
     "@expo/log-box": "workspace:^56.0.7",
     "@expo/metro": "~56.0.0",
     "@expo/metro-config": "workspace:~56.0.6",
-    "@expo/vector-icons": "^15.0.2",
     "@ungap/structured-clone": "^1.3.0",
     "babel-preset-expo": "workspace:~56.0.6",
     "expo-asset": "workspace:~56.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -415,6 +415,9 @@ importers:
       '@expo/styleguide-base':
         specifier: ^1.0.1
         version: 1.0.1(react@19.2.3)
+      '@expo/vector-icons':
+        specifier: ^15.0.2
+        version: 15.1.1(expo-font@packages+expo-font)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1243,6 +1246,9 @@ importers:
       '@expo/ui':
         specifier: workspace:*
         version: link:../../packages/expo-ui
+      '@expo/vector-icons':
+        specifier: ^15.0.2
+        version: 15.1.1(expo-font@packages+expo-font)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       '@react-navigation/bottom-tabs':
         specifier: ^7.15.5
         version: 7.15.5(4cf81f97ae4861b2ec2ba3fb0b222013)
@@ -3466,9 +3472,6 @@ importers:
       '@expo/metro-config':
         specifier: workspace:~56.0.6
         version: link:../@expo/metro-config
-      '@expo/vector-icons':
-        specifier: ^15.0.2
-        version: 15.1.1(expo-font@packages+expo-font)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       '@ungap/structured-clone':
         specifier: ^1.3.0
         version: 1.3.0


### PR DESCRIPTION
# Why

the expo package has a dependency on @expo/vector-icons which we don't want to have.

# How

remove the dep (but add it to the apps that depend on it, I'll migrate those to the community packages in another PR)

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)