### PR TITLE
[docs][router] Fix broken anchor in URL parameters hash support section

### DIFF
--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -338,7 +338,7 @@ export default function Route() {
 
 ## Hash support
 
-The URL [hash](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash) is a string that follows the `#` symbol in a URL. It is commonly used on websites to link to a specific section of a page, but it can also be used to store data. Expo Router treats the hash as a special search parameter using the name `#`. It can be accessed and modified using the same hooks and APIs from [search parameters](#local-versus-global-search-parameters).
+The URL [hash](https://developer.mozilla.org/en-US/docs/Web/API/URL/hash) is a string that follows the `#` symbol in a URL. It is commonly used on websites to link to a specific section of a page, but it can also be used to store data. Expo Router treats the hash as a special search parameter using the name `#`. It can be accessed and modified using the same hooks and APIs from [search parameters](#local-versus-global-url-parameters).
 
 {/* prettier-ignore */}
 ```tsx src/app/hash.tsx


### PR DESCRIPTION
# Why

The "Hash support" section in `docs/pages/router/reference/url-parameters.mdx` links to `#local-versus-global-search-parameters`, but that anchor doesn't exist on the page — the corresponding heading is `## Local versus global URL parameters` (slug `local-versus-global-url-parameters`).

The anchor became stale after #29799 renamed the section from "search parameters" to "URL parameters" to encompass both route and search params. The cross-link in the Hash support section was missed during that rename.

Result: clicking "search parameters" in the Hash support paragraph does nothing.

# How

Updated the anchor in the "Hash support" section to match the current heading slug.

### Diff

```diff
- It can be accessed and modified using the same hooks and APIs from [search parameters](#local-versus-global-search-parameters).
+ It can be accessed and modified using the same hooks and APIs from [search parameters](#local-versus-global-url-parameters).
```

# Test Plan

- Verified on http://localhost:3002/router/reference/url-parameters — clicking the "search parameters" link in the Hash support section now scrolls to the "Local versus global URL parameters" heading.
- Ran `pnpm lint` in `docs/` — all four checks pass (`oxfmt`, `oxlint`, `tsc`, `eslint`).

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources — N/A (docs-only change)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — N/A (docs-only change)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
