### PR TITLE
fix(expo-go): populate ExpoUpdates manifest before launcher is ready

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/Modules/ExpoGoExpoUpdatesModule.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Modules/ExpoGoExpoUpdatesModule.swift
@@ -1,6 +1,7 @@
 // Copyright 2023-present 650 Industries. All rights reserved.
 
 import ExpoModulesCore
+import EXManifests
 import EXUpdates
 
 /**
@@ -15,15 +16,17 @@ import EXUpdates
 final class ExpoGoExpoUpdatesModule: Module {
   private let scopeKey: String
   private let updatesKernelService: UpdatesBindingDelegate
+  private let manifest: Manifest
 
   // swiftlint:disable:next unavailable_function
   required init(appContext: AppContext) {
-    fatalError("Initializer not implemented, use init(appContext:updatesKernelService:scopeKey:) instead")
+    fatalError("Initializer not implemented, use init(appContext:updatesKernelService:scopeKey:manifest:) instead")
   }
 
-  required init(appContext: AppContext, updatesKernelService: UpdatesBindingDelegate, scopeKey: String) {
+  required init(appContext: AppContext, updatesKernelService: UpdatesBindingDelegate, scopeKey: String, manifest: Manifest) {
     self.updatesKernelService = updatesKernelService
     self.scopeKey = scopeKey
+    self.manifest = manifest
 
     super.init(appContext: appContext)
   }
@@ -33,8 +36,13 @@ final class ExpoGoExpoUpdatesModule: Module {
 
     Constants {
       let config = updatesKernelService.configForScopeKey(scopeKey)
-      return UpdatesModuleConstants(
-        launchedUpdate: updatesKernelService.launchedUpdateForScopeKey(scopeKey),
+      // Use the launcher's update if available, otherwise construct the
+      // manifest constants directly from the manifest that was passed at
+      // construction time. This avoids a race where the JS bridge evaluates
+      // module constants before the app launcher has finished initializing.
+      let launchedUpdate = updatesKernelService.launchedUpdateForScopeKey(scopeKey)
+      var constants = UpdatesModuleConstants(
+        launchedUpdate: launchedUpdate,
         launchDuration: updatesKernelService.launchDurationForScopeKey(scopeKey)?.doubleValue,
         embeddedUpdate: nil,
         emergencyLaunchException: nil,
@@ -47,6 +55,16 @@ final class ExpoGoExpoUpdatesModule: Module {
         shouldDeferToNativeForAPIMethodAvailabilityInDevelopment: true,
         initialContext: UpdatesStateContext()
       ).toModuleConstantsMap()
+
+      if launchedUpdate == nil {
+        if let expoUpdatesManifest = manifest as? ExpoUpdatesManifest {
+          constants["updateId"] = expoUpdatesManifest.rawId()
+          constants["commitTime"] = expoUpdatesManifest.createdAt()
+        }
+        constants["manifest"] = manifest.rawManifestJSON()
+      }
+
+      return constants
     }
 
     AsyncFunction("reload") { (promise: Promise) in

--- a/apps/expo-go/ios/Exponent/Versioned/Core/VersionManager.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/VersionManager.swift
@@ -121,7 +121,8 @@ final class VersionManager: EXVersionManagerObjC {
     appContext.moduleRegistry.register(module: ExpoGoExpoUpdatesModule(
       appContext: appContext,
       updatesKernelService: updatesKernelService,
-      scopeKey: manifest.scopeKey()
+      scopeKey: manifest.scopeKey(),
+      manifest: manifest
     ), name: nil, preventModuleOverriding: true)
 
     // Override expo-notifications modules


### PR DESCRIPTION
# Why

When loading an app via tunnel in Expo Go, there is a race condition between the JS bridge initializing and the app launcher finishing setup. The JS bridge starts as soon as the optimistic manifest arrives (triggering `isReadyToLoad`), but `ExpoGoExpoUpdatesModule.Constants` reads from `launchedUpdateForScopeKey:` which requires `_appLauncher` to be set -- and that only happens later in `didFinishWithLauncher:`.

When the bridge wins the race, `ExpoUpdates.manifest` is nil, so `Constants.expoConfig` falls through to `ExponentConstants.manifest` (Expo Go's own config), which lacks the project's `scheme`. This causes expo-router's `resolveScheme()` to throw: "Linking requires a build-time setting `scheme`".

Thread https://exponent-internal.slack.com/archives/C09AL5M1RU5/p1778275370578929

# How

Pass the manifest directly to `ExpoGoExpoUpdatesModule` at construction time via `VersionManager`. When the launcher's update is not yet available, the module populates `updateId`, `commitTime`, and `manifest` constants directly from this manifest. The manifest is always available when the bridge starts because it is what triggers bridge initialization in the first place.

This avoids the need for a fallback chain or additional stored state in the loader -- the module simply reads from a source that is guaranteed available by the time it runs.

# Test Plan

- Built Expo Go from source with an artificial 10-second delay on `_appLauncher` assignment in `EXAppLoaderExpoUpdates.m` to guarantee the race condition triggers
- Verified that without this fix, the scheme error reproduces every time
- Verified that with this fix, the manifest loads correctly with `scheme` present even under the artificial race
- Tested normal (non-delayed) app loading continues to work