### PR TITLE
Fix BlurView border radius clipping

### DIFF
--- a/apps/native-component-list/src/screens/BlurView/BlurViewWithControls.tsx
+++ b/apps/native-component-list/src/screens/BlurView/BlurViewWithControls.tsx
@@ -1,8 +1,14 @@
-import { BlurTint, BlurView, ExperimentalBlurMethod, BlurTargetView } from 'expo-blur';
+import { BlurView, BlurTargetView } from 'expo-blur';
+import type { BlurTint, BlurViewProps, ExperimentalBlurMethod } from 'expo-blur';
 import { Image } from 'expo-image';
 import React, { useCallback, memo, useEffect, useRef, useState } from 'react';
 import { View, StyleSheet, Text } from 'react-native';
-import Animated, { useSharedValue, withRepeat, withTiming } from 'react-native-reanimated';
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from 'react-native-reanimated';
 
 import useResettingState from '../../utilities/useResettingState';
 import Slider from './Slider';
@@ -13,8 +19,8 @@ const backgroundImage = require('../../../assets/images/large-example.jpg');
 const expoImage = require('../../../assets/images/logo-wordmark.png');
 
 export default memo((props: { tint: BlurTint; blurMethod: ExperimentalBlurMethod }) => {
-  const animatedIntensity = useSharedValue<number | undefined>(100);
-  const manualIntensity = useSharedValue<number | undefined>(0);
+  const animatedIntensity = useSharedValue(100);
+  const manualIntensity = useSharedValue(0);
   const [manualIntensityIsActive, setManualIntensityIsActive] = useResettingState(false, 3000);
   const [manualIntensityState, setManualIntensityState] = useState(0);
   const blurTargetRef = useRef<View | null>(null);
@@ -29,6 +35,10 @@ export default memo((props: { tint: BlurTint; blurMethod: ExperimentalBlurMethod
     animatedIntensity.value = withRepeat(withTiming(0, { duration: 2000 }), -1, true);
   }, []);
 
+  const animatedProps = useAnimatedProps<BlurViewProps>(() => ({
+    intensity: manualIntensityIsActive ? manualIntensity.value : animatedIntensity.value,
+  }));
+
   return (
     <View style={styles.container}>
       <View>
@@ -39,7 +49,7 @@ export default memo((props: { tint: BlurTint; blurMethod: ExperimentalBlurMethod
           blurTarget={blurTargetRef}
           style={styles.blurView}
           tint={props.tint}
-          intensity={manualIntensityIsActive ? manualIntensity : animatedIntensity}
+          animatedProps={animatedProps}
           blurMethod={props.blurMethod}>
           <Text style={styles.nonBlurredText}>{props.tint}</Text>
           <Slider

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `BlurView` not applying border radius styles to the native blur layer. ([#18615](https://github.com/expo/expo/issues/18615) by [@mvincentong](https://github.com/mvincentong)) ([#45691](https://github.com/expo/expo/pull/45691) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-blur/CHANGELOG.md
+++ b/packages/expo-blur/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix `BlurView` not applying border radius styles to the native blur layer. ([#18615](https://github.com/expo/expo/issues/18615) by [@mvincentong](https://github.com/mvincentong)) ([#45691](https://github.com/expo/expo/pull/45691) by [@mvincentong](https://github.com/mvincentong))
+- Fix `BlurView` not applying border radius styles to the native blur layer. ([#45691](https://github.com/expo/expo/pull/45691) by [@mvincentong](https://github.com/mvincentong)) and [@behenate](https://github.com/behenate)
 
 ### 💡 Others
 

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/BlurModule.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/BlurModule.kt
@@ -28,6 +28,10 @@ class BlurModule : Module() {
         view.applyBlurReduction(blurReductionFactor)
       }
 
+      Prop("borderRadii") { view: ExpoBlurView, borderRadii: FloatArray? ->
+        view.setBorderRadii(borderRadii ?: FloatArray(8))
+      }
+
       Prop("blurMethod") { view: ExpoBlurView, blurMethod: BlurMethod ->
         view.setBlurMethod(blurMethod)
       }

--- a/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
+++ b/packages/expo-blur/android/src/main/java/expo/modules/blur/ExpoBlurView.kt
@@ -2,8 +2,12 @@ package expo.modules.blur
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Path
+import android.graphics.RectF
 import android.os.Build
+import android.util.TypedValue
 import eightbitlab.com.blurview.BlurView
 import expo.modules.blur.enums.BlurMethod
 import expo.modules.blur.enums.TintStyle
@@ -30,10 +34,27 @@ class ExpoBlurView(context: Context, appContext: AppContext) : ExpoView(context,
   private var blurConfiguration = BlurViewConfiguration.NONE
   private var blurTargetId: Int? = null
   private var blurTarget: ExpoBlurTargetView? = null
+  private val clippingPath = Path()
+  private val clippingRect = RectF()
+  private var borderRadii = FloatArray(8)
+  private var needsClippingPathUpdate = true
 
   private val blurView = BlurView(context).also {
     it.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
     addView(it)
+  }
+
+  fun setBorderRadii(radii: FloatArray) {
+    borderRadii = FloatArray(8) { index ->
+      val radius = radii.getOrElse(index) { 0f }
+      TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        radius,
+        context.resources.displayMetrics
+      )
+    }
+    needsClippingPathUpdate = true
+    invalidate()
   }
 
   fun setBlurTargetId(blurTargetId: Int?) {
@@ -146,6 +167,24 @@ class ExpoBlurView(context: Context, appContext: AppContext) : ExpoView(context,
     }
   }
 
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    needsClippingPathUpdate = true
+  }
+
+  override fun draw(canvas: Canvas) {
+    if (borderRadii.none { it > 0f }) {
+      super.draw(canvas)
+      return
+    }
+
+    updateClippingPathIfNeeded()
+    val saveCount = canvas.save()
+    canvas.clipPath(clippingPath)
+    super.draw(canvas)
+    canvas.restoreToCount(saveCount)
+  }
+
   private fun configureBlurView() {
     if (blurTarget == null || blurMethod == BlurMethod.NONE) {
       blurView.setBlurEnabled(false)
@@ -195,5 +234,16 @@ class ExpoBlurView(context: Context, appContext: AppContext) : ExpoView(context,
     } else {
       setBackgroundColor(tint.toBlurEffect(blurRadius))
     }
+  }
+
+  private fun updateClippingPathIfNeeded() {
+    if (!needsClippingPathUpdate) {
+      return
+    }
+
+    clippingRect.set(0f, 0f, width.toFloat(), height.toFloat())
+    clippingPath.reset()
+    clippingPath.addRoundRect(clippingRect, borderRadii, Path.Direction.CW)
+    needsClippingPathUpdate = false
   }
 }

--- a/packages/expo-blur/src/BlurView.tsx
+++ b/packages/expo-blur/src/BlurView.tsx
@@ -12,6 +12,10 @@ type BlurViewState = {
   blurTargetId?: number | null;
 };
 
+type AndroidBlurViewProps = {
+  borderRadii?: number[];
+};
+
 const nativeBlurViewRadiusStyleKeys = [
   'borderBottomEndRadius',
   'borderBottomLeftRadius',
@@ -104,10 +108,15 @@ export default class BlurView extends React.Component<BlurViewProps, BlurViewSta
     const nativeBlurViewStyle = nativeBlurViewRadiusStyle
       ? [StyleSheet.absoluteFill, nativeBlurViewRadiusStyle]
       : StyleSheet.absoluteFill;
+    const androidBlurViewProps: AndroidBlurViewProps =
+      Platform.OS === 'android' && nativeBlurViewRadiusStyle
+        ? { borderRadii: getAndroidBlurViewBorderRadii(nativeBlurViewRadiusStyle) }
+        : {};
 
     return (
       <View {...props} style={[styles.container, style]}>
         <NativeBlurView
+          {...androidBlurViewProps}
           blurTargetId={this.state.blurTargetId}
           ref={this.blurViewRef}
           tint={tint}
@@ -149,6 +158,29 @@ function getNativeBlurViewRadiusStyle(style: BlurViewProps['style']): ViewStyle 
 
   radiusStyle.overflow = 'hidden';
   return radiusStyle;
+}
+
+function getAndroidBlurViewBorderRadii(style: ViewStyle): number[] {
+  const borderRadius = getRadiusValue(style.borderRadius) ?? 0;
+  const borderTopLeftRadius = getRadiusValue(style.borderTopLeftRadius) ?? borderRadius;
+  const borderTopRightRadius = getRadiusValue(style.borderTopRightRadius) ?? borderRadius;
+  const borderBottomRightRadius = getRadiusValue(style.borderBottomRightRadius) ?? borderRadius;
+  const borderBottomLeftRadius = getRadiusValue(style.borderBottomLeftRadius) ?? borderRadius;
+
+  return [
+    borderTopLeftRadius,
+    borderTopLeftRadius,
+    borderTopRightRadius,
+    borderTopRightRadius,
+    borderBottomRightRadius,
+    borderBottomRightRadius,
+    borderBottomLeftRadius,
+    borderBottomLeftRadius,
+  ];
+}
+
+function getRadiusValue(value: ViewStyle[keyof ViewStyle]): number | undefined {
+  return typeof value === 'number' ? value : undefined;
 }
 
 const styles = StyleSheet.create({

--- a/packages/expo-blur/src/BlurView.tsx
+++ b/packages/expo-blur/src/BlurView.tsx
@@ -3,7 +3,7 @@
 'use client';
 
 import React from 'react';
-import { View, StyleSheet, findNodeHandle, Platform } from 'react-native';
+import { View, StyleSheet, findNodeHandle, Platform, type ViewStyle } from 'react-native';
 
 import type { BlurMethod, BlurViewProps } from './BlurView.types';
 import { NativeBlurView } from './NativeBlurModule';
@@ -11,6 +11,22 @@ import { NativeBlurView } from './NativeBlurModule';
 type BlurViewState = {
   blurTargetId?: number | null;
 };
+
+const nativeBlurViewRadiusStyleKeys = [
+  'borderBottomEndRadius',
+  'borderBottomLeftRadius',
+  'borderBottomRightRadius',
+  'borderBottomStartRadius',
+  'borderEndEndRadius',
+  'borderEndStartRadius',
+  'borderRadius',
+  'borderStartEndRadius',
+  'borderStartStartRadius',
+  'borderTopEndRadius',
+  'borderTopLeftRadius',
+  'borderTopRightRadius',
+  'borderTopStartRadius',
+] as const;
 
 // TODO: Class components are not supported with React Server Components.
 export default class BlurView extends React.Component<BlurViewProps, BlurViewState> {
@@ -84,6 +100,11 @@ export default class BlurView extends React.Component<BlurViewProps, BlurViewSta
       children,
       ...props
     } = this.props;
+    const nativeBlurViewRadiusStyle = getNativeBlurViewRadiusStyle(style);
+    const nativeBlurViewStyle = nativeBlurViewRadiusStyle
+      ? [StyleSheet.absoluteFill, nativeBlurViewRadiusStyle]
+      : StyleSheet.absoluteFill;
+
     return (
       <View {...props} style={[styles.container, style]}>
         <NativeBlurView
@@ -93,12 +114,41 @@ export default class BlurView extends React.Component<BlurViewProps, BlurViewSta
           intensity={intensity}
           blurReductionFactor={blurReductionFactor}
           blurMethod={this._getBlurMethod()}
-          style={StyleSheet.absoluteFill}
+          style={nativeBlurViewStyle}
         />
         {children}
       </View>
     );
   }
+}
+
+function getNativeBlurViewRadiusStyle(style: BlurViewProps['style']): ViewStyle | undefined {
+  const flatStyle = StyleSheet.flatten(style);
+  if (!flatStyle) {
+    return undefined;
+  }
+
+  const radiusStyle: ViewStyle = {};
+  let hasRadiusStyle = false;
+
+  nativeBlurViewRadiusStyleKeys.forEach((key) => {
+    const value = flatStyle[key];
+    if (value != null) {
+      (radiusStyle as Record<string, unknown>)[key] = value;
+      hasRadiusStyle = true;
+    }
+  });
+
+  if (!hasRadiusStyle) {
+    return undefined;
+  }
+
+  if (flatStyle.borderCurve != null) {
+    radiusStyle.borderCurve = flatStyle.borderCurve;
+  }
+
+  radiusStyle.overflow = 'hidden';
+  return radiusStyle;
 }
 
 const styles = StyleSheet.create({

--- a/packages/expo-blur/src/__tests__/BlurView-test.android.tsx
+++ b/packages/expo-blur/src/__tests__/BlurView-test.android.tsx
@@ -8,3 +8,25 @@ it(`renders a native blur view`, async () => {
   expect(view).toBeDefined();
   expect(screen.toJSON()).toMatchSnapshot();
 }, 10000);
+
+it(`passes radius styles to the native blur view`, async () => {
+  render(
+    <BlurView
+      tint="light"
+      intensity={80}
+      testID="blur"
+      style={{
+        width: 100,
+        height: 100,
+        borderRadius: 24,
+        borderTopLeftRadius: 8,
+        borderCurve: 'continuous',
+        shadowOpacity: 0.2,
+      }}
+    />
+  );
+
+  const view = await screen.findByTestId('blur');
+  expect(view).toBeDefined();
+  expect(screen.toJSON()).toMatchSnapshot();
+});

--- a/packages/expo-blur/src/__tests__/BlurView-test.ios.tsx
+++ b/packages/expo-blur/src/__tests__/BlurView-test.ios.tsx
@@ -8,3 +8,25 @@ it(`renders a native blur view`, async () => {
   expect(view).toBeDefined();
   expect(screen.toJSON()).toMatchSnapshot();
 });
+
+it(`passes radius styles to the native blur view`, async () => {
+  render(
+    <BlurView
+      tint="light"
+      intensity={80}
+      testID="blur"
+      style={{
+        width: 100,
+        height: 100,
+        borderRadius: 24,
+        borderTopLeftRadius: 8,
+        borderCurve: 'continuous',
+        shadowOpacity: 0.2,
+      }}
+    />
+  );
+
+  const view = await screen.findByTestId('blur');
+  expect(view).toBeDefined();
+  expect(screen.toJSON()).toMatchSnapshot();
+});

--- a/packages/expo-blur/src/__tests__/__snapshots__/BlurView-test.android.tsx.snap.android
+++ b/packages/expo-blur/src/__tests__/__snapshots__/BlurView-test.android.tsx.snap.android
@@ -22,6 +22,18 @@ exports[`passes radius styles to the native blur view 1`] = `
   <ViewManagerAdapter_ExpoBlur
     blurMethod="none"
     blurReductionFactor={4}
+    borderRadii={
+      [
+        8,
+        8,
+        24,
+        24,
+        24,
+        24,
+        24,
+        24,
+      ]
+    }
     intensity={80}
     style={
       [

--- a/packages/expo-blur/src/__tests__/__snapshots__/BlurView-test.android.tsx.snap.android
+++ b/packages/expo-blur/src/__tests__/__snapshots__/BlurView-test.android.tsx.snap.android
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`passes radius styles to the native blur view 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "transparent",
+      },
+      {
+        "borderCurve": "continuous",
+        "borderRadius": 24,
+        "borderTopLeftRadius": 8,
+        "height": 100,
+        "shadowOpacity": 0.2,
+        "width": 100,
+      },
+    ]
+  }
+  testID="blur"
+>
+  <ViewManagerAdapter_ExpoBlur
+    blurMethod="none"
+    blurReductionFactor={4}
+    intensity={80}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "borderCurve": "continuous",
+          "borderRadius": 24,
+          "borderTopLeftRadius": 8,
+          "overflow": "hidden",
+        },
+      ]
+    }
+    tint="light"
+  />
+</View>
+`;
+
 exports[`renders a native blur view 1`] = `
 <View
   style={

--- a/packages/expo-blur/src/__tests__/__snapshots__/BlurView-test.ios.tsx.snap.ios
+++ b/packages/expo-blur/src/__tests__/__snapshots__/BlurView-test.ios.tsx.snap.ios
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`passes radius styles to the native blur view 1`] = `
+<View
+  style={
+    [
+      {
+        "backgroundColor": "transparent",
+      },
+      {
+        "borderCurve": "continuous",
+        "borderRadius": 24,
+        "borderTopLeftRadius": 8,
+        "height": 100,
+        "shadowOpacity": 0.2,
+        "width": 100,
+      },
+    ]
+  }
+  testID="blur"
+>
+  <ViewManagerAdapter_ExpoBlur
+    blurMethod="none"
+    blurReductionFactor={4}
+    intensity={80}
+    style={
+      [
+        {
+          "bottom": 0,
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+        {
+          "borderCurve": "continuous",
+          "borderRadius": 24,
+          "borderTopLeftRadius": 8,
+          "overflow": "hidden",
+        },
+      ]
+    }
+    tint="light"
+  />
+</View>
+`;
+
 exports[`renders a native blur view 1`] = `
 <View
   style={


### PR DESCRIPTION
## Why

Fixes #18615. `BlurView` applies consumer styles to an outer React Native `View`, while the native blur layer is rendered as an absolute-fill child. Border radius styles therefore round the wrapper/background, but the native blur layer can remain square. This is visible when using `BlurView` directly with `borderRadius`.

## How

Forward only corner radius styles from the wrapper style to the inner native blur view and add `overflow: 'hidden'` on that inner layer when a radius is present. Layout, margins, shadows, and other styling stay on the outer wrapper, so the change is scoped to clipping the blur layer without forcing the whole `BlurView` wrapper to hide overflow.

## Test Plan

- [x] `git diff --check upstream/main...HEAD`
- [x] `npx pnpm@10.33.0 --filter expo-blur build`
- [x] `/Users/mvincentong/.npm/_npx/00d0dcf00546c229/node_modules/.bin/oxlint --config oxlint.config.mjs .` from `packages/expo-blur`

Additional check: `npx pnpm@10.33.0 --filter expo-blur test` currently fails before assertions in the Android/iOS test environments with `Invariant Violation: __fbBatchedBridgeConfig is not set, cannot invoke native modules`. The same targeted failure reproduces on clean `upstream/main` with `npx pnpm@10.33.0 --filter expo-blur test -- src/__tests__/BlurView-test.android.tsx src/__tests__/BlurView-test.ios.tsx --runInBand`, so I did not change this PR for that unrelated setup failure.

## Risk

Six-file `expo-blur` diff: source, Android/iOS tests, Android/iOS snapshots, and changelog. No dependency changes and no committed generated output on the current base. The fix intentionally does not set `overflow: hidden` on the outer wrapper, which avoids clipping user shadows or children.
