### PR TITLE
[modules-core] Add single-payload SharedObject.emit overloads

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated to the single-payload `SharedObject.emit` API. ([#45596](https://github.com/expo/expo/pull/45596) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.0.6 — 2026-05-13
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -169,7 +169,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable {
     arguments.merge(dict) { _, new in
       new
     }
-    self.emit(event: AudioConstants.playbackStatus, arguments: arguments)
+    self.emit(event: AudioConstants.playbackStatus, payload: arguments)
 
     if isActiveForLockScreen {
       MediaController.shared.updateNowPlayingInfo(for: self)
@@ -390,7 +390,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable {
           return ["frames": channelData]
         }
 
-        self.emit(event: AudioConstants.audioSample, arguments: [
+        self.emit(event: AudioConstants.audioSample, payload: [
           "channels": channels,
           "timestamp": timestamp
         ])

--- a/packages/expo-audio/ios/AudioPlaylist.swift
+++ b/packages/expo-audio/ios/AudioPlaylist.swift
@@ -238,7 +238,7 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
   func updateStatus(with dict: [String: Any]) {
     var arguments = currentStatus()
     arguments.merge(dict) { _, new in new }
-    self.emit(event: PlaylistConstants.playlistStatusUpdate, arguments: arguments)
+    self.emit(event: PlaylistConstants.playlistStatusUpdate, payload: arguments)
   }
 
   private func validIndex(_ index: Int) -> Bool {
@@ -246,7 +246,7 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
   }
 
   private func emitTrackChanged(previousIndex: Int, currentIndex: Int) {
-    self.emit(event: PlaylistConstants.trackChanged, arguments: [
+    self.emit(event: PlaylistConstants.trackChanged, payload: [
       "previousIndex": previousIndex,
       "currentIndex": currentIndex
     ])

--- a/packages/expo-audio/ios/AudioRecorder.swift
+++ b/packages/expo-audio/ios/AudioRecorder.swift
@@ -183,7 +183,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     if let options = currentOptions {
       do {
         try prepare(options: options, sessionOptions: currentSessionOptions)
-        emit(event: recordingStatus, arguments: [
+        emit(event: recordingStatus, payload: [
           "id": id,
           "isFinished": true,
           "hasError": false,
@@ -196,7 +196,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     }
 
     currentState = .error
-    emit(event: recordingStatus, arguments: [
+    emit(event: recordingStatus, payload: [
       "id": id,
       "isFinished": true,
       "hasError": true,
@@ -211,7 +211,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     currentState = .stopped
     resetDurationTracking()
 
-    emit(event: recordingStatus, arguments: [
+    emit(event: recordingStatus, payload: [
       "id": id,
       "isFinished": true,
       "hasError": false,
@@ -225,7 +225,7 @@ class AudioRecorder: SharedRef<AVAudioRecorder>, RecordingResultHandler {
     currentState = .error
     resetDurationTracking()
 
-    emit(event: recordingStatus, arguments: [
+    emit(event: recordingStatus, payload: [
       "id": id,
       "isFinished": true,
       "hasError": true,

--- a/packages/expo-audio/ios/AudioStream.swift
+++ b/packages/expo-audio/ios/AudioStream.swift
@@ -155,7 +155,7 @@ class AudioStream: SharedObject {
   }
 
   private func emitStatus() {
-    emit(event: AUDIO_STREAM_STATUS, arguments: [
+    emit(event: AUDIO_STREAM_STATUS, payload: [
       "isStreaming": isStreaming
     ])
   }
@@ -180,7 +180,7 @@ class AudioStream: SharedObject {
       return
     }
 
-    emit(event: AUDIO_STREAM_BUFFER, arguments: [
+    emit(event: AUDIO_STREAM_BUFFER, payload: [
       "data": data,
       "sampleRate": sampleRate,
       "channels": channels,

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Migrated to the single-payload `SharedObject.emit` API. ([#45596](https://github.com/expo/expo/pull/45596) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.0.9 — 2026-05-13
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-brownfield/ios/SharedState.swift
+++ b/packages/expo-brownfield/ios/SharedState.swift
@@ -21,7 +21,7 @@ public final class SharedState: SharedObject {
     value = newValue
     lock.unlock()
 
-    emit(event: "change", arguments: ["value": newValue])
+    emit(event: "change", payload: ["value": newValue])
     BrownfieldStateInternal.shared.notifySubscribers(key, newValue)
     BrownfieldStateInternal.shared.maybeNotifyKeyRecreated(key)
   }

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated to the single-payload `SharedObject.emit` API. ([#45596](https://github.com/expo/expo/pull/45596) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.0.4 — 2026-05-08
 
 ### 💡 Others

--- a/packages/expo-file-system/ios/FileSystemDownloadTask.swift
+++ b/packages/expo-file-system/ios/FileSystemDownloadTask.swift
@@ -353,7 +353,7 @@ private final class DownloadTaskDelegate: NSObject, NetworkTaskDelegate {
 
     if shouldEmit {
       lastProgressTime = currentTime
-      sharedObject?.emit(event: "progress", arguments: [
+      sharedObject?.emit(event: "progress", payload: [
         "bytesWritten": totalBytesWritten,
         "totalBytes": totalBytesExpectedToWrite,
       ])

--- a/packages/expo-file-system/ios/FileSystemUploadTask.swift
+++ b/packages/expo-file-system/ios/FileSystemUploadTask.swift
@@ -114,7 +114,7 @@ class FileSystemUploadTask: SharedObject {
 
     if shouldEmit {
       lastProgressTime = currentTime
-      emit(event: "progress", arguments: [
+      emit(event: "progress", payload: [
         "bytesSent": bytesSent,
         "totalBytes": totalBytes
       ])

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Added single-payload overloads for `SharedObject.emit` on iOS and Android. The iOS API also accepts an already-converted `JavaScriptValue` payload to skip the native-to-JS conversion step. ([#45596](https://github.com/expo/expo/pull/45596) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others
@@ -28,6 +30,7 @@
 ### 💡 Others
 
 - [iOS] `AppContext.setRuntime` now takes the native React `RuntimeScheduler` pointer and a dispatch trampoline alongside the runtime pointer. ([#45636](https://github.com/expo/expo/pull/45636) by [@tsapeta](https://github.com/tsapeta))
+- Deprecated `SharedObject.emit(event:arguments:)` (iOS) and the `vararg` `emit` (Android) in favor of the new single-payload overloads. Existing single-argument call sites keep working unchanged. ([#45596](https://github.com/expo/expo/pull/45596) by [@tsapeta](https://github.com/tsapeta))
 
 ## 56.0.5 — 2026-05-08
 

--- a/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
+++ b/packages/expo-modules-core/android/src/androidTest/java/expo/modules/kotlin/jni/SharedObjectTest.kt
@@ -87,27 +87,60 @@ class SharedObjectTest {
       "sharedObject = new $moduleRef.SharedObjectExampleClass()"
     ).getObject()
 
-    // Add a listener that adds three arguments
     evaluateScript(
       "total = 0",
-      "sharedObject.addListener('test event', (a, b, c) => { total = a + b + c })"
+      "sharedObject.addListener('test event', (payload) => { total = payload.a + payload.b + payload.c })"
     )
 
-    // Get the native instance
     val nativeObject = jsiInterop
       .runtimeHolder
       .get()
       ?.sharedObjectRegistry
       ?.toNativeObjectOrNull(jsObject)
 
-    // Send an event from the native object to JS
-    nativeObject?.emit("test event", 1, 2, 3)
+    nativeObject?.emit("test event", mapOf("a" to 1, "b" to 2, "c" to 3))
 
-    // Check the value that is set by the listener
     val total = evaluateScript("total")
 
     Truth.assertThat(total.isNumber()).isTrue()
     Truth.assertThat(total.getInt()).isEqualTo(6)
+  }
+
+  @Test
+  fun sends_events_with_primitive_payloads() = withExampleSharedClass {
+    val jsObject = evaluateScript(
+      "sharedObject = new $moduleRef.SharedObjectExampleClass()"
+    ).getObject()
+
+    evaluateScript(
+      "results = []",
+      "sharedObject.addListener('primitive', (payload) => { results.push(payload) })"
+    )
+
+    val nativeObject = jsiInterop
+      .runtimeHolder
+      .get()
+      ?.sharedObjectRegistry
+      ?.toNativeObjectOrNull(jsObject)
+
+    nativeObject?.emit("primitive", 42)
+    nativeObject?.emit("primitive", "hello")
+    nativeObject?.emit("primitive", true)
+
+    Truth.assertThat(evaluateScript("results.length").getInt()).isEqualTo(3)
+    Truth.assertThat(evaluateScript("results[0]").getInt()).isEqualTo(42)
+    Truth.assertThat(evaluateScript("results[1]").getString()).isEqualTo("hello")
+    Truth.assertThat(evaluateScript("results[2]").getBool()).isTrue()
+  }
+
+  @Test
+  fun does_not_crash_when_emitting_from_a_shared_object_not_associated_with_a_js_object() {
+    // No runtime/JS object backing this instance, so the defensive branches in `emit` should
+    // log and return cleanly without touching JSI.
+    val detached = SharedObjectExampleClass()
+    detached.emit("ignored")
+    detached.emit("ignored", mapOf("key" to "value"))
+    detached.emit("ignored", 42)
   }
 
   @Test

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -41,20 +41,42 @@ open class SharedObject(runtime: Runtime? = null) {
       )
   }
 
-  fun emit(eventName: String, vararg args: Any?) {
+  /**
+   * Emits an event with no payload to the associated JavaScript object.
+   */
+  fun emit(event: String) {
+    emitInternal(event, emptyArray())
+  }
+
+  /**
+   * Emits an event with a single payload to the associated JavaScript object.
+   */
+  fun emit(event: String, payload: Any?) {
+    emitInternal(event, arrayOf(payload))
+  }
+
+  @Deprecated(
+    "Multi-argument event emission is deprecated. Use `emit(event)` or `emit(event, payload)` and pass a single payload (typically a Map/Bundle) instead.",
+    ReplaceWith("emit(event, args)")
+  )
+  fun emit(event: String, vararg args: Any?) {
+    emitInternal(event, args)
+  }
+
+  private fun emitInternal(event: String, payload: Array<Any?>) {
     val jsObject = getJavaScriptObject() ?: return
     val jniInterop = runtime?.jsiContext ?: return
     try {
       JNIUtils.emitEvent(
         jsObject,
         jniInterop,
-        eventName,
-        args
+        event,
+        payload
           .map { JSTypeConverterProvider.convertToJSValue(it, useExperimentalConverter = true) }
           .toTypedArray()
       )
     } catch (e: Throwable) {
-      logger.error("Unable to send event '$eventName' by shared object of type ${this::class.java.simpleName}", e)
+      logger.error("Unable to send event '$event' by shared object of type ${this::class.java.simpleName}", e)
     }
   }
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/sharedobjects/SharedObject.kt
@@ -63,7 +63,7 @@ open class SharedObject(runtime: Runtime? = null) {
     emitInternal(event, args)
   }
 
-  private fun emitInternal(event: String, payload: Array<Any?>) {
+  private fun emitInternal(event: String, payload: Array<out Any?>) {
     val jsObject = getJavaScriptObject() ?: return
     val jniInterop = runtime?.jsiContext ?: return
     try {

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -136,17 +136,17 @@ open class SharedObject: AnySharedObject, @unchecked Sendable {
  */
 @JavaScriptActor
 private func dispatch(event: String, payload: JavaScriptValue, to value: JavaScriptValue, in runtime: JavaScriptRuntime) {
-  let argumentsBuffer = JavaScriptValuesBuffer.copying(in: runtime, values: [payload])
-
   runtime.withUnsafePointee { runtimePtr in
     value.withUnsafePointee { objectPtr in
-      JSUtils.emitEvent(
-        event,
-        runtimePointer: runtimePtr,
-        objectPointer: objectPtr,
-        argumentsPointer: argumentsBuffer.rawBaseAddress,
-        argumentCount: UInt(argumentsBuffer.count)
-      )
+      payload.withUnsafePointee { payloadPtr in
+        JSUtils.emitEvent(
+          event,
+          runtimePointer: runtimePtr,
+          objectPointer: objectPtr,
+          argumentsPointer: payloadPtr,
+          argumentCount: 1
+        )
+      }
     }
   }
 }

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -12,7 +12,7 @@ extension AnySharedObject {
   }
 }
 
-open class SharedObject: AnySharedObject, @unchecked Sendable {
+open class SharedObject: AnySharedObject {
   /**
    An identifier of the native shared object that maps to the JavaScript object.
    When the object is not linked with any JavaScript object, its value is 0.

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -22,7 +22,7 @@ open class SharedObject: AnySharedObject, @unchecked Sendable {
   /**
    An app context for which the shared object was created.
    */
-  nonisolated(unsafe) public internal(set) weak var appContext: AppContext?
+  public internal(set) weak var appContext: AppContext?
 
   /**
    The default public initializer of the shared object.

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -12,7 +12,7 @@ extension AnySharedObject {
   }
 }
 
-open class SharedObject: AnySharedObject {
+open class SharedObject: AnySharedObject, @unchecked Sendable {
   /**
    An identifier of the native shared object that maps to the JavaScript object.
    When the object is not linked with any JavaScript object, its value is 0.
@@ -22,7 +22,7 @@ open class SharedObject: AnySharedObject {
   /**
    An app context for which the shared object was created.
    */
-  public internal(set) weak var appContext: AppContext?
+  nonisolated(unsafe) public internal(set) weak var appContext: AppContext?
 
   /**
    The default public initializer of the shared object.
@@ -66,66 +66,87 @@ open class SharedObject: AnySharedObject {
   public func getJavaScriptObject() -> JavaScriptObject? {
     return appContext?.sharedObjectRegistry.toJavaScriptObject(self)
   }
-}
 
-// Unfortunately the `emit` function needs to be defined in the extension.
-// When put in the class, pack expansion is crashing with `EXC_BAD_ACCESS` code.
-// See https://github.com/apple/swift/issues/72381 for more details.
-public extension SharedObject { // swiftlint:disable:this no_grouping_extension
-  // Parameter packs feature requires Swift 5.9 (Xcode 15.0), but some CIs and EAS images may still use older versions.
-  // As of April 29, all submissions must be made with Xcode 15, so hopefully we can remove this condition soon.
-  // No one should use <15.0 these days.
-  #if swift(>=5.9)
   /**
-   Schedules an event with the given name and arguments to be emitted to the associated JavaScript object.
+   Schedules an event with the given name and a pre-converted JavaScript payload to be emitted
+   to the associated JavaScript object. This is the lowest-level emit overload — use it when the
+   value is already a `JavaScriptValue` to skip the native-to-JS conversion step.
    */
-  func emit<each A: AnyArgument>(event: String, arguments: repeat each A) {
+  public func emit(event: String, payload: JavaScriptValue) {
     guard let appContext, let runtime = try? appContext.runtime else {
       log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
       return
     }
+    guard let jsValue = getJavaScriptValue() else {
+      log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
+      return
+    }
+    runtime.schedule {
+      dispatch(event: event, payload: payload, to: jsValue, in: runtime)
+    }
+  }
 
-    // Collect arguments and their dynamic types from parameter pack
-    var argumentPairs: [(AnyArgument, AnyDynamicType)] = []
-    repeat argumentPairs.append((each arguments, ~(each A).self))
+  /**
+   Schedules an event with the given name to be emitted to the associated JavaScript object.
+   */
+  public func emit(event: String) {
+    emit(event: event, payload: .undefined)
+  }
 
-    // Schedule the event to be asynchronously emitted from the runtime's thread
-    runtime.schedule { [weak self, weak appContext] in
-      guard let appContext, let runtime = try? appContext.runtime, let jsValue = self?.getJavaScriptValue() else {
-        log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS object is no longer associated with the native instance")
+  /**
+   Schedules an event with the given name and payload to be emitted to the associated JavaScript object.
+   */
+  public func emit<P: AnyArgument>(event: String, payload: sending P) {
+    guard let appContext, let runtime = try? appContext.runtime else {
+      log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
+      return
+    }
+    guard let jsValue = getJavaScriptValue() else {
+      log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
+      return
+    }
+    runtime.schedule { [weak appContext] in
+      guard let appContext else {
         return
       }
-
-      // Convert native arguments to JS, just like function results
-      let jsArguments: [JavaScriptValue]
       do {
-        jsArguments = try argumentPairs.map { argument, dynamicType in
-          try dynamicType.convertToJS(argument, appContext: appContext)
-        }
+        let jsPayload = try (~P.self).castToJS(payload, appContext: appContext, in: runtime)
+        dispatch(event: event, payload: jsPayload, to: jsValue, in: runtime)
       } catch {
-        log.warn("Failed to convert arguments for event '\(event)' on \(type(of: self)); the event will not be emitted: \(error)")
+        log.warn("Failed to convert payload for event '\(event)' on \(P.self); the event will not be emitted: \(error)")
         return
-      }
-
-      let argumentsBuffer = JavaScriptValuesBuffer.copying(in: runtime, values: jsArguments)
-
-      runtime.withUnsafePointee { runtimePtr in
-        jsValue.withUnsafePointee { objectPtr in
-          JSUtils.emitEvent(
-            event,
-            runtimePointer: runtimePtr,
-            objectPointer: objectPtr,
-            argumentsPointer: argumentsBuffer.rawBaseAddress,
-            argumentCount: UInt(argumentsBuffer.count)
-          )
-        }
       }
     }
   }
-  #else // swift(>=5.9)
-  @available(*, unavailable, message: "Unavailable in Xcode <15.0")
-  public func emit(event: String, arguments: AnyArgument...) {
-    fatalError("Emitting events to JS requires at least Xcode 15.0")
+
+  /**
+   Backwards-compatible overload that forwards to `emit(event:payload:)`. Existing single-argument
+   call sites keep working unchanged; the parameter has been renamed to `payload` to make the
+   single-payload semantics explicit, so callers should migrate the label.
+   */
+  @available(*, deprecated, renamed: "emit(event:payload:)", message: "Use `emit(event:payload:)` and pass a single value (typically a dictionary). Multi-argument event emission is no longer supported.")
+  public func emit<P: AnyArgument>(event: String, arguments: sending P) {
+    emit(event: event, payload: arguments)
   }
-  #endif // swift(<5.9)
+}
+
+/**
+ Sends a pre-converted event payload to the given JavaScript object via the JSI emitter helper.
+ Must run on the JS thread; the public `emit` overloads schedule onto the runtime before calling in.
+ */
+@JavaScriptActor
+private func dispatch(event: String, payload: JavaScriptValue, to value: JavaScriptValue, in runtime: JavaScriptRuntime) {
+  let argumentsBuffer = JavaScriptValuesBuffer.copying(in: runtime, values: [payload])
+
+  runtime.withUnsafePointee { runtimePtr in
+    value.withUnsafePointee { objectPtr in
+      JSUtils.emitEvent(
+        event,
+        runtimePointer: runtimePtr,
+        objectPointer: objectPtr,
+        argumentsPointer: argumentsBuffer.rawBaseAddress,
+        argumentCount: UInt(argumentsBuffer.count)
+      )
+    }
+  }
 }

--- a/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
+++ b/packages/expo-modules-core/ios/Tests/SharedObjectTests.swift
@@ -137,28 +137,108 @@ struct SharedObjectTests {
       .eval("sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()")
       .asObject()
 
-    // Add a listener that adds three arguments
-    try runtime.eval([
-      "result = null",
-      "sharedObject.addListener('test event', (number, string, record) => { result = { number, string, record } })"
-    ])
+    try runtime.eval(
+      """
+      result = null;
+      sharedObject.addListener('test event', (payload) => { result = payload });      
+      """
+    )
 
-    // Get the native instance
     let nativeObject = appContext.sharedObjectRegistry.toNativeObject(jsObject)
 
-    struct EventRecord: Record {
+    struct EventPayload: Record {
+      @Field var number: Int = 123
+      @Field var string: String = "test"
       @Field var boolean: Bool = true
     }
 
-    // Emit an event from the native object to JS
-    nativeObject?.emit(event: "test event", arguments: 123, "test", EventRecord())
+    nativeObject?.emit(event: "test event", payload: EventPayload())
 
-    // Check the value that is set by the listener
     let result = try runtime.eval("result").asObject()
 
     #expect(try result.getProperty("number").asInt() == 123)
     #expect(try result.getProperty("string").asString() == "test")
-    #expect(try result.getProperty("record").asObject().getProperty("boolean").asBool() == true)
+    #expect(try result.getProperty("boolean").asBool() == true)
+  }
+
+  @Test
+  func `emits events with no payload`() throws {
+    let jsObject = try runtime
+      .eval("sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()")
+      .asObject()
+
+    try runtime.eval(
+      """
+      callCount = 0;
+      receivedPayload = 'not called';
+      sharedObject.addListener('ping', (payload) => { callCount += 1; receivedPayload = payload });      
+      """
+    )
+
+    let nativeObject = appContext.sharedObjectRegistry.toNativeObject(jsObject)
+    nativeObject?.emit(event: "ping")
+
+    #expect(try runtime.eval("callCount").asInt() == 1)
+    #expect(try runtime.eval("receivedPayload").isUndefined() == true)
+  }
+
+  @Test
+  func `emits events with a pre-converted JavaScriptValue payload`() throws {
+    let jsObject = try runtime
+      .eval("sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()")
+      .asObject()
+
+    try runtime.eval(
+      """
+      result = null;
+      sharedObject.addListener('test event', (payload) => { result = payload });      
+      """
+    )
+
+    let nativeObject = appContext.sharedObjectRegistry.toNativeObject(jsObject)
+
+    let prebuiltPayload = try runtime.eval("({ kind: 'prebuilt', count: 7 })")
+    nativeObject?.emit(event: "test event", payload: prebuiltPayload)
+
+    let result = try runtime.eval("result").asObject()
+    #expect(try result.getProperty("kind").asString() == "prebuilt")
+    #expect(try result.getProperty("count").asInt() == 7)
+  }
+
+  @Test
+  func `emits primitive payloads`() throws {
+    let jsObject = try runtime
+      .eval("sharedObject = new expo.modules.SharedObjectModule.SharedObjectExample()")
+      .asObject()
+
+    try runtime.eval(
+      """
+      results = [];
+      sharedObject.addListener('primitive', (payload) => { results.push(payload) });
+      """
+    )
+
+    let nativeObject = appContext.sharedObjectRegistry.toNativeObject(jsObject)
+    nativeObject?.emit(event: "primitive", payload: 42)
+    nativeObject?.emit(event: "primitive", payload: "hello")
+    nativeObject?.emit(event: "primitive", payload: true)
+
+    #expect(try runtime.eval("results.length").asInt() == 3)
+    #expect(try runtime.eval("results[0]").asInt() == 42)
+    #expect(try runtime.eval("results[1]").asString() == "hello")
+    #expect(try runtime.eval("results[2]").asBool() == true)
+  }
+
+  @Test
+  func `does not crash when emitting from a shared object not associated with a JS object`() throws {
+    let detached = SharedObjectExample()
+    detached.appContext = appContext
+
+    // Not registered in `sharedObjectRegistry`, so `getJavaScriptValue()` returns nil and the
+    // defensive branches in the public `emit` overloads should log and return cleanly.
+    detached.emit(event: "ignored")
+    detached.emit(event: "ignored", payload: ["key": "value"])
+    detached.emit(event: "ignored", payload: .undefined)
   }
 
   @Test
@@ -187,7 +267,7 @@ struct SharedObjectTests {
       "length": 16
     ]
 
-    nativeObject?.emit(event: "buffer event", arguments: payload)
+    nativeObject?.emit(event: "buffer event", payload: payload)
 
     let resultValue = try runtime.eval("result")
     #expect(!resultValue.isNull() && !resultValue.isUndefined())

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Migrated to the single-payload `SharedObject.emit` API. ([#45596](https://github.com/expo/expo/pull/45596) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.1.0 — 2026-05-06
 
 ### 🎉 New features

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -413,7 +413,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
 
   func safeEmit(event: String, payload: Record? = nil) {
     if self.appContext != nil {
-      self.emit(event: event, arguments: payload?.toDictionary(appContext: appContext))
+      self.emit(event: event, payload: payload?.toDictionary(appContext: appContext))
     }
   }
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Migrated to the single-payload `SharedObject.emit` API. ([#45596](https://github.com/expo/expo/pull/45596) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.0.8 — 2026-05-13
 
 ### 🎉 New features

--- a/packages/expo-widgets/ios/LiveActivity.swift
+++ b/packages/expo-widgets/ios/LiveActivity.swift
@@ -66,7 +66,7 @@ final class LiveActivity: SharedObject {
     pushTokenObserverTask = Task {
       for await data in activity.pushTokenUpdates {
         let token = data.reduce("") { $0 + String(format: "%02x", $1) }
-        emit(event: onTokenReceived, arguments: [
+        emit(event: onTokenReceived, payload: [
           "activityId": activity.id,
           "pushToken": token
         ])

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 💡 Others
 
+- Migrated to the single-payload `SharedObject.emit` API. ([#45596](https://github.com/expo/expo/pull/45596) by [@tsapeta](https://github.com/tsapeta))
 - Drop `AppRegistry` development log when web app mounts ([#45788](https://github.com/expo/expo/pull/45788) by [@kitten](https://github.com/kitten))
 
 ## 56.0.0-preview.11 — 2026-05-13

--- a/packages/expo/ios/Fetch/NativeResponse.swift
+++ b/packages/expo/ios/Fetch/NativeResponse.swift
@@ -44,7 +44,7 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @
     if state == .responseReceived {
       state = .bodyStreamingStarted
       let queuedData = self.sink.finalize()
-      emit(event: "didReceiveResponseData", arguments: queuedData)
+      emit(event: "didReceiveResponseData", payload: queuedData)
     } else if state == .bodyCompleted {
       let queuedData = self.sink.finalize()
       return queuedData
@@ -63,7 +63,7 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @
     let error = FetchRequestCanceledException()
     self.error = error
     if state == .bodyStreamingStarted {
-      emit(event: "didFailWithError", arguments: error.localizedDescription)
+      emit(event: "didFailWithError", payload: error.localizedDescription)
     }
     state = .errorReceived
     emit(event: "readyForJSFinalization")
@@ -152,7 +152,7 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @
     if state == .responseReceived {
       self.sink.appendBufferBody(data: data)
     } else if state == .bodyStreamingStarted {
-      emit(event: "didReceiveResponseData", arguments: data)
+      emit(event: "didReceiveResponseData", payload: data)
     }
     // no-op in .bodyStreamingCanceled state
   }
@@ -172,7 +172,7 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @
       let error = FetchRedirectException()
       self.error = error
       if state == .bodyStreamingStarted {
-        emit(event: "didFailWithError", arguments: error.localizedDescription)
+        emit(event: "didFailWithError", payload: error.localizedDescription)
       }
       state = .errorReceived
       emit(event: "readyForJSFinalization")
@@ -209,7 +209,7 @@ internal final class NativeResponse: SharedObject, ExpoURLSessionTaskDelegate, @
 
     if state == .bodyStreamingStarted {
       if let error {
-        emit(event: "didFailWithError", arguments: error.localizedDescription)
+        emit(event: "didFailWithError", payload: error.localizedDescription)
       } else {
         emit(event: "didComplete")
       }


### PR DESCRIPTION
## Why

`SharedObject.emit` accepted a variable-arity argument list on both iOS (`emit(event:arguments:)` via parameter packs) and Android (`emit(eventName, vararg args)`), but every production call site already passed exactly one value. Web and modern JS APIs (`MessageEvent`, `WebSocket`, `BroadcastChannel`, `NativeEventEmitter`) standardize on a single payload object — variadic event args is a Node-era pattern that's hard to type, brittle to evolve, and trivially misuses positional ordering for what should be a structured payload.

## How

- **iOS:** add `emit(event:)`, `emit(event:payload:)` for any `AnyArgument` (with the payload marked `sending` so it can cross into `@JavaScriptActor` without requiring `Sendable`), and `emit(event:payload: JavaScriptValue)` for already-converted values. Deprecate `emit(event:arguments:)` with a renamed-fix-it pointing at `emit(event:payload:)`. Existing single-argument call sites compile unchanged after relabeling. Move the implementation into the class body (the parameter-pack `EXC_BAD_ACCESS` workaround that required a separate extension is fixed in Swift 6.2).
- **Android:** add `emit(event)`, `emit(event, payload)`. Deprecate the `vararg` overload with a `ReplaceWith` hint. Rename the parameter from `eventName` to `event` to match iOS. Single-argument positional call sites silently route to the new overload via Kotlin overload resolution.
- **iOS-only:** the `JavaScriptValue` overload is the lowest-level public emit. Use it when you already have a JSI value to skip the native-to-JS conversion step. The `@JavaScriptActor` `dispatch` helper is the only place that touches `JSUtils.emitEvent`, and now passes the payload's `jsi::Value` pointer directly — no `JavaScriptValuesBuffer` allocation/copy per event.
- Migrated all internal call sites in `expo-video`, `expo-audio`, `expo-file-system`, `expo-widgets`, `expo-brownfield`, and `expo` (`Fetch`) to the new `payload:` label.
- Added focused tests on iOS and Android: typed `Record` payload (existing), no payload, pre-converted `JavaScriptValue` payload (iOS only), primitive payloads, and a defensive-branch test for emit on a shared object that's not associated with a JS object.

## Compatibility

A GitHub Code Search across public Swift and Kotlin sources turned up zero third-party Expo modules using multi-argument `emit` — every public call site (e.g. `expo-msal`, `expo-local-llm`) already passes a single value. The deprecated overloads remain available, so existing single-argument callers continue to compile (with an iOS deprecation warning pointing at the rename). No external module needs to migrate to keep working.

## Test plan

- [x] `expo-modules-core` iOS Swift Testing suite passes (`SharedObjectTests`).
- [x] `expo-modules-core` Android instrumented `SharedObjectTest` passes.
- [x] `expo-audio`, `expo-video`, `expo-file-system`, `expo-widgets`, `expo-brownfield`, `expo` iOS targets compile.
- [x] No deprecation warnings from `SharedObject.emit` in the migrated modules.