### PR TITLE
[widgets] Fix module precompile dependencies

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix module precompile.
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-11

--- a/packages/expo-widgets/spm.config.json
+++ b/packages/expo-widgets/spm.config.json
@@ -12,6 +12,7 @@
         "React",
         "Hermes",
         "expo-modules-core/ExpoModulesCore",
+        "expo-modules-core/ExpoModulesWorklets",
         "@expo/ui/ExpoUI"
       ],
       "targets": [
@@ -25,6 +26,7 @@
             "React",
             "Hermes",
             "expo-modules-core/ExpoModulesCore",
+            "expo-modules-core/ExpoModulesWorklets",
             "@expo/ui/ExpoUI"
           ],
           "linkedFrameworks": [


### PR DESCRIPTION
# Why

The smoke test precompile step is currently failing because expo-ui's dependency is missing during the build.

# How

Add `ExpoModulesWorklets` as an explicit dependency.

# Test Plan

CI should be green.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
