### PR TITLE
[core][iOS] Add JSValueDecoder to support Decodable function arguments

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] `Decodable` types can now be used as native function arguments. JS values are decoded through the dynamic-type registry, so arrays, dictionaries, optionals, `RawRepresentable` enums and `Convertible`s are coerced consistently. ([#45705](https://github.com/expo/expo/pull/45705) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/ios/Core/AnyCodingKey.swift
+++ b/packages/expo-modules-core/ios/Core/AnyCodingKey.swift
@@ -1,0 +1,21 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+/**
+ A coding key carrying just a string and an integer index. Used to extend
+ `codingPath` with array indices in unkeyed containers, since unkeyed
+ containers have no associated `Key` type to draw from.
+ */
+internal struct AnyCodingKey: CodingKey {
+  let stringValue: String
+  let intValue: Int?
+
+  init(stringValue: String) {
+    self.stringValue = stringValue
+    self.intValue = Int(stringValue)
+  }
+
+  init(intValue: Int) {
+    self.stringValue = String(intValue)
+    self.intValue = intValue
+  }
+}

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicCodableType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicCodableType.swift
@@ -3,29 +3,33 @@
 import ExpoModulesJSI
 
 /**
- Dynamic type for values conforming to `Encodable` protocol.
- Note that currently it can only encode from native to JavaScript values, thus cannot be used for arguments.
+ Dynamic type for values that conform to `Encodable` and/or `Decodable`. Native→JS
+ goes through `JSValueEncoder` (requires `Encodable`); JS→native goes through
+ `JSValueDecoder` (requires `Decodable`). Either direction throws if the wrapped
+ type doesn't conform to the protocol it needs.
  */
-internal struct DynamicEncodableType: AnyDynamicType {
-  static let shared = DynamicEncodableType()
-
-  func wraps<InnerType>(_ type: InnerType.Type) -> Bool {
-    return type is Encodable
+internal struct DynamicCodableType<InnerType>: AnyDynamicType {
+  func wraps<AnyInnerType>(_ type: AnyInnerType.Type) -> Bool {
+    return type == InnerType.self
   }
 
   func equals(_ type: any AnyDynamicType) -> Bool {
-    // Just mocking it here as we don't really need this function and we rather want to keep it a singleton
-    return false
+    return type is Self
   }
 
   func cast(jsValue: JavaScriptValue, appContext: AppContext) throws -> Any {
-    // TODO: Create DynamicDecodableType and reuse it here – that would work perfectly with Codable types
-    fatalError("DynamicEncodableType can only cast to JavaScript, not from")
+    guard let DecodableType = InnerType.self as? Decodable.Type else {
+      throw Conversions.CastingJSValueException<InnerType>(jsValue.kind)
+    }
+    let decoder = try JSValueDecoder(value: jsValue, appContext: appContext)
+    return try DecodableType.init(from: decoder)
   }
 
   func cast<ValueType>(_ value: ValueType, appContext: AppContext) throws -> Any {
-    // TODO: Create DynamicDecodableType and reuse it here – that would work perfectly with Codable types
-    fatalError("DynamicEncodableType can only cast to JavaScript, not from")
+    if let value = value as? InnerType {
+      return value
+    }
+    throw Conversions.CastingException<InnerType>(value)
   }
 
   func castToJS<ValueType>(_ value: ValueType, appContext: AppContext) throws -> JavaScriptValue {
@@ -50,6 +54,6 @@ internal struct DynamicEncodableType: AnyDynamicType {
   }
 
   var description: String {
-    "Encodable"
+    "Codable<\(InnerType.self)>"
   }
 }

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicType.swift
@@ -19,10 +19,10 @@ private func DynamicType<T>(_ type: T.Type) -> AnyDynamicType {
   if T.self == Void.self {
     return DynamicVoidType.shared
   }
-  if T.self is Encodable.Type {
-    // There is no dedicated `~` operator overload for encodables to avoid ambiguity
-    // when the type is both `AnyArgument` and `Encodable` (e.g. strings, numeric types).
-    return DynamicEncodableType.shared
+  if T.self is Encodable.Type || T.self is Decodable.Type {
+    // There is no dedicated `~` operator overload for Codable types to avoid ambiguity
+    // when the type is both `AnyArgument` and `Encodable`/`Decodable` (e.g. strings, numeric types).
+    return DynamicCodableType<T>()
   }
   return DynamicRawType(innerType: T.self)
 }

--- a/packages/expo-modules-core/ios/Core/JSValueDecoder.swift
+++ b/packages/expo-modules-core/ios/Core/JSValueDecoder.swift
@@ -1,0 +1,452 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import ExpoModulesJSI
+
+/**
+ Decodes `JavaScriptValue`s into `Decodable` Swift values.
+
+ For any property whose static type is known to the dynamic-type registry
+ (anything routed via the `~` operator: arrays, dictionaries, optionals,
+ `RawRepresentable` enums, `Convertible`s, `JavaScriptValue` and so on),
+ the decoder takes the fast path through `cast(jsValue:)`, preserving full
+ element-type metadata and picking up `Convertible` coercions for free.
+
+ Only types the registry doesn't recognize (i.e. plain `Decodable` structs and
+ classes) fall back to Swift's `Decodable` machinery via `T.init(from: decoder)`.
+ */
+internal final class JSValueDecoder: Decoder {
+  private let appContext: AppContext
+  private let runtime: JavaScriptRuntime
+  private let value: JavaScriptValue
+
+  /**
+   Initializes the decoder with the given JS value and app context.
+   Throws if the runtime has been lost.
+   */
+  convenience init(value: JavaScriptValue, appContext: AppContext) throws {
+    try self.init(value: value, appContext: appContext, runtime: appContext.runtime)
+  }
+
+  /**
+   Initializes the decoder with the given JS value, app context and an explicit runtime.
+   Use this when the source JS value lives in a runtime other than the one currently
+   held by the app context.
+   */
+  convenience init(value: JavaScriptValue, appContext: AppContext, runtime: JavaScriptRuntime) {
+    self.init(value: value, appContext: appContext, runtime: runtime, codingPath: [])
+  }
+
+  fileprivate init(
+    value: JavaScriptValue,
+    appContext: AppContext,
+    runtime: JavaScriptRuntime,
+    codingPath: [any CodingKey]
+  ) {
+    self.value = value
+    self.appContext = appContext
+    self.runtime = runtime
+    self.codingPath = codingPath
+  }
+
+  // MARK: - Decoder
+
+  let codingPath: [any CodingKey]
+  let userInfo: [CodingUserInfoKey: Any] = [:]
+
+  func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> where Key: CodingKey {
+    guard value.isObject() else {
+      throw DecodingError.typeMismatch(
+        [String: Any].self,
+        DecodingError.Context(
+          codingPath: codingPath,
+          debugDescription: "Expected a JavaScript object to decode keyed container, got \(value.kind.rawValue)"
+        )
+      )
+    }
+    let container = JSObjectDecodingContainer<Key>(
+      object: value.getObject(),
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath
+    )
+    return KeyedDecodingContainer(container)
+  }
+
+  func unkeyedContainer() throws -> any UnkeyedDecodingContainer {
+    guard value.isArray() else {
+      throw DecodingError.typeMismatch(
+        [Any].self,
+        DecodingError.Context(
+          codingPath: codingPath,
+          debugDescription: "Expected a JavaScript array to decode unkeyed container, got \(value.kind.rawValue)"
+        )
+      )
+    }
+    return JSArrayDecodingContainer(
+      array: value.getArray(),
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath
+    )
+  }
+
+  func singleValueContainer() throws -> any SingleValueDecodingContainer {
+    return JSValueDecodingContainer(
+      value: value,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath
+    )
+  }
+}
+
+// MARK: - Shared decoding logic
+
+/**
+ Decodes a single JS value into a typed Swift value, routing through the
+ dynamic-type registry whenever possible and falling back to `Decodable` only
+ for plain types.
+ */
+private func decodeUsingDynamicType<ValueType: Decodable>(
+  _ type: ValueType.Type,
+  from jsValue: JavaScriptValue,
+  appContext: AppContext,
+  runtime: JavaScriptRuntime,
+  codingPath: [any CodingKey]
+) throws -> ValueType {
+  let dynamicType = ~ValueType.self
+
+  if !(dynamicType is DynamicCodableType<ValueType>) {
+    do {
+      let anyValue = try JavaScriptActor.assumeIsolated {
+        return try dynamicType.cast(jsValue: jsValue, appContext: appContext)
+      }
+      guard let typed = anyValue as? ValueType else {
+        throw DecodingError.typeMismatch(
+          ValueType.self,
+          DecodingError.Context(
+            codingPath: codingPath,
+            debugDescription: "Dynamic type \(dynamicType) produced \(Swift.type(of: anyValue)) which is not \(ValueType.self)"
+          )
+        )
+      }
+      return typed
+    } catch let error as DecodingError {
+      throw error
+    } catch {
+      throw DecodingError.dataCorrupted(
+        DecodingError.Context(
+          codingPath: codingPath,
+          debugDescription: "Failed to cast JS value to \(ValueType.self)",
+          underlyingError: error
+        )
+      )
+    }
+  }
+
+  // Plain Decodable type the registry doesn't recognize — recurse via Decodable.
+  let decoder = JSValueDecoder(value: jsValue, appContext: appContext, runtime: runtime, codingPath: codingPath)
+  return try ValueType(from: decoder)
+}
+
+// MARK: - Containers
+
+/**
+ Single value container that reads a JS primitive (or unwraps an Optional).
+ */
+private struct JSValueDecodingContainer: SingleValueDecodingContainer {
+  private let appContext: AppContext
+  private let runtime: JavaScriptRuntime
+  private let value: JavaScriptValue
+  let codingPath: [any CodingKey]
+
+  init(value: JavaScriptValue, appContext: AppContext, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
+    self.value = value
+    self.appContext = appContext
+    self.runtime = runtime
+    self.codingPath = codingPath
+  }
+
+  func decodeNil() -> Bool {
+    return value.isNull() || value.isUndefined()
+  }
+
+  func decode<ValueType: Decodable>(_ type: ValueType.Type) throws -> ValueType {
+    return try decodeUsingDynamicType(
+      type,
+      from: value,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath
+    )
+  }
+}
+
+/**
+ Keyed container that reads from a JS object.
+
+ - Note: This is a `class` (not a `struct`) for the same reason as the encoder's
+   keyed container: it holds a non-copyable `JavaScriptObject`. See
+   `JSObjectEncodingContainer` for the full rationale.
+ */
+private final class JSObjectDecodingContainer<Key: CodingKey>: KeyedDecodingContainerProtocol {
+  private let appContext: AppContext
+  private let runtime: JavaScriptRuntime
+  private let object: JavaScriptObject
+  let codingPath: [any CodingKey]
+
+  init(object: consuming JavaScriptObject, appContext: AppContext, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
+    self.object = object
+    self.appContext = appContext
+    self.runtime = runtime
+    self.codingPath = codingPath
+  }
+
+  lazy var allKeys: [Key] = object.getPropertyNames().compactMap { Key(stringValue: $0) }
+
+  func contains(_ key: Key) -> Bool {
+    return object.hasProperty(key.stringValue)
+  }
+
+  func decodeNil(forKey key: Key) throws -> Bool {
+    let value = object.getProperty(key.stringValue)
+    return value.isNull() || value.isUndefined()
+  }
+
+  // JS doesn't meaningfully distinguish "key absent" from "value undefined" at the
+  // consumer level — a single `getProperty` fetch returns `undefined` in both cases.
+  // Collapse both into `keyNotFound` so the caller gets the more useful error.
+  func decode<ValueType: Decodable>(_ type: ValueType.Type, forKey key: Key) throws -> ValueType {
+    let jsValue = object.getProperty(key.stringValue)
+    if jsValue.isUndefined() {
+      throw DecodingError.keyNotFound(
+        key,
+        DecodingError.Context(
+          codingPath: codingPath,
+          debugDescription: "No value found for key \(key.stringValue)"
+        )
+      )
+    }
+    return try decodeUsingDynamicType(
+      type,
+      from: jsValue,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+  }
+
+  // Swift's default `decodeIfPresent` calls `contains(key)` and then `decodeNil(forKey:)`;
+  // for present-but-null JS keys this works, but it doesn't reach our dynamic-type
+  // fast path. Override to make optional decoding consistently route through it.
+  // `JavaScriptObject.getProperty` returns `undefined` for missing keys, so a single
+  // fetch covers both "absent" and "explicit null/undefined" cases.
+  func decodeIfPresent<ValueType: Decodable>(_ type: ValueType.Type, forKey key: Key) throws -> ValueType? {
+    let jsValue = object.getProperty(key.stringValue)
+    if jsValue.isNull() || jsValue.isUndefined() {
+      return nil
+    }
+    return try decodeUsingDynamicType(
+      type,
+      from: jsValue,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+  }
+
+  func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+    let jsValue = object.getProperty(key.stringValue)
+    guard jsValue.isObject() else {
+      throw DecodingError.typeMismatch(
+        [String: Any].self,
+        DecodingError.Context(
+          codingPath: codingPath + [key],
+          debugDescription: "Expected a JavaScript object for nested keyed container, got \(jsValue.kind.rawValue)"
+        )
+      )
+    }
+    let container = JSObjectDecodingContainer<NestedKey>(
+      object: jsValue.getObject(),
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+    return KeyedDecodingContainer(container)
+  }
+
+  func nestedUnkeyedContainer(forKey key: Key) throws -> any UnkeyedDecodingContainer {
+    let jsValue = object.getProperty(key.stringValue)
+    guard jsValue.isArray() else {
+      throw DecodingError.typeMismatch(
+        [Any].self,
+        DecodingError.Context(
+          codingPath: codingPath + [key],
+          debugDescription: "Expected a JavaScript array for nested unkeyed container, got \(jsValue.kind.rawValue)"
+        )
+      )
+    }
+    return JSArrayDecodingContainer(
+      array: jsValue.getArray(),
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+  }
+
+  func superDecoder() throws -> any Decoder {
+    throw DecodingError.dataCorrupted(
+      DecodingError.Context(
+        codingPath: codingPath,
+        debugDescription: "JSValueDecoder does not support superDecoder()"
+      )
+    )
+  }
+
+  func superDecoder(forKey key: Key) throws -> any Decoder {
+    throw DecodingError.dataCorrupted(
+      DecodingError.Context(
+        codingPath: codingPath + [key],
+        debugDescription: "JSValueDecoder does not support superDecoder(forKey:)"
+      )
+    )
+  }
+}
+
+/**
+ Unkeyed container that reads from a JS array.
+
+ Like `JSObjectDecodingContainer`, this is a `class` so it can hold the
+ non-copyable `JavaScriptArray` directly.
+ */
+private final class JSArrayDecodingContainer: UnkeyedDecodingContainer {
+  private let appContext: AppContext
+  private let runtime: JavaScriptRuntime
+  private let array: JavaScriptArray
+  let codingPath: [any CodingKey]
+  var currentIndex: Int = 0
+
+  init(array: consuming JavaScriptArray, appContext: AppContext, runtime: JavaScriptRuntime, codingPath: [any CodingKey]) {
+    self.array = array
+    self.appContext = appContext
+    self.runtime = runtime
+    self.codingPath = codingPath
+  }
+
+  var count: Int? { array.length }
+  var isAtEnd: Bool { currentIndex >= array.length }
+
+  func decodeNil() throws -> Bool {
+    let jsValue = try nextValue(Any?.self)
+    if jsValue.isNull() || jsValue.isUndefined() {
+      currentIndex += 1
+      return true
+    }
+    return false
+  }
+
+  func decode<ValueType: Decodable>(_ type: ValueType.Type) throws -> ValueType {
+    let jsValue = try nextValue(type)
+    let key = AnyCodingKey(intValue: currentIndex)
+    let decoded = try decodeUsingDynamicType(
+      type,
+      from: jsValue,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+    currentIndex += 1
+    return decoded
+  }
+
+  func decodeIfPresent<ValueType: Decodable>(_ type: ValueType.Type) throws -> ValueType? {
+    if isAtEnd {
+      return nil
+    }
+    let jsValue = try array.getValue(at: currentIndex)
+    if jsValue.isNull() || jsValue.isUndefined() {
+      currentIndex += 1
+      return nil
+    }
+    let key = AnyCodingKey(intValue: currentIndex)
+    let decoded = try decodeUsingDynamicType(
+      type,
+      from: jsValue,
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+    currentIndex += 1
+    return decoded
+  }
+
+  func nestedContainer<NestedKey>(keyedBy keyType: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> where NestedKey: CodingKey {
+    let jsValue = try nextValue(KeyedDecodingContainer<NestedKey>.self)
+    let key = AnyCodingKey(intValue: currentIndex)
+    guard jsValue.isObject() else {
+      throw DecodingError.typeMismatch(
+        [String: Any].self,
+        DecodingError.Context(
+          codingPath: codingPath + [key],
+          debugDescription: "Expected a JavaScript object for nested keyed container, got \(jsValue.kind.rawValue)"
+        )
+      )
+    }
+    let container = JSObjectDecodingContainer<NestedKey>(
+      object: jsValue.getObject(),
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+    currentIndex += 1
+    return KeyedDecodingContainer(container)
+  }
+
+  func nestedUnkeyedContainer() throws -> any UnkeyedDecodingContainer {
+    let jsValue = try nextValue((any UnkeyedDecodingContainer).self)
+    let key = AnyCodingKey(intValue: currentIndex)
+    guard jsValue.isArray() else {
+      throw DecodingError.typeMismatch(
+        [Any].self,
+        DecodingError.Context(
+          codingPath: codingPath + [key],
+          debugDescription: "Expected a JavaScript array for nested unkeyed container, got \(jsValue.kind.rawValue)"
+        )
+      )
+    }
+    let container = JSArrayDecodingContainer(
+      array: jsValue.getArray(),
+      appContext: appContext,
+      runtime: runtime,
+      codingPath: codingPath + [key]
+    )
+    currentIndex += 1
+    return container
+  }
+
+  // Reads the element at `currentIndex`, throwing `valueNotFound` (rather than letting
+  // `JavaScriptArray.getValue(at:)` throw its non-`DecodingError` out-of-range error)
+  // when the unkeyed container has been exhausted.
+  private func nextValue<RequestedType>(_ expected: RequestedType.Type) throws -> JavaScriptValue {
+    if isAtEnd {
+      throw DecodingError.valueNotFound(
+        expected,
+        DecodingError.Context(
+          codingPath: codingPath + [AnyCodingKey(intValue: currentIndex)],
+          debugDescription: "Unkeyed container is at end — no value available at index \(currentIndex)"
+        )
+      )
+    }
+    return try array.getValue(at: currentIndex)
+  }
+
+  func superDecoder() throws -> any Decoder {
+    throw DecodingError.dataCorrupted(
+      DecodingError.Context(
+        codingPath: codingPath,
+        debugDescription: "JSValueDecoder does not support superDecoder()"
+      )
+    )
+  }
+}
+

--- a/packages/expo-modules-core/ios/Core/JSValueEncoder.swift
+++ b/packages/expo-modules-core/ios/Core/JSValueEncoder.swift
@@ -107,7 +107,7 @@ private func encodeUsingDynamicType<ValueType: Encodable>(
 ) throws -> JavaScriptValue {
   let dynamicType = ~ValueType.self
 
-  if !(dynamicType is DynamicEncodableType) {
+  if !(dynamicType is DynamicCodableType<ValueType>) {
     return try dynamicType.castToJS(value, appContext: appContext, in: runtime)
   }
 
@@ -345,24 +345,3 @@ private final class JSArrayEncodingContainer: UnkeyedEncodingContainer {
   }
 }
 
-// MARK: - Helpers
-
-/**
- A coding key carrying just a string and an integer index. Used to extend
- `codingPath` with array indices in the unkeyed container, since unkeyed
- containers have no associated `Key` type to draw from.
- */
-private struct AnyCodingKey: CodingKey {
-  let stringValue: String
-  let intValue: Int?
-
-  init(stringValue: String) {
-    self.stringValue = stringValue
-    self.intValue = Int(stringValue)
-  }
-
-  init(intValue: Int) {
-    self.stringValue = String(intValue)
-    self.intValue = intValue
-  }
-}

--- a/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
+++ b/packages/expo-modules-core/ios/Tests/DynamicTypeTests.swift
@@ -717,11 +717,11 @@ struct DynamicTypeTests {
     }
   }
 
-  // MARK: - DynamicEncodableType
+  // MARK: - DynamicCodableType
 
-  @Suite("DynamicEncodableType")
+  @Suite("DynamicCodableType")
   @JavaScriptActor
-  struct DynamicEncodableTypeTests {
+  struct DynamicCodableTypeTests {
     let appContext: AppContext
     var runtime: ExpoRuntime {
       get throws {
@@ -746,7 +746,7 @@ struct DynamicTypeTests {
 
     @Test
     func `is created`() {
-      #expect(~TestEncodable.self is DynamicEncodableType)
+      #expect(~TestEncodable.self is DynamicCodableType<TestEncodable>)
     }
 
     @Test

--- a/packages/expo-modules-core/ios/Tests/FunctionTests.swift
+++ b/packages/expo-modules-core/ios/Tests/FunctionTests.swift
@@ -46,6 +46,30 @@ struct FunctionTests {
       let version: Int
     }
 
+    struct TestDecodable: Decodable, Equatable, AnyArgument {
+      let name: String
+      let version: Int
+      static func getDynamicType() -> any AnyDynamicType {
+        return DynamicCodableType<TestDecodable>()
+      }
+    }
+
+    struct TestDecodableNested: Decodable, Equatable, AnyArgument {
+      let id: Int
+      let inner: TestDecodable
+      static func getDynamicType() -> any AnyDynamicType {
+        return DynamicCodableType<TestDecodableNested>()
+      }
+    }
+
+    enum TestDecodableDirection: String, Decodable, AnyArgument {
+      case north
+      case south
+      static func getDynamicType() -> any AnyDynamicType {
+        return DynamicCodableType<TestDecodableDirection>()
+      }
+    }
+
     init() {
       appContext = AppContext.create()
 
@@ -130,6 +154,18 @@ struct FunctionTests {
 
         Function("returnEncodable") {
           return TestEncodable(name: "Expo SDK", version: 55)
+        }
+
+        Function("withDecodable") { (input: TestDecodable) -> String in
+          return "\(input.name) v\(input.version)"
+        }
+
+        Function("withNestedDecodable") { (input: TestDecodableNested) -> String in
+          return "\(input.id):\(input.inner.name) v\(input.inner.version)"
+        }
+
+        Function("withDecodableEnum") { (direction: TestDecodableDirection) -> String in
+          return direction.rawValue
         }
 
         Function("withSharedObject") {
@@ -345,6 +381,33 @@ struct FunctionTests {
       #expect(result.getObject().getPropertyNames().contains("version"))
       #expect(try result.getObject().getProperty("name").asString() == "Expo SDK")
       #expect(try result.getObject().getProperty("version").asInt() == 55)
+    }
+
+    @Test
+    func `accepts a Decodable struct argument`() throws {
+      let result = try runtime.eval("expo.modules.TestModule.withDecodable({name: 'Expo SDK', version: 55})")
+      #expect(try result.asString() == "Expo SDK v55")
+    }
+
+    @Test
+    func `accepts a nested Decodable struct argument`() throws {
+      let result = try runtime.eval("""
+        expo.modules.TestModule.withNestedDecodable({id: 7, inner: {name: 'Expo SDK', version: 55}})
+      """)
+      #expect(try result.asString() == "7:Expo SDK v55")
+    }
+
+    @Test
+    func `accepts a Decodable enum argument`() throws {
+      let result = try runtime.eval("expo.modules.TestModule.withDecodableEnum('north')")
+      #expect(try result.asString() == "north")
+    }
+
+    @Test
+    func `throws when a Decodable argument is missing a required field`() throws {
+      #expect(throws: (any Error).self) {
+        try runtime.eval("expo.modules.TestModule.withDecodable({name: 'Expo SDK'})")
+      }
     }
 
     @Test

--- a/packages/expo-modules-core/ios/Tests/JSValueDecoderTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JSValueDecoderTests.swift
@@ -1,0 +1,447 @@
+// Copyright 2026-present 650 Industries. All rights reserved.
+
+import CoreGraphics
+import Foundation
+import Testing
+import ExpoModulesJSI
+
+@testable import ExpoModulesCore
+
+@Suite("JSValueDecoder")
+@JavaScriptActor
+struct JSValueDecoderTests {
+  let appContext = AppContext.create()
+
+  private func decode<ValueType: Decodable>(_ type: ValueType.Type, from source: String) throws -> ValueType {
+    let jsValue = try appContext.runtime.eval(source)
+    let decoder = try JSValueDecoder(value: jsValue, appContext: appContext)
+    return try ValueType(from: decoder)
+  }
+
+  // MARK: - Primitives in single-value container
+
+  @Test
+  func `decodes a string`() throws {
+    #expect(try decode(String.self, from: "'expo'") == "expo")
+  }
+
+  @Test
+  func `decodes an int`() throws {
+    #expect(try decode(Int.self, from: "42") == 42)
+  }
+
+  @Test
+  func `decodes a double`() throws {
+    #expect(try decode(Double.self, from: "3.5") == 3.5)
+  }
+
+  @Test
+  func `decodes a bool`() throws {
+    #expect(try decode(Bool.self, from: "true") == true)
+  }
+
+  @Test
+  func `decodes a top-level nil optional from null`() throws {
+    #expect(try decode(String?.self, from: "null") == nil)
+  }
+
+  @Test
+  func `decodes a top-level present optional`() throws {
+    #expect(try decode(String?.self, from: "'expo'") == "expo")
+  }
+
+  // MARK: - Plain Decodable struct
+
+  @Test
+  func `decodes a flat struct`() throws {
+    struct Point: Decodable, Equatable {
+      let x: Int
+      let y: Int
+    }
+    #expect(try decode(Point.self, from: "({x: 3, y: 4})") == Point(x: 3, y: 4))
+  }
+
+  // MARK: - Nested keyed container
+
+  @Test
+  func `decodes a nested struct`() throws {
+    struct Inner: Decodable, Equatable {
+      let label: String
+    }
+    struct Outer: Decodable, Equatable {
+      let id: Int
+      let inner: Inner
+    }
+
+    let result = try decode(Outer.self, from: "({id: 1, inner: {label: 'hello'}})")
+    #expect(result == Outer(id: 1, inner: Inner(label: "hello")))
+  }
+
+  // MARK: - Arrays
+
+  @Test
+  func `decodes an array of primitives`() throws {
+    #expect(try decode([Int].self, from: "[10, 20, 30]") == [10, 20, 30])
+  }
+
+  @Test
+  func `decodes a struct field that is an array of structs`() throws {
+    struct Item: Decodable, Equatable {
+      let value: Int
+    }
+    struct List: Decodable, Equatable {
+      let items: [Item]
+    }
+
+    let result = try decode(List.self, from: "({items: [{value: 1}, {value: 2}, {value: 3}]})")
+    #expect(result == List(items: [Item(value: 1), Item(value: 2), Item(value: 3)]))
+  }
+
+  // MARK: - Dictionaries
+
+  @Test
+  func `decodes a string-keyed dictionary field`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let counts: [String: Int]
+    }
+    let result = try decode(Wrapper.self, from: "({counts: {a: 1, b: 2}})")
+    #expect(result == Wrapper(counts: ["a": 1, "b": 2]))
+  }
+
+  // MARK: - Optionals
+
+  @Test
+  func `decodes a present optional field`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let label: String?
+    }
+    let result = try decode(Wrapper.self, from: "({label: 'present'})")
+    #expect(result == Wrapper(label: "present"))
+  }
+
+  @Test
+  func `decodes a null optional field as nil`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let label: String?
+    }
+    let result = try decode(Wrapper.self, from: "({label: null})")
+    #expect(result == Wrapper(label: nil))
+  }
+
+  @Test
+  func `decodes a missing optional field as nil`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let label: String?
+    }
+    let result = try decode(Wrapper.self, from: "({})")
+    #expect(result == Wrapper(label: nil))
+  }
+
+  // MARK: - RawRepresentable enums
+
+  @Test
+  func `decodes a string-backed enum field as its raw value`() throws {
+    enum Direction: String, Decodable, Enumerable {
+      case north
+      case south
+    }
+    struct Wrapper: Decodable, Equatable {
+      let direction: Direction
+    }
+
+    let result = try decode(Wrapper.self, from: "({direction: 'north'})")
+    #expect(result == Wrapper(direction: .north))
+  }
+
+  @Test
+  func `decodes an int-backed enum field as its raw value`() throws {
+    enum Code: Int, Decodable, Enumerable {
+      case ok = 200
+      case notFound = 404
+    }
+    struct Wrapper: Decodable, Equatable {
+      let code: Code
+    }
+
+    let result = try decode(Wrapper.self, from: "({code: 404})")
+    #expect(result == Wrapper(code: .notFound))
+  }
+
+  // MARK: - Edge cases
+
+  @Test
+  func `decodes an empty array`() throws {
+    #expect(try decode([Int].self, from: "[]") == [])
+  }
+
+  @Test
+  func `decodes an empty struct`() throws {
+    struct Empty: Decodable, Equatable {}
+    _ = try decode(Empty.self, from: "({})")
+  }
+
+  @Test
+  func `decodes a nested array of arrays`() throws {
+    #expect(try decode([[Int]].self, from: "[[1, 2], [3, 4, 5]]") == [[1, 2], [3, 4, 5]])
+  }
+
+  @Test
+  func `decodes empty strings and zero numbers as themselves`() throws {
+    #expect(try decode(String.self, from: "''") == "")
+    #expect(try decode(Int.self, from: "0") == 0)
+    #expect(try decode(Double.self, from: "0.0") == 0)
+    #expect(try decode(Bool.self, from: "false") == false)
+  }
+
+  // MARK: - All 14 primitive optional fields, nil and present
+
+  @Test
+  func `decodes all primitive nil optional fields`() throws {
+    struct AllNils: Decodable, Equatable {
+      let aBool: Bool?
+      let aString: String?
+      let aDouble: Double?
+      let aFloat: Float?
+      let aInt: Int?
+      let aInt8: Int8?
+      let aInt16: Int16?
+      let aInt32: Int32?
+      let aInt64: Int64?
+      let aUInt: UInt?
+      let aUInt8: UInt8?
+      let aUInt16: UInt16?
+      let aUInt32: UInt32?
+      let aUInt64: UInt64?
+    }
+
+    let source = """
+    ({
+      aBool: null, aString: null, aDouble: null, aFloat: null,
+      aInt: null, aInt8: null, aInt16: null, aInt32: null, aInt64: null,
+      aUInt: null, aUInt8: null, aUInt16: null, aUInt32: null, aUInt64: null
+    })
+    """
+    let result = try decode(AllNils.self, from: source)
+    #expect(result.aBool == nil)
+    #expect(result.aString == nil)
+    #expect(result.aDouble == nil)
+    #expect(result.aFloat == nil)
+    #expect(result.aInt == nil)
+    #expect(result.aInt8 == nil)
+    #expect(result.aInt16 == nil)
+    #expect(result.aInt32 == nil)
+    #expect(result.aInt64 == nil)
+    #expect(result.aUInt == nil)
+    #expect(result.aUInt8 == nil)
+    #expect(result.aUInt16 == nil)
+    #expect(result.aUInt32 == nil)
+    #expect(result.aUInt64 == nil)
+  }
+
+  @Test
+  func `decodes all primitive present optional fields`() throws {
+    struct AllSet: Decodable, Equatable {
+      let aBool: Bool?
+      let aString: String?
+      let aDouble: Double?
+      let aFloat: Float?
+      let aInt: Int?
+      let aInt8: Int8?
+      let aInt16: Int16?
+      let aInt32: Int32?
+      let aInt64: Int64?
+      let aUInt: UInt?
+      let aUInt8: UInt8?
+      let aUInt16: UInt16?
+      let aUInt32: UInt32?
+      let aUInt64: UInt64?
+    }
+
+    let source = """
+    ({
+      aBool: true, aString: 'expo', aDouble: 1.5, aFloat: 2.5,
+      aInt: 7, aInt8: -8, aInt16: -16, aInt32: -32, aInt64: -64,
+      aUInt: 1, aUInt8: 8, aUInt16: 0xFFFF, aUInt32: 32, aUInt64: 64
+    })
+    """
+    let result = try decode(AllSet.self, from: source)
+    #expect(result.aBool == true)
+    #expect(result.aString == "expo")
+    #expect(result.aDouble == 1.5)
+    #expect(result.aFloat == 2.5)
+    #expect(result.aInt == 7)
+    #expect(result.aInt8 == -8)
+    #expect(result.aInt16 == -16)
+    #expect(result.aInt32 == -32)
+    #expect(result.aInt64 == -64)
+    #expect(result.aUInt == 1)
+    #expect(result.aUInt8 == 8)
+    #expect(result.aUInt16 == 0xFFFF)
+    #expect(result.aUInt32 == 32)
+    #expect(result.aUInt64 == 64)
+  }
+
+  // MARK: - Convertible types
+
+  @Test
+  func `decodes a URL field`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let url: URL
+    }
+    let result = try decode(Wrapper.self, from: "({url: 'https://expo.dev/foo'})")
+    #expect(result.url == URL(string: "https://expo.dev/foo")!)
+  }
+
+  @Test
+  func `decodes a CGPoint field`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let point: CGPoint
+    }
+    let result = try decode(Wrapper.self, from: "({point: {x: 10, y: 20}})")
+    #expect(result.point == CGPoint(x: 10, y: 20))
+  }
+
+  @Test
+  func `decodes a CGSize field`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let size: CGSize
+    }
+    let result = try decode(Wrapper.self, from: "({size: {width: 100, height: 200}})")
+    #expect(result.size == CGSize(width: 100, height: 200))
+  }
+
+  @Test
+  func `decodes a CGRect field`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let rect: CGRect
+    }
+    let result = try decode(Wrapper.self, from: "({rect: {x: 1, y: 2, width: 3, height: 4}})")
+    #expect(result.rect == CGRect(x: 1, y: 2, width: 3, height: 4))
+  }
+
+  // MARK: - Optional Convertible
+
+  @Test
+  func `decodes a present optional Convertible field`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let url: URL?
+    }
+    let result = try decode(Wrapper.self, from: "({url: 'https://expo.dev/foo'})")
+    #expect(result.url == URL(string: "https://expo.dev/foo")!)
+  }
+
+  @Test
+  func `decodes a null optional Convertible field as nil`() throws {
+    struct Wrapper: Decodable, Equatable {
+      let url: URL?
+    }
+    let result = try decode(Wrapper.self, from: "({url: null})")
+    #expect(result.url == nil)
+  }
+
+  // MARK: - Top-level collections
+
+  @Test
+  func `decodes a top-level dictionary`() throws {
+    #expect(try decode([String: Int].self, from: "({a: 1, b: 2})") == ["a": 1, "b": 2])
+  }
+
+  @Test
+  func `decodes an array of CGPoint`() throws {
+    let result = try decode([CGPoint].self, from: "[{x: 1, y: 2}, {x: 3, y: 4}]")
+    #expect(result == [CGPoint(x: 1, y: 2), CGPoint(x: 3, y: 4)])
+  }
+
+  // MARK: - Class
+
+  @Test
+  func `decodes a class as a JS object`() throws {
+    final class Person: Decodable {
+      let name: String
+      let age: Int
+    }
+    let result = try decode(Person.self, from: "({name: 'Anna', age: 30})")
+    #expect(result.name == "Anna")
+    #expect(result.age == 30)
+  }
+
+  // MARK: - Error cases
+
+  @Test
+  func `throws keyNotFound for missing non-optional field`() throws {
+    struct Wrapper: Decodable {
+      let required: String
+    }
+    #expect(throws: DecodingError.self) {
+      _ = try decode(Wrapper.self, from: "({})")
+    }
+  }
+
+  @Test
+  func `throws typeMismatch when expecting object but got primitive`() throws {
+    struct Wrapper: Decodable {
+      let value: Int
+    }
+    #expect(throws: DecodingError.self) {
+      _ = try decode(Wrapper.self, from: "42")
+    }
+  }
+
+  @Test
+  func `throws keyNotFound when non-optional field is explicitly undefined`() throws {
+    struct Wrapper: Decodable {
+      let required: String
+    }
+    #expect(throws: DecodingError.self) {
+      _ = try decode(Wrapper.self, from: "({required: undefined})")
+    }
+  }
+
+  @Test
+  func `throws when non-optional field is null`() throws {
+    struct Wrapper: Decodable {
+      let required: String
+    }
+    #expect(throws: DecodingError.self) {
+      _ = try decode(Wrapper.self, from: "({required: null})")
+    }
+  }
+
+  @Test
+  func `throws valueNotFound when unkeyed container is exhausted`() throws {
+    // A struct that asks for more elements than the array provides — forces the
+    // unkeyed container past `isAtEnd` and exercises the guard in `nextValue`.
+    struct ThreeInts: Decodable {
+      let a: Int
+      let b: Int
+      let c: Int
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        self.a = try container.decode(Int.self)
+        self.b = try container.decode(Int.self)
+        self.c = try container.decode(Int.self)
+      }
+    }
+    #expect(throws: DecodingError.self) {
+      _ = try decode(ThreeInts.self, from: "[1, 2]")
+    }
+  }
+
+  // MARK: - Routing through DynamicCodableType
+
+  @Test
+  func `DynamicCodableType cast(jsValue:) decodes a struct end-to-end`() throws {
+    struct User: Decodable, Equatable {
+      let name: String
+      let age: Int
+    }
+
+    let dynamicType = ~User.self
+    #expect(dynamicType is DynamicCodableType<User>)
+
+    let jsValue = try appContext.runtime.eval("({name: 'Anna', age: 30})")
+    let any = try dynamicType.cast(jsValue: jsValue, appContext: appContext)
+    let user = try #require(any as? User)
+    #expect(user == User(name: "Anna", age: 30))
+  }
+}

