### PR TITLE
fix(metro-config): widen postcss range to ^8.4.32 (CVE-2026-41305)

### DIFF
--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -79,7 +79,7 @@
     "jsc-safe-url": "^0.2.4",
     "lightningcss": "^1.30.1",
     "picomatch": "^4.0.3",
-    "postcss": "~8.4.32",
+    "postcss": "^8.4.32",
     "resolve-from": "^5.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
## Why

`@expo/metro-config` currently pins postcss to `~8.4.32`, which resolves to `>=8.4.32 <8.5.0`. Versions of postcss before 8.5.10 are vulnerable to [CVE-2026-41305 / GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) - XSS via unescaped `</style>` in CSS stringify output.

This change widens the range to `^8.4.32`, which:

1. Allows the CVE-patched 8.5.x line to resolve
2. Matches the caret-range convention used by every other dependency in the same file (`lightningcss: ^1.30.1`, `picomatch: ^4.0.3`, `jsc-safe-url: ^0.2.4`, etc.)
3. Eliminates the need for downstream `npm overrides` workarounds

Closes #45620.

## Relationship to #45076

Dependabot's #45076 proposed `~8.4.32` -> `~8.5.10` (still narrow tilde). It has been open 17 days with the lockfile update blocked by a Dependabot/pnpm tooling issue.

This PR uses a caret range instead because:

- It aligns with the rest of the file's dependency conventions
- It avoids needing another version-bump PR the next time postcss ships a patch

If maintainers prefer the tilde approach, happy to revise to match #45076's range.

## Lockfile

`pnpm-lock.yaml` is **not** updated in this PR. Regenerating the lockfile requires running `pnpm install` against the full workspace, which I am not set up to do cleanly outside Expo's environment (see #45076 for the same constraint Dependabot hit). Please regenerate locally before merging, or apply the same lockfile workflow used for #45076.

## Test plan

- [ ] `pnpm install` resolves postcss to a 8.5.x version without warnings
- [ ] `npm audit` no longer reports the GHSA-qx2v-qp2m-jg93 advisory in a fresh `create-expo-app` project
- [ ] Existing CSS pipeline tests in `packages/@expo/metro-config` still pass