### PR TITLE
[docs] Update EAS CLI version in its reference

### DIFF
--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.12.2
+cliVersion: 18.12.3
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.12.0
+cliVersion: 18.12.1
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.12.3
+cliVersion: 18.13.0
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.11.0
+cliVersion: 18.12.0
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -2,7 +2,7 @@
 title: EAS CLI reference
 sidebar_title: EAS CLI
 description: EAS CLI is a command-line tool that allows you to interact with Expo Application Services (EAS) from your terminal.
-cliVersion: 18.12.1
+cliVersion: 18.12.2
 ---
 
 import { EASCLIReference } from '~/ui/components/EASCLIReference';

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-05-06T07:28:30.145Z",
-    "cliVersion": "18.11.0"
+    "fetchedAt": "2026-05-12T14:01:10.342Z",
+    "cliVersion": "18.12.0"
   },
   "totalCommands": 114,
   "commands": [

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-05-14T06:38:37.484Z",
-    "cliVersion": "18.12.3"
+    "fetchedAt": "2026-05-15T07:28:06.661Z",
+    "cliVersion": "18.13.0"
   },
   "totalCommands": 114,
   "commands": [

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-05-13T07:11:44.298Z",
-    "cliVersion": "18.12.2"
+    "fetchedAt": "2026-05-14T06:38:37.484Z",
+    "cliVersion": "18.12.3"
   },
   "totalCommands": 114,
   "commands": [

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-05-12T15:31:28.358Z",
-    "cliVersion": "18.12.1"
+    "fetchedAt": "2026-05-13T07:11:44.298Z",
+    "cliVersion": "18.12.2"
   },
   "totalCommands": 114,
   "commands": [

--- a/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
+++ b/docs/ui/components/EASCLIReference/data/eas-cli-commands.json
@@ -1,8 +1,8 @@
 {
   "source": {
     "url": "https://raw.githubusercontent.com/expo/eas-cli/main/packages/eas-cli/README.md",
-    "fetchedAt": "2026-05-12T14:01:10.342Z",
-    "cliVersion": "18.12.0"
+    "fetchedAt": "2026-05-12T15:31:28.358Z",
+    "cliVersion": "18.12.1"
   },
   "totalCommands": 114,
   "commands": [


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Update EAS CLI version in its reference to 18.12.3.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Run `pnpm eas-cli-sync`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