--- a/packages/expo-modules-core/ios/Tests/JSValueDecoderTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JSValueDecoderTests.swift
@@ -444,4 +444,117 @@ struct JSValueDecoderTests {
     let user = try #require(any as? User)
     #expect(user == User(name: "Anna", age: 30))
   }
+
+  // MARK: - More error cases
+
+  @Test
+  func `throws typeMismatch when expecting array but got primitive`() throws {
+    #expect(throws: DecodingError.self) {
+      _ = try decode([Int].self, from: "42")
+    }
+  }
+
+  @Test
+  func `wraps Convertible coercion failures as dataCorrupted`() throws {
+    struct Wrapper: Decodable {
+      let url: URL
+    }
+    #expect(throws: DecodingError.self) {
+      _ = try decode(Wrapper.self, from: "({url: 42})")
+    }
+  }
+
+  // MARK: - Unkeyed container — direct surface via custom init(from:)
+
+  @Test
+  func `unkeyed decodeNil reports null elements without advancing past non-null`() throws {
+    struct NullThenInt: Decodable {
+      let first: Int?
+      let second: Int
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        if try container.decodeNil() {
+          self.first = nil
+        } else {
+          self.first = try container.decode(Int.self)
+        }
+        self.second = try container.decode(Int.self)
+      }
+    }
+
+    let nullFirst = try decode(NullThenInt.self, from: "[null, 7]")
+    #expect(nullFirst.first == nil)
+    #expect(nullFirst.second == 7)
+
+    let intFirst = try decode(NullThenInt.self, from: "[3, 7]")
+    #expect(intFirst.first == 3)
+    #expect(intFirst.second == 7)
+  }
+
+  @Test
+  func `unkeyed decodeIfPresent returns nil at end and skips null`() throws {
+    struct ThreeMaybeInts: Decodable {
+      let values: [Int?]
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        var collected: [Int?] = []
+        while !container.isAtEnd {
+          collected.append(try container.decodeIfPresent(Int.self))
+        }
+        self.values = collected
+      }
+    }
+
+    let result = try decode(ThreeMaybeInts.self, from: "[1, null, 3]")
+    #expect(result.values == [1, nil, 3])
+  }
+
+  @Test
+  func `unkeyed nestedContainer throws typeMismatch when element is not an object`() throws {
+    struct PullsObject: Decodable {
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        _ = try container.nestedContainer(keyedBy: AnyCodingKey.self)
+      }
+    }
+    #expect(throws: DecodingError.self) {
+      _ = try decode(PullsObject.self, from: "[1]")
+    }
+  }
+
+  @Test
+  func `unkeyed nestedUnkeyedContainer throws typeMismatch when element is not an array`() throws {
+    struct PullsArray: Decodable {
+      init(from decoder: Decoder) throws {
+        var container = try decoder.unkeyedContainer()
+        _ = try container.nestedUnkeyedContainer()
+      }
+    }
+    #expect(throws: DecodingError.self) {
+      _ = try decode(PullsArray.self, from: "[1]")
+    }
+  }
+
+  // MARK: - Keyed container — allKeys / contains
+
+  @Test
+  func `keyed allKeys and contains expose JS object property names`() throws {
+    struct KeyReport: Decodable {
+      let keys: [String]
+      let hasFoo: Bool
+      let hasMissing: Bool
+
+      init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: AnyCodingKey.self)
+        self.keys = container.allKeys.map(\.stringValue).sorted()
+        self.hasFoo = container.contains(AnyCodingKey(stringValue: "foo"))
+        self.hasMissing = container.contains(AnyCodingKey(stringValue: "missing"))
+      }
+    }
+
+    let result = try decode(KeyReport.self, from: "({foo: 1, bar: 2})")
+    #expect(result.keys == ["bar", "foo"])
+    #expect(result.hasFoo == true)
+    #expect(result.hasMissing == false)
+  }
 }

