### PR TITLE
[JSI][core] Fix launch crash with source-built RN

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -564,11 +564,9 @@ PODS:
     - Yoga
   - ExpoModulesJSI (56.0.2):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
   - ExpoModulesJSI/Tests (56.0.2):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
   - ExpoModulesTestCore (56.0.0):
     - ExpoModulesCore
@@ -4019,7 +4017,7 @@ SPEC CHECKSUMS:
   ExpoMediaLibrary: ee2d74d5e52154305b8229dcb5c4319c84f30311
   ExpoMeshGradient: baf62012104fd9c1719de67f88c69958abcd2ed1
   ExpoModulesCore: 5bca19db7db63ab6b60af8b6853f05e7d41fda4c
-  ExpoModulesJSI: 7312f97b995c769bbfa60182be4dc47814a0a59c
+  ExpoModulesJSI: 0740aeb1d9d2d3a7e4cd3368b09835d59cba0eb6
   ExpoModulesTestCore: 5660ab6b5928747366d4946580622a578865696a
   ExpoModulesWorklets: f6674212fdcd312c11642b1e51b9433ab1940a2f
   ExpoModulesWorkletsAdapter: 23fa6f8b59e1096e35849bf4f13210640b896822

--- a/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/AppInstance/ExpoGoReactNativeFactory.mm
@@ -4,7 +4,9 @@
 #import <RCTAppSetupUtils.h>
 #import <React/CoreModulesPlugins.h>
 #import <ExpoModulesCore/EXHostWrapper.h>
+#import <ExpoModulesCore/EXReactSchedulerDispatch.h>
 #import <ExpoModulesCore-Swift.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
 
 
 @implementation ExpoGoReactNativeFactory
@@ -49,8 +51,14 @@
   ExpoAppInstance *appInstance = (ExpoAppInstance *)self.delegate;
   EXAppContext *appContext = [appInstance createExpoGoAppContext];
 
