### PR TITLE
[docs][react-compiler] Replace deprecated eslint-plugin-react-compiler with eslint-plugin-react-hooks

### DIFF
--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -69,7 +69,7 @@ Additionally, you should use the ESLint plugin to continuously enforce the rules
 
 Run [`npx expo lint`](/guides/using-eslint/#eslint) to ensure ESLint is setup in your app, then install the ESLint plugin for React Compiler:
 
-<Terminal cmd={['$ npx expo install eslint-plugin-react-compiler -- -D']} />
+<Terminal cmd={['$ npx expo install eslint-plugin-react-hooks -- -D']} />
 
 </Step>
 
@@ -81,11 +81,11 @@ Update your [ESLint configuration](/guides/using-eslint/) to include the plugin:
 // https://docs.expo.dev/guides/using-eslint/
 const { defineConfig } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
-const reactCompiler = require('eslint-plugin-react-compiler');
+const reactHooks = require('eslint-plugin-react-hooks');
 
 module.exports = defineConfig([
   expoConfig,
-  reactCompiler.configs.recommended,
+  reactHooks.configs.flat['recommended-latest'],
   {
     ignores: ['dist/*'],
   },


### PR DESCRIPTION
# Why

Fixes #44237.

The React Compiler guide at `docs/pages/guides/react-compiler.mdx` recommends installing `eslint-plugin-react-compiler`, but that package is deprecated. Per the [React Compiler 1.0 announcement](https://react.dev/blog/2025/10/07/react-compiler-1) and the [React Compiler installation guide](https://react.dev/learn/react-compiler/installation), the compiler ESLint rules have been absorbed into `eslint-plugin-react-hooks@^7` and are exposed via the `recommended-latest` preset.

This was confirmed by @kitten on the issue: _"Yes, the former is deprecated, and the functionality is being absorbed by `eslint-plugin-react-hooks`"_.

# How

Updated three references in `docs/pages/guides/react-compiler.mdx`:

1. The install command — `eslint-plugin-react-compiler` → `eslint-plugin-react-hooks`.
2. The `require(...)` call and its variable name.
3. The config entry — `reactCompiler.configs.recommended` → `reactHooks.configs.flat['recommended-latest']`, matching the [official `eslint-plugin-react-hooks` README](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md) (note the `.flat.` path and the `recommended-latest` key, which is what enables the compiler rules).

### Diff

```diff
- $ npx expo install eslint-plugin-react-compiler -- -D
+ $ npx expo install eslint-plugin-react-hooks -- -D

- const reactCompiler = require('eslint-plugin-react-compiler');
+ const reactHooks = require('eslint-plugin-react-hooks');

- reactCompiler.configs.recommended,
+ reactHooks.configs.flat['recommended-latest'],
```

# Test Plan

- Verified the rendered page at http://localhost:3002/guides/react-compiler — both the install command and the `.eslintrc.js` snippet display the new package name and config path correctly.
- Ran `pnpm lint` in `docs/` — all four checks pass (`oxfmt`, `oxlint`, `tsc`, `eslint`).

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources — N/A (docs-only change)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin) — N/A (docs-only change)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
