### PR TITLE
[expo-router] replace jest image mapper with transform

### DIFF
--- a/packages/expo-router/__mocks__/imageMock.js
+++ b/packages/expo-router/__mocks__/imageMock.js
@@ -1,2 +1,0 @@
-// Jest mock for image/file imports (png, jpg, etc.)
-module.exports = 1;

--- a/packages/expo-router/__mocks__/imageTransformer.js
+++ b/packages/expo-router/__mocks__/imageTransformer.js
@@ -1,0 +1,9 @@
+// Jest transformer for image assets. Jest's resolver runs first, so a broken
+// relative path fails with "Cannot find module ..." before this transformer is
+// invoked — that's the regression guard against bugs like #45170. When the
+// file exists, return a numeric stub like Metro does.
+module.exports = {
+  process() {
+    return { code: 'module.exports = 1;' };
+  },
+};

--- a/packages/expo-router/jest.config.js
+++ b/packages/expo-router/jest.config.js
@@ -20,8 +20,10 @@ function withDefaults({ watchPlugins, ...config }) {
       '^.+\\.module\\.css$': '<rootDir>/__mocks__/styleMock.js',
       // Plain CSS (and other style files) can be stubbed with an empty object.
       '^.+\\.(css|less|sass|scss)$': '<rootDir>/__mocks__/styleMock.js',
-      // Image assets: stub with a simple numeric value (like Metro does).
-      '^.+\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/__mocks__/imageMock.js',
+    },
+    transform: {
+      ...(config.transform || {}),
+      '^.+\\.(png|jpg|jpeg|gif|svg)$': '<rootDir>/__mocks__/imageTransformer.js',
     },
   };
 }


### PR DESCRIPTION
# Why

In order to avoid regressions similar to https://github.com/expo/expo/issues/45532, I propose that instead of mocking image assets in router, we transform them to simple number export. This way if the asset is removed or file is moved, we will see the regression while running unit tests.

# How

Replace `packages/expo-router/__mocks__/imageMock.js` with `packages/expo-router/__mocks__/imageTransformer.js`

# Test Plan

CI (it will fail until https://github.com/expo/expo/pull/45170#pullrequestreview-4261833066 is not merged)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