-  // Inject and decorate the `global.expo` object
-  [appContext setRuntime:&runtime];
+  // See ExpoReactNativeFactory.mm for the rationale behind passing the React
+  // runtime scheduler + dispatch trampoline alongside the runtime pointer.
+  auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(runtime);
+  auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
+
+  [appContext setRuntime:&runtime
+               scheduler:scheduler.get()
+                dispatch:scheduler ? reinterpret_cast<const void *>(&expo::dispatchOnReactScheduler) : nullptr];
   [appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
 
   [appContext registerNativeModules];

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -249,11 +249,9 @@ PODS:
     - Yoga
   - ExpoModulesJSI (56.0.2):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
   - ExpoModulesJSI/Tests (56.0.2):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
   - ExpoModulesTestCore (56.0.0):
     - ExpoModulesCore
@@ -4682,7 +4680,7 @@ SPEC CHECKSUMS:
   ExpoMailComposer: e202b670f62063851ed74c964034037312d523a8
   ExpoMediaLibrary: ee2d74d5e52154305b8229dcb5c4319c84f30311
   ExpoModulesCore: 2a0440b73015179c83c0bd92e2ffdf8decb41c00
-  ExpoModulesJSI: 7312f97b995c769bbfa60182be4dc47814a0a59c
+  ExpoModulesJSI: 0740aeb1d9d2d3a7e4cd3368b09835d59cba0eb6
   ExpoModulesTestCore: 5660ab6b5928747366d4946580622a578865696a
   ExpoModulesWorklets: f6674212fdcd312c11642b1e51b9433ab1940a2f
   ExpoModulesWorkletsAdapter: 23fa6f8b59e1096e35849bf4f13210640b896822

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [iOS] `AppContext.setRuntime` now takes the native React `RuntimeScheduler` pointer and a dispatch trampoline alongside the runtime pointer. ([#45636](https://github.com/expo/expo/pull/45636) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -4,13 +4,13 @@
 
 ### 🛠 Breaking changes
 
-- [iOS] `AppContext.setRuntime` now takes the native React `RuntimeScheduler` pointer and a dispatch trampoline alongside the runtime pointer. ([#45636](https://github.com/expo/expo/pull/45636) by [@tsapeta](https://github.com/tsapeta))
-
 ### 🎉 New features
 
 ### 🐛 Bug fixes
 
 ### 💡 Others
+
+- [iOS] `AppContext.setRuntime` now takes the native React `RuntimeScheduler` pointer and a dispatch trampoline alongside the runtime pointer. ([#45636](https://github.com/expo/expo/pull/45636) by [@tsapeta](https://github.com/tsapeta))
 
 ## 56.0.5 — 2026-05-08
 

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -429,12 +429,26 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
   // MARK: - Runtime
 
   /**
-   Sets the JavaScript runtime from a raw pointer to a `facebook::jsi::Runtime` instance.
-   Called from ObjC++ (e.g. `ExpoReactNativeFactory`) when React Native initializes the runtime.
+   Sets the JavaScript runtime from raw pointers. Called by `ExpoReactNativeFactory`
+   when React Native initializes the runtime. The native scheduler reference and
+   dispatch trampoline are required so `JavaScriptRuntime.schedule(...)` /
+   `.execute(...)` can dispatch onto the JS thread.
+
+   `dispatch` is a raw pointer to a C function with signature
+   `void (*)(void *scheduler, int priority, void (^callback)())` — cast back
+   to the typed pointer inside `ExpoModulesJSI`.
    */
   @objc
-  public func setRuntime(_ runtimePointer: UnsafeMutableRawPointer) {
-    _runtime = ExpoRuntime(unsafePointer: runtimePointer)
+  public func setRuntime(
+    _ runtimePointer: UnsafeMutableRawPointer,
+    nativeScheduler: UnsafeMutableRawPointer,
+    dispatch: UnsafeRawPointer
+  ) {
+    _runtime = ExpoRuntime(
+      unsafePointer: runtimePointer,
+      nativeScheduler: nativeScheduler,
+      dispatch: dispatch
+    )
   }
 
   @JavaScriptActor

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -430,25 +430,33 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
 
   /**
    Sets the JavaScript runtime from raw pointers. Called by `ExpoReactNativeFactory`
-   when React Native initializes the runtime. The native scheduler reference and
-   dispatch trampoline are required so `JavaScriptRuntime.schedule(...)` /
-   `.execute(...)` can dispatch onto the JS thread.
+   when React Native initializes the runtime. When `nativeScheduler` and `dispatch`
+   are both provided, `JavaScriptRuntime.schedule(...)` / `.execute(...)` dispatch
+   onto the JS thread through them. When either is `nil`, the runtime falls back
+   to a synchronous no-op scheduler — callers can detect this via
+   `JavaScriptRuntime.supportsAsyncScheduling`.
 
    `dispatch` is a raw pointer to a C function with signature
    `void (*)(void *scheduler, int priority, void (^callback)())` — cast back
-   to the typed pointer inside `ExpoModulesJSI`.
+   to the typed pointer inside `ExpoModulesJSI`. It's typed as `UnsafeRawPointer`
+   here rather than `@convention(c)` so the symbol can cross the Objective-C
+   bridge without needing a Swift-typed entry point.
    */
   @objc
   public func setRuntime(
     _ runtimePointer: UnsafeMutableRawPointer,
-    nativeScheduler: UnsafeMutableRawPointer,
-    dispatch: UnsafeRawPointer
+    nativeScheduler: UnsafeMutableRawPointer?,
+    dispatch: UnsafeRawPointer?
   ) {
-    _runtime = ExpoRuntime(
-      unsafePointer: runtimePointer,
-      nativeScheduler: nativeScheduler,
-      dispatch: dispatch
-    )
+    if let nativeScheduler, let dispatch {
+      _runtime = ExpoRuntime(
+        unsafePointer: runtimePointer,
+        nativeScheduler: nativeScheduler,
+        dispatch: dispatch
+      )
+    } else {
+      _runtime = ExpoRuntime(unsafePointer: runtimePointer)
+    }
   }
 
   @JavaScriptActor

--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -430,7 +430,7 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
 
   /**
    Sets the JavaScript runtime from raw pointers. Called by `ExpoReactNativeFactory`
-   when React Native initializes the runtime. When `nativeScheduler` and `dispatch`
+   when React Native initializes the runtime. When `scheduler` and `dispatch`
    are both provided, `JavaScriptRuntime.schedule(...)` / `.execute(...)` dispatch
    onto the JS thread through them. When either is `nil`, the runtime falls back
    to a synchronous no-op scheduler — callers can detect this via
@@ -445,13 +445,13 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
   @objc
   public func setRuntime(
     _ runtimePointer: UnsafeMutableRawPointer,
-    nativeScheduler: UnsafeMutableRawPointer?,
+    scheduler: UnsafeMutableRawPointer?,
     dispatch: UnsafeRawPointer?
   ) {
-    if let nativeScheduler, let dispatch {
+    if let scheduler, let dispatch {
       _runtime = ExpoRuntime(
         unsafePointer: runtimePointer,
-        nativeScheduler: nativeScheduler,
+        scheduler: scheduler,
         dispatch: dispatch
       )
     } else {

--- a/packages/expo-modules-core/ios/JS/EXReactSchedulerDispatch.h
+++ b/packages/expo-modules-core/ios/JS/EXReactSchedulerDispatch.h
@@ -4,6 +4,8 @@
 
 #ifdef __cplusplus
 
+namespace expo {
+
 /**
  Trampoline that `ExpoModulesJSI` calls to dispatch work onto the JS thread.
  Casts the `nativeScheduler` pointer back to a `react::RuntimeScheduler *` and
@@ -19,8 +21,6 @@
  pass `&expo::dispatchOnReactScheduler` as the `dispatch` argument to
  `AppContext.setRuntime`.
  */
-namespace expo {
-
 void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callback)()) noexcept;
 
 } // namespace expo

--- a/packages/expo-modules-core/ios/JS/EXReactSchedulerDispatch.h
+++ b/packages/expo-modules-core/ios/JS/EXReactSchedulerDispatch.h
@@ -1,0 +1,28 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#ifdef __cplusplus
+
+/**
+ Trampoline that `ExpoModulesJSI` calls to dispatch work onto the JS thread.
+ Casts the `nativeScheduler` pointer back to a `react::RuntimeScheduler *` and
+ calls `scheduleTask` on it. The signature matches `expo::RuntimeScheduler::ScheduleFn`
+ declared in the xcframework's `RuntimeScheduler.h`.
+
+ Lives in ExpoModulesCore (rather than in the xcframework) so that
+ ExpoModulesJSI.framework's prebuilt binary doesn't need to link against
+ React-runtimescheduler — important for source-built RN, where those symbols
+ are hidden after link and unreachable via -undefined dynamic_lookup.
+
+ Hosts that initialize their own runtime (e.g. ExpoReactNativeFactory, Expo Go)
+ pass `&expo::dispatchOnReactScheduler` as the `dispatch` argument to
+ `AppContext.setRuntime`.
+ */
+namespace expo {
+
+void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callback)()) noexcept;
+
+} // namespace expo
+
+#endif // __cplusplus

--- a/packages/expo-modules-core/ios/JS/EXReactSchedulerDispatch.mm
+++ b/packages/expo-modules-core/ios/JS/EXReactSchedulerDispatch.mm
@@ -1,0 +1,19 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+#import "EXReactSchedulerDispatch.h"
+
+#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
+
+namespace expo {
+
+void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callback)()) noexcept
+{
+  auto *scheduler = static_cast<facebook::react::RuntimeScheduler *>(nativeScheduler);
+  scheduler->scheduleTask(
+    static_cast<facebook::react::SchedulerPriority>(priority),
+    [callback](facebook::jsi::Runtime &) {
+      callback();
+    });
+}
+
+} // namespace expo

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed launch-time crash in apps with source-built React Native. ([#45636](https://github.com/expo/expo/pull/45636) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.2 — 2026-05-08

--- a/packages/expo-modules-jsi/apple/ExpoModulesJSI.podspec
+++ b/packages/expo-modules-jsi/apple/ExpoModulesJSI.podspec
@@ -51,7 +51,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-Core'
   s.dependency 'ReactCommon'
-  s.dependency 'React-runtimescheduler'
 
   # Create a stub xcframework if needed, so CocoaPods generates the
   # "[CP] Copy XCFrameworks" and "[CP] Embed Pods Frameworks" build phases.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/RuntimeScheduler.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/RuntimeScheduler.h
@@ -2,65 +2,76 @@
 
 #ifdef __cplusplus
 
-#include <memory>
+#include <atomic>
 #include <swift/bridging>
-#include <jsi/jsi.h>
-#include <react/renderer/runtimescheduler/RuntimeScheduler.h>
-#include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
-
-namespace jsi = facebook::jsi;
-namespace react = facebook::react;
 
 namespace expo {
 
 /**
- Wrapper for RuntimeScheduler from React which for some reason cannot be constructed from Swift.
- Imported as a shared reference type so Swift manages its lifetime via retain/release.
+ Wrapper around React Native's RuntimeScheduler. The native scheduler reference
+ and dispatch trampoline are supplied by the host (e.g. ExpoReactNativeFactory)
+ at construction time. The xcframework intentionally avoids linking against
+ React-runtimescheduler so the prebuilt binary works with hosts that build RN
+ either as a dynamic framework or as a static archive — without needing
+ -undefined dynamic_lookup to resolve React internals.
+
+ Priority values mirror facebook::react::SchedulerPriority — kept here as a
+ plain enum so we don't include the React header.
  */
 class RuntimeScheduler {
-private:
-  std::shared_ptr<react::RuntimeScheduler> reactRuntimeScheduler;
+public:
+  enum class Priority : int {
+    ImmediatePriority = 1,
+    UserBlockingPriority = 2,
+    NormalPriority = 3,
+    LowPriority = 4,
+    IdlePriority = 5,
+  };
+
+  using ScheduleTaskCallback = void(^)();
 
   /**
-   Reference count managed by Swift's ARC via SWIFT_SHARED_REFERENCE.
-   Prevents premature deallocation when C++ shared_ptr and Swift references coexist.
+   Trampoline implemented by the host — casts `nativeScheduler` back to
+   react::RuntimeScheduler* and calls scheduleTask on it. Keeping it as a
+   function pointer keeps React types out of this header.
    */
+  using ScheduleFn = void (*)(void *nativeScheduler, int priority, ScheduleTaskCallback callback);
+
+private:
+  void *const nativeScheduler{nullptr};
+  const ScheduleFn scheduleFn{nullptr};
+
   std::atomic<int> refCount{1};
 
 public:
   /**
-   Constructs the scheduler from a React Native runtime binding.
-   Falls back to a no-op scheduler when no binding is installed.
+   Constructs a scheduler bound to a host-provided native RuntimeScheduler.
+   `scheduleTask` dispatches through `fn`, which the host implements against
+   the real react::RuntimeScheduler.
    */
-  RuntimeScheduler(jsi::Runtime &runtime) {
-    if (auto binding = react::RuntimeSchedulerBinding::getBinding(runtime)) {
-      reactRuntimeScheduler = binding->getRuntimeScheduler();
-    }
-  }
+  RuntimeScheduler(void *scheduler, ScheduleFn fn) noexcept
+      : nativeScheduler(scheduler), scheduleFn(fn) {}
 
   /**
-   Constructs a no-op scheduler for standalone runtimes (e.g. tests).
-   Scheduled tasks are executed synchronously by the caller.
+   Constructs a no-op scheduler. Scheduled tasks run synchronously on the
+   caller's thread — intended for standalone runtimes (e.g. tests) that have
+   no React scheduler.
    */
   RuntimeScheduler() {}
 
-  RuntimeScheduler(const RuntimeScheduler &) = delete; // non-copyable
+  RuntimeScheduler(const RuntimeScheduler &) = delete;
 
   /**
    Whether the scheduler can dispatch work asynchronously to the JS thread.
    When false, tasks run synchronously and callers should avoid dispatching to background queues.
    */
   bool supportsAsyncScheduling() const noexcept {
-    return reactRuntimeScheduler != nullptr;
+    return scheduleFn != nullptr;
   }
 
-  using ScheduleTaskCallback = void(^)();
-
-  void scheduleTask(react::SchedulerPriority priority, ScheduleTaskCallback callback) noexcept {
-    if (reactRuntimeScheduler) {
-      reactRuntimeScheduler->scheduleTask(priority, [callback = std::move(callback)](jsi::Runtime &runtime) {
-        callback();
-      });
+  void scheduleTask(Priority priority, ScheduleTaskCallback callback) noexcept {
+    if (scheduleFn != nullptr) {
+      scheduleFn(nativeScheduler, static_cast<int>(priority), callback);
     } else {
       callback();
     }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -38,28 +38,55 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   lazy var runtimeActor: JavaScriptRuntimeActor = JavaScriptRuntimeActor(runtime: self)
 
   /**
-   Creates a runtime from the JSI runtime.
+   Creates a runtime from the JSI runtime. The scheduler runs tasks synchronously
+   on the caller's thread — for the React-backed runtime, use
+   `init(unsafePointer:nativeScheduler:dispatch:)` instead.
    */
   internal init(_ runtime: facebook.jsi.Runtime) {
     self.pointee = runtime
-    self.scheduler = expo.RuntimeScheduler(runtime)
+    self.scheduler = expo.RuntimeScheduler()
   }
 
   /**
-   Creates Hermes runtime.
+   Creates a standalone Hermes runtime. Scheduled tasks run synchronously —
+   no React scheduler is wired up.
    */
   public init() {
     self.pointee = expo.createHermesRuntime()
-    self.scheduler = expo.RuntimeScheduler(pointee)
+    self.scheduler = expo.RuntimeScheduler()
   }
 
   /**
    Creates a runtime from a raw pointer to the underlying `facebook.jsi.Runtime`.
+   Scheduled tasks run synchronously — for the React-backed runtime, use
+   `init(unsafePointer:nativeScheduler:dispatch:)` instead.
    */
   public init(unsafePointer: UnsafeMutableRawPointer) {
     let runtime = unsafeBitCast(unsafePointer, to: facebook.jsi.Runtime.self)
     self.pointee = runtime
-    self.scheduler = expo.RuntimeScheduler(runtime)
+    self.scheduler = expo.RuntimeScheduler()
+  }
+
+  /**
+   Creates a runtime bound to a host-provided React `RuntimeScheduler`. Calls to
+   `schedule(...)` / `.execute(...)` dispatch through `dispatch`, which the host
+   implements against the real `react::RuntimeScheduler`. This is the path the
+   React Native factory uses.
+
+   - `unsafePointer`: raw pointer to the underlying `facebook::jsi::Runtime`.
+   - `nativeScheduler`: raw pointer to the `react::RuntimeScheduler` instance.
+   - `dispatch`: raw pointer to a C function with signature
+     `void (*)(void *scheduler, int priority, void (^callback)())`.
+   */
+  public init(
+    unsafePointer: UnsafeMutableRawPointer,
+    nativeScheduler: UnsafeMutableRawPointer,
+    dispatch: UnsafeRawPointer
+  ) {
+    let runtime = unsafeBitCast(unsafePointer, to: facebook.jsi.Runtime.self)
+    let fn = unsafeBitCast(dispatch, to: expo.RuntimeScheduler.ScheduleFn.self)
+    self.pointee = runtime
+    self.scheduler = expo.RuntimeScheduler(nativeScheduler, fn)
   }
 
   /**
@@ -348,8 +375,8 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    Schedules a closure to be executed with granted synchronized access to the runtime.
    */
   public func schedule(priority: SchedulerPriority = .normal, @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () -> sending Void) -> Void {
-    let reactPriority = facebook.react.SchedulerPriority(rawValue: priority.rawValue) ?? .NormalPriority
-    scheduler.scheduleTask(reactPriority) {
+    let cxxPriority = expo.RuntimeScheduler.Priority(rawValue: priority.rawValue) ?? .NormalPriority
+    scheduler.scheduleTask(cxxPriority) {
       JavaScriptActor.assumeIsolated(closure)
     }
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -74,19 +74,19 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    React Native factory uses.
 
    - `unsafePointer`: raw pointer to the underlying `facebook::jsi::Runtime`.
-   - `nativeScheduler`: raw pointer to the `react::RuntimeScheduler` instance.
+   - `scheduler`: raw pointer to the `react::RuntimeScheduler` instance.
    - `dispatch`: raw pointer to a C function with signature
      `void (*)(void *scheduler, int priority, void (^callback)())`.
    */
   public init(
     unsafePointer: UnsafeMutableRawPointer,
-    nativeScheduler: UnsafeMutableRawPointer,
+    scheduler: UnsafeMutableRawPointer,
     dispatch: UnsafeRawPointer
   ) {
     let runtime = unsafeBitCast(unsafePointer, to: facebook.jsi.Runtime.self)
     let fn = unsafeBitCast(dispatch, to: expo.RuntimeScheduler.ScheduleFn.self)
     self.pointee = runtime
-    self.scheduler = expo.RuntimeScheduler(nativeScheduler, fn)
+    self.scheduler = expo.RuntimeScheduler(scheduler, fn)
   }
 
   /**

--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed launch-time crash in apps with source-built React Native by wiring the React `RuntimeScheduler` into `ExpoModulesJSI` from `ExpoReactNativeFactory`. ([#45636](https://github.com/expo/expo/pull/45636) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.0-preview.7 — 2026-05-08

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -19,6 +19,26 @@
 #import "ExpoModulesCore-Swift.h"
 #endif
 #import <ReactCommon/RCTHost.h>
+#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
+#import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+
+namespace {
+
+// Trampoline that ExpoModulesJSI calls to dispatch work onto the JS thread.
+// Defined here (rather than in the xcframework) so the xcframework's prebuilt
+// binary doesn't need to link against React-runtimescheduler.
+void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callback)()) noexcept
+{
+  auto *scheduler = static_cast<facebook::react::RuntimeScheduler *>(nativeScheduler);
+  void (^retained)() = [callback copy];
+  scheduler->scheduleTask(
+    static_cast<facebook::react::SchedulerPriority>(priority),
+    [retained](facebook::jsi::Runtime &) {
+      retained();
+    });
+}
+
+} // namespace
 
 @implementation EXReactNativeFactory {
   EXAppContext *_appContext;
@@ -31,11 +51,20 @@
 {
   _appContext = [[EXAppContext alloc] init];
 
-  // Inject and decorate the `global.expo` object
-  [_appContext setRuntime:&runtime];
+  // Resolve the React runtime scheduler so ExpoModulesJSI can dispatch work onto
+  // the JS thread. Doing it here (rather than inside the xcframework) keeps
+  // React-runtimescheduler symbols out of the prebuilt ExpoModulesJSI.framework
+  // — important for source-built RN, where those symbols are hidden after link
+  // and unreachable via -undefined dynamic_lookup.
+  auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(runtime);
+  auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
+  NSAssert(scheduler != nullptr, @"React Native did not install a RuntimeScheduler before didInitializeRuntime; ExpoModulesJSI cannot dispatch work onto the JS thread.");
+
+  [_appContext setRuntime:&runtime
+          nativeScheduler:scheduler.get()
+                 dispatch:reinterpret_cast<const void *>(&dispatchOnReactScheduler)];
   [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
 
-  
   [_appContext registerNativeModules];
 }
 

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -30,11 +30,10 @@ namespace {
 void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callback)()) noexcept
 {
   auto *scheduler = static_cast<facebook::react::RuntimeScheduler *>(nativeScheduler);
-  void (^retained)() = [callback copy];
   scheduler->scheduleTask(
     static_cast<facebook::react::SchedulerPriority>(priority),
-    [retained](facebook::jsi::Runtime &) {
-      retained();
+    [callback](facebook::jsi::Runtime &) {
+      callback();
     });
 }
 
@@ -56,13 +55,17 @@ void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callba
   // React-runtimescheduler symbols out of the prebuilt ExpoModulesJSI.framework
   // — important for source-built RN, where those symbols are hidden after link
   // and unreachable via -undefined dynamic_lookup.
+  //
+  // If RN didn't install a RuntimeSchedulerBinding for some reason, pass nullptr
+  // for both — AppContext.setRuntime falls back to a synchronous no-op scheduler
+  // so the app still launches; modules that require async dispatch can gate on
+  // `JavaScriptRuntime.supportsAsyncScheduling`.
   auto binding = facebook::react::RuntimeSchedulerBinding::getBinding(runtime);
   auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
-  NSAssert(scheduler != nullptr, @"React Native did not install a RuntimeScheduler before didInitializeRuntime; ExpoModulesJSI cannot dispatch work onto the JS thread.");
 
   [_appContext setRuntime:&runtime
           nativeScheduler:scheduler.get()
-                 dispatch:reinterpret_cast<const void *>(&dispatchOnReactScheduler)];
+                 dispatch:scheduler ? reinterpret_cast<const void *>(&dispatchOnReactScheduler) : nullptr];
   [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
 
   [_appContext registerNativeModules];

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -19,25 +19,8 @@
 #import "ExpoModulesCore-Swift.h"
 #endif
 #import <ReactCommon/RCTHost.h>
-#import <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
-
-namespace {
-
-// Trampoline that ExpoModulesJSI calls to dispatch work onto the JS thread.
-// Defined here (rather than in the xcframework) so the xcframework's prebuilt
-// binary doesn't need to link against React-runtimescheduler.
-void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callback)()) noexcept
-{
-  auto *scheduler = static_cast<facebook::react::RuntimeScheduler *>(nativeScheduler);
-  scheduler->scheduleTask(
-    static_cast<facebook::react::SchedulerPriority>(priority),
-    [callback](facebook::jsi::Runtime &) {
-      callback();
-    });
-}
-
-} // namespace
+#import <ExpoModulesCore/EXReactSchedulerDispatch.h>
 
 @implementation EXReactNativeFactory {
   EXAppContext *_appContext;
@@ -64,8 +47,8 @@ void dispatchOnReactScheduler(void *nativeScheduler, int priority, void (^callba
   auto scheduler = binding ? binding->getRuntimeScheduler() : nullptr;
 
   [_appContext setRuntime:&runtime
-          nativeScheduler:scheduler.get()
-                 dispatch:scheduler ? reinterpret_cast<const void *>(&dispatchOnReactScheduler) : nullptr];
+                scheduler:scheduler.get()
+                 dispatch:scheduler ? reinterpret_cast<const void *>(&expo::dispatchOnReactScheduler) : nullptr];
   [_appContext setHostWrapper:[[EXHostWrapper alloc] initWithHost:host]];
 
   [_appContext registerNativeModules];


### PR DESCRIPTION
## Why

Apps that build React Native from source crash on launch with `EXC_BAD_ACCESS (KERN_PROTECTION_FAILURE) at 0x0` inside `expo::RuntimeScheduler::RuntimeScheduler`. Prebuilt-RN apps work fine.

```
Thread 11 Crashed:
0  ???             0x0  0x0 + 0
1  ExpoModulesJSI  expo::RuntimeScheduler::RuntimeScheduler(facebook::jsi::Runtime&) + 44
2  ExpoModulesJSI  JavaScriptRuntime.init(unsafePointer:) + 96
3  OdjazdowyKrk    ExpoRuntime.init(unsafePointer:) + 12
…
8  OdjazdowyKrk    -[EXReactNativeFactory host:didInitializeRuntime:] + 80
```

## Root cause

`ExpoModulesJSI.framework` is built with `-undefined dynamic_lookup` so its xcframework can be built without RN sources. Inside the constructor it calls `react::RuntimeSchedulerBinding::getBinding(runtime)`.

- **Prebuilt RN**: `React-runtimescheduler` ships as a dynamic framework, dyld finds `getBinding` at load time. Works.
- **Source-built RN**: `React-runtimescheduler` is a static archive that CocoaPods compiles with `-fvisibility=hidden`. After linking into the host binary, the symbol is `private extern` — present but invisible to dyld. The lookup resolves to a null stub.

Force-loading the archive (`-force_load`), demanding the symbol (`-Wl,-u`), and exporting it (`-Wl,-export_dynamic` / `-Wl,-exported_symbol`) all individually fail to make it dyld-visible because of the hidden visibility baked into the `.o`.

## Fix

Move the React lookup out of the xcframework. The factory (`ExpoReactNativeFactory.mm` for bare apps, `ExpoGoReactNativeFactory.mm` for Expo Go) already links `React-runtimescheduler` directly (no dynamic_lookup), so it can call `getBinding` itself, then pass the resulting `react::RuntimeScheduler*` and a small dispatch trampoline into `ExpoModulesJSI` at runtime construction.

`expo::RuntimeScheduler` no longer includes any React headers and has no `getBinding` reference — the xcframework's undefined-symbol list drops the `RuntimeSchedulerBinding::getBinding`, `RuntimeSchedulerBinding::getRuntimeScheduler`, and `RuntimeScheduler::scheduleTask` entries. `React-runtimescheduler` is also dropped from the xcframework's podspec dependencies.

The new `JavaScriptRuntime.init(unsafePointer:scheduler:dispatch:)` takes everything it needs at construction time, so there's no window where the runtime exists with an async scheduler that hasn't been wired up yet.

If RN doesn't install a `RuntimeSchedulerBinding` for some reason, the factory passes `nullptr` for both pointers and the runtime falls back to a synchronous no-op scheduler — callers that need async dispatch can gate on `JavaScriptRuntime.supportsAsyncScheduling`.

The dispatch trampoline (`expo::dispatchOnReactScheduler`) lives in `EXReactSchedulerDispatch.{h,mm}` in `expo-modules-core` and is reused by both factories.

## API change

`EXAppContext.setRuntime` gains `scheduler:` and `dispatch:` parameters (both nullable). Only the factories call it today, and `expo` + `expo-modules-core` ship together, so this is filed under "Others" rather than a breaking change.

Drive-by: `ExpoGoReactNativeFactory.mm` was still calling the single-arg `setRuntime:` selector — fixed to use the new signature.

## Test plan

- [x] Verified the fix on a physical device (iPhone 16 Pro, iOS 26.4) with `observe-tester` using `buildReactNativeFromSource: true` — app launches successfully, no crash
- [x] Pre-fix crash reproduced on the same device
- [x] Confirmed `ExpoModulesJSI.framework` no longer has undefined `RuntimeScheduler*` / `getBinding` symbols via `nm -u`
- [x] Confirmed bare-expo still builds after dropping the `React-runtimescheduler` podspec dep
- [x] Verify prebuilt-RN path still works (the same trampoline runs — `getBinding` resolves through the dynamic React framework)
- [x] Verify Swift Testing suite in `expo-modules-jsi` still passes (standalone Hermes path uses the no-op scheduler now)
- [x] Verify Expo Go's iOS build (the factory file's `setRuntime:` callsite changed)
- [x] Sanity-check the no-scheduler fallback: confirm the runtime initializes with `supportsAsyncScheduling == false` when `scheduler` is `nullptr`