### PR TITLE
fix(metro-file-map): Fork disk cache file for Bun

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix `'..'` at root handling to align with Metro ([#45687](https://github.com/expo/expo/pull/45687) by [@kitten](https://github.com/kitten))
+- Fork disk cache binary file for Bun ([#45677](https://github.com/expo/expo/pull/45677) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/metro-file-map/build/cache/DiskCacheManager.d.ts
+++ b/packages/@expo/metro-file-map/build/cache/DiskCacheManager.d.ts
@@ -5,6 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 import type { BuildParameters, CacheData, CacheManager, CacheManagerFactoryOptions, CacheManagerWriteOptions } from '../types';
+declare global {
+    namespace NodeJS {
+        interface Process {
+            isBun?: boolean;
+        }
+    }
+}
 interface AutoSaveOptions {
     readonly debounceMs: number;
 }

--- a/packages/@expo/metro-file-map/build/cache/DiskCacheManager.js
+++ b/packages/@expo/metro-file-map/build/cache/DiskCacheManager.js
@@ -17,7 +17,12 @@ const timers_1 = require("timers");
 const v8_1 = require("v8");
 const rootRelativeCacheKeys_1 = __importDefault(require("../lib/rootRelativeCacheKeys"));
 const debug = require('debug')('Metro:FileMapCache');
-const DEFAULT_PREFIX = 'metro-file-map';
+let DEFAULT_PREFIX = 'metro-file-map';
+if (process.isBun) {
+    // NOTE(@kitten): The v8 serialize/deserialize format isn't 100% compatible between
+    // Node and Bun and therefore we should fork the cache file
+    DEFAULT_PREFIX += '-bun';
+}
 const DEFAULT_DIRECTORY = (0, os_1.tmpdir)();
 const DEFAULT_AUTO_SAVE_DEBOUNCE_MS = 5000;
 // NOTE(@kitten): We're incompatible with Metro, so need our own naming

--- a/packages/@expo/metro-file-map/src/cache/DiskCacheManager.ts
+++ b/packages/@expo/metro-file-map/src/cache/DiskCacheManager.ts
@@ -22,6 +22,14 @@ import type {
 
 const debug = require('debug')('Metro:FileMapCache');
 
+declare global {
+  namespace NodeJS {
+    export interface Process {
+      isBun?: boolean;
+    }
+  }
+}
+
 interface AutoSaveOptions {
   readonly debounceMs: number;
 }
@@ -32,7 +40,13 @@ interface DiskCacheConfig {
   readonly cacheDirectory?: string | undefined | null;
 }
 
-const DEFAULT_PREFIX = 'metro-file-map';
+let DEFAULT_PREFIX = 'metro-file-map';
+if (process.isBun) {
+  // NOTE(@kitten): The v8 serialize/deserialize format isn't 100% compatible between
+  // Node and Bun and therefore we should fork the cache file
+  DEFAULT_PREFIX += '-bun';
+}
+
 const DEFAULT_DIRECTORY = tmpdir();
 const DEFAULT_AUTO_SAVE_DEBOUNCE_MS = 5000;
 


### PR DESCRIPTION
# Why

The v8 deserialize/serialize format isn't 100% compatible between Node and Bun.

# How

- Fork disk cache file for Bun off of the main path

# Test Plan

- Run `expo start` with Node then with Bun

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
