### PR TITLE
[cli] Add --minimal flag to expo start.

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Add `--minimal` flag to `expo start` to hide the keybindings table on startup, keeping the QR code visible in large terminals. Press `?` to show all commands. ([#45701](https://github.com/expo/expo/pull/45701) by [@gsdv](https://github.com/gsdv))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/cli/src/start/index.ts
+++ b/packages/@expo/cli/src/start/index.ts
@@ -28,6 +28,7 @@ export const expoStart: Command = async (argv) => {
       '--localhost': Boolean,
       '--offline': Boolean,
       '--go': Boolean,
+      '--minimal': Boolean,
       // Aliases
       '-h': '--help',
       '-c': '--clear',
@@ -71,6 +72,7 @@ export const expoStart: Command = async (argv) => {
         `--localhost                     Same as --host localhost`,
         ``,
         `--offline                       Skip network requests and use anonymous manifest signatures`,
+        `--minimal                       Hide the keybindings table on startup`,
         chalk`--https                         Start the dev server with https protocol. {bold Deprecated in favor of --tunnel}`,
         `--scheme <scheme>               Custom URI protocol to use when launching an app`,
         chalk`-p, --port <number>             Port to start the dev server on (does not apply to web or tunnel). {dim Default: 8081}`,

--- a/packages/@expo/cli/src/start/interface/__tests__/commandsTable-test.ts
+++ b/packages/@expo/cli/src/start/interface/__tests__/commandsTable-test.ts
@@ -1,0 +1,75 @@
+import * as Log from '../../../log';
+import { printUsage } from '../commandsTable';
+
+jest.mock('../../../log');
+
+const captureOutput = () => {
+  return jest
+    .mocked(Log.log)
+    .mock.calls.map((args) => args.join(' '))
+    .join('\n');
+};
+
+describe(printUsage, () => {
+  beforeEach(() => {
+    jest.mocked(Log.log).mockClear();
+  });
+
+  it(`hides the keybindings table when minimal is true`, () => {
+    printUsage(
+      {
+        devClient: false,
+        isWebSocketsEnabled: true,
+        platforms: ['ios', 'android', 'web'],
+        minimal: true,
+      },
+      { verbose: false, rows: 1000 }
+    );
+    const output = captureOutput();
+    expect(output).not.toMatch(/open Android/);
+    expect(output).not.toMatch(/open iOS/);
+    expect(output).not.toMatch(/open web/);
+    expect(output).not.toMatch(/reload app/);
+    expect(output).not.toMatch(/open debugger/);
+    expect(output).not.toMatch(/open project code in your editor/);
+  });
+
+  it(`includes the "Press s to switch" hint when minimal is true`, () => {
+    printUsage(
+      {
+        devClient: false,
+        isWebSocketsEnabled: true,
+        platforms: ['ios', 'android', 'web'],
+        minimal: true,
+      },
+      { verbose: false, rows: 1000 }
+    );
+    expect(captureOutput()).toMatch(/Press .*s.* to switch to development build/);
+  });
+
+  it(`still prints the full table when verbose is true, even if minimal is true`, () => {
+    printUsage(
+      {
+        devClient: false,
+        isWebSocketsEnabled: true,
+        platforms: ['ios', 'android', 'web'],
+        minimal: true,
+      },
+      { verbose: true }
+    );
+    const output = captureOutput();
+    expect(output).toMatch(/open Android/);
+    expect(output).toMatch(/reload app/);
+    expect(output).toMatch(/open project code in your editor/);
+  });
+
+  it(`prints the full table by default when rows are sufficient`, () => {
+    printUsage(
+      { devClient: false, isWebSocketsEnabled: true, platforms: ['ios', 'android', 'web'] },
+      { verbose: false, rows: 1000 }
+    );
+    const output = captureOutput();
+    expect(output).toMatch(/open Android/);
+    expect(output).toMatch(/reload app/);
+  });
+});

--- a/packages/@expo/cli/src/start/interface/commandsTable.ts
+++ b/packages/@expo/cli/src/start/interface/commandsTable.ts
@@ -22,6 +22,8 @@ export type StartOptions = {
   platforms?: ExpoConfig['platforms'];
   mcpServer?: McpServer;
   dependencyCheckRef?: DependencyCheckRef;
+  /** Hide the keybindings table on startup. The `?` keybinding can still surface it on demand. */
+  minimal?: boolean;
 };
 
 export const printHelp = (): void => {
@@ -39,7 +41,7 @@ export const printItem = (text: string, opts?: { dim: boolean }): string => {
 };
 
 export function printUsage(
-  options: Pick<StartOptions, 'devClient' | 'isWebSocketsEnabled' | 'platforms'>,
+  options: Pick<StartOptions, 'devClient' | 'isWebSocketsEnabled' | 'platforms' | 'minimal'>,
   { verbose, rows }: { verbose: boolean; rows?: number }
 ) {
   const isMac = process.platform === 'darwin';
@@ -81,6 +83,13 @@ export function printUsage(
       { key: 'c', msg: 'show project QR' },
       {},
     ]).print();
+  }
+
+  // `--minimal` skips the keybindings table on startup so the QR code stays in view.
+  // The "Press ? │ show all commands" hint printed by the caller is the escape hatch.
+  if (options.minimal) {
+    printPrefix({ short: false });
+    return;
   }
 
   const table = logCommandsTable([

--- a/packages/@expo/cli/src/start/interface/interactiveActions.ts
+++ b/packages/@expo/cli/src/start/interface/interactiveActions.ts
@@ -33,7 +33,7 @@ export class DevServerManagerActions {
   printDevServerInfo(
     options: Pick<
       StartOptions,
-      'devClient' | 'isWebSocketsEnabled' | 'platforms' | 'dependencyCheckRef'
+      'devClient' | 'isWebSocketsEnabled' | 'platforms' | 'dependencyCheckRef' | 'minimal'
     >
   ) {
     // Keep track of approximately how much space we have to print our usage guide

--- a/packages/@expo/cli/src/start/interface/startInterface.ts
+++ b/packages/@expo/cli/src/start/interface/startInterface.ts
@@ -37,7 +37,7 @@ const PLATFORM_SETTINGS: Record<
 
 export async function startInterfaceAsync(
   devServerManager: DevServerManager,
-  options: Pick<StartOptions, 'devClient' | 'platforms' | 'mcpServer' | 'dependencyCheckRef'>
+  options: Pick<StartOptions, 'devClient' | 'platforms' | 'mcpServer' | 'dependencyCheckRef' | 'minimal'>
 ) {
   // Spend one-tick waiting for the dependency check result
   if (options.dependencyCheckRef) {

--- a/packages/@expo/cli/src/start/resolveOptions.ts
+++ b/packages/@expo/cli/src/start/resolveOptions.ts
@@ -23,6 +23,8 @@ export type Options = {
   devClient: boolean;
   scheme: string | null;
   host: 'localhost' | 'lan' | 'tunnel';
+  /** Hide the keybindings table on startup. */
+  minimal: boolean;
 };
 
 export async function resolveOptionsAsync(projectRoot: string, args: any): Promise<Options> {
@@ -79,6 +81,8 @@ export async function resolveOptionsAsync(projectRoot: string, args: any): Promi
 
     scheme,
     host,
+
+    minimal: !!args['--minimal'],
   };
 }
 

--- a/packages/@expo/cli/src/start/startAsync.ts
+++ b/packages/@expo/cli/src/start/startAsync.ts
@@ -144,6 +144,7 @@ export async function startAsync(
       platforms: exp.platforms ?? ['ios', 'android', 'web'],
       mcpServer,
       dependencyCheckRef,
+      minimal: options.minimal,
     });
   } else {
     // Display the server location in CI...


### PR DESCRIPTION
# Why
<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
In terminal windows, the keybindings table printed at startup pushes the QR code off-screen, making users scroll up to scan it on their device. [#42835](https://github.com/expo/expo/pull/42835) added a row-aware short-circuit to skip the table when the terminal is too short, but a user who wants a **tall terminal** *and* a **short startup UI** has no way to opt in today. The current workaround is `stty rows 10 && npx expo start`, which is hacky.

`--minimal` is an opt-in flag that forces the short branch unconditionally. The QR code, server URLs, `Using <target> (Press s to switch...)` line, and `Press ? │ show all commands` hint all still print — only the keybindings table is omitted. Pressing `?` surfaces the full table on demand.


# How

<!--
How did you build this feature or fix this bug and why?
-->
- Declared `--minimal: Boolean` in `packages/@expo/cli/src/start/index.ts` and added a help line alongside `--offline`.
- Resolved into `Options.minimal` in `packages/@expo/cli/src/start/resolveOptions.ts`.
- In `commandsTable.ts#printUsage`, the short-circuit is placed **after** the `verbose` branch, so pressing `?` still surfaces the full table when `--minimal` is set. This preserves the escape hatch.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->
`pnpm test src/start` passes. `pnpm lint` and `pnpm typecheck` are clean. Manually verified in a tall terminal that `expo start --minimal` prints the QR + `?` hint without the keybindings table, that `expo start` without the flag still prints the full table.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
