### PR TITLE
[docs][blur-view] fix android SDK version reference

### DIFF
--- a/docs/pages/versions/unversioned/sdk/blur-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/blur-view.mdx
@@ -206,7 +206,7 @@ To blur the background of a view on Android, wrap the content to be blurred in a
 
 ### Performance
 
-The blur can be achieved efficiently only by using the [RenderNode](https://developer.android.com/reference/android/graphics/RenderNode) Android API, which was introduced in Android SDK 31 (Android 9.0). Due to this, on older versions of Android `expo-blur` uses the much less efficient [RenderScript](https://developer.android.com/guide/topics/renderscript/compute) API.
+The blur can be achieved efficiently only by using the [RenderNode](https://developer.android.com/reference/android/graphics/RenderNode) Android API, which was introduced in Android SDK 31 (Android 12.0). Due to this, on older versions of Android `expo-blur` uses the much less efficient [RenderScript](https://developer.android.com/guide/topics/renderscript/compute) API.
 If you want to avoid the performance penalty on older platforms you can use the `dimezisBlurViewSdk31Plus` [BlurMethod](#blurmethod-1)
 which will only blur on newer versions of Android and fall back to the [`none`](#blurmethod-1) on older versions.
 


### PR DESCRIPTION
# Why

Fixes an incorrect Android version reference. SDK 31 is Android 12, not Android 9.

`RenderNode` was added in API level 29, but the blur-related APIs are available from API level 31

References:
https://developer.android.com/reference/android/graphics/RenderNode#setRenderEffect(android.graphics.RenderEffect)
https://developer.android.com/reference/android/graphics/RenderEffect

# How

Updated the BlurView docs to refer to Android SDK 31 as Android 12.

# Test Plan

N/A (Docs only change, references above for render effect version)

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
