### PR TITLE
[go] disable hbc

### DIFF
--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -30,7 +30,8 @@
           "EXPO_ROOT_DIR": "/Users/expo/workingdir/build",
           "SHARP_IGNORE_GLOBAL_LIBVIPS": "1",
           "EAS_BUILD_DISABLE_BUNDLE_JAVASCRIPT_STEP": "1",
-          "EAS_RESTORE_CACHE": "0"
+          "EAS_RESTORE_CACHE": "0",
+          "USE_CCACHE": "0"
         }
       }
     },

--- a/apps/eas-expo-go/eas.json
+++ b/apps/eas-expo-go/eas.json
@@ -17,7 +17,8 @@
           "EAS_DANGEROUS_OVERRIDE_ANDROID_APPLICATION_ID": "host.exp.exponent",
           "EXPO_ROOT_DIR": "/home/expo/workingdir/build",
           "SHARP_IGNORE_GLOBAL_LIBVIPS": "1",
-          "EAS_BUILD_DISABLE_BUNDLE_JAVASCRIPT_STEP": "1"
+          "EAS_BUILD_DISABLE_BUNDLE_JAVASCRIPT_STEP": "1",
+          "EAS_RESTORE_CACHE": "0"
         }
       },
       "ios": {
@@ -28,7 +29,8 @@
           "EAS_BUILD_PLATFORM": "ios",
           "EXPO_ROOT_DIR": "/Users/expo/workingdir/build",
           "SHARP_IGNORE_GLOBAL_LIBVIPS": "1",
-          "EAS_BUILD_DISABLE_BUNDLE_JAVASCRIPT_STEP": "1"
+          "EAS_BUILD_DISABLE_BUNDLE_JAVASCRIPT_STEP": "1",
+          "EAS_RESTORE_CACHE": "0"
         }
       }
     },

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -38,6 +38,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 import java.io.File
+import java.net.URI
 import javax.inject.Inject
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -259,7 +260,8 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
             // ReactAndroid will load the bundle on its own in development mode
             if (!manifest.isDevelopmentMode()) {
               val launchAssetFile = launcher.launchAssetFile!!
-              if (HermesBundleUtils.isHermesBundle(File(launchAssetFile))) {
+              val isEasUpdate = runCatching { URI(manifestUrl).host }.getOrNull() == "u.expo.dev"
+              if (!isEasUpdate && HermesBundleUtils.isHermesBundle(File(launchAssetFile))) {
                 val errorJson = JSONObject().apply {
                   put("errorCode", "EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED")
                   put("message", "Hermes bytecode bundle is not supported by Expo Go")

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -30,6 +30,7 @@ import host.exp.exponent.kernel.ExpoViewKernel
 import host.exp.exponent.kernel.Kernel
 import host.exp.exponent.kernel.KernelConfig
 import host.exp.exponent.storage.ExponentSharedPreferences
+import host.exp.exponent.utils.HermesBundleUtils
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -257,7 +258,15 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
 
             // ReactAndroid will load the bundle on its own in development mode
             if (!manifest.isDevelopmentMode()) {
-              callback.onBundleCompleted(launcher.launchAssetFile!!)
+              val launchAssetFile = launcher.launchAssetFile!!
+              if (HermesBundleUtils.isHermesBundle(File(launchAssetFile))) {
+                val errorJson = JSONObject().apply {
+                  put("errorCode", "EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED")
+                  put("message", "Hermes bytecode bundle is not supported by Expo Go")
+                }
+                throw ManifestException(null, manifestUrl, errorJson)
+              }
+              callback.onBundleCompleted(launchAssetFile)
             }
           } catch (e: Exception) {
             callback.onError(e)

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -37,6 +37,7 @@ class ManifestException : ExponentException {
           }
           "EXPERIENCE_SDK_VERSION_TOO_NEW" -> "Project is incompatible with this version of Expo Go"
           "SNACK_NOT_FOUND_FOR_SDK_VERSION" -> "This Snack is incompatible with this version of Expo Go"
+          "EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED" -> "Project is incompatible with Expo Go"
           else -> null
         }
       } catch (e: JSONException) {
@@ -114,6 +115,13 @@ class ManifestException : ExponentException {
             formattedMessage = "The experience you requested is not viewable by you."
             fixInstructions =
               "You need to log in. If the snack is still unavailable after logging in, ask the owner to grant you access."
+          }
+
+          "EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED" -> {
+            formattedMessage = "This project was published with a precompiled Hermes bytecode bundle. Expo Go runs plain JavaScript bundles, so it can't load this update."
+            fixInstructions =
+              "Open this project in a <a href='https://docs.expo.dev/develop/development-builds/introduction/'>development build</a> instead."
+            canRetry = false
           }
 
           "USER_SNACK_NOT_FOUND", "SNACK_NOT_FOUND" ->

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/exceptions/ManifestException.kt
@@ -120,7 +120,7 @@ class ManifestException : ExponentException {
           "EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED" -> {
             formattedMessage = "This project was published with a precompiled Hermes bytecode bundle. Expo Go runs plain JavaScript bundles, so it can't load this update."
             fixInstructions =
-              "Open this project in a <a href='https://docs.expo.dev/develop/development-builds/introduction/'>development build</a> instead."
+              "Open this project in a <a href='https://docs.expo.dev/develop/development-builds/introduction/'>development build</a> instead, or use <b>eas update --no-bytecode</b>."
             canRetry = false
           }
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -399,7 +399,7 @@ abstract class ReactNativeActivity :
           }
           KernelProvider.instance.handleError(ManifestException(null, capturedManifestUrl, errorJson))
         }
-      },
+      }
     )
     val hostWrapper = ReactNativeHostWrapper(application, nativeHost)
 

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/experience/ReactNativeActivity.kt
@@ -24,6 +24,7 @@ import com.facebook.react.ReactNativeHost
 import com.facebook.react.bridge.ReactContext.RCTDeviceEventEmitter
 import com.facebook.react.devsupport.DefaultDevLoadingViewImplementation
 import com.facebook.react.devsupport.DevInternalSettings
