### PR TITLE
[core][Android] Cleanup headers

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.cpp
@@ -2,9 +2,6 @@
 
 #include "Exceptions.h"
 
-#include "JSIContext.h"
-#include "JSReferencesCache.h"
-
 namespace jni = facebook::jni;
 
 namespace expo {

--- a/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
+++ b/packages/expo-modules-core/android/src/main/cpp/Exceptions.h
@@ -2,10 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <optional>
+#include "ExpoHeader.pch"
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoHeader.pch
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoHeader.pch
@@ -1,11 +1,9 @@
 #pragma once
 
 #include <functional>
-#include <map>
 #include <memory>
 #include <optional>
 #include <type_traits>
-#include <unistd.h>
 #include <unordered_map>
 #include <vector>
 

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.cpp
@@ -1,10 +1,9 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "ExpoHeader.pch"
 #include "ExpoModulesHostObject.h"
 #include "LazyObject.h"
 
-#include <folly/dynamic.h>
-#include <jsi/JSIDynamic.h>
 #include <react/bridging/LongLivedObject.h>
 
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ExpoModulesHostObject.h
@@ -2,11 +2,9 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JSIContext.h"
 
-#include <jsi/jsi.h>
-
-#include <vector>
 #import <unordered_map>
 
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/JNIDeallocator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIDeallocator.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
+#include "ExpoHeader.pch"
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.cpp
@@ -2,7 +2,6 @@
 
 #include "JNIFunctionBody.h"
 #include "Exceptions.h"
-#include "JavaReferencesCache.h"
 
 namespace jni = facebook::jni;
 namespace react = facebook::react;

--- a/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIFunctionBody.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-#include <react/jni/ReadableNativeArray.h>
+#include "ExpoHeader.pch"
 
 namespace jni = facebook::jni;
 namespace react = facebook::react;

--- a/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIInjector.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "ExpoHeader.pch"
 #include "RuntimeHolder.h"
 #include "JSIContext.h"
 #include "JavaScriptModuleObject.h"
@@ -26,7 +27,6 @@
 #endif
 
 #include <jni.h>
-#include <fbjni/fbjni.h>
 
 // Install all jni bindings
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *) {

--- a/packages/expo-modules-core/android/src/main/cpp/JNIUtils.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIUtils.cpp
@@ -1,10 +1,10 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "ExpoHeader.pch"
 #include "JNIUtils.h"
 #include "EventEmitter.h"
 #include "JSIUtils.h"
 #include "types/JNIToJSIConverter.h"
-#include <jsi/JSIDynamic.h>
 #include "JSIContext.h"
 #include "Exceptions.h"
 

--- a/packages/expo-modules-core/android/src/main/cpp/JNIUtils.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JNIUtils.h
@@ -2,12 +2,7 @@
 
 #pragma once
 
-#include <vector>
-#include <functional>
-
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-#include <react/jni/ReadableNativeMap.h>
+#include "ExpoHeader.pch"
 
 #include "JSIContext.h"
 #include "JavaScriptObject.h"

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.cpp
@@ -1,21 +1,17 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "ExpoHeader.pch"
 #include "JSIContext.h"
 #include "Exceptions.h"
-#include "ExpoModulesHostObject.h"
 #include "JavaReferencesCache.h"
 #include "JSReferencesCache.h"
 #include "JSIUtils.h"
 #include "SharedObject.h"
-#include "SharedRef.h"
-#include "NativeModule.h"
 #include "decorators/JSDecoratorsBridgingObject.h"
 #include "decorators/JSClassesDecorator.h"
 
 #include <fbjni/detail/Meta.h>
-#include <fbjni/fbjni.h>
 
-#include <memory>
 #include <shared_mutex>
 
 namespace jni = facebook::jni;

--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JavaScriptRuntime.h"
 #include "JavaScriptModuleObject.h"
 #include "JavaScriptValue.h"
@@ -12,8 +13,6 @@
 #include "ThreadSafeJNIGlobalRef.h"
 #include "javaclasses/JSRunnable.h"
 
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
 #include <ReactCommon/CallInvokerHolder.h>
 #include <ReactCommon/CallInvoker.h>
 
@@ -23,10 +22,6 @@
 #include <react/jni/JRuntimeExecutor.h>
 
 #endif
-
-#include <ReactCommon/NativeMethodCallInvokerHolder.h>
-
-#include <memory>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/JSITypeConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSITypeConverter.h
@@ -2,12 +2,8 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JSIObjectWrapper.h"
-
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <type_traits>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/JSharedObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSharedObject.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
+#include "ExpoHeader.pch"
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -1,19 +1,10 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "ExpoHeader.pch"
 #include "JavaCallback.h"
 #include "JSIContext.h"
 #include "types/JNIToJSIConverter.h"
 #include "Exceptions.h"
-
-#include "JSIUtils.h"
-#include "JNIUtils.h"
-
-#include <fbjni/fbjni.h>
-#include <fbjni/fbjni.h>
-#include <folly/dynamic.h>
-#include <jsi/JSIDynamic.h>
-
-#include <functional>
 
 namespace expo {
 
@@ -59,7 +50,6 @@ void JavaCallback::registerNatives() {
                    makeNativeMethod("invokeDoubleArray", JavaCallback::invokeDoubleArray),
                  });
 }
