### PR TITLE
[tools] Fix docsInline typecheck against TypeDoc 0.28 NormalizedPath

### DIFF
--- a/tools/src/generate-docs-api-data/docsInline.ts
+++ b/tools/src/generate-docs-api-data/docsInline.ts
@@ -78,6 +78,7 @@ import path from 'node:path';
 import {
   Application,
   Configuration,
+  normalizePath,
   ReflectionKind,
   TSConfigReader,
   TypeDocReader,
@@ -241,7 +242,7 @@ async function collectTaggedDeclarations(
 
   const result = new Map<string, JSONOutput.DeclarationReflection>();
   if (project) {
-    const json = app.serializer.projectToObject(project, process.cwd()) as unknown;
+    const json = app.serializer.projectToObject(project, normalizePath(process.cwd())) as unknown;
     walk(json, (node) => {
       if (isObject(node) && typeof node.name === 'string' && taggedTypes.has(node.name)) {
         result.set(node.name, node as unknown as JSONOutput.DeclarationReflection);


### PR DESCRIPTION
# Why

The TypeDoc 0.28 bump in #45370 changed `Serializer.projectToObject`'s second parameter from `string` to a branded `NormalizedPath` type, leaving `tools/src/generate-docs-api-data/docsInline.ts:244` failing typecheck on `main`. https://github.com/expo/expo/actions/runs/25574662049/job/75078794192?pr=45571


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

 - Import `normalizePath` from `typedoc` and wrap `process.cwd()` with it before passing to `app.serializer.projectToObject(...)`.
 
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- `cd tools && pnpm tsc --noEmit` is clean locally.          
- CI passes - https://github.com/expo/expo/actions/runs/25574858257/job/75079413411?pr=45573

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
