### PR TITLE
[docs] fix expo-ui drop-in replacement listing

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/index.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/index.mdx
@@ -20,6 +20,4 @@ Components are available for the following platforms:
 
 ## Drop-in replacements
 
-API-compatible replacements for popular React Native community libraries:
-
-- **[DateTimePicker](drop-in-replacements/datetimepicker)**: Compatible with `@react-native-community/datetimepicker`
+See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacements for popular React Native community libraries.

--- a/docs/pages/versions/v55.0.0/sdk/ui/index.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/ui/index.mdx
@@ -19,6 +19,4 @@ Components are available for the following platforms:
 
 ## Drop-in replacements
 
-API-compatible replacements for popular React Native community libraries:
-
-- **[DateTimePicker](drop-in-replacements/datetimepicker)**: Compatible with `@react-native-community/datetimepicker`
+See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacements for popular React Native community libraries.

--- a/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/index.mdx
@@ -20,6 +20,4 @@ Components are available for the following platforms:
 
 ## Drop-in replacements
 
-API-compatible replacements for popular React Native community libraries:
-
-- **[DateTimePicker](drop-in-replacements/datetimepicker)**: Compatible with `@react-native-community/datetimepicker`
+See **[Drop-in replacements](drop-in-replacements)** for API-compatible replacements for popular React Native community libraries.


### PR DESCRIPTION
# Why



The Expo UI overview page listed only `DateTimePicker` under "Drop-in replacements",  
while the dedicated `drop-in-replacements` page listed the full set. Two lists drifted
out of sync. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)