### PR TITLE
[image-manipulator][Android] Fix scoped cache output

### DIFF
--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Save manipulated images in the scoped cache directory. ([#22141](https://github.com/expo/expo/issues/22141) by [@mvincentong](https://github.com/mvincentong))
+- [Android] Save manipulated images in the scoped cache directory. ([#45708](https://github.com/expo/expo/pull/45708) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-image-manipulator/CHANGELOG.md
+++ b/packages/expo-image-manipulator/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Save manipulated images in the scoped cache directory. ([#22141](https://github.com/expo/expo/issues/22141) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-11

--- a/packages/expo-image-manipulator/android/build.gradle
+++ b/packages/expo-image-manipulator/android/build.gradle
@@ -13,3 +13,8 @@ android {
     versionName "56.0.6"
   }
 }
+
+dependencies {
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.robolectric:robolectric:4.16'
+}

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/FileUtils.kt
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/FileUtils.kt
@@ -1,14 +1,13 @@
 package expo.modules.imagemanipulator
 
-import android.content.Context
 import java.io.File
 import java.io.IOException
 import java.util.*
 
 internal object FileUtils {
   @Throws(IOException::class)
-  fun generateRandomOutputPath(context: Context, imageFormat: ImageFormat): String {
-    val directory = File("${context.cacheDir}${File.separator}ImageManipulator")
+  fun generateRandomOutputPath(cacheDirectory: File, imageFormat: ImageFormat): String {
+    val directory = File(cacheDirectory, "ImageManipulator")
     ensureDirExists(directory)
     return "${directory}${File.separator}${UUID.randomUUID()}${imageFormat.fileExtension}"
   }

--- a/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt
+++ b/packages/expo-image-manipulator/android/src/main/java/expo/modules/imagemanipulator/ImageManipulatorModule.kt
@@ -1,6 +1,5 @@
 package expo.modules.imagemanipulator
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
@@ -29,9 +28,6 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 class ImageManipulatorModule : Module() {
-  private val context: Context
-    get() = appContext.reactContext ?: throw Exceptions.ReactContextLost()
-
   private fun createManipulatorContext(url: Uri): ImageManipulatorContext {
     val loader = suspend {
       val imageLoader = appContext.service<ImageLoaderInterface>()
@@ -116,7 +112,7 @@ class ImageManipulatorModule : Module() {
 
       AsyncFunction("saveAsync") Coroutine { image: ImageRef, options: ManipulateOptions? ->
         val options = options ?: ManipulateOptions()
-        val path = FileUtils.generateRandomOutputPath(context, options.format)
+        val path = FileUtils.generateRandomOutputPath(appContext.cacheDirectory, options.format)
         val compression = (options.compress * 100).toInt()
         val resultBitmap = image.ref
 

--- a/packages/expo-image-manipulator/android/src/test/java/expo/modules/imagemanipulator/FileUtilsTest.kt
+++ b/packages/expo-image-manipulator/android/src/test/java/expo/modules/imagemanipulator/FileUtilsTest.kt
@@ -1,0 +1,25 @@
+package expo.modules.imagemanipulator
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+import kotlin.io.path.createTempDirectory
+
+@RunWith(RobolectricTestRunner::class)
+class FileUtilsTest {
+  @Test
+  fun generateRandomOutputPathUsesProvidedCacheDirectory() {
+    val cacheDirectory = createTempDirectory("image-manipulator-cache").toFile()
+
+    val outputPath = FileUtils.generateRandomOutputPath(cacheDirectory, ImageFormat.JPEG)
+    val outputFile = File(outputPath)
+    val expectedDirectory = File(cacheDirectory, "ImageManipulator")
+
+    assertEquals(expectedDirectory.canonicalPath, outputFile.parentFile?.canonicalPath)
+    assertTrue(expectedDirectory.isDirectory)
+    assertTrue(outputFile.name.endsWith(".jpg"))
+  }
+}


### PR DESCRIPTION
Why

Fixes #22141.

On Android, expo-image-manipulator saved manipulated images under the host React context cache directory. In Expo Go, file permissions are scoped around the appContext cache directory, so the URI returned from saveAsync could point outside the scoped cache path and fail when passed to expo-file-system operations like moveAsync.

How

Pass appContext.cacheDirectory into the image manipulator output path helper and create the ImageManipulator output directory under that scoped cache path. The change keeps the existing output naming and save flow intact, and adds a focused Android unit test for the generated output directory.

Test Plan

- pnpm --filter expo-image-manipulator lint - passed
- pnpm --filter expo-image-manipulator build - passed
- pnpm --filter expo-image-manipulator test - passed
- env ANDROID_HOME=/Users/mvincentong/Library/Android/sdk et native-unit-tests --packages expo-image-manipulator -p android - passed
- git diff --check - passed
- git diff --cached --check - passed

Risk

Low. The change only moves the generated output file into the module scoped cache directory while preserving the same ImageManipulator subdirectory, file extension, compression, and response shape.