### PR TITLE
[expo][Android] Suppress `DelicateCoroutinesApi` warning in `ExpoModulesPackageList`

### DIFF
--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -44,7 +44,6 @@ import okhttp3.OkHttpClient
 import java.io.File
 import java.util.concurrent.ConcurrentHashMap
 
-@DelicateCoroutinesApi
 @androidx.annotation.OptIn(androidx.media3.common.util.UnstableApi::class)
 class AudioModule : Module() {
   private lateinit var audioManager: AudioManager
@@ -200,6 +199,7 @@ class AudioModule : Module() {
     focusAcquired = false
   }
 
+  @OptIn(DelicateCoroutinesApi::class)
   override fun definition() = ModuleDefinition {
     Name("ExpoAudio")
 


### PR DESCRIPTION
# Why

Suppresses `DelicateCoroutinesApi` warning in the `ExpoModulesPackageList`.
Instead of forcing consumers of `AudioModule` to opt into DelicateCoroutinesApi, I've made the `AudioModule` opt in.

# Test Plan

- bare-expo ✅ 