### PR TITLE
[core][Android] Replace `JString::toString()` with faster alternative

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -160,7 +160,11 @@ void JavaCallback::invokeFloat(float result) {
 }
 
 void JavaCallback::invokeString(jni::alias_ref<jstring> result) {
-  invokeJSFunction(result->toStdString());
+  JNIEnv *env = jni::Environment::current();
+  const char *rawValue = env->GetStringUTFChars(result.get(), nullptr);
+  std::string parsedResult = rawValue;
+  env->ReleaseStringUTFChars(result.get(), rawValue);
+  invokeJSFunction(parsedResult);
 }
 
 void JavaCallback::invokeCollection(jni::alias_ref<jni::JCollection<jobject>> result) {
@@ -188,7 +192,8 @@ void JavaCallback::invokeSharedObject(jni::alias_ref<JSharedObject::javaobject> 
   invokeJSFunction(jni::make_global(result));
 }
 
-void JavaCallback::invokeJavaScriptArrayBuffer(jni::alias_ref<JavaScriptArrayBuffer::javaobject> result) {
+void JavaCallback::invokeJavaScriptArrayBuffer(
+  jni::alias_ref<JavaScriptArrayBuffer::javaobject> result) {
   invokeJSFunction(jni::make_global(result));
 }
 

--- a/packages/expo-modules-core/android/src/main/cpp/concepts/jni.h
+++ b/packages/expo-modules-core/android/src/main/cpp/concepts/jni.h
@@ -14,9 +14,6 @@ template<typename T>
 concept HasCthis = requires(T &t) { t->cthis(); };
 
 template<typename T>
-concept HasToStdString = requires(T &t) { t->toStdString(); };
-
-template<typename T>
 concept HasValue = requires(T &t) { t->value(); };
 
 template<typename T>
@@ -24,6 +21,9 @@ concept HasGetRegion = requires(T &t, jsize s) { t->getRegion(s, s); };
 
 template<typename T>
 concept IsJBoolean = std::is_same_v<jni_deref_t<T>, jni::JBoolean>;
+
+template<typename T>
+concept IsJString = std::is_same_v<jni_deref_t<T>, jni::JString>;
 
 template<typename T>
 concept JniRef =

--- a/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/types/JNIToJSIConverter.h
@@ -54,11 +54,17 @@ struct RawArray {
 };
 
 template<typename T>
-inline auto unwrapJNIRef(T &&value) {
+inline auto unwrapJNIRef(
+  JNIEnv *env,
+  T &&value
+) {
   if constexpr (HasCthis<T>) {
     return value->cthis();
-  } else if constexpr (HasToStdString<T>) {
-    return value->toStdString();
+  } else if constexpr (IsJString<T>) {
+    const char *rawValue = env->GetStringUTFChars(value.get(), nullptr);
+    std::string result = rawValue;
+    env->ReleaseStringUTFChars(value.get(), rawValue);
+    return result;
   } else if constexpr (IsJBoolean<T>) {
     return static_cast<bool>(value->value());
   } else if constexpr (HasValue<T>) {
@@ -278,13 +284,13 @@ concept SimpleConversion = requires(JNIEnv *env, jsi::Runtime &rt, T value) {
 
 template<typename T>
 jsi::Value convertToJS(JNIEnv *env, jsi::Runtime &rt, T &&value) {
-  using UnwrappedType = decltype(unwrapJNIRef(std::declval<T>()));
+  using UnwrappedType = decltype(unwrapJNIRef(env, std::declval<T>()));
   using Converter = JNIToJSIConverter<UnwrappedType>;
 
   if constexpr (SimpleConversion<Converter, UnwrappedType>) {
-    return Converter::convert(env, rt, unwrapJNIRef(std::forward<T>(value)));
+    return Converter::convert(env, rt, unwrapJNIRef(env, std::forward<T>(value)));
   } else {
-    return Converter::convert(env, rt, unwrapJNIRef(value), value);
+    return Converter::convert(env, rt, unwrapJNIRef(env, value), value);
   }
 }
 


### PR DESCRIPTION
# Why

Replaces `JString::toString()` with getting raw data directly using JNI. 
This approach is much faster. The benchmark from NCL was reduced from ~210ms to ~140ms (1.5x faster).

# Test Plan

- bare-expo ✅ 
- unit tests ✅ 