+import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.DoubleTapReloadRecognizer
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.interfaces.fabric.ReactSurface
@@ -38,6 +39,7 @@ import expo.modules.manifests.core.Manifest
 import host.exp.exponent.ExponentManifest
 import host.exp.exponent.analytics.EXL
 import host.exp.exponent.di.NativeModuleDepsProvider
+import host.exp.exponent.exceptions.ManifestException
 import host.exp.exponent.experience.BaseExperienceActivity.ExperienceContentLoaded
 import host.exp.exponent.experience.splashscreen.LoadingView
 import host.exp.exponent.factories.ReactHostFactory
@@ -62,6 +64,7 @@ import org.json.JSONObject
 import versioned.host.exp.exponent.ExpoNetworkInterceptor
 import versioned.host.exp.exponent.ExponentDevBundleDownloadListener
 import versioned.host.exp.exponent.ExponentPackage
+import java.io.File
 import java.util.LinkedList
 import java.util.Queue
 import javax.inject.Inject
@@ -381,7 +384,23 @@ abstract class ReactNativeActivity :
       instanceManagerBuilderProperties
     )
 
-    val devBundleDownloadListener = ExponentDevBundleDownloadListener(progressListener)
+    var devSupportManager: DevSupportManager? = null
+    val capturedManifestUrl = manifestUrl
+    val devBundleDownloadListener = ExponentDevBundleDownloadListener(
+      progressListener,
+      downloadedBundleFileProvider = {
+        (devSupportManager as? DevSupportManagerBase)?.downloadedJSBundleFile?.let(::File)
+      },
+      onHermesDetected = {
+        if (capturedManifestUrl != null) {
+          val errorJson = JSONObject().apply {
+            put("errorCode", "EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED")
+            put("message", "Hermes bytecode bundle is not supported by Expo Go")
+          }
+          KernelProvider.instance.handleError(ManifestException(null, capturedManifestUrl, errorJson))
+        }
+      },
+    )
     val hostWrapper = ReactNativeHostWrapper(application, nativeHost)
 
     if (delegate.isDebugModeEnabled) {
@@ -393,6 +412,7 @@ abstract class ReactNativeActivity :
     }
 
     val reactHost = ReactHostFactory.createFromReactNativeHost(this, hostWrapper, devBundleDownloadListener)
