### PR TITLE
[expo-modules-jsi] Add facebook.jsi.IRuntime support

### DIFF
--- a/apps/bare-expo/ios/Podfile.lock
+++ b/apps/bare-expo/ios/Podfile.lock
@@ -4048,7 +4048,7 @@ SPEC CHECKSUMS:
   EXUpdates: a736b2b35ca152b45b5abf0c2d45409a7deee697
   EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 725fd85144e1348879039099a6be950c471a4f2c
+  hermes-engine: 407f52f1dca2c25263c5f76e80cc38a39e0f6ec0
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4066,7 +4066,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: fde6815789f6abf356769ef91706ab8edd09483e
+  React-Core-prebuilt: ee944566afb140e48954ed57c988acfc3d610fe9
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -4137,7 +4137,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 4a6399e11baf2544e971652efe65e3d3f29d5080
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: 3d528364388addff90003964f5c3a003b40939d2
+  ReactNativeDependencies: 81b14f08cc6fcb035f2200f62cc405372b032428
   RNCAsyncStorage: 2ad919e88b8bc2cd80e8697ce66d04d006743283
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNCPicker: d74667bdfc08ed389a2a277d95b8faf2349290a9

--- a/apps/brownfield-tester/integrated/ios/Podfile.lock
+++ b/apps/brownfield-tester/integrated/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - EXConstants (56.0.1):
+  - EXConstants (56.0.9):
     - ExpoModulesCore
   - EXJSONUtils (56.0.0)
-  - EXManifests (56.0.1):
+  - EXManifests (56.0.3):
     - ExpoModulesCore
-  - Expo (56.0.0-preview.2):
+  - Expo (56.0.0-preview.10):
     - ExpoModulesCore
     - ExpoModulesJSI
     - hermes-engine
@@ -30,8 +30,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu (56.0.0):
-    - expo-dev-menu/Main (= 56.0.0)
+  - expo-dev-menu (56.0.8):
+    - expo-dev-menu/Main (= 56.0.8)
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -53,8 +53,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu-interface (56.0.0)
-  - expo-dev-menu/Main (56.0.0):
+  - expo-dev-menu-interface (56.0.1)
+  - expo-dev-menu/Main (56.0.8):
     - EXManifests
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -80,34 +80,34 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoAsset (56.0.1):
+  - ExpoAsset (56.0.8):
     - ExpoModulesCore
-  - ExpoBrownfield (56.0.0):
+  - ExpoBrownfield (56.0.8):
     - ExpoModulesCore
-  - ExpoDevice (56.0.1):
+  - ExpoDevice (56.0.4):
     - ExpoModulesCore
-  - ExpoDomWebView (56.0.1):
+  - ExpoDomWebView (56.0.4):
     - ExpoModulesCore
-  - ExpoFileSystem (56.0.1):
+  - ExpoFileSystem (56.0.4):
     - ExpoModulesCore
-  - ExpoFont (56.0.1):
+  - ExpoFont (56.0.3):
     - ExpoModulesCore
-  - ExpoGlassEffect (56.0.1):
+  - ExpoGlassEffect (56.0.4):
     - ExpoModulesCore
-  - ExpoImage (56.0.1):
+  - ExpoImage (56.0.4):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoKeepAwake (56.0.1):
+  - ExpoKeepAwake (56.0.3):
     - ExpoModulesCore
-  - ExpoLinking (56.0.0):
+  - ExpoLinking (56.0.6):
     - ExpoModulesCore
-  - ExpoLogBox (56.0.1):
+  - ExpoLogBox (56.0.8):
     - React-Core
-  - ExpoModulesCore (56.0.0):
+  - ExpoModulesCore (56.0.7):
     - ExpoModulesJSI
     - hermes-engine
     - RCTRequired
@@ -131,30 +131,29 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoModulesJSI (56.0.0):
+  - ExpoModulesJSI (56.0.3):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
-  - ExpoModulesWorklets (56.0.0):
+  - ExpoModulesWorklets (56.0.7):
     - ExpoModulesCore
     - ExpoModulesJSI
-  - ExpoModulesWorkletsAdapter (56.0.0):
+  - ExpoModulesWorkletsAdapter (56.0.7):
     - ExpoModulesCore
     - ExpoModulesJSI
     - ExpoModulesWorklets
     - RNWorklets
-  - ExpoRouter (56.0.1):
+  - ExpoRouter (56.1.4):
     - ExpoModulesCore
     - RNScreens
-  - ExpoSymbols (56.0.1):
+  - ExpoSymbols (56.0.5):
     - ExpoModulesCore
-  - ExpoSystemUI (56.0.1):
+  - ExpoSystemUI (56.0.4):
     - ExpoModulesCore
-  - ExpoUI (56.0.1):
+  - ExpoUI (56.0.6):
     - ExpoModulesCore
     - ExpoModulesWorklets
     - React-RCTFabric
-  - ExpoWebBrowser (56.0.1):
+  - ExpoWebBrowser (56.0.4):
     - ExpoModulesCore
   - FBLazyVector (0.85.3)
   - hermes-engine (250829098.0.10):
