### PR TITLE
[docs][ui] Add React Native trigger example for Menu and DropdownMenu

### DIFF
--- a/apps/native-component-list/src/screens/UI/DropdownMenuScreen.android.tsx
+++ b/apps/native-component-list/src/screens/UI/DropdownMenuScreen.android.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuItem,
   Host,
   Icon,
+  RNHostView,
   Row,
   Switch,
   Text as ComposeText,
@@ -14,7 +15,7 @@ import {
 } from '@expo/ui/jetpack-compose';
 import { background } from '@expo/ui/jetpack-compose/modifiers';
 import * as React from 'react';
-import { View, Text, Alert } from 'react-native';
+import { View, Text, Alert, Pressable } from 'react-native';
 
 import { Section } from '../../components/Page';
 
@@ -39,6 +40,7 @@ export default function DropdownMenuScreen() {
   const [colorfulMenuExpanded, setColorfulMenuExpanded] = React.useState(false);
   const [sectionsMenuExpanded, setSectionsMenuExpanded] = React.useState(false);
   const [submenuExpanded, setSubmenuExpanded] = React.useState(false);
+  const [rnTriggerMenuExpanded, setRnTriggerMenuExpanded] = React.useState(false);
 
   React.useEffect(() => {
     if (sectionsMenuExpanded === false) {
@@ -314,6 +316,41 @@ export default function DropdownMenuScreen() {
                 <DropdownMenuItem.LeadingIcon>
                   <Icon source={logoutIcon} size={24} />
                 </DropdownMenuItem.LeadingIcon>
+              </DropdownMenuItem>
+            </DropdownMenu.Items>
+          </DropdownMenu>
+        </Host>
+      </Section>
+      <Section title="Dropdown Menu with RN Trigger">
+        <Host matchContents>
+          <DropdownMenu
+            expanded={rnTriggerMenuExpanded}
+            onDismissRequest={() => setRnTriggerMenuExpanded(false)}>
+            <DropdownMenu.Trigger>
+              <RNHostView matchContents>
+                <Pressable
+                  onPress={() => setRnTriggerMenuExpanded(true)}
+                  style={{
+                    alignSelf: 'flex-start',
+                    paddingHorizontal: 16,
+                    paddingVertical: 10,
+                    borderRadius: 8,
+                    backgroundColor: '#9B59B6',
+                  }}>
+                  <Text style={{ color: 'white', fontWeight: '600' }}>RN Pressable Trigger</Text>
+                </Pressable>
+              </RNHostView>
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Items>
+              <DropdownMenuItem onClick={() => setRnTriggerMenuExpanded(false)}>
+                <DropdownMenuItem.Text>
+                  <ComposeText>Item 1</ComposeText>
+                </DropdownMenuItem.Text>
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => setRnTriggerMenuExpanded(false)}>
+                <DropdownMenuItem.Text>
+                  <ComposeText>Item 2</ComposeText>
+                </DropdownMenuItem.Text>
               </DropdownMenuItem>
             </DropdownMenu.Items>
           </DropdownMenu>

--- a/apps/native-component-list/src/screens/UI/MenuScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/MenuScreen.ios.tsx
@@ -9,6 +9,7 @@ import {
   Section,
   Divider,
   Picker,
+  RNHostView,
 } from '@expo/ui/swift-ui';
 import {
   buttonStyle,
@@ -18,6 +19,7 @@ import {
   tag,
 } from '@expo/ui/swift-ui/modifiers';
 import * as React from 'react';
+import { Pressable, Text as RNText } from 'react-native';
 
 export default function MenuScreen() {
   const [selectedIndex, setSelectedIndex] = React.useState<number | undefined>(1);
@@ -51,6 +53,30 @@ export default function MenuScreen() {
           <Menu label={<Text modifiers={[foregroundStyle('accentColor')]}>Custom Label</Text>}>
             <Button onPress={() => console.log('Action 1')} label="Action 1" />
             <Button onPress={() => console.log('Action 2')} label="Action 2" />
+          </Menu>
+        </Section>
+
+        <Section title="RN Pressable label">
+          <Menu
+            label={
+              <RNHostView matchContents>
+                <Pressable
+                  onPress={() => console.log('RN trigger pressed')}
+                  style={{
+                    paddingHorizontal: 16,
+                    paddingVertical: 10,
+                    borderRadius: 8,
+                    alignSelf: 'flex-start',
+                    backgroundColor: '#9B59B6',
+                  }}>
+                  <RNText style={{ color: 'white', fontWeight: '600' }}>
+                    RN Pressable Trigger
+                  </RNText>
+                </Pressable>
+              </RNHostView>
+            }>
+            <Button onPress={() => console.log('Item 1')} label="Item 1" />
+            <Button onPress={() => console.log('Item 2')} label="Item 2" />
           </Menu>
         </Section>
 

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -28,7 +28,14 @@ Expo UI DropdownMenu matches the official Jetpack Compose [Menu API](https://dev
 ### Basic dropdown menu
 
 ```tsx BasicDropdownMenuExample.tsx
-import { Host, DropdownMenu, Button, Text, Icon } from '@expo/ui/jetpack-compose';
+import {
+  Host,
+  DropdownMenu,
+  DropdownMenuItem,
+  Button,
+  Text,
+  Icon,
+} from '@expo/ui/jetpack-compose';
 import { useState } from 'react';
 
 export default function BasicDropdownMenuExample() {

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -28,14 +28,7 @@ Expo UI DropdownMenu matches the official Jetpack Compose [Menu API](https://dev
 ### Basic dropdown menu
 
 ```tsx BasicDropdownMenuExample.tsx
-import {
-  Host,
-  DropdownMenu,
-  DropdownMenuItem,
-  Button,
-  Text,
-  Icon,
-} from '@expo/ui/jetpack-compose';
+import { Host, DropdownMenu, DropdownMenuItem, Button, Text, Icon } from '@expo/ui/jetpack-compose';
 import { useState } from 'react';
 
 export default function BasicDropdownMenuExample() {

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -61,6 +61,59 @@ export default function BasicDropdownMenuExample() {
 }
 ```
 
+### React Native components as trigger
+
+You can use a React Native view (such as `Pressable`) as the dropdown's trigger by wrapping it in [`RNHostView`](rnhostview).
+
+```tsx RNTriggerDropdownMenuExample.tsx
+import {
+  Host,
+  DropdownMenu,
+  DropdownMenuItem,
+  Text as ComposeText,
+  RNHostView,
+} from '@expo/ui/jetpack-compose';
+import { useState } from 'react';
+import { Pressable, Text } from 'react-native';
+
+export default function RNTriggerDropdownMenuExample() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <Host matchContents>
+      <DropdownMenu expanded={isExpanded} onDismissRequest={() => setIsExpanded(false)}>
+        <DropdownMenu.Trigger>
+          <RNHostView matchContents>
+            <Pressable
+              onPress={() => setIsExpanded(true)}
+              style={{
+                alignSelf: 'flex-start',
+                paddingHorizontal: 16,
+                paddingVertical: 10,
+                borderRadius: 8,
+                backgroundColor: '#9B59B6',
+              }}>
+              <Text style={{ color: 'white', fontWeight: '600' }}>RN Pressable Trigger</Text>
+            </Pressable>
+          </RNHostView>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Items>
+          <DropdownMenuItem onClick={() => setIsExpanded(false)}>
+            <DropdownMenuItem.Text>
+              <ComposeText>Item 1</ComposeText>
+            </DropdownMenuItem.Text>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setIsExpanded(false)}>
+            <DropdownMenuItem.Text>
+              <ComposeText>Item 2</ComposeText>
+            </DropdownMenuItem.Text>
+          </DropdownMenuItem>
+        </DropdownMenu.Items>
+      </DropdownMenu>
+    </Host>
+  );
+}
+```
+
 ## API
 
 ```tsx

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/menu.mdx
@@ -88,6 +88,41 @@ export default function CustomLabelMenuExample() {
 }
 ```
 
+### React Native components as label
+
+You can use a React Native view (such as `Pressable`) as the menu's label by wrapping it in [`RNHostView`](rnhostview).
+
+```tsx RNLabelMenuExample.tsx
+import { Host, Menu, Button, RNHostView } from '@expo/ui/swift-ui';
+import { Pressable, Text } from 'react-native';
+
+export default function RNLabelMenuExample() {
+  return (
+    <Host matchContents>
+      <Menu
+        label={
+          <RNHostView matchContents>
+            <Pressable
+              onPress={() => console.log('RN trigger pressed')}
+              style={{
+                alignSelf: 'flex-start',
+                paddingHorizontal: 16,
+                paddingVertical: 10,
+                borderRadius: 8,
+                backgroundColor: '#9B59B6',
+              }}>
+              <Text style={{ color: 'white', fontWeight: '600' }}>RN Pressable Trigger</Text>
+            </Pressable>
+          </RNHostView>
+        }>
+        <Button label="Item 1" onPress={() => console.log('Item 1')} />
+        <Button label="Item 2" onPress={() => console.log('Item 2')} />
+      </Menu>
+    </Host>
+  );
+}
+```
+
 ### Nested menu
 
 Menus can be nested to create submenus.

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -28,7 +28,14 @@ Expo UI DropdownMenu matches the official Jetpack Compose [Menu API](https://dev
 ### Basic dropdown menu
 
 ```tsx BasicDropdownMenuExample.tsx
-import { Host, DropdownMenu, Button, Text, Icon } from '@expo/ui/jetpack-compose';
+import {
+  Host,
+  DropdownMenu,
+  DropdownMenuItem,
+  Button,
+  Text,
+  Icon,
+} from '@expo/ui/jetpack-compose';
 import { useState } from 'react';
 
 export default function BasicDropdownMenuExample() {

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -28,14 +28,7 @@ Expo UI DropdownMenu matches the official Jetpack Compose [Menu API](https://dev
 ### Basic dropdown menu
 
 ```tsx BasicDropdownMenuExample.tsx
-import {
-  Host,
-  DropdownMenu,
-  DropdownMenuItem,
-  Button,
-  Text,
-  Icon,
-} from '@expo/ui/jetpack-compose';
+import { Host, DropdownMenu, DropdownMenuItem, Button, Text, Icon } from '@expo/ui/jetpack-compose';
 import { useState } from 'react';
 
 export default function BasicDropdownMenuExample() {

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/dropdownmenu.mdx
@@ -61,6 +61,59 @@ export default function BasicDropdownMenuExample() {
 }
 ```
 
+### React Native components as trigger
+
+You can use a React Native view (such as `Pressable`) as the dropdown's trigger by wrapping it in [`RNHostView`](rnhostview).
+
+```tsx RNTriggerDropdownMenuExample.tsx
+import {
+  Host,
+  DropdownMenu,
+  DropdownMenuItem,
+  Text as ComposeText,
+  RNHostView,
+} from '@expo/ui/jetpack-compose';
+import { useState } from 'react';
+import { Pressable, Text } from 'react-native';
+
+export default function RNTriggerDropdownMenuExample() {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <Host matchContents>
+      <DropdownMenu expanded={isExpanded} onDismissRequest={() => setIsExpanded(false)}>
+        <DropdownMenu.Trigger>
+          <RNHostView matchContents>
+            <Pressable
+              onPress={() => setIsExpanded(true)}
+              style={{
+                alignSelf: 'flex-start',
+                paddingHorizontal: 16,
+                paddingVertical: 10,
+                borderRadius: 8,
+                backgroundColor: '#9B59B6',
+              }}>
+              <Text style={{ color: 'white', fontWeight: '600' }}>RN Pressable Trigger</Text>
+            </Pressable>
+          </RNHostView>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Items>
+          <DropdownMenuItem onClick={() => setIsExpanded(false)}>
+            <DropdownMenuItem.Text>
+              <ComposeText>Item 1</ComposeText>
+            </DropdownMenuItem.Text>
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={() => setIsExpanded(false)}>
+            <DropdownMenuItem.Text>
+              <ComposeText>Item 2</ComposeText>
+            </DropdownMenuItem.Text>
+          </DropdownMenuItem>
+        </DropdownMenu.Items>
+      </DropdownMenu>
+    </Host>
+  );
+}
+```
+
 ## API
 
 ```tsx

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/menu.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/menu.mdx
@@ -88,6 +88,41 @@ export default function CustomLabelMenuExample() {
 }
 ```
 
+### React Native components as label
+
+You can use a React Native view (such as `Pressable`) as the menu's label by wrapping it in [`RNHostView`](rnhostview).
+
+```tsx RNLabelMenuExample.tsx
+import { Host, Menu, Button, RNHostView } from '@expo/ui/swift-ui';
+import { Pressable, Text } from 'react-native';
+
+export default function RNLabelMenuExample() {
+  return (
+    <Host matchContents>
+      <Menu
+        label={
+          <RNHostView matchContents>
+            <Pressable
+              onPress={() => console.log('RN trigger pressed')}
+              style={{
+                alignSelf: 'flex-start',
+                paddingHorizontal: 16,
+                paddingVertical: 10,
+                borderRadius: 8,
+                backgroundColor: '#9B59B6',
+              }}>
+              <Text style={{ color: 'white', fontWeight: '600' }}>RN Pressable Trigger</Text>
+            </Pressable>
+          </RNHostView>
+        }>
+        <Button label="Item 1" onPress={() => console.log('Item 1')} />
+        <Button label="Item 2" onPress={() => console.log('Item 2')} />
+      </Menu>
+    </Host>
+  );
+}
+```
+
 ### Nested menu
 
 Menus can be nested to create submenus.


### PR DESCRIPTION
# Why

https://x.com/TheFireAndCode/status/2052993701744394455?s=20

Showcase how to use a React Native view (e.g. `Pressable`) as the trigger for `DropdownMenu` (Android) and the label for`Menu` (iOS) via `RNHostView`.


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

  - Add NCL examples in `DropdownMenuScreen.android.tsx` and `MenuScreen.ios.tsx`.
  - Document the pattern in unversioned and SDK 56 docs (`dropdownmenu.mdx`, `menu.mdx`).
  - Fix missing `DropdownMenuItem` import in the existing basic dropdown menu doc example.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

  Tested examples in NCL.


https://github.com/user-attachments/assets/bc1967dd-6bef-4633-9cb1-6ffdc8054617


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
