### PR TITLE
fix(cli): Fix `LogRespectingTerminal` regressing on stderr on exit

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix regression hiding stderr output on fatal exit ([#45641](https://github.com/expo/expo/pull/45641) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.1.0 — 2026-05-08

--- a/packages/@expo/cli/src/log.ts
+++ b/packages/@expo/cli/src/log.ts
@@ -1,5 +1,9 @@
 import chalk from 'chalk';
 
+// NOTE(@kitten): LogRespectingTerminal in instantiateMetro regressed on fatal errors and
+// logs may be swallowed before exiting. We redirect them to a direct write when we're about to exit
+let isExiting = false;
+
 export function time(label?: string): void {
   console.time(label);
 }
@@ -9,6 +13,14 @@ export function timeEnd(label?: string): void {
 }
 
 export function error(...message: string[]): void {
+  if (isExiting) {
+    // `console.error` may be patched to route through an async stderr queue
+    // (see LogRespectingTerminal in instantiateMetro.ts). On the exit path
+    // that queue has no chance to drain before `process.exit`, so write
+    // synchronously to bypass it.
+    process.stderr.write(message.join(' ') + '\n');
+    return;
+  }
   console.error(...message);
 }
 
@@ -19,10 +31,18 @@ export function exception(e: Error): void {
 }
 
 export function warn(...message: string[]): void {
+  if (isExiting) {
+    process.stderr.write(message.map((value) => chalk.yellow(value)).join(' ') + '\n');
+    return;
+  }
   console.warn(...message.map((value) => chalk.yellow(value)));
 }
 
 export function log(...message: string[]): void {
+  if (isExiting) {
+    process.stdout.write(message.join(' ') + '\n');
+    return;
+  }
   console.log(...message);
 }
 
@@ -38,19 +58,16 @@ export function clear(): void {
 
 /** Log a message and exit the current process. If the `code` is non-zero then `console.error` will be used instead of `console.log`. */
 export function exit(message: string | Error, code: number = 1): never {
+  isExiting = true;
   if (message instanceof Error) {
     exception(message);
-    process.exit(code);
-  }
-
-  if (message) {
+  } else if (message) {
     if (code === 0) {
       log(message);
     } else {
       error(message);
     }
   }
-
   process.exit(code);
 }
 

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -125,6 +125,16 @@ class LogRespectingTerminal extends Terminal {
     console.info = sendLog;
     console.warn = sendStderr;
     console.error = sendStderr;
+
+    // NOTE(@kitten): We flush the stderr queue immediately when we're about to exit
+    process.on('exit', () => {
+      if (!this.#drainingStderr && this.#stderrQueue.length) {
+        this.#drainingStderr = true;
+        this.status('');
+        const lines = this.#stderrQueue.splice(0);
+        process.stderr.write(lines.join('\n') + '\n');
+      }
+    });
   }
 
   /** Write to stderr without corrupting Terminal's cursor tracking. */


### PR DESCRIPTION
# Why

Fix regression in #45523

Because we use `console.*` methods, and these are buffered, output might be lost if we're logging just before we call `process.exit`. Similarly, other output in our CLI is lost when we're fatally crashing.

# How

- Add an `on('exit')` handler to `LogRespectingTerminal` that manually flushes
- Guard with `isExiting` in `log.ts` that manually writes to `stdout`/`stderr` instead

# Test Plan

- Manually tested to restore fatal stderr output

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
