### PR TITLE
[core][iOS] Rewrite JSValueEncoder to route through dynamic types

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix encoding `Encodable` function results so arrays, dictionaries, optionals, `RawRepresentable` enums and `Convertible`s route through their dynamic types instead of producing wrong shapes. ([#45575](https://github.com/expo/expo/pull/45575) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-11

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEncodableType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicEncodableType.swift
@@ -29,15 +29,16 @@ internal struct DynamicEncodableType: AnyDynamicType {
   }
 
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
+    return try castToJS(value, appContext: appContext, in: try appContext.runtime)
+  }
+
+  func castToJS<ValueType>(_ value: ValueType, appContext: AppContext, in runtime: JavaScriptRuntime) throws -> JavaScriptValue {
     if let value = value as? JavaScriptValue {
       return value
     }
     if let value = value as? Encodable {
-      let runtime = try appContext.runtime
-      let encoder = JSValueEncoder(runtime: runtime)
-
+      let encoder = JSValueEncoder(appContext: appContext, runtime: runtime)
       try value.encode(to: encoder)
-
       return encoder.value
     }
     throw Conversions.ConversionToJSFailedException((kind: .object, nativeType: ValueType.self))

--- a/packages/expo-modules-core/ios/Core/JSValueEncoder.swift
+++ b/packages/expo-modules-core/ios/Core/JSValueEncoder.swift
@@ -3,12 +3,21 @@
 import ExpoModulesJSI
 
 /**
- Encodes `Encodable` objects or values to `JavaScriptValue`. This implementation is incomplete,
- but it supports basic use cases with structs defined by the user and when the default `Encodable` implementation is used.
+ Encodes `Encodable` values to `JavaScriptValue`.
+
+ For any property whose static type is known to the dynamic-type registry
+ (anything routed via the `~` operator: arrays, dictionaries, optionals,
+ `RawRepresentable` enums, `Convertible`s, `JavaScriptValue` and so on),
+ the encoder takes the fast path through `castToJS`, preserving full
+ element-type metadata.
+
+ Only types the registry doesn't recognize (i.e. plain `Encodable` structs and
+ classes) fall back to Swift's `Encodable` machinery via `value.encode(to:)`.
  */
 internal final class JSValueEncoder: Encoder {
+  private weak var appContext: AppContext?
   private let runtime: JavaScriptRuntime
-  private let valueHolder = JSValueHolder()
+  private let valueHolder: JSValueHolder
 
   /**
    The result of encoding to `JavaScriptValue`. Use this property after running `encode(to:)` on the encodable.
@@ -18,43 +27,110 @@ internal final class JSValueEncoder: Encoder {
   }
 
   /**
-   Initializes the encoder with the given runtime in which the value will be created.
+   Initializes the encoder with the given app context. Throws if the runtime has been lost.
    */
-  init(runtime: JavaScriptRuntime) {
+  convenience init(appContext: AppContext) throws {
+    try self.init(appContext: appContext, runtime: appContext.runtime)
+  }
+
+  /**
+   Initializes the encoder with the given app context and an explicit runtime.
+   Use this when produced JS values must live in a runtime other than the
+   app context's main runtime (e.g. a worklet runtime).
+   */
+  convenience init(appContext: AppContext, runtime: JavaScriptRuntime) {
+    self.init(
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: [],
+      valueHolder: JSValueHolder()
+    )
+  }
+
+  fileprivate init(
+    appContext: AppContext?,
+    runtime: JavaScriptRuntime,
+    codingPath: [any CodingKey],
+    valueHolder: JSValueHolder
+  ) {
+    self.appContext = appContext
     self.runtime = runtime
+    self.codingPath = codingPath
+    self.valueHolder = valueHolder
   }
 
   // MARK: - Encoder
 
-  // We don't use `codingPath` and `userInfo`, but they are required by the protocol.
-  let codingPath: [any CodingKey] = []
+  let codingPath: [any CodingKey]
   let userInfo: [CodingUserInfoKey: Any] = [:]
 
-  /**
-   Returns an encoding container appropriate for holding multiple values keyed by the given key type.
-   */
   func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
-    let container = JSObjectEncodingContainer<Key>(to: valueHolder, runtime: runtime)
+    let container = JSObjectEncodingContainer<Key>(
+      to: valueHolder,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath
+    )
     return KeyedEncodingContainer(container)
   }
 
-  /**
-   Returns an encoding container appropriate for holding multiple unkeyed values.
-   */
   func unkeyedContainer() -> any UnkeyedEncodingContainer {
-    return JSArrayEncodingContainer(to: valueHolder, runtime: runtime)
+    return JSArrayEncodingContainer(
+      to: valueHolder,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath
+    )
   }
 
-  /**
-   Returns an encoding container appropriate for holding a single primitive value, including optionals.
-   */
   func singleValueContainer() -> any SingleValueEncodingContainer {
-    return JSValueEncodingContainer(to: valueHolder, runtime: runtime)
+    return JSValueEncodingContainer(
+      to: valueHolder,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath
+    )
   }
 }
 
+// MARK: - Shared encoding logic
+
 /**
- An object that holds a JS value that could be overriden by the encoding container.
+ Encodes a single value into a `JavaScriptValue`, routing through the dynamic-type
+ registry whenever possible and falling back to `Encodable` only for plain types.
+ */
+private func encodeUsingDynamicType<ValueType: Encodable>(
+  _ value: ValueType,
+  appContext: AppContext?,
+  runtime: JavaScriptRuntime,
+  codingPath: [any CodingKey]
+) throws -> JavaScriptValue {
+  let dynamicType = ~ValueType.self
+
+  if !(dynamicType is DynamicEncodableType) {
+    guard let appContext else {
+      // App context is gone; nothing useful we can do.
+      return .undefined
+    }
+    return try dynamicType.castToJS(value, appContext: appContext, in: runtime)
+  }
+
+  // Plain Encodable type the registry doesn't recognize — recurse via Encodable.
+  let holder = JSValueHolder()
+  let encoder = JSValueEncoder(
+    appContext: appContext,
+    runtime: runtime,
+    codingPath: codingPath,
+    valueHolder: holder
+  )
+  try value.encode(to: encoder)
+  return holder.value
+}
+
+// MARK: - Containers
+
+/**
+ An object that holds a JS value, mutated by an encoding container as it makes progress.
  */
 private final class JSValueHolder {
   var value: JavaScriptValue = .undefined
@@ -64,146 +140,232 @@ private final class JSValueHolder {
  Single value container used to encode primitive values, including optionals.
  */
 private struct JSValueEncodingContainer: SingleValueEncodingContainer {
-  private weak var runtime: JavaScriptRuntime?
+  private weak var appContext: AppContext?
+  private let runtime: JavaScriptRuntime
   private let valueHolder: JSValueHolder
+  let codingPath: [any CodingKey]
 
-  init(to valueHolder: JSValueHolder, runtime: JavaScriptRuntime?) {
-    self.runtime = runtime
+  init(to valueHolder: JSValueHolder, appContext: AppContext?, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
     self.valueHolder = valueHolder
+    self.appContext = appContext
+    self.runtime = runtime
+    self.codingPath = codingPath
   }
 
-  // MARK: - SingleValueEncodingContainer
-
-  // Unused, but required by the protocol.
-  let codingPath: [any CodingKey] = []
-
   mutating func encodeNil() throws {
-    self.valueHolder.value = .null
+    valueHolder.value = .null
   }
 
   mutating func encode<ValueType: Encodable>(_ value: ValueType) throws {
-    guard let runtime else {
-      // Do nothing when the runtime is already deallocated
-      return
-    }
-    let jsValue = JavaScriptValue.from(value, runtime: runtime)
-
-    // If the given value couldn't be converted to JavaScriptValue, try to encode it farther.
-    // It might be the case when the default implementation of `Encodable` has chosen the single value container
-    // for an optional type that should rather use keyed or unkeyed container when unwrapped.
-    if jsValue.isUndefined() {
-      let encoder = JSValueEncoder(runtime: runtime)
-      try value.encode(to: encoder)
-      self.valueHolder.value = encoder.value
-      return
-    }
-    self.valueHolder.value = jsValue
+    valueHolder.value = try encodeUsingDynamicType(
+      value,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath
+    )
   }
 }
 
 /**
  Keyed container that encodes to a JavaScript object.
 
- - Note: This is a `class` (rather than `struct` like `JSArrayEncodingContainer` below)
-   because it holds a non-copyable `JavaScriptObject`. A struct property of a non-copyable
-   type makes the containing struct non-copyable too, which conflicts with
-   `KeyedEncodingContainerProtocol`'s expectation of a copyable conformer. Using a class
-   sidesteps the constraint via reference semantics.
+ - Note: This is a `class` (not a `struct`) because it holds a non-copyable
+   `JavaScriptObject`. A struct property of a non-copyable type makes the
+   containing struct non-copyable too, which conflicts with
+   `KeyedEncodingContainerProtocol`'s expectation of a copyable conformer.
+   Using a class sidesteps the constraint via reference semantics.
  */
-private class JSObjectEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProtocol {
-  private weak var runtime: JavaScriptRuntime?
+private final class JSObjectEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProtocol {
+  private weak var appContext: AppContext?
+  private let runtime: JavaScriptRuntime
   private let valueHolder: JSValueHolder
   private var object: JavaScriptObject
+  let codingPath: [any CodingKey]
 
-  init(to valueHolder: JSValueHolder, runtime: JavaScriptRuntime) {
+  init(to valueHolder: JSValueHolder, appContext: AppContext?, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
     let object = runtime.createObject()
     valueHolder.value = object.asValue()
 
+    self.appContext = appContext
     self.runtime = runtime
-    self.object = object
     self.valueHolder = valueHolder
+    self.object = object
+    self.codingPath = codingPath
   }
-
-  // MARK: - KeyedEncodingContainerProtocol
-
-  // Unused, but required by the protocol.
-  var codingPath: [any CodingKey] = []
 
   func encodeNil(forKey key: Key) throws {
     object.setProperty(key.stringValue, value: JavaScriptValue.null)
   }
 
   func encode<ValueType: Encodable>(_ value: ValueType, forKey key: Key) throws {
-    guard let runtime else {
-      // Do nothing when the runtime is already deallocated
-      return
+    let encoded = try encodeUsingDynamicType(
+      value,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+    object.setProperty(key.stringValue, value: encoded)
+  }
+
+  // The default `KeyedEncodingContainerProtocol.encodeIfPresent` skips nil values
+  // entirely, which would leave JS objects with missing keys. Override every
+  // overload (one per primitive plus a generic `Encodable` one) so nil optional
+  // fields produce an explicit `null` instead.
+  func encodeIfPresent<ValueType: Encodable>(_ value: ValueType?, forKey key: Key) throws {
+    if let value {
+      try encode(value, forKey: key)
+    } else {
+      try encodeNil(forKey: key)
     }
-    let encoder = JSValueEncoder(runtime: runtime)
-    try value.encode(to: encoder)
-    object.setProperty(key.stringValue, value: encoder.value)
+  }
+
+  func encodeIfPresent(_ value: Bool?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: String?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: Double?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: Float?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: Int?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: Int8?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: Int16?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: Int32?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: Int64?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: UInt?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: UInt8?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: UInt16?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: UInt32?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+  func encodeIfPresent(_ value: UInt64?, forKey key: Key) throws { try encodeOptional(value, forKey: key) }
+
+  private func encodeOptional<ValueType: Encodable>(_ value: ValueType?, forKey key: Key) throws {
+    if let value {
+      try encode(value, forKey: key)
+    } else {
+      try encodeNil(forKey: key)
+    }
   }
 
   func nestedContainer<NestedKey: CodingKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
-    fatalError("JSValueEncoder does not support nested containers")
+    let holder = JSValueHolder()
+    let container = JSObjectEncodingContainer<NestedKey>(
+      to: holder,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+    object.setProperty(key.stringValue, value: holder.value)
+    return KeyedEncodingContainer(container)
   }
 
   func nestedUnkeyedContainer(forKey key: Key) -> any UnkeyedEncodingContainer {
-    fatalError("JSValueEncoder does not support nested containers")
+    let holder = JSValueHolder()
+    let container = JSArrayEncodingContainer(
+      to: holder,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+    object.setProperty(key.stringValue, value: holder.value)
+    return container
   }
 
   func superEncoder() -> any Encoder {
-    fatalError("superEncoder() is not implemented in JSValueEncoder")
+    fatalError("JSValueEncoder does not support superEncoder()")
   }
 
   func superEncoder(forKey key: Key) -> any Encoder {
-    return self.superEncoder()
+    fatalError("JSValueEncoder does not support superEncoder(forKey:)")
   }
 }
 
 /**
  Unkeyed container that encodes values to a JavaScript array.
+
+ Like `JSObjectEncodingContainer`, this is a `class` so it can hold the
+ non-copyable `JavaScriptArray` directly without forcing the container itself
+ to be non-copyable.
  */
-private struct JSArrayEncodingContainer: UnkeyedEncodingContainer {
-  private weak var runtime: JavaScriptRuntime?
+private final class JSArrayEncodingContainer: UnkeyedEncodingContainer {
+  private weak var appContext: AppContext?
+  private let runtime: JavaScriptRuntime
   private let valueHolder: JSValueHolder
-  private var items: [JavaScriptValue] = []
-
-  init(to valueHolder: JSValueHolder, runtime: JavaScriptRuntime) {
-    self.runtime = runtime
-    self.valueHolder = valueHolder
-  }
-
-  // MARK: - UnkeyedEncodingContainer
-
-  // Unused, but required by the protocol.
-  var codingPath: [any CodingKey] = []
+  private var array: JavaScriptArray
+  let codingPath: [any CodingKey]
   var count: Int = 0
 
-  mutating func encodeNil() throws {
-    items.append(JavaScriptValue.null)
+  init(to valueHolder: JSValueHolder, appContext: AppContext?, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
+    let array = runtime.createArray()
+    valueHolder.value = array.asValue()
+
+    self.appContext = appContext
+    self.runtime = runtime
+    self.valueHolder = valueHolder
+    self.array = array
+    self.codingPath = codingPath
   }
 
-  mutating func encode<ValueType: Encodable>(_ value: ValueType) throws {
-    guard let runtime else {
-      // Do nothing when the runtime is already deallocated
-      return
-    }
-    let encoder = JSValueEncoder(runtime: runtime)
-    try value.encode(to: encoder)
-
-    items.append(encoder.value)
-    valueHolder.value = .representing(value: items, in: runtime)
+  func encodeNil() throws {
+    array[count] = JavaScriptValue.null
+    count += 1
   }
 
-  mutating func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> where NestedKey : CodingKey {
-    fatalError("JSValueEncoder does not support nested containers")
+  func encode<ValueType: Encodable>(_ value: ValueType) throws {
+    let encoded = try encodeUsingDynamicType(
+      value,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [AnyCodingKey(intValue: count)]
+    )
+    array[count] = encoded
+    count += 1
   }
 
-  mutating func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
-    fatalError("JSValueEncoder does not support nested containers")
+  func nestedContainer<NestedKey: CodingKey>(keyedBy keyType: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+    let holder = JSValueHolder()
+    let container = JSObjectEncodingContainer<NestedKey>(
+      to: holder,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [AnyCodingKey(intValue: count)]
+    )
+    array[count] = holder.value
+    count += 1
+    return KeyedEncodingContainer(container)
   }
 
-  mutating func superEncoder() -> any Encoder {
-    fatalError("superEncoder() is not implemented in JSValueEncoder")
+  func nestedUnkeyedContainer() -> any UnkeyedEncodingContainer {
+    let holder = JSValueHolder()
+    let container = JSArrayEncodingContainer(
+      to: holder,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [AnyCodingKey(intValue: count)]
+    )
+    array[count] = holder.value
+    count += 1
+    return container
+  }
+
+  func superEncoder() -> any Encoder {
+    fatalError("JSValueEncoder does not support superEncoder()")
+  }
+}
+
+// MARK: - Helpers
+
+/**
+ A coding key carrying just a string and an integer index. Used to extend
+ `codingPath` with array indices in the unkeyed container, since unkeyed
+ containers have no associated `Key` type to draw from.
+ */
+private struct AnyCodingKey: CodingKey {
+  let stringValue: String
+  let intValue: Int?
+
+  init(stringValue: String) {
+    self.stringValue = stringValue
+    self.intValue = nil
+  }
+
+  init(intValue: Int) {
+    self.stringValue = String(intValue)
+    self.intValue = intValue
   }
 }

--- a/packages/expo-modules-core/ios/Core/JSValueEncoder.swift
+++ b/packages/expo-modules-core/ios/Core/JSValueEncoder.swift
@@ -15,7 +15,7 @@ import ExpoModulesJSI
  classes) fall back to Swift's `Encodable` machinery via `value.encode(to:)`.
  */
 internal final class JSValueEncoder: Encoder {
-  private weak var appContext: AppContext?
+  private let appContext: AppContext
   private let runtime: JavaScriptRuntime
   private let valueHolder: JSValueHolder
 
@@ -36,7 +36,7 @@ internal final class JSValueEncoder: Encoder {
   /**
    Initializes the encoder with the given app context and an explicit runtime.
    Use this when produced JS values must live in a runtime other than the
-   app context's main runtime (e.g. a worklet runtime).
+   one currently held by the app context.
    */
   convenience init(appContext: AppContext, runtime: JavaScriptRuntime) {
     self.init(
@@ -48,7 +48,7 @@ internal final class JSValueEncoder: Encoder {
   }
 
   fileprivate init(
-    appContext: AppContext?,
+    appContext: AppContext,
     runtime: JavaScriptRuntime,
     codingPath: [any CodingKey],
     valueHolder: JSValueHolder
@@ -101,17 +101,13 @@ internal final class JSValueEncoder: Encoder {
  */
 private func encodeUsingDynamicType<ValueType: Encodable>(
   _ value: ValueType,
-  appContext: AppContext?,
+  appContext: AppContext,
   runtime: JavaScriptRuntime,
   codingPath: [any CodingKey]
 ) throws -> JavaScriptValue {
   let dynamicType = ~ValueType.self
 
   if !(dynamicType is DynamicEncodableType) {
-    guard let appContext else {
-      // App context is gone; nothing useful we can do.
-      return .undefined
-    }
     return try dynamicType.castToJS(value, appContext: appContext, in: runtime)
   }
 
@@ -140,12 +136,12 @@ private final class JSValueHolder {
  Single value container used to encode primitive values, including optionals.
  */
 private struct JSValueEncodingContainer: SingleValueEncodingContainer {
-  private weak var appContext: AppContext?
+  private let appContext: AppContext
   private let runtime: JavaScriptRuntime
   private let valueHolder: JSValueHolder
   let codingPath: [any CodingKey]
 
-  init(to valueHolder: JSValueHolder, appContext: AppContext?, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
+  init(to valueHolder: JSValueHolder, appContext: AppContext, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
     self.valueHolder = valueHolder
     self.appContext = appContext
     self.runtime = runtime
@@ -176,13 +172,13 @@ private struct JSValueEncodingContainer: SingleValueEncodingContainer {
    Using a class sidesteps the constraint via reference semantics.
  */
 private final class JSObjectEncodingContainer<Key: CodingKey>: KeyedEncodingContainerProtocol {
-  private weak var appContext: AppContext?
+  private let appContext: AppContext
   private let runtime: JavaScriptRuntime
   private let valueHolder: JSValueHolder
-  private var object: JavaScriptObject
+  private let object: JavaScriptObject
   let codingPath: [any CodingKey]
 
-  init(to valueHolder: JSValueHolder, appContext: AppContext?, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
+  init(to valueHolder: JSValueHolder, appContext: AppContext, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
     let object = runtime.createObject()
     valueHolder.value = object.asValue()
 
@@ -207,10 +203,11 @@ private final class JSObjectEncodingContainer<Key: CodingKey>: KeyedEncodingCont
     object.setProperty(key.stringValue, value: encoded)
   }
 
-  // The default `KeyedEncodingContainerProtocol.encodeIfPresent` skips nil values
-  // entirely, which would leave JS objects with missing keys. Override every
-  // overload (one per primitive plus a generic `Encodable` one) so nil optional
-  // fields produce an explicit `null` instead.
+  // The default `KeyedEncodingContainerProtocol.encodeIfPresent` does nothing for
+  // nil values, which leaves the JS object without the key entirely — so `'label' in obj`
+  // returns false and consumers can't distinguish "absent" from "explicitly null".
+  // Override every overload (one per primitive plus a generic `Encodable` one) so nil
+  // optional fields produce an explicit `null` instead.
   func encodeIfPresent<ValueType: Encodable>(_ value: ValueType?, forKey key: Key) throws {
     if let value {
       try encode(value, forKey: key)
@@ -283,14 +280,14 @@ private final class JSObjectEncodingContainer<Key: CodingKey>: KeyedEncodingCont
  to be non-copyable.
  */
 private final class JSArrayEncodingContainer: UnkeyedEncodingContainer {
-  private weak var appContext: AppContext?
+  private let appContext: AppContext
   private let runtime: JavaScriptRuntime
   private let valueHolder: JSValueHolder
-  private var array: JavaScriptArray
+  private let array: JavaScriptArray
   let codingPath: [any CodingKey]
   var count: Int = 0
 
-  init(to valueHolder: JSValueHolder, appContext: AppContext?, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
+  init(to valueHolder: JSValueHolder, appContext: AppContext, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
     let array = runtime.createArray()
     valueHolder.value = array.asValue()
 
@@ -361,7 +358,7 @@ private struct AnyCodingKey: CodingKey {
 
   init(stringValue: String) {
     self.stringValue = stringValue
-    self.intValue = nil
+    self.intValue = Int(stringValue)
   }
 
   init(intValue: Int) {

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
@@ -763,10 +763,14 @@ struct DynamicTypeTests {
       let result = try (~TestEncodable.self).castToJS(encodable, appContext: appContext)
       let propertyNames = result.getObject().getPropertyNames()
 
-      #expect(propertyNames.count == 3)
+      // Nil optional fields are emitted as explicit `null` rather than omitted,
+      // so the resulting JS object exposes every declared field.
+      #expect(propertyNames.count == 5)
       #expect(propertyNames.contains("string"))
       #expect(propertyNames.contains("number"))
       #expect(propertyNames.contains("bool"))
+      #expect(propertyNames.contains("object"))
+      #expect(propertyNames.contains("array"))
     }
 
     @Test
@@ -778,8 +782,8 @@ struct DynamicTypeTests {
       #expect(try object.getProperty("string").asString() == encodable.string)
       #expect(try object.getProperty("number").asInt() == encodable.number)
       #expect(try object.getProperty("bool").asBool() == encodable.bool)
-      #expect(object.getProperty("object").isUndefined() == true)
-      #expect(object.getProperty("array").isUndefined() == true)
+      #expect(object.getProperty("object").isNull() == true)
+      #expect(object.getProperty("array").isNull() == true)
     }
 
     @Test

--- a/packages/expo-modules-core/ios/Tests/JSValueEncoderTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JSValueEncoderTests.swift
@@ -1,0 +1,437 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import CoreGraphics
+import Foundation
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("JSValueEncoder")
+@JavaScriptActor
+struct JSValueEncoderTests {
+  let appContext = AppContext.create()
+
+  private func encode<ValueType: Encodable>(_ value: ValueType) throws -> JavaScriptValue {
+    let encoder = try JSValueEncoder(appContext: appContext)
+    try value.encode(to: encoder)
+    return encoder.value
+  }
+
+  // MARK: - Primitives in single-value container
+
+  @Test
+  func `encodes a string`() throws {
+    #expect(try encode("expo").getString() == "expo")
+  }
+
+  @Test
+  func `encodes an int`() throws {
+    #expect(try encode(42).getInt() == 42)
+  }
+
+  @Test
+  func `encodes a double`() throws {
+    #expect(try encode(3.5).getDouble() == 3.5)
+  }
+
+  @Test
+  func `encodes a bool`() throws {
+    #expect(try encode(true).getBool() == true)
+  }
+
+  @Test
+  func `encodes a top-level nil optional as null`() throws {
+    let value: String? = nil
+    #expect(try encode(value).isNull() == true)
+  }
+
+  @Test
+  func `encodes a top-level present optional as the wrapped value`() throws {
+    let value: String? = "expo"
+    #expect(try encode(value).getString() == "expo")
+  }
+
+  // MARK: - Plain Encodable struct
+
+  @Test
+  func `encodes a flat struct`() throws {
+    struct Point: Encodable {
+      let x: Int
+      let y: Int
+    }
+    let result = try encode(Point(x: 3, y: 4)).getObject()
+
+    #expect(result.getProperty("x").getInt() == 3)
+    #expect(result.getProperty("y").getInt() == 4)
+    #expect(result.getPropertyNames().count == 2)
+  }
+
+  // MARK: - Nested keyed container
+
+  @Test
+  func `encodes a nested struct using a nested keyed container`() throws {
+    struct Inner: Encodable {
+      let label: String
+    }
+    struct Outer: Encodable {
+      let id: Int
+      let inner: Inner
+    }
+
+    let result = try encode(Outer(id: 1, inner: Inner(label: "hello"))).getObject()
+
+    #expect(result.getProperty("id").getInt() == 1)
+    #expect(result.getPropertyAsObject("inner").getProperty("label").getString() == "hello")
+  }
+
+  // MARK: - Arrays
+
+  @Test
+  func `encodes an array of primitives`() throws {
+    let array = try encode([10, 20, 30]).getArray()
+
+    #expect(array.length == 3)
+    #expect(try array.getValue(at: 0).getInt() == 10)
+    #expect(try array.getValue(at: 2).getInt() == 30)
+  }
+
+  @Test
+  func `encodes a struct field that is an array of structs`() throws {
+    struct Item: Encodable {
+      let value: Int
+    }
+    struct List: Encodable {
+      let items: [Item]
+    }
+
+    let result = try encode(List(items: [Item(value: 1), Item(value: 2), Item(value: 3)])).getObject()
+    let items = result.getProperty("items").getArray()
+
+    #expect(items.length == 3)
+    #expect(try items.getValue(at: 0).getObject().getProperty("value").getInt() == 1)
+    #expect(try items.getValue(at: 2).getObject().getProperty("value").getInt() == 3)
+  }
+
+  // MARK: - Dictionaries
+
+  @Test
+  func `encodes a string-keyed dictionary field`() throws {
+    struct Wrapper: Encodable {
+      let counts: [String: Int]
+    }
+    let result = try encode(Wrapper(counts: ["a": 1, "b": 2])).getObject()
+    let counts = result.getPropertyAsObject("counts")
+
+    #expect(counts.getProperty("a").getInt() == 1)
+    #expect(counts.getProperty("b").getInt() == 2)
+  }
+
+  // MARK: - Optionals
+
+  @Test
+  func `encodes a present optional field`() throws {
+    struct Wrapper: Encodable {
+      let label: String?
+    }
+    let result = try encode(Wrapper(label: "present")).getObject()
+
+    #expect(result.getProperty("label").getString() == "present")
+  }
+
+  @Test
+  func `encodes a nil optional field as null`() throws {
+    struct Wrapper: Encodable {
+      let label: String?
+    }
+    let result = try encode(Wrapper(label: nil)).getObject()
+
+    #expect(result.getProperty("label").isNull() == true)
+  }
+
+  // MARK: - RawRepresentable enums
+
+  @Test
+  func `encodes a string-backed enum field as its raw value`() throws {
+    enum Direction: String, Encodable {
+      case north
+      case south
+    }
+    struct Wrapper: Encodable {
+      let direction: Direction
+    }
+
+    let result = try encode(Wrapper(direction: .north)).getObject()
+    #expect(result.getProperty("direction").getString() == "north")
+  }
+
+  @Test
+  func `encodes an int-backed enum field as its raw value`() throws {
+    enum Code: Int, Encodable {
+      case ok = 200
+      case notFound = 404
+    }
+    struct Wrapper: Encodable {
+      let code: Code
+    }
+
+    let result = try encode(Wrapper(code: .notFound)).getObject()
+    #expect(result.getProperty("code").getInt() == 404)
+  }
+
+  // MARK: - Unkeyed container with mixed nesting
+
+  @Test
+  func `encodes an array with nested objects using an unkeyed container`() throws {
+    struct Inner: Encodable {
+      let n: Int
+    }
+    struct Holder: Encodable {
+      let entries: [Inner]
+    }
+
+    let result = try encode(Holder(entries: (0..<5).map { Inner(n: $0 * 10) })).getObject()
+    let entries = result.getProperty("entries").getArray()
+
+    #expect(entries.length == 5)
+    for index in 0..<5 {
+      #expect(try entries.getValue(at: index).getObject().getProperty("n").getInt() == index * 10)
+    }
+  }
+
+  // MARK: - Edge cases
+
+  @Test
+  func `encodes an empty array`() throws {
+    let array = try encode([Int]()).getArray()
+    #expect(array.length == 0)
+  }
+
+  @Test
+  func `encodes an empty struct`() throws {
+    struct Empty: Encodable {}
+    let result = try encode(Empty()).getObject()
+    #expect(result.getPropertyNames().isEmpty == true)
+  }
+
+  @Test
+  func `encodes a nested array of arrays`() throws {
+    let outer = try encode([[1, 2], [3, 4, 5]]).getArray()
+
+    #expect(outer.length == 2)
+
+    let first = try outer.getValue(at: 0).getArray()
+    #expect(first.length == 2)
+    #expect(try first.getValue(at: 0).getInt() == 1)
+    #expect(try first.getValue(at: 1).getInt() == 2)
+
+    let second = try outer.getValue(at: 1).getArray()
+    #expect(second.length == 3)
+    #expect(try second.getValue(at: 2).getInt() == 5)
+  }
+
+  @Test
+  func `emits null for every primitive nil optional field`() throws {
+    struct AllNils: Encodable {
+      let aBool: Bool?
+      let aString: String?
+      let aDouble: Double?
+      let aFloat: Float?
+      let aInt: Int?
+      let aInt8: Int8?
+      let aInt16: Int16?
+      let aInt32: Int32?
+      let aInt64: Int64?
+      let aUInt: UInt?
+      let aUInt8: UInt8?
+      let aUInt16: UInt16?
+      let aUInt32: UInt32?
+      let aUInt64: UInt64?
+
+      init() {
+        self.aBool = nil
+        self.aString = nil
+        self.aDouble = nil
+        self.aFloat = nil
+        self.aInt = nil
+        self.aInt8 = nil
+        self.aInt16 = nil
+        self.aInt32 = nil
+        self.aInt64 = nil
+        self.aUInt = nil
+        self.aUInt8 = nil
+        self.aUInt16 = nil
+        self.aUInt32 = nil
+        self.aUInt64 = nil
+      }
+    }
+
+    let result = try encode(AllNils()).getObject()
+    let propertyNames = ["aBool", "aString", "aDouble", "aFloat", "aInt", "aInt8", "aInt16", "aInt32", "aInt64", "aUInt", "aUInt8", "aUInt16", "aUInt32", "aUInt64"]
+    for name in propertyNames {
+      #expect(result.getProperty(name).isNull() == true, "expected \(name) to be null")
+    }
+  }
+
+  @Test
+  func `emits values for every primitive present optional field`() throws {
+    struct AllSet: Encodable {
+      let aBool: Bool? = true
+      let aString: String? = "expo"
+      let aDouble: Double? = 1.5
+      let aInt: Int? = 7
+      let aUInt16: UInt16? = 0xFFFF
+    }
+
+    let result = try encode(AllSet()).getObject()
+    #expect(result.getProperty("aBool").getBool() == true)
+    #expect(result.getProperty("aString").getString() == "expo")
+    #expect(result.getProperty("aDouble").getDouble() == 1.5)
+    #expect(result.getProperty("aInt").getInt() == 7)
+    #expect(result.getProperty("aUInt16").getInt() == 0xFFFF)
+  }
+
+  // MARK: - Convertible types
+
+  @Test
+  func `encodes a URL field as its absolute string`() throws {
+    struct Wrapper: Encodable {
+      let url: URL
+    }
+
+    let result = try encode(Wrapper(url: URL(string: "https://expo.dev/foo")!)).getObject()
+    #expect(result.getProperty("url").getString() == "https://expo.dev/foo")
+  }
+
+  @Test
+  func `encodes a CGPoint field as an object with x and y`() throws {
+    struct Wrapper: Encodable {
+      let point: CGPoint
+    }
+
+    let result = try encode(Wrapper(point: CGPoint(x: 10, y: 20))).getObject()
+    let point = result.getPropertyAsObject("point")
+
+    #expect(point.getProperty("x").getDouble() == 10)
+    #expect(point.getProperty("y").getDouble() == 20)
+  }
+
+  @Test
+  func `encodes a CGSize field as an object with width and height`() throws {
+    struct Wrapper: Encodable {
+      let size: CGSize
+    }
+
+    let result = try encode(Wrapper(size: CGSize(width: 100, height: 200))).getObject()
+    let size = result.getPropertyAsObject("size")
+
+    #expect(size.getProperty("width").getDouble() == 100)
+    #expect(size.getProperty("height").getDouble() == 200)
+  }
+
+  @Test
+  func `encodes a CGRect field as an object with x y width height`() throws {
+    struct Wrapper: Encodable {
+      let rect: CGRect
+    }
+
+    let result = try encode(Wrapper(rect: CGRect(x: 1, y: 2, width: 3, height: 4))).getObject()
+    let rect = result.getPropertyAsObject("rect")
+
+    #expect(rect.getProperty("x").getDouble() == 1)
+    #expect(rect.getProperty("y").getDouble() == 2)
+    #expect(rect.getProperty("width").getDouble() == 3)
+    #expect(rect.getProperty("height").getDouble() == 4)
+  }
+
+  // MARK: - More edge cases
+
+  @Test
+  func `encodes a top-level dictionary`() throws {
+    let result = try encode(["a": 1, "b": 2]).getObject()
+    #expect(result.getProperty("a").getInt() == 1)
+    #expect(result.getProperty("b").getInt() == 2)
+  }
+
+  @Test
+  func `encodes an optional Convertible field`() throws {
+    struct Wrapper: Encodable {
+      let url: URL?
+    }
+
+    let present = try encode(Wrapper(url: URL(string: "https://expo.dev/foo")!)).getObject()
+    #expect(present.getProperty("url").getString() == "https://expo.dev/foo")
+
+    let absent = try encode(Wrapper(url: nil)).getObject()
+    #expect(absent.getProperty("url").isNull() == true)
+  }
+
+  @Test
+  func `encodes an array of optional strings with nil entries`() throws {
+    let array = try encode(["a", nil, "c"] as [String?]).getArray()
+
+    #expect(array.length == 3)
+    #expect(try array.getValue(at: 0).getString() == "a")
+    #expect(try array.getValue(at: 1).isNull() == true)
+    #expect(try array.getValue(at: 2).getString() == "c")
+  }
+
+  @Test
+  func `encodes an array of CGPoint through the two-level fast path`() throws {
+    let array = try encode([CGPoint(x: 1, y: 2), CGPoint(x: 3, y: 4)]).getArray()
+
+    #expect(array.length == 2)
+    let first = try array.getValue(at: 0).getObject()
+    #expect(first.getProperty("x").getDouble() == 1)
+    #expect(first.getProperty("y").getDouble() == 2)
+    let second = try array.getValue(at: 1).getObject()
+    #expect(second.getProperty("x").getDouble() == 3)
+    #expect(second.getProperty("y").getDouble() == 4)
+  }
+
+  @Test
+  func `encodes empty strings and zero numbers as themselves not null`() throws {
+    #expect(try encode("").getString() == "")
+    #expect(try encode(0).getInt() == 0)
+    #expect(try encode(0.0).getDouble() == 0)
+    #expect(try encode(false).getBool() == false)
+  }
+
+  @Test
+  func `encodes a class as a JS object`() throws {
+    final class Person: Encodable {
+      let name: String
+      let age: Int
+      init(name: String, age: Int) {
+        self.name = name
+        self.age = age
+      }
+    }
+
+    let result = try encode(Person(name: "Anna", age: 30)).getObject()
+    #expect(result.getProperty("name").getString() == "Anna")
+    #expect(result.getProperty("age").getInt() == 30)
+  }
+
+  // MARK: - Routing through DynamicEncodableType
+
+  @Test
+  func `DynamicEncodableType castToJS encodes a struct end-to-end`() throws {
+    struct User: Encodable {
+      let name: String
+      let age: Int
+    }
+
+    let dynamicType = ~User.self
+    #expect(dynamicType is DynamicEncodableType)
+
+    let result = try dynamicType.castToJS(
+      User(name: "Anna", age: 30),
+      appContext: appContext,
+      in: appContext.runtime
+    ).getObject()
+
+    #expect(result.getProperty("name").getString() == "Anna")
+    #expect(result.getProperty("age").getInt() == 30)
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JSValueEncoderTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JSValueEncoderTests.swift
@@ -279,16 +279,34 @@ struct JSValueEncoderTests {
       let aBool: Bool? = true
       let aString: String? = "expo"
       let aDouble: Double? = 1.5
+      let aFloat: Float? = 2.5
       let aInt: Int? = 7
+      let aInt8: Int8? = -8
+      let aInt16: Int16? = -16
+      let aInt32: Int32? = -32
+      let aInt64: Int64? = -64
+      let aUInt: UInt? = 1
+      let aUInt8: UInt8? = 8
       let aUInt16: UInt16? = 0xFFFF
+      let aUInt32: UInt32? = 32
+      let aUInt64: UInt64? = 64
     }
 
     let result = try encode(AllSet()).getObject()
     #expect(result.getProperty("aBool").getBool() == true)
     #expect(result.getProperty("aString").getString() == "expo")
     #expect(result.getProperty("aDouble").getDouble() == 1.5)
+    #expect(result.getProperty("aFloat").getDouble() == 2.5)
     #expect(result.getProperty("aInt").getInt() == 7)
+    #expect(result.getProperty("aInt8").getInt() == -8)
+    #expect(result.getProperty("aInt16").getInt() == -16)
+    #expect(result.getProperty("aInt32").getInt() == -32)
+    #expect(result.getProperty("aInt64").getInt() == -64)
+    #expect(result.getProperty("aUInt").getInt() == 1)
+    #expect(result.getProperty("aUInt8").getInt() == 8)
     #expect(result.getProperty("aUInt16").getInt() == 0xFFFF)
+    #expect(result.getProperty("aUInt32").getInt() == 32)
+    #expect(result.getProperty("aUInt64").getInt() == 64)
   }
 
   // MARK: - Convertible types


### PR DESCRIPTION
## Why

`JSValueEncoder` was an experimental, never-completed encoder that only handled basic structs and primitives. It bypassed the existing dynamic-type registry, so encoding a struct with an `[Foo]`, `[String: Int]`, optional, `RawRepresentable` enum, or `Convertible` field either produced wrong shapes or crashed via `fatalError`.

It also took only a `JavaScriptRuntime` (not an `AppContext`), which limited where it could plug into the rest of the casting machinery.

## How

Static type wins. Every `encode<T: Encodable>(...)` resolves the dynamic type via `~T.self`. If the registry recognized the type as anything other than a plain `Encodable` struct, take the fast path through `castToJS(value, appContext:, in: runtime)` — preserving full element-type metadata for arrays, dictionaries, optionals, enums, and `Convertible`s. Only plain `Encodable` types fall back to `value.encode(to:)`.

### Other fixes
- **AppContext-aware**: `init(appContext:)` and `init(appContext:runtime:)` (the latter for routing values into a runtime other than `appContext.runtime`). Every container carries `appContext`, `runtime`, `codingPath`, and a `JSValueHolder`.
- **Nested containers**: `nestedContainer<Key>(keyedBy:)` and `nestedUnkeyedContainer()` are now implemented properly via shared JSI references — children mutate the same JS object/array the parent already wired up.
- **Array bug**: `JavaScriptArray.set(value:at:)` requires `index < length`. Switched to the auto-resizing subscript so a freshly-created array doesn't `indexOutOfRange` on the first append.
- **`count`**: now actually increments per element, as the protocol requires.
- **`codingPath`**: propagated through every container/child for diagnostic value.
- **Nil optionals**: Swift's `encodeIfPresent` skips nil keys entirely. Override every overload (the generic `<T: Encodable>` plus 14 primitive specializations) so nil optional fields produce explicit `null` in JS instead of being absent.
- **`DynamicEncodableType`**: now implements the runtime-aware `castToJS` overload, threading the explicit `runtime` through to `JSValueEncoder`. Note: end-to-end runtime threading for nested optional/enum/convertible fields still relies on those dynamic types overriding the runtime-aware `castToJS` themselves — left for a follow-up.
- **`superEncoder()` and `cast(jsValue:)` / `cast(_:)`** stay as `fatalError`s — out of scope (decoder is a separate PR).

## Tests

Adds `JSValueEncoderTests.swift` — 36 Swift Testing tests across:
- primitives in single-value container (string, int, double, bool, empty/zero values)
- top-level optionals (nil + present)
- plain `Encodable` struct (flat + nested)
- arrays (top-level, struct field, of structs, of optionals, of `CGPoint`, nested array of arrays, empty)
- dictionaries (top-level + as struct field)
- optionals as fields (present + nil) — including all 14 primitive `encodeIfPresent` overloads in one struct for both the nil and the present case, to lock in correct behavior across `Bool`/`String`/`Double`/`Float`/`Int`/`Int8…64`/`UInt`/`UInt8…64`
- `RawRepresentable` enums (string-backed and int-backed)
- `Convertible`s: `URL`, `CGPoint`, `CGSize`, `CGRect`
- empty struct, class instead of struct
- end-to-end via `DynamicEncodableType.castToJS`

### Notes
- A `Date` test was prototyped and revealed an unrelated **pre-existing infinite recursion** in `DynamicConvertibleType.castToJS` for `Convertible`s whose `convertResult` returns the value unchanged (`Date`, `CMTime`, SwiftUI `Color`, `UnitPoint`). Out of scope; left for a separate PR.
- `Record` works via the existing `directJSValueIfPossible` fast path in `DynamicConvertibleType` — but only if a user makes their record `Encodable`-conforming, which is unusual.
- `SharedObject` is intentionally **not** `Encodable` — the right native→JS path is the existing `DynamicSharedObjectType` (returns the bound JS reference), not value-snapshot serialization.