### PR TITLE
fix(jest-expo): Distinguish directory-scoped Babel configs

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix babel config resolution to distinguish project-wide configs (`babel.config.*`) from directory-scoped configs (`.babelrc`). ([#45683](https://github.com/expo/expo/pull/45683) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.0 — 2026-05-05

--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix babel config resolution to distinguish project-wide configs (`babel.config.*`) from directory-scoped configs (`.babelrc`). ([#45683](https://github.com/expo/expo/pull/45683) by [@mvincentong](https://github.com/mvincentong))
+- Align babel config resolution with Expo CLI's project-root config lookup. ([#45683](https://github.com/expo/expo/pull/45683) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -26,10 +26,7 @@ if (upstreamBabelJest) {
 const babelOpts = {
   caller: { name: 'metro', bundler: 'metro', platform: 'ios' },
 };
-const babelConfigFile = resolveBabelConfig(process.cwd());
-if (babelConfigFile) {
-  babelOpts.configFile = babelConfigFile;
-}
+Object.assign(babelOpts, resolveBabelConfig(process.cwd()));
 jestPreset.transform['\\.[jt]sx?$'] = ['babel-jest', babelOpts];
 
 /* Update this when metro changes their default extensions */

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -37,6 +37,7 @@
     "preset": "jest-expo/universal"
   },
   "dependencies": {
+    "@expo/metro-config": "workspace:~56.0.6",
     "@jest/create-cache-key-function": "^29.2.1",
     "@jest/globals": "^29.2.1",
     "babel-jest": "^29.2.1",

--- a/packages/jest-expo/src/resolveBabelConfig.js
+++ b/packages/jest-expo/src/resolveBabelConfig.js
@@ -5,15 +5,20 @@ const path = require('node:path');
  * Resolve the babel `configFile` option.
  */
 function resolveBabelConfig(projectRoot) {
-  // TODO(EvanBacon): We might want to disable babelrc lookup when the user specifies `enableBabelRCLookup: false`.
-  const possibleBabelRCPaths = ['.babelrc', '.babelrc.js', 'babel.config.js'];
-  const foundBabelRCPath = possibleBabelRCPaths.find((configFileName) =>
-    fs.existsSync(path.resolve(process.cwd(), configFileName))
+  // Project-wide configs (babel.config.*) apply to all files including those
+  // in node_modules, so Babel's default resolution handles everything.
+  const projectWideConfigs = ['babel.config.js', 'babel.config.cjs', 'babel.config.mjs', 'babel.config.json'];
+  const hasProjectWideConfig = projectWideConfigs.some((configFileName) =>
+    fs.existsSync(path.resolve(projectRoot, configFileName))
   );
-  if (foundBabelRCPath) {
-    // If the user has a babel config file, we should return null and use the default configFile resolution from babel.
+  if (hasProjectWideConfig) {
     return null;
   }
+
+  // Directory-scoped configs (.babelrc, .babelrc.js) only apply to files
+  // within their directory tree. They won't transform files outside that tree
+  // (e.g. node_modules/react-native/jest/setup.js), so we must still provide
+  // the expo babel preset via configFile.
 
   try {
     return require.resolve('expo/internal/babel-preset', {

--- a/packages/jest-expo/src/resolveBabelConfig.js
+++ b/packages/jest-expo/src/resolveBabelConfig.js
@@ -1,42 +1,33 @@
-const fs = require('node:fs');
+const { resolveBabelrcName } = require('@expo/metro-config/build/loadBabelConfig');
 const path = require('node:path');
 
 /**
- * Resolve the babel `configFile` option.
+ * Resolve the babel options that match Expo CLI's project-root config lookup.
  */
 function resolveBabelConfig(projectRoot) {
-  // Project-wide configs (babel.config.*) apply to all files including those
-  // in node_modules, so Babel's default resolution handles everything.
-  const projectWideConfigs = [
-    'babel.config.js',
-    'babel.config.cjs',
-    'babel.config.mjs',
-    'babel.config.json',
-  ];
-  const hasProjectWideConfig = projectWideConfigs.some((configFileName) =>
-    fs.existsSync(path.resolve(projectRoot, configFileName))
-  );
-  if (hasProjectWideConfig) {
-    return null;
+  const foundBabelRCName = resolveBabelrcName(projectRoot);
+  if (foundBabelRCName) {
+    return {
+      extends: path.resolve(projectRoot, foundBabelRCName),
+    };
   }
 
-  // Directory-scoped configs (.babelrc, .babelrc.js) only apply to files
-  // within their directory tree. They won't transform files outside that tree
-  // (e.g. node_modules/react-native/jest/setup.js), so we must still provide
-  // the expo babel preset via configFile.
-
   try {
-    return require.resolve('expo/internal/babel-preset', {
-      paths: [projectRoot, __dirname],
-    });
+    return {
+      configFile: require.resolve('expo/internal/babel-preset', {
+        paths: [projectRoot, __dirname],
+      }),
+    };
   } catch {
     try {
       // TODO(@kitten): Temporary, since our E2E tests don't use monorepo
       // packages consistently, including the `expo` package
-      return require.resolve('babel-preset-expo');
+      return {
+        configFile: require.resolve('babel-preset-expo'),
+      };
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND') {
-        return null;
+        return {};
       }
       throw error;
     }

--- a/packages/jest-expo/src/resolveBabelConfig.js
+++ b/packages/jest-expo/src/resolveBabelConfig.js
@@ -7,7 +7,12 @@ const path = require('node:path');
 function resolveBabelConfig(projectRoot) {
   // Project-wide configs (babel.config.*) apply to all files including those
   // in node_modules, so Babel's default resolution handles everything.
-  const projectWideConfigs = ['babel.config.js', 'babel.config.cjs', 'babel.config.mjs', 'babel.config.json'];
+  const projectWideConfigs = [
+    'babel.config.js',
+    'babel.config.cjs',
+    'babel.config.mjs',
+    'babel.config.json',
+  ];
   const hasProjectWideConfig = projectWideConfigs.some((configFileName) =>
     fs.existsSync(path.resolve(projectRoot, configFileName))
   );

--- a/packages/jest-expo/tests/__tests__/resolveBabelConfig-test.js
+++ b/packages/jest-expo/tests/__tests__/resolveBabelConfig-test.js
@@ -9,12 +9,22 @@ function withTempProject(files, callback) {
 
   try {
     for (const file of files) {
-      fs.writeFileSync(path.join(projectRoot, file), 'module.exports = {};');
+      fs.writeFileSync(path.join(projectRoot, file), getBabelConfigFixture(file));
     }
     return callback(projectRoot);
   } finally {
     fs.rmSync(projectRoot, { recursive: true, force: true });
   }
+}
+
+function getBabelConfigFixture(file) {
+  if (file === '.babelrc' || file.endsWith('.json')) {
+    return '{}';
+  }
+  if (file.endsWith('.mjs') || file.endsWith('.mts')) {
+    return 'export default {};';
+  }
+  return 'module.exports = {};';
 }
 
 it.each([

--- a/packages/jest-expo/tests/__tests__/resolveBabelConfig-test.js
+++ b/packages/jest-expo/tests/__tests__/resolveBabelConfig-test.js
@@ -17,23 +17,33 @@ function withTempProject(files, callback) {
   }
 }
 
-it.each(['babel.config.js', 'babel.config.cjs', 'babel.config.mjs', 'babel.config.json'])(
-  'defers to Babel default resolution for %s',
-  (configFileName) => {
-    withTempProject([configFileName], (projectRoot) => {
-      expect(resolveBabelConfig(projectRoot)).toBeNull();
+it.each([
+  '.babelrc',
+  '.babelrc.js',
+  '.babelrc.cjs',
+  '.babelrc.mjs',
+  '.babelrc.json',
+  '.babelrc.cts',
+  'babel.config.js',
+  'babel.config.cjs',
+  'babel.config.mjs',
+  'babel.config.json',
+  'babel.config.cts',
+  'babel.config.ts',
+  'babel.config.mts',
+])('extends the Expo Metro resolved config for %s', (configFileName) => {
+  withTempProject([configFileName], (projectRoot) => {
+    expect(resolveBabelConfig(projectRoot)).toEqual({
+      extends: path.join(projectRoot, configFileName),
     });
-  }
-);
+  });
+});
 
-it.each(['.babelrc', '.babelrc.js'])(
-  'uses the Expo babel preset for directory-scoped %s',
-  (configFileName) => {
-    withTempProject([configFileName], (projectRoot) => {
-      expect(resolveBabelConfig(projectRoot)).toContain('babel-preset');
-    });
-  }
-);
+it('uses the Expo babel preset when the project has no babel config', () => {
+  withTempProject([], (projectRoot) => {
+    expect(resolveBabelConfig(projectRoot).configFile).toContain('babel-preset');
+  });
+});
 
 it('resolves configs from the project root, not the current working directory', () => {
   const previousCwd = process.cwd();
@@ -42,7 +52,9 @@ it('resolves configs from the project root, not the current working directory', 
     withTempProject([], (cwd) => {
       try {
         process.chdir(cwd);
-        expect(resolveBabelConfig(projectRoot)).toBeNull();
+        expect(resolveBabelConfig(projectRoot)).toEqual({
+          extends: path.join(projectRoot, 'babel.config.js'),
+        });
       } finally {
         process.chdir(previousCwd);
       }

--- a/packages/jest-expo/tests/__tests__/resolveBabelConfig-test.js
+++ b/packages/jest-expo/tests/__tests__/resolveBabelConfig-test.js
@@ -1,0 +1,51 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { resolveBabelConfig } = require('../../src/resolveBabelConfig');
+
+function withTempProject(files, callback) {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'jest-expo-babel-'));
+
+  try {
+    for (const file of files) {
+      fs.writeFileSync(path.join(projectRoot, file), 'module.exports = {};');
+    }
+    return callback(projectRoot);
+  } finally {
+    fs.rmSync(projectRoot, { recursive: true, force: true });
+  }
+}
+
+it.each(['babel.config.js', 'babel.config.cjs', 'babel.config.mjs', 'babel.config.json'])(
+  'defers to Babel default resolution for %s',
+  (configFileName) => {
+    withTempProject([configFileName], (projectRoot) => {
+      expect(resolveBabelConfig(projectRoot)).toBeNull();
+    });
+  }
+);
+
+it.each(['.babelrc', '.babelrc.js'])(
+  'uses the Expo babel preset for directory-scoped %s',
+  (configFileName) => {
+    withTempProject([configFileName], (projectRoot) => {
+      expect(resolveBabelConfig(projectRoot)).toContain('babel-preset');
+    });
+  }
+);
+
+it('resolves configs from the project root, not the current working directory', () => {
+  const previousCwd = process.cwd();
+
+  withTempProject(['babel.config.js'], (projectRoot) => {
+    withTempProject([], (cwd) => {
+      try {
+        process.chdir(cwd);
+        expect(resolveBabelConfig(projectRoot)).toBeNull();
+      } finally {
+        process.chdir(previousCwd);
+      }
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6009,6 +6009,9 @@ importers:
 
   packages/jest-expo:
     dependencies:
+      '@expo/metro-config':
+        specifier: workspace:~56.0.6
+        version: link:../@expo/metro-config
       '@jest/create-cache-key-function':
         specifier: ^29.2.1
         version: 29.7.0


### PR DESCRIPTION
## Summary

- Split from #44189 per maintainer request.
- Reuses `@expo/metro-config`'s `resolveBabelrcName` so `jest-expo` and Expo CLI share the same project-root Babel config lookup.
- Passes the discovered project Babel config through Babel's `extends` option, and falls back to Expo's Babel preset only when no project config exists.

Fixes #43980

## Test plan

- [x] `pnpm --filter jest-expo test -- tests/__tests__/resolveBabelConfig-test.js --runInBand`
- [x] `pnpm --filter jest-expo lint`
- [x] `pnpm --filter jest-expo test --runInBand`
- [x] `git diff --check`
