### PR TITLE
[expo-go] Set constants to `EXConstantsBinding`

### DIFF
--- a/apps/expo-go/ios/Exponent-Bridging-Header.h
+++ b/apps/expo-go/ios/Exponent-Bridging-Header.h
@@ -30,3 +30,4 @@
 #import "EXReactAppManager.h"
 #import "EXAbstractLoader.h"
 #import "EXProgressHUD.h"
+#import "EXConstantsBinding.h"

--- a/apps/expo-go/ios/Exponent/Versioned/Core/VersionManager.swift
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/VersionManager.swift
@@ -62,6 +62,13 @@ final class VersionManager: EXVersionManagerObjC {
     self.appContext = appContext
     self.legacyModuleRegistry = legacyModuleRegistry
 
+    // The ConstantsProvider hardcodes `executionEnvironment ti "bare"` and reads `manifest` from
+    // EXConstants.bundle. In Expo Go we need `executionEnvironment to be
+    // "storeClient". EXConstantsBinding merges them on top of the
+    // base constants, so installing it here makes `Constants.expoConfig`,
+    // `Constants.executionEnvironment` resolve correctly.
+    appContext.constants = EXConstantsBinding(params: params)
+
     registerExpoModules(appContext)
     hasRegisteredExpoModules = true
 


### PR DESCRIPTION
# Why
Supersedes #45583
https://exponent-internal.slack.com/archives/C09AL5M1RU5/p1778275370578929

Regression from #41339. We moved `EXConstantsService` into expo-modules-core and changed `AppContext.constants` from `legacyModule(implementing: EXConstantsInterface.self)` to a hardcoded `ConstantsProvider.shared` default. Expo Go relied on the legacy-registry lookup for  its own `EXConstantsBinding`, which merges `_unversionedConstants` on top of the base constants. The shared provider unconditionally returns `bare` as the `executionEnvironment`.


# How
In `getOrCreateAppContext()`, install `EXConstantsBinding(params: params)` as `appContext.constants`. 

# Test Plan
Used Evans repro steps from #45583, using a forced delay in `appLoaderTask:didFinishWithLauncher:`. After the fix, constants are loaded correctly. I also logged them to check the expected values
```json
{
  "executionEnvironment": "storeClient", // was "bare" before fix
  "appOwnership": "expo",
  "expoConfig_scheme": "ncl", // the loaded app's scheme, not Expo Go's
  "expoConfig_slug": "native-component-list",
  "ExpoUpdates_manifest_present": true,
}
```
