### PR TITLE
[widgets] Support `ChartView` from `@expo/ui`

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Added `@expo/ui/community/slider`, a drop-in replacement for `@react-native-community/slider`. ([#45623](https://github.com/expo/expo/pull/45623) by [@nishan](https://github.com/intergalacticspacehighway))
-- Make `ChartView` public.
+- Make `ChartView` public. ([#45674](https://github.com/expo/expo/pull/45674) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added `@expo/ui/community/slider`, a drop-in replacement for `@react-native-community/slider`. ([#45623](https://github.com/expo/expo/pull/45623) by [@nishan](https://github.com/intergalacticspacehighway))
+- Make `ChartView` public.
 
 ### 🐛 Bug fixes
 
@@ -349,7 +350,7 @@ _This version does not introduce any user-facing changes._
 - [iOS] - Add range and custom label support in `DatePicker` ([#41546](https://github.com/expo/expo/pull/41546) by [@nishan](https://github.com/intergalacticspacehighway))
 - [jetpack-compose] Added `matchContents` support to `Host`. ([#41553](https://github.com/expo/expo/pull/41553) by [@kudo](https://github.com/kudo))
 - [iOS] Add `timerInterval` to `Progress` component. ([#41598](https://github.com/expo/expo/pull/41598) by [@jakex7](https://github.com/jakex7))
-- [iOS] Make some views public.
+- [iOS] Make some views public. ([#41641](https://github.com/expo/expo/pull/41641) by [@jakex7](https://github.com/jakex7))
 - [iOS] - Add `Menu` component ([#41664](https://github.com/expo/expo/pull/41664) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Remove presentation props from `BottomSheet` and add equivalent modifiers ([#42029](https://github.com/expo/expo/pull/42029) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] - Nested `Text` support ([#41707](https://github.com/expo/expo/pull/41707) by [@intergalacticspacehighway](https://github.com/intergalacticspacehighway))

--- a/packages/expo-ui/ios/ChartView.swift
+++ b/packages/expo-ui/ios/ChartView.swift
@@ -77,7 +77,7 @@ struct RuleChartStyle: Record {
   @Field var dashArray: [Double]?
 }
 
-final class ChartProps: UIBaseViewProps {
+public final class ChartProps: UIBaseViewProps {
   @Field var data: [ChartDataPoint] = []
   @Field var type: ChartType = .line
   @Field var showGrid: Bool = true
@@ -93,8 +93,12 @@ final class ChartProps: UIBaseViewProps {
   @Field var ruleStyle: RuleChartStyle?
 }
 
-struct ChartView: ExpoSwiftUI.View {
-  @ObservedObject var props: ChartProps
+public struct ChartView: ExpoSwiftUI.View {
+  @ObservedObject public var props: ChartProps
+
+  public init(props: ChartProps) {
+    self.props = props
+  }
 
   @available(iOS 16.0, tvOS 16.0, *)
   private func createBaseBarMark(for dataPoint: ChartDataPoint) -> BarMark {
@@ -188,7 +192,7 @@ struct ChartView: ExpoSwiftUI.View {
     return ruleMark.lineStyle(.init(lineWidth: CGFloat(lineWidth)))
   }
 
-  var body: some View {
+  public var body: some View {
     if #available(iOS 16.0, tvOS 16.0, *) {
       let hasIndividualColors = props.data.contains { $0.color != nil }
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- Add `ChartView` support.
+- Add `ChartView` support. ([#45674](https://github.com/expo/expo/pull/45674) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `ChartView` support.
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-widgets/ios/Widgets/DynamicView.swift
+++ b/packages/expo-widgets/ios/Widgets/DynamicView.swift
@@ -81,6 +81,8 @@ public struct WidgetsDynamicView: View, ExpoSwiftUI.AnyChild {
       render(UnevenRoundedRectangleView.self, UnevenRoundedRectangleViewProps.self)
     case "GaugeView":
       render(GaugeView.self, GaugeProps.self)
+    case "ChartView":
+      render(ChartView.self, ChartProps.self)
     case "Button":
       if #available(iOS 17.0, *) {
         switch kind {


### PR DESCRIPTION
# Why

It's possible to display charts from expo-ui.

# How

* Make `ChartView` public in expo-ui
* Add `ChartView` to dynamic view list.

# Test Plan

Use ChartView in widget.
|  |  |  |
| --- | --- | --- |
| <img width="150" alt="image" src="https://github.com/user-attachments/assets/06a8c80f-2d54-4416-be34-fac9a27b788e" /> | <img width="150" alt="image" src="https://github.com/user-attachments/assets/f975184c-a170-4ef3-b4b7-278da1a87bc8" /> | <img width="150" alt="image" src="https://github.com/user-attachments/assets/4d0a9d96-f1eb-4e0b-ae84-257c30a79550" /> |


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
