### PR TITLE
Fix iOS animated image blur radius

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
 - [Android] Fixed `useImage` crashing on SVG sources, and made `maxWidth`/`maxHeight` preserve the SVG's aspect ratio. ([#46077](https://github.com/expo/expo/pull/46077) by [@nishan](https://github.com/intergalacticspacehighway))
-- [iOS] Apply `blurRadius` to animated images. ([#21634](https://github.com/expo/expo/issues/21634) by [@mvincentong](https://github.com/mvincentong))
+- [iOS] Apply `blurRadius` to animated images. ([#21634](https://github.com/expo/expo/issues/21634) by [@mvincentong](https://github.com/mvincentong)) ([#45706](https://github.com/expo/expo/pull/45706) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
 - [Android] Fixed `useImage` crashing on SVG sources, and made `maxWidth`/`maxHeight` preserve the SVG's aspect ratio. ([#46077](https://github.com/expo/expo/pull/46077) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Apply `blurRadius` to animated images. ([#21634](https://github.com/expo/expo/issues/21634) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -28,8 +28,8 @@ public final class ImageView: ExpoView {
   var loadingOptions: SDWebImageOptions = [
     .retryFailed, // Don't blacklist URLs that failed downloading
     .handleCookies, // Handle cookies stored in the shared `HTTPCookieStore`
-    // Images from cache are `AnimatedImage`s. BlurRadius is done via a SDImageBlurTransformer
-    // so this flag needs to be enabled. Beware most transformers cannot manage animated images.
+    // Images from cache are `AnimatedImage`s. Keep animated transform support enabled; per-frame
+    // transforms that are not safe for request-time animation processing are applied below.
     .transformAnimatedImage
   ]
 
@@ -454,13 +454,20 @@ public final class ImageView: ExpoView {
       return nil
     }
     sdImageView.animationTransformer = nil
+
+    let shouldResize = allowDownscaling && shouldDownscale(image: image, toSize: idealSize, scale: scale)
+
+    if image.sd_isAnimated {
+      let resizeSize: CGSize? = shouldResize ? idealSize * scale : nil
+      sdImageView.animationTransformer = createAnimatedImageTransformPipeline(
+        resizeSize: resizeSize,
+        blurRadius: blurRadius
+      )
+      return image
+    }
+
     // Downscale the image only when necessary
-    if allowDownscaling && shouldDownscale(image: image, toSize: idealSize, scale: scale) {
-      if image.sd_isAnimated {
-        let size = idealSize * scale
-        sdImageView.animationTransformer = SDImageResizingTransformer(size: size, scaleMode: .fill)
-        return image
-      }
+    if shouldResize {
       return resize(image: image, toSize: idealSize, scale: scale)
     }
     return image
@@ -854,4 +861,28 @@ func localAssetName(from url: URL?) -> String? {
   }
 
   return path.isEmpty ? nil : path
+}
+
+func createAnimatedImageTransformPipeline(resizeSize: CGSize?, blurRadius: CGFloat) -> SDImageTransformer? {
+  var transformers: [SDImageTransformer] = []
+
+  if let resizeSize {
+    transformers.append(SDImageResizingTransformer(size: resizeSize, scaleMode: .fill))
+  }
+  if blurRadius > 0 {
+    transformers.append(SDImageBlurTransformer(radius: blurRadius))
+  }
+
+  return createImageTransformPipeline(transformers)
+}
+
+func createImageTransformPipeline(_ transformers: [SDImageTransformer]) -> SDImageTransformer? {
+  switch transformers.count {
+  case 0:
+    return nil
+  case 1:
+    return transformers[0]
+  default:
+    return SDImagePipelineTransformer(transformers: transformers)
+  }
 }

--- a/packages/expo-image/ios/Tests/ImageResizingSpec.swift
+++ b/packages/expo-image/ios/Tests/ImageResizingSpec.swift
@@ -1,11 +1,42 @@
 import Foundation
 import ExpoModulesTestCore
+internal import SDWebImage
 
 @testable import ExpoModulesCore
 @testable import ExpoImage
 
 class ImageResizingSpec: ExpoSpec {
   override class func spec() {
+    describe("animated image transform pipeline") {
+      it("returns nil when no animated transforms are needed") {
+        expect(createAnimatedImageTransformPipeline(resizeSize: nil, blurRadius: 0)).to(beNil())
+      }
+
+      it("returns a blur transformer when only blur is needed") {
+        let transformer = createAnimatedImageTransformPipeline(resizeSize: nil, blurRadius: 4)
+
+        expect(transformer).to(beAKindOf(SDImageBlurTransformer.self))
+      }
+
+      it("returns a resize transformer when only resize is needed") {
+        let transformer = createAnimatedImageTransformPipeline(
+          resizeSize: CGSize(width: 100, height: 80),
+          blurRadius: 0
+        )
+
+        expect(transformer).to(beAKindOf(SDImageResizingTransformer.self))
+      }
+
+      it("returns a pipeline when resize and blur are both needed") {
+        let transformer = createAnimatedImageTransformPipeline(
+          resizeSize: CGSize(width: 100, height: 80),
+          blurRadius: 4
+        )
+
+        expect(transformer).to(beAKindOf(SDImagePipelineTransformer.self))
+      }
+    }
+
     describe("ideal size") {
       // For simplicity use the same container size for all tests
       let containerSize = CGSize(width: 150, height: 100)


### PR DESCRIPTION
Why:
- Fixes https://github.com/expo/expo/issues/21634.
- On iOS, animated images were returned from `processImage` before applying `blurRadius` through `SDAnimatedImageView.animationTransformer`, so GIF frames could keep rendering unblurred even though static images used the SDWebImage blur transformer.

How:
- Keeps the existing static-image blur transformer path unchanged.
- Builds an animated-image transformer pipeline for `SDAnimatedImageView.animationTransformer` that preserves the existing animated resize behavior and adds `SDImageBlurTransformer` when `blurRadius > 0`.
- Adds focused iOS unit coverage for the animated transform helper: no-op, blur-only, resize-only, and resize-plus-blur.
- Context7 SDWebImage docs/examples were consulted for `SDAnimatedImageView.animationTransformer`; they show per-frame transforms are the intended path for animated image rendering.

Test Plan:
- `pnpm --filter expo-image lint` - passed.
- `pnpm --filter expo-image build` - passed.
- `git diff --check` and `git diff --cached --check` - passed.
- `pnpm --filter expo-image test` - attempted; exits with "No tests found" because the package Jest script has no JS tests.
- `et native-unit-tests --packages expo-image -p ios` - attempted; runner found `ExpoImage-Unit-Tests` but failed before running tests because the local Ruby bundle is missing required gems, including `fastlane`, `cocoapods`, and `xcpretty`.

Risk:
- Changed files: 1 iOS source file, 1 iOS test file, 1 changelog entry.
- No generated output changed after `pnpm --filter expo-image build`.
- Main risk is iOS animated-image rendering behavior; scope is limited to animated images and keeps the existing static blur request transformer unchanged.
