### PR TITLE
refactor(metro-file-map): Make `TreeFS` tree walkers monomorphic and ditch generators

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Add hints and start node for `TreeFS.hierarchicalLookup` improving performance for metro's `getClosestPackage` lookups ([#45650](https://github.com/expo/expo/pull/45650) by [@kitten](https://github.com/kitten))
+- Refactor `TreeFS` to make tree walkers monomorphic and ditch generators ([#45651](https://github.com/expo/expo/pull/45651) by [@kitten](https://github.com/kitten))
 
 ## 56.0.0 — 2026-05-08
 

--- a/packages/@expo/metro-file-map/build/lib/TreeFS.js
+++ b/packages/@expo/metro-file-map/build/lib/TreeFS.js
@@ -116,8 +116,11 @@ class TreeFS {
         return tfs;
     }
     getSize(mixedPath) {
-        const fileMetadata = this.#getFileData(mixedPath);
-        return (fileMetadata && fileMetadata[constants_1.default.SIZE]) ?? null;
+        const result = this.#lookup(this.#normalizePath(mixedPath));
+        if (!result.exists || isDirectory(result.node)) {
+            return null;
+        }
+        return result.node[constants_1.default.SIZE] ?? null;
     }
     getDifference(files, options) {
         const changedFiles = new Map(files);
@@ -127,9 +130,7 @@ class TreeFS {
         let rootNode = this.#rootNode;
         let prefix = '';
         if (subpath != null && subpath !== '') {
-            const lookupResult = this.#lookupByNormalPath(subpath, {
-                followLeaf: true,
-            });
+            const lookupResult = this.#lookup(subpath);
             if (!lookupResult.exists || !isDirectory(lookupResult.node)) {
                 // Directory doesn't exist, nothing to compare - all files are new
                 return { changedFiles, removedFiles };
@@ -137,15 +138,12 @@ class TreeFS {
             rootNode = lookupResult.node;
             prefix = lookupResult.canonicalPath;
         }
-        for (const { canonicalPath, metadata } of this.#metadataIterator(rootNode, {
-            includeNodeModules: true,
-            includeSymlinks: true,
-        }, prefix)) {
+        this.#forEachMetadata(rootNode, { includeNodeModules: true, includeSymlinks: true }, prefix, (_baseName, canonicalPath, metadata) => {
             const newMetadata = files.get(canonicalPath);
             if (newMetadata) {
                 if (isRegularFile(newMetadata) !== isRegularFile(metadata)) {
                     // Types differ, file has changed
-                    continue;
+                    return;
                 }
                 if (newMetadata[constants_1.default.MTIME] != null &&
                     newMetadata[constants_1.default.MTIME] !== 0 &&
@@ -170,28 +168,29 @@ class TreeFS {
             else {
                 removedFiles.add(canonicalPath);
             }
-        }
+        });
         return {
             changedFiles,
             removedFiles,
         };
     }
     getMtimeByNormalPath(normalPath) {
-        const result = this.#lookupByNormalPath(normalPath, {
-            followLeaf: false,
-            skipFallback: true,
-        });
+        // skipFallback=true: this is a cache-validation lookup; consulting the
+        // fallback filesystem here would be expensive AND mutate the tree as a
+        // side effect via `#populateFromFilesystem`.
+        const result = this.#walkLookupNoFollow(this.#rootNode, 0, 0, normalPath, undefined, true);
         return result.exists && !isDirectory(result.node) ? result.node[constants_1.default.MTIME] : null;
     }
     getSha1(mixedPath) {
-        const fileMetadata = this.#getFileData(mixedPath);
-        return (fileMetadata && fileMetadata[constants_1.default.SHA1]) ?? null;
+        const result = this.#lookup(this.#normalizePath(mixedPath));
+        if (!result.exists || isDirectory(result.node)) {
+            return null;
+        }
+        return result.node[constants_1.default.SHA1] ?? null;
     }
     async getOrComputeSha1(mixedPath) {
         const normalPath = this.#normalizePath(mixedPath);
-        const result = this.#lookupByNormalPath(normalPath, {
-            followLeaf: true,
-        });
+        const result = this.#lookup(normalPath);
         if (!result.exists || isDirectory(result.node)) {
             return null;
         }
