### PR TITLE
chore: Bump picomatch

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 💡 Others
 
 - Target only the first compatible device architecture during Android debug builds to speed up build time. ([#44907](https://github.com/expo/expo/pull/44907) by [@AntoineThibi](https://github.com/AntoineThibi))
+- Bump to `picomatch@^4.0.4` ([#45698](https://github.com/expo/expo/pull/45698) by [@kitten](https://github.com/kitten))
 
 ## 56.1.2 — 2026-05-12
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -92,7 +92,7 @@
     "node-forge": "^1.3.3",
     "npm-package-arg": "^11.0.0",
     "ora": "^3.4.0",
-    "picomatch": "^4.0.3",
+    "picomatch": "^4.0.4",
     "pretty-format": "^29.7.0",
     "progress": "^2.0.3",
     "prompts": "^2.3.2",

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `picomatch@^4.0.4` ([#45698](https://github.com/expo/expo/pull/45698) by [@kitten](https://github.com/kitten))
+
 ## 56.0.6 — 2026-05-11
 
 ### 🛠 Breaking changes

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -81,7 +81,7 @@
     "hermes-parser": "^0.33.3",
     "jsc-safe-url": "^0.2.4",
     "lightningcss": "^1.30.1",
-    "picomatch": "^4.0.3",
+    "picomatch": "^4.0.4",
     "postcss": "^8.5.14",
     "resolve-from": "^5.0.0"
   },

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `picomatch@^2.3.2` ([#45698](https://github.com/expo/expo/pull/45698) by [@kitten](https://github.com/kitten))
+
 ## 3.7.3 — 2026-05-07
 
 ### 💡 Others

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -56,7 +56,7 @@
     "glob": "^13.0.0",
     "nock": "^14.0.10",
     "ora": "3.4.0",
-    "picomatch": "^2.3.1",
+    "picomatch": "^2.3.2",
     "prompts": "^2.4.2",
     "multitars": "^1.0.0",
     "update-check": "^1.5.4"

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `picomatch@^4.0.4` ([#45698](https://github.com/expo/expo/pull/45698) by [@kitten](https://github.com/kitten))
+
 ## 56.0.7 — 2026-05-11
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -71,7 +71,7 @@
     "express": "^5.1.0",
     "form-data": "^4.0.4",
     "memfs": "^3.2.0",
-    "picomatch": "^4.0.2",
+    "picomatch": "^4.0.4",
     "ts-node": "^10.9.2",
     "xstate": "^4.37.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1915,8 +1915,8 @@ importers:
         specifier: ^3.4.0
         version: 3.4.0
       picomatch:
-        specifier: ^4.0.3
-        version: 4.0.3
+        specifier: ^4.0.4
+        version: 4.0.4
       pretty-format:
         specifier: ^29.7.0
         version: 29.7.0
@@ -2578,8 +2578,8 @@ importers:
         specifier: ^1.30.1
         version: 1.32.0
       picomatch:
-        specifier: ^4.0.3
-        version: 4.0.3
+        specifier: ^4.0.4
+        version: 4.0.4
       postcss:
         specifier: ^8.5.14
         version: 8.5.14
@@ -3208,8 +3208,8 @@ importers:
         specifier: 3.4.0
         version: 3.4.0
       picomatch:
-        specifier: ^2.3.1
-        version: 2.3.1
+        specifier: ^2.3.2
+        version: 2.3.2
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -5832,8 +5832,8 @@ importers:
         specifier: ^3.2.0
         version: 3.6.0
       picomatch:
-        specifier: ^4.0.2
-        version: 4.0.3
+        specifier: ^4.0.4
+        version: 4.0.4
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)
@@ -13767,12 +13767,12 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pidtree@0.6.0:
@@ -18433,7 +18433,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -20047,7 +20047,7 @@ snapshots:
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   arg@4.1.3: {}
 
@@ -22014,9 +22014,9 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fetch-nodeshim@0.4.10: {}
 
@@ -23363,7 +23363,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   jest-validate@29.7.0:
     dependencies:
@@ -24120,7 +24120,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -24445,7 +24445,7 @@ snapshots:
       ansi-styles: 6.2.3
       cross-spawn: 7.0.6
       memorystream: 0.3.1
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       pidtree: 0.6.0
       read-package-json-fast: 4.0.0
       shell-quote: 1.8.3
@@ -24709,9 +24709,9 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
 
@@ -25439,7 +25439,7 @@ snapshots:
 
   readdirp@3.6.0:
     dependencies:
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   readdirp@4.1.2: {}
 
@@ -26371,8 +26371,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tmp@0.2.5: {}
 
@@ -26425,7 +26425,7 @@ snapshots:
 
   ts-declaration-location@1.0.7(typescript@6.0.3):
     dependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       typescript: 6.0.3
 
   ts-interface-checker@0.1.13: {}


### PR DESCRIPTION
# Why

Supersedes https://github.com/expo/expo/pull/44258

> [!NOTE]
> Fixes are within range and don't affect how we're using picomatch (ReDOS and property pollution assuming attacker-controlled values), as such no backport is necessary

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
