### PR TITLE
Avoid remounting Compose views during reparenting

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Avoid remounting Jetpack Compose views during same-frame React Native reparenting. ([#45711](https://github.com/expo/expo/pull/45711) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.7 — 2026-05-13

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -193,13 +193,11 @@ abstract class ExpoComposeView<T : ComposeProps>(
           Content()
         }
       }
-      it.addOnAttachStateChangeListener(object : OnAttachStateChangeListener {
-        override fun onViewAttachedToWindow(v: View) {
+      it.addOnAttachStateChangeListener(
+        OnAttachAfterDetachmentListener(onAttachAfterDetachment = {
           it.disposeComposition()
-        }
-
-        override fun onViewDetachedFromWindow(v: View) = Unit
-      })
+        })
+      )
     }
     addView(composeView)
   }

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/OnAttachAfterDetachmentListener.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/views/OnAttachAfterDetachmentListener.kt
@@ -1,0 +1,41 @@
+package expo.modules.kotlin.views
+
+import android.os.Handler
+import android.os.Looper
+import android.view.View
+
+/**
+ * Runs a callback only when a view is attached after staying detached through one main-loop turn.
+ * React Native can synchronously detach and reattach native children during view reparenting, and
+ * those moves should not be treated like a full detach.
+ */
+internal class OnAttachAfterDetachmentListener(
+  private val onAttachAfterDetachment: () -> Unit,
+  private val post: (Runnable) -> Unit = { runnable ->
+    Handler(Looper.getMainLooper()).post(runnable)
+  }
+) : View.OnAttachStateChangeListener {
+  private var shouldRunOnAttach = false
+  private var detachGeneration = 0
+
+  override fun onViewAttachedToWindow(v: View) {
+    detachGeneration += 1
+
+    if (shouldRunOnAttach) {
+      shouldRunOnAttach = false
+      onAttachAfterDetachment()
+    }
+  }
+
+  override fun onViewDetachedFromWindow(v: View) {
+    val generation = ++detachGeneration
+
+    post(
+      Runnable {
+        if (detachGeneration == generation && !v.isAttachedToWindow) {
+          shouldRunOnAttach = true
+        }
+      }
+    )
+  }
+}

--- a/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/OnAttachAfterDetachmentListenerTest.kt
+++ b/packages/expo-modules-core/android/src/test/java/expo/modules/kotlin/views/OnAttachAfterDetachmentListenerTest.kt
@@ -1,0 +1,67 @@
+package expo.modules.kotlin.views
+
+import android.view.View
+import com.google.common.truth.Truth
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+
+class OnAttachAfterDetachmentListenerTest {
+  @Test
+  fun `does not run callback when view reattaches before detach check`() {
+    val view = mockk<View>()
+    val postedRunnables = mutableListOf<Runnable>()
+    var callbackCount = 0
+    every { view.isAttachedToWindow } returns false
+
+    val listener = OnAttachAfterDetachmentListener(
+      onAttachAfterDetachment = { callbackCount += 1 },
+      post = { postedRunnables.add(it) }
+    )
+
+    listener.onViewDetachedFromWindow(view)
+    listener.onViewAttachedToWindow(view)
+    postedRunnables.single().run()
+
+    Truth.assertThat(callbackCount).isEqualTo(0)
+  }
+
+  @Test
+  fun `runs callback when view reattaches after detach check`() {
+    val view = mockk<View>()
+    val postedRunnables = mutableListOf<Runnable>()
+    var callbackCount = 0
+    every { view.isAttachedToWindow } returns false
+
+    val listener = OnAttachAfterDetachmentListener(
+      onAttachAfterDetachment = { callbackCount += 1 },
+      post = { postedRunnables.add(it) }
+    )
+
+    listener.onViewDetachedFromWindow(view)
+    postedRunnables.single().run()
+    listener.onViewAttachedToWindow(view)
+
+    Truth.assertThat(callbackCount).isEqualTo(1)
+  }
+
+  @Test
+  fun `runs callback only once for a completed detach cycle`() {
+    val view = mockk<View>()
+    val postedRunnables = mutableListOf<Runnable>()
+    var callbackCount = 0
+    every { view.isAttachedToWindow } returns false
+
+    val listener = OnAttachAfterDetachmentListener(
+      onAttachAfterDetachment = { callbackCount += 1 },
+      post = { postedRunnables.add(it) }
+    )
+
+    listener.onViewDetachedFromWindow(view)
+    postedRunnables.single().run()
+    listener.onViewAttachedToWindow(view)
+    listener.onViewAttachedToWindow(view)
+
+    Truth.assertThat(callbackCount).isEqualTo(1)
+  }
+}


### PR DESCRIPTION
Why

Fixes #36921.

`ExpoComposeView` currently disposes its child `ComposeView` composition every time the child attaches. That preserves the previous navigation workaround for compose views that were detached and later shown again, but it also means React Native same-turn reparenting can recreate every Compose composition. Toggling a parent `importantForAccessibility` value from or to `auto` can synchronously detach and reattach native children, so a screen with many Compose views remounts all of them and janks.

I checked the current Android Compose interop guidance via Context7. `DisposeOnViewTreeLifecycleDestroyed` is the recommended strategy when the lifecycle owner should control disposal, while detach-based strategies can lose state during temporary view moves. This PR keeps the lifecycle strategy and avoids treating same-turn reparenting like a full detach.

How

Add a small Android attach-state listener in `expo-modules-core` that runs its callback only when a view stayed detached through one main-loop turn and then attaches again. `ExpoComposeView` now uses that listener before calling `disposeComposition()`. This keeps the existing delayed reattach/navigation behavior while skipping disposal for synchronous RN reparenting during prop updates.

Changed package: `expo-modules-core` only.

Test Plan

- env ANDROID_HOME=/Users/mvincentong/Library/Android/sdk et native-unit-tests --packages expo-modules-core -p android - passed
- pnpm --filter expo-modules-core lint - passed
- pnpm --filter expo-modules-core test - passed; existing React act warnings in PermissionsHook tests were printed, all 22 suites / 168 tests passed
- pnpm --filter expo-modules-core build - passed
- git diff --check - passed
- git diff --cached --check - passed

Risk

Low to medium. The source diff is scoped to one helper, one ComposeView call site, one focused unit test file, and one changelog entry. No generated output changed. The remaining risk is around the existing navigation workaround from #34689; this PR preserves disposal after a completed detach cycle instead of removing it outright.