### PR TITLE
[dev-menu] Fix FAB safe-area bounds

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix FAB safe-area bounds ([#45647](https://github.com/expo/expo/pull/45647) by [@Wenszel](https://github.com/Wenszel))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-08

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FabState.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FabState.kt
@@ -12,7 +12,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.edit
 import kotlinx.coroutines.delay
@@ -26,7 +25,6 @@ private const val FAB_POSITION_UNSET = -1f
 class FabState(
   initialOffset: Offset,
   var fabAreaBounds: Offset,
-  var dragBounds: Rect,
   val prefs: SharedPreferences
 ) {
   val animatedOffset = Animatable(initialOffset, Offset.VectorConverter)
@@ -54,7 +52,7 @@ class FabState(
 }
 
 @Composable
-fun rememberFabState(fabAreaBounds: Offset, totalFabSizePx: Offset): FabState {
+fun rememberFabState(fabAreaBounds: Offset): FabState {
   val context = LocalContext.current
   val prefs = remember { context.getSharedPreferences(FAB_PREFS, Context.MODE_PRIVATE) }
 
@@ -71,19 +69,10 @@ fun rememberFabState(fabAreaBounds: Offset, totalFabSizePx: Offset): FabState {
     }
   }
 
-  val halfFab = Offset(totalFabSizePx.x / 2f, totalFabSizePx.y / 2f)
-  val dragBounds = Rect(
-    left = -halfFab.x,
-    top = -halfFab.y,
-    right = fabAreaBounds.x + halfFab.x,
-    bottom = fabAreaBounds.y + halfFab.y
-  )
-
-  val state = remember { FabState(initialOffset, fabAreaBounds, dragBounds, prefs) }
+  val state = remember { FabState(initialOffset, fabAreaBounds, prefs) }
   // We can't simply update the entire state when the bounds change,
   // because it would result in resetting the interaction state (isPressed, isDragging).
   state.fabAreaBounds = fabAreaBounds
-  state.dragBounds = dragBounds
 
   LaunchedEffect(state.lastInteractionTime) {
     state.isIdle = false

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FabState.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FabState.kt
@@ -4,8 +4,6 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.VectorConverter
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -14,8 +12,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.core.content.edit
 import kotlinx.coroutines.delay
 
@@ -25,17 +23,10 @@ private const val FAB_POSITION_X = "fabPositionX"
 private const val FAB_POSITION_Y = "fabPositionY"
 private const val FAB_POSITION_UNSET = -1f
 
-data class FabBounds(
-  val screen: Offset,
-  val safe: Offset,
-  val safeMinY: Float,
-  val drag: Offset,
-  val halfFab: Offset
-)
-
 class FabState(
   initialOffset: Offset,
-  val bounds: FabBounds,
+  var fabAreaBounds: Offset,
+  var dragBounds: Rect,
   val prefs: SharedPreferences
 ) {
   val animatedOffset = Animatable(initialOffset, Offset.VectorConverter)
@@ -51,12 +42,9 @@ class FabState(
   }
 
   fun savePosition(offset: Offset) {
-    val safeWidth = bounds.safe.x
-    val safeHeight = bounds.safe.y - bounds.safeMinY
-
     // Store position as 0–1 ratios within the safe area so it survives screen size changes
-    val normalizedX = if (safeWidth > 0f) offset.x / safeWidth else 0f
-    val normalizedY = if (safeHeight > 0f) (offset.y - bounds.safeMinY) / safeHeight else 0f
+    val normalizedX = if (fabAreaBounds.x > 0f) offset.x / fabAreaBounds.x else 0f
+    val normalizedY = if (fabAreaBounds.y > 0f) offset.y / fabAreaBounds.y else 0f
 
     prefs.edit {
       putFloat(FAB_POSITION_X, normalizedX)
@@ -66,40 +54,36 @@ class FabState(
 }
 
 @Composable
-fun rememberFabState(screenBounds: Offset, totalFabSizePx: Offset): FabState {
-  val density = LocalDensity.current
-  val systemBarInsets = WindowInsets.systemBars
-  val safeInsetTop = with(density) { systemBarInsets.getTop(this).toFloat() }
-  val safeInsetBottom = with(density) { systemBarInsets.getBottom(this).toFloat() }
-  val halfFab = Offset(totalFabSizePx.x / 2f, totalFabSizePx.y / 2f)
-
-  val fabBounds = FabBounds(
-    screen = screenBounds,
-    safe = Offset(screenBounds.x, screenBounds.y - safeInsetBottom),
-    safeMinY = safeInsetTop,
-    drag = Offset(screenBounds.x + halfFab.x, screenBounds.y + halfFab.y),
-    halfFab = halfFab
-  )
-
+fun rememberFabState(fabAreaBounds: Offset, totalFabSizePx: Offset): FabState {
   val context = LocalContext.current
   val prefs = remember { context.getSharedPreferences(FAB_PREFS, Context.MODE_PRIVATE) }
 
-  val initialOffset = remember(fabBounds.safe, fabBounds.safeMinY) {
+  val initialOffset = remember {
     val savedX = prefs.getFloat(FAB_POSITION_X, FAB_POSITION_UNSET)
     val savedY = prefs.getFloat(FAB_POSITION_Y, FAB_POSITION_UNSET)
-    val safeMaxX = maxOf(0f, fabBounds.safe.x)
-    val safeMaxY = maxOf(fabBounds.safeMinY, fabBounds.safe.y)
     if (savedX != FAB_POSITION_UNSET && savedY != FAB_POSITION_UNSET) {
       Offset(
-        x = (savedX * safeMaxX).coerceIn(0f, safeMaxX),
-        y = (savedY * (safeMaxY - fabBounds.safeMinY) + fabBounds.safeMinY).coerceIn(fabBounds.safeMinY, safeMaxY)
+        x = (savedX * fabAreaBounds.x).coerceIn(0f, fabAreaBounds.x),
+        y = (savedY * fabAreaBounds.y).coerceIn(0f, fabAreaBounds.y)
       )
     } else {
-      Offset(fabBounds.safe.x, fabBounds.safeMinY)
+      Offset(fabAreaBounds.x, 0f)
     }
   }
 
-  val state = remember { FabState(initialOffset, fabBounds, prefs) }
+  val halfFab = Offset(totalFabSizePx.x / 2f, totalFabSizePx.y / 2f)
+  val dragBounds = Rect(
+    left = -halfFab.x,
+    top = -halfFab.y,
+    right = fabAreaBounds.x + halfFab.x,
+    bottom = fabAreaBounds.y + halfFab.y
+  )
+
+  val state = remember { FabState(initialOffset, fabAreaBounds, dragBounds, prefs) }
+  // We can't simply update the entire state when the bounds change,
+  // because it would result in resetting the interaction state (isPressed, isDragging).
+  state.fabAreaBounds = fabAreaBounds
+  state.dragBounds = dragBounds
 
   LaunchedEffect(state.lastInteractionTime) {
     state.isIdle = false

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FabUtils.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FabUtils.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.unit.IntOffset
 import expo.modules.devmenu.fab.ExpoVelocityTracker.PointF
 import kotlin.math.roundToInt
@@ -46,6 +47,15 @@ internal fun Offset.coerceIn(minX: Float = 0f, maxX: Float, minY: Float = 0f, ma
   return this.copy(
     x = this.x.coerceIn(minX, maxX),
     y = this.y.coerceIn(minY, maxY)
+  )
+}
+
+internal fun Offset.coerceIn(rect: Rect): Offset {
+  return this.coerceIn(
+    minX = rect.left,
+    maxX = rect.right,
+    minY = rect.top,
+    maxY = rect.bottom
   )
 }
 

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -48,7 +49,7 @@ fun MovableFloatingActionButton(
   margin: Dp = Margin,
   onPress: () -> Unit = {}
 ) {
-  BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+  BoxWithConstraints(modifier = modifier.safeDrawingPadding().fillMaxSize()) {
     val totalFabSize = DpSize(fabSize.width + margin * 2, fabSize.height + margin * 2)
     val totalFabSizePx = with(LocalDensity.current) {
       Offset(totalFabSize.width.toPx(), totalFabSize.height.toPx())
@@ -70,7 +71,7 @@ fun MovableFloatingActionButton(
     LaunchedEffect(state.isOpen) {
       if (state.isOpen) {
         fab.restingOffset = fab.animatedOffset.value
-        val isOnLeftSide = fab.animatedOffset.value.x < fab.bounds.safe.x / 2f
+        val isOnLeftSide = fab.animatedOffset.value.x < fab.fabAreaBounds.x / 2f
         val offScreenX = if (isOnLeftSide) -totalFabSizePx.x else constraints.maxWidth.toFloat()
         fab.animatedOffset.animateTo(
           targetValue = Offset(offScreenX, fab.animatedOffset.value.y),
@@ -97,14 +98,13 @@ fun MovableFloatingActionButton(
       previousBounds?.let {
         val oldX = fab.animatedOffset.value.x
         val oldY = fab.animatedOffset.value.y
-        val newX = (oldX / previousBounds.x) * fab.bounds.safe.x
-        val newY = (oldY / previousBounds.y) * fab.bounds.safe.y
+        val newX = (oldX / previousBounds.x) * fab.fabAreaBounds.x
+        val newY = (oldY / previousBounds.y) * fab.fabAreaBounds.y
         val newTarget = calculateTargetPosition(
           currentPosition = Offset(newX, newY),
           velocity = ExpoVelocityTracker.PointF(0f, 0f),
-          bounds = fab.bounds.safe,
-          totalFabWidth = totalFabSizePx.x,
-          minY = fab.bounds.safeMinY
+          bounds = fab.fabAreaBounds,
+          totalFabWidth = totalFabSizePx.x
         )
 
         fab.animatedOffset.snapTo(newTarget)
@@ -140,7 +140,12 @@ fun MovableFloatingActionButton(
 
                   drag(pointerId) { change ->
                     dragOffset = (dragOffset + change.positionChange())
-                      .coerceIn(minX = -fab.bounds.halfFab.x, maxX = fab.bounds.drag.x, minY = -fab.bounds.halfFab.y, maxY = fab.bounds.drag.y)
+                      .coerceIn(
+                        minX = fab.dragBounds.left,
+                        maxX = fab.dragBounds.right,
+                        minY = fab.dragBounds.top,
+                        maxY = fab.dragBounds.bottom
+                      )
                     dragDistance += change.positionChange().getDistance()
                     velocityTracker.registerPosition(dragOffset.x, dragOffset.y)
 
@@ -187,7 +192,12 @@ private fun CoroutineScope.handleRelease(
   totalFabSizePx: Offset
 ) {
   val velocity = velocityTracker.calculateVelocity()
-  val newOffset = calculateTargetPosition(fab.animatedOffset.value, velocity, fab.bounds.safe, totalFabSizePx.x, fab.bounds.safeMinY)
+  val newOffset = calculateTargetPosition(
+    currentPosition = fab.animatedOffset.value,
+    velocity = velocity,
+    bounds = fab.fabAreaBounds,
+    totalFabWidth = totalFabSizePx.x
+  )
 
   velocityTracker.clear()
   launch {

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
@@ -50,7 +50,11 @@ fun MovableFloatingActionButton(
   margin: Dp = Margin,
   onPress: () -> Unit = {}
 ) {
-  BoxWithConstraints(modifier = modifier.safeDrawingPadding().fillMaxSize()) {
+  BoxWithConstraints(
+    modifier = modifier
+      .safeDrawingPadding()
+      .fillMaxSize()
+  ) {
     val totalFabSize = DpSize(fabSize.width + margin * 2, fabSize.height + margin * 2)
     val totalFabSizePx = with(LocalDensity.current) {
       Offset(totalFabSize.width.toPx(), totalFabSize.height.toPx())

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalDensity
@@ -59,7 +60,16 @@ fun MovableFloatingActionButton(
       y = constraints.maxHeight - totalFabSizePx.y
     )
 
-    val fab = rememberFabState(bounds, totalFabSizePx)
+    val halfFab = Offset(totalFabSizePx.x / 2f, totalFabSizePx.y / 2f)
+    val dragBounds = Rect(
+      left = -halfFab.x,
+      top = -halfFab.y,
+      right = bounds.x + halfFab.x,
+      bottom = bounds.y + halfFab.y
+    )
+
+    val fab = rememberFabState(bounds)
+
     val isFabDisplayable = state.showFab &&
       !state.isInPictureInPictureMode &&
       bounds.x >= 0f &&
@@ -140,12 +150,7 @@ fun MovableFloatingActionButton(
 
                   drag(pointerId) { change ->
                     dragOffset = (dragOffset + change.positionChange())
-                      .coerceIn(
-                        minX = fab.dragBounds.left,
-                        maxX = fab.dragBounds.right,
-                        minY = fab.dragBounds.top,
-                        maxY = fab.dragBounds.bottom
-                      )
+                      .coerceIn(dragBounds)
                     dragDistance += change.positionChange().getDistance()
                     velocityTracker.registerPosition(dragOffset.x, dragOffset.y)
 


### PR DESCRIPTION
# Why

There was a bug in calculating the safe area bounds for the FAB. In the first invocation of `rememberFabState`, `SafeBarInsets` were (0,0). 

<img width="906" height="50" alt="Screenshot 2026-05-11 at 15 09 16" src="https://github.com/user-attachments/assets/35f0a8c1-eef8-47db-9a58-b9b92764cb65" /> 

This value stayed in `FabState` forever because the `remember` clause lacked change keys, causing the FAB to be positioned above the statusBar: 
<img width="377" height="93" alt="Screenshot 2026-05-12 at 10 52 11" src="https://github.com/user-attachments/assets/415a047d-2f57-4a19-a769-b7f9ee0ee463" />

The easier fix would be to make bounds mutable:
```kotlin

val state = remember { FabState(initialOffset, fabBounds, prefs) }
state.fabBounds = fabBounds
``` 

However, there is a better solution: slightly changing the architecture to move safe-area responsibility to `MovableFloatingActionButton`. This is achieved with the `safeDrawingPadding` modifier. It works like `WindowInsets.systemBars` but removes the need for manual calculations in `rememberFabState`. This way, the source of truth for bounds is the `BoxWithConstraints` size, not `rememberFabState` logic.

# How

- Simplified FabState to properties used inside the class; moved the rest of responsibilities to `MovableFloatingActionButton`
- Made state bounds mutable so they can update when they change (as seen in the screenshot above).

# Test Plan

BareExpo ✅
[Screen_recording_20260512_104957.webm](https://github.com/user-attachments/assets/352ed42a-fec9-479c-9216-8c950a7f9fe3)

