### PR TITLE
fix(cli): Remove redundant env-var parsing in resolver hot-path

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Add general `eslint-disable` comment to Router's type-gen output ([#41637](https://github.com/expo/expo/pull/41637) by [@matinzd](https://github.com/matinzd))
 - Drop `better-opn` ([#45654](https://github.com/expo/expo/pull/45654) by [@kitten](https://github.com/kitten))
+- Remove redundant env-var parsing in CLI resolver hot paths ([#45658](https://github.com/expo/expo/pull/45658) by [@kitten](https://github.com/kitten))
 
 ## 56.1.4 — 2026-05-13
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -365,6 +365,11 @@ export function withExtendedResolver(
     },
   ];
 
+  const skipMetroMainFieldOverride = env.EXPO_METRO_NO_MAIN_FIELD_OVERRIDE;
+  const useExpoUnstableWebModule = env.EXPO_UNSTABLE_WEB_MODAL;
+  const useExpoUnstableLogBox = env.EXPO_UNSTABLE_LOG_BOX;
+  const disableReactNavigationCheck = env.EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK;
+
   const metroConfigWithCustomResolver = withMetroResolvers(config, [
     // Mock out production react imports in development.
     function requestDevMockProdReact(
@@ -618,7 +623,7 @@ export function withExtendedResolver(
       const doReplaceStrict = (from: string, to: string | undefined) =>
         doReplace(from, to, { throws: true });
 
-      if (env.EXPO_UNSTABLE_WEB_MODAL) {
+      if (useExpoUnstableWebModule) {
         const webModalModule = doReplace(
           'expo-router/build/layouts/_web-modal.js',
           'expo-router/build/layouts/ExperimentalModalStack.js'
@@ -629,7 +634,7 @@ export function withExtendedResolver(
         }
       }
 
-      if (!env.EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK) {
+      if (!disableReactNavigationCheck) {
         // TODO(@ubax): Remove this rewrite once we published migration guide for library authors
         if (isExpoRouterInstalled && moduleName.startsWith('@react-navigation/')) {
           const filePath = context.originModulePath;
@@ -722,7 +727,7 @@ export function withExtendedResolver(
         );
         if (hmrModule) return hmrModule;
 
-        if (env.EXPO_UNSTABLE_LOG_BOX) {
+        if (useExpoUnstableLogBox) {
           const logBoxModule = doReplace(
             'react-native/Libraries/LogBox/LogBoxInspectorContainer.js',
             '@expo/log-box/swap-rn-logbox.js'
@@ -806,7 +811,7 @@ export function withExtendedResolver(
       } else {
         // Non-server changes
 
-        if (!env.EXPO_METRO_NO_MAIN_FIELD_OVERRIDE && platform && platform in preferredMainFields) {
+        if (!skipMetroMainFieldOverride && platform && platform in preferredMainFields) {
           context.mainFields = preferredMainFields[platform]!;
         }
       }


### PR DESCRIPTION
# Why

This doesn't have a big impact on performance, but makes the stack a bit harder to parse for candidates to optimise, since it's redundant work.

# How

- Hoist `env.*` access since they're lazy getters, out of active resolver functions

# Test Plan

- Tests should pass unchanged

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
