### PR TITLE
fix(metro-file-map): Fix Windows cross-device path resolution (follow-up)

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `'..'` at root handling to align with Metro ([#45687](https://github.com/expo/expo/pull/45687) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.0.1 — 2026-05-11

--- a/packages/@expo/metro-file-map/build/lib/RootPathUtils.js
+++ b/packages/@expo/metro-file-map/build/lib/RootPathUtils.js
@@ -130,10 +130,11 @@ class RootPathUtils {
         if (right.length === 0) {
             return left;
         }
-        else if (pos > this.#rootDepth * UP_FRAGMENT_SEP_LENGTH) {
-            // When we walk above the filesystem root, we emit the remaining path as is.
-            // This is important on Windows, since we're canonicalizing cross-device paths
-            // as relative paths from rootDir
+        else if (IS_WIN32 && pos > this.#rootDepth * UP_FRAGMENT_SEP_LENGTH) {
+            // On a real file system, navigating to `..` at the top level (posix `/`
+            // or Windows drive) is a no-op, but we can't respect that on Windows
+            // because Metro uses e.g. `..\..\D:\foo` to represent cross-drive
+            // relative paths.
             return right;
         }
         // left may already end in a path separator only if it is a filesystem root,

--- a/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
+++ b/packages/@expo/metro-file-map/src/lib/RootPathUtils.ts
@@ -156,10 +156,11 @@ export class RootPathUtils {
     const right = pos === 0 ? normalPath : normalPath.slice(pos);
     if (right.length === 0) {
       return left;
-    } else if (pos > this.#rootDepth * UP_FRAGMENT_SEP_LENGTH) {
-      // When we walk above the filesystem root, we emit the remaining path as is.
-      // This is important on Windows, since we're canonicalizing cross-device paths
-      // as relative paths from rootDir
+    } else if (IS_WIN32 && pos > this.#rootDepth * UP_FRAGMENT_SEP_LENGTH) {
+      // On a real file system, navigating to `..` at the top level (posix `/`
+      // or Windows drive) is a no-op, but we can't respect that on Windows
+      // because Metro uses e.g. `..\..\D:\foo` to represent cross-drive
+      // relative paths.
       return right;
     }
     // left may already end in a path separator only if it is a filesystem root,

--- a/packages/@expo/metro-file-map/src/lib/__tests__/RootPathUtils.test.ts
+++ b/packages/@expo/metro-file-map/src/lib/__tests__/RootPathUtils.test.ts
@@ -99,6 +99,8 @@ describe.each([['win32'], ['posix']] as const)('RootPathUtils on %s', (platform)
             p('../normal/path'),
             p('../normal/path/'),
             p('../../normal/path'),
+            // On POSIX, `..` at the root re-enters the root
+            ...(platform === 'posix' ? [p('../../../normal/path')] : []),
           ]
         : [p('..'), p('../..'), p('../../'), p('normal/path'), p('normal/path/')];
 
@@ -127,6 +129,10 @@ describe.each([['win32'], ['posix']] as const)('RootPathUtils on %s', (platform)
             p('../../project/root'),
             p('../../project/root/'),
             p('../../..'),
+            // On POSIX, `..` at the root re-enters the root
+            ...(platform === 'posix'
+              ? [p('../../../normal/path'), p('../../../normal/path/')]
+              : []),
           ]
         : [p('..')];
 


### PR DESCRIPTION
# Why

Follow-up to #45648 to address review feedback at https://github.com/facebook/metro/pull/1711 (ongoing)

# How

- Fix `'..'` at root handling to align with Metro

# Test Plan

- Covered by unit test changes

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