@@ -2074,7 +2073,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNReanimated (4.3.0):
+  - RNReanimated (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2097,36 +2096,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/apple (= 4.3.0)
-    - RNReanimated/common (= 4.3.0)
+    - RNReanimated/apple (= 4.3.1)
+    - RNReanimated/common (= 4.3.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/apple (4.3.0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-jsitooling
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - RNWorklets
-    - Yoga
-  - RNReanimated/common (4.3.0):
+  - RNReanimated/apple (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2151,7 +2125,32 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.25.0-beta.1):
+  - RNReanimated/common (4.3.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-jsitooling
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - RNWorklets
+    - Yoga
+  - RNScreens (4.25.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2173,9 +2172,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.25.0-beta.1)
+    - RNScreens/common (= 4.25.0)
     - Yoga
-  - RNScreens/common (4.25.0-beta.1):
+  - RNScreens/common (4.25.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2389,8 +2388,8 @@ DEPENDENCIES:
   - "ReactNativeDependencies (from `../../../../node_modules/.pnpm/react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-preset@0.85.3_@babel+core@7.2_87b68a5d07f50c0f905b0a793dc3ac61/node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)"
   - "RNCMaskedView (from `../../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.85.3_@babel+core@7.29.0_@rea_da87b02ae003a7f77089f8e22aa53d01/node_modules/@react-native-masked-view/masked-view`)"
   - "RNGestureHandler (from `../../../../node_modules/.pnpm/react-native-gesture-handler@2.30.0_react-native@0.85.3_@babel+core@7.29.0_@react-nativ_9a6358180c81a5519b6da847dcb246ed/node_modules/react-native-gesture-handler`)"
-  - "RNReanimated (from `../../../../node_modules/.pnpm/react-native-reanimated@4.3.0_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_c36a92bb9a27c676b0bae54fbc6a1908/node_modules/react-native-reanimated`)"
-  - "RNScreens (from `../../../../node_modules/.pnpm/react-native-screens@4.25.0-beta.1_react-native@0.85.3_@babel+core@7.29.0_@react-native_1106fa305397b6dce5495e57c42d635a/node_modules/react-native-screens`)"
+  - "RNReanimated (from `../../../../node_modules/.pnpm/react-native-reanimated@4.3.1_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_1a5e3d09dfc1ab41347a1ceaceaf61bc/node_modules/react-native-reanimated`)"
+  - "RNScreens (from `../../../../node_modules/.pnpm/react-native-screens@4.25.0_react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-p_27bafc37770a4b472b96129a8e818eae/node_modules/react-native-screens`)"
   - "RNWorklets (from `../../../../node_modules/.pnpm/react-native-worklets@0.8.3_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_42b4111e02dad0db2c0db5ed881424fc/node_modules/react-native-worklets`)"
   - "Yoga (from `../../../../node_modules/.pnpm/react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-preset@0.85.3_@babel+core@7.2_87b68a5d07f50c0f905b0a793dc3ac61/node_modules/react-native/ReactCommon/yoga`)"
 
@@ -2611,43 +2610,43 @@ EXTERNAL SOURCES:
   RNGestureHandler:
     :path: "../../../../node_modules/.pnpm/react-native-gesture-handler@2.30.0_react-native@0.85.3_@babel+core@7.29.0_@react-nativ_9a6358180c81a5519b6da847dcb246ed/node_modules/react-native-gesture-handler"
   RNReanimated:
-    :path: "../../../../node_modules/.pnpm/react-native-reanimated@4.3.0_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_c36a92bb9a27c676b0bae54fbc6a1908/node_modules/react-native-reanimated"
+    :path: "../../../../node_modules/.pnpm/react-native-reanimated@4.3.1_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_1a5e3d09dfc1ab41347a1ceaceaf61bc/node_modules/react-native-reanimated"
   RNScreens:
-    :path: "../../../../node_modules/.pnpm/react-native-screens@4.25.0-beta.1_react-native@0.85.3_@babel+core@7.29.0_@react-native_1106fa305397b6dce5495e57c42d635a/node_modules/react-native-screens"
+    :path: "../../../../node_modules/.pnpm/react-native-screens@4.25.0_react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-p_27bafc37770a4b472b96129a8e818eae/node_modules/react-native-screens"
   RNWorklets:
     :path: "../../../../node_modules/.pnpm/react-native-worklets@0.8.3_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_42b4111e02dad0db2c0db5ed881424fc/node_modules/react-native-worklets"
   Yoga:
     :path: "../../../../node_modules/.pnpm/react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-preset@0.85.3_@babel+core@7.2_87b68a5d07f50c0f905b0a793dc3ac61/node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EXConstants: 4566f0d13529256a948e0e757c689ed62eadc33f
+  EXConstants: b9b5efac469bb032f9bf7507a2fe3df3508a4ff3
   EXJSONUtils: dba2755f4e24009eaf87a876b2d615ea06c16e42
-  EXManifests: 23fadfe43e47a071950a5d2cc698e2ec9e869af6
-  Expo: b58705d25d040c50297d0a42e7e9bafbd5edbd38
-  expo-dev-menu: 9ff0583e2561b819aae98e4d1d3c66a737c18699
-  expo-dev-menu-interface: de90cd44d311f247f5cb599aaedc44b2a3739f53
-  ExpoAsset: 705ac2c9a4efe8f68ed83ebc4c4bd2f335513122
-  ExpoBrownfield: 42fab7dca07231ccf968358820afe0de674620d4
-  ExpoDevice: 687a6a9f1119a062e411479daebaa98db2df9baf
-  ExpoDomWebView: 418bc24c668bf84ed99187cdef4733dc294f1af1
-  ExpoFileSystem: 9087d62edbffa4565e4b4568fab5db0528d810ac
-  ExpoFont: a82790c3ad1bee08435ab3359bf87218ce20f858
-  ExpoGlassEffect: 22eecdd9abf6600bff806f2d3fe38ac8e8efabe0
-  ExpoImage: fa4120fb31153caeee95d748c1c609ae7c888ae9
-  ExpoKeepAwake: e889b7d99d846a45458baf9cf5a1d1cc96ee7b48
-  ExpoLinking: 4e2e8c58e148dd22a6cfda744796abf36bae8787
-  ExpoLogBox: ff246a45c7fc0827f9460af43dda85759eea2354
-  ExpoModulesCore: 83913161a08b2e283e96fb814fb7204524b63f75
-  ExpoModulesJSI: ea32f68254fb0bb09198bc0b40489d4a9df4c708
-  ExpoModulesWorklets: 8bcb73d4467bf0363e0eb1f8a040fe1e37c18f79
-  ExpoModulesWorkletsAdapter: 5631cef4d9e611930b01dae859a6ffa6f1bdf1b4
-  ExpoRouter: 3c50a81167c9621bc47d2376e12e5d0c2853be29
-  ExpoSymbols: 1103331f1192e922fef6a8f3f96bf6be446dc8a9
-  ExpoSystemUI: a8225377947e7066d86eb041c9b45f0835a2015f
-  ExpoUI: 378f546ff55a433636e7f09d0fad1792b20bf9f1
-  ExpoWebBrowser: d7c838c799939f1f7574a54b691b501da9a2996e
+  EXManifests: 67869a6d8efa7cb53a7b8b53f451d378c124073f
+  Expo: 44aecef3556a88407ec4aaa4f1d672088c7d85ef
+  expo-dev-menu: 422a6a7188c134d0b7e72748e7b622133e0fe916
+  expo-dev-menu-interface: 65402d4affb8b418aa6cec29b3abb0e313c8f443
+  ExpoAsset: cd59c97de137fe4af1efe5033d2c660f85f0442d
+  ExpoBrownfield: b52c7e9382071d03325ffe08ea4da5ac40770992
+  ExpoDevice: f527f8bbefa6efa12f8ef63e9038dd1d5d903697
+  ExpoDomWebView: 6061a678d7b9a4d3e9b456b651cd2031b4186f56
+  ExpoFileSystem: 16e678f837808810b2bc562570976b04414eda67
+  ExpoFont: 8b9b7b0fe8a5e563a69e7b132749e50a85afb6e4
+  ExpoGlassEffect: 7d4233dc0727ee2b28dd757eda70e1b6abf662fd
+  ExpoImage: 59f71ed6d030241ffadead114064cfd01bd0dc12
+  ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
+  ExpoLinking: 04f9f1792a62699d115ba25fcbbf7136f69acdf5
+  ExpoLogBox: f5bb088ecceacdaf4adc5813b93f4cd6459fb27b
+  ExpoModulesCore: 575102f00470ad80a763c1a6b7ef952d668800ca
+  ExpoModulesJSI: f672bac18356446b024588f7a77b364d80909e71
+  ExpoModulesWorklets: d7a299391940073b848863bfe6b3d4be3541a83c
+  ExpoModulesWorkletsAdapter: 984e3788c7c1a6db50ae61aab1eb72f734f215d0
+  ExpoRouter: 8a4b4a2c4796ae20c87affc536e5d2089197ba3e
+  ExpoSymbols: f83c91f2897d37102b98b9224c603095630be9d0
+  ExpoSystemUI: 6f9eddf66c31d074c402ba4a9e5cd2320edda37f
+  ExpoUI: a0e4c1d09202627e388118d8b5e80831909a2378
+  ExpoWebBrowser: fb9b5a94ebaa3483987f4acf4af6fd85c401df3e
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 016123a2cd29a466f68cf832d43da12f4ac69df7
+  hermes-engine: 407f52f1dca2c25263c5f76e80cc38a39e0f6ec0
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -2659,7 +2658,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: 735071f9b9b5e3716c800f2f49a4847593218170
+  React-Core-prebuilt: 80a1e215fb014ff2be6aa7bf0208bb7cf05e5711
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -2722,11 +2721,11 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: abe9af4cbab941b07df19aa2301f3aa6072e4884
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: b017f036efeb4db7e45a89e13e9eb82c83cdbac8
+  ReactNativeDependencies: bab650e27ee97dc71c8ec0e902cd954bcd682e94
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec
-  RNReanimated: fea5f61f6980b489b887ea2f417a3d50ecd2b298
-  RNScreens: c476f5f41b7c4ddce3e73f838c23d40c5e33384c
+  RNReanimated: 35139d2806b6cab5920e05aceb3a880285e170d1
+  RNScreens: a6a509f05ea74d50abab8c21b319b33cfca1ea1c
   RNWorklets: c5360c95530e03ff709009a269294cfe022a78ef
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -4719,11 +4719,11 @@ SPEC CHECKSUMS:
   FirebaseRemoteConfigInterop: 85bdce8babed7814816496bb6f082bc05b0a45e1
   FirebaseSessions: f5c6bfeb66a7202deaf33352017bb6365e395820
   fmt: 530618a01105dae0fa3a2f27c81ae11fa8f67eac
-  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
+  glog: e56ede4028c4b7418e6b1195a36b1656bb35e225
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: 971c315ad976a4dcbf09795cb72e85ea3f7200d9
+  hermes-engine: 4de4833a80a7b39c6c5d6c725a600e2faa49bc14
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -4735,7 +4735,7 @@ SPEC CHECKSUMS:
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   Quick: 83e25bf349dd84f894b024f48033274512d6129b
-  RCT-Folly: 121436bcc4611f6bde5c09bf35f0a7a82cef1969
+  RCT-Folly: 36c4f904fb6cd0219dcb76b94e9502d2a72fab0b
   RCTDeprecation: 225e022b85a206cf0883a909c4a114159783363c
   RCTRequired: 827a95c181af0886a11e21bc66c084088cf87839
   RCTSwiftUI: 7babb07156ae0a8e5ea97f77e43959ddaca2c6f2

--- a/apps/minimal-tester/ios/Podfile.lock
+++ b/apps/minimal-tester/ios/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
-  - EASClient (56.0.0):
+  - EASClient (56.0.1):
     - ExpoModulesCore
-  - EXConstants (56.0.1):
+  - EXConstants (56.0.9):
     - ExpoModulesCore
   - EXJSONUtils (56.0.0)
-  - EXManifests (56.0.1):
+  - EXManifests (56.0.3):
     - ExpoModulesCore
-  - Expo (56.0.0-preview.2):
+  - Expo (56.0.0-preview.10):
     - boost
     - DoubleConversion
     - ExpoModulesCore
@@ -40,17 +40,17 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-client (56.0.0):
+  - expo-dev-client (56.0.9):
     - EXManifests
     - expo-dev-launcher
     - expo-dev-menu
     - expo-dev-menu-interface
     - EXUpdatesInterface
-  - expo-dev-launcher (56.0.0):
+  - expo-dev-launcher (56.0.9):
     - boost
     - DoubleConversion
     - EXManifests
-    - expo-dev-launcher/Main (= 56.0.0)
+    - expo-dev-launcher/Main (= 56.0.9)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -83,7 +83,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Main (56.0.0):
+  - expo-dev-launcher/Main (56.0.9):
     - boost
     - DoubleConversion
     - EXManifests
@@ -120,7 +120,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-launcher/Unsafe (56.0.0):
+  - expo-dev-launcher/Unsafe (56.0.9):
     - boost
     - DoubleConversion
     - EXManifests
@@ -156,10 +156,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu (56.0.0):
+  - expo-dev-menu (56.0.8):
     - boost
     - DoubleConversion
-    - expo-dev-menu/Main (= 56.0.0)
+    - expo-dev-menu/Main (= 56.0.8)
     - fast_float
     - fmt
     - glog
@@ -185,8 +185,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - expo-dev-menu-interface (56.0.0)
-  - expo-dev-menu/Main (56.0.0):
+  - expo-dev-menu-interface (56.0.1)
+  - expo-dev-menu/Main (56.0.8):
     - boost
     - DoubleConversion
     - EXManifests
@@ -219,40 +219,40 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoAppleAuthentication (56.0.0):
+  - ExpoAppleAuthentication (56.0.3):
     - ExpoModulesCore
-  - ExpoAsset (56.0.1):
+  - ExpoAsset (56.0.8):
     - ExpoModulesCore
-  - ExpoBlur (56.0.0):
+  - ExpoBlur (56.0.3):
     - ExpoModulesCore
-  - ExpoBrownfield (56.0.0):
+  - ExpoBrownfield (56.0.8):
     - ExpoModulesCore
-  - ExpoCamera (56.0.0):
+  - ExpoCamera (56.0.4):
     - ExpoModulesCore
-  - ExpoCameraBarcodeScanning (56.0.0):
+  - ExpoCameraBarcodeScanning (56.0.4):
     - ExpoCamera
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - ExpoDomWebView (56.0.1):
+  - ExpoDomWebView (56.0.4):
     - ExpoModulesCore
-  - ExpoFileSystem (56.0.1):
+  - ExpoFileSystem (56.0.4):
     - ExpoModulesCore
-  - ExpoFont (56.0.1):
+  - ExpoFont (56.0.3):
     - ExpoModulesCore
-  - ExpoImage (56.0.1):
+  - ExpoImage (56.0.4):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoKeepAwake (56.0.1):
+  - ExpoKeepAwake (56.0.3):
     - ExpoModulesCore
-  - ExpoLinearGradient (56.0.0):
+  - ExpoLinearGradient (56.0.4):
     - ExpoModulesCore
-  - ExpoLogBox (56.0.1):
+  - ExpoLogBox (56.0.8):
     - React-Core
-  - ExpoModulesCore (56.0.0):
+  - ExpoModulesCore (56.0.7):
     - boost
     - DoubleConversion
     - ExpoModulesJSI
@@ -282,19 +282,18 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - ExpoModulesJSI (56.0.0):
+  - ExpoModulesJSI (56.0.3):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
-  - ExpoModulesWorklets (56.0.0):
+  - ExpoModulesWorklets (56.0.7):
     - ExpoModulesCore
     - ExpoModulesJSI
-  - ExpoSplashScreen (56.0.1):
+  - ExpoSplashScreen (56.0.5):
     - ExpoModulesCore
-  - ExpoVideo (56.0.0):
+  - ExpoVideo (56.1.0):
     - ExpoModulesCore
   - EXStructuredHeaders (56.0.0)
-  - EXUpdates (56.0.1):
+  - EXUpdates (56.0.10):
     - boost
     - DoubleConversion
     - EASClient
@@ -328,7 +327,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - EXUpdatesInterface (56.0.1):
+  - EXUpdatesInterface (56.0.2):
     - ExpoModulesCore
   - fast_float (8.0.0)
   - FBLazyVector (0.85.3)
@@ -3169,41 +3168,41 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
-  EASClient: 92d4859ba99ccb9e6b15e4a6f6bf729eac5e14ce
-  EXConstants: 6808b4bf46160e72c034afe57b857a64896979fd
+  EASClient: 2321f8d99fa86c710a6f68e017f3b54366baed9f
+  EXConstants: 98c1080d565bbb5d69f9c28627b0a0ee25f7e1c5
   EXJSONUtils: dba2755f4e24009eaf87a876b2d615ea06c16e42
-  EXManifests: 23fadfe43e47a071950a5d2cc698e2ec9e869af6
-  Expo: 7920336c4fe0e12f8869d32d83af270f595b3c2e
-  expo-dev-client: 67f2a4045a9590813cca3c9b43ab27f1f571cd20
-  expo-dev-launcher: 905c6232443757348484856b5728e172c7e1666e
-  expo-dev-menu: 7445b0437bfbd3630a3341e1bf15af02b30d8a61
-  expo-dev-menu-interface: de90cd44d311f247f5cb599aaedc44b2a3739f53
-  ExpoAppleAuthentication: f019fcbd9bdea1a3158aa936a5e1e26891652fd4
-  ExpoAsset: 705ac2c9a4efe8f68ed83ebc4c4bd2f335513122
-  ExpoBlur: e392a6e09db71eef1e500e878112e1119c1ff1d0
-  ExpoBrownfield: 42fab7dca07231ccf968358820afe0de674620d4
-  ExpoCamera: 4947e7537ee2709669d51db62756cf8cfecca168
-  ExpoCameraBarcodeScanning: 190a1fc2bf354ba6e8b446b2e9316fc1d245cc24
-  ExpoDomWebView: 418bc24c668bf84ed99187cdef4733dc294f1af1
-  ExpoFileSystem: 9087d62edbffa4565e4b4568fab5db0528d810ac
-  ExpoFont: a82790c3ad1bee08435ab3359bf87218ce20f858
-  ExpoImage: fa4120fb31153caeee95d748c1c609ae7c888ae9
-  ExpoKeepAwake: e889b7d99d846a45458baf9cf5a1d1cc96ee7b48
-  ExpoLinearGradient: 9ecd05fed3d86b96c18ab3e8881e4932aae584c6
-  ExpoLogBox: ff246a45c7fc0827f9460af43dda85759eea2354
-  ExpoModulesCore: f8003617d9d93c335bdd60f97e00270aee29dfd3
-  ExpoModulesJSI: b091a3946c9c7f299ce190b738486c4454b9b02c
-  ExpoModulesWorklets: 8bcb73d4467bf0363e0eb1f8a040fe1e37c18f79
-  ExpoSplashScreen: 35e0a73159ac739d1b37a0fdec44374160b98f7b
-  ExpoVideo: b90f337707445c6e8ba140769246b907ec7799b1
+  EXManifests: 67869a6d8efa7cb53a7b8b53f451d378c124073f
+  Expo: 8c70cb699627a748421d7967513ecc38ef7fe3bc
+  expo-dev-client: ab1d62441bbe8a35adeb34f64223038bf933f43c
+  expo-dev-launcher: 0ed3630a336fdb87b8d94d6c34205934bc9b20cc
+  expo-dev-menu: 2d6803d821153ebd74f8660ac5d6e4f526c8c247
+  expo-dev-menu-interface: 65402d4affb8b418aa6cec29b3abb0e313c8f443
+  ExpoAppleAuthentication: 47f6f6c6722a7facef29d15397635b785086bc5e
+  ExpoAsset: cd59c97de137fe4af1efe5033d2c660f85f0442d
+  ExpoBlur: caddd80171e5f8f3581ff3d865e99c6465047240
+  ExpoBrownfield: b52c7e9382071d03325ffe08ea4da5ac40770992
+  ExpoCamera: 2d8fe4b1b98824db41a214f1d1da434d897f1278
+  ExpoCameraBarcodeScanning: 59a32965ad98f0ce58f1c7f235e36fa3d58c4f6b
+  ExpoDomWebView: 6061a678d7b9a4d3e9b456b651cd2031b4186f56
+  ExpoFileSystem: 16e678f837808810b2bc562570976b04414eda67
+  ExpoFont: 8b9b7b0fe8a5e563a69e7b132749e50a85afb6e4
+  ExpoImage: 59f71ed6d030241ffadead114064cfd01bd0dc12
+  ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
+  ExpoLinearGradient: 16c2b9c6105444883d34958d573725de1293b8d0
+  ExpoLogBox: f5bb088ecceacdaf4adc5813b93f4cd6459fb27b
+  ExpoModulesCore: da0defdff29a41193cd6ffdcf81a0040b9f281ac
+  ExpoModulesJSI: bef2cecf9180ffd4f974a30c6c246c3b9de16b43
+  ExpoModulesWorklets: d7a299391940073b848863bfe6b3d4be3541a83c
+  ExpoSplashScreen: 81c769db994659e1b0d2c38ba7ac9ce5add3d74a
+  ExpoVideo: fa20020308f9f8e3458c05c7216d139d47fc1b32
   EXStructuredHeaders: 9e89bcdd636ae2ecb59995cfba3230f5d7547c08
-  EXUpdates: d04e6a5cd6cd842a202e040d863a95be899f9cf0
-  EXUpdatesInterface: d9c69c30c1c124bf5a73d8965bace90038146cf0
+  EXUpdates: bcff6c210499d5bc10034c4b440252ff58c7a62d
+  EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
   FBLazyVector: 473b935415b82ae4f7f9aa9d5b3378491143ccbf
   fmt: 530618a01105dae0fa3a2f27c81ae11fa8f67eac
   glog: e56ede4028c4b7418e6b1195a36b1656bb35e225
-  hermes-engine: 016123a2cd29a466f68cf832d43da12f4ac69df7
+  hermes-engine: 407f52f1dca2c25263c5f76e80cc38a39e0f6ec0
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3286,6 +3285,6 @@ SPEC CHECKSUMS:
   Yoga: 9d8e8094a2bed6a175d9e6001a0546d5dae663ee
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: b0847af061ce9dcf90444b64ff4455c11d3a58a9
+PODFILE CHECKSUM: 770467ac9ba70f9509b4ee51a41372e528e573ec
 
 COCOAPODS: 1.16.2

--- a/apps/native-component-list/src/screens/ImagePicker/ImagePickerAssetsList.tsx
+++ b/apps/native-component-list/src/screens/ImagePicker/ImagePickerAssetsList.tsx
@@ -8,7 +8,9 @@ export default function ImagePickerAssetsList(
 ): React.ReactElement | void {
   return (
     <View>
-      {result.assets?.map((asset, index) => <AssetViewContainer key={index} asset={asset} />)}
+      {result.assets?.map((asset, index) => (
+        <AssetViewContainer key={index} asset={asset} />
+      ))}
     </View>
   );
 }

--- a/apps/native-component-list/src/screens/ImagePicker/ImagePickerAssetsList.tsx
+++ b/apps/native-component-list/src/screens/ImagePicker/ImagePickerAssetsList.tsx
@@ -8,9 +8,7 @@ export default function ImagePickerAssetsList(
 ): React.ReactElement | void {
   return (
     <View>
-      {result.assets?.map((asset, index) => (
-        <AssetViewContainer key={index} asset={asset} />
-      ))}
+      {result.assets?.map((asset, index) => <AssetViewContainer key={index} asset={asset} />)}
     </View>
   );
 }

--- a/apps/native-tests/ios/Podfile.lock
+++ b/apps/native-tests/ios/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
-  - EASClient (56.0.0):
+  - EASClient (56.0.1):
     - ExpoModulesCore
-  - EASClient/Tests (56.0.0):
+  - EASClient/Tests (56.0.1):
     - ExpoModulesCore
     - ExpoModulesTestCore
   - EXJSONUtils (56.0.0)
   - EXJSONUtils/Tests (56.0.0)
-  - EXManifests (56.0.1):
+  - EXManifests (56.0.3):
     - ExpoModulesCore
-  - EXManifests/Tests (56.0.1):
+  - EXManifests/Tests (56.0.3):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - Expo (56.0.0-preview.2):
+  - Expo (56.0.0-preview.10):
     - ExpoModulesCore
     - ExpoModulesJSI
     - hermes-engine
@@ -37,9 +37,9 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-launcher (56.0.0):
+  - expo-dev-launcher (56.0.9):
     - EXManifests
-    - expo-dev-launcher/Main (= 56.0.0)
+    - expo-dev-launcher/Main (= 56.0.9)
     - expo-dev-menu
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -68,7 +68,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-launcher/Main (56.0.0):
+  - expo-dev-launcher/Main (56.0.9):
     - EXManifests
     - expo-dev-launcher/Unsafe
     - expo-dev-menu
@@ -99,7 +99,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-launcher/Tests (56.0.0):
+  - expo-dev-launcher/Tests (56.0.9):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -134,7 +134,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-launcher/Unsafe (56.0.0):
+  - expo-dev-launcher/Unsafe (56.0.9):
     - EXManifests
     - expo-dev-menu
     - expo-dev-menu-interface
@@ -164,8 +164,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu (56.0.0):
-    - expo-dev-menu/Main (= 56.0.0)
+  - expo-dev-menu (56.0.8):
+    - expo-dev-menu/Main (= 56.0.8)
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -187,8 +187,8 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu-interface (56.0.0)
-  - expo-dev-menu/Main (56.0.0):
+  - expo-dev-menu-interface (56.0.1)
+  - expo-dev-menu/Main (56.0.8):
     - EXManifests
     - expo-dev-menu-interface
     - ExpoModulesCore
@@ -214,7 +214,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu/Tests (56.0.0):
+  - expo-dev-menu/Tests (56.0.8):
     - ExpoModulesTestCore
     - hermes-engine
     - Nimble
@@ -240,7 +240,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - expo-dev-menu/UITests (56.0.0):
+  - expo-dev-menu/UITests (56.0.8):
     - ExpoModulesTestCore
     - hermes-engine
     - RCTRequired
@@ -266,7 +266,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - Expo/Tests (56.0.0-preview.2):
+  - Expo/Tests (56.0.0-preview.10):
     - ExpoModulesCore
     - ExpoModulesJSI
     - ExpoModulesTestCore
@@ -293,7 +293,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoAppMetrics (56.0.0):
+  - ExpoAppMetrics (56.0.7):
     - ExpoModulesCore
     - EXUpdatesInterface
     - hermes-engine
@@ -317,7 +317,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoAppMetrics/Tests (56.0.0):
+  - ExpoAppMetrics/Tests (56.0.7):
     - ExpoModulesCore
     - EXUpdatesInterface
     - hermes-engine
@@ -341,26 +341,26 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoBackgroundTask (56.0.0):
+  - ExpoBackgroundTask (56.0.7):
     - ExpoModulesCore
     - ExpoTaskManager
-  - ExpoBackgroundTask/Tests (56.0.0):
+  - ExpoBackgroundTask/Tests (56.0.7):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - ExpoTaskManager
-  - ExpoClipboard (56.0.0):
+  - ExpoClipboard (56.0.3):
     - ExpoModulesCore
-  - ExpoClipboard/Tests (56.0.0):
+  - ExpoClipboard/Tests (56.0.3):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoImage (56.0.1):
+  - ExpoImage (56.0.4):
     - ExpoModulesCore
     - libavif/libdav1d
     - SDWebImage (~> 5.21.0)
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoImage/Tests (56.0.1):
+  - ExpoImage/Tests (56.0.4):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - libavif/libdav1d
@@ -368,14 +368,14 @@ PODS:
     - SDWebImageAVIFCoder (~> 0.11.0)
     - SDWebImageSVGCoder (~> 1.7.0)
     - SDWebImageWebPCoder (~> 0.14.6)
-  - ExpoMediaLibrary (56.0.0):
+  - ExpoMediaLibrary (56.0.4):
     - ExpoModulesCore
     - React-Core
-  - ExpoMediaLibrary/Tests (56.0.0):
+  - ExpoMediaLibrary/Tests (56.0.4):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - React-Core
-  - ExpoModulesCore (56.0.0):
+  - ExpoModulesCore (56.0.7):
     - ExpoModulesJSI
     - hermes-engine
     - RCTRequired
@@ -399,7 +399,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoModulesCore/Tests (56.0.0):
+  - ExpoModulesCore/Tests (56.0.7):
     - ExpoModulesJSI
     - ExpoModulesTestCore
     - hermes-engine
@@ -424,25 +424,23 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoModulesJSI (56.0.0):
+  - ExpoModulesJSI (56.0.3):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
-  - ExpoModulesJSI/Tests (56.0.0):
+  - ExpoModulesJSI/Tests (56.0.3):
     - React-Core
-    - React-runtimescheduler
     - ReactCommon
-  - ExpoModulesTestCore (56.0.0):
+  - ExpoModulesTestCore (56.0.1):
     - ExpoModulesCore
     - Nimble (~> 13.0.0)
     - Quick (~> 7.3.0)
     - React-hermes
-  - ExpoNotifications (56.0.0):
+  - ExpoNotifications (56.0.7):
     - ExpoModulesCore
-  - ExpoNotifications/Tests (56.0.0):
+  - ExpoNotifications/Tests (56.0.7):
     - ExpoModulesCore
     - ExpoModulesTestCore
-  - ExpoObserve (56.0.0):
+  - ExpoObserve (56.0.7):
     - EASClient
     - ExpoAppMetrics
     - ExpoModulesCore
@@ -467,7 +465,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoObserve/Tests (56.0.0):
+  - ExpoObserve/Tests (56.0.7):
     - EASClient
     - ExpoAppMetrics
     - ExpoModulesCore
@@ -492,23 +490,23 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - ExpoRouter (56.0.1):
+  - ExpoRouter (56.1.4):
     - ExpoModulesCore
     - RNScreens
-  - ExpoRouter/Tests (56.0.1):
+  - ExpoRouter/Tests (56.1.4):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - RNScreens
-  - ExpoTaskManager (56.0.0):
+  - ExpoTaskManager (56.0.7):
     - ExpoModulesCore
     - UMAppLoader
-  - ExpoTaskManager/Tests (56.0.0):
+  - ExpoTaskManager/Tests (56.0.7):
     - ExpoModulesCore
     - ExpoModulesTestCore
     - UMAppLoader
   - EXStructuredHeaders (56.0.0)
   - EXStructuredHeaders/Tests (56.0.0)
-  - EXUpdates (56.0.1):
+  - EXUpdates (56.0.10):
     - EASClient
     - EXManifests
     - ExpoModulesCore
@@ -536,7 +534,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - EXUpdates/Tests (56.0.1):
+  - EXUpdates/Tests (56.0.10):
     - EASClient
     - EXManifests
     - ExpoModulesCore
@@ -565,7 +563,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - EXUpdatesInterface (56.0.1):
+  - EXUpdatesInterface (56.0.2):
     - ExpoModulesCore
   - FBLazyVector (0.85.3)
   - hermes-engine (250829098.0.10):
@@ -2501,7 +2499,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - RNReanimated (4.3.0):
+  - RNReanimated (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2524,36 +2522,11 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNReanimated/apple (= 4.3.0)
-    - RNReanimated/common (= 4.3.0)
+    - RNReanimated/apple (= 4.3.1)
+    - RNReanimated/common (= 4.3.1)
     - RNWorklets
     - Yoga
-  - RNReanimated/apple (4.3.0):
-    - hermes-engine
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-Core-prebuilt
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-jsitooling
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - ReactNativeDependencies
-    - RNWorklets
-    - Yoga
-  - RNReanimated/common (4.3.0):
+  - RNReanimated/apple (4.3.1):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2578,7 +2551,32 @@ PODS:
     - ReactNativeDependencies
     - RNWorklets
     - Yoga
-  - RNScreens (4.25.0-beta.1):
+  - RNReanimated/common (4.3.1):
+    - hermes-engine
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-Core-prebuilt
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-jsitooling
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - ReactNativeDependencies
+    - RNWorklets
+    - Yoga
+  - RNScreens (4.25.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2600,9 +2598,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
-    - RNScreens/common (= 4.25.0-beta.1)
+    - RNScreens/common (= 4.25.0)
     - Yoga
-  - RNScreens/common (4.25.0-beta.1):
+  - RNScreens/common (4.25.0):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2710,8 +2708,8 @@ PODS:
   - SDWebImageWebPCoder (0.14.6):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.17)
-  - UMAppLoader (56.0.0)
-  - UMAppLoader/Tests (56.0.0):
+  - UMAppLoader (56.0.1)
+  - UMAppLoader/Tests (56.0.1):
     - ExpoModulesTestCore
   - Yoga (0.0.0)
 
@@ -2835,8 +2833,8 @@ DEPENDENCIES:
   - "ReactNativeDependencies (from `../../../node_modules/.pnpm/react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-preset@0.85.3_@babel+core@7.2_87b68a5d07f50c0f905b0a793dc3ac61/node_modules/react-native/third-party-podspecs/ReactNativeDependencies.podspec`)"
   - "RNCMaskedView (from `../../../node_modules/.pnpm/@react-native-masked-view+masked-view@0.3.2_react-native@0.85.3_@babel+core@7.29.0_@rea_da87b02ae003a7f77089f8e22aa53d01/node_modules/@react-native-masked-view/masked-view`)"
   - "RNGestureHandler (from `../../../node_modules/.pnpm/react-native-gesture-handler@2.30.0_react-native@0.85.3_@babel+core@7.29.0_@react-nativ_9a6358180c81a5519b6da847dcb246ed/node_modules/react-native-gesture-handler`)"
-  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.3.0_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_c36a92bb9a27c676b0bae54fbc6a1908/node_modules/react-native-reanimated`)"
-  - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.25.0-beta.1_react-native@0.85.3_@babel+core@7.29.0_@react-native_1106fa305397b6dce5495e57c42d635a/node_modules/react-native-screens`)"
+  - "RNReanimated (from `../../../node_modules/.pnpm/react-native-reanimated@4.3.1_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_1a5e3d09dfc1ab41347a1ceaceaf61bc/node_modules/react-native-reanimated`)"
+  - "RNScreens (from `../../../node_modules/.pnpm/react-native-screens@4.25.0_react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-p_27bafc37770a4b472b96129a8e818eae/node_modules/react-native-screens`)"
   - "RNWorklets (from `../../../node_modules/.pnpm/react-native-worklets@0.8.3_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_42b4111e02dad0db2c0db5ed881424fc/node_modules/react-native-worklets`)"
   - UMAppLoader (from `../../../packages/unimodules-app-loader/ios`)
   - UMAppLoader/Tests (from `../../../packages/unimodules-app-loader/ios`)
@@ -3074,9 +3072,9 @@ EXTERNAL SOURCES:
   RNGestureHandler:
     :path: "../../../node_modules/.pnpm/react-native-gesture-handler@2.30.0_react-native@0.85.3_@babel+core@7.29.0_@react-nativ_9a6358180c81a5519b6da847dcb246ed/node_modules/react-native-gesture-handler"
   RNReanimated:
-    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.3.0_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_c36a92bb9a27c676b0bae54fbc6a1908/node_modules/react-native-reanimated"
+    :path: "../../../node_modules/.pnpm/react-native-reanimated@4.3.1_patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8_1a5e3d09dfc1ab41347a1ceaceaf61bc/node_modules/react-native-reanimated"
   RNScreens:
-    :path: "../../../node_modules/.pnpm/react-native-screens@4.25.0-beta.1_react-native@0.85.3_@babel+core@7.29.0_@react-native_1106fa305397b6dce5495e57c42d635a/node_modules/react-native-screens"
+    :path: "../../../node_modules/.pnpm/react-native-screens@4.25.0_react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-p_27bafc37770a4b472b96129a8e818eae/node_modules/react-native-screens"
   RNWorklets:
     :path: "../../../node_modules/.pnpm/react-native-worklets@0.8.3_patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89_42b4111e02dad0db2c0db5ed881424fc/node_modules/react-native-worklets"
   UMAppLoader:
@@ -3086,30 +3084,30 @@ EXTERNAL SOURCES:
     :path: "../../../node_modules/.pnpm/react-native@0.85.3_@babel+core@7.29.0_@react-native+jest-preset@0.85.3_@babel+core@7.2_87b68a5d07f50c0f905b0a793dc3ac61/node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  EASClient: 92d4859ba99ccb9e6b15e4a6f6bf729eac5e14ce
+  EASClient: 2321f8d99fa86c710a6f68e017f3b54366baed9f
   EXJSONUtils: dba2755f4e24009eaf87a876b2d615ea06c16e42
-  EXManifests: 23fadfe43e47a071950a5d2cc698e2ec9e869af6
-  Expo: b58705d25d040c50297d0a42e7e9bafbd5edbd38
-  expo-dev-launcher: a41702af6ac74a0c7a9696fbedc013e4f8285826
-  expo-dev-menu: 9ff0583e2561b819aae98e4d1d3c66a737c18699
-  expo-dev-menu-interface: de90cd44d311f247f5cb599aaedc44b2a3739f53
-  ExpoAppMetrics: 9de60583f47a8e9c71d39e8c90ef54966bc1fe44
-  ExpoBackgroundTask: b87922a5bc1da38177482cb41d3c33aeee8e3e42
-  ExpoClipboard: 4b208fe6266ed723a2e0770c500b910422d62b44
-  ExpoImage: fa4120fb31153caeee95d748c1c609ae7c888ae9
-  ExpoMediaLibrary: b3a987d115a5e06fb1763efc25b8ddf528a8357e
-  ExpoModulesCore: 83913161a08b2e283e96fb814fb7204524b63f75
-  ExpoModulesJSI: ea32f68254fb0bb09198bc0b40489d4a9df4c708
-  ExpoModulesTestCore: 5660ab6b5928747366d4946580622a578865696a
-  ExpoNotifications: 98b903ae77c702da2feb1d065d7fc62d40dc720c
-  ExpoObserve: 219630651e73e8ab63e768287daf35c62beff909
-  ExpoRouter: 3c50a81167c9621bc47d2376e12e5d0c2853be29
-  ExpoTaskManager: 303bf0ec470e95b4d7fcf0016a925c77f2f2df52
+  EXManifests: 67869a6d8efa7cb53a7b8b53f451d378c124073f
+  Expo: 44aecef3556a88407ec4aaa4f1d672088c7d85ef
+  expo-dev-launcher: 0dac6c478b1325d827f015d72ebd1c7705e57413
+  expo-dev-menu: 422a6a7188c134d0b7e72748e7b622133e0fe916
+  expo-dev-menu-interface: 65402d4affb8b418aa6cec29b3abb0e313c8f443
+  ExpoAppMetrics: c8a40f0baf474493a1e732e7ffb78b7750169084
+  ExpoBackgroundTask: be387114533be898d4f9ed5120eb1288183578ce
+  ExpoClipboard: eee843698341fd26d571fd2807800f98abb6123c
+  ExpoImage: 59f71ed6d030241ffadead114064cfd01bd0dc12
+  ExpoMediaLibrary: 2ee3defd62fa8da9cb80fdcca71968cdeec7b24f
+  ExpoModulesCore: 575102f00470ad80a763c1a6b7ef952d668800ca
+  ExpoModulesJSI: f672bac18356446b024588f7a77b364d80909e71
+  ExpoModulesTestCore: 8a57d88aaeae674725ab11d01c43c138d279dfc9
+  ExpoNotifications: d4a747ad585d5d5c5101de08c252080e3fae820c
+  ExpoObserve: 7d9c3e168eacf6dbcd9a5a6ae677412a9a5e6ab1
+  ExpoRouter: 8a4b4a2c4796ae20c87affc536e5d2089197ba3e
+  ExpoTaskManager: 19399a53bf382076051b07c9aed79a1191cd0f1e
   EXStructuredHeaders: 9e89bcdd636ae2ecb59995cfba3230f5d7547c08
-  EXUpdates: 9f90d5a4b98b6ed922c2d8139ad912d0905892fa
-  EXUpdatesInterface: d9c69c30c1c124bf5a73d8965bace90038146cf0
+  EXUpdates: a736b2b35ca152b45b5abf0c2d45409a7deee697
+  EXUpdatesInterface: 25408a97d682355eb9fb37e5aa6e22caece1881f
   FBLazyVector: 24e62c765683b8d89006a88a2c8f5cf019f0074d
-  hermes-engine: 016123a2cd29a466f68cf832d43da12f4ac69df7
+  hermes-engine: 407f52f1dca2c25263c5f76e80cc38a39e0f6ec0
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
@@ -3125,7 +3123,7 @@ SPEC CHECKSUMS:
   React: e2dc35338068bbd299c66f043ae0d7f25de8499e
   React-callinvoker: 28b25d21b124c26cebaea713ba7d801b9351dc48
   React-Core: 02ed7d2ffb70437bdf2aba074a13078a7b0b9ff0
-  React-Core-prebuilt: ddb263ca5b1c329ab4302d82e25574152c5f5985
+  React-Core-prebuilt: cf0ea92a0ddc51494c68ab97610d31dc2c71a41e
   React-CoreModules: b3a5a42dadcde3b5d47b325bd912eb2ced89e146
   React-cxxreact: fe8f88dda044e5905e99a00f41b7a874c3908716
   React-debug: 92944dc4d89f56d640e75498266cbde557a48189
@@ -3188,17 +3186,17 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 25c9c516839be2c5e3d3344f95dc7da5f7e63fc2
   ReactCodegen: 363b5e311c22e0e907a7a79b5d8fd095fbe4e561
   ReactCommon: 7dfc3250793bf36cf221096ff59e1179e13eef7f
-  ReactNativeDependencies: 310299f6437e20099421d6687b40aa87d9417cf2
+  ReactNativeDependencies: 5b4aaa18ba20efebc7a0a839b6bba354b1522eac
   RNCMaskedView: eb2b2e538afa907f05a5848a1a1ac26092e6fec9
   RNGestureHandler: c84901d120acdae2f6f27b5889a7cf144e64e6ec
-  RNReanimated: b64e22b2ee046cd2dcb2a25d134eff25f64eba0d
-  RNScreens: c476f5f41b7c4ddce3e73f838c23d40c5e33384c
+  RNReanimated: a1b89be9f4b3f85c708900d0a167cd22d869a198
+  RNScreens: a6a509f05ea74d50abab8c21b319b33cfca1ea1c
   RNWorklets: edcd0af162eba9fb81af89a4761f1af35086d1cc
   SDWebImage: e9fc87c1aab89a8ab1bbd74eba378c6f53be8abf
   SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  UMAppLoader: 114b4c89b0083f3e103be55fe0ff0950475f267b
+  UMAppLoader: b7d22886a244871c20b5a8f2fcea13c18534e677
   Yoga: 77dfa8673de2874e1855002ae59c68b8be9b007b
 
 PODFILE CHECKSUM: c1fa3c47ac8104c9b87b9c45bbdfecedc9b1ae15

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Added support for `facebook::jsi::IRuntime` so the package builds against React Native 0.86+, while staying compatible with 0.85 and react-native-tvos. ([#45728](https://github.com/expo/expo/pull/45728) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-11

--- a/packages/expo-modules-jsi/apple/APINotes/jsi.apinotes
+++ b/packages/expo-modules-jsi/apple/APINotes/jsi.apinotes
@@ -14,3 +14,11 @@ Namespaces:
       SwiftImportAs: reference
       SwiftReleaseOp: immortal
       SwiftRetainOp: immortal
+    - Name: IRuntime
+      SwiftImportAs: reference
+      SwiftReleaseOp: immortal
+      SwiftRetainOp: immortal
+    - Name: ICast
+      SwiftImportAs: reference
+      SwiftReleaseOp: immortal
+      SwiftRetainOp: immortal

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/TypedArray.cpp
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/TypedArray.cpp
@@ -23,7 +23,7 @@ TypedArrayKind getTypedArrayKindForName(const std::string &name) {
   return nameToKindMap.at(name);
 }
 
-TypedArrayKind getTypedArrayKind(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+TypedArrayKind getTypedArrayKind(jsi::IRuntime &runtime, const jsi::Object &jsObj) {
   auto constructorName = jsObj.getPropertyAsObject(runtime, "constructor")
                              .getProperty(runtime, "name")
                              .asString(runtime)
@@ -31,7 +31,7 @@ TypedArrayKind getTypedArrayKind(jsi::Runtime &runtime, const jsi::Object &jsObj
   return getTypedArrayKindForName(constructorName);
 }
 
-jsi::ArrayBuffer getTypedArrayBuffer(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+jsi::ArrayBuffer getTypedArrayBuffer(jsi::IRuntime &runtime, const jsi::Object &jsObj) {
   auto buffer = jsObj.getProperty(runtime, "buffer");
   if (buffer.isObject() && buffer.asObject(runtime).isArrayBuffer(runtime)) {
     return buffer.asObject(runtime).getArrayBuffer(runtime);
@@ -39,7 +39,7 @@ jsi::ArrayBuffer getTypedArrayBuffer(jsi::Runtime &runtime, const jsi::Object &j
   throw std::runtime_error("no ArrayBuffer attached");
 }
 
-bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj) {
+bool isTypedArray(jsi::IRuntime &runtime, const jsi::Object &jsObj) {
   jsi::Object ArrayBuffer = runtime
     .global()
     .getPropertyAsObject(runtime, "ArrayBuffer");

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/CppError.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/CppError.h
@@ -3,7 +3,8 @@
 #include <exception>
 #include <memory>
 #include <swift/bridging>
-#include <jsi/jsi.h>
+
+#include "IRuntimeCompat.h"
 
 namespace expo {
 
@@ -62,7 +63,7 @@ public:
    Returns the underlying JavaScript value of the wrapped `jsi::JSError`.
    This is a JavaScript Error object with all its properties preserved.
    */
-  inline jsi::Value asValue(jsi::Runtime &runtime) noexcept {
+  inline jsi::Value asValue(jsi::IRuntime &runtime) noexcept {
     return jsi::Value(runtime, jsError.value());
   }
 
@@ -72,7 +73,7 @@ public:
    using `getCurrent()`. The function returns `nullptr` when an exception occurs.
    */
   template <typename Result>
-  inline static Result tryCatch(jsi::Runtime &runtime, Result(^block)(void)) {
+  inline static Result tryCatch(jsi::IRuntime &runtime, Result(^block)(void)) {
     try {
       return block();
     } catch (jsi::JSError e) {
@@ -116,7 +117,7 @@ public:
    Sets the current thread's error by creating a `jsi::JSError` from the given message.
    Called from Swift when a host function closure throws a plain error.
    */
-  inline static void setCurrent(jsi::Runtime &runtime, const std::string &message) {
+  inline static void setCurrent(jsi::IRuntime &runtime, const std::string &message) {
     _current = std::make_unique<CppError>(jsi::JSError(runtime, message));
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/HostObject.h
@@ -4,10 +4,10 @@
 
 #include <string>
 #include <vector>
-#include <jsi/jsi.h>
 
 #include "CppError.h"
 #include "HostObjectCallbacks.h"
+#include "IRuntimeCompat.h"
 
 namespace jsi = facebook::jsi;
 
@@ -47,7 +47,7 @@ public:
     return _callbacks.getPropertyNames();
   }
 
-  inline static jsi::Object makeObject(jsi::Runtime &runtime, HostObjectCallbacks callbacks) {
+  inline static jsi::Object makeObject(jsi::IRuntime &runtime, HostObjectCallbacks callbacks) {
     return jsi::Object::createFromHostObject(runtime, std::make_shared<HostObject>(callbacks));
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/IRuntimeCompat.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/IRuntimeCompat.h
@@ -1,0 +1,22 @@
+#pragma once
+#ifdef __cplusplus
+
+#include <jsi/jsi.h>
+
+// React Native 0.86 split the JSI API into the abstract `jsi::IRuntime` base
+// and the concrete `jsi::Runtime` derived class — most value/object/function
+// methods now take `IRuntime&` instead of `Runtime&`. Older React Native
+// versions (e.g. react-native-tvos 0.85) only have `jsi::Runtime`. Alias
+// `IRuntime` to `Runtime` there so the same source compiles against both.
+#if __has_include(<cxxreact/ReactNativeVersion.h>)
+#include <cxxreact/ReactNativeVersion.h>
+#endif
+
+#if !defined(REACT_NATIVE_VERSION_MAJOR) || \
+    (REACT_NATIVE_VERSION_MAJOR == 0 && REACT_NATIVE_VERSION_MINOR < 86)
+namespace facebook::jsi {
+using IRuntime = Runtime;
+} // namespace facebook::jsi
+#endif
+
+#endif // __cplusplus

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -3,10 +3,11 @@
 #pragma once
 #ifdef __cplusplus
 
-#include <jsi/jsi.h>
 #include <hermes/hermes.h>
+
 #include "HostFunctionClosure.h"
 #include "CppError.h"
+#include "IRuntimeCompat.h"
 #include "MemoryBuffer.h"
 #include "NativeState.h"
 #include "TypedArray.h"
@@ -19,24 +20,35 @@ namespace jsi = facebook::jsi;
 
 namespace expo {
 
-inline jsi::Value valueFromFunction(jsi::Runtime &runtime, const jsi::Function &function) {
+/**
+ Upcasts a `jsi::Runtime&` to a `jsi::IRuntime&`. RN 0.86 split the JSI API into
+ the abstract `IRuntime` base and concrete `Runtime` derived class — most
+ value/object/function methods now take `IRuntime&`. Swift's C++ interop does
+ not auto-upcast between two `SwiftImportAs: reference` types, so Swift can't
+ pass a `Runtime` reference where `IRuntime` is expected without this helper.
+ */
+inline jsi::IRuntime &iruntime(jsi::Runtime &runtime) noexcept {
+  return runtime;
+}
+
+inline jsi::Value valueFromFunction(jsi::IRuntime &runtime, const jsi::Function &function) {
   return jsi::Value(runtime, function);
 }
 
 // `jsi::Object::setProperty` is a template function that Swift does not support. We need to provide specialized versions.
-inline void setProperty(jsi::Runtime &runtime, const jsi::Object &object, const char *name, const jsi::Value value) {
+inline void setProperty(jsi::IRuntime &runtime, const jsi::Object &object, const char *name, const jsi::Value value) {
   object.setProperty(runtime, name, value);
 }
 
-inline void setProperty(jsi::Runtime &runtime, const jsi::Array &array, const char *name, const jsi::Value &value) {
+inline void setProperty(jsi::IRuntime &runtime, const jsi::Array &array, const char *name, const jsi::Value &value) {
   array.setProperty(runtime, name, value);
 }
 
-inline void setValueAtIndex(jsi::Runtime &runtime, const jsi::Array &array, size_t index, const jsi::Value &value) {
+inline void setValueAtIndex(jsi::IRuntime &runtime, const jsi::Array &array, size_t index, const jsi::Value &value) {
   array.setValueAtIndex(runtime, index, value);
 }
 
-inline void setArrayLength(jsi::Runtime &runtime, const jsi::Array &array, long length) {
+inline void setArrayLength(jsi::IRuntime &runtime, const jsi::Array &array, long length) {
   auto oldLength = (int)array.size(runtime);
   auto newLength = (int)length;
 
@@ -52,15 +64,15 @@ inline void setArrayLength(jsi::Runtime &runtime, const jsi::Array &array, long 
   }
 }
 
-inline jsi::Value getProperty(jsi::Runtime &runtime, const jsi::Array &array, const jsi::PropNameID &name) {
+inline jsi::Value getProperty(jsi::IRuntime &runtime, const jsi::Array &array, const jsi::PropNameID &name) {
   return array.getProperty(runtime, name);
 }
 
-inline jsi::Value valueFromArray(jsi::Runtime &runtime, const jsi::Array &array) {
+inline jsi::Value valueFromArray(jsi::IRuntime &runtime, const jsi::Array &array) {
   return jsi::Value(runtime, array);
 }
 
-inline const jsi::Value valueFromError(jsi::Runtime &runtime, const jsi::JSError &error) {
+inline const jsi::Value valueFromError(jsi::IRuntime &runtime, const jsi::JSError &error) {
   return jsi::Value(runtime, error.value());
 }
 
@@ -68,7 +80,7 @@ inline std::shared_ptr<const jsi::Buffer> makeSharedStringBuffer(const std::stri
   return std::make_shared<jsi::StringBuffer>(source);
 }
 
-inline jsi::Function createHostFunction(jsi::Runtime &runtime, const jsi::PropNameID &propName, HostFunctionClosure *closure) {
+inline jsi::Function createHostFunction(jsi::IRuntime &runtime, const jsi::PropNameID &propName, HostFunctionClosure *closure) {
   auto closurePtr = std::shared_ptr<HostFunctionClosure>(closure);
   return jsi::Function::createFromHostFunction(runtime, propName, 0, [closurePtr](jsi::Runtime &runtime, const jsi::Value &thisValue, const jsi::Value *_Nonnull args, size_t count) -> jsi::Value {
     auto result = closurePtr->call(thisValue, args, count);
@@ -82,7 +94,7 @@ inline jsi::Function createHostFunction(jsi::Runtime &runtime, const jsi::PropNa
   });
 }
 
-inline jsi::Function createHostFunction(jsi::Runtime &runtime, const char *name, HostFunctionClosure *closure) {
+inline jsi::Function createHostFunction(jsi::IRuntime &runtime, const char *name, HostFunctionClosure *closure) {
   jsi::PropNameID propName = jsi::PropNameID::forAscii(runtime, name);
   return createHostFunction(runtime, propName, closure);
 }
@@ -93,31 +105,31 @@ inline jsi::Function createHostFunction(jsi::Runtime &runtime, const char *name,
  and by JS engines themselves. Wraps the templated `jsi::Object::isHostObject<T>` so the
  check is callable from Swift, where C++ function templates cannot be imported directly.
  */
-inline bool isHostObject(jsi::Runtime &runtime, const jsi::Object &object) {
+inline bool isHostObject(jsi::IRuntime &runtime, const jsi::Object &object) {
   return object.isHostObject<jsi::HostObject>(runtime);
 }
 
 jsi::Runtime* createHermesRuntime();
 
-inline jsi::Value evaluateJavaScript(jsi::Runtime &runtime, const std::shared_ptr<const jsi::Buffer>& buffer, const std::string& sourceURL) {
+inline jsi::Value evaluateJavaScript(jsi::IRuntime &runtime, const std::shared_ptr<const jsi::Buffer>& buffer, const std::string& sourceURL) {
   return expo::CppError::tryCatch(runtime, ^{
     return runtime.evaluateJavaScript(buffer, sourceURL);
   });
 }
 
-inline jsi::Value callFunction(jsi::Runtime &runtime, const jsi::Function &function, const jsi::Value *_Nullable args, size_t count) {
+inline jsi::Value callFunction(jsi::IRuntime &runtime, const jsi::Function &function, const jsi::Value *_Nullable args, size_t count) {
   return expo::CppError::tryCatch(runtime, ^{
     return function.call(runtime, args, count);
   });
 }
 
-inline jsi::Value callFunctionWithThis(jsi::Runtime &runtime, const jsi::Function &function, const jsi::Object &jsThis, const jsi::Value *_Nullable args, size_t count) {
+inline jsi::Value callFunctionWithThis(jsi::IRuntime &runtime, const jsi::Function &function, const jsi::Object &jsThis, const jsi::Value *_Nullable args, size_t count) {
   return expo::CppError::tryCatch(runtime, ^{
     return function.callWithThis(runtime, jsThis, args, count);
   });
 }
 
-inline jsi::Value callAsConstructor(jsi::Runtime &runtime, const jsi::Function &function, const jsi::Value *_Nullable args, size_t count) {
+inline jsi::Value callAsConstructor(jsi::IRuntime &runtime, const jsi::Function &function, const jsi::Value *_Nullable args, size_t count) {
   return expo::CppError::tryCatch(runtime, ^{
     return function.callAsConstructor(runtime, args, count);
   });
@@ -129,28 +141,28 @@ inline jsi::Value callAsConstructor(jsi::Runtime &runtime, const jsi::Function &
  * Converts a `jsi::ArrayBuffer` to a `jsi::Value`. Needed because Swift/C++ interop
  * does not implicitly upcast `ArrayBuffer` to `Object` for the `Value` constructor.
  */
-inline jsi::Value valueFromArrayBuffer(jsi::Runtime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
+inline jsi::Value valueFromArrayBuffer(jsi::IRuntime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
   return jsi::Value(runtime, arrayBuffer);
 }
 
 /**
  * Returns the size of the array buffer storage in bytes.
  */
-inline size_t arrayBufferSize(jsi::Runtime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
+inline size_t arrayBufferSize(jsi::IRuntime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
   return arrayBuffer.size(runtime);
 }
 
 /**
  * Returns a pointer to the underlying data of the array buffer.
  */
-inline uint8_t *arrayBufferData(jsi::Runtime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
+inline uint8_t *arrayBufferData(jsi::IRuntime &runtime, const jsi::ArrayBuffer &arrayBuffer) {
   return arrayBuffer.data(runtime);
 }
 
 /**
  * Creates a new array buffer of the given size with zero-initialized memory.
  */
-inline jsi::ArrayBuffer createArrayBuffer(jsi::Runtime &runtime, size_t size) {
+inline jsi::ArrayBuffer createArrayBuffer(jsi::IRuntime &runtime, size_t size) {
   uint8_t *data = new uint8_t[size]();
   auto buffer = std::make_shared<MemoryBuffer>(data, size, [data]() { delete[] data; });
   return jsi::ArrayBuffer(runtime, std::move(buffer));
@@ -161,7 +173,7 @@ inline jsi::ArrayBuffer createArrayBuffer(jsi::Runtime &runtime, size_t size) {
  * The cleanup function is called (with the cleanup context) when the ArrayBuffer is deallocated.
  */
 inline jsi::ArrayBuffer createArrayBuffer(
-  jsi::Runtime &runtime,
+  jsi::IRuntime &runtime,
   uint8_t *data,
   size_t size,
   void *_Nonnull cleanupContext,
@@ -179,20 +191,20 @@ inline jsi::ArrayBuffer createArrayBuffer(
 
 // MARK: - Native state
 
-inline bool hasNativeState(jsi::Runtime &runtime, const jsi::Object &object) {
+inline bool hasNativeState(jsi::IRuntime &runtime, const jsi::Object &object) {
   return object.hasNativeState<expo::NativeState>(runtime);
 }
 
-inline void setNativeState(jsi::Runtime &runtime, const jsi::Object &object, expo::NativeState &nativeState) {
+inline void setNativeState(jsi::IRuntime &runtime, const jsi::Object &object, expo::NativeState &nativeState) {
   std::shared_ptr<expo::NativeState> nativeStatePtr = std::shared_ptr<expo::NativeState>(&nativeState);
   object.setNativeState(runtime, nativeStatePtr);
 }
 
-inline void unsetNativeState(jsi::Runtime &runtime, const jsi::Object &object) {
+inline void unsetNativeState(jsi::IRuntime &runtime, const jsi::Object &object) {
   object.setNativeState(runtime, nullptr);
 }
 
-inline expo::NativeState *_Nullable getNativeState(jsi::Runtime &runtime, const jsi::Object &object) {
+inline expo::NativeState *_Nullable getNativeState(jsi::IRuntime &runtime, const jsi::Object &object) {
   if (!object.hasNativeState<expo::NativeState>(runtime)) {
     // JSI's implementation asserts if `hasNativeState` returns true, but we prefer to make it nullable.
     return nullptr;

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/TypedArray.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/TypedArray.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <jsi/jsi.h>
+#include "IRuntimeCompat.h"
 
 namespace jsi = facebook::jsi;
 
@@ -26,19 +26,19 @@ enum class TypedArrayKind {
   BigUint64Array = 11,
 };
 
-bool isTypedArray(jsi::Runtime &runtime, const jsi::Object &jsObj);
+bool isTypedArray(jsi::IRuntime &runtime, const jsi::Object &jsObj);
 
 /**
  * Returns the `TypedArrayKind` of the given typed-array object, derived from its
  * `constructor.name` (e.g. `Uint8Array`, `Float32Array`).
  */
-TypedArrayKind getTypedArrayKind(jsi::Runtime &runtime, const jsi::Object &jsObj);
+TypedArrayKind getTypedArrayKind(jsi::IRuntime &runtime, const jsi::Object &jsObj);
 
 /**
  * Returns the underlying `ArrayBuffer` backing the given typed-array object.
  * Throws if the object has no attached ArrayBuffer.
  */
-jsi::ArrayBuffer getTypedArrayBuffer(jsi::Runtime &runtime, const jsi::Object &jsObj);
+jsi::ArrayBuffer getTypedArrayBuffer(jsi::IRuntime &runtime, const jsi::Object &jsObj);
 
 } // namespace expo
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
@@ -7,21 +7,21 @@ internal import ExpoModulesJSI_Cxx
  */
 internal protocol JSIRepresentable: JavaScriptRepresentable, Sendable, ~Copyable {
   /**
-   Creates an instance of this type from the given `facebook.jsi.Value` in `facebook.jsi.Runtime`.
+   Creates an instance of this type from the given `facebook.jsi.Value` in `facebook.jsi.IRuntime`.
    */
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> Self
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Self
   /**
    Creates a JSI value representing this value in the given JSI runtime.
    */
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value
 }
 
 internal extension JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> Self {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Self {
     FatalError.unimplemented()
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     FatalError.unimplemented()
   }
 }
@@ -29,11 +29,11 @@ internal extension JSIRepresentable {
 // MARK: - Implementations
 
 extension Bool: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> Bool {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Bool {
     return value.getBool()
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return facebook.jsi.Value(self)
   }
 }
@@ -41,19 +41,19 @@ extension Bool: JSIRepresentable {
 internal protocol JSIRepresentableNumber: JSIRepresentable {}
 
 extension JSIRepresentableNumber {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> Int where Self: FixedWidthInteger {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Int where Self: FixedWidthInteger {
     return Int(value.getNumber())
   }
 
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> Double where Self: BinaryFloatingPoint {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Double where Self: BinaryFloatingPoint {
     return value.getNumber()
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value where Self: FixedWidthInteger {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value where Self: FixedWidthInteger {
     return facebook.jsi.Value(Double(self))
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value where Self: BinaryFloatingPoint {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value where Self: BinaryFloatingPoint {
     return facebook.jsi.Value(Double(self))
   }
 }
@@ -74,30 +74,30 @@ extension Float64: JSIRepresentableNumber {}
 extension CGFloat: JSIRepresentableNumber {}
 
 extension String: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> String {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> String {
     return String(value.getString(runtime).utf8(runtime))
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return facebook.jsi.Value(runtime, facebook.jsi.String.createFromUtf8(runtime, std.string(self)))
   }
 }
 
 extension Optional: JSIRepresentable where Wrapped: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> Self {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Self {
     if value.isNull() || value.isUndefined() {
       return nil
     }
     return Wrapped.fromJSIValue(value, in: runtime)
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return self?.toJSIValue(in: runtime) ?? .null()
   }
 }
 
 extension Array: JSIRepresentable where Element: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> Array<Element> {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Array<Element> {
     let jsiArray = value.getObject(runtime).getArray(runtime)
     let size = jsiArray.size(runtime)
     var result: Self = []
@@ -110,7 +110,7 @@ extension Array: JSIRepresentable where Element: JSIRepresentable {
     return result
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     let jsiArray = facebook.jsi.Array(runtime, count)
 
     for index in 0..<count {
@@ -121,7 +121,7 @@ extension Array: JSIRepresentable where Element: JSIRepresentable {
 }
 
 extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> Dictionary<Key, Value> {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Dictionary<Key, Value> {
     let object = value.getObject(runtime)
     let propertyNames = object.getPropertyNames(runtime)
     let size = propertyNames.size(runtime)
@@ -137,7 +137,7 @@ extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresenta
     return result
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     let object = facebook.jsi.Object(runtime)
 
     for (key, value) in self {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRef.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRef.swift
@@ -91,11 +91,11 @@ public final class JavaScriptRef<T: JavaScriptType & ~Copyable>: JavaScriptType,
 
 extension JavaScriptRef: JavaScriptRepresentable where T: JavaScriptRepresentable & ~Copyable {}
 extension JavaScriptRef: JSIRepresentable where T: JSIRepresentable & ~Copyable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> JavaScriptRef {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptRef {
     FatalError.unimplemented()
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return take()?.toJSIValue(in: runtime) ?? .undefined()
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -22,14 +22,25 @@ internal import ExpoModulesJSI_Cxx
  */
 open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   /**
-   The underlying JSI runtime this `JavaScriptRuntime` points to.
-   Note that `facebook.jsi.Runtime` is annotated with `SWIFT_UNSAFE_REFERENCE` in our copy of `jsi.h` header,
-   so for the Swift compiler it is treated as a reference type (like `class` and not `struct`).
-   This is important because the `facebook.jsi.Runtime`:
-   - is an abstract class with many virtual methods. Swift/C++ interop does not support calling pure virtual methods on value types.
-   - is non-copyable. As a value type, we would have to "borrow" it from React Native in an unsafe manner.
+   The underlying JSI runtime this `JavaScriptRuntime` points to, exposed as
+   `IRuntime` — the abstract base interface that virtually all JSI value/object/
+   function methods take (`Value::getString`, `Object::setProperty`,
+   `Function::call`, …) since RN 0.86 split the API. Stored as the upcast result
+   of `runtimePointee` because Swift's C++ interop does not auto-upcast between
+   two `SwiftImportAs: reference` types.
+
+   Use ``runtimePointee`` instead when you specifically need a `jsi::Runtime&`
+   (e.g. constructing an `expo.RuntimeScheduler` whose binding lookup is typed on
+   `Runtime&` upstream).
+
+   Note that `facebook.jsi.IRuntime` and `facebook.jsi.Runtime` are imported as
+   reference types so for the Swift compiler they are treated like classes.
+   This is important because they:
+   - are abstract classes with many virtual methods. Swift/C++ interop does not support calling pure virtual methods on value types.
+   - are non-copyable. As value types, we would have to "borrow" them from React Native in an unsafe manner.
    */
-  internal let pointee: facebook.jsi.Runtime
+  internal let pointee: facebook.jsi.IRuntime
+  internal let runtimePointee: facebook.jsi.Runtime
   internal let scheduler: expo.RuntimeScheduler
 
   /**
@@ -43,7 +54,8 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    `init(unsafePointer:nativeScheduler:dispatch:)` instead.
    */
   internal init(_ runtime: facebook.jsi.Runtime) {
-    self.pointee = runtime
+    self.runtimePointee = runtime
+    self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
   }
 
@@ -52,7 +64,9 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    no React scheduler is wired up.
    */
   public init() {
-    self.pointee = expo.createHermesRuntime()
+    let runtime = expo.createHermesRuntime()
+    self.runtimePointee = runtime
+    self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
   }
 
@@ -63,7 +77,8 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    */
   public init(unsafePointer: UnsafeMutableRawPointer) {
     let runtime = unsafeBitCast(unsafePointer, to: facebook.jsi.Runtime.self)
-    self.pointee = runtime
+    self.runtimePointee = runtime
+    self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
   }
 
@@ -85,7 +100,8 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   ) {
     let runtime = unsafeBitCast(unsafePointer, to: facebook.jsi.Runtime.self)
     let fn = unsafeBitCast(dispatch, to: expo.RuntimeScheduler.ScheduleFn.self)
-    self.pointee = runtime
+    self.runtimePointee = runtime
+    self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler(scheduler, fn)
   }
 
@@ -94,7 +110,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
    The pointer is valid only for the duration of the closure and must not be stored or escaped.
    */
   public func withUnsafePointee<R>(_ body: (UnsafeMutableRawPointer) throws -> R) rethrows -> R {
-    return try body(Unmanaged<facebook.jsi.Runtime>.passUnretained(pointee).toOpaque())
+    return try body(Unmanaged<facebook.jsi.Runtime>.passUnretained(runtimePointee).toOpaque())
   }
 
   /**

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptBigInt.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptBigInt.swift
@@ -308,11 +308,11 @@ extension JavaScriptBigInt: JavaScriptRepresentable {
 }
 
 extension JavaScriptBigInt: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> JavaScriptBigInt {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptBigInt {
     fatalError("Not implemented: Use JavaScriptValue.getBigInt() instead")
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return asJSIValue()
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptError.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptError.swift
@@ -67,11 +67,11 @@ extension JavaScriptError: JavaScriptRepresentable {
 }
 
 extension JavaScriptError: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> JavaScriptError {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptError {
     FatalError.unimplemented()
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return asJSIValue()
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptFunction.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptFunction.swift
@@ -130,11 +130,11 @@ extension JavaScriptFunction: JavaScriptRepresentable {
 }
 
 extension JavaScriptFunction: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> JavaScriptFunction {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptFunction {
     FatalError.unimplemented()
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return asJSIValue()
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -587,11 +587,11 @@ extension JavaScriptObject: JavaScriptRepresentable {
 }
 
 extension JavaScriptObject: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> JavaScriptObject {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptObject {
     FatalError.unimplemented()
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return asJSIValue()
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -704,11 +704,11 @@ extension JavaScriptValue: JavaScriptRepresentable {
 }
 
 extension JavaScriptValue: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.Runtime) -> JavaScriptValue {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptValue {
     FatalError.unimplemented()
   }
 
-  func toJSIValue(in runtime: facebook.jsi.Runtime) -> facebook.jsi.Value {
+  func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return facebook.jsi.Value(runtime, pointee)
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2330,7 +2330,7 @@ importers:
         version: 5.3.2
       minimatch:
         specifier: ^10.2.2
-        version: 10.2.4
+        version: 10.2.5
       resolve-from:
         specifier: ^5.0.0
         version: 5.0.0
@@ -3340,13 +3340,13 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       eslint-plugin-prettier:
         specifier: ^5.2.1
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.5.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.3)
       eslint8:
         specifier: npm:eslint@^8.57.1
         version: eslint@8.57.1
       prettier:
         specifier: ^3.4.2
-        version: 3.5.3
+        version: 3.8.3
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -3376,7 +3376,7 @@ importers:
         version: 11.1.0(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-prettier:
         specifier: ^5.2.6
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.5.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.3)
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4(jiti@1.21.7))
@@ -3401,7 +3401,7 @@ importers:
         version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3))
       prettier:
         specifier: ^3.5.3
-        version: 3.5.3
+        version: 3.8.3
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -4379,7 +4379,7 @@ importers:
         version: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-reanimated:
         specifier: '*'
-        version: 4.3.0(patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8f5c3f4b237a0559138)(react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        version: 4.3.1(patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8f5c3f4b237a0559138)(react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-web:
         specifier: '*'
         version: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4892,7 +4892,7 @@ importers:
         version: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-worklets:
         specifier: ^0.7.4 || ^0.8.0
-        version: 0.8.1(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        version: 0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@testing-library/react-native':
         specifier: ^13.3.0
@@ -4926,7 +4926,7 @@ importers:
         version: 13.0.6
       prettier:
         specifier: ^3.0.3
-        version: 3.5.3
+        version: 3.8.3
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -5659,7 +5659,7 @@ importers:
         version: 12.1.0
       prettier:
         specifier: ^3.0.3
-        version: 3.5.3
+        version: 3.8.3
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -6353,7 +6353,7 @@ importers:
         version: 7.4.0(eslint@9.39.4(jiti@1.21.7))
       prettier:
         specifier: ^3.3.3
-        version: 3.5.3
+        version: 3.8.3
       taskr:
         specifier: 1.1.0
         version: 1.1.0
@@ -7509,7 +7509,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
@@ -9581,6 +9581,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -10190,10 +10191,6 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
-    engines: {node: 18 || 20 || >=22}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -13251,10 +13248,6 @@ packages:
     deprecated: please don't use. see readme (https://github.com/fizker/minifier) for details
     hasBin: true
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
-    engines: {node: 18 || 20 || >=22}
-
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -13932,10 +13925,6 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.4.49:
-    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -14225,13 +14214,6 @@ packages:
       react-native: 0.85.3
       react-native-safe-area-context: '*'
 
-  react-native-reanimated@4.3.0:
-    resolution: {integrity: sha512-HOTTPdKtddXTOsmQxDASXEwLS3lqEHrKERD3XOgzSqWJ7L3x81Pnx7mTcKx1FKdkgomMug/XSmm1C6Z7GIowxA==}
-    peerDependencies:
-      react: 19.2.3
-      react-native: 0.85.3
-      react-native-worklets: 0.8.x
-
   react-native-reanimated@4.3.1:
     resolution: {integrity: sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q==}
     peerDependencies:
@@ -14296,14 +14278,6 @@ packages:
   react-native-webview@13.16.1:
     resolution: {integrity: sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==}
     peerDependencies:
-      react: 19.2.3
-      react-native: 0.85.3
-
-  react-native-worklets@0.8.1:
-    resolution: {integrity: sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==}
-    peerDependencies:
-      '@babel/core': '*'
-      '@react-native/metro-config': '*'
       react: 19.2.3
       react-native: 0.85.3
 
@@ -14834,6 +14808,7 @@ packages:
 
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
+    deprecated: Unsupported
 
   slugify@1.6.8:
     resolution: {integrity: sha512-HVk9X1E0gz3mSpoi60h/saazLKXKaZThMLU3u/aNwoYn8/xQyX2MGxL0ui2eaokkD7tF+Zo+cKTHUbe1mmmGzA==}
@@ -19753,7 +19728,7 @@ snapshots:
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -20429,10 +20404,6 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
-
-  brace-expansion@5.0.4:
-    dependencies:
-      balanced-match: 4.0.4
 
   brace-expansion@5.0.6:
     dependencies:
@@ -21556,10 +21527,10 @@ snapshots:
       resolve: 1.22.11
       semver: 6.3.1
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.5.3):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.3):
     dependencies:
       eslint: 9.39.4(jiti@1.21.7)
-      prettier: 3.5.3
+      prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
@@ -22369,14 +22340,14 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.4
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -22646,9 +22617,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.4.49):
+  icss-utils@5.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
 
   idb@7.0.1: {}
 
@@ -23535,7 +23506,7 @@ snapshots:
       js-yaml: 4.1.1
       lodash: 4.17.23
       minimist: 1.2.8
-      prettier: 3.5.3
+      prettier: 3.8.3
       tinyglobby: 0.2.15
 
   json-schema-traverse@0.4.1: {}
@@ -24166,10 +24137,6 @@ snapshots:
       sqwish: 0.2.2
       uglify-js: 2.8.29
 
-  minimatch@10.2.4:
-    dependencies:
-      brace-expansion: 5.0.4
-
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -24786,54 +24753,54 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.4.49):
+  postcss-import@15.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.4.49):
+  postcss-js@4.1.0(postcss@8.5.14):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.49
+      postcss: 8.5.14
 
-  postcss-load-config@3.1.4(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)):
+  postcss-load-config@3.1.4(postcss@8.5.14)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.3
     optionalDependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
       ts-node: 10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.4.49)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.4.49
+      postcss: 8.5.14
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.4.49):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.4.49):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.14):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.49)
-      postcss: 8.4.49
+      icss-utils: 5.1.0(postcss@8.5.14)
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.4.49):
+  postcss-modules-scope@3.2.1(postcss@8.5.14):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
-  postcss-nested@6.2.0(postcss@8.4.49):
+  postcss-nested@6.2.0(postcss@8.5.14):
     dependencies:
-      postcss: 8.4.49
+      postcss: 8.5.14
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -24847,12 +24814,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.49:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.14:
     dependencies:
@@ -25174,14 +25135,6 @@ snapshots:
       react-native-safe-area-context: 5.6.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
 
-  react-native-reanimated@4.3.0(patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8f5c3f4b237a0559138)(react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
-    dependencies:
-      react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
-      react-native-worklets: 0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
-      semver: 7.7.4
-
   react-native-reanimated@4.3.1(patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8f5c3f4b237a0559138)(react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -25257,26 +25210,6 @@ snapshots:
       invariant: 2.2.4
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-
-  react-native-worklets@0.8.1(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@react-native/metro-config': 0.85.3(@babel/core@7.29.0)
-      convert-source-map: 2.0.0
-      react: 19.2.3
-      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
 
   react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -26262,11 +26195,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.4.49
-      postcss-import: 15.1.0(postcss@8.4.49)
-      postcss-js: 4.1.0(postcss@8.4.49)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.4.49)(tsx@4.21.0)(yaml@2.8.3)
-      postcss-nested: 6.2.0(postcss@8.4.49)
+      postcss: 8.5.14
+      postcss-import: 15.1.0(postcss@8.5.14)
+      postcss-js: 4.1.0(postcss@8.5.14)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-nested: 6.2.0(postcss@8.5.14)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -26606,14 +26539,14 @@ snapshots:
       '@types/postcss-modules-local-by-default': 4.0.2
       '@types/postcss-modules-scope': 3.0.4
       dotenv: 16.6.1
-      icss-utils: 5.1.0(postcss@8.4.49)
+      icss-utils: 5.1.0(postcss@8.5.14)
       less: 4.6.4
       lodash.camelcase: 4.3.0
-      postcss: 8.4.49
-      postcss-load-config: 3.1.4(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3))
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.49)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.4.49)
-      postcss-modules-scope: 3.2.1(postcss@8.4.49)
+      postcss: 8.5.14
+      postcss-load-config: 3.1.4(postcss@8.5.14)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3))
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.14)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.14)
+      postcss-modules-scope: 3.2.1(postcss@8.5.14)
       reserved-words: 0.1.2
       sass: 1.98.0
       source-map-js: 1.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2330,7 +2330,7 @@ importers:
         version: 5.3.2
       minimatch:
         specifier: ^10.2.2
-        version: 10.2.5
+        version: 10.2.4
       resolve-from:
         specifier: ^5.0.0
         version: 5.0.0
@@ -3340,13 +3340,13 @@ importers:
         version: 9.39.4(jiti@1.21.7)
       eslint-plugin-prettier:
         specifier: ^5.2.1
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.5.3)
       eslint8:
         specifier: npm:eslint@^8.57.1
         version: eslint@8.57.1
       prettier:
         specifier: ^3.4.2
-        version: 3.8.3
+        version: 3.5.3
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -3376,7 +3376,7 @@ importers:
         version: 11.1.0(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-prettier:
         specifier: ^5.2.6
-        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.3)
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.5.3)
       eslint-plugin-react:
         specifier: ^7.37.5
         version: 7.37.5(eslint@9.39.4(jiti@1.21.7))
@@ -3401,7 +3401,7 @@ importers:
         version: 29.7.0(@types/node@22.19.15)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3))
       prettier:
         specifier: ^3.5.3
-        version: 3.8.3
+        version: 3.5.3
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -4379,7 +4379,7 @@ importers:
         version: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-reanimated:
         specifier: '*'
-        version: 4.3.1(patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8f5c3f4b237a0559138)(react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        version: 4.3.0(patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8f5c3f4b237a0559138)(react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-web:
         specifier: '*'
         version: 0.21.2(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -4892,7 +4892,7 @@ importers:
         version: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
       react-native-worklets:
         specifier: ^0.7.4 || ^0.8.0
-        version: 0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+        version: 0.8.1(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
     devDependencies:
       '@testing-library/react-native':
         specifier: ^13.3.0
@@ -4926,7 +4926,7 @@ importers:
         version: 13.0.6
       prettier:
         specifier: ^3.0.3
-        version: 3.8.3
+        version: 3.5.3
       xml-js:
         specifier: ^1.6.11
         version: 1.6.11
@@ -5659,7 +5659,7 @@ importers:
         version: 12.1.0
       prettier:
         specifier: ^3.0.3
-        version: 3.8.3
+        version: 3.5.3
       typescript:
         specifier: ~6.0.3
         version: 6.0.3
@@ -6353,7 +6353,7 @@ importers:
         version: 7.4.0(eslint@9.39.4(jiti@1.21.7))
       prettier:
         specifier: ^3.3.3
-        version: 3.8.3
+        version: 3.5.3
       taskr:
         specifier: 1.1.0
         version: 1.1.0
@@ -7509,7 +7509,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
@@ -9581,7 +9581,6 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
-    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -10191,6 +10190,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.4:
+    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+    engines: {node: 18 || 20 || >=22}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -13248,6 +13251,10 @@ packages:
     deprecated: please don't use. see readme (https://github.com/fizker/minifier) for details
     hasBin: true
 
+  minimatch@10.2.4:
+    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -13925,6 +13932,10 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
+  postcss@8.4.49:
+    resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -14214,6 +14225,13 @@ packages:
       react-native: 0.85.3
       react-native-safe-area-context: '*'
 
+  react-native-reanimated@4.3.0:
+    resolution: {integrity: sha512-HOTTPdKtddXTOsmQxDASXEwLS3lqEHrKERD3XOgzSqWJ7L3x81Pnx7mTcKx1FKdkgomMug/XSmm1C6Z7GIowxA==}
+    peerDependencies:
+      react: 19.2.3
+      react-native: 0.85.3
+      react-native-worklets: 0.8.x
+
   react-native-reanimated@4.3.1:
     resolution: {integrity: sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q==}
     peerDependencies:
@@ -14278,6 +14296,14 @@ packages:
   react-native-webview@13.16.1:
     resolution: {integrity: sha512-If0eHhoEdOYDcHsX+xBFwHMbWBGK1BvGDQDQdVkwtSIXiq1uiqjkpWVP2uQ1as94J0CzvFE9PUNDuhiX0Z6ubw==}
     peerDependencies:
+      react: 19.2.3
+      react-native: 0.85.3
+
+  react-native-worklets@0.8.1:
+    resolution: {integrity: sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==}
+    peerDependencies:
+      '@babel/core': '*'
+      '@react-native/metro-config': '*'
       react: 19.2.3
       react-native: 0.85.3
 
@@ -14808,7 +14834,6 @@ packages:
 
   sliced@1.0.1:
     resolution: {integrity: sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==}
-    deprecated: Unsupported
 
   slugify@1.6.8:
     resolution: {integrity: sha512-HVk9X1E0gz3mSpoi60h/saazLKXKaZThMLU3u/aNwoYn8/xQyX2MGxL0ui2eaokkD7tF+Zo+cKTHUbe1mmmGzA==}
@@ -19728,7 +19753,7 @@ snapshots:
       '@typescript-eslint/types': 8.59.1
       '@typescript-eslint/visitor-keys': 8.59.1
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.4
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -20404,6 +20429,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
 
   brace-expansion@5.0.6:
     dependencies:
@@ -21527,10 +21556,10 @@ snapshots:
       resolve: 1.22.11
       semver: 6.3.1
 
-  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)))(eslint@9.39.4(jiti@1.21.7))(prettier@3.5.3):
     dependencies:
       eslint: 9.39.4(jiti@1.21.7)
-      prettier: 3.8.3
+      prettier: 3.5.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.12
     optionalDependencies:
@@ -22340,14 +22369,14 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 4.2.3
-      minimatch: 10.2.5
+      minimatch: 10.2.4
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
 
   glob@13.0.6:
     dependencies:
-      minimatch: 10.2.5
+      minimatch: 10.2.4
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -22617,9 +22646,9 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.14):
+  icss-utils@5.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.4.49
 
   idb@7.0.1: {}
 
@@ -23506,7 +23535,7 @@ snapshots:
       js-yaml: 4.1.1
       lodash: 4.17.23
       minimist: 1.2.8
-      prettier: 3.8.3
+      prettier: 3.5.3
       tinyglobby: 0.2.15
 
   json-schema-traverse@0.4.1: {}
@@ -24137,6 +24166,10 @@ snapshots:
       sqwish: 0.2.2
       uglify-js: 2.8.29
 
+  minimatch@10.2.4:
+    dependencies:
+      brace-expansion: 5.0.4
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -24753,54 +24786,54 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.14):
+  postcss-import@15.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.4.49
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.14):
+  postcss-js@4.1.0(postcss@8.4.49):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.14
+      postcss: 8.4.49
 
-  postcss-load-config@3.1.4(postcss@8.5.14)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)):
+  postcss-load-config@3.1.4(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.3
     optionalDependencies:
-      postcss: 8.5.14
+      postcss: 8.4.49
       ts-node: 10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3)
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.4.49)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.14
+      postcss: 8.4.49
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.14):
+  postcss-modules-extract-imports@3.1.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.4.49
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.14):
+  postcss-modules-local-by-default@4.2.0(postcss@8.4.49):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.14)
-      postcss: 8.5.14
+      icss-utils: 5.1.0(postcss@8.4.49)
+      postcss: 8.4.49
       postcss-selector-parser: 7.1.1
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.14):
+  postcss-modules-scope@3.2.1(postcss@8.4.49):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.4.49
       postcss-selector-parser: 7.1.1
 
-  postcss-nested@6.2.0(postcss@8.5.14):
+  postcss-nested@6.2.0(postcss@8.4.49):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.4.49
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.1.2:
@@ -24814,6 +24847,12 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.49:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.14:
     dependencies:
@@ -25135,6 +25174,14 @@ snapshots:
       react-native-safe-area-context: 5.6.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       use-latest-callback: 0.2.6(react@19.2.3)
 
+  react-native-reanimated@4.3.0(patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8f5c3f4b237a0559138)(react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-worklets: 0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      semver: 7.7.4
+
   react-native-reanimated@4.3.1(patch_hash=1e34e4238541638db96b94d5a2e974e73f3b801788a3d8f5c3f4b237a0559138)(react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -25210,6 +25257,26 @@ snapshots:
       invariant: 2.2.4
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+
+  react-native-worklets@0.8.1(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@react-native/metro-config': 0.85.3(@babel/core@7.29.0)
+      convert-source-map: 2.0.0
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+      semver: 7.7.4
+    transitivePeerDependencies:
+      - supports-color
 
   react-native-worklets@0.8.3(patch_hash=3f49a21b44ba558989a3366eeff9c92ee331e18b736dbe89c5962ecc6f2802f1)(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -26195,11 +26262,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.14
-      postcss-import: 15.1.0(postcss@8.5.14)
-      postcss-js: 4.1.0(postcss@8.5.14)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.14)(tsx@4.21.0)(yaml@2.8.3)
-      postcss-nested: 6.2.0(postcss@8.5.14)
+      postcss: 8.4.49
+      postcss-import: 15.1.0(postcss@8.4.49)
+      postcss-js: 4.1.0(postcss@8.4.49)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.4.49)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -26539,14 +26606,14 @@ snapshots:
       '@types/postcss-modules-local-by-default': 4.0.2
       '@types/postcss-modules-scope': 3.0.4
       dotenv: 16.6.1
-      icss-utils: 5.1.0(postcss@8.5.14)
+      icss-utils: 5.1.0(postcss@8.4.49)
       less: 4.6.4
       lodash.camelcase: 4.3.0
-      postcss: 8.5.14
-      postcss-load-config: 3.1.4(postcss@8.5.14)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3))
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.14)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.14)
-      postcss-modules-scope: 3.2.1(postcss@8.5.14)
+      postcss: 8.4.49
+      postcss-load-config: 3.1.4(postcss@8.4.49)(ts-node@10.9.2(@swc/core@1.15.18)(@types/node@22.19.15)(typescript@6.0.3))
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.49)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.4.49)
+      postcss-modules-scope: 3.2.1(postcss@8.4.49)
       reserved-words: 0.1.2
       sass: 1.98.0
       source-map-js: 1.2.1


### PR DESCRIPTION
# Why

React Native 0.86 splits `facebook::jsi::Runtime` into an `IRuntime` abstract base and a `Runtime` derived class. Most JSI methods now take `IRuntime&` instead of `Runtime&`, so `expo-modules-jsi` don't build against 0.86+.

# How

- Updated the C++ headers and Swift sources to use `IRuntime&` where the JSI API expects it.
- Added `IRuntime` and `ICast` to `jsi.apinotes` so Swift C++ interop imports them as immortal reference types, same as the existing `Runtime` entry.
- Added an `IRuntimeCompat.h` shim that aliases `IRuntime` to `Runtime` on React Native older than 0.86 (detected via `cxxreact/ReactNativeVersion.h`), so the same source still compiles against 0.85 and react-native-tvos.

# Test Plan

- Built `expo-modules-jsi` against react native 0.86.0 rc.0 (the upgrade branch) and against current main (0.85.x). Both produce the xcframework without errors.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
