### PR TITLE
fix(metro-file-map): Fix Windows cross-device path resolution

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Windows path resolution for cross-device resolved paths ([#45648](https://github.com/expo/expo/pull/45648) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.0.0 — 2026-05-08

--- a/packages/@expo/metro-file-map/build/lib/RootPathUtils.js
+++ b/packages/@expo/metro-file-map/build/lib/RootPathUtils.js
@@ -48,6 +48,15 @@ const UP_FRAGMENT_SEP = '..' + path_1.default.sep;
 const SEP_UP_FRAGMENT = path_1.default.sep + '..';
 const UP_FRAGMENT_SEP_LENGTH = UP_FRAGMENT_SEP.length;
 const CURRENT_FRAGMENT = '.' + path_1.default.sep;
+const IS_WIN32 = path_1.default.sep === '\\';
+const ROOT_BASE_IDX = IS_WIN32 ? 0 : 1;
+function startsWithDriveLetter(str) {
+    if (!IS_WIN32 || str.charCodeAt(1) !== 58 /* ':' */) {
+        return false;
+    }
+    const c = str.charCodeAt(0);
+    return (c >= 65 && c <= 90) /* A-Z */ || (c >= 97 && c <= 122) /* a-z */;
+}
 class RootPathUtils {
     #rootDir;
     #rootDirnames;
@@ -121,6 +130,12 @@ class RootPathUtils {
         if (right.length === 0) {
             return left;
         }
+        else if (pos > this.#rootDepth * UP_FRAGMENT_SEP_LENGTH) {
+            // When we walk above the filesystem root, we emit the remaining path as is.
+            // This is important on Windows, since we're canonicalizing cross-device paths
+            // as relative paths from rootDir
+            return right;
+        }
         // left may already end in a path separator only if it is a filesystem root,
         // '/' or 'X:\'.
         if (i === this.#rootDepth) {
@@ -135,8 +150,11 @@ class RootPathUtils {
     resolveSymlinkToNormal(symlinkNormalPath, readlinkResult) {
         let target = (0, normalizePathSeparatorsToSystem_1.default)(readlinkResult);
         // WARN: This only applies to Windows + Node 20 case, where the value is completely
-        // unnormalized and a trailing slash may be returned
-        if (target[target.length - 1] === path_1.default.sep) {
+        // unnormalized and a trailing slash may be returned. Skip the strip when the target
+        // is a filesystem root: POSIX '/' or Windows 'X:\'
+        const len = target.length;
+        const isFsRoot = len === 1 || (len === 3 && startsWithDriveLetter(target));
+        if (!isFsRoot && target[len - 1] === path_1.default.sep) {
             target = target.slice(0, -1);
         }
         if (path_1.default.isAbsolute(target)) {
@@ -176,7 +194,7 @@ class RootPathUtils {
         if (relativePath === '') {
             return { collapsedSegments: 0, normalPath };
         }
-        const left = normalPath + path_1.default.sep;
+        const left = normalPath.endsWith(path_1.default.sep) ? normalPath : normalPath + path_1.default.sep;
         const rawPath = left + relativePath;
         if (normalPath === '..' || normalPath.endsWith(SEP_UP_FRAGMENT)) {
             const collapsed = this.#tryCollapseIndirectionsInSuffix(rawPath, 0, 0);
@@ -262,9 +280,10 @@ class RootPathUtils {
                     collapsedSegments,
                 };
             }
-            // Cap the number of indirections at the total number of root segments.
-            // File systems treat '..' at the root as '.'.
-            if (totalUpIndirections < this.#rootParts.length - 1) {
+            // Cap the number of indirections at the total number of root parts.
+            // File systems treat '..' at the root as '.'. For Windows, cross-device
+            // paths need to survive this
+            if (totalUpIndirections < this.#rootParts.length - ROOT_BASE_IDX) {
                 totalUpIndirections++;
             }
             if (nextIndirection !== pos + 1 || // Fallback when ./ later in the path, or leading

--- a/packages/@expo/metro-file-map/build/lib/TreeFS.js
+++ b/packages/@expo/metro-file-map/build/lib/TreeFS.js
@@ -379,6 +379,9 @@ class TreeFS {
     }
     remove(mixedPath, changeListener) {
         const normalPath = this.#normalizePath(mixedPath);
+        this.#removeNormalPath(normalPath, changeListener);
+    }
+    #removeNormalPath(normalPath, changeListener) {
         const result = this.#lookupByNormalPath(normalPath, { followLeaf: false });
         if (!result.exists) {
             return;
@@ -386,7 +389,7 @@ class TreeFS {
         const { parentNode, canonicalPath, node } = result;
         if (isDirectory(node) && node.size > 0) {
             for (const basename of node.keys()) {
-                this.remove(canonicalPath + path_1.default.sep + basename, changeListener);
+                this.#removeNormalPath(canonicalPath + path_1.default.sep + basename, changeListener);
             }
             // Removing the last file will delete this directory
             return;
@@ -407,7 +410,7 @@ class TreeFS {
                 // that's not expected to be a case common enough to justify
                 // implementation complexity, or slowing down more common uses of
                 // _lookupByNormalPath.
-                this.remove(path_1.default.dirname(canonicalPath), changeListener);
+                this.#removeNormalPath(path_1.default.dirname(canonicalPath), changeListener);
             }
         }
     }

--- a/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
+++ b/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
@@ -45,6 +45,16 @@ const SEP_UP_FRAGMENT = path.sep + '..';
 const UP_FRAGMENT_SEP_LENGTH = UP_FRAGMENT_SEP.length;
 const CURRENT_FRAGMENT = '.' + path.sep;
 
+const IS_WIN32 = path.sep === '\\';
+
+function startsWithDriveLetter(str: string): boolean {
+  if (!IS_WIN32 || str.charCodeAt(1) !== 58 /* ':' */) {
+    return false;
+  }
+  const c = str.charCodeAt(0);
+  return (c >= 65 && c <= 90) /* A-Z */ || (c >= 97 && c <= 122) /* a-z */;
+}
+
 export class RootPathUtils {
   #rootDir: string;
   #rootDirnames: readonly string[];
@@ -169,8 +179,11 @@ export class RootPathUtils {
   resolveSymlinkToNormal(symlinkNormalPath: string, readlinkResult: string): string {
     let target = normalizePathSeparatorsToSystem(readlinkResult);
     // WARN: This only applies to Windows + Node 20 case, where the value is completely
-    // unnormalized and a trailing slash may be returned
-    if (target[target.length - 1] === path.sep) {
+    // unnormalized and a trailing slash may be returned. Skip the strip when the target
+    // is a filesystem root: POSIX '/' or Windows 'X:\'
+    const len = target.length;
+    const isFsRoot = len === 1 || (len === 3 && startsWithDriveLetter(target));
+    if (!isFsRoot && target[len - 1] === path.sep) {
       target = target.slice(0, -1);
     }
     if (path.isAbsolute(target)) {

--- a/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
+++ b/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
@@ -229,7 +229,7 @@ export class RootPathUtils {
     if (relativePath === '') {
       return { collapsedSegments: 0, normalPath };
     }
-    const left = normalPath + path.sep;
+    const left = normalPath.endsWith(path.sep) ? normalPath : normalPath + path.sep;
     const rawPath = left + relativePath;
     if (normalPath === '..' || normalPath.endsWith(SEP_UP_FRAGMENT)) {
       const collapsed = this.#tryCollapseIndirectionsInSuffix(rawPath, 0, 0);

--- a/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
+++ b/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
@@ -46,6 +46,7 @@ const UP_FRAGMENT_SEP_LENGTH = UP_FRAGMENT_SEP.length;
 const CURRENT_FRAGMENT = '.' + path.sep;
 
 const IS_WIN32 = path.sep === '\\';
+const ROOT_BASE_IDX = IS_WIN32 ? 0 : 1;
 
 function startsWithDriveLetter(str: string): boolean {
   if (!IS_WIN32 || str.charCodeAt(1) !== 58 /* ':' */) {
@@ -322,9 +323,10 @@ export class RootPathUtils {
         };
       }
 
-      // Cap the number of indirections at the total number of root segments.
-      // File systems treat '..' at the root as '.'.
-      if (totalUpIndirections < this.#rootParts.length - 1) {
+      // Cap the number of indirections at the total number of root parts.
+      // File systems treat '..' at the root as '.'. For Windows, cross-device
+      // paths need to survive this
+      if (totalUpIndirections < this.#rootParts.length - ROOT_BASE_IDX) {
         totalUpIndirections++;
       }
 

--- a/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
+++ b/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
@@ -145,6 +145,11 @@ export class RootPathUtils {
     const right = pos === 0 ? normalPath : normalPath.slice(pos);
     if (right.length === 0) {
       return left;
+    } else if (pos > this.#rootDepth * UP_FRAGMENT_SEP_LENGTH) {
+      // When we walk above the filesystem root, we emit the remaining path as is.
+      // This is important on Windows, since we're canonicalizing cross-device paths
+      // as relative paths from rootDir
+      return right;
     }
     // left may already end in a path separator only if it is a filesystem root,
     // '/' or 'X:\'.

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -527,6 +527,10 @@ export default class TreeFS implements MutableFileSystem {
 
   remove(mixedPath: Path, changeListener?: FileSystemListener): void {
     const normalPath = this.#normalizePath(mixedPath);
+    this.#removeNormalPath(normalPath, changeListener);
+  }
+
+  #removeNormalPath(normalPath: string, changeListener?: FileSystemListener): void {
     const result = this.#lookupByNormalPath(normalPath, { followLeaf: false });
     if (!result.exists) {
       return;
@@ -535,7 +539,7 @@ export default class TreeFS implements MutableFileSystem {
 
     if (isDirectory(node) && node.size > 0) {
       for (const basename of node.keys()) {
-        this.remove(canonicalPath + path.sep + basename, changeListener);
+        this.#removeNormalPath(canonicalPath + path.sep + basename, changeListener);
       }
       // Removing the last file will delete this directory
       return;
@@ -555,7 +559,7 @@ export default class TreeFS implements MutableFileSystem {
         // that's not expected to be a case common enough to justify
         // implementation complexity, or slowing down more common uses of
         // _lookupByNormalPath.
-        this.remove(path.dirname(canonicalPath), changeListener);
+        this.#removeNormalPath(path.dirname(canonicalPath), changeListener);
       }
     }
   }

--- a/packages/@expo/metro-file-map/src/lib/__tests__/RootPathUtils.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/RootPathUtils.test.ts
@@ -114,29 +114,37 @@ describe.each([['win32'], ['posix']] as const)('RootPathUtils on %s', (platform)
       }
     );
 
-    test.each([
-      p('..'),
-      p('../root'),
-      p('../root/path'),
-      p('../project'),
-      p('../project/'),
-      p('../../project/root'),
-      p('../../project/root/'),
-      p('../../../normal/path'),
-      p('../../../normal/path/'),
-      p('../../..'),
-    ])(`relativeToNormal('%s') matches path.resolve + path.relative`, (relativePath) => {
-      let expected = mockPathModule.relative(
-        rootDir,
-        mockPathModule.resolve(rootDir, relativePath)
-      );
-      // Unlike native path.resolve + path.relative, we expect to preserve
-      // trailing separators. (Consistent with path.normalize.)
-      if (relativePath.endsWith(sep) && !expected.endsWith(sep) && expected !== '') {
-        expected += sep;
+    // relativeToNormal no longer collapses non-canonical leading '..' chains
+    // (no in-function clip); inputs are expected to be canonical for rootDir.
+    const relativeToNormalInputs =
+      rootDir === p('/project/root')
+        ? [
+            p('..'),
+            p('../root'),
+            p('../root/path'),
+            p('../project'),
+            p('../project/'),
+            p('../../project/root'),
+            p('../../project/root/'),
+            p('../../..'),
+          ]
+        : [p('..')];
+
+    test.each(relativeToNormalInputs)(
+      `relativeToNormal('%s') matches path.resolve + path.relative`,
+      (relativePath) => {
+        let expected = mockPathModule.relative(
+          rootDir,
+          mockPathModule.resolve(rootDir, relativePath)
+        );
+        // Unlike native path.resolve + path.relative, we expect to preserve
+        // trailing separators. (Consistent with path.normalize.)
+        if (relativePath.endsWith(sep) && !expected.endsWith(sep) && expected !== '') {
+          expected += sep;
+        }
+        expect(pathUtils.relativeToNormal(relativePath)).toEqual(expected);
       }
-      expect(pathUtils.relativeToNormal(relativePath)).toEqual(expected);
-    });
+    );
   });
 
   test.each([

--- a/packages/@expo/metro-file-map/src/lib/__tests__/RootPathUtils.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/RootPathUtils.test.ts
@@ -85,24 +85,34 @@ describe.each([['win32'], ['posix']] as const)('RootPathUtils on %s', (platform)
       expect(pathRelative).toHaveBeenCalled();
     });
 
-    test.each([
-      p('..'),
-      p('../..'),
-      p('../../'),
-      p('normal/path'),
-      p('normal/path/'),
-      p('../normal/path'),
-      p('../normal/path/'),
-      p('../../normal/path'),
-      p('../../../normal/path'),
-    ])(`normalToAbsolute('%s') matches path.resolve`, (normalPath) => {
-      let expected = mockPathModule.resolve(rootDir, normalPath);
-      // Unlike path.resolve, we expect to preserve trailing separators.
-      if (normalPath.endsWith(sep) && !expected.endsWith(sep)) {
-        expected += sep;
+    // normalToAbsolute is documented to take normal (root-relative, no
+    // redundant indirections) paths; inputs with more '..'s than rootDepth
+    // are non-canonical and out of contract.
+    const normalToAbsoluteInputs =
+      rootDir === p('/project/root')
+        ? [
+            p('..'),
+            p('../..'),
+            p('../../'),
+            p('normal/path'),
+            p('normal/path/'),
+            p('../normal/path'),
+            p('../normal/path/'),
+            p('../../normal/path'),
+          ]
+        : [p('..'), p('../..'), p('../../'), p('normal/path'), p('normal/path/')];
+
+    test.each(normalToAbsoluteInputs)(
+      `normalToAbsolute('%s') matches path.resolve`,
+      (normalPath) => {
+        let expected = mockPathModule.resolve(rootDir, normalPath);
+        // Unlike path.resolve, we expect to preserve trailing separators.
+        if (normalPath.endsWith(sep) && !expected.endsWith(sep)) {
+          expected += sep;
+        }
+        expect(pathUtils.normalToAbsolute(normalPath)).toEqual(expected);
       }
-      expect(pathUtils.normalToAbsolute(normalPath)).toEqual(expected);
-    });
+    );
 
     test.each([
       p('..'),
@@ -258,4 +268,90 @@ describe.each([['win32'], ['posix']] as const)('RootPathUtils on %s', (platform)
       expect(pattern.test(p('src/foo.js'))).toBe(false);
     });
   });
+
+  // See: https://github.com/facebook/metro/pull/1696
+  // When a path and rootDir differ in drives on Windows, we expect the resulting
+  // path to have an anchor (D:) on the new drive
+  if (platform === 'win32') {
+    describe('cross-drive absolute paths (Windows)', () => {
+      test.each(['C:\\project\\root', 'C:\\'])(
+        'path.relative returns cross-drive target as-is from rootDir=%s',
+        (rootDir) => {
+          expect(mockPathModule.relative(rootDir, 'D:\\some\\file.js')).toEqual(
+            'D:\\some\\file.js'
+          );
+        }
+      );
+
+      // Pin the ..-chain encoding so we keep the "normal paths are root-
+      // relative" invariant; only normalToAbsolute observes the cross-drive
+      // case and returns the absolute remainder.
+      test.each([
+        ['C:\\project\\root', 'D:\\some\\file.js', '..\\..\\..\\D:\\some\\file.js'],
+        ['C:\\project\\root', 'D:\\some\\', '..\\..\\..\\D:\\some\\'],
+        ['C:\\project\\root', 'D:\\', '..\\..\\..\\D:\\'],
+        ['C:\\', 'D:\\some\\file.js', '..\\D:\\some\\file.js'],
+        ['C:\\', 'D:\\', '..\\D:\\'],
+        ['D:\\project\\root', 'C:\\file.js', '..\\..\\..\\C:\\file.js'],
+      ])(
+        'absoluteToNormal emits a ..-chain (rootDir=%s, X=%s -> %s)',
+        (rootDir, absolutePath, expectedNormal) => {
+          pathUtils = new RootPathUtils(rootDir);
+          expect(pathUtils.absoluteToNormal(absolutePath)).toEqual(expectedNormal);
+        }
+      );
+
+      test.each([
+        ['C:\\project\\root', 'D:\\some\\file.js'],
+        ['C:\\project\\root', 'D:\\some\\'],
+        ['C:\\project\\root', 'D:\\'],
+        ['C:\\', 'D:\\some\\file.js'],
+        ['C:\\', 'D:\\some\\'],
+        ['C:\\', 'D:\\'],
+        ['D:\\project\\root', 'C:\\file.js'],
+        ['D:\\project\\root', 'C:\\'],
+      ])(
+        'normalToAbsolute(absoluteToNormal(X)) === X for rootDir=%s, X=%s',
+        (rootDir, absolutePath) => {
+          pathUtils = new RootPathUtils(rootDir);
+          const normal = pathUtils.absoluteToNormal(absolutePath);
+          expect(pathUtils.normalToAbsolute(normal)).toEqual(absolutePath);
+        }
+      );
+
+      test.each([
+        ['C:\\project\\root', 'D:\\dir\\sub', 'extra\\file.js'],
+        ['C:\\project\\root', 'D:\\', 'foo.js'],
+        ['C:\\', 'D:\\dir', 'sub\\file.js'],
+      ])(
+        'joinNormalToRelative round-trips cross-drive (rootDir=%s, base=%s, rel=%s)',
+        (rootDir, baseAbsolute, relativePath) => {
+          pathUtils = new RootPathUtils(rootDir);
+          const baseNormal = pathUtils.absoluteToNormal(baseAbsolute);
+          const { normalPath } = pathUtils.joinNormalToRelative(baseNormal, relativePath);
+          expect(pathUtils.normalToAbsolute(normalPath)).toEqual(
+            mockPathModule.join(baseAbsolute, relativePath)
+          );
+        }
+      );
+
+      test.each([
+        ['C:\\project\\root', 'link', 'D:\\target.js'],
+        ['C:\\project\\root', 'a\\b\\link', 'D:\\sub\\target.js'],
+        // 'D:\\' hits a distinct path: the leading trailing-separator strip
+        // turns it into 'D:', which path.win32.isAbsolute rejects, so this
+        // falls through to the relative branch instead of absoluteToNormal.
+        ['C:\\project\\root', 'link', 'D:\\'],
+        ['C:\\', 'link', 'D:\\target.js'],
+        ['C:\\', 'link', 'D:\\'],
+      ])(
+        'resolveSymlinkToNormal round-trips a cross-drive target (rootDir=%s, %s -> %s)',
+        (rootDir, symlinkNormalPath, readlinkResult) => {
+          pathUtils = new RootPathUtils(rootDir);
+          const normal = pathUtils.resolveSymlinkToNormal(symlinkNormalPath, readlinkResult);
+          expect(pathUtils.normalToAbsolute(normal)).toEqual(readlinkResult);
+        }
+      );
+    });
+  }
 });

--- a/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
@@ -1973,23 +1973,22 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
         const fbTfs = makeFallbackTfs({
           serverRoot: p('/project'),
           files: new Map([
-            [p('node_modules/react'), [0, 0, 0, null, '../../.bun-cache/react', null] as any],
+            // Canonical normal target for /.bun-cache/react under rootDir
+            // /project is '../.bun-cache/react' (rootDepth=1).
+            [p('node_modules/react'), [0, 0, 0, null, '../.bun-cache/react', null] as any],
           ]),
         });
 
         mockFallback.readdir.mockImplementation(
           (normalPath: string, _absolutePath: string, dirNode: any) => {
             const result = dirNode ?? new Map();
-            if (normalPath === p('../..')) {
+            if (normalPath === p('..')) {
               if (!result.has('.bun-cache')) {
                 result.set('.bun-cache', markFallbackDir(new Map()));
               }
               return markFallbackDir(result, 1);
             }
-            if (
-              normalPath === p('../../.bun-cache/react') ||
-              normalPath === p('node_modules/react')
-            ) {
+            if (normalPath === p('../.bun-cache/react') || normalPath === p('node_modules/react')) {
               result.set('package.json', [100, 5, 0, null, 0, null]);
               result.set('index.js', [100, 5, 0, null, 0, null]);
               return markFallbackDir(result, 1);
@@ -1998,7 +1997,7 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
           }
         );
         mockFallback.lookup.mockImplementation((normalPath: string) => {
-          if (normalPath === p('../../.bun-cache/react')) {
+          if (normalPath === p('../.bun-cache/react')) {
             return markFallbackDir(new Map<string, any>());
           }
           return null;
@@ -2013,7 +2012,7 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
         );
         expect(found).not.toBeNull();
         expect(found?.absolutePath).toBe(
-          mockPathModule.resolve(p('/project'), p('../../.bun-cache/react/package.json'))
+          mockPathModule.resolve(p('/project'), p('../.bun-cache/react/package.json'))
         );
       });
 
@@ -2497,4 +2496,70 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
       });
     });
   });
+
+  if (platform === 'win32') {
+    describe('cross-drive paths (Windows)', () => {
+      let tfsCD: TreeFSType;
+      const externalMeta: FileMetadata = [123, 4, 0, null, 0, 'external'];
+
+      beforeEach(() => {
+        tfsCD = new TreeFS({
+          rootDir: 'C:\\project',
+          files: new Map<CanonicalPath, FileMetadata>([
+            ['bar.js', [234, 3, 0, null, 0, 'bar']],
+            // Canonical form of 'D:\\external\\file.js' for rootDepth=1.
+            ['..\\..\\D:\\external\\file.js', externalMeta],
+          ]),
+          processFile: async () => {
+            throw new Error('Not implemented');
+          },
+        });
+      });
+
+      test('exists() finds a seeded cross-drive file', () => {
+        expect(tfsCD.exists('D:\\external\\file.js')).toBe(true);
+      });
+
+      test('lookup() returns the absolute drive-prefixed path as realPath', () => {
+        expect(tfsCD.lookup('D:\\external\\file.js')).toMatchObject({
+          exists: true,
+          type: 'f',
+          realPath: 'D:\\external\\file.js',
+        });
+      });
+
+      test('getAllFiles() enumerates cross-drive and in-tree files side by side', () => {
+        expect(tfsCD.getAllFiles().sort()).toEqual([
+          'C:\\project\\bar.js',
+          'D:\\external\\file.js',
+        ]);
+      });
+
+      test('addOrModify() accepts a new cross-drive absolute path', () => {
+        tfsCD.addOrModify('D:\\added\\later.js', [1, 1, 0, null, 0, 'later']);
+        expect(tfsCD.exists('D:\\added\\later.js')).toBe(true);
+        expect(tfsCD.lookup('D:\\added\\later.js')).toMatchObject({
+          exists: true,
+          type: 'f',
+          realPath: 'D:\\added\\later.js',
+        });
+      });
+
+      test('remove() deletes a cross-drive entry and prunes empty ancestor dirs', () => {
+        tfsCD.remove('D:\\external\\file.js');
+        expect(tfsCD.exists('D:\\external\\file.js')).toBe(false);
+        // Intermediate 'D:' / 'external' directory nodes pruned.
+        expect(tfsCD.lookup('D:\\external').exists).toBe(false);
+        expect(tfsCD.exists('C:\\project\\bar.js')).toBe(true);
+      });
+
+      test('lookup() reports missing for non-existent cross-drive path', () => {
+        expect(tfsCD.lookup('D:\\external\\missing.js')).toMatchObject({
+          exists: false,
+        });
+        // A different drive (E:) was never seeded — also missing.
+        expect(tfsCD.exists('E:\\anywhere.js')).toBe(false);
+      });
+    });
+  }
 });


### PR DESCRIPTION
# Why

Reported at https://github.com/facebook/metro/pull/1696. This PR is being upstreamed at: https://github.com/facebook/metro/pull/1711

The intention in Metro is that cross-device paths are represented as relative normal paths. If the root dir is at `C:\project` then a cross-device normal path at `D:\temp` is represented as `..\..\D:\temp`. This assumption is broken in several places, like `normalToAbsolute` printing, leading to `C:\D:\` paths that are invalid.

# How

- Fix `normalToAbsolute` not cutting off cross-device absolute paths
- Fix `resolveSymlinkToNormal` cutting off trailing slash for absolute Windows device paths
- Prevent double slash when appending normal path to root `C:\` path
- Prevent `TreeFS#remove` from re-normalizing internally built paths, which can lead to excessively clamped paths
- Adjust relative root maximum depth for Windows (remove `-1` adjustment for Windows)

# Test Plan

- Represented in unit test changes
- **Note:** Invalid unit tests have been removed for paths that rise above the filesystem root

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
