### PR TITLE
chore(jest-expo): Switch to new `@react-native/jest-preset` package

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Switch from `react-native/jest-preset` to `@react-native/jest-preset` ([#45699](https://github.com/expo/expo/pull/45699) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 - Bump to `react-server-dom-webpack@~19.0.6` ([#45645](https://github.com/expo/expo/pull/45645) by [@kitten](https://github.com/kitten))

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -3,7 +3,7 @@
 const cloneDeep = require('lodash/cloneDeep');
 const isEqual = require('lodash/isEqual');
 // Derive the Expo Jest preset from the React Native one
-const jestPreset = cloneDeep(require('react-native/jest-preset'));
+const jestPreset = cloneDeep(require('@react-native/jest-preset'));
 
 const { withTypescriptMapping } = require('./src/preset/withTypescriptMapping');
 const { resolveBabelConfig } = require('./src/resolveBabelConfig');

--- a/packages/jest-expo/jest-preset.js
+++ b/packages/jest-expo/jest-preset.js
@@ -2,8 +2,26 @@
 
 const cloneDeep = require('lodash/cloneDeep');
 const isEqual = require('lodash/isEqual');
-// Derive the Expo Jest preset from the React Native one
-const jestPreset = cloneDeep(require('@react-native/jest-preset'));
+
+let jestPreset;
+try {
+  jestPreset = require('@react-native/jest-preset');
+} catch (error) {
+  if (error.code === 'MODULE_NOT_FOUND') {
+    try {
+      // NOTE(@kitten): We can still try the old import to see if it
+      // works, in case there's some kind of version mismatch
+      jestPreset = require('react-native/jest-preset');
+    } catch {
+      throw new Error(
+        'The React Native Jest preset that jest-expo relies on has moved to a separate package.\n' +
+          'To migrate, please install "@react-native/jest-preset" to fulfill jest-expo\'s peer dependency.'
+      );
+    }
+  }
+}
+
+jestPreset = cloneDeep(jestPreset);
 
 const { withTypescriptMapping } = require('./src/preset/withTypescriptMapping');
 const { resolveBabelConfig } = require('./src/resolveBabelConfig');

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "react-native": "*",
-    "@react-native/jest-preset": ">=0.85.0",
+    "@react-native/jest-preset": "^0.85.0",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
   "peerDependenciesMeta": {

--- a/packages/jest-expo/package.json
+++ b/packages/jest-expo/package.json
@@ -52,6 +52,7 @@
   },
   "peerDependencies": {
     "react-native": "*",
+    "@react-native/jest-preset": ">=0.85.0",
     "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
   },
   "peerDependenciesMeta": {
@@ -61,6 +62,7 @@
   },
   "devDependencies": {
     "@types/react": "~19.2.0",
+    "@react-native/jest-preset": "0.85.3",
     "react-server-dom-webpack": "~19.0.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6049,6 +6049,9 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
     devDependencies:
+      '@react-native/jest-preset':
+        specifier: 0.85.3
+        version: 0.85.3(@babel/core@7.29.0)(react@19.2.3)
       '@types/react':
         specifier: ~19.2.0
         version: 19.2.14


### PR DESCRIPTION
# Why

The `react-native/jest-preset` has moved to: `@react-native/jest-preset` and we'll need to update `jest-expo`.

I've opted to add a peer dependency, so users will get the benefit of auto-installing peer dependencies. This might cause a version mismatch for some, but that's not as bad as depending on a single-version, which could then imply that users will have to keep track of `jest-expo`'s version instead, and don't get a warning about this ever.

Also added an improved error message when the peer dependency isn't fulfiled.

# How

- Add `peerDependencies['@react-native/jest-preset']` to `jest-expo` (on `^0.85.0`)
- Add specific error message when require fails

# Test Plan

- Tested `require('./jest.config')` manually

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
