### PR TITLE
[docs] Animate App.js Conf banner mount and dismiss

### DIFF
--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -25,8 +25,12 @@ export function AppJSBanner() {
 
   useEffect(() => {
     if (isLoaded && isAppJSBannerVisible && showAppJSConfShoutout) {
-      const id = requestAnimationFrame(() => setIsOpen(true));
-      return () => cancelAnimationFrame(id);
+      const id = requestAnimationFrame(() => {
+        setIsOpen(true);
+      });
+      return () => {
+        cancelAnimationFrame(id);
+      };
     }
   }, [isLoaded, isAppJSBannerVisible, showAppJSConfShoutout]);
 

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -37,8 +37,8 @@ export function AppJSBanner() {
   return (
     <div
       className={mergeClasses(
-        'grid transition-[grid-template-rows,opacity] duration-300 ease-out motion-reduce:transition-none',
-        isOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+        'grid transition-[grid-template-rows,opacity] duration-[600ms] ease-out motion-reduce:transition-none',
+        isOpen ? 'grid-rows-[1fr] opacity-100 delay-500' : 'grid-rows-[0fr] opacity-0'
       )}
       onTransitionEnd={event => {
         if (event.propertyName === 'grid-template-rows' && !isOpen) {

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -10,6 +10,7 @@ import { AppJSIcon } from './AppJSIcon';
 
 export function AppJSBanner() {
   const [isLoaded, setIsLoaded] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const [isAppJSBannerVisible, setIsAppJSBannerVisible] = useLocalStorage<boolean>({
     name: '2026-appjs-banner',
     defaultValue: true,
@@ -22,55 +23,75 @@ export function AppJSBanner() {
     setIsLoaded(true);
   }, []);
 
-  if (!isAppJSBannerVisible || !showAppJSConfShoutout || !isLoaded) {
+  useEffect(() => {
+    if (isLoaded && isAppJSBannerVisible && showAppJSConfShoutout) {
+      const id = requestAnimationFrame(() => setIsOpen(true));
+      return () => cancelAnimationFrame(id);
+    }
+  }, [isLoaded, isAppJSBannerVisible, showAppJSConfShoutout]);
+
+  if (!isLoaded || !isAppJSBannerVisible || !showAppJSConfShoutout) {
     return null;
   }
 
   return (
     <div
       className={mergeClasses(
-        'relative mb-6 flex items-center justify-between gap-3 overflow-hidden rounded-lg px-6 py-4',
-        'bg-[#eef0ff] dark:bg-[#494CFC22]',
-        'border border-[#494CFC] dark:border-[#3133b0]',
-        'max-md-gutters:flex-wrap'
-      )}>
-      <div className="flex items-center gap-4">
-        <div className="max-sm-gutters:hidden relative z-10 p-2">
-          <div className="asset-sm-shadow absolute inset-0 rounded-md bg-[#494CFC]" />
-          <AppJSIcon className="icon-lg text-palette-white relative z-10" />
-        </div>
-        <div className="relative grid grid-cols-1">
-          <p className="text-base font-medium text-[#494CFC] dark:text-[#a0b9ff]">
-            App.js Conf 2026
-          </p>
-          <p className="text-sm text-[#494CFC] dark:text-[#a0b9ff]">
-            Join us at the biggest React Native & Expo-focused conference.
-          </p>
-        </div>
-      </div>
-      <div className="z-10 flex items-center gap-3">
-        <Button
-          size="xs"
-          href="https://appjs.co/"
-          openInNewTab
-          rightSlot={<ArrowUpRightIcon className="icon-xs text-palette-white opacity-75" />}
+        'grid transition-[grid-template-rows,opacity] duration-300 ease-out motion-reduce:transition-none',
+        isOpen ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+      )}
+      onTransitionEnd={event => {
+        if (event.propertyName === 'grid-template-rows' && !isOpen) {
+          setIsAppJSBannerVisible(false);
+        }
+      }}>
+      <div className="min-h-0 overflow-hidden">
+        <div
           className={mergeClasses(
-            'text-palette-white gap-1.5 border-[#494CFC] bg-[#494CFC] shadow-none',
-            'dark:hocus:border-[#23257b] dark:hocus:bg-[#23257b]',
-            'hocus:border-[#7189ff] hocus:bg-[#7189ff]'
+            'relative mb-6 flex items-center justify-between gap-3 overflow-hidden rounded-lg px-6 py-4',
+            'bg-[#eef0ff] dark:bg-[#494CFC22]',
+            'border border-[#494CFC] dark:border-[#3133b0]',
+            'max-md-gutters:flex-wrap'
           )}>
-          Learn More
-        </Button>
-        <Button
-          size="xs"
-          theme="tertiary"
-          aria-label="Dismiss banner"
-          onClick={() => {
-            setIsAppJSBannerVisible(false);
-          }}
-          className="text-palette-white hocus:bg-[#ccd8ff] dark:hocus:bg-[#23257b] bg-transparent shadow-none"
-          leftSlot={<XIcon className="text-[#494CFC]" />}
-        />
+          <div className="flex items-center gap-4">
+            <div className="max-sm-gutters:hidden relative z-10 p-2">
+              <div className="asset-sm-shadow absolute inset-0 rounded-md bg-[#494CFC]" />
+              <AppJSIcon className="icon-lg text-palette-white relative z-10" />
+            </div>
+            <div className="relative grid grid-cols-1">
+              <p className="text-base font-medium text-[#494CFC] dark:text-[#a0b9ff]">
+                App.js Conf 2026
+              </p>
+              <p className="text-sm text-[#494CFC] dark:text-[#a0b9ff]">
+                Join us at the biggest React Native & Expo-focused conference.
+              </p>
+            </div>
+          </div>
+          <div className="z-10 flex items-center gap-3">
+            <Button
+              size="xs"
+              href="https://appjs.co/"
+              openInNewTab
+              rightSlot={<ArrowUpRightIcon className="icon-xs text-palette-white opacity-75" />}
+              className={mergeClasses(
+                'text-palette-white gap-1.5 border-[#494CFC] bg-[#494CFC] shadow-none',
+                'dark:hocus:border-[#23257b] dark:hocus:bg-[#23257b]',
+                'hocus:border-[#7189ff] hocus:bg-[#7189ff]'
+              )}>
+              Learn More
+            </Button>
+            <Button
+              size="xs"
+              theme="tertiary"
+              aria-label="Dismiss banner"
+              onClick={() => {
+                setIsOpen(false);
+              }}
+              className="text-palette-white hocus:bg-[#ccd8ff] dark:hocus:bg-[#23257b] bg-transparent shadow-none"
+              leftSlot={<XIcon className="text-[#494CFC]" />}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/docs/ui/components/AppJSBanner/index.tsx
+++ b/docs/ui/components/AppJSBanner/index.tsx
@@ -37,8 +37,10 @@ export function AppJSBanner() {
   return (
     <div
       className={mergeClasses(
-        'grid transition-[grid-template-rows,opacity] duration-[600ms] ease-out motion-reduce:transition-none',
-        isOpen ? 'grid-rows-[1fr] opacity-100 delay-500' : 'grid-rows-[0fr] opacity-0'
+        'grid motion-reduce:transition-none',
+        isOpen
+          ? 'grid-rows-[1fr] opacity-100 [transition:grid-template-rows_350ms_ease-out_250ms,opacity_250ms_ease-out_600ms]'
+          : 'grid-rows-[0fr] opacity-0 transition-[grid-template-rows,opacity] duration-400 ease-out'
       )}
       onTransitionEnd={event => {
         if (event.propertyName === 'grid-template-rows' && !isOpen) {


### PR DESCRIPTION
# Why

The banner gates rendering on a post-hydration `localStorage` read, so it pops in late and instantly shoves the page down. Same on dismiss in reverse.

https://github.com/user-attachments/assets/c86e8d44-86ec-48aa-b8bf-6f08962b1770

# How

CSS `grid-template-rows: 0fr → 1fr` transition — pure CSS, no JS measurement.

- After hydration, render at `grid-rows-[0fr]`, flip to `1fr` on the next frame (`requestAnimationFrame`) so the browser actually interpolates.
- Inner `min-h-0 overflow-hidden` so the grid item collapses below content size; `mb-6` moves inside so the margin animates with the height.
- Entrance is sequenced: 250ms delay → 350ms height → 250ms opacity (starts at 600ms). Dismiss is 400ms simultaneous and `onTransitionEnd` commits the `localStorage` flag once the collapse finishes.
- `motion-reduce:transition-none` for `prefers-reduced-motion`.

# Test Plan

- Hard reload — banner expands smoothly, content fades in after the height settles.
- Click X — collapses smoothly, stays dismissed across reloads.
- Reduced motion — entrance and dismiss are instant.
- Light/dark themes and `max-md-gutters` / `max-sm-gutters` breakpoints.

https://github.com/user-attachments/assets/fc00b04b-ec42-4dbe-8816-23253661e0c4