### PR TITLE
[expo-dev-menu] Add EXDevMenuSkipOnboarding build-time switch

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `EXDevMenuSkipOnboarding` build-time switch (Android `<meta-data>` / iOS Info.plist) to opt out of the dev-menu first-launch onboarding overlay. Useful for E2E test runs (Maestro, Detox) and CI pipelines that wipe app data between runs. ([#45640](https://github.com/expo/expo/issues/45640) by [@TomKalina](https://github.com/TomKalina))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/DevMenuPreferences.kt
@@ -5,6 +5,7 @@ import android.content.Context.MODE_PRIVATE
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Bundle
+import androidx.core.content.edit
 import expo.modules.devmenu.helpers.preferences
 
 private const val DEV_SETTINGS_PREFERENCES = "expo.modules.devmenu.sharedpreferences"
@@ -67,7 +68,8 @@ class DevMenuDefaultPreferences(
 
   private val fabDefault = metaDataBool("EXDevMenuShowFloatingActionButton", true)
   private val showsAtLaunchDefault = metaDataBool("EXDevMenuShowsAtLaunch", true)
-  private val isOnboardingFinishedDefault = metaDataBool("EXDevMenuIsOnboardingFinished", false)
+  private val skipOnboarding = metaDataBool("EXDevMenuSkipOnboarding", false)
+  private val isOnboardingFinishedDefault = metaDataBool("EXDevMenuIsOnboardingFinished", skipOnboarding)
 
   private val listeners = mutableListOf<() -> Unit>()
 
@@ -104,7 +106,13 @@ class DevMenuDefaultPreferences(
     by preferences(sharedPreferences, showsAtLaunchDefault)
 
   override var isOnboardingFinished: Boolean
-    by preferences(sharedPreferences, isOnboardingFinishedDefault)
+    get() = skipOnboarding ||
+      sharedPreferences.getBoolean("isOnboardingFinished", isOnboardingFinishedDefault)
+    set(value) {
+      sharedPreferences.edit(commit = true) {
+        putBoolean("isOnboardingFinished", value)
+      }
+    }
 
   override var showFab: Boolean
     by preferences(sharedPreferences, fabDefault)

--- a/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
+++ b/packages/expo-dev-menu/ios/Modules/DevMenuPreferences.swift
@@ -6,6 +6,7 @@ let touchGestureEnabledKey = "EXDevMenuTouchGestureEnabled"
 let keyCommandsEnabledKey = "EXDevMenuKeyCommandsEnabled"
 let showsAtLaunchKey = "EXDevMenuShowsAtLaunch"
 let isOnboardingFinishedKey = "EXDevMenuIsOnboardingFinished"
+let skipOnboardingKey = "EXDevMenuSkipOnboarding"
 let showFloatingActionButtonKey = "EXDevMenuShowFloatingActionButton"
 
 public class DevMenuPreferences: Module {
@@ -129,6 +130,9 @@ public class DevMenuPreferences: Module {
    */
   public static var isOnboardingFinished: Bool {
     get {
+      if Bundle.main.object(forInfoDictionaryKey: skipOnboardingKey) as? Bool == true {
+        return true
+      }
       return DevMenuTestInterceptorManager.interceptor?.isOnboardingFinishedKey ?? boolForKey(isOnboardingFinishedKey)
     }
     set {


### PR DESCRIPTION
# Why

Resolves #45640.

`expo-dev-menu` shows a full-screen onboarding overlay on first launch ("This is the developer menu…"). Dismissal is persisted via `isOnboardingFinished` in `SharedPreferences` (Android) / `NSUserDefaults` (iOS). E2E test runners like [maestro-parallel](https://github.com/TomKalina/maestro-parallel) and Detox wipe app data between runs to get a deterministic starting state, which resets the flag to `false` on every device. The same hits CI pipelines provisioning fresh emulators/sims.

Today there is no first-class way to opt out — only `patch-package`, ad‑hoc Config Plugins, or per-flow Maestro `tapOn: "Got it!"` workarounds.

# How

Adds a new build-time flag analogous to the existing `EXDevMenuShowFloatingActionButton`:

- Android `<meta-data android:name="EXDevMenuSkipOnboarding" android:value="true" />`
- iOS Info.plist `<key>EXDevMenuSkipOnboarding</key><true/>`

When set, `DevMenuPreferences.isOnboardingFinished` getter returns `true` unconditionally. The setter is unchanged, so runtime writes still go to the underlying store and the flag is purely additive — apps not opting in see no behavior change.

On Android the existing `EXDevMenuIsOnboardingFinished` default also falls back to `skipOnboarding`, so the flag composes cleanly with the prior meta-data tag.

# Test Plan

- Built `expo-dev-menu` with `EXDevMenuSkipOnboarding=true` in a debug Android build and an iOS simulator build (`AndroidManifest.xml` meta-data tag / Info.plist key respectively).
- Cleared app data / reinstalled — onboarding overlay no longer appears on first launch; shake gesture still brings up the dev menu.
- Verified without the flag, behavior is identical to `main` (overlay shows once, dismissal persists).
- Diff is small (~16 lines across 3 files) and confined to debug-only sources.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (Android meta-data and iOS Info.plist entries are read at runtime; no plugin changes required for users who configure manually).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)