### PR TITLE
Fix Android image picker crop overflow menu background

### DIFF
--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix the crop editor overflow menu background color. ([#44324](https://github.com/expo/expo/issues/44324) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 - Updated permission hooks and permission type imports to be imported from `expo` instead of `expo-modules-core` ([#45565](https://github.com/expo/expo/pull/45565) by [@Wenszel](https://github.com/Wenszel))

--- a/packages/expo-image-picker/android/src/main/AndroidManifest.xml
+++ b/packages/expo-image-picker/android/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
       tools:replace="android:exported" />
     <activity
       android:name="expo.modules.imagepicker.ExpoCropImageActivity"
-      android:theme="@style/Base.Theme.AppCompat"
+      android:theme="@style/Theme.Expo.ImagePicker.Crop"
       android:exported="false"
       tools:replace="android:exported" />
     <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->

--- a/packages/expo-image-picker/android/src/main/res/values/styles.xml
+++ b/packages/expo-image-picker/android/src/main/res/values/styles.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Expo.ImagePicker.Crop" parent="Base.Theme.AppCompat">
+        <item name="actionBarPopupTheme">@style/ThemeOverlay.Expo.ImagePicker.Crop.Popup</item>
+        <item name="actionOverflowMenuStyle">@style/Widget.Expo.ImagePicker.Crop.OverflowMenu</item>
+        <item name="android:actionOverflowMenuStyle">@style/Widget.Expo.ImagePicker.Crop.OverflowMenu</item>
+    </style>
+
+    <style name="ThemeOverlay.Expo.ImagePicker.Crop.Popup" parent="ThemeOverlay.AppCompat">
+        <item name="android:colorBackground">@color/expoCropBackgroundColor</item>
+        <item name="android:textColorPrimary">@color/expoCropToolbarActionTextColor</item>
+        <item name="colorBackground">@color/expoCropBackgroundColor</item>
+    </style>
+
+    <style name="Widget.Expo.ImagePicker.Crop.OverflowMenu" parent="Widget.AppCompat.PopupMenu.Overflow">
+        <item name="android:popupBackground">@color/expoCropBackgroundColor</item>
+        <item name="popupBackground">@color/expoCropBackgroundColor</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Why

Fixes https://github.com/expo/expo/issues/44324.

Expo wraps the pinned `android-image-cropper` activity to apply crop editor colors. The upstream activity applies the configured menu text/icon colors, including submenu items, but the overflow/submenu popup background still comes from the activity popup theme. In light mode that can produce dark popup chrome behind dark menu text, making "Flip Horizontal" and "Flip Vertical" hard to read.

## How

- Added a dedicated `Theme.Expo.ImagePicker.Crop` AppCompat theme for `ExpoCropImageActivity`.
- Kept the existing `Base.Theme.AppCompat` parent behavior.
- Routed the action bar popup/overflow menu styles to use the existing `expoCropBackgroundColor` and `expoCropToolbarActionTextColor` resources, including their `values-night` overrides.
- Updated the crop activity manifest entry to use the new theme.

I checked the pinned `com.vanniktech:android-image-cropper:4.7.0` source/AAR while scoping this. The menu XML contains the flip submenu, and `CropImageActivity` already spans the submenu title text color from `activityMenuTextColor`; this PR fills the missing popup background theme path.

## Test Plan

- `pnpm --filter expo-image-picker lint` passed.
- `pnpm --filter expo-image-picker test` passed: 4 suites, 10 tests.
- `env ANDROID_HOME=/Users/mvincentong/Library/Android/sdk ./gradlew :expo-image-picker:compileDebugLibraryResources :expo-image-picker:processDebugManifest --no-daemon --no-configuration-cache` passed from `apps/bare-expo/android`.
- `git diff --cached --check` passed.

The Gradle manifest task emitted existing `tools:replace` warnings for activity `android:exported` declarations, but the build completed successfully.

## Risk

Changed-file summary: 1 Android manifest line, 1 new Android style resource file, and 1 changelog entry.

This is resource-only and limited to the image picker crop activity theme. It does not change cropper options, permissions, JavaScript APIs, or native control flow.
