### PR TITLE
[docs] Fix Props rendering on API reference pages

### DIFF
--- a/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
+++ b/docs/components/plugins/__snapshots__/APISection.test.tsx.snap
@@ -372,7 +372,7 @@ for more details.
       </p>
     </div>
     <div
-      class="[&>*]:last:mb-0!"
+      class="border-palette-gray4 mb-5 overflow-hidden rounded-lg border shadow-xs [&_h2]:mt-0 [&_h3]:mt-0 [&_h4]:mt-0 [&_h3]:mb-1.5 [&_h4]:mb-0 [&_li]:mb-0 [&_thead]:border-palette-gray4 [&_th]:text-tertiary [&_th]:px-4 [&_td]:border-palette-gray4 [&_td]:py-3 [&_.table-wrapper]:border-palette-gray4 [&_.table-wrapper]:mb-0 [&_.table-wrapper]:shadow-none [&>*:last-child]:mb-0!"
     >
       <div
         class="border-palette-gray4 border-t first:border-t-0"

--- a/docs/components/plugins/api/APISectionProps.tsx
+++ b/docs/components/plugins/api/APISectionProps.tsx
@@ -26,7 +26,7 @@ import {
   resolveTypeName,
 } from './APISectionUtils';
 import { APICommentTextBlock } from './components/APICommentTextBlock';
-import { ELEMENT_SPACING, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
+import { ELEMENT_SPACING, STYLES_APIBOX, STYLES_SECONDARY, VERTICAL_SPACING } from './styles';
 
 export type APISectionPropsProps = {
   data: PropsDefinitionData[];
@@ -115,7 +115,9 @@ const renderProps = (
     .filter((dec, i, arr) => arr.findIndex(t => t?.name === dec?.name) === i);
 
   return (
-    <div key={`props-definition-${def.name}`} className="[&>*]:last:mb-0!">
+    <div
+      key={`props-definition-${def.name}`}
+      className={mergeClasses(STYLES_APIBOX, '[&>*:last-child]:mb-0!')}>
       {propsDeclarations?.map(prop =>
         prop
           ? renderProp(


### PR DESCRIPTION
# Why

The `Props` block on API reference pages renders as a bare list of rows separated by thin top borders, without the rounded outer card that wraps every other API section (Constants, Methods, Types, Enums). The mismatch is visible on `/versions/v56.0.0/sdk/router/experimental-stack/`, where the Props block sits right above a Types card and reads as visually unfinished.


<img width="2418" height="598" alt="CleanShot 2026-05-11 at 16 19 12@2x" src="https://github.com/user-attachments/assets/929dc00e-f408-4878-94d7-98d7cde7210f" />


# How

<!--
How did you build this feature or fix this bug and why?
-->

Fix Props rendering on API reference pages by using `STYLES_APIBOX`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2524" height="474" alt="CleanShot 2026-05-12 at 13 29 53@2x" src="https://github.com/user-attachments/assets/956a43f5-41e8-4141-b45e-1ced4c380c05" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