--- a/packages/expo-modules-core/ios/Tests/JSValueEncoderTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JSValueEncoderTests.swift
@@ -431,17 +431,17 @@ struct JSValueEncoderTests {
     #expect(result.getProperty("age").getInt() == 30)
   }
 
-  // MARK: - Routing through DynamicEncodableType
+  // MARK: - Routing through DynamicCodableType
 
   @Test
-  func `DynamicEncodableType castToJS encodes a struct end-to-end`() throws {
+  func `DynamicCodableType castToJS encodes a struct end-to-end`() throws {
     struct User: Encodable {
       let name: String
       let age: Int
     }
 
     let dynamicType = ~User.self
-    #expect(dynamicType is DynamicEncodableType)
+    #expect(dynamicType is DynamicCodableType<User>)
 
     let result = try dynamicType.castToJS(
       User(name: "Anna", age: 30),


### PR DESCRIPTION
## Why

Native modules accept JS arguments through the dynamic-type registry, but plain `Decodable` Swift types had no path: `DynamicEncodableType` only handled the native→JS direction (and threw `fatalError` for `cast(jsValue:)`). This PR adds the JS→native side so a Swift function can declare a `Decodable` argument and receive a JS object decoded through the same coercion rules as records, enums and `Convertible`s.

Stacked on top of #45575 (encoder rewrite) so the routing changes there are reused.

## How

**Unified `DynamicCodableType<InnerType>`** replaces the singleton `DynamicEncodableType`. The registry branch in `DynamicType<T>()` now matches `Encodable` _or_ `Decodable`, and the type is generic so `cast(jsValue:)` knows the static target. `castToJS` still requires `Encodable`; `cast(jsValue:)` requires `Decodable`. Either direction throws cleanly if the wrapped type lacks the conformance it needs.

**New `JSValueDecoder`** mirrors `JSValueEncoder`. For any property whose static type is known to the dynamic-type registry — arrays, dictionaries, optionals, `RawRepresentable` enums, `Convertible`s, `JavaScriptValue` — the decoder takes the fast path through `~T.self.cast(jsValue:)`. Only plain `Decodable` structs/classes fall back to Swift's `Decoder` machinery via `T.init(from: decoder)`.

Three containers (`JSObjectDecodingContainer`, `JSArrayDecodingContainer`, `JSValueDecodingContainer`) mirror the encoder containers. Throws standard `DecodingError` (`keyNotFound`, `typeMismatch`, `valueNotFound`, `dataCorrupted`) so consumer code keeps working with `JSONDecoder` idioms.

### Notable details
- **`decodeIfPresent` override**: Swift's default routes through `contains(key)` + `decodeNil(forKey:)`, missing the dynamic-type fast path. The override fetches the value once and treats `null`/`undefined` as nil — covering both "absent key" and "explicit null" with a single JSI roundtrip.
- **`decode(_:forKey:)`**: collapses "key absent" and "explicit `undefined`" into `keyNotFound` (one `getProperty` call instead of `hasProperty` + `getProperty`). JS doesn't meaningfully distinguish the two at the consumer level.
- **Actor isolation**: `cast(jsValue:)` is `@JavaScriptActor`-isolated. The decoder uses `JavaScriptActor.assumeIsolated { ... }` since it's always reached from an already-isolated caller.

## Performance note

This is intentionally not a perf-first implementation. For hot paths, `Record` types are still meaningfully faster (cached field metadata, no per-call `~T.self` resolution, struct mutation instead of class containers). Codable's appeal here is ergonomics: standard Swift idiom, `JSONDecoder`-compatible, no `@Field` boilerplate. Cache-based wins exist if profiling demands it.

## Tests

Adds `JSValueDecoderTests.swift` with coverage symmetric to the encoder tests:
- primitives in single-value container (string, int, double, bool, empty/zero values)
- top-level optionals (nil + present)
- plain `Decodable` struct (flat + nested)
- arrays (top-level, struct field, of structs, nested array of arrays, empty)
- dictionaries (top-level + as struct field)
- optionals as fields (present, null, absent) — including all 14 primitive overloads in both the nil and present case (`Bool`/`String`/`Double`/`Float`/`Int`/`Int8…64`/`UInt`/`UInt8…64`)
- `RawRepresentable` enums (string-backed and int-backed)
- `Convertible`s: `URL`, `CGPoint`, `CGSize`, `CGRect`, optional `URL`
- empty struct, class instead of struct
- error cases: `keyNotFound` for missing field, `typeMismatch` for wrong shape, explicit `undefined`, `null` on non-optional
- end-to-end via `DynamicCodableType.cast(jsValue:)`

Pre-existing `JSValueEncoderTests` and `DynamicTypeTests` are updated for the `DynamicEncodableType` → `DynamicCodableType<T>` rename.