### PR TITLE
perf(metro-file-map): Add fast path to `TreeFS.#checkCandidateHasSubpath`

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Add hints and start node for `TreeFS.hierarchicalLookup` improving performance for metro's `getClosestPackage` lookups ([#45650](https://github.com/expo/expo/pull/45650) by [@kitten](https://github.com/kitten))
+
 ## 56.0.0 — 2026-05-08
 
 ### 💡 Others

--- a/packages/@expo/metro-file-map/build/lib/TreeFS.js
+++ b/packages/@expo/metro-file-map/build/lib/TreeFS.js
@@ -669,7 +669,11 @@ class TreeFS {
             collectLinkPaths: invalidatedBy,
         });
         if (closestLookup.exists && isDirectory(closestLookup.node)) {
-            const maybeAbsolutePathMatch = this.#checkCandidateHasSubpath(closestLookup.canonicalPath, subpath, opts.subpathType, invalidatedBy, null);
+            const maybeAbsolutePathMatch = this.#checkCandidateHasSubpath(closestLookup.canonicalPath, subpath, opts.subpathType, invalidatedBy, {
+                ancestorOfRootIdx: closestLookup.ancestorOfRootIdx,
+                node: closestLookup.node,
+                pathIdx: closestLookup.canonicalPath.length > 0 ? closestLookup.canonicalPath.length + 1 : 0,
+            });
             if (maybeAbsolutePathMatch != null) {
                 return {
                     absolutePath: maybeAbsolutePathMatch,
@@ -752,7 +756,11 @@ class TreeFS {
         let nextNode = commonRoot;
         let depthBelowCommonRoot = 0;
         while (isDirectory(nextNode)) {
-            const maybeAbsolutePathMatch = this.#checkCandidateHasSubpath(candidateNormalPath, subpath, opts.subpathType, invalidatedBy, null);
+            const maybeAbsolutePathMatch = this.#checkCandidateHasSubpath(candidateNormalPath, subpath, opts.subpathType, invalidatedBy, {
+                ancestorOfRootIdx: commonRootDepth + depthBelowCommonRoot,
+                node: nextNode,
+                pathIdx: candidateNormalPath.length > 0 ? candidateNormalPath.length + 1 : 0,
+            });
             if (maybeAbsolutePathMatch != null) {
                 const rootDirParts = this.#pathUtils.getParts();
                 const relativeParts = depthBelowCommonRoot > 0
@@ -774,8 +782,50 @@ class TreeFS {
         return null;
     }
     #checkCandidateHasSubpath(normalCandidatePath, subpath, subpathType, invalidatedBy, start) {
+        // NOTE(@kitten): The most common call for package.json only needs a simple map
+        // lookup, and can skip traversal entirely
+        if (start != null &&
+            subpath.length > 0 &&
+            subpath !== '.' &&
+            subpath !== '..' &&
+            subpath.indexOf(path_1.default.sep) === -1) {
+            const child = start.node.get(subpath);
+            if (child == null) {
+                if (this.#fallbackFilesystem != null) {
+                    // noop: fall through to slow-path
+                }
+                else {
+                    if (invalidatedBy) {
+                        invalidatedBy.add(this.#pathUtils.normalToAbsolute(normalCandidatePath === '' ? subpath : normalCandidatePath + path_1.default.sep + subpath));
+                    }
+                    return null;
+                }
+            }
+            else {
+                const childIsDirectory = isDirectory(child);
+                if (!childIsDirectory && !isRegularFile(child)) {
+                    // noop: Handle symlinks in the slow path, since it needs state tracking
+                }
+                else {
+                    const absolutePath = this.#pathUtils.normalToAbsolute(normalCandidatePath === '' ? subpath : normalCandidatePath + path_1.default.sep + subpath);
+                    if (childIsDirectory === (subpathType === 'd')) {
+                        return absolutePath;
+                    }
+                    else {
+                        if (invalidatedBy)
+                            invalidatedBy.add(absolutePath);
+                        return null;
+                    }
+                }
+            }
+        }
+        // NOTE(@kitten): We can forward `start` if there's no indirection in the candidate path
+        const canForwardStart = start != null &&
+            normalCandidatePath !== '..' &&
+            !normalCandidatePath.endsWith(path_1.default.sep + '..');
         const lookupResult = this.#lookupByNormalPath(this.#pathUtils.joinNormalToRelative(normalCandidatePath, subpath).normalPath, {
             collectLinkPaths: invalidatedBy,
+            start: canForwardStart ? start : undefined,
         });
         if (lookupResult.exists &&
             // Should be a Map iff subpathType is directory

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -935,7 +935,12 @@ export default class TreeFS implements MutableFileSystem {
         subpath,
         opts.subpathType,
         invalidatedBy,
-        null
+        {
+          ancestorOfRootIdx: closestLookup.ancestorOfRootIdx,
+          node: closestLookup.node,
+          pathIdx:
+            closestLookup.canonicalPath.length > 0 ? closestLookup.canonicalPath.length + 1 : 0,
+        }
       );
       if (maybeAbsolutePathMatch != null) {
         return {
@@ -1046,7 +1051,11 @@ export default class TreeFS implements MutableFileSystem {
         subpath,
         opts.subpathType,
         invalidatedBy,
-        null
+        {
+          ancestorOfRootIdx: commonRootDepth + depthBelowCommonRoot,
+          node: nextNode,
+          pathIdx: candidateNormalPath.length > 0 ? candidateNormalPath.length + 1 : 0,
+        }
       );
       if (maybeAbsolutePathMatch != null) {
         const rootDirParts = this.#pathUtils.getParts();
@@ -1087,10 +1096,57 @@ export default class TreeFS implements MutableFileSystem {
       | null
       | undefined
   ): string | null {
+    // NOTE(@kitten): The most common call for package.json only needs a simple map
+    // lookup, and can skip traversal entirely
+    if (
+      start != null &&
+      subpath.length > 0 &&
+      subpath !== '.' &&
+      subpath !== '..' &&
+      subpath.indexOf(path.sep) === -1
+    ) {
+      const child = start.node.get(subpath);
+      if (child == null) {
+        if (this.#fallbackFilesystem != null) {
+          // noop: fall through to slow-path
+        } else {
+          if (invalidatedBy) {
+            invalidatedBy.add(
+              this.#pathUtils.normalToAbsolute(
+                normalCandidatePath === '' ? subpath : normalCandidatePath + path.sep + subpath
+              )
+            );
+          }
+          return null;
+        }
+      } else {
+        const childIsDirectory = isDirectory(child);
+        if (!childIsDirectory && !isRegularFile(child)) {
+          // noop: Handle symlinks in the slow path, since it needs state tracking
+        } else {
+          const absolutePath = this.#pathUtils.normalToAbsolute(
+            normalCandidatePath === '' ? subpath : normalCandidatePath + path.sep + subpath
+          );
+          if (childIsDirectory === (subpathType === 'd')) {
+            return absolutePath;
+          } else {
+            if (invalidatedBy) invalidatedBy.add(absolutePath);
+            return null;
+          }
+        }
+      }
+    }
+
+    // NOTE(@kitten): We can forward `start` if there's no indirection in the candidate path
+    const canForwardStart =
+      start != null &&
+      normalCandidatePath !== '..' &&
+      !normalCandidatePath.endsWith(path.sep + '..');
     const lookupResult = this.#lookupByNormalPath(
       this.#pathUtils.joinNormalToRelative(normalCandidatePath, subpath).normalPath,
       {
         collectLinkPaths: invalidatedBy,
+        start: canForwardStart ? start! : undefined,
       }
     );
     if (

--- a/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
@@ -845,6 +845,84 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
         expect(invalidatedBy).toEqual(new Set(expectedInvalidatedBy.map(p)));
       }
     );
+
+    test('subpathType "d": matches directory child', () => {
+      const invalidatedBy = new Set<string>();
+      expect(
+        hlTfs.hierarchicalLookup(p('/A/B/C/a'), 'b', {
+          breakOnSegment: 'n_m',
+          invalidatedBy,
+          subpathType: 'd',
+        })
+      ).toEqual({ absolutePath: p('/A/B/C/a/b'), containerRelativePath: '' });
+      expect(invalidatedBy).toEqual(new Set());
+    });
+
+    test('subpathType "d": skips file ancestor, matches directory ancestor', () => {
+      const invalidatedBy = new Set<string>();
+      expect(
+        hlTfs.hierarchicalLookup(p('/A/B/C/a/b/c/d/foo.js'), 'package.json', {
+          breakOnSegment: 'n_m',
+          invalidatedBy,
+          subpathType: 'd',
+        })
+      ).toEqual({
+        absolutePath: p('/A/B/C/a/b/package.json'),
+        containerRelativePath: p('c/d/foo.js'),
+      });
+      expect(invalidatedBy).toEqual(
+        new Set([
+          p('/A/B/C/a/b/c/d/foo.js'),
+          p('/A/B/C/a/b/c/d/package.json'),
+          p('/A/B/C/a/b/c/package.json'),
+        ])
+      );
+    });
+
+    test('multi-segment subpath resolves against Phase 1 candidate', () => {
+      const invalidatedBy = new Set<string>();
+      expect(
+        hlTfs.hierarchicalLookup(p('/A/B/C/a/n_m/pkg/foo.js'), p('subpath/package.json'), {
+          breakOnSegment: 'n_m',
+          invalidatedBy,
+          subpathType: 'f',
+        })
+      ).toEqual({
+        absolutePath: p('/A/B/C/a/n_m/pkg/subpath/package.json'),
+        containerRelativePath: 'foo.js',
+      });
+    });
+
+    test('multi-segment subpath resolves against Phase 2 candidate above root', () => {
+      // Phase 2 candidate ends in `..`, so `start` is not forwarded to the
+      // slow path — joinNormalToRelative would otherwise collapse the suffix.
+      const invalidatedBy = new Set<string>();
+      expect(
+        hlTfs.hierarchicalLookup(p('/A/B/foo'), p('C/a/package.json'), {
+          breakOnSegment: 'n_m',
+          invalidatedBy,
+          subpathType: 'f',
+        })
+      ).toEqual({
+        absolutePath: p('/A/B/C/a/package.json'),
+        containerRelativePath: 'foo',
+      });
+      expect(invalidatedBy).toEqual(new Set([p('/A/B/foo')]));
+    });
+
+    test('symlink at subpath resolves via slow path', () => {
+      const invalidatedBy = new Set<string>();
+      expect(
+        hlTfs.hierarchicalLookup(p('/A/B/C/a/1/foo.js'), 'package.json', {
+          breakOnSegment: 'n_m',
+          invalidatedBy,
+          subpathType: 'f',
+        })
+      ).toEqual({
+        absolutePath: p('/A/B/C/a/1/real-package.json'),
+        containerRelativePath: 'foo.js',
+      });
+    });
   });
 
   describe('matchFiles', () => {


### PR DESCRIPTION
# Why

The `TreeFS.hierarchicalLookup` code path is exercised quite often by Metro. It's called on each `getPackageForModule` lookup, effectively searching for `./package.json` at each parent hierarchically until the `node_modules` boundary.

This is a special case that makes the `TreeFS.#checkCandidateHasSubpath` check trivial, which means it can be sped up. An improvement here (which is about 20%) yields an outsized improvement on resolution performance.

# How

- Add fast-path to `TreeFS.#checkCandidateHasSubpath` for simple sub-paths

# Test Plan

- Tests pass unchanged
- New tests cover uncovered code paths

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
