### PR TITLE
[docs] Add `include` option and `apple` platform in autolinking reference

### DIFF
--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -126,7 +126,7 @@ A list of additional package names to verify for deduplication. This is useful f
 }
 ```
 
-Unlike other options, per-platform `include` lists are merged with the root list rather than overridden. The configuration below verifies a third-party library on every platform and additionally checks `some-android-utility` only on Android:
+Unlike other options, per-platform `include` lists are merged with the root list rather than overridden. The configuration below verifies a third-party library on every platform and additionally checks for platform-specific library only on Android:
 
 ```json package.json
 {
@@ -134,7 +134,7 @@ Unlike other options, per-platform `include` lists are merged with the root list
     "autolinking": {
       "include": ["third-party-expo-module"],
       "android": {
-        "include": ["some-android-utility"]
+        "include": ["third-party-android-module"]
       }
     }
   }

--- a/docs/pages/modules/autolinking.mdx
+++ b/docs/pages/modules/autolinking.mdx
@@ -38,7 +38,7 @@ The autolinked modules are automatically added to the build, which usually means
 The behavior of the module resolution can be customized using some configuration options. These options can be defined in three different places, from the lowest to the highest precedence:
 
 - `expo.autolinking` config object in application's **package.json**
-- per platform overrides with `expo.autolinking.ios` and `expo.autolinking.android` objects
+- per platform overrides with `expo.autolinking.android`, `expo.autolinking.ios`, and `expo.autolinking.apple` objects (`apple` falls back to `ios` when `apple` is missing)
 - options provided to the CLI command, the `use_expo_modules!` method in the **Podfile** or `useExpoModules` function in the **settings.gradle**
 
 <PaddedAPIBox header="searchPaths">
@@ -108,6 +108,38 @@ module.exports = {
 ```
 
 > **info** Before **SDK 54**, the `exclude` option only applied to Expo modules and not React Native modules. React Native modules could only be excluded using a **react-native.config.js** file in the root directory of your project.
+
+</PaddedAPIBox>
+<PaddedAPIBox header="include">
+
+> **info** Available in **SDK 55 and later**.
+
+A list of additional package names to verify for deduplication. This is useful for utility libraries that should not be duplicated because of singleton or internal state, even when they aren't native modules.
+
+```json package.json
+{
+  "expo": {
+    "autolinking": {
+      "include": ["third-party-expo-module"]
+    }
+  }
+}
+```
+
+Unlike other options, per-platform `include` lists are merged with the root list rather than overridden. The configuration below verifies a third-party library on every platform and additionally checks `some-android-utility` only on Android:
+
+```json package.json
+{
+  "expo": {
+    "autolinking": {
+      "include": ["third-party-expo-module"],
+      "android": {
+        "include": ["some-android-utility"]
+      }
+    }
+  }
+}
+```
 
 </PaddedAPIBox>
 <PaddedAPIBox header="flags" platforms={["ios"]}>


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The `/modules/autolinking` Configuration section is missing the `include` option, which shipped in `expo-modules-autolinking@55.0.11` ([#43724](https://github.com/expo/expo/pull/43724), [CHANGELOG](https://github.com/expo/expo/blob/main/packages/expo-modules-autolinking/CHANGELOG.md#55011---2026-03-18)) .

# How

- Adds a new `<PaddedAPIBox header="include">` entry between `exclude` and `flags`, with an "Available in SDK 55 and later" callout. 
- The platform-overrides bullet in the Configuration intro is updated to list `android`, `ios`, and `apple`, with the `apple` to `ios` fallback noted inline.

# Test Plan


<img width="2340" height="1566" alt="CleanShot 2026-05-10 at 02 11 23@2x" src="https://github.com/user-attachments/assets/2184a432-6d03-4090-ba26-017d0936ae41" />


<img width="2356" height="510" alt="CleanShot 2026-05-10 at 02 08 36@2x" src="https://github.com/user-attachments/assets/8433ab31-23dd-4241-a36b-e4fce37067c3" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).