+    devSupportManager = reactHost.devSupportManager
     reactNativeHost = nativeHost
 
     val bundle = Bundle()

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/HermesBundleUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/HermesBundleUtils.kt
@@ -1,0 +1,26 @@
+// Copyright 2015-present 650 Industries. All rights reserved.
+package host.exp.exponent.utils
+
+import java.io.File
+import java.io.IOException
+
+object HermesBundleUtils {
+  // https://github.com/facebook/hermes/blob/ae8554141cd3d3f64eb98d70c97112fcc6143d34/include/hermes/BCGen/HBC/BytecodeFileFormat.h#L26-L27
+  private val HERMES_MAGIC_HEADER = byteArrayOf(
+    0xc6.toByte(), 0x1f.toByte(), 0xbc.toByte(), 0x03.toByte(),
+    0xc1.toByte(), 0x03.toByte(), 0x19.toByte(), 0x1f.toByte()
+  )
+
+  fun isHermesBundle(file: File): Boolean {
+    if (!file.exists() || file.length() < HERMES_MAGIC_HEADER.size) return false
+    return try {
+      file.inputStream().use { input ->
+        val bytes = ByteArray(HERMES_MAGIC_HEADER.size)
+        val read = input.read(bytes, 0, bytes.size)
+        read == HERMES_MAGIC_HEADER.size && bytes.contentEquals(HERMES_MAGIC_HEADER)
+      }
+    } catch (e: IOException) {
+      false
+    }
+  }
+}

