### PR TITLE
feat(expo-doctor): Update `MetroConfigCheck` for SDK 56+

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### 🎉 New features
 
+- Skip `watchFolders` check for SDK 56 ([#45567](https://github.com/expo/expo/pull/45567) by [@kitten](https://github.com/kitten))
+- Warn when `blacklistRE` or invalid `blockList` regex are used ([#45567](https://github.com/expo/expo/pull/45567) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-doctor/src/checks/MetroConfigCheck.ts
+++ b/packages/expo-doctor/src/checks/MetroConfigCheck.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import semver from 'semver';
 
 import type { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
 import { learnMore } from '../utils/TerminalLink';
@@ -22,7 +23,7 @@ export class MetroConfigCheck implements DoctorCheck {
 
   sdkVersionRange = '>=51.0.0';
 
-  async runAsync({ projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+  async runAsync({ projectRoot, exp }: DoctorCheckParams): Promise<DoctorCheckResult> {
     const issues: string[] = [];
     if (!(await configExistsAsync(projectRoot))) {
       return {
@@ -56,15 +57,49 @@ export class MetroConfigCheck implements DoctorCheck {
     const expoMetroConfig = await loadExpoMetroConfig(projectRoot);
     const defaultConfig = expoMetroConfig.getDefaultConfig(projectRoot);
 
-    if (!isPathsSubsetOf(defaultConfig.watchFolders, userConfig.watchFolders)) {
+    // From SDK 56+, the on-demand filesystem (experiments.onDemandFilesystem) makes `watchFolders`
+    // a non-critical configuration that doesn't block file discovery. There's still potential for
+    // errors with it being misconfigured, but the risk is lower, and users may now legitimately
+    // "optimize" what they want to crawl and watch
+    const isSdk56OrLater =
+      exp.sdkVersion === 'UNVERSIONED' ||
+      (exp.sdkVersion != null && semver.satisfies(exp.sdkVersion, '>=56.0.0'));
+    if (
+      (!isSdk56OrLater || exp.experiments?.onDemandFilesystem === false) &&
+      !isPathsSubsetOf(defaultConfig.watchFolders, userConfig.watchFolders)
+    ) {
       issues.push(`- "watchFolders" does not contain all entries from Expo's defaults`);
     }
 
     if (userConfig.resolver) {
+      if (userConfig.resolver.blacklistRE != null) {
+        issues.push(
+          `- "resolver.blacklistRE" is deprecated. Replace it with "resolver.blockList" or remove it.`
+        );
+      }
+
+      const blockList = userConfig.resolver.blockList;
+      const blockListPatterns: RegExp[] = Array.isArray(blockList)
+        ? blockList.filter((p): p is RegExp => p instanceof RegExp)
+        : blockList instanceof RegExp
+          ? [blockList]
+          : [];
+      for (const pattern of blockListPatterns) {
+        const offending = pattern.flags.match(/[gy]/g)?.join('');
+        if (offending) {
+          issues.push(
+            `- "resolver.blockList"'s ${pattern} uses the stateful "${offending}" flag, which causes inconsistent matches.`
+          );
+        }
+      }
+
       // `nodeModulesPaths` is likely to be empty, except in monorepos. But this setting
       // usually doesn't matter as much. We still apply checks, but don't expect this to
       // fail often
+      // NOTE (@kitten): `nodeModulesPaths` are fallbacks, so considering `disableHierarchicalLookup`
+      // is enforced below, we don't have to check this, if the user has emptied it out
       if (
+        userConfig.resolver?.nodeModulesPaths?.length &&
         !isPathsSubsetOf(
           defaultConfig.resolver?.nodeModulesPaths,
           userConfig.resolver?.nodeModulesPaths

--- a/packages/expo-doctor/src/checks/__tests__/MetroConfigCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/MetroConfigCheck.test.ts
@@ -21,6 +21,26 @@ const additionalProjectProps = {
   dynamicConfigPath: null,
 };
 
+const stubDefaultConfig = () =>
+  ({
+    watchFolders: [],
+    transformer: {
+      _expoRelativeProjectRoot: '.',
+    },
+    resolver: {
+      nodeModulesPaths: [],
+      sourceExts: ['js', 'ts'],
+      assetExts: ['png'],
+      platforms: ['ios', 'android'],
+    },
+  }) as any;
+
+const mockExpoMetroConfig = (overrides: Record<string, unknown> = {}) => {
+  jest.mocked(loadExpoMetroConfig).mockResolvedValueOnce({
+    getDefaultConfig: () => ({ ...stubDefaultConfig(), ...overrides }),
+  } as any);
+};
+
 describe('runAsync', () => {
   beforeEach(() => {
     jest.mocked(loadExpoMetroConfig).mockResolvedValueOnce({
@@ -66,5 +86,182 @@ describe('runAsync', () => {
       ...additionalProjectProps,
     });
     expect(result.isSuccessful).toBeFalsy();
+  });
+});
+
+describe('config-comparison checks', () => {
+  beforeEach(() => {
+    jest.mocked(configExistsAsync).mockResolvedValue(true);
+  });
+
+  const runWithUserConfig = async (
+    userConfig: Record<string, unknown>,
+    expOverrides: Record<string, unknown> = {}
+  ) => {
+    jest.mocked(loadExpoMetroConfig).mockReset();
+    mockExpoMetroConfig();
+    jest.mocked(loadConfigAsync).mockResolvedValueOnce({
+      ...stubDefaultConfig(),
+      ...userConfig,
+    } as any);
+    const check = new MetroConfigCheck();
+    return check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+      exp: { ...additionalProjectProps.exp, sdkVersion: '56.0.0', ...expOverrides },
+    });
+  };
+
+  it('passes when user config matches Expo defaults', async () => {
+    const result = await runWithUserConfig({});
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it('skips watchFolders subset check on SDK 56+ with onDemandFilesystem default', async () => {
+    const result = await runWithUserConfig(
+      { watchFolders: [] },
+      { experiments: { onDemandFilesystem: true } }
+    );
+    expect(result.issues.find((i) => i.includes('watchFolders'))).toBeUndefined();
+  });
+
+  it('runs watchFolders subset check on SDK 56+ when onDemandFilesystem is disabled', async () => {
+    jest.mocked(loadExpoMetroConfig).mockReset();
+    mockExpoMetroConfig({
+      watchFolders: ['/path/to/project/packages/foo'],
+    });
+    jest.mocked(loadConfigAsync).mockResolvedValueOnce({
+      ...stubDefaultConfig(),
+      watchFolders: [],
+    } as any);
+    const check = new MetroConfigCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+      exp: {
+        ...additionalProjectProps.exp,
+        sdkVersion: '56.0.0',
+        experiments: { onDemandFilesystem: false },
+      } as any,
+    });
+    expect(result.issues.find((i) => i.includes('watchFolders'))).toBeDefined();
+  });
+
+  it('runs watchFolders subset check on SDK <56 regardless of experiments', async () => {
+    jest.mocked(loadExpoMetroConfig).mockReset();
+    mockExpoMetroConfig({
+      watchFolders: ['/path/to/project/packages/foo'],
+    });
+    jest.mocked(loadConfigAsync).mockResolvedValueOnce({
+      ...stubDefaultConfig(),
+      watchFolders: [],
+    } as any);
+    const check = new MetroConfigCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+      exp: { ...additionalProjectProps.exp, sdkVersion: '55.0.0' } as any,
+    });
+    expect(result.issues.find((i) => i.includes('watchFolders'))).toBeDefined();
+  });
+
+  it('flags deprecated resolver.blacklistRE', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, blacklistRE: /node_modules/ },
+    });
+    expect(result.issues.find((i) => i.includes('blacklistRE'))).toBeDefined();
+  });
+
+  it('flags blockList patterns with the `g` flag', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, blockList: /foo/g },
+    });
+    expect(result.issues.find((i) => i.includes('blockList'))).toBeDefined();
+  });
+
+  it('flags blockList patterns with the `y` flag in arrays', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, blockList: [/safe/, /sticky/y] },
+    });
+    expect(result.issues.find((i) => i.includes('blockList'))).toBeDefined();
+  });
+
+  it('passes for blockList patterns without `g` or `y` flags', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, blockList: [/foo/i, /bar/] },
+    });
+    expect(result.issues.find((i) => i.includes('blockList'))).toBeUndefined();
+  });
+
+  it('flags nodeModulesPaths missing Expo defaults', async () => {
+    jest.mocked(loadExpoMetroConfig).mockReset();
+    mockExpoMetroConfig({
+      resolver: { ...stubDefaultConfig().resolver, nodeModulesPaths: ['/expected/node_modules'] },
+    });
+    jest.mocked(loadConfigAsync).mockResolvedValueOnce({
+      ...stubDefaultConfig(),
+      resolver: { ...stubDefaultConfig().resolver, nodeModulesPaths: ['/other/node_modules'] },
+    } as any);
+    const check = new MetroConfigCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+      exp: { ...additionalProjectProps.exp, sdkVersion: '56.0.0' } as any,
+    });
+    expect(result.issues.find((i) => i.includes('nodeModulesPaths'))).toBeDefined();
+  });
+
+  it('skips nodeModulesPaths check when user has not set any', async () => {
+    jest.mocked(loadExpoMetroConfig).mockReset();
+    mockExpoMetroConfig({
+      resolver: { ...stubDefaultConfig().resolver, nodeModulesPaths: ['/expected/node_modules'] },
+    });
+    jest.mocked(loadConfigAsync).mockResolvedValueOnce({ ...stubDefaultConfig() } as any);
+    const check = new MetroConfigCheck();
+    const result = await check.runAsync({
+      projectRoot: '/path/to/project',
+      ...additionalProjectProps,
+      exp: { ...additionalProjectProps.exp, sdkVersion: '56.0.0' } as any,
+    });
+    expect(result.issues.find((i) => i.includes('nodeModulesPaths'))).toBeUndefined();
+  });
+
+  it('flags missing source/asset extensions', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, sourceExts: ['js'], assetExts: ['png'] },
+    });
+    expect(
+      result.issues.find((i) => i.includes('sourceExts') && i.includes('assetExts'))
+    ).toBeDefined();
+  });
+
+  it('passes when extensions are moved between source and asset', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, sourceExts: ['js'], assetExts: ['png', 'ts'] },
+    });
+    expect(
+      result.issues.find((i) => i.includes('sourceExts') && i.includes('assetExts'))
+    ).toBeUndefined();
+  });
+
+  it('flags resolver.disableHierarchicalLookup mismatch', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, disableHierarchicalLookup: true },
+    });
+    expect(result.issues.find((i) => i.includes('disableHierarchicalLookup'))).toBeDefined();
+  });
+
+  it('flags resolver.unstable_allowRequireContext mismatch', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, unstable_allowRequireContext: false },
+    });
+    expect(result.issues.find((i) => i.includes('unstable_allowRequireContext'))).toBeDefined();
+  });
+
+  it('flags resolver.unstable_enableSymlinks mismatch', async () => {
+    const result = await runWithUserConfig({
+      resolver: { ...stubDefaultConfig().resolver, unstable_enableSymlinks: false },
+    });
+    expect(result.issues.find((i) => i.includes('unstable_enableSymlinks'))).toBeDefined();
   });
 });


### PR DESCRIPTION
# Why

The main notable change in SDK 56 is that `watchFolders` isn't a load-bearing config option anymore. It could legitimately be set to `config.watchFolders = [];` (project root will be added automatically) and an app in a monorepo will continue working. The On-Demand Filesystem in `@expo/metro-file-map` will continue crawling on-the-fly, if a file is missing in the monorepo, and will leave the monorepo even as needed.

Additionally, some changes have been made to `blockList`. They don't break, but they surfaced that there's some common mistakes we can avoid. `blacklistRE` is deprecated and we can always warn about it. A `/.../g` or `/.../y` regex in `blockList` is a simple mistake, since it's a stateful regex and should be removed.

# How

- Only check `watchFolders` if user is below SDK 56 or if `onDemandFilesystem` is disabled
- Check `blockList` for regexes with `//g` or `//y` flag
- Warn when `blacklistRE` is used, since it's deprecated and conflicts

# Test Plan

- Unit tests added

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