@@ -230,16 +229,13 @@ class TreeFS {
             : { sha1 };
     }
     exists(mixedPath) {
-        const result = this.#getFileData(mixedPath);
-        return result != null;
+        const result = this.#lookup(this.#normalizePath(mixedPath));
+        return result.exists && !isDirectory(result.node);
     }
     lookup(mixedPath) {
         const normalPath = this.#normalizePath(mixedPath);
         const links = new Set();
-        const result = this.#lookupByNormalPath(normalPath, {
-            collectLinkPaths: links,
-            followLeaf: true,
-        });
+        const result = this.#lookup(normalPath, links);
         if (!result.exists) {
             const { canonicalMissingPath } = result;
             return {
@@ -257,19 +253,33 @@ class TreeFS {
         return { exists: true, links, realPath, type: 'f', metadata: node };
     }
     getAllFiles() {
-        return Array.from(this.metadataIterator({
-            includeNodeModules: true,
-            includeSymlinks: false,
-        }), ({ canonicalPath }) => this.#pathUtils.normalToAbsolute(canonicalPath));
+        const result = [];
+        this.#collectAllFilesInto(this.#rootNode, '', result);
+        return result;
+    }
+    // NOTE(@kitten): Specialize the `getAllFiles` collector, to avoid a megamorphic deopt in V8
+    #collectAllFilesInto(node, prefix, result) {
+        for (const [name, child] of node) {
+            if (child == null) {
+                continue;
+            }
+            const prefixedName = prefix === '' ? name : prefix + path_1.default.sep + name;
+            if (isDirectory(child)) {
+                this.#collectAllFilesInto(child, prefixedName, result);
+            }
+            else if (isRegularFile(child)) {
+                result.push(this.#pathUtils.normalToAbsolute(prefixedName));
+            }
+        }
     }
     linkStats(mixedPath) {
-        const fileMetadata = this.#getFileData(mixedPath, { followLeaf: false });
-        if (fileMetadata == null) {
+        const result = this.#lookupNoFollow(this.#normalizePath(mixedPath));
+        if (!result.exists || isDirectory(result.node)) {
             return null;
         }
-        const fileType = isRegularFile(fileMetadata) ? 'f' : 'l';
+        const fileMetadata = result.node;
         return {
-            fileType,
+            fileType: isRegularFile(fileMetadata) ? 'f' : 'l',
             modifiedTime: fileMetadata[constants_1.default.MTIME],
             size: fileMetadata[constants_1.default.SIZE],
         };
@@ -282,7 +292,7 @@ class TreeFS {
     *matchFiles(opts) {
         const { filter = null, filterCompareAbsolute = false, filterComparePosix = false, follow = false, recursive = true, rootDir = null, } = opts;
         const normalRoot = rootDir == null ? '' : this.#normalizePath(rootDir);
-        const contextRootResult = this.#lookupByNormalPath(normalRoot);
+        const contextRootResult = this.#lookup(normalRoot);
         if (!contextRootResult.exists) {
             return;
         }
@@ -295,13 +305,14 @@ class TreeFS {
         const contextRootAbsolutePathForComparison = filterComparePosix && path_1.default.sep !== '/'
             ? contextRootAbsolutePath.replaceAll(path_1.default.sep, '/')
             : contextRootAbsolutePath;
-        for (const relativePathForComparison of this.#pathIterator(contextRoot, contextRootParent, ancestorOfRootIdx, {
+        const matches = [];
+        this.#forEachPath(contextRoot, contextRootParent, ancestorOfRootIdx, {
             alwaysYieldPosix: filterComparePosix,
             canonicalPathOfRoot: rootRealPath,
             follow,
             recursive,
             subtreeOnly: rootDir != null,
-        })) {
+        }, '', new Set(), (relativePathForComparison) => {
             if (filter == null ||
                 filter.test(
                 // NOTE(EvanBacon): Ensure files start with `./` for matching purposes
@@ -313,24 +324,44 @@ class TreeFS {
                 const relativePath = filterComparePosix === true && path_1.default.sep !== '/'
                     ? relativePathForComparison.replaceAll('/', path_1.default.sep)
                     : relativePathForComparison;
-                yield path_1.default.join(contextRootAbsolutePath, relativePath);
+                matches.push(path_1.default.join(contextRootAbsolutePath, relativePath));
             }
-        }
+        });
+        yield* matches;
     }
     addOrModify(mixedPath, metadata, changeListener) {
         const normalPath = this.#normalizePath(mixedPath);
+        const dirname = path_1.default.dirname(normalPath);
+        const basename = path_1.default.basename(normalPath);
         // Walk the tree to find the *real* path of the parent node, creating
         // directories as we need.
-        const parentDirNode = this.#lookupByNormalPath(path_1.default.dirname(normalPath), {
-            changeListener,
-            makeDirectories: true,
-        });
+        const onSegment = changeListener
+            ? (_node, segmentNormalPath, _segmentName, _idx, isNewlyCreated) => {
+                if (isNewlyCreated) {
+                    changeListener.directoryAdded(segmentNormalPath);
+                }
+            }
+            : undefined;
+        const parentDirNode = this.#walkAndMakeDirectories(this.#rootNode, 0, 0, dirname, true, onSegment);
         if (!parentDirNode.exists) {
             throw new Error(`TreeFS: Failed to make parent directory entry for ${mixedPath}`);
         }
-        // Normalize the resulting path to account for the parent node being root.
-        const canonicalPath = this.#normalizePath(parentDirNode.canonicalPath + path_1.default.sep + path_1.default.basename(normalPath));
-        this.bulkAddOrModify(new Map([[canonicalPath, metadata]]), changeListener);
+        if (!isDirectory(parentDirNode.node)) {
+            throw new Error(`TreeFS: Could not add directory ${dirname}, adding ${mixedPath}. ` +
+                `${dirname} already exists in the file map as a file.`);
+        }
+        const canonicalPath = this.#normalizePath(parentDirNode.canonicalPath + path_1.default.sep + basename);
+        if (changeListener != null) {
+            const existingNode = parentDirNode.node.get(basename);
+            if (existingNode != null) {
+                (0, invariant_1.default)(!isDirectory(existingNode), 'Detected addition or modification of file %s, but it is tracked as a non-empty directory', canonicalPath);
+                changeListener.fileModified(canonicalPath, existingNode, metadata);
+            }
+            else {
+                changeListener.fileAdded(canonicalPath, metadata);
+            }
+        }
+        parentDirNode.node.set(basename, metadata);
     }
     bulkAddOrModify(addedOrModifiedFiles, changeListener) {
         // Optimisation: Bulk FileData are typically clustered by directory, so we
@@ -339,16 +370,19 @@ class TreeFS {
         // faster than caching all lookups in a Map, and 70% faster than no cache.
         let lastDir;
         let directoryNode;
+        const onSegment = changeListener
+            ? (_node, segmentNormalPath, _segmentName, _idx, isNewlyCreated) => {
+                if (isNewlyCreated) {
+                    changeListener.directoryAdded(segmentNormalPath);
+                }
+            }
+            : undefined;
         for (const [normalPath, metadata] of addedOrModifiedFiles) {
             const lastSepIdx = normalPath.lastIndexOf(path_1.default.sep);
             const dirname = lastSepIdx === -1 ? '' : normalPath.slice(0, lastSepIdx);
             const basename = lastSepIdx === -1 ? normalPath : normalPath.slice(lastSepIdx + 1);
             if (directoryNode == null || dirname !== lastDir) {
-                const lookup = this.#lookupByNormalPath(dirname, {
-                    changeListener,
-                    followLeaf: false,
-                    makeDirectories: true,
-                });
+                const lookup = this.#walkAndMakeDirectories(this.#rootNode, 0, 0, dirname, false, onSegment);
                 if (!lookup.exists) {
                     // This should only be possible if the input is non-real and
                     // lookup hits a broken symlink.
@@ -382,7 +416,7 @@ class TreeFS {
         this.#removeNormalPath(normalPath, changeListener);
     }
     #removeNormalPath(normalPath, changeListener) {
-        const result = this.#lookupByNormalPath(normalPath, { followLeaf: false });
+        const result = this.#lookupNoFollow(normalPath);
         if (!result.exists) {
             return;
         }
@@ -408,8 +442,7 @@ class TreeFS {
                 // NB: This isn't the most efficient algorithm - in the case of
                 // removing the last file in a deep hierarchy it's O(depth^2), but
                 // that's not expected to be a case common enough to justify
-                // implementation complexity, or slowing down more common uses of
-                // _lookupByNormalPath.
+                // implementation complexity, or slowing down more common lookups.
                 this.#removeNormalPath(path_1.default.dirname(canonicalPath), changeListener);
             }
         }
@@ -428,8 +461,15 @@ class TreeFS {
      *
      * Note that this code is extremely hot during resolution, being the most
      * expensive part of a file existence check. Benchmark any modifications!
+     *
+     * Each flag combination is implemented as its own specialised walker
+     * (`#walkLookup`, `#walkLookupNoFollow`, `#walkAndMakeDirectories`) so
+     * the hot inner loop has no per-iteration
+     * `opts.X` branches. Thin convenience wrappers below (`#lookup`,
+     * `#lookupNoFollow`, `#lookupFromNode`, `#walkAndStream`) cover the
+     * common call shapes.
      */
-    #lookupByNormalPath(requestedNormalPath, opts = { followLeaf: true, makeDirectories: false }) {
+    #walkLookup(startNode, startPathIdx, startAncestorOfRootIdx, requestedNormalPath, onSegment, collectLinkPaths) {
         // We'll update the target if we hit a symlink.
         let targetNormalPath = requestedNormalPath;
         // Lazy-initialised set of seen target paths, to detect symlink cycles.
@@ -437,20 +477,11 @@ class TreeFS {
         // Set when a symlink is followed, to allow fallback population outside
         // the boundary for paths reachable transitively through symlinks.
         let followedSymlink = false;
-        // Pointer to the first character of the current path segment in
-        // targetNormalPath.
-        let fromIdx = opts.start?.pathIdx ?? 0;
-        // The parent of the current segment.
-        let parentNode = opts.start?.node ?? this.#rootNode;
-        // If a returned node is (an ancestor of) the root, this is the number of
-        // levels below the root, i.e. '' is 0, '..' is 1, '../..' is 2, otherwise
-        // null.
-        let ancestorOfRootIdx = opts.start?.ancestorOfRootIdx ?? 0;
-        const { collectAncestors, changeListener } = opts;
-        // Used only when collecting ancestors, to avoid double-counting nodes and
+        let fromIdx = startPathIdx;
+        let parentNode = startNode;
+        let ancestorOfRootIdx = startAncestorOfRootIdx;
+        // Used only when streaming ancestors, to avoid double-yielding nodes and
         // paths when traversing a symlink takes us back to rootNode and out again.
-        // This tracks the first character of the first segment not already
-        // collected.
         let unseenPathFromIdx = 0;
         while (targetNormalPath.length > fromIdx) {
             const nextSepIdx = targetNormalPath.indexOf(path_1.default.sep, fromIdx);
@@ -464,24 +495,22 @@ class TreeFS {
                 continue;
             }
             let segmentNode = parentNode.get(segmentName);
-            // In normal paths all indirections are at the prefix, so we are at the
-            // nth ancestor of the root iff the path so far is n '..' segments.
             if (segmentName === '..' && ancestorOfRootIdx != null) {
                 ancestorOfRootIdx++;
             }
             else if (segmentNode != null) {
-                ancestorOfRootIdx = null;
+                ancestorOfRootIdx = undefined;
             }
             if (segmentNode == null) {
-                if (opts.makeDirectories !== true && segmentName !== '..') {
-                    if (!opts.skipFallback && this.#fallbackFilesystem != null) {
+                if (segmentName !== '..') {
+                    if (this.#fallbackFilesystem != null) {
                         const parentEnd = isLastSegment
                             ? fromIdx - segmentName.length - 1
                             : fromIdx - segmentName.length - 2;
                         const parentCanonicalPath = parentEnd > 0 ? targetNormalPath.slice(0, parentEnd) : '';
                         segmentNode = this.#populateFromFilesystem(parentNode, segmentName, parentCanonicalPath, followedSymlink);
                         if (segmentNode != null) {
-                            ancestorOfRootIdx = null;
+                            ancestorOfRootIdx = undefined;
                         }
                     }
                     if (segmentNode == null) {
@@ -496,16 +525,7 @@ class TreeFS {
                 }
                 if (segmentNode == null) {
                     segmentNode = new Map();
-                    if (opts.makeDirectories === true) {
-                        if (changeListener != null) {
-                            const canonicalPath = isLastSegment
-                                ? targetNormalPath
-                                : targetNormalPath.slice(0, fromIdx - 1);
-                            changeListener.directoryAdded(canonicalPath);
-                        }
-                        parentNode.set(segmentName, segmentNode);
-                    }
-                    else if (!opts.skipFallback && this.#fallbackFilesystem != null) {
+                    if (this.#fallbackFilesystem != null) {
                         parentNode.set(segmentName, segmentNode);
                     }
                 }
@@ -514,13 +534,12 @@ class TreeFS {
             if (
             // ...at a directory node and the only subsequent character is `/`, or
             (nextSepIdx === targetNormalPath.length - 1 && isDirectory(segmentNode)) ||
-                // there are no subsequent `/`, and this node is anything but a symlink
-                // we're required to resolve due to followLeaf.
-                (isLastSegment &&
-                    (isDirectory(segmentNode) || isRegularFile(segmentNode) || opts.followLeaf === false))) {
+                // ...there are no subsequent `/`, and this node is a directory or a
+                // regular file. (A leaf symlink falls through and is followed.)
+                (isLastSegment && (isDirectory(segmentNode) || isRegularFile(segmentNode)))) {
                 return {
                     ancestorOfRootIdx,
-                    canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1), // remove trailing `/`
+                    canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1),
                     exists: true,
                     node: segmentNode,
                     parentNode,
@@ -529,16 +548,11 @@ class TreeFS {
             // If the next node is a directory, go into it
             if (isDirectory(segmentNode)) {
                 parentNode = segmentNode;
-                if (collectAncestors && isUnseen) {
+                if (onSegment != null && isUnseen) {
                     const currentPath = isLastSegment
                         ? targetNormalPath
                         : targetNormalPath.slice(0, fromIdx - 1);
-                    collectAncestors.push({
-                        ancestorOfRootIdx,
-                        node: segmentNode,
-                        normalPath: currentPath,
-                        segmentName,
-                    });
+                    onSegment(segmentNode, currentPath, segmentName, ancestorOfRootIdx);
                 }
             }
             else {
@@ -562,8 +576,8 @@ class TreeFS {
                         missingSegmentName: segmentName,
                     };
                 }
-                if (opts.collectLinkPaths) {
-                    opts.collectLinkPaths.add(this.#pathUtils.normalToAbsolute(currentPath));
+                if (collectLinkPaths != null) {
+                    collectLinkPaths.add(this.#pathUtils.normalToAbsolute(currentPath));
                 }
                 const remainingTargetPath = isLastSegment ? '' : targetNormalPath.slice(fromIdx);
                 // Append any subsequent path segments to the symlink target, and reset
@@ -572,18 +586,19 @@ class TreeFS {
                 targetNormalPath = joinedResult.normalPath;
                 // Two special cases (covered by unit tests):
                 //
-                // If the symlink target is the root, the root should be a counted as
-                // an ancestor. We'd otherwise miss counting it because we normally
-                // push new ancestors only when entering a directory.
+                // If the symlink target is the root, the root should be counted as an
+                // ancestor. We'd otherwise miss it because new ancestors are only
+                // streamed when entering a directory.
                 //
                 // If the symlink target is an ancestor of the root *and* joining it
                 // with the remaining path results in collapsing segments, e.g:
-                // '../..' + 'parentofroot/root/foo.js' = 'foo.js', then we must add
+                // '../..' + 'parentofroot/root/foo.js' = 'foo.js', then we must yield
                 // parentofroot and root as ancestors.
-                if (collectAncestors &&
+                if (onSegment != null &&
                     !isLastSegment &&
                     // No-op optimisation to bail out the common case of nothing to do.
-                    ((ancestorOfRootIdx = this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget)) === 0 ||
+                    ((ancestorOfRootIdx =
+                        this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget) ?? undefined) === 0 ||
                         joinedResult.collapsedSegments > 0)) {
                     let node = this.#rootNode;
                     let collapsedPath = '';
@@ -605,12 +620,16 @@ class TreeFS {
                         node = node.get('..') ?? new Map();
                         collapsedPath = collapsedPath === '' ? '..' : collapsedPath + path_1.default.sep + '..';
                     }
-                    collectAncestors.push(...reverseAncestors.reverse());
+                    // Emit in shallowest-first order, matching today's
+                    // collectAncestors.push(...reverseAncestors.reverse()).
+                    for (let i = reverseAncestors.length - 1; i >= 0; i--) {
+                        const a = reverseAncestors[i];
+                        onSegment(a.node, a.normalPath, a.segmentName, a.ancestorOfRootIdx);
+                    }
                 }
-                // For the purpose of collecting ancestors: Ignore the traversal to
-                // the symlink target, and start collecting ancestors only
-                // from the target itself (ie, the basename of the normal target path)
-                // onwards.
+                // For the purpose of streaming ancestors: Ignore the traversal to the
+                // symlink target, and start yielding ancestors only from the target
+                // itself (i.e. the basename of the normal target path) onwards.
                 unseenPathFromIdx = normalSymlinkTarget.lastIndexOf(path_1.default.sep) + 1;
                 if (seen == null) {
                     // Optimisation: set this lazily only when we've encountered a symlink
@@ -637,8 +656,288 @@ class TreeFS {
             canonicalPath: targetNormalPath,
             exists: true,
             node: this.#rootNode,
-            parentNode: null,
+            parentNode: undefined,
         };
+    }
+    /**
+     * Specialised body for lstat-style lookups: followLeaf=false,
+     * makeDirectories=false. A symlink at the leaf is returned as-is.
+     * `skipFallback=true` disables the fallback-FS consultation (used by
+     * `getMtimeByNormalPath`, which must not trigger fallback population as
+     * a side effect of validation).
+     */
+    #walkLookupNoFollow(startNode, startPathIdx, startAncestorOfRootIdx, requestedNormalPath, onSegment, skipFallback) {
+        let targetNormalPath = requestedNormalPath;
+        let seen;
+        let followedSymlink = false;
+        let fromIdx = startPathIdx;
+        let parentNode = startNode;
+        let ancestorOfRootIdx = startAncestorOfRootIdx;
+        let unseenPathFromIdx = 0;
+        while (targetNormalPath.length > fromIdx) {
+            const nextSepIdx = targetNormalPath.indexOf(path_1.default.sep, fromIdx);
+            const isLastSegment = nextSepIdx === -1;
+            const segmentName = isLastSegment
+                ? targetNormalPath.slice(fromIdx)
+                : targetNormalPath.slice(fromIdx, nextSepIdx);
+            const isUnseen = fromIdx >= unseenPathFromIdx;
+            fromIdx = !isLastSegment ? nextSepIdx + 1 : targetNormalPath.length;
+            if (segmentName === '.') {
+                continue;
+            }
+            let segmentNode = parentNode.get(segmentName);
+            if (segmentName === '..' && ancestorOfRootIdx != null) {
+                ancestorOfRootIdx++;
+            }
+            else if (segmentNode != null) {
+                ancestorOfRootIdx = undefined;
+            }
+            if (segmentNode == null) {
+                if (segmentName !== '..') {
+                    if (!skipFallback && this.#fallbackFilesystem != null) {
+                        const parentEnd = isLastSegment
+                            ? fromIdx - segmentName.length - 1
+                            : fromIdx - segmentName.length - 2;
+                        const parentCanonicalPath = parentEnd > 0 ? targetNormalPath.slice(0, parentEnd) : '';
+                        segmentNode = this.#populateFromFilesystem(parentNode, segmentName, parentCanonicalPath, followedSymlink);
+                        if (segmentNode != null) {
+                            ancestorOfRootIdx = undefined;
+                        }
+                    }
+                    if (segmentNode == null) {
+                        return {
+                            canonicalMissingPath: isLastSegment
+                                ? targetNormalPath
+                                : targetNormalPath.slice(0, fromIdx - 1),
+                            exists: false,
+                            missingSegmentName: segmentName,
+                        };
+                    }
+                }
+                if (segmentNode == null) {
+                    segmentNode = new Map();
+                    if (!skipFallback && this.#fallbackFilesystem != null) {
+                        parentNode.set(segmentName, segmentNode);
+                    }
+                }
+            }
+            // Done: at the last segment we return whatever we found (no leaf
+            // follow). Also done if the only remaining character is the trailing
+            // path separator and the node is a directory.
+            if (isLastSegment ||
+                (nextSepIdx === targetNormalPath.length - 1 && isDirectory(segmentNode))) {
+                return {
+                    ancestorOfRootIdx,
+                    canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1),
+                    exists: true,
+                    node: segmentNode,
+                    parentNode,
+                };
+            }
+            if (isDirectory(segmentNode)) {
+                parentNode = segmentNode;
+                if (onSegment != null && isUnseen) {
+                    const currentPath = targetNormalPath.slice(0, fromIdx - 1);
+                    onSegment(segmentNode, currentPath, segmentName, ancestorOfRootIdx);
+                }
+            }
+            else {
+                const currentPath = targetNormalPath.slice(0, fromIdx - 1);
+                if (isRegularFile(segmentNode)) {
+                    return {
+                        canonicalMissingPath: currentPath,
+                        exists: false,
+                        missingSegmentName: segmentName,
+                    };
+                }
+                // Symlink in an interior position — still follow it (only the leaf
+                // is exempt from following under followLeaf=false).
+                const normalSymlinkTarget = this.#resolveSymlinkTargetToNormalPath(segmentNode, currentPath);
+                if (normalSymlinkTarget == null) {
+                    return {
+                        canonicalMissingPath: currentPath,
+                        exists: false,
+                        missingSegmentName: segmentName,
+                    };
+                }
+                const remainingTargetPath = targetNormalPath.slice(fromIdx);
+                const joinedResult = this.#pathUtils.joinNormalToRelative(normalSymlinkTarget, remainingTargetPath);
+                targetNormalPath = joinedResult.normalPath;
+                if (onSegment != null &&
+                    ((ancestorOfRootIdx =
+                        this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget) ?? undefined) === 0 ||
+                        joinedResult.collapsedSegments > 0)) {
+                    let node = this.#rootNode;
+                    let collapsedPath = '';
+                    const reverseAncestors = [];
+                    for (let i = 0; i <= joinedResult.collapsedSegments && isDirectory(node); i++) {
+                        if (i > 0 || ancestorOfRootIdx === 0 || joinedResult.collapsedSegments > 0) {
+                            reverseAncestors.push({
+                                ancestorOfRootIdx: i,
+                                node,
+                                normalPath: collapsedPath,
+                                segmentName: this.#pathUtils.getBasenameOfNthAncestor(i),
+                            });
+                        }
+                        node = node.get('..') ?? new Map();
+                        collapsedPath = collapsedPath === '' ? '..' : collapsedPath + path_1.default.sep + '..';
+                    }
+                    for (let i = reverseAncestors.length - 1; i >= 0; i--) {
+                        const a = reverseAncestors[i];
+                        onSegment(a.node, a.normalPath, a.segmentName, a.ancestorOfRootIdx);
+                    }
+                }
+                unseenPathFromIdx = normalSymlinkTarget.lastIndexOf(path_1.default.sep) + 1;
+                if (seen == null) {
+                    seen = new Set([requestedNormalPath]);
+                }
+                if (seen.has(targetNormalPath)) {
+                    return {
+                        canonicalMissingPath: targetNormalPath,
+                        exists: false,
+                        missingSegmentName: segmentName,
+                    };
+                }
+                seen.add(targetNormalPath);
+                followedSymlink = true;
+                fromIdx = 0;
+                parentNode = this.#rootNode;
+                ancestorOfRootIdx = 0;
+            }
+        }
+        (0, invariant_1.default)(parentNode === this.#rootNode, 'Unexpectedly escaped traversal');
+        return {
+            ancestorOfRootIdx: 0,
+            canonicalPath: targetNormalPath,
+            exists: true,
+            node: this.#rootNode,
+            parentNode: undefined,
+        };
+    }
+    /**
+     * Specialised body that creates missing directory nodes as it walks.
+     * `followLeaf` is parameterised so callers that look up `dirname(...)`
+     * can choose lstat-style or stat-style at the leaf. `onSegment` fires
+     * for every directory encountered, with `isNewlyCreated` distinguishing
+     * dirs the walker just created from dirs that already existed.
+     */
+    #walkAndMakeDirectories(startNode, startPathIdx, startAncestorOfRootIdx, requestedNormalPath, followLeaf, onSegment) {
+        let targetNormalPath = requestedNormalPath;
+        let seen;
+        let fromIdx = startPathIdx;
+        let parentNode = startNode;
+        let ancestorOfRootIdx = startAncestorOfRootIdx;
+        let unseenPathFromIdx = 0;
+        while (targetNormalPath.length > fromIdx) {
+            const nextSepIdx = targetNormalPath.indexOf(path_1.default.sep, fromIdx);
+            const isLastSegment = nextSepIdx === -1;
+            const segmentName = isLastSegment
+                ? targetNormalPath.slice(fromIdx)
+                : targetNormalPath.slice(fromIdx, nextSepIdx);
+            const isUnseen = fromIdx >= unseenPathFromIdx;
+            fromIdx = !isLastSegment ? nextSepIdx + 1 : targetNormalPath.length;
+            if (segmentName === '.') {
+                continue;
+            }
+            let segmentNode = parentNode.get(segmentName);
+            let wasJustCreated = false;
+            if (segmentName === '..' && ancestorOfRootIdx != null) {
+                ancestorOfRootIdx++;
+            }
+            else if (segmentNode != null) {
+                ancestorOfRootIdx = undefined;
+            }
+            if (segmentNode == null) {
+                segmentNode = new Map();
+                parentNode.set(segmentName, segmentNode);
+                wasJustCreated = true;
+            }
+            if ((nextSepIdx === targetNormalPath.length - 1 && isDirectory(segmentNode)) ||
+                (isLastSegment && (isDirectory(segmentNode) || isRegularFile(segmentNode) || !followLeaf))) {
+                if (wasJustCreated && onSegment != null) {
+                    const currentPath = isLastSegment
+                        ? targetNormalPath
+                        : targetNormalPath.slice(0, fromIdx - 1);
+                    onSegment(segmentNode, currentPath, segmentName, ancestorOfRootIdx, true);
+                }
+                return {
+                    ancestorOfRootIdx,
+                    canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1),
+                    exists: true,
+                    node: segmentNode,
+                    parentNode,
+                };
+            }
+            if (isDirectory(segmentNode)) {
+                parentNode = segmentNode;
+                if (onSegment != null && isUnseen) {
+                    const currentPath = isLastSegment
+                        ? targetNormalPath
+                        : targetNormalPath.slice(0, fromIdx - 1);
+                    onSegment(segmentNode, currentPath, segmentName, ancestorOfRootIdx, wasJustCreated);
+                }
+            }
+            else {
+                const currentPath = isLastSegment
+                    ? targetNormalPath
+                    : targetNormalPath.slice(0, fromIdx - 1);
+                if (isRegularFile(segmentNode)) {
+                    return {
+                        canonicalMissingPath: currentPath,
+                        exists: false,
+                        missingSegmentName: segmentName,
+                    };
+                }
+                // Interior symlink: follow it.
+                const normalSymlinkTarget = this.#resolveSymlinkTargetToNormalPath(segmentNode, currentPath);
+                if (normalSymlinkTarget == null) {
+                    return {
+                        canonicalMissingPath: currentPath,
+                        exists: false,
+                        missingSegmentName: segmentName,
+                    };
+                }
+                const remainingTargetPath = isLastSegment ? '' : targetNormalPath.slice(fromIdx);
+                const joinedResult = this.#pathUtils.joinNormalToRelative(normalSymlinkTarget, remainingTargetPath);
+                targetNormalPath = joinedResult.normalPath;
+                unseenPathFromIdx = normalSymlinkTarget.lastIndexOf(path_1.default.sep) + 1;
+                if (seen == null) {
+                    seen = new Set([requestedNormalPath]);
+                }
+                if (seen.has(targetNormalPath)) {
+                    return {
+                        canonicalMissingPath: targetNormalPath,
+                        exists: false,
+                        missingSegmentName: segmentName,
+                    };
+                }
+                seen.add(targetNormalPath);
+                fromIdx = 0;
+                parentNode = this.#rootNode;
+                ancestorOfRootIdx = 0;
+            }
+        }
+        (0, invariant_1.default)(parentNode === this.#rootNode, 'Unexpectedly escaped traversal');
+        return {
+            ancestorOfRootIdx: 0,
+            canonicalPath: targetNormalPath,
+            exists: true,
+            node: this.#rootNode,
+            parentNode: undefined,
+        };
+    }
+    // Convenience wrappers for the common walker call shapes.
+    #lookup(normalPath, collectLinkPaths) {
+        return this.#walkLookup(this.#rootNode, 0, 0, normalPath, undefined, collectLinkPaths);
+    }
+    #lookupNoFollow(normalPath) {
+        return this.#walkLookupNoFollow(this.#rootNode, 0, 0, normalPath, undefined, false);
+    }
+    #lookupFromNode(startNode, startPathIdx, startAncestorOfRootIdx, target, collectLinkPaths) {
+        return this.#walkLookup(startNode, startPathIdx, startAncestorOfRootIdx, target, undefined, collectLinkPaths);
+    }
+    #walkAndStream(normalPath, onSegment, collectLinkPaths) {
+        return this.#walkLookup(this.#rootNode, 0, 0, normalPath, onSegment, collectLinkPaths);
     }
     /**
      * Given a start path (which need not exist), a subpath and type, and
@@ -666,11 +965,16 @@ class TreeFS {
     hierarchicalLookup(mixedStartPath, subpath, opts) {
         const ancestorsOfInput = [];
         const normalPath = this.#normalizePath(mixedStartPath);
-        const invalidatedBy = opts.invalidatedBy;
-        const closestLookup = this.#lookupByNormalPath(normalPath, {
-            collectAncestors: ancestorsOfInput,
-            collectLinkPaths: invalidatedBy,
-        });
+        const invalidatedBy = opts.invalidatedBy ?? undefined;
+        const onSegment = (node, normalPathOfDir, segmentName, ancestorOfRootIdx) => {
+            ancestorsOfInput.push({
+                ancestorOfRootIdx,
+                node,
+                normalPath: normalPathOfDir,
+                segmentName,
+            });
+        };
+        const closestLookup = this.#walkAndStream(normalPath, onSegment, invalidatedBy);
         if (closestLookup.exists && isDirectory(closestLookup.node)) {
             const maybeAbsolutePathMatch = this.#checkCandidateHasSubpath(closestLookup.canonicalPath, subpath, opts.subpathType, invalidatedBy, {
                 ancestorOfRootIdx: closestLookup.ancestorOfRootIdx,
@@ -719,7 +1023,7 @@ class TreeFS {
                 commonRoot = ancestor.node;
             }
         }
-        // Phase 1: Consider descendenants of the common root, from deepest to
+        // Phase 1: Consider descendants of the common root, from deepest to
         // shallowest.
         for (let candidateIdx = ancestorsOfInput.length - 1; candidateIdx >= commonRootDepth; --candidateIdx) {
             const candidate = ancestorsOfInput[candidateIdx];
@@ -732,15 +1036,12 @@ class TreeFS {
                 pathIdx: candidate.normalPath.length > 0 ? candidate.normalPath.length + 1 : 0,
             });
             if (maybeAbsolutePathMatch != null) {
-                // Determine the input path relative to the current candidate. Note
-                // that the candidate path will always be canonical (real), whereas the
-                // input may contain symlinks, so the candidate is not necessarily a
-                // prefix of the input. Use the fact that each remaining candidate
-                // corresponds to a leading segment of the input normal path, and
-                // discard the first candidateIdx + 1 segments of the input path.
-                //
-                // The next 5 lines are equivalent to (but faster than)
-                // normalPath.split('/').slice(candidateIdx + 1).join('/').
+                // Determine the input path relative to the current candidate. The
+                // candidate path is always canonical (real); the input may contain
+                // symlinks, so the candidate is not necessarily a prefix of the input.
+                // Use the fact that each remaining candidate corresponds to a leading
+                // segment of the input normal path, and discard the first
+                // candidateIdx + 1 segments of the input path.
                 let prefixLength = commonRootDepth * 3; // Leading '../'
                 for (let i = commonRootDepth; i <= candidateIdx; i++) {
                     prefixLength = normalPath.indexOf(path_1.default.sep, prefixLength + 1);
@@ -752,8 +1053,7 @@ class TreeFS {
                 };
             }
         }
-        // Phase 2: Consider the common root and its ancestors
-        // This will be '', '..', '../..', etc.
+        // Phase 2: Consider the common root and its ancestors.
         let candidateNormalPath = commonRootDepth > 0 ? normalPath.slice(0, 3 * commonRootDepth - 1) : '';
         const remainingNormalPath = normalPath.slice(commonRootDepth * 3);
         let nextNode = commonRoot;
@@ -826,10 +1126,10 @@ class TreeFS {
         const canForwardStart = start != null &&
             normalCandidatePath !== '..' &&
             !normalCandidatePath.endsWith(path_1.default.sep + '..');
-        const lookupResult = this.#lookupByNormalPath(this.#pathUtils.joinNormalToRelative(normalCandidatePath, subpath).normalPath, {
-            collectLinkPaths: invalidatedBy,
-            start: canForwardStart ? start : undefined,
-        });
+        const target = this.#pathUtils.joinNormalToRelative(normalCandidatePath, subpath).normalPath;
+        const lookupResult = canForwardStart
+            ? this.#lookupFromNode(start.node, start.pathIdx, start.ancestorOfRootIdx, target, invalidatedBy)
+            : this.#lookup(target, invalidatedBy);
         if (lookupResult.exists &&
             // Should be a Map iff subpathType is directory
             isDirectory(lookupResult.node) === (subpathType === 'd')) {
@@ -840,10 +1140,14 @@ class TreeFS {
         }
         return null;
     }
-    metadataIterator(opts) {
-        return this.#metadataIterator(this.#rootNode, opts);
+    *metadataIterator(opts) {
+        const buffer = [];
+        this.#forEachMetadata(this.#rootNode, opts, '', (baseName, canonicalPath, metadata) => {
+            buffer.push({ baseName, canonicalPath, metadata });
+        });
+        yield* buffer;
     }
-    *#metadataIterator(rootNode, opts, prefix = '') {
+    #forEachMetadata(rootNode, opts, prefix, callback) {
         for (const [name, node] of rootNode) {
             if (node == null) {
                 continue;
@@ -853,10 +1157,10 @@ class TreeFS {
             }
             const prefixedName = prefix === '' ? name : prefix + path_1.default.sep + name;
             if (isDirectory(node)) {
-                yield* this.#metadataIterator(node, opts, prefixedName);
+                this.#forEachMetadata(node, opts, prefixedName, callback);
             }
             else if (isRegularFile(node) || opts.includeSymlinks) {
-                yield { baseName: name, canonicalPath: prefixedName, metadata: node };
+                callback(name, prefixedName, node);
             }
         }
     }
@@ -865,17 +1169,13 @@ class TreeFS {
             ? this.#pathUtils.absoluteToNormal(relativeOrAbsolutePath)
             : this.#pathUtils.relativeToNormal(relativeOrAbsolutePath);
     }
-    *#directoryNodeIterator(node, parent, ancestorOfRootIdx) {
-        if (ancestorOfRootIdx != null && ancestorOfRootIdx > 0 && parent) {
-            yield [this.#pathUtils.getBasenameOfNthAncestor(ancestorOfRootIdx - 1), parent];
-        }
-        yield* node.entries();
-    }
     /**
      * Enumerate paths under a given node, including symlinks and through
-     * symlinks (if `follow` is enabled).
+     * symlinks (if `follow` is enabled). Invokes `callback` for each matching
+     * path. Inlines what was previously `#directoryNodeIterator` (yielding the
+     * parent entry first when `ancestorOfRootIdx > 0`).
      */
-    *#pathIterator(iterationRootNode, iterationRootParentNode, ancestorOfRootIdx, opts, pathPrefix = '', followedLinks = new Set()) {
+    #forEachPath(iterationRootNode, iterationRootParentNode, ancestorOfRootIdx, opts, pathPrefix, followedLinks, callback) {
         const pathSep = opts.alwaysYieldPosix ? '/' : path_1.default.sep;
         const prefixWithSep = pathPrefix === '' ? pathPrefix : pathPrefix + pathSep;
         // Optimization: We can attempt to eagerly populate directories we're visiting
@@ -888,18 +1188,18 @@ class TreeFS {
             const rootCanonical = pathPrefix === '' ? canonicalRoot : canonicalRoot + path_1.default.sep + pathPrefix;
             this.#populateDirFromFilesystem(iterationRootNode, rootCanonical, false, false);
         }
-        for (const [name, node] of this.#directoryNodeIterator(iterationRootNode, iterationRootParentNode, ancestorOfRootIdx)) {
+        const visitEntry = (name, node) => {
             if (node == null) {
-                continue;
+                return;
             }
             else if (opts.subtreeOnly && name === '..') {
-                continue;
+                return;
             }
             const nodePath = prefixWithSep + name;
             if (!isDirectory(node)) {
                 if (isRegularFile(node)) {
                     // regular file
-                    yield nodePath;
+                    callback(nodePath);
                 }
                 else {
                     // symlink
@@ -911,24 +1211,22 @@ class TreeFS {
                     // its normal path, and we need a canonical path for resolution
                     // (imagine our normal path contains a symlink 'bar' -> '.', and we
                     // are at /foo/bar/baz where baz -> '..' - that should resolve to
-                    // /foo, not /foo/bar). We *can* use _lookupByNormalPath to walk to
-                    // the canonical symlink, and then to its target.
-                    const resolved = this.#lookupByNormalPath(normalPathOfSymlink, {
-                        followLeaf: true,
-                    });
+                    // /foo, not /foo/bar). We *can* use #walkLookup to walk to the
+                    // canonical symlink, and then to its target.
+                    const resolved = this.#lookup(normalPathOfSymlink);
                     if (!resolved.exists) {
                         // Symlink goes nowhere, nothing to report.
-                        continue;
+                        return;
                     }
                     const target = resolved.node;
                     if (!isDirectory(target)) {
                         // Symlink points to a file, just yield the path of the symlink.
-                        yield nodePath;
+                        callback(nodePath);
                     }
                     else if (opts.recursive && opts.follow && !followedLinks.has(node)) {
                         // Symlink points to a directory - iterate over its contents using
                         // the path where we found the symlink as a prefix.
-                        yield* this.#pathIterator(target, resolved.parentNode, resolved.ancestorOfRootIdx, opts, nodePath, new Set([...followedLinks, node]));
+                        this.#forEachPath(target, resolved.parentNode, resolved.ancestorOfRootIdx, opts, nodePath, new Set([...followedLinks, node]), callback);
                     }
                 }
             }
@@ -942,8 +1240,16 @@ class TreeFS {
                         : opts.canonicalPathOfRoot + path_1.default.sep + nodePathWithSystemSeparators;
                     this.#populateDirFromFilesystem(node, canonicalPath, false, false);
                 }
-                yield* this.#pathIterator(node, iterationRootParentNode, ancestorOfRootIdx != null && ancestorOfRootIdx > 0 ? ancestorOfRootIdx - 1 : null, opts, nodePath, followedLinks);
+                this.#forEachPath(node, iterationRootParentNode, ancestorOfRootIdx != null && ancestorOfRootIdx > 0 ? ancestorOfRootIdx - 1 : undefined, opts, nodePath, followedLinks, callback);
             }
+        };
+        // Inlined #directoryNodeIterator: yield the parent entry first when we're
+        // at a directory above the root, then iterate `node.entries()`.
+        if (ancestorOfRootIdx != null && ancestorOfRootIdx > 0 && iterationRootParentNode) {
+            visitEntry(this.#pathUtils.getBasenameOfNthAncestor(ancestorOfRootIdx - 1), iterationRootParentNode);
+        }
+        for (const [name, node] of iterationRootNode) {
+            visitEntry(name, node);
         }
     }
     #resolveSymlinkTargetToNormalPath(symlinkNode, canonicalPathOfSymlink) {
@@ -959,29 +1265,19 @@ class TreeFS {
                 return normalTarget;
             }
             catch {
-                return null;
+                return undefined;
             }
         }
         else if (symlinkTarget === 0 || symlinkTarget == null) {
             // WARN: We shouldn't call this method on non-symlinks. Outside of tests
             // this condition shouldn't trigger. It's fine not to resolve a symlink if
             // it does trigger however
-            return null;
+            return undefined;
         }
         else {
             (0, invariant_1.default)(typeof symlinkTarget === 'string', 'Expected symlink target to be populated.');
             return (0, normalizePathSeparatorsToSystem_1.default)(symlinkTarget);
         }
-    }
-    #getFileData(filePath, opts = { followLeaf: true }) {
-        const normalPath = this.#normalizePath(filePath);
-        const result = this.#lookupByNormalPath(normalPath, {
-            followLeaf: opts.followLeaf,
-        });
-        if (!result.exists || isDirectory(result.node)) {
-            return null;
-        }
-        return result.node;
     }
     /**
      * Return a filtered view of the tree containing only content under watched
@@ -1090,7 +1386,7 @@ class TreeFS {
     }
     /**
      * Populate an existing (potentially empty sentinel) directory node from
-     * the filesystem. Used by #pathIterator to fill lazy directories before
+     * the filesystem. Used by #forEachPath to fill lazy directories before
      * iteration, and by #populateFromFilesystem for optimistic parent
      * population.
      */

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -294,7 +294,10 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   getMtimeByNormalPath(normalPath: Path): number | null {
-    const result = this.#walkLookupSkipFallback(this.#rootNode, 0, 0, normalPath);
+    // skipFallback=true: this is a cache-validation lookup; consulting the
+    // fallback filesystem here would be expensive AND mutate the tree as a
+    // side effect via `#populateFromFilesystem`.
+    const result = this.#walkLookupNoFollow(this.#rootNode, 0, 0, normalPath, undefined, true);
     return result.exists && !isDirectory(result.node) ? result.node[H.MTIME] : null;
   }
 
@@ -627,8 +630,8 @@ export default class TreeFS implements MutableFileSystem {
    * expensive part of a file existence check. Benchmark any modifications!
    *
    * Each flag combination is implemented as its own specialised walker
-   * (`#walkLookup`, `#walkLookupNoFollow`, `#walkLookupSkipFallback`,
-   * `#walkAndMakeDirectories`) so the hot inner loop has no per-iteration
+   * (`#walkLookup`, `#walkLookupNoFollow`, `#walkAndMakeDirectories`) so
+   * the hot inner loop has no per-iteration
    * `opts.X` branches. Thin convenience wrappers below (`#lookup`,
    * `#lookupNoFollow`, `#lookupFromNode`, `#walkAndStream`) cover the
    * common call shapes.
@@ -868,15 +871,18 @@ export default class TreeFS implements MutableFileSystem {
 
   /**
    * Specialised body for lstat-style lookups: followLeaf=false,
-   * makeDirectories=false, fallback enabled. A symlink at the leaf is
-   * returned as-is.
+   * makeDirectories=false. A symlink at the leaf is returned as-is.
+   * `skipFallback=true` disables the fallback-FS consultation (used by
+   * `getMtimeByNormalPath`, which must not trigger fallback population as
+   * a side effect of validation).
    */
   #walkLookupNoFollow(
     startNode: DirectoryNode,
     startPathIdx: number,
     startAncestorOfRootIdx: number | undefined,
     requestedNormalPath: string,
-    onSegment: SegmentCallback | undefined
+    onSegment: SegmentCallback | undefined,
+    skipFallback: boolean
   ): WalkResult {
     let targetNormalPath = requestedNormalPath;
     let seen: Set<string> | undefined;
@@ -909,7 +915,7 @@ export default class TreeFS implements MutableFileSystem {
 
       if (segmentNode == null) {
         if (segmentName !== '..') {
-          if (this.#fallbackFilesystem != null) {
+          if (!skipFallback && this.#fallbackFilesystem != null) {
             const parentEnd = isLastSegment
               ? fromIdx - segmentName.length - 1
               : fromIdx - segmentName.length - 2;
@@ -937,7 +943,7 @@ export default class TreeFS implements MutableFileSystem {
         }
         if (segmentNode == null) {
           segmentNode = new Map();
-          if (this.#fallbackFilesystem != null) {
+          if (!skipFallback && this.#fallbackFilesystem != null) {
             parentNode.set(segmentName, segmentNode);
           }
         }
@@ -1043,131 +1049,6 @@ export default class TreeFS implements MutableFileSystem {
         }
         seen.add(targetNormalPath);
         followedSymlink = true;
-        fromIdx = 0;
-        parentNode = this.#rootNode;
-        ancestorOfRootIdx = 0;
-      }
-    }
-    invariant(parentNode === this.#rootNode, 'Unexpectedly escaped traversal');
-    return {
-      ancestorOfRootIdx: 0,
-      canonicalPath: targetNormalPath,
-      exists: true,
-      node: this.#rootNode,
-      parentNode: undefined,
-    };
-  }
-
-  /**
-   * Specialised body that does not consult the fallback filesystem.
-   * followLeaf=false (the only existing caller, `getMtimeByNormalPath`,
-   * always lstat-style). No symlink-path collection.
-   */
-  #walkLookupSkipFallback(
-    startNode: DirectoryNode,
-    startPathIdx: number,
-    startAncestorOfRootIdx: number | undefined,
-    requestedNormalPath: string
-  ): WalkResult {
-    let targetNormalPath = requestedNormalPath;
-    let seen: Set<string> | undefined;
-    let fromIdx = startPathIdx;
-    let parentNode = startNode;
-    let ancestorOfRootIdx: number | undefined = startAncestorOfRootIdx;
-
-    while (targetNormalPath.length > fromIdx) {
-      const nextSepIdx = targetNormalPath.indexOf(path.sep, fromIdx);
-      const isLastSegment = nextSepIdx === -1;
-      const segmentName = isLastSegment
-        ? targetNormalPath.slice(fromIdx)
-        : targetNormalPath.slice(fromIdx, nextSepIdx);
-      fromIdx = !isLastSegment ? nextSepIdx + 1 : targetNormalPath.length;
-
-      if (segmentName === '.') {
-        continue;
-      }
-
-      let segmentNode: MixedNode | null | undefined = parentNode.get(segmentName);
-
-      if (segmentName === '..' && ancestorOfRootIdx != null) {
-        ancestorOfRootIdx++;
-      } else if (segmentNode != null) {
-        ancestorOfRootIdx = undefined;
-      }
-
-      if (segmentNode == null) {
-        if (segmentName !== '..') {
-          return {
-            canonicalMissingPath: isLastSegment
-              ? targetNormalPath
-              : targetNormalPath.slice(0, fromIdx - 1),
-            exists: false,
-            missingSegmentName: segmentName,
-          };
-        }
-        // segmentName === '..': transient empty Map to keep traversing
-        // ancestors of the root that aren't materialised in the tree.
-        segmentNode = new Map();
-      }
-
-      if (
-        isLastSegment ||
-        (nextSepIdx === targetNormalPath.length - 1 && isDirectory(segmentNode))
-      ) {
-        return {
-          ancestorOfRootIdx,
-          canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1),
-          exists: true,
-          node: segmentNode,
-          parentNode,
-        };
-      }
-
-      if (isDirectory(segmentNode)) {
-        parentNode = segmentNode;
-      } else {
-        const currentPath = targetNormalPath.slice(0, fromIdx - 1);
-
-        if (isRegularFile(segmentNode)) {
-          return {
-            canonicalMissingPath: currentPath,
-            exists: false,
-            missingSegmentName: segmentName,
-          };
-        }
-
-        // Symlink in an interior position — follow it. Fallback is disabled
-        // so we never lazily resolve missing segments along the new target.
-        const normalSymlinkTarget = this.#resolveSymlinkTargetToNormalPath(
-          segmentNode,
-          currentPath
-        );
-        if (normalSymlinkTarget == null) {
-          return {
-            canonicalMissingPath: currentPath,
-            exists: false,
-            missingSegmentName: segmentName,
-          };
-        }
-
-        const remainingTargetPath = targetNormalPath.slice(fromIdx);
-        const joinedResult = this.#pathUtils.joinNormalToRelative(
-          normalSymlinkTarget,
-          remainingTargetPath
-        );
-        targetNormalPath = joinedResult.normalPath;
-
-        if (seen == null) {
-          seen = new Set([requestedNormalPath]);
-        }
-        if (seen.has(targetNormalPath)) {
-          return {
-            canonicalMissingPath: targetNormalPath,
-            exists: false,
-            missingSegmentName: segmentName,
-          };
-        }
-        seen.add(targetNormalPath);
         fromIdx = 0;
         parentNode = this.#rootNode;
         ancestorOfRootIdx = 0;
@@ -1332,7 +1213,7 @@ export default class TreeFS implements MutableFileSystem {
     return this.#walkLookup(this.#rootNode, 0, 0, normalPath, undefined, collectLinkPaths);
   }
   #lookupNoFollow(normalPath: string): WalkResult {
-    return this.#walkLookupNoFollow(this.#rootNode, 0, 0, normalPath, undefined);
+    return this.#walkLookupNoFollow(this.#rootNode, 0, 0, normalPath, undefined, false);
   }
   #lookupFromNode(
     startNode: DirectoryNode,

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -483,6 +483,8 @@ export default class TreeFS implements MutableFileSystem {
 
   addOrModify(mixedPath: Path, metadata: FileMetadata, changeListener?: FileSystemListener): void {
     const normalPath = this.#normalizePath(mixedPath);
+    const dirname = path.dirname(normalPath);
+    const basename = path.basename(normalPath);
     // Walk the tree to find the *real* path of the parent node, creating
     // directories as we need.
     const onSegment: MakeDirsSegmentCallback | undefined = changeListener
@@ -496,18 +498,34 @@ export default class TreeFS implements MutableFileSystem {
       this.#rootNode,
       0,
       0,
-      path.dirname(normalPath),
+      dirname,
       true,
       onSegment
     );
     if (!parentDirNode.exists) {
       throw new Error(`TreeFS: Failed to make parent directory entry for ${mixedPath}`);
     }
-    // Normalize the resulting path to account for the parent node being root.
-    const canonicalPath = this.#normalizePath(
-      parentDirNode.canonicalPath + path.sep + path.basename(normalPath)
-    );
-    this.bulkAddOrModify(new Map([[canonicalPath, metadata]]), changeListener);
+    if (!isDirectory(parentDirNode.node)) {
+      throw new Error(
+        `TreeFS: Could not add directory ${dirname}, adding ${mixedPath}. ` +
+          `${dirname} already exists in the file map as a file.`
+      );
+    }
+    const canonicalPath = this.#normalizePath(parentDirNode.canonicalPath + path.sep + basename);
+    if (changeListener != null) {
+      const existingNode = parentDirNode.node.get(basename);
+      if (existingNode != null) {
+        invariant(
+          !isDirectory(existingNode),
+          'Detected addition or modification of file %s, but it is tracked as a non-empty directory',
+          canonicalPath
+        );
+        changeListener.fileModified(canonicalPath, existingNode, metadata);
+      } else {
+        changeListener.fileAdded(canonicalPath, metadata);
+      }
+    }
+    parentDirNode.node.set(basename, metadata);
   }
 
   bulkAddOrModify(addedOrModifiedFiles: FileData, changeListener?: FileSystemListener): void {

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -246,47 +246,45 @@ export default class TreeFS implements MutableFileSystem {
       prefix = lookupResult.canonicalPath;
     }
 
-    for (const { canonicalPath, metadata } of this.#metadataIterator(
+    this.#forEachMetadata(
       rootNode,
-      {
-        includeNodeModules: true,
-        includeSymlinks: true,
-      },
-      prefix
-    )) {
-      const newMetadata = files.get(canonicalPath);
-      if (newMetadata) {
-        if (isRegularFile(newMetadata) !== isRegularFile(metadata)) {
-          // Types differ, file has changed
-          continue;
+      { includeNodeModules: true, includeSymlinks: true },
+      prefix,
+      (_baseName, canonicalPath, metadata) => {
+        const newMetadata = files.get(canonicalPath);
+        if (newMetadata) {
+          if (isRegularFile(newMetadata) !== isRegularFile(metadata)) {
+            // Types differ, file has changed
+            return;
+          }
+          if (
+            newMetadata[H.MTIME] != null &&
+            newMetadata[H.MTIME] !== 0 &&
+            newMetadata[H.MTIME] === metadata[H.MTIME]
+          ) {
+            // Types and modified time match - not changed.
+            changedFiles.delete(canonicalPath);
+          } else if (
+            (newMetadata[H.MTIME] == null || newMetadata[H.MTIME] === 0) &&
+            (metadata[H.MTIME] == null || metadata[H.MTIME] === 0)
+          ) {
+            // If file is still untouched then mark it as unchanged
+            changedFiles.delete(canonicalPath);
+          } else if (
+            newMetadata[H.SHA1] != null &&
+            newMetadata[H.SHA1] === metadata[H.SHA1] &&
+            metadata[H.VISITED] === 1
+          ) {
+            // Content matches - update modified time but don't revisit
+            const updatedMetadata = [...metadata] as FileMetadata;
+            updatedMetadata[H.MTIME] = newMetadata[H.MTIME];
+            changedFiles.set(canonicalPath, updatedMetadata);
+          }
+        } else {
+          removedFiles.add(canonicalPath);
         }
-        if (
-          newMetadata[H.MTIME] != null &&
-          newMetadata[H.MTIME] !== 0 &&
-          newMetadata[H.MTIME] === metadata[H.MTIME]
-        ) {
-          // Types and modified time match - not changed.
-          changedFiles.delete(canonicalPath);
-        } else if (
-          (newMetadata[H.MTIME] == null || newMetadata[H.MTIME] === 0) &&
-          (metadata[H.MTIME] == null || metadata[H.MTIME] === 0)
-        ) {
-          // If file is still untouched then mark it as unchanged
-          changedFiles.delete(canonicalPath);
-        } else if (
-          newMetadata[H.SHA1] != null &&
-          newMetadata[H.SHA1] === metadata[H.SHA1] &&
-          metadata[H.VISITED] === 1
-        ) {
-          // Content matches - update modified time but don't revisit
-          const updatedMetadata = [...metadata] as FileMetadata;
-          updatedMetadata[H.MTIME] = newMetadata[H.MTIME];
-          changedFiles.set(canonicalPath, updatedMetadata);
-        }
-      } else {
-        removedFiles.add(canonicalPath);
       }
-    }
+    );
     return {
       changedFiles,
       removedFiles,
@@ -388,13 +386,16 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   getAllFiles(): Path[] {
-    return Array.from(
-      this.metadataIterator({
-        includeNodeModules: true,
-        includeSymlinks: false,
-      }),
-      ({ canonicalPath }) => this.#pathUtils.normalToAbsolute(canonicalPath)
+    const result: Path[] = [];
+    this.#forEachMetadata(
+      this.#rootNode,
+      { includeNodeModules: true, includeSymlinks: false },
+      '',
+      (_baseName, canonicalPath) => {
+        result.push(this.#pathUtils.normalToAbsolute(canonicalPath));
+      }
     );
+    return result;
   }
 
   linkStats(mixedPath: Path): FileStats | null {
@@ -448,7 +449,8 @@ export default class TreeFS implements MutableFileSystem {
         ? contextRootAbsolutePath.replaceAll(path.sep, '/')
         : contextRootAbsolutePath;
 
-    for (const relativePathForComparison of this.#pathIterator(
+    const matches: Path[] = [];
+    this.#forEachPath(
       contextRoot,
       contextRootParent,
       ancestorOfRootIdx,
@@ -458,27 +460,30 @@ export default class TreeFS implements MutableFileSystem {
         follow,
         recursive,
         subtreeOnly: rootDir != null,
+      },
+      '',
+      new Set(),
+      (relativePathForComparison) => {
+        if (
+          filter == null ||
+          filter.test(
+            // NOTE(EvanBacon): Ensure files start with `./` for matching purposes
+            // this ensures packages work across Metro and Webpack (ex: Storybook for React DOM / React Native).
+            // `a/b.js` -> `./a/b.js`
+            filterCompareAbsolute === true
+              ? path.join(contextRootAbsolutePathForComparison, relativePathForComparison)
+              : prefix + relativePathForComparison
+          )
+        ) {
+          const relativePath =
+            filterComparePosix === true && path.sep !== '/'
+              ? relativePathForComparison.replaceAll('/', path.sep)
+              : relativePathForComparison;
+          matches.push(path.join(contextRootAbsolutePath, relativePath));
+        }
       }
-    )) {
-      if (
-        filter == null ||
-        filter.test(
-          // NOTE(EvanBacon): Ensure files start with `./` for matching purposes
-          // this ensures packages work across Metro and Webpack (ex: Storybook for React DOM / React Native).
-          // `a/b.js` -> `./a/b.js`
-          filterCompareAbsolute === true
-            ? path.join(contextRootAbsolutePathForComparison, relativePathForComparison)
-            : prefix + relativePathForComparison
-        )
-      ) {
-        const relativePath =
-          filterComparePosix === true && path.sep !== '/'
-            ? relativePathForComparison.replaceAll('/', path.sep)
-            : relativePathForComparison;
-
-        yield path.join(contextRootAbsolutePath, relativePath);
-      }
-    }
+    );
+    yield* matches;
   }
 
   addOrModify(mixedPath: Path, metadata: FileMetadata, changeListener?: FileSystemListener): void {
@@ -1546,23 +1551,24 @@ export default class TreeFS implements MutableFileSystem {
     return null;
   }
 
-  metadataIterator(opts: MetadataIteratorOptions): Generator<{
+  *metadataIterator(opts: MetadataIteratorOptions): Generator<{
     baseName: string;
     canonicalPath: string;
     metadata: FileMetadata;
   }> {
-    return this.#metadataIterator(this.#rootNode, opts);
+    const buffer: { baseName: string; canonicalPath: string; metadata: FileMetadata }[] = [];
+    this.#forEachMetadata(this.#rootNode, opts, '', (baseName, canonicalPath, metadata) => {
+      buffer.push({ baseName, canonicalPath, metadata });
+    });
+    yield* buffer;
   }
 
-  *#metadataIterator(
+  #forEachMetadata(
     rootNode: DirectoryNode,
     opts: Readonly<{ includeSymlinks: boolean; includeNodeModules: boolean }>,
-    prefix: string = ''
-  ): Generator<{
-    baseName: string;
-    canonicalPath: string;
-    metadata: FileMetadata;
-  }> {
+    prefix: string,
+    callback: (baseName: string, canonicalPath: string, metadata: FileMetadata) => void
+  ): void {
     for (const [name, node] of rootNode) {
       if (node == null) {
         continue;
@@ -1571,9 +1577,9 @@ export default class TreeFS implements MutableFileSystem {
       }
       const prefixedName = prefix === '' ? name : prefix + path.sep + name;
       if (isDirectory(node)) {
-        yield* this.#metadataIterator(node, opts, prefixedName);
+        this.#forEachMetadata(node, opts, prefixedName, callback);
       } else if (isRegularFile(node) || opts.includeSymlinks) {
-        yield { baseName: name, canonicalPath: prefixedName, metadata: node };
+        callback(name, prefixedName, node);
       }
     }
   }
@@ -1584,22 +1590,13 @@ export default class TreeFS implements MutableFileSystem {
       : this.#pathUtils.relativeToNormal(relativeOrAbsolutePath);
   }
 
-  *#directoryNodeIterator(
-    node: DirectoryNode,
-    parent: DirectoryNode | undefined,
-    ancestorOfRootIdx: number | undefined
-  ): Generator<[string, MixedNode | null]> {
-    if (ancestorOfRootIdx != null && ancestorOfRootIdx > 0 && parent) {
-      yield [this.#pathUtils.getBasenameOfNthAncestor(ancestorOfRootIdx - 1), parent];
-    }
-    yield* node.entries();
-  }
-
   /**
    * Enumerate paths under a given node, including symlinks and through
-   * symlinks (if `follow` is enabled).
+   * symlinks (if `follow` is enabled). Invokes `callback` for each matching
+   * path. Inlines what was previously `#directoryNodeIterator` (yielding the
+   * parent entry first when `ancestorOfRootIdx > 0`).
    */
-  *#pathIterator(
+  #forEachPath(
     iterationRootNode: DirectoryNode,
     iterationRootParentNode: DirectoryNode | undefined,
     ancestorOfRootIdx: number | undefined,
@@ -1610,9 +1607,10 @@ export default class TreeFS implements MutableFileSystem {
       recursive: boolean;
       subtreeOnly: boolean;
     }>,
-    pathPrefix: string = '',
-    followedLinks: ReadonlySet<FileMetadata> = new Set()
-  ): Iterable<Path> {
+    pathPrefix: string,
+    followedLinks: ReadonlySet<FileMetadata>,
+    callback: (path: Path) => void
+  ): void {
     const pathSep = opts.alwaysYieldPosix ? '/' : path.sep;
     const prefixWithSep = pathPrefix === '' ? pathPrefix : pathPrefix + pathSep;
 
@@ -1630,22 +1628,18 @@ export default class TreeFS implements MutableFileSystem {
       this.#populateDirFromFilesystem(iterationRootNode, rootCanonical, false, false);
     }
 
-    for (const [name, node] of this.#directoryNodeIterator(
-      iterationRootNode,
-      iterationRootParentNode,
-      ancestorOfRootIdx
-    )) {
+    const visitEntry = (name: string, node: MixedNode | null): void => {
       if (node == null) {
-        continue;
+        return;
       } else if (opts.subtreeOnly && name === '..') {
-        continue;
+        return;
       }
 
       const nodePath = prefixWithSep + name;
       if (!isDirectory(node)) {
         if (isRegularFile(node)) {
           // regular file
-          yield nodePath;
+          callback(nodePath);
         } else {
           // symlink
           const nodePathWithSystemSeparators =
@@ -1667,22 +1661,23 @@ export default class TreeFS implements MutableFileSystem {
           const resolved = this.#lookup(normalPathOfSymlink);
           if (!resolved.exists) {
             // Symlink goes nowhere, nothing to report.
-            continue;
+            return;
           }
           const target = resolved.node;
           if (!isDirectory(target)) {
             // Symlink points to a file, just yield the path of the symlink.
-            yield nodePath;
+            callback(nodePath);
           } else if (opts.recursive && opts.follow && !followedLinks.has(node)) {
             // Symlink points to a directory - iterate over its contents using
             // the path where we found the symlink as a prefix.
-            yield* this.#pathIterator(
+            this.#forEachPath(
               target,
               resolved.parentNode,
               resolved.ancestorOfRootIdx,
               opts,
               nodePath,
-              new Set([...followedLinks, node])
+              new Set([...followedLinks, node]),
+              callback
             );
           }
         }
@@ -1698,15 +1693,28 @@ export default class TreeFS implements MutableFileSystem {
               : opts.canonicalPathOfRoot + path.sep + nodePathWithSystemSeparators;
           this.#populateDirFromFilesystem(node, canonicalPath, false, false);
         }
-        yield* this.#pathIterator(
+        this.#forEachPath(
           node,
           iterationRootParentNode,
           ancestorOfRootIdx != null && ancestorOfRootIdx > 0 ? ancestorOfRootIdx - 1 : undefined,
           opts,
           nodePath,
-          followedLinks
+          followedLinks,
+          callback
         );
       }
+    };
+
+    // Inlined #directoryNodeIterator: yield the parent entry first when we're
+    // at a directory above the root, then iterate `node.entries()`.
+    if (ancestorOfRootIdx != null && ancestorOfRootIdx > 0 && iterationRootParentNode) {
+      visitEntry(
+        this.#pathUtils.getBasenameOfNthAncestor(ancestorOfRootIdx - 1),
+        iterationRootParentNode
+      );
+    }
+    for (const [name, node] of iterationRootNode) {
+      visitEntry(name, node);
     }
   }
 
@@ -1869,7 +1877,7 @@ export default class TreeFS implements MutableFileSystem {
 
   /**
    * Populate an existing (potentially empty sentinel) directory node from
-   * the filesystem. Used by #pathIterator to fill lazy directories before
+   * the filesystem. Used by #forEachPath to fill lazy directories before
    * iteration, and by #populateFromFilesystem for optimistic parent
    * population.
    */

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -31,6 +31,42 @@ type DirectoryNode = Map<string, MixedNode | null>;
 type FileNode = FileMetadata;
 type MixedNode = FileNode | DirectoryNode;
 
+type SegmentCallback = (
+  node: DirectoryNode,
+  normalPath: string,
+  segmentName: string,
+  ancestorOfRootIdx: number | undefined
+) => void;
+
+type MakeDirsSegmentCallback = (
+  node: DirectoryNode,
+  normalPath: string,
+  segmentName: string,
+  ancestorOfRootIdx: number | undefined,
+  isNewlyCreated: boolean
+) => void;
+
+type WalkResult =
+  | {
+      exists: true;
+      ancestorOfRootIdx: number | undefined;
+      canonicalPath: string;
+      node: MixedNode;
+      parentNode: DirectoryNode;
+    }
+  | {
+      exists: true;
+      ancestorOfRootIdx: number | undefined;
+      canonicalPath: string;
+      node: DirectoryNode;
+      parentNode: undefined;
+    }
+  | {
+      exists: false;
+      canonicalMissingPath: string;
+      missingSegmentName: string;
+    };
+
 function isDirectory(node: MixedNode | null | undefined): node is DirectoryNode {
   return node instanceof Map;
 }
@@ -201,9 +237,7 @@ export default class TreeFS implements MutableFileSystem {
     let rootNode: DirectoryNode = this.#rootNode;
     let prefix: string = '';
     if (subpath != null && subpath !== '') {
-      const lookupResult = this.#lookupByNormalPath(subpath, {
-        followLeaf: true,
-      });
+      const lookupResult = this.#lookup(subpath);
       if (!lookupResult.exists || !isDirectory(lookupResult.node)) {
         // Directory doesn't exist, nothing to compare - all files are new
         return { changedFiles, removedFiles };
@@ -260,10 +294,7 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   getMtimeByNormalPath(normalPath: Path): number | null {
-    const result = this.#lookupByNormalPath(normalPath, {
-      followLeaf: false,
-      skipFallback: true,
-    });
+    const result = this.#walkLookupSkipFallback(this.#rootNode, 0, 0, normalPath);
     return result.exists && !isDirectory(result.node) ? result.node[H.MTIME] : null;
   }
 
@@ -276,9 +307,7 @@ export default class TreeFS implements MutableFileSystem {
     mixedPath: Path
   ): Promise<{ sha1: string; content?: Buffer } | null | undefined> {
     const normalPath = this.#normalizePath(mixedPath);
-    const result = this.#lookupByNormalPath(normalPath, {
-      followLeaf: true,
-    });
+    const result = this.#lookup(normalPath);
     if (!result.exists || isDirectory(result.node)) {
       return null;
     }
@@ -332,10 +361,7 @@ export default class TreeFS implements MutableFileSystem {
   lookup(mixedPath: Path): LookupResult {
     const normalPath = this.#normalizePath(mixedPath);
     const links = new Set<string>();
-    const result = this.#lookupByNormalPath(normalPath, {
-      collectLinkPaths: links,
-      followLeaf: true,
-    });
+    const result = this.#lookup(normalPath, links);
     if (!result.exists) {
       const { canonicalMissingPath } = result;
       return {
@@ -396,7 +422,7 @@ export default class TreeFS implements MutableFileSystem {
       rootDir = null,
     } = opts;
     const normalRoot = rootDir == null ? '' : this.#normalizePath(rootDir);
-    const contextRootResult = this.#lookupByNormalPath(normalRoot);
+    const contextRootResult = this.#lookup(normalRoot);
     if (!contextRootResult.exists) {
       return;
     }
@@ -456,10 +482,21 @@ export default class TreeFS implements MutableFileSystem {
     const normalPath = this.#normalizePath(mixedPath);
     // Walk the tree to find the *real* path of the parent node, creating
     // directories as we need.
-    const parentDirNode = this.#lookupByNormalPath(path.dirname(normalPath), {
-      changeListener,
-      makeDirectories: true,
-    });
+    const onSegment: MakeDirsSegmentCallback | undefined = changeListener
+      ? (_node, segmentNormalPath, _segmentName, _idx, isNewlyCreated) => {
+          if (isNewlyCreated) {
+            changeListener.directoryAdded(segmentNormalPath);
+          }
+        }
+      : undefined;
+    const parentDirNode = this.#walkAndMakeDirectories(
+      this.#rootNode,
+      0,
+      0,
+      path.dirname(normalPath),
+      true,
+      onSegment
+    );
     if (!parentDirNode.exists) {
       throw new Error(`TreeFS: Failed to make parent directory entry for ${mixedPath}`);
     }
@@ -478,17 +515,28 @@ export default class TreeFS implements MutableFileSystem {
     let lastDir: string | undefined;
     let directoryNode: DirectoryNode | undefined;
 
+    const onSegment: MakeDirsSegmentCallback | undefined = changeListener
+      ? (_node, segmentNormalPath, _segmentName, _idx, isNewlyCreated) => {
+          if (isNewlyCreated) {
+            changeListener.directoryAdded(segmentNormalPath);
+          }
+        }
+      : undefined;
+
     for (const [normalPath, metadata] of addedOrModifiedFiles) {
       const lastSepIdx = normalPath.lastIndexOf(path.sep);
       const dirname = lastSepIdx === -1 ? '' : normalPath.slice(0, lastSepIdx);
       const basename = lastSepIdx === -1 ? normalPath : normalPath.slice(lastSepIdx + 1);
 
       if (directoryNode == null || dirname !== lastDir) {
-        const lookup = this.#lookupByNormalPath(dirname, {
-          changeListener,
-          followLeaf: false,
-          makeDirectories: true,
-        });
+        const lookup = this.#walkAndMakeDirectories(
+          this.#rootNode,
+          0,
+          0,
+          dirname,
+          false,
+          onSegment
+        );
         if (!lookup.exists) {
           // This should only be possible if the input is non-real and
           // lookup hits a broken symlink.
@@ -531,7 +579,7 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   #removeNormalPath(normalPath: string, changeListener?: FileSystemListener): void {
-    const result = this.#lookupByNormalPath(normalPath, { followLeaf: false });
+    const result = this.#lookupNoFollow(normalPath);
     if (!result.exists) {
       return;
     }
@@ -557,8 +605,7 @@ export default class TreeFS implements MutableFileSystem {
         // NB: This isn't the most efficient algorithm - in the case of
         // removing the last file in a deep hierarchy it's O(depth^2), but
         // that's not expected to be a case common enough to justify
-        // implementation complexity, or slowing down more common uses of
-        // _lookupByNormalPath.
+        // implementation complexity, or slowing down more common lookups.
         this.#removeNormalPath(path.dirname(canonicalPath), changeListener);
       }
     }
@@ -578,69 +625,22 @@ export default class TreeFS implements MutableFileSystem {
    *
    * Note that this code is extremely hot during resolution, being the most
    * expensive part of a file existence check. Benchmark any modifications!
+   *
+   * Each flag combination is implemented as its own specialised walker
+   * (`#walkLookup`, `#walkLookupNoFollow`, `#walkLookupSkipFallback`,
+   * `#walkAndMakeDirectories`) so the hot inner loop has no per-iteration
+   * `opts.X` branches. Thin convenience wrappers below (`#lookup`,
+   * `#lookupNoFollow`, `#lookupFromNode`, `#walkAndStream`) cover the
+   * common call shapes.
    */
-  #lookupByNormalPath(
+  #walkLookup(
+    startNode: DirectoryNode,
+    startPathIdx: number,
+    startAncestorOfRootIdx: number | undefined,
     requestedNormalPath: string,
-    opts: {
-      collectAncestors?: {
-        ancestorOfRootIdx: number | null | undefined;
-        node: DirectoryNode;
-        normalPath: string;
-        segmentName: string;
-      }[];
-      /**
-       * Mutable Set into which absolute real paths of traversed symlinks will
-       * be added. Omit for performance if not needed.
-       */
-      collectLinkPaths?: Set<string> | null | undefined;
-
-      /**
-       * Low-level callbacks called on mutations of TreeFS data.
-       * Omit for performance if not needed.
-       */
-      changeListener?: FileSystemListener;
-
-      /**
-       * Like lstat vs stat, whether to follow a symlink at the basename of
-       * the given path, or return the details of the symlink itself.
-       */
-      followLeaf?: boolean;
-      /**
-       * Whether to (recursively) create missing directory nodes during
-       * traversal, useful when adding files. Will throw if an expected
-       * directory is already present as a file.
-       */
-      makeDirectories?: boolean;
-      /** Whether to use the fallback filesystem during discovery */
-      skipFallback?: boolean;
-      startPathIdx?: number;
-      startNode?: DirectoryNode;
-      start?: {
-        ancestorOfRootIdx: number | null | undefined;
-        node: DirectoryNode;
-        pathIdx: number;
-      };
-    } = { followLeaf: true, makeDirectories: false }
-  ):
-    | {
-        ancestorOfRootIdx: number | null | undefined;
-        canonicalPath: string;
-        exists: true;
-        node: MixedNode;
-        parentNode: DirectoryNode;
-      }
-    | {
-        ancestorOfRootIdx: number | null | undefined;
-        canonicalPath: string;
-        exists: true;
-        node: DirectoryNode;
-        parentNode: null;
-      }
-    | {
-        canonicalMissingPath: string;
-        missingSegmentName: string;
-        exists: false;
-      } {
+    onSegment: SegmentCallback | undefined,
+    collectLinkPaths: Set<string> | undefined
+  ): WalkResult {
     // We'll update the target if we hit a symlink.
     let targetNormalPath = requestedNormalPath;
     // Lazy-initialised set of seen target paths, to detect symlink cycles.
@@ -648,22 +648,12 @@ export default class TreeFS implements MutableFileSystem {
     // Set when a symlink is followed, to allow fallback population outside
     // the boundary for paths reachable transitively through symlinks.
     let followedSymlink = false;
-    // Pointer to the first character of the current path segment in
-    // targetNormalPath.
-    let fromIdx = opts.start?.pathIdx ?? 0;
-    // The parent of the current segment.
-    let parentNode = opts.start?.node ?? this.#rootNode;
-    // If a returned node is (an ancestor of) the root, this is the number of
-    // levels below the root, i.e. '' is 0, '..' is 1, '../..' is 2, otherwise
-    // null.
-    let ancestorOfRootIdx: number | null | undefined = opts.start?.ancestorOfRootIdx ?? 0;
+    let fromIdx = startPathIdx;
+    let parentNode = startNode;
+    let ancestorOfRootIdx: number | undefined = startAncestorOfRootIdx;
 
-    const { collectAncestors, changeListener } = opts;
-
-    // Used only when collecting ancestors, to avoid double-counting nodes and
+    // Used only when streaming ancestors, to avoid double-yielding nodes and
     // paths when traversing a symlink takes us back to rootNode and out again.
-    // This tracks the first character of the first segment not already
-    // collected.
     let unseenPathFromIdx = 0;
 
     while (targetNormalPath.length > fromIdx) {
@@ -681,17 +671,15 @@ export default class TreeFS implements MutableFileSystem {
 
       let segmentNode: MixedNode | null | undefined = parentNode.get(segmentName);
 
-      // In normal paths all indirections are at the prefix, so we are at the
-      // nth ancestor of the root iff the path so far is n '..' segments.
       if (segmentName === '..' && ancestorOfRootIdx != null) {
         ancestorOfRootIdx++;
       } else if (segmentNode != null) {
-        ancestorOfRootIdx = null;
+        ancestorOfRootIdx = undefined;
       }
 
       if (segmentNode == null) {
-        if (opts.makeDirectories !== true && segmentName !== '..') {
-          if (!opts.skipFallback && this.#fallbackFilesystem != null) {
+        if (segmentName !== '..') {
+          if (this.#fallbackFilesystem != null) {
             const parentEnd = isLastSegment
               ? fromIdx - segmentName.length - 1
               : fromIdx - segmentName.length - 2;
@@ -703,7 +691,7 @@ export default class TreeFS implements MutableFileSystem {
               followedSymlink
             );
             if (segmentNode != null) {
-              ancestorOfRootIdx = null;
+              ancestorOfRootIdx = undefined;
             }
           }
 
@@ -719,15 +707,7 @@ export default class TreeFS implements MutableFileSystem {
         }
         if (segmentNode == null) {
           segmentNode = new Map();
-          if (opts.makeDirectories === true) {
-            if (changeListener != null) {
-              const canonicalPath = isLastSegment
-                ? targetNormalPath
-                : targetNormalPath.slice(0, fromIdx - 1);
-              changeListener.directoryAdded(canonicalPath);
-            }
-            parentNode.set(segmentName, segmentNode);
-          } else if (!opts.skipFallback && this.#fallbackFilesystem != null) {
+          if (this.#fallbackFilesystem != null) {
             parentNode.set(segmentName, segmentNode);
           }
         }
@@ -737,14 +717,13 @@ export default class TreeFS implements MutableFileSystem {
       if (
         // ...at a directory node and the only subsequent character is `/`, or
         (nextSepIdx === targetNormalPath.length - 1 && isDirectory(segmentNode)) ||
-        // there are no subsequent `/`, and this node is anything but a symlink
-        // we're required to resolve due to followLeaf.
-        (isLastSegment &&
-          (isDirectory(segmentNode) || isRegularFile(segmentNode) || opts.followLeaf === false))
+        // ...there are no subsequent `/`, and this node is a directory or a
+        // regular file. (A leaf symlink falls through and is followed.)
+        (isLastSegment && (isDirectory(segmentNode) || isRegularFile(segmentNode)))
       ) {
         return {
           ancestorOfRootIdx,
-          canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1), // remove trailing `/`
+          canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1),
           exists: true,
           node: segmentNode,
           parentNode,
@@ -754,16 +733,11 @@ export default class TreeFS implements MutableFileSystem {
       // If the next node is a directory, go into it
       if (isDirectory(segmentNode)) {
         parentNode = segmentNode;
-        if (collectAncestors && isUnseen) {
+        if (onSegment != null && isUnseen) {
           const currentPath = isLastSegment
             ? targetNormalPath
             : targetNormalPath.slice(0, fromIdx - 1);
-          collectAncestors.push({
-            ancestorOfRootIdx,
-            node: segmentNode,
-            normalPath: currentPath,
-            segmentName,
-          });
+          onSegment(segmentNode, currentPath, segmentName, ancestorOfRootIdx);
         }
       } else {
         const currentPath = isLastSegment
@@ -791,8 +765,8 @@ export default class TreeFS implements MutableFileSystem {
             missingSegmentName: segmentName,
           };
         }
-        if (opts.collectLinkPaths) {
-          opts.collectLinkPaths.add(this.#pathUtils.normalToAbsolute(currentPath));
+        if (collectLinkPaths != null) {
+          collectLinkPaths.add(this.#pathUtils.normalToAbsolute(currentPath));
         }
 
         const remainingTargetPath = isLastSegment ? '' : targetNormalPath.slice(fromIdx);
@@ -808,24 +782,30 @@ export default class TreeFS implements MutableFileSystem {
 
         // Two special cases (covered by unit tests):
         //
-        // If the symlink target is the root, the root should be a counted as
-        // an ancestor. We'd otherwise miss counting it because we normally
-        // push new ancestors only when entering a directory.
+        // If the symlink target is the root, the root should be counted as an
+        // ancestor. We'd otherwise miss it because new ancestors are only
+        // streamed when entering a directory.
         //
         // If the symlink target is an ancestor of the root *and* joining it
         // with the remaining path results in collapsing segments, e.g:
-        // '../..' + 'parentofroot/root/foo.js' = 'foo.js', then we must add
+        // '../..' + 'parentofroot/root/foo.js' = 'foo.js', then we must yield
         // parentofroot and root as ancestors.
         if (
-          collectAncestors &&
+          onSegment != null &&
           !isLastSegment &&
           // No-op optimisation to bail out the common case of nothing to do.
-          ((ancestorOfRootIdx = this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget)) === 0 ||
+          ((ancestorOfRootIdx =
+            this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget) ?? undefined) === 0 ||
             joinedResult.collapsedSegments > 0)
         ) {
           let node: MixedNode = this.#rootNode;
           let collapsedPath = '';
-          const reverseAncestors = [];
+          const reverseAncestors: {
+            ancestorOfRootIdx: number;
+            node: DirectoryNode;
+            normalPath: string;
+            segmentName: string;
+          }[] = [];
           for (let i = 0; i <= joinedResult.collapsedSegments && isDirectory(node); i++) {
             if (
               // Add the root only if the target is the root or we have
@@ -844,13 +824,17 @@ export default class TreeFS implements MutableFileSystem {
             node = node.get('..') ?? new Map();
             collapsedPath = collapsedPath === '' ? '..' : collapsedPath + path.sep + '..';
           }
-          collectAncestors.push(...reverseAncestors.reverse());
+          // Emit in shallowest-first order, matching today's
+          // collectAncestors.push(...reverseAncestors.reverse()).
+          for (let i = reverseAncestors.length - 1; i >= 0; i--) {
+            const a = reverseAncestors[i]!;
+            onSegment(a.node, a.normalPath, a.segmentName, a.ancestorOfRootIdx);
+          }
         }
 
-        // For the purpose of collecting ancestors: Ignore the traversal to
-        // the symlink target, and start collecting ancestors only
-        // from the target itself (ie, the basename of the normal target path)
-        // onwards.
+        // For the purpose of streaming ancestors: Ignore the traversal to the
+        // symlink target, and start yielding ancestors only from the target
+        // itself (i.e. the basename of the normal target path) onwards.
         unseenPathFromIdx = normalSymlinkTarget.lastIndexOf(path.sep) + 1;
 
         if (seen == null) {
@@ -878,8 +862,500 @@ export default class TreeFS implements MutableFileSystem {
       canonicalPath: targetNormalPath,
       exists: true,
       node: this.#rootNode,
-      parentNode: null,
+      parentNode: undefined,
     };
+  }
+
+  /**
+   * Specialised body for lstat-style lookups: followLeaf=false,
+   * makeDirectories=false, fallback enabled. A symlink at the leaf is
+   * returned as-is.
+   */
+  #walkLookupNoFollow(
+    startNode: DirectoryNode,
+    startPathIdx: number,
+    startAncestorOfRootIdx: number | undefined,
+    requestedNormalPath: string,
+    onSegment: SegmentCallback | undefined
+  ): WalkResult {
+    let targetNormalPath = requestedNormalPath;
+    let seen: Set<string> | undefined;
+    let followedSymlink = false;
+    let fromIdx = startPathIdx;
+    let parentNode = startNode;
+    let ancestorOfRootIdx: number | undefined = startAncestorOfRootIdx;
+    let unseenPathFromIdx = 0;
+
+    while (targetNormalPath.length > fromIdx) {
+      const nextSepIdx = targetNormalPath.indexOf(path.sep, fromIdx);
+      const isLastSegment = nextSepIdx === -1;
+      const segmentName = isLastSegment
+        ? targetNormalPath.slice(fromIdx)
+        : targetNormalPath.slice(fromIdx, nextSepIdx);
+      const isUnseen = fromIdx >= unseenPathFromIdx;
+      fromIdx = !isLastSegment ? nextSepIdx + 1 : targetNormalPath.length;
+
+      if (segmentName === '.') {
+        continue;
+      }
+
+      let segmentNode: MixedNode | null | undefined = parentNode.get(segmentName);
+
+      if (segmentName === '..' && ancestorOfRootIdx != null) {
+        ancestorOfRootIdx++;
+      } else if (segmentNode != null) {
+        ancestorOfRootIdx = undefined;
+      }
+
+      if (segmentNode == null) {
+        if (segmentName !== '..') {
+          if (this.#fallbackFilesystem != null) {
+            const parentEnd = isLastSegment
+              ? fromIdx - segmentName.length - 1
+              : fromIdx - segmentName.length - 2;
+            const parentCanonicalPath = parentEnd > 0 ? targetNormalPath.slice(0, parentEnd) : '';
+            segmentNode = this.#populateFromFilesystem(
+              parentNode,
+              segmentName,
+              parentCanonicalPath,
+              followedSymlink
+            );
+            if (segmentNode != null) {
+              ancestorOfRootIdx = undefined;
+            }
+          }
+
+          if (segmentNode == null) {
+            return {
+              canonicalMissingPath: isLastSegment
+                ? targetNormalPath
+                : targetNormalPath.slice(0, fromIdx - 1),
+              exists: false,
+              missingSegmentName: segmentName,
+            };
+          }
+        }
+        if (segmentNode == null) {
+          segmentNode = new Map();
+          if (this.#fallbackFilesystem != null) {
+            parentNode.set(segmentName, segmentNode);
+          }
+        }
+      }
+
+      // Done: at the last segment we return whatever we found (no leaf
+      // follow). Also done if the only remaining character is the trailing
+      // path separator and the node is a directory.
+      if (
+        isLastSegment ||
+        (nextSepIdx === targetNormalPath.length - 1 && isDirectory(segmentNode))
+      ) {
+        return {
+          ancestorOfRootIdx,
+          canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1),
+          exists: true,
+          node: segmentNode,
+          parentNode,
+        };
+      }
+
+      if (isDirectory(segmentNode)) {
+        parentNode = segmentNode;
+        if (onSegment != null && isUnseen) {
+          const currentPath = targetNormalPath.slice(0, fromIdx - 1);
+          onSegment(segmentNode, currentPath, segmentName, ancestorOfRootIdx);
+        }
+      } else {
+        const currentPath = targetNormalPath.slice(0, fromIdx - 1);
+
+        if (isRegularFile(segmentNode)) {
+          return {
+            canonicalMissingPath: currentPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+
+        // Symlink in an interior position — still follow it (only the leaf
+        // is exempt from following under followLeaf=false).
+        const normalSymlinkTarget = this.#resolveSymlinkTargetToNormalPath(
+          segmentNode,
+          currentPath
+        );
+        if (normalSymlinkTarget == null) {
+          return {
+            canonicalMissingPath: currentPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+
+        const remainingTargetPath = targetNormalPath.slice(fromIdx);
+        const joinedResult = this.#pathUtils.joinNormalToRelative(
+          normalSymlinkTarget,
+          remainingTargetPath
+        );
+        targetNormalPath = joinedResult.normalPath;
+
+        if (
+          onSegment != null &&
+          ((ancestorOfRootIdx =
+            this.#pathUtils.getAncestorOfRootIdx(normalSymlinkTarget) ?? undefined) === 0 ||
+            joinedResult.collapsedSegments > 0)
+        ) {
+          let node: MixedNode = this.#rootNode;
+          let collapsedPath = '';
+          const reverseAncestors: {
+            ancestorOfRootIdx: number;
+            node: DirectoryNode;
+            normalPath: string;
+            segmentName: string;
+          }[] = [];
+          for (let i = 0; i <= joinedResult.collapsedSegments && isDirectory(node); i++) {
+            if (i > 0 || ancestorOfRootIdx === 0 || joinedResult.collapsedSegments > 0) {
+              reverseAncestors.push({
+                ancestorOfRootIdx: i,
+                node,
+                normalPath: collapsedPath,
+                segmentName: this.#pathUtils.getBasenameOfNthAncestor(i),
+              });
+            }
+            node = node.get('..') ?? new Map();
+            collapsedPath = collapsedPath === '' ? '..' : collapsedPath + path.sep + '..';
+          }
+          for (let i = reverseAncestors.length - 1; i >= 0; i--) {
+            const a = reverseAncestors[i]!;
+            onSegment(a.node, a.normalPath, a.segmentName, a.ancestorOfRootIdx);
+          }
+        }
+
+        unseenPathFromIdx = normalSymlinkTarget.lastIndexOf(path.sep) + 1;
+
+        if (seen == null) {
+          seen = new Set([requestedNormalPath]);
+        }
+        if (seen.has(targetNormalPath)) {
+          return {
+            canonicalMissingPath: targetNormalPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+        seen.add(targetNormalPath);
+        followedSymlink = true;
+        fromIdx = 0;
+        parentNode = this.#rootNode;
+        ancestorOfRootIdx = 0;
+      }
+    }
+    invariant(parentNode === this.#rootNode, 'Unexpectedly escaped traversal');
+    return {
+      ancestorOfRootIdx: 0,
+      canonicalPath: targetNormalPath,
+      exists: true,
+      node: this.#rootNode,
+      parentNode: undefined,
+    };
+  }
+
+  /**
+   * Specialised body that does not consult the fallback filesystem.
+   * followLeaf=false (the only existing caller, `getMtimeByNormalPath`,
+   * always lstat-style). No symlink-path collection.
+   */
+  #walkLookupSkipFallback(
+    startNode: DirectoryNode,
+    startPathIdx: number,
+    startAncestorOfRootIdx: number | undefined,
+    requestedNormalPath: string
+  ): WalkResult {
+    let targetNormalPath = requestedNormalPath;
+    let seen: Set<string> | undefined;
+    let fromIdx = startPathIdx;
+    let parentNode = startNode;
+    let ancestorOfRootIdx: number | undefined = startAncestorOfRootIdx;
+
+    while (targetNormalPath.length > fromIdx) {
+      const nextSepIdx = targetNormalPath.indexOf(path.sep, fromIdx);
+      const isLastSegment = nextSepIdx === -1;
+      const segmentName = isLastSegment
+        ? targetNormalPath.slice(fromIdx)
+        : targetNormalPath.slice(fromIdx, nextSepIdx);
+      fromIdx = !isLastSegment ? nextSepIdx + 1 : targetNormalPath.length;
+
+      if (segmentName === '.') {
+        continue;
+      }
+
+      let segmentNode: MixedNode | null | undefined = parentNode.get(segmentName);
+
+      if (segmentName === '..' && ancestorOfRootIdx != null) {
+        ancestorOfRootIdx++;
+      } else if (segmentNode != null) {
+        ancestorOfRootIdx = undefined;
+      }
+
+      if (segmentNode == null) {
+        if (segmentName !== '..') {
+          return {
+            canonicalMissingPath: isLastSegment
+              ? targetNormalPath
+              : targetNormalPath.slice(0, fromIdx - 1),
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+        // segmentName === '..': transient empty Map to keep traversing
+        // ancestors of the root that aren't materialised in the tree.
+        segmentNode = new Map();
+      }
+
+      if (
+        isLastSegment ||
+        (nextSepIdx === targetNormalPath.length - 1 && isDirectory(segmentNode))
+      ) {
+        return {
+          ancestorOfRootIdx,
+          canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1),
+          exists: true,
+          node: segmentNode,
+          parentNode,
+        };
+      }
+
+      if (isDirectory(segmentNode)) {
+        parentNode = segmentNode;
+      } else {
+        const currentPath = targetNormalPath.slice(0, fromIdx - 1);
+
+        if (isRegularFile(segmentNode)) {
+          return {
+            canonicalMissingPath: currentPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+
+        // Symlink in an interior position — follow it. Fallback is disabled
+        // so we never lazily resolve missing segments along the new target.
+        const normalSymlinkTarget = this.#resolveSymlinkTargetToNormalPath(
+          segmentNode,
+          currentPath
+        );
+        if (normalSymlinkTarget == null) {
+          return {
+            canonicalMissingPath: currentPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+
+        const remainingTargetPath = targetNormalPath.slice(fromIdx);
+        const joinedResult = this.#pathUtils.joinNormalToRelative(
+          normalSymlinkTarget,
+          remainingTargetPath
+        );
+        targetNormalPath = joinedResult.normalPath;
+
+        if (seen == null) {
+          seen = new Set([requestedNormalPath]);
+        }
+        if (seen.has(targetNormalPath)) {
+          return {
+            canonicalMissingPath: targetNormalPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+        seen.add(targetNormalPath);
+        fromIdx = 0;
+        parentNode = this.#rootNode;
+        ancestorOfRootIdx = 0;
+      }
+    }
+    invariant(parentNode === this.#rootNode, 'Unexpectedly escaped traversal');
+    return {
+      ancestorOfRootIdx: 0,
+      canonicalPath: targetNormalPath,
+      exists: true,
+      node: this.#rootNode,
+      parentNode: undefined,
+    };
+  }
+
+  /**
+   * Specialised body that creates missing directory nodes as it walks.
+   * `followLeaf` is parameterised so callers that look up `dirname(...)`
+   * can choose lstat-style or stat-style at the leaf. `onSegment` fires
+   * for every directory encountered, with `isNewlyCreated` distinguishing
+   * dirs the walker just created from dirs that already existed.
+   */
+  #walkAndMakeDirectories(
+    startNode: DirectoryNode,
+    startPathIdx: number,
+    startAncestorOfRootIdx: number | undefined,
+    requestedNormalPath: string,
+    followLeaf: boolean,
+    onSegment: MakeDirsSegmentCallback | undefined
+  ): WalkResult {
+    let targetNormalPath = requestedNormalPath;
+    let seen: Set<string> | undefined;
+    let fromIdx = startPathIdx;
+    let parentNode = startNode;
+    let ancestorOfRootIdx: number | undefined = startAncestorOfRootIdx;
+    let unseenPathFromIdx = 0;
+
+    while (targetNormalPath.length > fromIdx) {
+      const nextSepIdx = targetNormalPath.indexOf(path.sep, fromIdx);
+      const isLastSegment = nextSepIdx === -1;
+      const segmentName = isLastSegment
+        ? targetNormalPath.slice(fromIdx)
+        : targetNormalPath.slice(fromIdx, nextSepIdx);
+      const isUnseen = fromIdx >= unseenPathFromIdx;
+      fromIdx = !isLastSegment ? nextSepIdx + 1 : targetNormalPath.length;
+
+      if (segmentName === '.') {
+        continue;
+      }
+
+      let segmentNode: MixedNode | null | undefined = parentNode.get(segmentName);
+      let wasJustCreated = false;
+
+      if (segmentName === '..' && ancestorOfRootIdx != null) {
+        ancestorOfRootIdx++;
+      } else if (segmentNode != null) {
+        ancestorOfRootIdx = undefined;
+      }
+
+      if (segmentNode == null) {
+        segmentNode = new Map();
+        parentNode.set(segmentName, segmentNode);
+        wasJustCreated = true;
+      }
+
+      if (
+        (nextSepIdx === targetNormalPath.length - 1 && isDirectory(segmentNode)) ||
+        (isLastSegment && (isDirectory(segmentNode) || isRegularFile(segmentNode) || !followLeaf))
+      ) {
+        if (wasJustCreated && onSegment != null) {
+          const currentPath = isLastSegment
+            ? targetNormalPath
+            : targetNormalPath.slice(0, fromIdx - 1);
+          onSegment(
+            segmentNode as DirectoryNode,
+            currentPath,
+            segmentName,
+            ancestorOfRootIdx,
+            true
+          );
+        }
+        return {
+          ancestorOfRootIdx,
+          canonicalPath: isLastSegment ? targetNormalPath : targetNormalPath.slice(0, -1),
+          exists: true,
+          node: segmentNode,
+          parentNode,
+        };
+      }
+
+      if (isDirectory(segmentNode)) {
+        parentNode = segmentNode;
+        if (onSegment != null && isUnseen) {
+          const currentPath = isLastSegment
+            ? targetNormalPath
+            : targetNormalPath.slice(0, fromIdx - 1);
+          onSegment(segmentNode, currentPath, segmentName, ancestorOfRootIdx, wasJustCreated);
+        }
+      } else {
+        const currentPath = isLastSegment
+          ? targetNormalPath
+          : targetNormalPath.slice(0, fromIdx - 1);
+
+        if (isRegularFile(segmentNode)) {
+          return {
+            canonicalMissingPath: currentPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+
+        // Interior symlink: follow it.
+        const normalSymlinkTarget = this.#resolveSymlinkTargetToNormalPath(
+          segmentNode,
+          currentPath
+        );
+        if (normalSymlinkTarget == null) {
+          return {
+            canonicalMissingPath: currentPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+
+        const remainingTargetPath = isLastSegment ? '' : targetNormalPath.slice(fromIdx);
+        const joinedResult = this.#pathUtils.joinNormalToRelative(
+          normalSymlinkTarget,
+          remainingTargetPath
+        );
+        targetNormalPath = joinedResult.normalPath;
+
+        unseenPathFromIdx = normalSymlinkTarget.lastIndexOf(path.sep) + 1;
+
+        if (seen == null) {
+          seen = new Set([requestedNormalPath]);
+        }
+        if (seen.has(targetNormalPath)) {
+          return {
+            canonicalMissingPath: targetNormalPath,
+            exists: false,
+            missingSegmentName: segmentName,
+          };
+        }
+        seen.add(targetNormalPath);
+        fromIdx = 0;
+        parentNode = this.#rootNode;
+        ancestorOfRootIdx = 0;
+      }
+    }
+    invariant(parentNode === this.#rootNode, 'Unexpectedly escaped traversal');
+    return {
+      ancestorOfRootIdx: 0,
+      canonicalPath: targetNormalPath,
+      exists: true,
+      node: this.#rootNode,
+      parentNode: undefined,
+    };
+  }
+
+  // Convenience wrappers for the common walker call shapes.
+  #lookup(normalPath: string, collectLinkPaths?: Set<string> | undefined): WalkResult {
+    return this.#walkLookup(this.#rootNode, 0, 0, normalPath, undefined, collectLinkPaths);
+  }
+  #lookupNoFollow(normalPath: string): WalkResult {
+    return this.#walkLookupNoFollow(this.#rootNode, 0, 0, normalPath, undefined);
+  }
+  #lookupFromNode(
+    startNode: DirectoryNode,
+    startPathIdx: number,
+    startAncestorOfRootIdx: number | undefined,
+    target: string,
+    collectLinkPaths?: Set<string> | undefined
+  ): WalkResult {
+    return this.#walkLookup(
+      startNode,
+      startPathIdx,
+      startAncestorOfRootIdx,
+      target,
+      undefined,
+      collectLinkPaths
+    );
+  }
+  #walkAndStream(
+    normalPath: string,
+    onSegment: SegmentCallback,
+    collectLinkPaths?: Set<string> | undefined
+  ): WalkResult {
+    return this.#walkLookup(this.#rootNode, 0, 0, normalPath, onSegment, collectLinkPaths);
   }
 
   /**
@@ -921,17 +1397,22 @@ export default class TreeFS implements MutableFileSystem {
     | null
     | undefined {
     const ancestorsOfInput: {
-      ancestorOfRootIdx: number | null | undefined;
+      ancestorOfRootIdx: number | undefined;
       node: DirectoryNode;
       normalPath: string;
       segmentName: string;
     }[] = [];
     const normalPath = this.#normalizePath(mixedStartPath);
-    const invalidatedBy = opts.invalidatedBy;
-    const closestLookup = this.#lookupByNormalPath(normalPath, {
-      collectAncestors: ancestorsOfInput,
-      collectLinkPaths: invalidatedBy,
-    });
+    const invalidatedBy: Set<string> | undefined = opts.invalidatedBy ?? undefined;
+    const onSegment: SegmentCallback = (node, normalPathOfDir, segmentName, ancestorOfRootIdx) => {
+      ancestorsOfInput.push({
+        ancestorOfRootIdx,
+        node,
+        normalPath: normalPathOfDir,
+        segmentName,
+      });
+    };
+    const closestLookup = this.#walkAndStream(normalPath, onSegment, invalidatedBy);
 
     if (closestLookup.exists && isDirectory(closestLookup.node)) {
       const maybeAbsolutePathMatch = this.#checkCandidateHasSubpath(
@@ -995,7 +1476,7 @@ export default class TreeFS implements MutableFileSystem {
       }
     }
 
-    // Phase 1: Consider descendenants of the common root, from deepest to
+    // Phase 1: Consider descendants of the common root, from deepest to
     // shallowest.
     for (
       let candidateIdx = ancestorsOfInput.length - 1;
@@ -1018,15 +1499,12 @@ export default class TreeFS implements MutableFileSystem {
         }
       );
       if (maybeAbsolutePathMatch != null) {
-        // Determine the input path relative to the current candidate. Note
-        // that the candidate path will always be canonical (real), whereas the
-        // input may contain symlinks, so the candidate is not necessarily a
-        // prefix of the input. Use the fact that each remaining candidate
-        // corresponds to a leading segment of the input normal path, and
-        // discard the first candidateIdx + 1 segments of the input path.
-        //
-        // The next 5 lines are equivalent to (but faster than)
-        // normalPath.split('/').slice(candidateIdx + 1).join('/').
+        // Determine the input path relative to the current candidate. The
+        // candidate path is always canonical (real); the input may contain
+        // symlinks, so the candidate is not necessarily a prefix of the input.
+        // Use the fact that each remaining candidate corresponds to a leading
+        // segment of the input normal path, and discard the first
+        // candidateIdx + 1 segments of the input path.
         let prefixLength = commonRootDepth * 3; // Leading '../'
         for (let i = commonRootDepth; i <= candidateIdx; i++) {
           prefixLength = normalPath.indexOf(path.sep, prefixLength + 1);
@@ -1039,9 +1517,7 @@ export default class TreeFS implements MutableFileSystem {
       }
     }
 
-    // Phase 2: Consider the common root and its ancestors
-
-    // This will be '', '..', '../..', etc.
+    // Phase 2: Consider the common root and its ancestors.
     let candidateNormalPath =
       commonRootDepth > 0 ? normalPath.slice(0, 3 * commonRootDepth - 1) : '';
     const remainingNormalPath = normalPath.slice(commonRootDepth * 3);
@@ -1090,14 +1566,13 @@ export default class TreeFS implements MutableFileSystem {
     normalCandidatePath: string,
     subpath: string,
     subpathType: 'f' | 'd',
-    invalidatedBy: Set<string> | null | undefined,
+    invalidatedBy: Set<string> | undefined,
     start:
       | {
-          ancestorOfRootIdx: number | null | undefined;
+          ancestorOfRootIdx: number | undefined;
           node: DirectoryNode;
           pathIdx: number;
         }
-      | null
       | undefined
   ): string | null {
     // NOTE(@kitten): The most common call for package.json only needs a simple map
@@ -1146,13 +1621,16 @@ export default class TreeFS implements MutableFileSystem {
       start != null &&
       normalCandidatePath !== '..' &&
       !normalCandidatePath.endsWith(path.sep + '..');
-    const lookupResult = this.#lookupByNormalPath(
-      this.#pathUtils.joinNormalToRelative(normalCandidatePath, subpath).normalPath,
-      {
-        collectLinkPaths: invalidatedBy,
-        start: canForwardStart ? start! : undefined,
-      }
-    );
+    const target = this.#pathUtils.joinNormalToRelative(normalCandidatePath, subpath).normalPath;
+    const lookupResult = canForwardStart
+      ? this.#lookupFromNode(
+          start!.node,
+          start!.pathIdx,
+          start!.ancestorOfRootIdx,
+          target,
+          invalidatedBy
+        )
+      : this.#lookup(target, invalidatedBy);
     if (
       lookupResult.exists &&
       // Should be a Map iff subpathType is directory
@@ -1209,8 +1687,8 @@ export default class TreeFS implements MutableFileSystem {
 
   *#directoryNodeIterator(
     node: DirectoryNode,
-    parent: DirectoryNode | null | undefined,
-    ancestorOfRootIdx: number | null | undefined
+    parent: DirectoryNode | undefined,
+    ancestorOfRootIdx: number | undefined
   ): Generator<[string, MixedNode | null]> {
     if (ancestorOfRootIdx != null && ancestorOfRootIdx > 0 && parent) {
       yield [this.#pathUtils.getBasenameOfNthAncestor(ancestorOfRootIdx - 1), parent];
@@ -1224,8 +1702,8 @@ export default class TreeFS implements MutableFileSystem {
    */
   *#pathIterator(
     iterationRootNode: DirectoryNode,
-    iterationRootParentNode: DirectoryNode | null | undefined,
-    ancestorOfRootIdx: number | null | undefined,
+    iterationRootParentNode: DirectoryNode | undefined,
+    ancestorOfRootIdx: number | undefined,
     opts: Readonly<{
       alwaysYieldPosix: boolean;
       canonicalPathOfRoot: string;
@@ -1285,11 +1763,9 @@ export default class TreeFS implements MutableFileSystem {
           // its normal path, and we need a canonical path for resolution
           // (imagine our normal path contains a symlink 'bar' -> '.', and we
           // are at /foo/bar/baz where baz -> '..' - that should resolve to
-          // /foo, not /foo/bar). We *can* use _lookupByNormalPath to walk to
-          // the canonical symlink, and then to its target.
-          const resolved = this.#lookupByNormalPath(normalPathOfSymlink, {
-            followLeaf: true,
-          });
+          // /foo, not /foo/bar). We *can* use #walkLookup to walk to the
+          // canonical symlink, and then to its target.
+          const resolved = this.#lookup(normalPathOfSymlink);
           if (!resolved.exists) {
             // Symlink goes nowhere, nothing to report.
             continue;
@@ -1326,7 +1802,7 @@ export default class TreeFS implements MutableFileSystem {
         yield* this.#pathIterator(
           node,
           iterationRootParentNode,
-          ancestorOfRootIdx != null && ancestorOfRootIdx > 0 ? ancestorOfRootIdx - 1 : null,
+          ancestorOfRootIdx != null && ancestorOfRootIdx > 0 ? ancestorOfRootIdx - 1 : undefined,
           opts,
           nodePath,
           followedLinks
@@ -1338,7 +1814,7 @@ export default class TreeFS implements MutableFileSystem {
   #resolveSymlinkTargetToNormalPath(
     symlinkNode: FileMetadata,
     canonicalPathOfSymlink: Path
-  ): Path | null {
+  ): Path | undefined {
     const symlinkTarget = symlinkNode[H.SYMLINK];
     if (symlinkTarget === 1) {
       // Symlink target not yet resolved — read it lazily on first traversal
@@ -1353,13 +1829,13 @@ export default class TreeFS implements MutableFileSystem {
         symlinkNode[H.VISITED] = 1;
         return normalTarget;
       } catch {
-        return null;
+        return undefined;
       }
     } else if (symlinkTarget === 0 || symlinkTarget == null) {
       // WARN: We shouldn't call this method on non-symlinks. Outside of tests
       // this condition shouldn't trigger. It's fine not to resolve a symlink if
       // it does trigger however
-      return null;
+      return undefined;
     } else {
       invariant(typeof symlinkTarget === 'string', 'Expected symlink target to be populated.');
       return normalizePathSeparatorsToSystem(symlinkTarget);
@@ -1371,9 +1847,7 @@ export default class TreeFS implements MutableFileSystem {
     opts: { followLeaf: boolean } = { followLeaf: true }
   ): FileMetadata | null {
     const normalPath = this.#normalizePath(filePath);
-    const result = this.#lookupByNormalPath(normalPath, {
-      followLeaf: opts.followLeaf,
-    });
+    const result = opts.followLeaf ? this.#lookup(normalPath) : this.#lookupNoFollow(normalPath);
     if (!result.exists || isDirectory(result.node)) {
       return null;
     }

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -211,8 +211,11 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   getSize(mixedPath: Path): number | null {
-    const fileMetadata = this.#getFileData(mixedPath);
-    return (fileMetadata && fileMetadata[H.SIZE]) ?? null;
+    const result = this.#lookup(this.#normalizePath(mixedPath));
+    if (!result.exists || isDirectory(result.node)) {
+      return null;
+    }
+    return result.node[H.SIZE] ?? null;
   }
 
   getDifference(
@@ -300,8 +303,11 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   getSha1(mixedPath: Path): string | null {
-    const fileMetadata = this.#getFileData(mixedPath);
-    return (fileMetadata && fileMetadata[H.SHA1]) ?? null;
+    const result = this.#lookup(this.#normalizePath(mixedPath));
+    if (!result.exists || isDirectory(result.node)) {
+      return null;
+    }
+    return result.node[H.SHA1] ?? null;
   }
 
   async getOrComputeSha1(
@@ -355,8 +361,8 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   exists(mixedPath: Path): boolean {
-    const result = this.#getFileData(mixedPath);
-    return result != null;
+    const result = this.#lookup(this.#normalizePath(mixedPath));
+    return result.exists && !isDirectory(result.node);
   }
 
   lookup(mixedPath: Path): LookupResult {
@@ -399,13 +405,13 @@ export default class TreeFS implements MutableFileSystem {
   }
 
   linkStats(mixedPath: Path): FileStats | null {
-    const fileMetadata = this.#getFileData(mixedPath, { followLeaf: false });
-    if (fileMetadata == null) {
+    const result = this.#lookupNoFollow(this.#normalizePath(mixedPath));
+    if (!result.exists || isDirectory(result.node)) {
       return null;
     }
-    const fileType = isRegularFile(fileMetadata) ? 'f' : 'l';
+    const fileMetadata = result.node;
     return {
-      fileType,
+      fileType: isRegularFile(fileMetadata) ? 'f' : 'l',
       modifiedTime: fileMetadata[H.MTIME],
       size: fileMetadata[H.SIZE],
     };
@@ -1747,18 +1753,6 @@ export default class TreeFS implements MutableFileSystem {
       invariant(typeof symlinkTarget === 'string', 'Expected symlink target to be populated.');
       return normalizePathSeparatorsToSystem(symlinkTarget);
     }
-  }
-
-  #getFileData(
-    filePath: Path,
-    opts: { followLeaf: boolean } = { followLeaf: true }
-  ): FileMetadata | null {
-    const normalPath = this.#normalizePath(filePath);
-    const result = opts.followLeaf ? this.#lookup(normalPath) : this.#lookupNoFollow(normalPath);
-    if (!result.exists || isDirectory(result.node)) {
-      return null;
-    }
-    return result.node;
   }
 
   /**

--- a/packages/@expo/metro-file-map/src/lib/TreeFS.ts
+++ b/packages/@expo/metro-file-map/src/lib/TreeFS.ts
@@ -393,15 +393,23 @@ export default class TreeFS implements MutableFileSystem {
 
   getAllFiles(): Path[] {
     const result: Path[] = [];
-    this.#forEachMetadata(
-      this.#rootNode,
-      { includeNodeModules: true, includeSymlinks: false },
-      '',
-      (_baseName, canonicalPath) => {
-        result.push(this.#pathUtils.normalToAbsolute(canonicalPath));
-      }
-    );
+    this.#collectAllFilesInto(this.#rootNode, '', result);
     return result;
+  }
+
+  // NOTE(@kitten): Specialize the `getAllFiles` collector, to avoid a megamorphic deopt in V8
+  #collectAllFilesInto(node: DirectoryNode, prefix: string, result: Path[]): void {
+    for (const [name, child] of node) {
+      if (child == null) {
+        continue;
+      }
+      const prefixedName = prefix === '' ? name : prefix + path.sep + name;
+      if (isDirectory(child)) {
+        this.#collectAllFilesInto(child, prefixedName, result);
+      } else if (isRegularFile(child)) {
+        result.push(this.#pathUtils.normalToAbsolute(prefixedName));
+      }
+    }
   }
 
   linkStats(mixedPath: Path): FileStats | null {

--- a/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/TreeFS.test.ts
@@ -88,6 +88,35 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
     expect(tfs.exists(p('/project/link-to-nowhere'))).toBe(false);
   });
 
+  describe('linkStats edge cases (followLeaf=false)', () => {
+    test('returns type "l" for a symlink to a directory', () => {
+      // link-to-foo → foo (a directory). followLeaf=false returns the symlink.
+      expect(tfs.linkStats(p('/project/link-to-foo'))).toMatchObject({ fileType: 'l' });
+    });
+
+    test('returns type "l" for a broken symlink at the leaf', () => {
+      // followLeaf=false: leaf symlink is returned regardless of target validity.
+      expect(tfs.linkStats(p('/project/link-to-nowhere'))).toMatchObject({ fileType: 'l' });
+    });
+
+    test('resolves non-leaf symlinks, returns terminal symlink as "l"', () => {
+      // link-to-foo is followed (non-leaf); link-to-bar.js at leaf is returned as 'l'.
+      expect(tfs.linkStats(p('/project/link-to-foo/link-to-bar.js'))).toMatchObject({
+        fileType: 'l',
+      });
+    });
+
+    test('returns null when a non-leaf segment is a regular file', () => {
+      expect(tfs.linkStats(p('/project/bar.js/no-such'))).toBeNull();
+    });
+
+    test('cycling symlink at leaf returns "l" without consulting cycle detection', () => {
+      // followLeaf=false short-circuits at the leaf — the symlink target isn't
+      // resolved, so the cycle never has a chance to be observed.
+      expect(tfs.linkStats(p('/project/link-cycle-1'))).toMatchObject({ fileType: 'l' });
+    });
+  });
+
   test('implements linkStats()', () => {
     expect(tfs.linkStats(p('/project/link-to-foo/another.js'))).toEqual({
       fileType: 'f',
@@ -198,6 +227,15 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
         exists: false,
         missing: p('/deep/project/root/baz.js'),
       });
+    });
+
+    test('symlink to itself returns missing (cycle detection)', () => {
+      expect(tfs.lookup(p('/project/link-to-self'))).toMatchObject({ exists: false });
+    });
+
+    test('two-node symlink cycle returns missing from either entry point', () => {
+      expect(tfs.lookup(p('/project/link-cycle-1'))).toMatchObject({ exists: false });
+      expect(tfs.lookup(p('/project/link-cycle-2'))).toMatchObject({ exists: false });
     });
   });
 
@@ -685,6 +723,32 @@ describe.each([['win32'], ['posix']] as const)('TreeFS on %s', (platform) => {
         },
       });
       expect(nullMtimeTfs.getMtimeByNormalPath(p('a.js'))).toBeNull();
+    });
+
+    test('skipFallback: does not invoke the fallback filesystem', () => {
+      // getMtimeByNormalPath passes skipFallback: true. Even when a fallback FS
+      // is configured, missing paths must return null without consulting it.
+      const mockFallback = {
+        lookup: jest.fn().mockReturnValue(null),
+        readdir: jest.fn().mockReturnValue(null),
+      };
+      const fbTfs = new TreeFS({
+        rootDir: p('/project'),
+        files: new Map<CanonicalPath, FileMetadata>([
+          [p('existing.js'), [555, 5, 0, null, 0, null]],
+        ]),
+        fallbackFilesystem: mockFallback,
+        processFile: async () => {
+          throw new Error('Not implemented');
+        },
+      });
+      // In-tree path: returns mtime, no fallback call.
+      expect(fbTfs.getMtimeByNormalPath(p('existing.js'))).toBe(555);
+      // Missing path: returns null, fallback not consulted.
+      expect(fbTfs.getMtimeByNormalPath(p('missing.js'))).toBeNull();
+      expect(fbTfs.getMtimeByNormalPath(p('missing/dir/file.js'))).toBeNull();
+      expect(mockFallback.lookup).not.toHaveBeenCalled();
+      expect(mockFallback.readdir).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# Why

Stacked on #45650

While it's a larger divergence from upstream, converting the walkers to cleaner methods with no `opts` is a little more maintainable from an isolated perspective and allows us to experiment with more changes faster.

Ditching the generators also yields a small performance improvement on the methods that use them only internally.

# How

- Replace `lookupByNormalPath` with individual walkers with callbacks
- Remove double parent directory walk from `addOrModify`
- Ditch internal generator methods for `forEach` callbacks

# Test Plan

- Tests should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