--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/HermesBundleUtils.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/utils/HermesBundleUtils.kt
@@ -7,8 +7,14 @@ import java.io.IOException
 object HermesBundleUtils {
   // https://github.com/facebook/hermes/blob/ae8554141cd3d3f64eb98d70c97112fcc6143d34/include/hermes/BCGen/HBC/BytecodeFileFormat.h#L26-L27
   private val HERMES_MAGIC_HEADER = byteArrayOf(
-    0xc6.toByte(), 0x1f.toByte(), 0xbc.toByte(), 0x03.toByte(),
-    0xc1.toByte(), 0x03.toByte(), 0x19.toByte(), 0x1f.toByte()
+    0xc6.toByte(),
+    0x1f.toByte(),
+    0xbc.toByte(),
+    0x03.toByte(),
+    0xc1.toByte(),
+    0x03.toByte(),
+    0x19.toByte(),
+    0x1f.toByte()
   )
 
   fun isHermesBundle(file: File): Boolean {

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentDevBundleDownloadListener.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentDevBundleDownloadListener.kt
@@ -14,7 +14,7 @@ import kotlin.Exception
 class ExponentDevBundleDownloadListener(
   private val listener: DevBundleDownloadProgressListener,
   private val downloadedBundleFileProvider: (() -> File?)? = null,
-  private val onHermesDetected: ((Exception) -> Unit)? = null,
+  private val onHermesDetected: ((Exception) -> Unit)? = null
 ) : DevBundleDownloadListener {
   override fun onSuccess() {
     val bundleFile = downloadedBundleFileProvider?.invoke()

--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentDevBundleDownloadListener.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/ExponentDevBundleDownloadListener.kt
@@ -2,15 +2,28 @@ package versioned.host.exp.exponent
 
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import host.exp.exponent.experience.DevBundleDownloadProgressListener
+import host.exp.exponent.utils.HermesBundleUtils
+import java.io.File
 import kotlin.Exception
 
 /**
  * Acts as a bridge between the versioned DevBundleDownloadListener and unversioned
- * DevBundleDownloadProgressListener
+ * DevBundleDownloadProgressListener. Optionally sniffs the downloaded bundle for the
+ * Hermes magic header and fails instead of succeeding when matched.
  */
-class ExponentDevBundleDownloadListener(private val listener: DevBundleDownloadProgressListener) :
-  DevBundleDownloadListener {
+class ExponentDevBundleDownloadListener(
+  private val listener: DevBundleDownloadProgressListener,
+  private val downloadedBundleFileProvider: (() -> File?)? = null,
+  private val onHermesDetected: ((Exception) -> Unit)? = null,
+) : DevBundleDownloadListener {
   override fun onSuccess() {
+    val bundleFile = downloadedBundleFileProvider?.invoke()
+    if (bundleFile != null && HermesBundleUtils.isHermesBundle(bundleFile)) {
+      val error = Exception("hermes bytecode bundle is not supported by expo-go")
+      onHermesDetected?.invoke(error)
+      listener.onFailure(error)
+      return
+    }
     listener.onSuccess()
   }
 

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.h
@@ -7,6 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString * const EXRuntimeErrorDomain;
 extern NSString * const EXFixInstructionsKey;
 extern NSString * const EXShowTryAgainButtonKey;
 

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -344,7 +344,7 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
     showTryAgainButton = false;
   } else if ([errorCode isEqualToString:@"EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED"]) {
     formattedMessage = @"This project was published with a precompiled Hermes bytecode bundle. Expo Go runs plain JavaScript bundles, so it can't load this update.";
-    fixInstructions = @"Open this project in a [development build](https://docs.expo.dev/develop/development-builds/introduction/) instead.";
+    fixInstructions = @"Open this project in a [development build](https://docs.expo.dev/develop/development-builds/introduction/) instead, or use **eas update --no-bytecode**.";
     showTryAgainButton = false;
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){
     formattedMessage = rawMessage; // No compatible experience found at ${originalUrl}. Only ${currentSdkVersions} are supported.

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/CachedResource/EXManifestResource.m
@@ -342,6 +342,10 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
     formattedMessage = @"The project you requested requires a newer version of Expo Go.";
     fixInstructions = @"Download the latest version of Expo Go from the App Store.";
     showTryAgainButton = false;
+  } else if ([errorCode isEqualToString:@"EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED"]) {
+    formattedMessage = @"This project was published with a precompiled Hermes bytecode bundle. Expo Go runs plain JavaScript bundles, so it can't load this update.";
+    fixInstructions = @"Open this project in a [development build](https://docs.expo.dev/develop/development-builds/introduction/) instead.";
+    showTryAgainButton = false;
   } else if ([errorCode isEqualToString:@"NO_COMPATIBLE_EXPERIENCE_FOUND"]){
     formattedMessage = rawMessage; // No compatible experience found at ${originalUrl}. Only ${currentSdkVersions} are supported.
   } else if ([errorCode isEqualToString:@"EXPERIENCE_NOT_VIEWABLE"]) {
@@ -391,6 +395,8 @@ NSString * const EXShowTryAgainButtonKey = @"showTryAgainButton";
     return @"Project is incompatible with this version of Expo Go";
   } else if ([errorCode isEqualToString:@"SNACK_NOT_FOUND_FOR_SDK_VERSION"]) {
     return @"This Snack is incompatible with this version of Expo Go";
+  } else if ([errorCode isEqualToString:@"EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED"]) {
+    return @"Project is incompatible with Expo Go";
   }
   return nil;
 }

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -259,7 +259,8 @@ NS_ASSUME_NONNULL_BEGIN
     return;
   }
   _bundle = [NSData dataWithContentsOfURL:launcher.launchAssetUrl];
-  if ([EXAppLoaderExpoUpdates isHermesBundle:_bundle]) {
+  BOOL isEasUpdate = [_httpManifestUrl.host isEqualToString:@"u.expo.dev"];
+  if (!isEasUpdate && [EXAppLoaderExpoUpdates isHermesBundle:_bundle]) {
     EXManifestResource *manifestResource = [[EXManifestResource alloc] initWithManifestUrl:_httpManifestUrl originalUrl:_manifestUrl];
     _error = [manifestResource formatError:[NSError errorWithDomain:EXRuntimeErrorDomain code:0 userInfo:@{
       @"errorCode": @"EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED",

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -259,6 +259,16 @@ NS_ASSUME_NONNULL_BEGIN
     return;
   }
   _bundle = [NSData dataWithContentsOfURL:launcher.launchAssetUrl];
+  if ([EXAppLoaderExpoUpdates isHermesBundle:_bundle]) {
+    EXManifestResource *manifestResource = [[EXManifestResource alloc] initWithManifestUrl:_httpManifestUrl originalUrl:_manifestUrl];
+    _error = [manifestResource formatError:[NSError errorWithDomain:EXRuntimeErrorDomain code:0 userInfo:@{
+      @"errorCode": @"EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED",
+    }]];
+    if (self.delegate) {
+      [self.delegate appLoader:self didFailWithError:_error];
+    }
+    return;
+  }
   _appLauncher = launcher;
   if (self.delegate) {
     [self.delegate appLoader:self didFinishLoadingManifest:_confirmedManifest bundle:_bundle];
@@ -295,6 +305,16 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)appLoaderTaskDidFinishAllLoading:(EXUpdatesAppLoaderTask *)appLoaderTask {}
 
 #pragma mark - internal
+
++ (BOOL)isHermesBundle:(NSData *)bundle
+{
+  // https://github.com/facebook/hermes/blob/ae8554141cd3d3f64eb98d70c97112fcc6143d34/include/hermes/BCGen/HBC/BytecodeFileFormat.h#L26-L27
+  static const uint8_t kHermesMagic[] = { 0xc6, 0x1f, 0xbc, 0x03, 0xc1, 0x03, 0x19, 0x1f };
+  if (bundle.length < sizeof(kHermesMagic)) {
+    return NO;
+  }
+  return memcmp(bundle.bytes, kHermesMagic, sizeof(kHermesMagic)) == 0;
+}
 
 + (NSURL *)_httpUrlFromManifestUrl:(NSURL *)url
 {
@@ -475,6 +495,18 @@ NS_ASSUME_NONNULL_BEGIN
       [self.delegate appLoader:self didLoadBundleWithProgress:progress];
     }
   } success:^(NSData *bundle) {
+    if ([EXAppLoaderExpoUpdates isHermesBundle:bundle]) {
+      EXManifestResource *manifestResource = [[EXManifestResource alloc] initWithManifestUrl:self.httpManifestUrl originalUrl:self.manifestUrl];
+      NSError *hermesError = [manifestResource formatError:[NSError errorWithDomain:EXRuntimeErrorDomain code:0 userInfo:@{
+        @"errorCode": @"EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED",
+      }]];
+      self.error = hermesError;
+      self.isLoadingDevelopmentJavaScriptResource = NO;
+      if (self.delegate) {
+        [self.delegate appLoader:self didFailWithError:hermesError];
+      }
+      return;
+    }
     self.isUpToDate = YES;
     self.bundle = bundle;
     self.isLoadingDevelopmentJavaScriptResource = NO;


### PR DESCRIPTION
# Why

disable hbc from expo-go

# How

- check hbc header and show error
- there're two different call paths: one from expo-updates and the other from dev bundle loading. these two paths are both disabled

# Test Plan

<img width="60%" src="https://github.com/user-attachments/assets/a9a9583a-77a0-43d5-9902-1b1d1cfd1566" />

<img width="60%" src="https://github.com/user-attachments/assets/0ded6a1b-0019-4b2f-9c5b-a196a4fbd9a4" />

- ✅ load sdk54 dev bundle - plain text js
- ✅ load hbc on u.expo.dev ios `xcrun simctl openurl booted 'exp://u.expo.dev/26e17874-0a0b-4338-81e2-de2a3c9e53b1/group/0f857e97-5c89-4981-b899-c6ebdf7857d3'`
- ✅ load hbc on u.expo.dev android `adb shell am start -a android.intent.action.VIEW -d 'exp://u.expo.dev/26e17874-0a0b-4338-81e2-de2a3c9e53b1/group/0f857e97-5c89-4981-b899-c6ebdf7857d3'`
- serve hbc from local dev server (which is not supported by dev-server but i would further disable the case in case people build their custom http server).
  - ✅ should show error from `xcrun simctl openurl booted 'exp://192.168.1.2:3000'`
  - ✅ should show error from `adb shell am start -a android.intent.action.VIEW -d 'exp://192.168.1.2:3000'`
  -
  <details>
  <summary>server.ts and run `DEV=1 bun run server.ts`</summary>

  ```ts
  import { readFileSync } from 'fs';
  import { randomUUID } from 'crypto';
  
  const HBC = readFileSync('./bundle.hbc');
  const HOST = process.env.HOST ?? '192.168.50.144';
  const PORT = Number(process.env.PORT ?? 3000);
  
  // Toggle to flip prod ↔ dev path:
  //   DEV=1 → dev manifest (currently bypasses the Hermes check)
  //   (default) → production manifest (current Hermes check should fire)
  const isDev = process.env.DEV === '1';
  
  // Build a fresh manifest per request so (scope_key, commit_time) never collides
  // in Expo Go's SQLite update cache across repeated test runs.
  function buildManifest() {
    const manifestId = randomUUID();
    return {
      id: manifestId,
      createdAt: new Date().toISOString(),
      runtimeVersion: 'exposdk:54.0.0',
      launchAsset: {
        key: 'bundle-' + manifestId,
        contentType: 'application/javascript',
        url: `http://${HOST}:${PORT}/index.hbc`,
      },
      assets: [],
      metadata: {},
      extra: {
        scopeKey: '@anonymous/hermes-repro',
        expoClient: {
          name: 'hermes-repro',
          slug: 'hermes-repro',
          version: '1.0.0',
          sdkVersion: '54.0.0',
          platforms: ['ios', 'android'],
          // expo-linking's resolveScheme() throws in non-dev bundles when no scheme is defined.
          // Set one so manifestSchemes.length > 0 and the throw branch is skipped.
          scheme: 'hermesrepro',
        },
        // `developer`, `packagerOpts`, and `debuggerHost` live under `extra.expoGo`
        // for ExpoUpdatesManifest — that's where Manifest.isUsingDeveloperTool(),
        // isDevelopmentMode(), and Android's testPackagerStatus read from.
        ...(isDev
          ? {
              expoGo: {
                developer: { tool: 'expo-cli' },
                packagerOpts: { dev: true },
                debuggerHost: `${HOST}:${PORT}`,
                mainModuleName: 'index',
              },
            }
          : {}),
      },
    };
  }
  
  function multipartManifest(): { body: Buffer; contentType: string } {
    const boundary = '----expo-go-repro-' + Date.now();
    const part = [
      `--${boundary}`,
      'Content-Disposition: form-data; name="manifest"',
      'Content-Type: application/json',
      '',
      JSON.stringify(buildManifest()),
      `--${boundary}--`,
      '',
    ].join('\r\n');
    return {
      body: Buffer.from(part, 'utf-8'),
      contentType: `multipart/mixed; boundary=${boundary}`,
    };
  }
  
  Bun.serve({
    port: PORT,
    hostname: '0.0.0.0',
    fetch(req) {
      const url = new URL(req.url);
      console.log(`${req.method} ${url.pathname}`);
  
      // Expo Go (Android) pings this to confirm the dev "packager" is alive.
      // The body must contain the literal string "running".
      if (url.pathname === '/status') {
        return new Response('packager-status:running', {
          headers: { 'Content-Type': 'text/plain' },
        });
      }
  
      if (url.pathname === '/index.hbc') {
        return new Response(HBC, {
          headers: { 'Content-Type': 'application/javascript' },
        });
      }
  
      const { body, contentType } = multipartManifest();
      return new Response(body, {
        headers: {
          'Content-Type': contentType,
          'expo-protocol-version': '0',
          'expo-sfv-version': '0',
        },
      });
    },
  });
  
  console.log(`Serving manifest at http://${HOST}:${PORT}`);
  console.log(`Open in Expo Go:  exp://${HOST}:${PORT}`);
  console.log(`Mode: ${isDev ? 'DEV (bypasses Hermes check)' : 'PROD (Hermes check should fire)'}`);
  ```

  </details>

- serve hbc from local update server. tested with `DEV=0 bun run server.ts`
  - ✅ should show error from `xcrun simctl openurl booted 'exp://192.168.1.2:3000'`
  - ✅ should show error from `adb shell am start -a android.intent.action.VIEW -d 'exp://192.168.1.2:3000'`

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
