### PR TITLE
[updates][android] Fix app restart when not using ReactApplication

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] Fix app restart when not using ReactApplication ([#45660](https://github.com/expo/expo/pull/45660) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [Android] Fix app restart when not using `ReactApplication` ([#45660](https://github.com/expo/expo/pull/45660) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix app restart when not using ReactApplication ([#45660](https://github.com/expo/expo/pull/45660) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 56.0.7 — 2026-05-11

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/DisabledUpdatesController.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import com.facebook.react.ReactHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.kotlin.exception.CodedException
@@ -88,6 +89,7 @@ class DisabledUpdatesController(
     get() = launcher?.bundleAssetName
   override val reloadScreenManager: ReloadScreenManager?
     get() = null
+  override var reactHost: WeakReference<ReactHost> = WeakReference(null)
 
   override fun onEventListenerStartObserving() {
     stateMachine.sendContextToJS()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import com.facebook.react.ReactHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.easclient.EASClientID
@@ -82,6 +83,7 @@ class EnabledUpdatesController(
   private val startupFinishedDeferred = CompletableDeferred<Unit>()
   private val startupFinishedMutex = Mutex()
   override val reloadScreenManager = ReloadScreenManager()
+  override var reactHost: WeakReference<ReactHost> = WeakReference(null)
 
   internal val stateChangeListenerMap: MutableMap<String, UpdatesStateChangeListener> = mutableMapOf()
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/IUpdatesController.kt
@@ -1,6 +1,7 @@
 package expo.modules.updates
 
 import android.os.Bundle
+import com.facebook.react.ReactHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.updates.db.entity.AssetEntity
@@ -11,6 +12,7 @@ import expo.modules.updates.manifest.Update
 import expo.modules.updates.reloadscreen.ReloadScreenManager
 import expo.modules.updates.statemachine.UpdatesStateContext
 import java.io.File
+import java.lang.ref.WeakReference
 import java.util.Date
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -34,6 +36,11 @@ interface IUpdatesController {
    * this.
    */
   val bundleAssetName: String?
+
+  /**
+   * The current [ReactHost], populated automatically by `ReactNativeHostHandler.onDidCreateReactHost`.
+   */
+  var reactHost: WeakReference<ReactHost>
 
   val reloadScreenManager: ReloadScreenManager?
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -2,7 +2,6 @@ package expo.modules.updates
 
 import android.content.Context
 import com.facebook.react.ReactApplication
-import com.facebook.react.ReactHost
 import expo.modules.updates.events.IUpdatesEventManagerObserver
 import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.logging.UpdatesErrorCode
@@ -25,13 +24,6 @@ object UpdatesController {
 
   @Volatile
   private var overrideConfiguration: UpdatesConfiguration? = null
-
-  /**
-   * Populated automatically by ReactNativeHostHandler.onDidCreateReactHost
-   */
-  @Volatile
-  @JvmStatic
-  var reactHost: WeakReference<ReactHost> = WeakReference(null)
 
   @JvmStatic
   val instance: IUpdatesController

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -31,7 +31,7 @@ object UpdatesController {
    */
   @Volatile
   @JvmStatic
-  var reactHost: ReactHost? = null
+  var reactHost: WeakReference<ReactHost> = WeakReference(null)
 
   @JvmStatic
   val instance: IUpdatesController

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesController.kt
@@ -2,6 +2,7 @@ package expo.modules.updates
 
 import android.content.Context
 import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
 import expo.modules.updates.events.IUpdatesEventManagerObserver
 import expo.modules.updates.loader.LoaderTask
 import expo.modules.updates.logging.UpdatesErrorCode
@@ -24,6 +25,13 @@ object UpdatesController {
 
   @Volatile
   private var overrideConfiguration: UpdatesConfiguration? = null
+
+  /**
+   * Populated automatically by ReactNativeHostHandler.onDidCreateReactHost
+   */
+  @Volatile
+  @JvmStatic
+  var reactHost: ReactHost? = null
 
   @JvmStatic
   val instance: IUpdatesController

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesDevLauncherController.kt
@@ -3,6 +3,7 @@ package expo.modules.updates
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import com.facebook.react.ReactHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import expo.modules.easclient.EASClientID
@@ -106,6 +107,7 @@ class UpdatesDevLauncherController(
     get() = throw Exception("IUpdatesController.bundleAssetName should not be called in dev client")
 
   override val reloadScreenManager = ReloadScreenManager()
+  override var reactHost: WeakReference<ReactHost> = WeakReference(null)
 
   override fun onEventListenerStartObserving() {
     // no-op for UpdatesDevLauncherController

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -38,6 +38,10 @@ class UpdatesPackage : Package {
         UpdatesController.initialize(context, useDeveloperSupport)
       }
 
+      override fun onDidCreateReactHost(context: Context, reactNativeHost: ReactHost) {
+        UpdatesController.reactHost = reactNativeHost
+      }
+
       override fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {
         UpdatesController.instance.onDidCreateDevSupportManager(devSupportManager)
       }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.lang.ref.WeakReference
 
 /**
  * Defines the internal and exported modules for expo-updates, as well as the auto-setup behavior in

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/UpdatesPackage.kt
@@ -39,7 +39,7 @@ class UpdatesPackage : Package {
       }
 
       override fun onDidCreateReactHost(context: Context, reactNativeHost: ReactHost) {
-        UpdatesController.reactHost = reactNativeHost
+        UpdatesController.instance.reactHost = WeakReference(reactNativeHost)
       }
 
       override fun onDidCreateDevSupportManager(devSupportManager: DevSupportManager) {

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RecreateReactContextProcedure.kt
@@ -2,7 +2,6 @@ package expo.modules.updates.procedures
 
 import android.app.Activity
 import android.content.Context
-import com.facebook.react.ReactApplication
 import expo.modules.updates.launcher.Launcher
 import expo.modules.updates.statemachine.UpdatesStateEvent
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +19,7 @@ class RecreateReactContextProcedure(
   override val loggerTimerLabel = "timer-recreate-react-context"
 
   override suspend fun run(procedureContext: ProcedureContext) {
-    val reactApplication = context.applicationContext as? ReactApplication ?: run inner@{
+    val reactHost = resolveReactHostForRestart(context) ?: run inner@{
       callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
       return
     }
@@ -29,7 +28,7 @@ class RecreateReactContextProcedure(
     callback.onSuccess()
     procedureScope.launch {
       withContext(Dispatchers.Main) {
-        reactApplication.restart(weakActivity?.get(), "Restart from RecreateReactContextProcedure")
+        reactHost.restart(weakActivity?.get(), "Restart from RecreateReactContextProcedure")
       }
     }
     procedureContext.resetStateAfterRestart()

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RelaunchProcedure.kt
@@ -2,7 +2,6 @@ package expo.modules.updates.procedures
 
 import android.app.Activity
 import android.content.Context
-import com.facebook.react.ReactApplication
 import expo.modules.updates.UpdatesConfiguration
 import expo.modules.updates.db.DatabaseHolder
 import expo.modules.updates.db.Reaper
@@ -41,7 +40,7 @@ class RelaunchProcedure(
   override val loggerTimerLabel = "timer-relaunch"
 
   override suspend fun run(procedureContext: ProcedureContext) {
-    val reactApplication = context as? ReactApplication ?: run inner@{
+    val reactHost = resolveReactHostForRestart(context) ?: run inner@{
       callback.onFailure(Exception("Could not reload application. Ensure you have passed the correct instance of ReactApplication into UpdatesController.initialize()."))
       return
     }
@@ -74,7 +73,7 @@ class RelaunchProcedure(
     procedureScope.launch {
       withContext(Dispatchers.Main) {
         reloadScreenManager?.show(weakActivity?.get())
-        reactApplication.restart(weakActivity?.get(), "Restart from RelaunchProcedure")
+        reactHost.restart(weakActivity?.get(), "Restart from RelaunchProcedure")
       }
     }
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RestartReactAppExtensions.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RestartReactAppExtensions.kt
@@ -11,13 +11,13 @@ import expo.modules.updates.UpdatesController
  * Resolve a [ReactHost] to reload, in order of preference:
  *   1. `(context.applicationContext as? ReactApplication)?.reactHost`, works for every app
  *       whose host `Application` implements [ReactApplication].
- *   2. [UpdatesController.reactHost], populated by the expo-modules-core `onDidCreateReactHost`
- *      lifecycle callback for brownfield consumers whose `Application` does not implement
- *      [ReactApplication].
+ *   2. [UpdatesController.instance].reactHost, populated by the expo-modules-core
+ *      `onDidCreateReactHost` lifecycle callback for brownfield consumers whose `Application`
+ *      does not implement [ReactApplication].
  */
 internal fun resolveReactHostForRestart(context: Context): ReactHost? =
   (context.applicationContext as? ReactApplication)?.reactHost
-    ?: UpdatesController.reactHost
+    ?: UpdatesController.instance.reactHost.get()
 
 /**
  * An extension for [ReactHost] to restart the app

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RestartReactAppExtensions.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/procedures/RestartReactAppExtensions.kt
@@ -1,20 +1,33 @@
 package expo.modules.updates.procedures
 
 import android.app.Activity
+import android.content.Context
 import com.facebook.react.ReactApplication
+import com.facebook.react.ReactHost
 import com.facebook.react.common.LifecycleState
+import expo.modules.updates.UpdatesController
 
 /**
- * An extension for [ReactApplication] to restart the app
+ * Resolve a [ReactHost] to reload, in order of preference:
+ *   1. `(context.applicationContext as? ReactApplication)?.reactHost`, works for every app
+ *       whose host `Application` implements [ReactApplication].
+ *   2. [UpdatesController.reactHost], populated by the expo-modules-core `onDidCreateReactHost`
+ *      lifecycle callback for brownfield consumers whose `Application` does not implement
+ *      [ReactApplication].
+ */
+internal fun resolveReactHostForRestart(context: Context): ReactHost? =
+  (context.applicationContext as? ReactApplication)?.reactHost
+    ?: UpdatesController.reactHost
+
+/**
+ * An extension for [ReactHost] to restart the app
  *
  * @param activity For bridgeless mode if the ReactHost is destroyed, we need an Activity to resume it.
  * @param reason The restart reason. Only used on bridgeless mode.
  */
-internal fun ReactApplication.restart(activity: Activity?, reason: String) {
-  val reactHost = this.reactHost
-  check(reactHost != null)
-  if (reactHost.lifecycleState != LifecycleState.RESUMED && activity != null) {
-    reactHost.onHostResume(activity)
+internal fun ReactHost.restart(activity: Activity?, reason: String) {
+  if (lifecycleState != LifecycleState.RESUMED && activity != null) {
+    onHostResume(activity)
   }
-  reactHost.reload(reason)
+  reload(reason)
 }


### PR DESCRIPTION
# Why

`Updates.reloadAsync()` would not work on Android unless the `Application` class implemented the deprecated `ReactApplication` class, whici is the case for a lot of  expo-brownfield users, where the host activity belongs to the existing native app and the `Application` class is whatever the consumer team already had (Compose, vanilla `Application`, etc.).

# How

By using the `ReactNativeHostHandler.onDidCreateReactHost(context, reactNativeHost)` callback from modules core, we can get a reference to `reactNativeHost` and restart the app directly, this way skipping the ReactApplication cast in apps that don't implement it. 

# Test Plan

Manual test on Android using the existing brownfield fixtures in this monorepo:

1. **Republish the brownfield AAR** from `apps/minimal-tester`:
   ```bash
   cd apps/minimal-tester
   npx expo-brownfield build:android --repository MavenLocal --release
   ``` 

2. **Build & launch the brownfield consumer** against the new AAR:
   ```bash
   cd apps/brownfield-tester/isolated/android
   ./gradlew installRelease
   adb shell am start -n dev.expo.brownfieldintegratedtester/.MainActivity
   adb logcat | grep -E "expo.modules.updates|RelaunchProcedure|RecreateReactContext"
   ```
   In the running app, exercise the fetch+reload flow  (publish a no-op update to the configured channel `u.expo.dev/ce96dd7b-…` first, then tap the *Fetch update* + *Reload* buttons). Confirm:
   - The string `"Could not reload application. Ensure you have passed the correct instance of ReactApplication"` does **not** appear in logcat.
   - Logs show `Restart from RelaunchProcedure` (or `RecreateReactContextProcedure`).
   - The brownfield activity reloads with the new JS bundle (visible UI / state reset).

4. **Non-brownfield regression**: build any standard Expo app, call `Updates.reloadAsync()`, and confirm reload still works. The helper takes the legacy `ReactApplication`-cast branch first, so behavior on existing apps is unchanged.

Automated tests for the procedures were considered but not added. I'll follow up with a dedicated test PR later for iOS and Android.
 
 
# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
