### PR TITLE
[docs] Fix code font size inside API reference tables

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -1035,7 +1035,7 @@ properties.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -1278,7 +1278,7 @@ properties.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -1721,7 +1721,7 @@ value depending on the state of the credential.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -1974,7 +1974,7 @@ refresh operation.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -2278,7 +2278,7 @@ sign-in operation.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -2605,7 +2605,7 @@ sign-out operation.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -3161,7 +3161,7 @@ for more details.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -3662,7 +3662,7 @@ may be
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -4284,7 +4284,7 @@ for more details.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -4616,7 +4616,7 @@ for more details.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -4968,7 +4968,7 @@ for more details.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -7310,7 +7310,7 @@ exports[`APISection expo-pedometer 1`] = `
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -7920,7 +7920,7 @@ available on this device.
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -8514,7 +8514,7 @@ After calling this function, the listener will no longer receive any events from
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"
@@ -8652,7 +8652,7 @@ After calling this function, the listener will no longer receive any events from
         class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden rounded-md border shadow-xs mx-4 mt-0.5"
       >
         <table
-          class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+          class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
         >
           <thead
             class="border-b-default bg-subtle border-b"
@@ -8923,7 +8923,7 @@ After calling this function, the listener will no longer receive any events from
       class="table-wrapper border-default mb-4 overflow-x-auto overflow-y-hidden shadow-xs mt-0.5 rounded-none border-0 border-t"
     >
       <table
-        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-inherit [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
+        class="text-default w-full rounded-none border-0 text-sm [&_p]:text-sm [&_li]:text-sm [&_span]:text-sm [&_code_span]:text-xs [&_strong]:text-sm [&_blockquote_div]:text-sm [&_blockquote_code]:px-1 [&_blockquote_code]:py-0"
       >
         <thead
           class="border-b-default bg-subtle border-b"

--- a/docs/ui/components/Table/Table.tsx
+++ b/docs/ui/components/Table/Table.tsx
@@ -29,7 +29,7 @@ export const Table = ({
         '[&_p]:text-sm',
         '[&_li]:text-sm',
         '[&_span]:text-sm',
-        '[&_code_span]:text-inherit',
+        '[&_code_span]:text-xs',
         '[&_strong]:text-sm',
         '[&_blockquote_div]:text-sm',
         '[&_blockquote_code]:px-1 [&_blockquote_code]:py-0',


### PR DESCRIPTION
# Why

Code blocks rendered inside API reference tables show their syntax-highlighted tokens at 14px while top-level code blocks on the same page render at 12px, producing visible size inconsistency. The mismatch is easiest to see on pages that mix top-level Examples (for example, `NativeTabs.Trigger.VectorIcon`) with in-table Examples (`SrcIcon`, `XcassetIcon`) on the same `expo-router/unstable-native-tabs` reference page.

<img width="2708" height="1706" alt="CleanShot 2026-05-04 at 22 33 59@2x" src="https://github.com/user-attachments/assets/71eee302-c649-4713-882a-ab659561aad9" />

<img width="2708" height="1268" alt="CleanShot 2026-05-04 at 22 33 57@2x" src="https://github.com/user-attachments/assets/05cf70ce-87dc-492c-b98c-69a2c4350b51" />

# How

The `Table` component in `ui/components/Table/Table.tsx` has `[&_span]:text-sm` to size prose spans inside cells, which also matches Prism's token spans inside `<code>` and inflates them to 14px. A companion rule `[&_code_span]:text-inherit` was meant to undo this, but Tailwind's `text-inherit` only resets `color`, not `font-size`. Replace it with `[&_code_span]:text-xs` so token spans render at the same 12px used by top-level code blocks.

# Test Plan

Open `/versions/latest/sdk/router/native-tabs/` and compare the Example block under `NativeTabs.Trigger.VectorIcon` with the Example blocks inside the `SrcIcon` and `XcassetIcon` interface tables: http://localhost:3002/versions/latest/sdk/router/native-tabs/#srcicon

**Preview**

<img width="2398" height="1652" alt="CleanShot 2026-05-10 at 15 21 31@2x" src="https://github.com/user-attachments/assets/d288b0f3-0eba-4993-8d76-bab5457fad0d" />

<img width="2288" height="1622" alt="CleanShot 2026-05-10 at 15 21 34@2x" src="https://github.com/user-attachments/assets/79dc3005-8786-47c5-a278-9c58e32d3411" />

<img width="2324" height="1148" alt="CleanShot 2026-05-10 at 15 21 38@2x" src="https://github.com/user-attachments/assets/2f8be485-8a07-4d9d-8aac-1a152c80dbe0" />


# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).