### PR TITLE
[docs] Add react-navigation migration callout to router reference page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/router/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/router/index.mdx
@@ -23,6 +23,8 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
   Icon={BookOpen02Icon}
 />
 
+> **Important** In **SDK 56 and later**, Expo Router no longer supports importing from external `@react-navigation/*` packages in application code. Repoint those imports to the matching `expo-router` entry points. Run the [codemod](/router/migrate/sdk-55-to-56#automated-migration) or follow the [SDK 55 to 56 migration guide](/router/migrate/sdk-55-to-56) to update your project.
+
 ## Installation
 
 To use Expo Router in your project, you need to install. Follow the instructions from the Expo Router's installation guide:

--- a/docs/pages/versions/v56.0.0/sdk/router/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/router/index.mdx
@@ -23,6 +23,8 @@ import { ConfigPluginExample, ConfigPluginProperties } from '~/ui/components/Con
   Icon={BookOpen02Icon}
 />
 
+> **Important** In **SDK 56 and later**, Expo Router no longer supports importing from external `@react-navigation/*` packages in application code. Repoint those imports to the matching `expo-router` entry points. Run the [codemod](/router/migrate/sdk-55-to-56#automated-migration) or follow the [SDK 55 to 56 migration guide](/router/migrate/sdk-55-to-56) to update your project.
+
 ## Installation
 
 To use Expo Router in your project, you need to install. Follow the instructions from the Expo Router's installation guide:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
