### PR TITLE
[test-core] Use `workspace` notation for dependecies

### DIFF
--- a/packages/expo-modules-test-core/package.json
+++ b/packages/expo-modules-test-core/package.json
@@ -36,6 +36,6 @@
     "prettier": "^3.0.3",
     "xml-js": "^1.6.11",
     "yaml": "^2.8.3",
-    "expo-type-information": "^0.0.1"
+    "expo-type-information": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4919,7 +4919,7 @@ importers:
         specifier: ^22.14.0
         version: 22.19.15
       expo-type-information:
-        specifier: ^0.0.1
+        specifier: workspace:*
         version: link:../expo-type-information
       glob:
         specifier: ^13.0.0


### PR DESCRIPTION
# Why

Uses `workspace` notation for `expo-type-information` instead of a hardcoded version. 