-
 
 jni::local_ref<JavaCallback::javaobject> JavaCallback::newInstance(
   JSIContext *jsiContext,

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -2,18 +2,12 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JNIDeallocator.h"
 #include "JSharedObject.h"
 #include "JavaScriptArrayBuffer.h"
 #include "NativeArrayBuffer.h"
 
-#include <jsi/jsi.h>
-#include <fbjni/fbjni.h>
-#include <folly/dynamic.h>
-#include <variant>
-
-#include <react/jni/WritableNativeArray.h>
-#include <react/jni/WritableNativeMap.h>
 #include <fbjni/detail/CoreClasses.h>
 #include <ReactCommon/CallInvoker.h>
 #include <react/bridging/LongLivedObject.h>

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.cpp
@@ -1,8 +1,7 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "ExpoHeader.pch"
 #include "JavaReferencesCache.h"
-
-#include <vector>
 
 namespace expo {
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaReferencesCache.h
@@ -2,10 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-
-#include <memory>
-#include <unordered_map>
+#include "ExpoHeader.pch"
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptArrayBuffer.h
@@ -1,13 +1,10 @@
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JNIDeallocator.h"
 #include "JavaScriptRuntime.h"
 
 #include <fbjni/ByteBuffer.h>
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <memory>
 
 namespace expo {
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptFunction.h
@@ -2,12 +2,10 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JSIObjectWrapper.h"
 #include "JavaScriptRuntime.h"
 #include "types/ExpectedType.h"
-
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;
@@ -39,7 +37,6 @@ public:
   );
 
   std::shared_ptr<jsi::Function> get() override;
-
 
 private:
   friend HybridBase;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptModuleObject.h
@@ -2,11 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <vector>
-#include <memory>
+#include "ExpoHeader.pch"
 
 #include "decorators/JSDecorator.h"
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptObject.h
@@ -2,17 +2,13 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JSIObjectWrapper.h"
 #include "JSITypeConverter.h"
 #include "JavaScriptRuntime.h"
 #include "JNIFunctionBody.h"
 #include "JNIDeallocator.h"
 #include "JSIUtils.h"
-
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <memory>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.cpp
@@ -5,7 +5,6 @@
 #include "JavaScriptObject.h"
 #include "Exceptions.h"
 #include "JSIContext.h"
-#include "JSIUtils.h"
 
 namespace jsi = facebook::jsi;
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptRuntime.h
@@ -2,10 +2,9 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JNIDeallocator.h"
 
-#include <jsi/jsi.h>
-#include <fbjni/fbjni.h>
 #include <ReactCommon/CallInvoker.h>
 
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptTypedArray.h
@@ -1,13 +1,10 @@
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "TypedArray.h"
 #include "JavaScriptObject.h"
 
-#include <fbjni/fbjni.h>
 #include <fbjni/ByteBuffer.h>
-#include <jsi/jsi.h>
-
-#include <memory>
 
 namespace expo {
 

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -2,15 +2,11 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JSIObjectWrapper.h"
 #include "JavaScriptTypedArray.h"
 #include "JavaScriptArrayBuffer.h"
 #include "JNIDeallocator.h"
-
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <memory>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptWeakObject.h
@@ -2,13 +2,9 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JNIDeallocator.h"
 #include "JavaScriptObject.h"
-
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <memory>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.cpp
@@ -1,8 +1,6 @@
+#include "ExpoHeader.pch"
 #include "MethodMetadata.h"
 #include "JSIContext.h"
-#include "JavaScriptValue.h"
-#include "JavaScriptObject.h"
-#include "JavaScriptTypedArray.h"
 #include "JavaReferencesCache.h"
 #include "Exceptions.h"
 #include "JavaCallback.h"
@@ -10,9 +8,6 @@
 #include "JSReferencesCache.h"
 
 #include <utility>
-#include <functional>
-#include <unistd.h>
-#include <optional>
 
 #include <react/bridging/LongLivedObject.h>
 

--- a/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
+++ b/packages/expo-modules-core/android/src/main/cpp/MethodMetadata.h
@@ -2,19 +2,11 @@
 
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "types/CppType.h"
 #include "types/ExpectedType.h"
 #include "types/AnyType.h"
 #include "types/ReturnType.h"
-
-#include <jsi/jsi.h>
-#include <fbjni/fbjni.h>
-#include <ReactCommon/TurboModuleUtils.h>
-#include <react/jni/ReadableNativeArray.h>
-#include <memory>
-#include <vector>
-#include <folly/dynamic.h>
-#include <jsi/JSIDynamic.h>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.h
+++ b/packages/expo-modules-core/android/src/main/cpp/NativeArrayBuffer.h
@@ -1,15 +1,12 @@
 #pragma once
 
+#include "ExpoHeader.pch"
 #include "JNIDeallocator.h"
 #include "JSIContext.h"
 
 #include <fbjni/ByteBuffer.h>
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
 
 #include "TypedArray.h"
-
-#include <memory>
 
 namespace expo {
 

--- a/packages/expo-modules-core/android/src/main/cpp/RuntimeHolder.h
+++ b/packages/expo-modules-core/android/src/main/cpp/RuntimeHolder.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
+#include "ExpoHeader.pch"
 
 #include <ReactCommon/CallInvokerHolder.h>
 #include <ReactCommon/CallInvoker.h>

--- a/packages/expo-modules-core/android/src/main/cpp/ThreadSafeJNIGlobalRef.h
+++ b/packages/expo-modules-core/android/src/main/cpp/ThreadSafeJNIGlobalRef.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
+#include "ExpoHeader.pch"
 #include <android/log.h>
 
 namespace jni = facebook::jni;

--- a/packages/expo-modules-core/android/src/main/cpp/concepts/jni.h
+++ b/packages/expo-modules-core/android/src/main/cpp/concepts/jni.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include <concepts>
-#include <fbjni/fbjni.h>
 #include "jni_deref.h"
 
 namespace jni = facebook::jni;

--- a/packages/expo-modules-core/android/src/main/cpp/concepts/jni_deref.h
+++ b/packages/expo-modules-core/android/src/main/cpp/concepts/jni_deref.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include <concepts>
-#include <fbjni/fbjni.h>
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/concepts/jsi.h
+++ b/packages/expo-modules-core/android/src/main/cpp/concepts/jsi.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include <concepts>
-#include <jsi/jsi.h>
 
 namespace jsi = facebook::jsi;
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSClassesDecorator.h
@@ -2,9 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-
-#include <map>
+#include "../ExpoHeader.pch"
 
 #include "JSDecorator.h"
 #include "../MethodMetadata.h"

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSConstantsDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSConstantsDecorator.cpp
@@ -1,14 +1,11 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "../ExpoHeader.pch"
 #include "JSConstantsDecorator.h"
 #include "../JavaScriptObject.h"
 #include "JSIUtils.h"
-#include "JSFunctionsDecorator.h"
 #include "../JSIContext.h"
 #include "../types/JNIToJSIConverter.h"
-
-#include <jsi/jsi.h>
-#include <jsi/JSIDynamic.h>
 
 namespace jsi = facebook::jsi;
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSConstantsDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSConstantsDecorator.h
@@ -2,9 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-#include <react/jni/ReadableNativeMap.h>
-#include <folly/dynamic.h>
+#include "../ExpoHeader.pch"
 
 #include "JSDecorator.h"
 #include "../JNIFunctionBody.h"

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecorator.h
@@ -2,8 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
+#include "../ExpoHeader.pch"
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
@@ -2,12 +2,9 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-
-#include <vector>
+#include "../ExpoHeader.pch"
 
 #include "JSDecorator.h"
-#include "../MethodMetadata.h"
 #include "../JNIFunctionBody.h"
 #include "../types/ExpectedType.h"
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.cpp
@@ -1,9 +1,8 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "../ExpoHeader.pch"
 #include "JSFunctionsDecorator.h"
 #include "JSIUtils.h"
-
-#include <jsi/jsi.h>
 
 namespace jsi = facebook::jsi;
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSFunctionsDecorator.h
@@ -2,11 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-
-#include <unordered_map>
-#include <memory>
+#include "../ExpoHeader.pch"
 
 #include "JSDecorator.h"
 #include "../MethodMetadata.h"

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSObjectDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSObjectDecorator.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
+#include "../ExpoHeader.pch"
 
 #include "JSDecorator.h"
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.cpp
@@ -1,11 +1,10 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "../ExpoHeader.pch"
 #include "JSPropertiesDecorator.h"
 #include "../JavaScriptObject.h"
 #include "JSIUtils.h"
 #include "JSFunctionsDecorator.h"
-
-#include <jsi/jsi.h>
 
 namespace jsi = facebook::jsi;
 

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSPropertiesDecorator.h
@@ -1,8 +1,6 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
-#include <fbjni/fbjni.h>
-
-#include <unordered_map>
+#include "../ExpoHeader.pch"
 
 #include "../MethodMetadata.h"
 #include "../JNIFunctionBody.h"

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/AndroidExpoViewProps.h
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/AndroidExpoViewProps.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include "ExpoViewProps.h"
 
-#include <fbjni/fbjni.h>
 #include <react/renderer/core/RawValue.h>
 
 namespace react = facebook::react;

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/AndroidExpoViewState.h
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/AndroidExpoViewState.h
@@ -1,8 +1,6 @@
+#include "../ExpoHeader.pch"
 #include "ExpoViewState.h"
 
-#include "AndroidExpoViewProps.h"
-#include <fbjni/fbjni.h>
-#include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/FabricComponentsRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/FabricComponentsRegistry.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
+#include "../ExpoHeader.pch"
 #include <CoreComponentsRegistry.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/NativeStatePropsGetter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/NativeStatePropsGetter.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <fbjni/fbjni.h>
-#include <react/fabric/CoreComponentsRegistry.h>
+#include "../ExpoHeader.pch"
 #include <react/fabric/StateWrapperImpl.h>
 
 namespace jni = facebook::jni;

--- a/packages/expo-modules-core/android/src/main/cpp/installers/MainRuntimeInstaller.h
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/MainRuntimeInstaller.h
@@ -1,10 +1,9 @@
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include "../JSIContext.h"
-#include <fbjni/fbjni.h>
 #include <ReactCommon/CallInvokerHolder.h>
 #include <ReactCommon/CallInvoker.h>
-#include "SharedObject.h"
 
 #if IS_NEW_ARCHITECTURE_ENABLED
 

--- a/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.h
+++ b/packages/expo-modules-core/android/src/main/cpp/installers/WorkletRuntimeInstaller.h
@@ -1,8 +1,7 @@
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include "MainRuntimeInstaller.h"
-
-#include <fbjni/fbjni.h>
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/javaclasses/Collections.h
+++ b/packages/expo-modules-core/android/src/main/cpp/javaclasses/Collections.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <fbjni/fbjni.h>
+#include "../ExpoHeader.pch"
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/javaclasses/JSRunnable.h
+++ b/packages/expo-modules-core/android/src/main/cpp/javaclasses/JSRunnable.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <fbjni/fbjni.h>
+#include "../ExpoHeader.pch"
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/AnyType.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/AnyType.cpp
@@ -2,7 +2,6 @@
 
 #include "AnyType.h"
 #include "FrontendConverterProvider.h"
-#include "../JSIContext.h"
 
 namespace expo {
 AnyType::AnyType(

--- a/packages/expo-modules-core/android/src/main/cpp/types/AnyType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/AnyType.h
@@ -2,10 +2,9 @@
 
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include "ExpectedType.h"
 #include "FrontendConverter.h"
-
-#include <fbjni/fbjni.h>
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/ExpectedType.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/ExpectedType.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include "CppType.h"
-#include <fbjni/fbjni.h>
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2021-present 650 Industries, Inc. (aka Expo)
 
+#include "../ExpoHeader.pch"
 #include "FrontendConverter.h"
 #include "ExpectedType.h"
 #include "FrontendConverterProvider.h"
@@ -17,7 +18,6 @@
 
 #include "react/jni/ReadableNativeMap.h"
 #include "react/jni/ReadableNativeArray.h"
-#include <jsi/JSIDynamic.h>
 
 #include <utility>
 #include <algorithm>

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.h
@@ -2,10 +2,8 @@
 
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include "CppType.h"
-
-#include <jsi/jsi.h>
-#include <fbjni/fbjni.h>
 
 #if WORKLETS_ENABLED
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverterProvider.h
@@ -2,14 +2,10 @@
 
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include "CppType.h"
 #include "FrontendConverter.h"
 #include "ExpectedType.h"
-
-#include <fbjni/fbjni.h>
-
-#include <memory>
-#include <unordered_map>
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
+#include "../ExpoHeader.pch"
 #include "../JSIContext.h"
 #include "../JSharedObject.h"
 #include "../JNIUtils.h"
 #include "ObjectDeallocator.h"
-#include "../javaclasses/Collections.h"
 #include "../JavaScriptArrayBuffer.h"
 #include "../NativeArrayBuffer.h"
 #include "../concepts/jni_deref.h"
@@ -14,16 +14,7 @@
 #include "../concepts/jsi.h"
 #include "ReturnType.h"
 
-#include <fbjni/fbjni.h>
-#include <jsi/jsi.h>
-#include <optional>
 #include <concepts>
-
-#include <react/jni/ReadableNativeMap.h>
-#include <react/jni/ReadableNativeArray.h>
-#include <react/jni/WritableNativeArray.h>
-#include <react/jni/WritableNativeMap.h>
-#include <jsi/JSIDynamic.h>
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/Serializable.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/Serializable.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "../ExpoHeader.pch"
+
 #if WORKLETS_ENABLED
 
 #include "../JSIContext.h"
 #include "../JNIDeallocator.h"
-#include "WorkletNativeRuntime.h"
 
-#include <fbjni/fbjni.h>
 #include <worklets/SharedItems/Serializable.h>
 
 namespace jni = facebook::jni;

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/Worklet.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/Worklet.h
@@ -1,14 +1,11 @@
 #pragma once
 
+#include "../ExpoHeader.pch"
+
 #if WORKLETS_ENABLED
 
-#include "../JSIContext.h"
-#include "../JNIDeallocator.h"
 #include "WorkletNativeRuntime.h"
 #include "Serializable.h"
-
-#include <fbjni/fbjni.h>
-#include <worklets/SharedItems/Serializable.h>
 
 namespace jni = facebook::jni;
 

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletJSCallInvoker.h
@@ -1,14 +1,12 @@
 #pragma once
 
+#include "../ExpoHeader.pch"
+
 #if WORKLETS_ENABLED
 
 #include <ReactCommon/CallInvoker.h>
-#include <ReactCommon/RuntimeExecutor.h>
 
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
-
-#include <memory>
-
 
 namespace jsi = facebook::jsi;
 namespace react = facebook::react;

--- a/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletNativeRuntime.h
+++ b/packages/expo-modules-core/android/src/main/cpp/worklets/WorkletNativeRuntime.h
@@ -1,12 +1,12 @@
 #pragma once
 
+#include "../ExpoHeader.pch"
+
 #if WORKLETS_ENABLED
 
 #include <worklets/WorkletRuntime/WorkletRuntime.h>
 
 #endif
-
-#include <fbjni/fbjni.h>
 
 namespace jni = facebook::jni;
 


### PR DESCRIPTION
# Why

Cleanup headers in `e-m-c`.

# How

- Replace individually included PCH-provided headers with a single `#include "ExpoHeader.pch"` across Android C++ files, reducing include clutter and making the PCH dependency explicit
- Remove unused #include directives
- Remove 2 unused headers from the PCH itself (<map> and <unistd.h> - zero usage in the codebase)

# Test Plan

- bare-expo ✅ 