### PR TITLE
[expo] Setup `CCACHE_BASEDIR`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,6 +8,9 @@ export ANDROID_HOME="${ANDROID_SDK_ROOT:=$ANDROID_SDK}"
 # Force all Expo modules to be compiled from source
 export EXPO_USE_SOURCE=1
 
+# Setup ccache dir to normalize paths  
+export CCACHE_BASEDIR=`pwd`
+
 source_local() {
   file=./.envrc.local
   if [[ -f "$file" ]]; then


### PR DESCRIPTION
# Why

Setups `CCACHE_BASEDIR` to allow ccache to work automatically with git worktrees. 

By default, ccache treats the same source file compiled from different worktrees as different compilations because the absolute paths differ. To share cache across worktrees, `CCACHE_BASEDIR` must be set to the repo root - ccache will then normalize all paths under it to relative paths before hashing.