### PR TITLE
[docs] Add configuration example for autolinking in package.json

### DIFF
--- a/docs/pages/versions/unversioned/config/package-json.mdx
+++ b/docs/pages/versions/unversioned/config/package-json.mdx
@@ -40,8 +40,7 @@ Allows configuring module resolution behavior by using `autolinking` property in
 {
   "expo": {
     "autolinking": {
-      "searchPaths": ["../../packages"],
-      "exclude": ["expo-splash-screen"]
+      "nativeModulesDir": "./modules"
     }
   }
 }

--- a/docs/pages/versions/unversioned/config/package-json.mdx
+++ b/docs/pages/versions/unversioned/config/package-json.mdx
@@ -5,7 +5,7 @@ description: A reference for Expo-specific properties that can be used in the pa
 
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 
-**package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used in the **package.json** file.
+**package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used by adding an `expo` field in the **package.json** file.
 
 <PaddedAPIBox>
 
@@ -16,7 +16,7 @@ The following commands perform a version check for the libraries installed in a 
 - `npx expo start` and `npx expo-doctor`
 - `npx expo install` (when installing a new version of that library or using `--check` or `--fix` options)
 
-By specifying the library under the `install.exclude` array in the **package.json** file, you can exclude it from the version checks:
+By adding the library under the `install.exclude` array in the **package.json** file, you can exclude it from the version checks:
 
 ```json package.json
 {
@@ -35,6 +35,17 @@ By specifying the library under the `install.exclude` array in the **package.jso
 ## `autolinking`
 
 Allows configuring module resolution behavior by using `autolinking` property in **package.json**.
+
+```json package.json
+{
+  "expo": {
+    "autolinking": {
+      "searchPaths": ["../../packages"],
+      "exclude": ["expo-splash-screen"]
+    }
+  }
+}
+```
 
 For complete reference, see [Autolinking configuration](/modules/autolinking/#configuration).
 

--- a/docs/pages/versions/v54.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v54.0.0/config/package-json.mdx
@@ -40,8 +40,7 @@ Allows configuring module resolution behavior by using `autolinking` property in
 {
   "expo": {
     "autolinking": {
-      "searchPaths": ["../../packages"],
-      "exclude": ["expo-splash-screen"]
+      "nativeModulesDir": "./modules"
     }
   }
 }

--- a/docs/pages/versions/v54.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v54.0.0/config/package-json.mdx
@@ -5,7 +5,7 @@ description: A reference for Expo-specific properties that can be used in the pa
 
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 
-**package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used in the **package.json** file.
+**package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used by adding an `expo` field in the **package.json** file.
 
 <PaddedAPIBox>
 
@@ -16,7 +16,7 @@ The following commands perform a version check for the libraries installed in a 
 - `npx expo start` and `npx expo-doctor`
 - `npx expo install` (when installing a new version of that library or using `--check` or `--fix` options)
 
-By specifying the library under the `install.exclude` array in the **package.json** file, you can exclude it from the version checks:
+By adding the library under the `install.exclude` array in the **package.json** file, you can exclude it from the version checks:
 
 ```json package.json
 {
@@ -35,6 +35,17 @@ By specifying the library under the `install.exclude` array in the **package.jso
 ## `autolinking`
 
 Allows configuring module resolution behavior by using `autolinking` property in **package.json**.
+
+```json package.json
+{
+  "expo": {
+    "autolinking": {
+      "searchPaths": ["../../packages"],
+      "exclude": ["expo-splash-screen"]
+    }
+  }
+}
+```
 
 For complete reference, see [Autolinking configuration](/modules/autolinking/#configuration).
 

--- a/docs/pages/versions/v55.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v55.0.0/config/package-json.mdx
@@ -40,8 +40,7 @@ Allows configuring module resolution behavior by using `autolinking` property in
 {
   "expo": {
     "autolinking": {
-      "searchPaths": ["../../packages"],
-      "exclude": ["expo-splash-screen"]
+      "nativeModulesDir": "./modules"
     }
   }
 }

--- a/docs/pages/versions/v55.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v55.0.0/config/package-json.mdx
@@ -5,7 +5,7 @@ description: A reference for Expo-specific properties that can be used in the pa
 
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 
-**package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used in the **package.json** file.
+**package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used by adding an `expo` field in the **package.json** file.
 
 <PaddedAPIBox>
 
@@ -16,7 +16,7 @@ The following commands perform a version check for the libraries installed in a 
 - `npx expo start` and `npx expo-doctor`
 - `npx expo install` (when installing a new version of that library or using `--check` or `--fix` options)
 
-By specifying the library under the `install.exclude` array in the **package.json** file, you can exclude it from the version checks:
+By adding the library under the `install.exclude` array in the **package.json** file, you can exclude it from the version checks:
 
 ```json package.json
 {
@@ -35,6 +35,17 @@ By specifying the library under the `install.exclude` array in the **package.jso
 ## `autolinking`
 
 Allows configuring module resolution behavior by using `autolinking` property in **package.json**.
+
+```json package.json
+{
+  "expo": {
+    "autolinking": {
+      "searchPaths": ["../../packages"],
+      "exclude": ["expo-splash-screen"]
+    }
+  }
+}
+```
 
 For complete reference, see [Autolinking configuration](/modules/autolinking/#configuration).
 

--- a/docs/pages/versions/v56.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v56.0.0/config/package-json.mdx
@@ -40,8 +40,7 @@ Allows configuring module resolution behavior by using `autolinking` property in
 {
   "expo": {
     "autolinking": {
-      "searchPaths": ["../../packages"],
-      "exclude": ["expo-splash-screen"]
+      "nativeModulesDir": "./modules"
     }
   }
 }

--- a/docs/pages/versions/v56.0.0/config/package-json.mdx
+++ b/docs/pages/versions/v56.0.0/config/package-json.mdx
@@ -5,7 +5,7 @@ description: A reference for Expo-specific properties that can be used in the pa
 
 import { PaddedAPIBox } from '~/components/plugins/PaddedAPIBox';
 
-**package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used in the **package.json** file.
+**package.json** is a JSON file that contains the metadata for a JavaScript project. This is a reference to Expo-specific properties that can be used by adding an `expo` field in the **package.json** file.
 
 <PaddedAPIBox>
 
@@ -16,7 +16,7 @@ The following commands perform a version check for the libraries installed in a 
 - `npx expo start` and `npx expo-doctor`
 - `npx expo install` (when installing a new version of that library or using `--check` or `--fix` options)
 
-By specifying the library under the `install.exclude` array in the **package.json** file, you can exclude it from the version checks:
+By adding the library under the `install.exclude` array in the **package.json** file, you can exclude it from the version checks:
 
 ```json package.json
 {
@@ -35,6 +35,17 @@ By specifying the library under the `install.exclude` array in the **package.jso
 ## `autolinking`
 
 Allows configuring module resolution behavior by using `autolinking` property in **package.json**.
+
+```json package.json
+{
+  "expo": {
+    "autolinking": {
+      "searchPaths": ["../../packages"],
+      "exclude": ["expo-splash-screen"]
+    }
+  }
+}
+```
 
 For complete reference, see [Autolinking configuration](/modules/autolinking/#configuration).
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21140

# How

<!--
How did you build this feature or fix this bug and why?
-->

# How

- Adds a JSON example to the `autolinking` section showing `searchPaths` and `exclude`, in the same style as the existing `install.exclude` and `doctor` examples on the page.
-  The intro line is reworded to spell out that properties go inside an `expo` field in `package.json` since every configuration field is part of the `expo` field.
- Update "By specifying the library" becomes "By adding the library" in the `install.exclude` paragraph for consistency.
- Changes applied to unversioned and backported to SDK 56, 55, 54.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2360" height="2136" alt="CleanShot 2026-05-10 at 01 49 38@2x" src="https://github.com/user-attachments/assets/5cdf9a70-2aa4-4477-92c0-de4124fdf769" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
