### PR TITLE
Fix Android one-time permission state

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Propagate async-function promise construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
 - [iOS] Read iPad-specific supported orientations from `UISupportedInterfaceOrientations~ipad`. ([#46281](https://github.com/expo/expo/issues/46281) by [@bryandent](https://github.com/bryandent)) ([#46306](https://github.com/expo/expo/pull/46306) by [@mvincentong](https://github.com/mvincentong))
+- [Android] Fix one-time permission revocations being reported as terminal denials. ([#44180](https://github.com/expo/expo/issues/44180) by [@Nezz](https://github.com/Nezz)) ([#45703](https://github.com/expo/expo/pull/45703) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/adapters/react/permissions/PermissionsService.kt
@@ -27,6 +27,7 @@ import java.util.Queue
 
 private const val PERMISSIONS_REQUEST: Int = 13
 private const val PREFERENCE_FILENAME = "expo.modules.permissions.asked"
+private const val PERMISSION_GRANTED_PREFERENCE_SUFFIX = ".granted"
 
 open class PermissionsService(val context: Context) : InternalModule, Permissions, LifecycleEventListener {
   private var mActivityProvider: ActivityProvider? = null
@@ -39,13 +40,32 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
   private val mPendingPermissionCalls: Queue<Pair<Array<String>, PermissionsResponseListener>> = LinkedList()
   private var mCurrentPermissionListener: PermissionsResponseListener? = null
 
-  private lateinit var mAskedPermissionsCache: SharedPreferences
+  private val mAskedPermissionsCache: SharedPreferences by lazy {
+    context.applicationContext.getSharedPreferences(PREFERENCE_FILENAME, Context.MODE_PRIVATE)
+  }
 
   private fun didAsk(permission: String): Boolean = mAskedPermissionsCache.getBoolean(permission, false)
+
+  private fun wasGranted(permission: String): Boolean = mAskedPermissionsCache.getBoolean(
+    "$permission$PERMISSION_GRANTED_PREFERENCE_SUFFIX",
+    false
+  )
 
   private fun addToAskedPermissionsCache(permissions: Array<out String>) {
     mAskedPermissionsCache.edit(commit = true) {
       permissions.forEach { putBoolean(it, true) }
+    }
+  }
+
+  private fun updateAskedPermissionsCache(permissions: Array<out String>, grantResults: IntArray) {
+    mAskedPermissionsCache.edit(commit = true) {
+      grantResults.zip(permissions).forEach { (result, permission) ->
+        putBoolean(permission, true)
+        putBoolean(
+          "$permission$PERMISSION_GRANTED_PREFERENCE_SUFFIX",
+          result == PackageManager.PERMISSION_GRANTED
+        )
+      }
     }
   }
 
@@ -56,7 +76,6 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
     mActivityProvider = moduleRegistry.getModule(ActivityProvider::class.java)
       ?: throw IllegalStateException("Couldn't find implementation for ActivityProvider.")
     moduleRegistry.getModule(UIManager::class.java).registerLifecycleEventListener(this)
-    mAskedPermissionsCache = context.applicationContext.getSharedPreferences(PREFERENCE_FILENAME, Context.MODE_PRIVATE)
   }
 
   override fun getPermissionsWithPromise(
@@ -136,6 +155,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
           PackageManager.PERMISSION_DENIED
         }
 
+        updateAskedPermissionsCache(arrayOf(Manifest.permission.WRITE_SETTINGS), intArrayOf(status))
         it[Manifest.permission.WRITE_SETTINGS] = getPermissionResponseFromNativeResponse(Manifest.permission.WRITE_SETTINGS, status)
         responseListener.onResult(it)
       }
@@ -219,7 +239,15 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
     } == true
   }
 
-  private fun parseNativeResult(permissionsString: Array<out String>, grantResults: IntArray): Map<String, PermissionsResponse> {
+  private fun parseNativeResult(
+    permissionsString: Array<out String>,
+    grantResults: IntArray,
+    updateCache: Boolean = false
+  ): Map<String, PermissionsResponse> {
+    if (updateCache) {
+      updateAskedPermissionsCache(permissionsString, grantResults)
+    }
+
     return HashMap<String, PermissionsResponse>().apply {
       grantResults.zip(permissionsString).forEach { (result, permission) ->
         this[permission] = getPermissionResponseFromNativeResponse(permission, result)
@@ -230,6 +258,7 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
   private fun getPermissionResponseFromNativeResponse(permission: String, result: Int): PermissionsResponse {
     val status = when {
       result == PackageManager.PERMISSION_GRANTED -> PermissionsStatus.GRANTED
+      wasGranted(permission) -> PermissionsStatus.UNDETERMINED
       didAsk(permission) -> PermissionsStatus.DENIED
       else -> PermissionsStatus.UNDETERMINED
     }
@@ -267,7 +296,13 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
         }
       }
     } else {
-      listener.onResult(parseNativeResult(permissions, IntArray(permissions.size) { PackageManager.PERMISSION_DENIED }))
+      listener.onResult(
+        parseNativeResult(
+          permissions,
+          IntArray(permissions.size) { PackageManager.PERMISSION_DENIED },
+          updateCache = true
+        )
+      )
     }
   }
 
@@ -276,16 +311,28 @@ open class PermissionsService(val context: Context) : InternalModule, Permission
       if (requestCode == PERMISSIONS_REQUEST) {
         synchronized(this@PermissionsService) {
           val currentListener = requireNotNull(mCurrentPermissionListener)
-          currentListener.onResult(parseNativeResult(receivePermissions, grantResults))
+          currentListener.onResult(parseNativeResult(receivePermissions, grantResults, updateCache = true))
           mCurrentPermissionListener = null
 
           mPendingPermissionCalls.poll()?.let { pendingCall ->
             val activity = mActivityProvider?.currentActivity as? PermissionAwareActivity
             if (activity == null) {
               // clear all pending calls, because we don't have access to the activity instance
-              pendingCall.second.onResult(parseNativeResult(pendingCall.first, IntArray(pendingCall.first.size) { PackageManager.PERMISSION_DENIED }))
+              pendingCall.second.onResult(
+                parseNativeResult(
+                  pendingCall.first,
+                  IntArray(pendingCall.first.size) { PackageManager.PERMISSION_DENIED },
+                  updateCache = true
+                )
+              )
               mPendingPermissionCalls.forEach {
-                it.second.onResult(parseNativeResult(it.first, IntArray(it.first.size) { PackageManager.PERMISSION_DENIED }))
+                it.second.onResult(
+                  parseNativeResult(
+                    it.first,
+                    IntArray(it.first.size) { PackageManager.PERMISSION_DENIED },
+                    updateCache = true
+                  )
+                )
               }
               mPendingPermissionCalls.clear()
               return@let

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/adapters/react/permissions/PermissionsServiceTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/adapters/react/permissions/PermissionsServiceTest.kt
@@ -1,0 +1,101 @@
+package expo.modules.adapters.react.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import expo.modules.interfaces.permissions.PermissionsResponse
+import expo.modules.interfaces.permissions.PermissionsStatus
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [30])
+class PermissionsServiceTest {
+  private lateinit var context: Context
+  private lateinit var preferences: SharedPreferences
+  private lateinit var permissionsService: TestPermissionsService
+
+  @Before
+  fun setUp() {
+    context = ApplicationProvider.getApplicationContext()
+    preferences = context.getSharedPreferences(PREFERENCE_FILENAME, Context.MODE_PRIVATE)
+    preferences.edit().clear().commit()
+    permissionsService = TestPermissionsService(context)
+  }
+
+  @Test
+  fun `returns undetermined for denied permission that was never requested`() {
+    permissionsService.manifestPermissionResult = PackageManager.PERMISSION_DENIED
+
+    val response = permissionsService.getPermission()
+
+    assertThat(response.status).isEqualTo(PermissionsStatus.UNDETERMINED)
+    assertThat(response.canAskAgain).isTrue()
+  }
+
+  @Test
+  fun `returns denied for denied permission that was last denied by the user`() {
+    markPermissionAsAsked(wasGranted = false)
+    permissionsService.manifestPermissionResult = PackageManager.PERMISSION_DENIED
+
+    val response = permissionsService.getPermission()
+
+    assertThat(response.status).isEqualTo(PermissionsStatus.DENIED)
+    assertThat(response.canAskAgain).isFalse()
+  }
+
+  @Test
+  fun `returns undetermined for denied permission that was granted before`() {
+    markPermissionAsAsked(wasGranted = true)
+    permissionsService.manifestPermissionResult = PackageManager.PERMISSION_DENIED
+
+    val response = permissionsService.getPermission()
+
+    assertThat(response.status).isEqualTo(PermissionsStatus.UNDETERMINED)
+    assertThat(response.canAskAgain).isTrue()
+  }
+
+  @Test
+  fun `returns granted for granted permission that was granted before`() {
+    markPermissionAsAsked(wasGranted = true)
+    permissionsService.manifestPermissionResult = PackageManager.PERMISSION_GRANTED
+
+    val response = permissionsService.getPermission()
+
+    assertThat(response.status).isEqualTo(PermissionsStatus.GRANTED)
+    assertThat(response.canAskAgain).isTrue()
+  }
+
+  private fun markPermissionAsAsked(wasGranted: Boolean) {
+    preferences.edit()
+      .putBoolean(RECORD_AUDIO, true)
+      .putBoolean("$RECORD_AUDIO$PERMISSION_GRANTED_PREFERENCE_SUFFIX", wasGranted)
+      .commit()
+  }
+
+  private fun TestPermissionsService.getPermission(): PermissionsResponse {
+    var response: PermissionsResponse? = null
+    getPermissions({ permissionsMap ->
+      response = permissionsMap[RECORD_AUDIO]
+    }, RECORD_AUDIO)
+    return requireNotNull(response)
+  }
+
+  private class TestPermissionsService(context: Context) : PermissionsService(context) {
+    var manifestPermissionResult: Int = PackageManager.PERMISSION_DENIED
+
+    override fun getManifestPermissionFromContext(permission: String): Int = manifestPermissionResult
+  }
+
+  private companion object {
+    const val PREFERENCE_FILENAME = "expo.modules.permissions.asked"
+    const val PERMISSION_GRANTED_PREFERENCE_SUFFIX = ".granted"
+    const val RECORD_AUDIO = Manifest.permission.RECORD_AUDIO
+  }
+}


### PR DESCRIPTION
Why:
- Closes #44180.
- Android can return a denied current permission after a previously granted one-time or ask-every-time permission is revoked. `PermissionsService` only persisted whether a permission had ever been requested, so this case was reported as a terminal denial with `canAskAgain: false`.

How:
- Persist the last runtime request grant result separately from the existing "asked" marker.
- Update that cache only from permission request results, not from passive permission reads.
- Treat a current denied result after a previous grant as `undetermined` with `canAskAgain: true`, while preserving the existing terminal denied result for permissions that were last denied by the user.
- Added focused Robolectric coverage for never-requested, denied, revoked-after-grant, and granted Android permission states.

Test Plan:
- `env ANDROID_HOME=/Users/mvincentong/Library/Android/sdk ./gradlew :expo-modules-core:testDebugUnitTest --tests expo.modules.adapters.react.permissions.PermissionsServiceTest --no-daemon --no-configuration-cache` passed.
- `pnpm --filter expo-modules-core lint` passed.
- `pnpm --filter expo-modules-core test` passed: 22 suites, 168 tests, 8 snapshots. Existing React `act(...)` warnings and Node circular dependency warnings were non-failing.
- `env ANDROID_HOME=/Users/mvincentong/Library/Android/sdk ./gradlew :expo-modules-core:testDebugUnitTest --no-daemon --no-configuration-cache` passed. Existing Robolectric Java 21 and Gradle deprecation warnings were non-failing.
- `git diff --cached --check` passed before commit.

Risk:
- Source files changed: 1.
- Test files changed: 1.
- Changelog files changed: 1.
- No docs or generated build output changes.
- Behavioral scope is Android permission state reporting in `expo-modules-core`; the main residual risk is platform-specific settings semantics outside the covered runtime permission states.
