### PR TITLE
[docs] Fix Tailwind v4 important syntax in arbitrary value classes

### DIFF
--- a/docs/components/plugins/api/APISectionTypes.tsx
+++ b/docs/components/plugins/api/APISectionTypes.tsx
@@ -178,7 +178,7 @@ const renderType = (
   const defaultValueElement = defaultValue ? (
     <CALLOUT className="flex items-start gap-1">
       <span className={STYLES_SECONDARY}>Default:</span>
-      <CODE className="text-[90!%]">{defaultValue}</CODE>
+      <CODE className="text-[90%]!">{defaultValue}</CODE>
     </CALLOUT>
   ) : undefined;
 

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -425,7 +425,7 @@ export const renderDefaultValue = (defaultValue?: string) =>
   defaultValue && defaultValue !== '...' ? (
     <div className="flex items-start gap-1">
       <span className={STYLES_SECONDARY}>Default:</span>
-      <CODE className="text-[90!%]">{defaultValue}</CODE>
+      <CODE className="text-[90%]!">{defaultValue}</CODE>
     </div>
   ) : undefined;
 

--- a/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
+++ b/docs/ui/components/Sidebar/SidebarSingleEntry.tsx
@@ -33,7 +33,7 @@ export const SidebarSingleEntry = ({
         <LinkBase
           href={href}
           className={mergeClasses(
-            'text-secondary flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm leading-[100!%]',
+            'text-secondary flex min-h-[32px] items-center gap-3 rounded-md px-2 py-1 text-sm leading-[100%]!',
             'hocus:bg-element',
             'focus-visible:relative focus-visible:z-10',
             allowCompactDisplay && 'compact-height:justify-center compact-height:bg-subtle',


### PR DESCRIPTION
# Why

The docs production build prints `Found 3 warnings while optimizing generated CSS` with `Unexpected token Delim('!')` against the values `100!%` and `90!%`. These come from arbitrary-value Tailwind classes where the `!important` modifier landed inside the brackets, producing invalid CSS for sidebar link `line-height` and the "Default:" prop-value `font-size`.

<img width="2318" height="1528" alt="CleanShot 2026-04-24 at 17 44 23@2x" src="https://github.com/user-attachments/assets/75d13667-5b79-4af9-867c-f0614a5207f8" />


# How

Move the `!` from inside the arbitrary-value bracket to Tailwind v4's trailing-suffix position, so `leading-[100!%]` becomes `leading-[100%]!` in `SidebarSingleEntry.tsx`, and `text-[90!%]` becomes `text-[90%]!` in `APISectionUtils.tsx` (renderDefaultValue) and `APISectionTypes.tsx`. The pre-v4 form was `!leading-[100%]` / `!text-[90%]`, and the migration in #43623 collapsed the prefix into the bracket value rather than emitting the new suffix syntax.

# Test Plan

Run a production build of the docs and confirm the three CSS optimizer warnings are gone. Open `/versions/latest/sdk/image/` and verify that the top sidebar link labels (Home, Guides, EAS, Reference, Learn) sit flush against their icons, and that the inline `<code>` next to "Default:" on props such as `priority` and `cachePolicy` renders visibly smaller than body text, both inside the Props table and the Types section.

Example:

<img width="2476" height="652" alt="CleanShot 2026-05-10 at 14 48 22@2x" src="https://github.com/user-attachments/assets/84f13d35-cea0-4b77-b78c-069bbe200479" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).