### PR TITLE
[jsi] Fix RN path in expo go

### DIFF
--- a/packages/expo-modules-jsi/apple/Package.swift
+++ b/packages/expo-modules-jsi/apple/Package.swift
@@ -14,8 +14,11 @@ let podsRoot = resolvePodsRoot()
 // framework and its headers don't get mirrored to Pods/Headers/Public. Clang
 // ignores missing `-I` paths, so they're no-ops elsewhere. `RN_ROOT` is
 // forwarded from build-xcframework.sh (Node-resolved for hoisted monorepos).
+// `REACT_NATIVE_PATH` is exported by Xcode for hosts that build RN from a
+// non-npm location, e.g. Expo Go.
 let publicHeaders = "\(podsRoot)/Headers/Public"
 let reactNative = ProcessInfo.processInfo.environment["RN_ROOT"]
+  ?? ProcessInfo.processInfo.environment["REACT_NATIVE_PATH"]
   ?? "\(podsRoot)/../../node_modules/react-native"
 let headerSearchPaths = [
   publicHeaders,

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -89,8 +89,10 @@ compute_hash() {
   # Force C locale so sort order is consistent regardless of the environment.
   # Xcode build phases run without locale variables, which changes sort ordering.
   (
-    # Include PODS_ROOT so switching between worktrees invalidates the cache.
+    # Include PODS_ROOT and RN_ROOT so switching between worktrees or RN
+    # sources invalidates the cache.
     echo "PODS_ROOT=${PODS_ROOT:-}"
+    echo "RN_ROOT=${RN_ROOT:-}"
     echo "$all_files" | LC_ALL=C sort | while IFS= read -r file; do
       echo "$file"
       cat "$file"
@@ -243,12 +245,20 @@ fi
 # whether PODS_ROOT was passed as relative or absolute.
 PODS_ROOT="$(cd "$PODS_ROOT" && pwd)"
 
-# Resolve react-native via Node so the build works in any node_modules layout
-# (hoisted monorepos, yarn/pnpm workspaces). Falls back to the relative path
-# when `node` is unavailable. Forwarded to Package.swift and the modulemap
-# generator below.
-RN_ROOT="$(node -p 'require("path").dirname(require.resolve("react-native/package.json"))' 2>/dev/null \
-  || echo "${PODS_ROOT}/../../node_modules/react-native")"
+# Resolve react-native. Order:
+#   1. REACT_NATIVE_PATH env var (set by Xcode from the Podfile's build setting)
+#      — for hosts that build RN from a non-npm location, e.g. Expo Go which
+#      uses the `react-native-lab/react-native` submodule, not node_modules.
+#   2. `node -p require.resolve(...)` so the script works in any node_modules
+#      layout (hoisted monorepos, pnpm/yarn workspaces).
+#   3. Relative fallback from PODS_ROOT for when `node` isn't on PATH.
+# Forwarded to Package.swift and the modulemap generator below.
+if [[ -n "${REACT_NATIVE_PATH:-}" && -d "${REACT_NATIVE_PATH}" ]]; then
+  RN_ROOT="$(cd "$REACT_NATIVE_PATH" && pwd)"
+else
+  RN_ROOT="$(node -p 'require("path").dirname(require.resolve("react-native/package.json"))' 2>/dev/null \
+    || echo "${PODS_ROOT}/../../node_modules/react-native")"
+fi
 
 mode="$( [[ -d "${PODS_ROOT}/React-Core-prebuilt/React.xcframework" ]] && echo "prebuilt RN" || echo "source-built RN")"
 [[ -f "${PODS_ROOT}/Target Support Files/React-jsi/React-jsi-umbrella.h" ]] && mode="${mode}, static frameworks"

--- a/packages/expo-modules-jsi/apple/scripts/generate-modulemap.sh
+++ b/packages/expo-modules-jsi/apple/scripts/generate-modulemap.sh
@@ -38,7 +38,10 @@ mkdir -p "$GENERATED_DIR"
 
 JSI_UMBRELLA="${PODS_ROOT}/Headers/Public/React-jsi/jsi/jsi.h"
 if [[ ! -f "$JSI_UMBRELLA" ]]; then
-  RN="${RN_ROOT:-$(node -p 'require("path").dirname(require.resolve("react-native/package.json"))' 2>/dev/null || echo "${PODS_ROOT}/../../node_modules/react-native")}"
+  # Resolution order matches build-xcframework.sh: RN_ROOT (forwarded by the
+  # build script), REACT_NATIVE_PATH (exported by Xcode for hosts like Expo Go
+  # that build RN from a submodule), node resolve, then a relative fallback.
+  RN="${RN_ROOT:-${REACT_NATIVE_PATH:-$(node -p 'require("path").dirname(require.resolve("react-native/package.json"))' 2>/dev/null || echo "${PODS_ROOT}/../../node_modules/react-native")}}"
   JSI_UMBRELLA="${RN}/ReactCommon/jsi/jsi/jsi.h"
 fi
 [[ -f "$JSI_UMBRELLA" ]] || { echo "error: cannot locate jsi.h" >&2; exit 1; }


### PR DESCRIPTION
# Why
Fixes a regression from #45508. Expo go would not build because we were not using the submodule.

The script's content hash also didn't include `RN_ROOT`, so once a stale xcframework was cached, switching RN sources wouldn't invalidate it so expo go would try to use the npm version of RN.

# How
Resolution order is now `REACT_NATIVE_PATH` → `node -p` → relative fallback. 

# Test Plan
Bare expo and expo go both build and use the expected version of RN.

