### PR TITLE
[docs] Clarify NODE_ENV's purpose in environment variables guide

### DIFF
--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -66,6 +66,8 @@ You may choose to commit the default **.env** file or other standard configurati
 
 #### Environment variables and `NODE_ENV`
 
+`NODE_ENV` is the standard Node.js variable that identifies the current mode (`development`, `production`, or `test`). Expo CLI sets it automatically for you in commands like `npx expo start` (sets `development`) and `npx expo export` (forces `production`), so you typically don't need to set it manually. The guidance below is about not using `NODE_ENV` to alter which **.env** file is loaded &mdash; not about avoiding `NODE_ENV` altogether.
+
 We recommend against using `NODE_ENV` to switch between **.env** files (such as **.env.test** and **.env.production**). While it is technically possible (`NODE_ENV=test npx expo start` will load **.env.test**) &mdash; it may not behave as you would expect. For example, `npx expo export` always forces `NODE_ENV` to `production`, so `NODE_ENV=test npx expo export` will not actually run the command with the `NODE_ENV` set to `test`.
 
 Other tools that build on top of Expo CLI commands will exhibit the same behavior &mdash; for example, `eas update` calls into `npx expo export` and, as a result, `NODE_ENV=test eas update` will similarly not run with the `NODE_ENV` set to `test` (it will be `production`). The `NODE_ENV` environment variable is used by many tools in different ways (for example, if you run `NODE_ENV=production npm install` then your `devDependencies` will not be installed) and we have found that for React Native projects, it's best not to overload it further for this use case.

--- a/docs/pages/guides/environment-variables.mdx
+++ b/docs/pages/guides/environment-variables.mdx
@@ -66,7 +66,7 @@ You may choose to commit the default **.env** file or other standard configurati
 
 #### Environment variables and `NODE_ENV`
 
-`NODE_ENV` is the standard Node.js variable that identifies the current mode (`development`, `production`, or `test`). Expo CLI sets it automatically for you in commands like `npx expo start` (sets `development`) and `npx expo export` (forces `production`), so you typically don't need to set it manually. The guidance below is about not using `NODE_ENV` to alter which **.env** file is loaded &mdash; not about avoiding `NODE_ENV` altogether.
+`NODE_ENV` is the standard Node.js variable that identifies which mode your code is running in (typically `development`, `production`, or `test`). Tools like module resolvers, bundlers, and test runners read it to decide how to build, install, or run your code.
 
 We recommend against using `NODE_ENV` to switch between **.env** files (such as **.env.test** and **.env.production**). While it is technically possible (`NODE_ENV=test npx expo start` will load **.env.test**) &mdash; it may not behave as you would expect. For example, `npx expo export` always forces `NODE_ENV` to `production`, so `NODE_ENV=test npx expo export` will not actually run the command with the `NODE_ENV` set to `test`.
 


### PR DESCRIPTION
# Why

Fixes #39842.

The `Environment variables and NODE_ENV` section in `docs/pages/guides/environment-variables.mdx` opens with `"We recommend against using NODE_ENV..."` without first defining what `NODE_ENV` is or noting that Expo CLI sets it automatically. Readers who then encounter `"The NODE_ENV environment variable is required but was not specified"` from `@expo/env` see the two as contradictory.

In the issue, @kitten confirmed this and suggested the docs `"could be extended to clarify NODE_ENV's purpose and definition"`.

# How

Added a short intro paragraph at the top of the `Environment variables and NODE_ENV` section. It:

1. Defines `NODE_ENV` as the standard Node.js variable for `development` / `production` / `test`.
2. Notes that Expo CLI sets it automatically (`npx expo start` → `development`, `npx expo export` → `production`), so manual setting is usually unnecessary.
3. Clarifies that the recommendation that follows is specifically about not using `NODE_ENV` to alter which `.env` file is loaded — not about avoiding `NODE_ENV` altogether.

The existing three paragraphs are unchanged.

### Diff

```diff
  #### Environment variables and `NODE_ENV`

+ `NODE_ENV` is the standard Node.js variable that identifies the current mode (`development`, `production`, or `test`). Expo CLI sets it automatically for you in commands like `npx expo start` (sets `development`) and `npx expo export` (forces `production`), so you typically don't need to set it manually. The guidance below is about not using `NODE_ENV` to alter which **.env** file is loaded — not about avoiding `NODE_ENV` altogether.
+
  We recommend against using `NODE_ENV` to switch between **.env** files (such as **.env.test** and **.env.production**)...
```

# Test Plan

- Verified the rendered page at http://localhost:3002/guides/environment-variables#environment-variables-and-node_env — new paragraph appears between the heading and the existing `"We recommend against..."` paragraph; inline code, bold `.env`, and the em-dash all render correctly.
- Ran `pnpm lint` in `docs/` — all four checks pass (`oxfmt`, `oxlint`, `tsc`, `eslint`).

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources — N/A (docs-only change in `docs/pages/guides/`, no package touched)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — N/A (docs-only change)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) (sentence case, inline code in backticks, active voice, second person)
