### PR TITLE
chore(cli): Drop `better-opn`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### 💡 Others
 
 - Add general `eslint-disable` comment to Router's type-gen output ([#41637](https://github.com/expo/expo/pull/41637) by [@matinzd](https://github.com/matinzd))
+- Drop `better-opn` ([#45654](https://github.com/expo/expo/pull/45654) by [@kitten](https://github.com/kitten))
 
 ## 56.1.4 — 2026-05-13
 

--- a/packages/@expo/cli/jest.setup.ts
+++ b/packages/@expo/cli/jest.setup.ts
@@ -7,7 +7,6 @@ jest.mock('@expo/package-manager');
 jest.mock('child_process');
 jest.mock('fs');
 jest.mock('fs/promises');
-jest.mock('better-opn');
 jest.mock('lan-network');
 jest.mock('ora');
 jest.mock('os');

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -74,7 +74,6 @@
     "@react-native/dev-middleware": "0.85.3",
     "accepts": "^1.3.8",
     "arg": "^5.0.2",
-    "better-opn": "~3.0.2",
     "bplist-creator": "0.1.0",
     "bplist-parser": "^0.3.1",
     "chalk": "^4.0.0",

--- a/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
+++ b/packages/@expo/cli/src/api/user/expoSsoLauncher.ts
@@ -1,11 +1,11 @@
 import assert from 'assert';
-import openBrowserAsync from 'better-opn';
 import crypto from 'crypto';
 import http from 'http';
 import type { Socket } from 'node:net';
 
 import * as Log from '../../log';
 import { CommandError } from '../../utils/errors';
+import { openBrowserAsync } from '../../utils/open';
 import { fetchAsync, getResponseDataOrThrow } from '../rest/client';
 
 const CLIENT_ID = 'expo-cli';

--- a/packages/@expo/cli/src/utils/open.ts
+++ b/packages/@expo/cli/src/utils/open.ts
@@ -1,24 +1,179 @@
-import betterOpenBrowserAsync from 'better-opn';
+import * as osascript from '@expo/osascript';
+import spawnAsync from '@expo/spawn-async';
+import path from 'path';
+
+/** Splits an inline script into trimmed, non-empty lines for `osascript -e <line>`. */
+function applescript(strings: TemplateStringsArray, ...values: unknown[]): string[] {
+  let raw = strings[0]!;
+  for (let i = 0; i < values.length; i++) {
+    raw += String(values[i]) + strings[i + 1];
+  }
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+}
+
+/** Escapes a value for safe interpolation inside an AppleScript double-quoted string. */
+function escapeAppleScriptString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n');
+}
+
+// See: https://github.com/ExiaSR/better-opn/blob/master/openChrome.applescript
+// MIT License, Copyright (c) 2015-present, Facebook, Inc. (originally from create-react-app)
+function buildOpenChromiumTabScript(target: string, matchUrl: string, browser: string): string[] {
+  const theURL = escapeAppleScriptString(target);
+  const matchURL = escapeAppleScriptString(matchUrl);
+  const theProgram = escapeAppleScriptString(browser);
+  return applescript`
+    property targetTab: null
+    property targetTabIndex: -1
+    property targetWindow: null
+    property theProgram: "${theProgram}"
+
+    on run
+      set theURL to "${theURL}"
+      set matchURL to "${matchURL}"
+      using terms from application "Google Chrome"
+        tell application theProgram
+          if (count every window) = 0 then
+            make new window
+          end if
+          set found to my lookupTabWithUrl(matchURL)
+          if found then
+            set targetWindow's active tab index to targetTabIndex
+            tell targetTab to reload
+            tell targetWindow to activate
+            set index of targetWindow to 1
+            return
+          end if
+          set found to my lookupTabWithUrl("chrome://newtab/")
+          if found then
+            set targetWindow's active tab index to targetTabIndex
+            set URL of targetTab to theURL
+            tell targetWindow to activate
+            return
+          end if
+          tell window 1
+            activate
+            make new tab with properties {URL:theURL}
+          end tell
+        end tell
+      end using terms from
+    end run
+
+    on lookupTabWithUrl(lookupUrl)
+      using terms from application "Google Chrome"
+        tell application theProgram
+          set found to false
+          set theTabIndex to -1
+          repeat with theWindow in every window
+            set theTabIndex to 0
+            repeat with theTab in every tab of theWindow
+              set theTabIndex to theTabIndex + 1
+              if (theTab's URL as string) contains lookupUrl then
+                set targetTab to theTab
+                set targetTabIndex to theTabIndex
+                set targetWindow to theWindow
+                set found to true
+                exit repeat
+              end if
+            end repeat
+            if found then exit repeat
+          end repeat
+        end tell
+      end using terms from
+      return found
+    end lookupTabWithUrl
+  `;
+}
+
+const CHROMIUM_BROWSERS = [
+  'Google Chrome Canary',
+  'Google Chrome',
+  'Microsoft Edge',
+  'Brave Browser',
+  'Vivaldi',
+  'Chromium',
+];
+
+function safeOrigin(target: string): string {
+  try {
+    return new URL(target).origin;
+  } catch {
+    return target;
+  }
+}
+
+async function tryOpenInChromiumTabAsync(target: string): Promise<boolean> {
+  const matchUrl = process.env.OPEN_MATCH_HOST_ONLY === 'true' ? safeOrigin(target) : target;
+  for (const browser of CHROMIUM_BROWSERS) {
+    const running = await osascript.isAppRunningAsync(browser).catch(() => false);
+    if (!running) continue;
+    try {
+      await osascript.spawnAsync(buildOpenChromiumTabScript(target, matchUrl, browser), {
+        stdio: 'ignore',
+      });
+      return true;
+    } catch {
+      // Try the next browser.
+    }
+  }
+  return false;
+}
 
 /**
- * Due to a bug in `open`, which is used as fallback on Windows, we need to ensure `process.env.SYSTEMROOT` is set.
- * This environment variable is set by Windows on `SystemRoot`, causing `open` to execute a command with an "unknown" drive letter.
+ * Opens a URL in the user's browser. Honors `BROWSER` (set to `none` to disable) and
+ * `BROWSER_ARGS` environment variables. On macOS, reuses an existing tab in a running
+ * Chromium-based browser when possible.
  *
- * @see https://github.com/sindresorhus/open/issues/205
+ * @returns `true` when a browser was launched, `false` when `BROWSER=none`.
  */
-export async function openBrowserAsync(
-  target: string,
-  options?: any
-): Promise<import('child_process').ChildProcess | false> {
-  if (process.platform !== 'win32') {
-    return await betterOpenBrowserAsync(target, options);
+export async function openBrowserAsync(target: string): Promise<boolean> {
+  const browserEnv = process.env.BROWSER?.trim();
+  if (browserEnv?.toLowerCase() === 'none') {
+    return false;
   }
 
-  const oldSystemRoot = process.env.SYSTEMROOT;
-  try {
-    process.env.SYSTEMROOT = process.env.SYSTEMROOT ?? process.env.SystemRoot;
-    return await betterOpenBrowserAsync(target, options);
-  } finally {
-    process.env.SYSTEMROOT = oldSystemRoot;
+  // On macOS, `BROWSER=open` historically meant "use the default handler" rather than
+  // "launch an app called open" — treat it as if BROWSER were unset.
+  const browserApp =
+    browserEnv && !(process.platform === 'darwin' && browserEnv.toLowerCase() === 'open')
+      ? browserEnv
+      : undefined;
+  const browserArgs = process.env.BROWSER_ARGS ? process.env.BROWSER_ARGS.split(' ') : [];
+
+  if (process.platform === 'darwin') {
+    const isDefaultOrChrome = !browserApp || browserApp.toLowerCase() === 'google chrome';
+    if (isDefaultOrChrome && (await tryOpenInChromiumTabAsync(target))) {
+      return true;
+    }
+    const openArgs: string[] = [];
+    if (browserApp) openArgs.push('-a', browserApp);
+    openArgs.push(target);
+    if (browserArgs.length > 0) openArgs.push('--args', ...browserArgs);
+    await spawnAsync('open', openArgs, { stdio: 'ignore' });
+    return true;
   }
+
+  if (process.platform === 'win32') {
+    // Windows preserves env var case in Node, but the OS variable is `SystemRoot`.
+    const systemRoot = process.env.SYSTEMROOT ?? process.env.SystemRoot ?? 'C:\\Windows';
+    const cmd = path.join(systemRoot, 'System32', 'cmd.exe');
+    // `start ""` — the empty quoted string is the window title, so the URL isn't
+    // interpreted as a title argument.
+    const startArgs = ['/c', 'start', '""'];
+    if (browserApp) startArgs.push(browserApp);
+    startArgs.push(target, ...browserArgs);
+    await spawnAsync(cmd, startArgs, { stdio: 'ignore' });
+    return true;
+  }
+
+  const command = browserApp ?? 'xdg-open';
+  await spawnAsync(command, [...browserArgs, target], { stdio: 'ignore' });
+  return true;
 }

--- a/packages/@expo/cli/src/utils/open.ts
+++ b/packages/@expo/cli/src/utils/open.ts
@@ -24,19 +24,18 @@ function escapeAppleScriptString(value: string): string {
     .replace(/\n/g, '\\n');
 }
 
-// See: https://github.com/ExiaSR/better-opn/blob/master/openChrome.applescript
-// MIT License, Copyright (c) 2015-present, Facebook, Inc. (originally from create-react-app)
-function buildOpenChromiumTabScript(target: string, matchUrl: string, browser: string): string[] {
+function buildOpenChromiumTabScript(target: string, matchUrl: string): string[] {
   const theURL = escapeAppleScriptString(target);
   const matchURL = escapeAppleScriptString(matchUrl);
-  const theProgram = escapeAppleScriptString(browser);
   return applescript`
     property targetTab: null
     property targetTabIndex: -1
     property targetWindow: null
-    property theProgram: "${theProgram}"
+    property theProgram: ""
 
     on run
+      set theProgram to my findRunningChromium()
+      if theProgram is "" then error "No Chromium browser is running."
       set theURL to "${theURL}"
       set matchURL to "${matchURL}"
       using terms from application "Google Chrome"
@@ -67,6 +66,18 @@ function buildOpenChromiumTabScript(target: string, matchUrl: string, browser: s
       end using terms from
     end run
 
+    on findRunningChromium()
+      set candidates to {"Google Chrome Canary", "Google Chrome", "Microsoft Edge", "Brave Browser", "Vivaldi", "Chromium"}
+      tell application "System Events"
+        set runningNames to name of every process
+      end tell
+      repeat with candidate in candidates
+        set candidateName to candidate as string
+        if candidateName is in runningNames then return candidateName
+      end repeat
+      return ""
+    end findRunningChromium
+
     on lookupTabWithUrl(lookupUrl)
       using terms from application "Google Chrome"
         tell application theProgram
@@ -93,15 +104,6 @@ function buildOpenChromiumTabScript(target: string, matchUrl: string, browser: s
   `;
 }
 
-const CHROMIUM_BROWSERS = [
-  'Google Chrome Canary',
-  'Google Chrome',
-  'Microsoft Edge',
-  'Brave Browser',
-  'Vivaldi',
-  'Chromium',
-];
-
 function safeOrigin(target: string): string {
   try {
     return new URL(target).origin;
@@ -112,19 +114,14 @@ function safeOrigin(target: string): string {
 
 async function tryOpenInChromiumTabAsync(target: string): Promise<boolean> {
   const matchUrl = process.env.OPEN_MATCH_HOST_ONLY === 'true' ? safeOrigin(target) : target;
-  for (const browser of CHROMIUM_BROWSERS) {
-    const running = await osascript.isAppRunningAsync(browser).catch(() => false);
-    if (!running) continue;
-    try {
-      await osascript.spawnAsync(buildOpenChromiumTabScript(target, matchUrl, browser), {
-        stdio: 'ignore',
-      });
-      return true;
-    } catch {
-      // Try the next browser.
-    }
+  try {
+    await osascript.spawnAsync(buildOpenChromiumTabScript(target, matchUrl), {
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
   }
-  return false;
 }
 
 /**

--- a/packages/@expo/cli/src/utils/open.ts
+++ b/packages/@expo/cli/src/utils/open.ts
@@ -1,5 +1,6 @@
 import * as osascript from '@expo/osascript';
 import spawnAsync from '@expo/spawn-async';
+import os from 'os';
 import path from 'path';
 
 /** Splits an inline script into trimmed, non-empty lines for `osascript -e <line>`. */
@@ -154,26 +155,52 @@ export async function openBrowserAsync(target: string): Promise<boolean> {
     }
     const openArgs: string[] = [];
     if (browserApp) openArgs.push('-a', browserApp);
-    openArgs.push(target);
+    // Per `open(1)`, everything following `--args` is forwarded to the launched app,
+    // so the target URL must come after the args block to reach the app alongside them.
     if (browserArgs.length > 0) openArgs.push('--args', ...browserArgs);
+    openArgs.push(target);
     await spawnAsync('open', openArgs, { stdio: 'ignore' });
     return true;
   }
 
   if (process.platform === 'win32') {
-    // Windows preserves env var case in Node, but the OS variable is `SystemRoot`.
-    const systemRoot = process.env.SYSTEMROOT ?? process.env.SystemRoot ?? 'C:\\Windows';
-    const cmd = path.join(systemRoot, 'System32', 'cmd.exe');
-    // `start ""` — the empty quoted string is the window title, so the URL isn't
-    // interpreted as a title argument.
-    const startArgs = ['/c', 'start', '""'];
-    if (browserApp) startArgs.push(browserApp);
-    startArgs.push(target, ...browserArgs);
-    await spawnAsync(cmd, startArgs, { stdio: 'ignore' });
+    await spawnWindowsStartAsync(target, browserApp, browserArgs);
+    return true;
+  }
+
+  // WSL: when the user hasn't overridden BROWSER, route through Windows `cmd.exe` so
+  // the URL opens in the user's Windows browser. Falls through to `xdg-open` otherwise.
+  if (!browserApp && isWsl()) {
+    await spawnAsync('/mnt/c/Windows/System32/cmd.exe', ['/c', 'start', '""', target], {
+      stdio: 'ignore',
+    });
     return true;
   }
 
   const command = browserApp ?? 'xdg-open';
   await spawnAsync(command, [...browserArgs, target], { stdio: 'ignore' });
   return true;
+}
+
+async function spawnWindowsStartAsync(
+  target: string,
+  browserApp: string | undefined,
+  browserArgs: string[]
+): Promise<void> {
+  // Windows preserves env var case in Node, but the OS variable is `SystemRoot`.
+  const systemRoot = process.env.SYSTEMROOT ?? process.env.SystemRoot ?? 'C:\\Windows';
+  const cmd = path.join(systemRoot, 'System32', 'cmd.exe');
+  // `start ""` — the empty quoted string is the window title, so the URL isn't
+  // interpreted as a title argument.
+  const startArgs = ['/c', 'start', '""'];
+  if (browserApp) startArgs.push(browserApp);
+  startArgs.push(target, ...browserArgs);
+  await spawnAsync(cmd, startArgs, { stdio: 'ignore' });
+}
+
+function isWsl(): boolean {
+  if (process.platform !== 'linux') return false;
+  if (process.env.WSL_DISTRO_NAME) return true;
+  const release = os.release().toLowerCase();
+  return release.includes('microsoft') || release.includes('wsl');
 }

--- a/packages/@expo/cli/ts-declarations/better-opn/index.d.ts
+++ b/packages/@expo/cli/ts-declarations/better-opn/index.d.ts
@@ -1,7 +1,0 @@
-declare module 'better-opn' {
-  function open(
-    target: string,
-    options?: any
-  ): Promise<import('child_process').ChildProcess | false>;
-  export = open;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1860,9 +1860,6 @@ importers:
       arg:
         specifier: ^5.0.2
         version: 5.0.2
-      better-opn:
-        specifier: ~3.0.2
-        version: 3.0.2
       bplist-creator:
         specifier: 0.1.0
         version: 0.1.0
@@ -10132,10 +10129,6 @@ packages:
 
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
-
-  better-opn@3.0.2:
-    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
-    engines: {node: '>=12.0.0'}
 
   better-sqlite3@11.10.0:
     resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
@@ -20328,10 +20321,6 @@ snapshots:
       safe-buffer: 5.1.2
 
   before-after-hook@2.2.3: {}
-
-  better-opn@3.0.2:
-    dependencies:
-      open: 8.4.2
 
   better-sqlite3@11.10.0:
     dependencies:


### PR DESCRIPTION
# Why

Resolves #41266

We already have the necessary packages to absorb the larger surface (except for the AppleScript itself) in `better-opn`. This also removes its synchronous start call, and removes its fallback to `open`, which needs an upgrade for its vendored `xdg-open` binary. Instead, we can for now assume that `xdg-open` is available in the `$PATH`. This holds for most Gnome/Plasma distributions, and is a known convention. While replacements exist, we can't realistically support all.

# How

- Replace `better-opn` with equivalent (but custom) logic
- Apply upstream/similar fixes from `open`
- Fold browser detection into AppleScript to improve latency  

# Test Plan

- Tested manually on Mac with and without Google Chrome installed
- Tested on Windows

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
