### PR TITLE
[test-suite] Remove async from describe callbacks

### DIFF
--- a/apps/test-suite/tests/Battery.js
+++ b/apps/test-suite/tests/Battery.js
@@ -6,8 +6,9 @@ export const name = 'Battery';
 
 export async function test({ describe, it, expect, jasmine }) {
   const isExpectedToSupport = Device.isDevice || Platform.OS === 'android';
+  const isAvailable = await Battery.isAvailableAsync();
 
-  describe('Battery', async () => {
+  describe('Battery', () => {
     describe(`isAvailableAsync`, () => {
       it(
         isExpectedToSupport
@@ -18,8 +19,6 @@ export async function test({ describe, it, expect, jasmine }) {
         }
       );
     });
-
-    const isAvailable = await Battery.isAvailableAsync();
 
     if (isAvailable) {
       describe(`getBatteryLevelAsync()`, () => {

--- a/apps/test-suite/tests/Blob.ts
+++ b/apps/test-suite/tests/Blob.ts
@@ -82,7 +82,7 @@ export async function test({ describe, it, expect }) {
     return out;
   };
 
-  describe('Blob', async () => {
+  describe('Blob', () => {
     describe('Blob creation', () => {
       it('Empty blob', () => {
         const blob = new Blob([]);
@@ -133,7 +133,7 @@ export async function test({ describe, it, expect }) {
         expect(slice.size).toBe(3);
         expect(bytes).toEqual(new TextEncoder().encode(str).slice(0, 3));
       });
-      describe('large slice start and end', async () => {
+      describe('large slice start and end', () => {
         it('large positive start', async () => {
           const blob = new Blob(['PASS']);
           const str = await blob.slice(10000).text();
@@ -201,7 +201,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('Bytes', async () => {
+    describe('Bytes', () => {
       it('Simple', async () => {
         const input_arr = new TextEncoder().encode('PASS');
         const blob = new Blob([input_arr]);
@@ -243,7 +243,7 @@ export async function test({ describe, it, expect }) {
     // Windows platforms use CRLF as the native line ending. All others use LF.
     const crlf = Platform.OS === 'windows';
     const native_ending = crlf ? '\r\n' : '\n';
-    describe('constructor-endings', async () => {
+    describe('constructor-endings', () => {
       it('valid endings value', () => {
         const blob0 = new Blob([], { endings: 'native' });
         const blob1 = new Blob([], { endings: 'transparent' });
@@ -932,7 +932,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('Text', async () => {
+    describe('Text', () => {
       it('simple', async () => {
         const blob = new Blob(['PASS']);
         const text = await blob.text();
@@ -991,7 +991,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('Worker', async () => {
+    describe('Worker', () => {
       it('Create Blob in Worker', async () => {
         const data = 'TEST';
         const blob = new Blob([data], { type: 'text/plain' });
@@ -999,7 +999,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('Blob slice overflow', async () => {
+    describe('Blob slice overflow', () => {
       let text = '';
 
       for (let i = 0; i < 2000; ++i) {
@@ -1031,7 +1031,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('Blob Slice', async () => {
+    describe('Blob Slice', () => {
       test_blob(
         () => {
           const blobTemp = new Blob(['PASS']);
@@ -1044,7 +1044,7 @@ export async function test({ describe, it, expect }) {
         }
       );
 
-      describe('Slices', async () => {
+      describe('Slices', () => {
         const blob1 = new Blob(['squiggle']);
         const blob2 = new Blob(['steak'], { type: 'content/type' });
 
@@ -1301,7 +1301,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('stream', async () => {
+    describe('stream', () => {
       it('stream byob crash', async () => {
         const a = new Blob(['', '', undefined], {});
         const b = a.stream();

--- a/apps/test-suite/tests/Crypto.js
+++ b/apps/test-suite/tests/Crypto.js
@@ -54,7 +54,7 @@ function supportedAlgorithm(algorithm) {
 
 export async function test({ describe, it, expect }) {
   describe('Crypto', () => {
-    describe('digestStringAsync()', async () => {
+    describe('digestStringAsync()', () => {
       it(`Invalid CryptoEncoding throws an error`, async () => {
         let error = null;
         try {
@@ -92,7 +92,7 @@ export async function test({ describe, it, expect }) {
       }
     });
 
-    describe('digest()', async () => {
+    describe('digest()', () => {
       for (const entry of Object.entries(CryptoDigestAlgorithm)) {
         const [key, algorithm] = entry;
         it(`CryptoDigestAlgorithm.${key}`, async () => {

--- a/apps/test-suite/tests/FirebaseJSSDK.js
+++ b/apps/test-suite/tests/FirebaseJSSDK.js
@@ -48,8 +48,8 @@ export async function test({ describe, it, expect }) {
     auth = initializeAuth(getApp(), { persistence: getReactNativePersistence(AsyncStorage) });
   } catch {}
 
-  describe('FirebaseJSSDK', async () => {
-    describe('auth', async () => {
+  describe('FirebaseJSSDK', () => {
+    describe('auth', () => {
       it(`calls getAuth() succesfully`, () => {
         expect(auth).not.toBeNull();
       });
@@ -62,7 +62,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('database', async () => {
+    describe('database', () => {
       it(`calls getDatabase() succesfully`, () => {
         expect(getDatabase()).not.toBeNull();
       });
@@ -82,7 +82,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('firestore', async () => {
+    describe('firestore', () => {
       it(`calls getFirestore() succesfully`, () => {
         expect(getFirestore()).not.toBeNull();
       });
@@ -117,7 +117,7 @@ export async function test({ describe, it, expect }) {
       });
     });
 
-    describe('functions', async () => {
+    describe('functions', () => {
       it(`calls getFunctions() succesfully`, () => {
         expect(getFunctions()).not.toBeNull();
       });

--- a/apps/test-suite/tests/Image.js
+++ b/apps/test-suite/tests/Image.js
@@ -173,7 +173,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
       });
     });
 
-    t.describe('getCachePathAsync', async () => {
+    t.describe('getCachePathAsync', () => {
       t.it('returns path to cached image when it does exist in the cache', async () => {
         await mountAndWaitFor(
           <Image source={REMOTE_SOURCE} style={{ height: 100, width: 100 }} />,
@@ -216,7 +216,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
       });
     });
 
-    t.describe('prefetch', async () => {
+    t.describe('prefetch', () => {
       t.it('prefetches an image and resolves promise to true', async () => {
         await Image.clearDiskCache();
         const result = await Image.prefetch(REMOTE_SOURCE.uri);
@@ -256,7 +256,7 @@ export async function test(t, { setPortalChild, cleanupPortal }) {
     });
 
     if (Platform.OS === 'ios') {
-      t.describe('generateBlurhashAsync', async () => {
+      t.describe('generateBlurhashAsync', () => {
         t.it('returns a correct blurhash for url', async () => {
           const result = await Image.generateBlurhashAsync(REMOTE_SOURCE.uri, [4, 3]);
           t.expect(result).toBe(REMOTE_SOURCE.blurhash);

--- a/apps/test-suite/tests/ImagePicker.js
+++ b/apps/test-suite/tests/ImagePicker.js
@@ -84,7 +84,7 @@ export async function test({ it, beforeAll, expect, jasmine, describe, afterAll 
       }
     });
 
-    describe('launchImageLibraryAsync', async () => {
+    describe('launchImageLibraryAsync', () => {
       it('mediaType: image', async () => {
         await alertAndWaitForResponse('Please choose an image.');
         const result = await ImagePicker.launchImageLibraryAsync({

--- a/apps/test-suite/tests/MediaLibrary.js
+++ b/apps/test-suite/tests/MediaLibrary.js
@@ -140,7 +140,7 @@ export async function test(t) {
       }
     });
 
-    t.describe('With default assets', async () => {
+    t.describe('With default assets', () => {
       let testAssets;
       let album;
 
@@ -185,7 +185,7 @@ export async function test(t) {
         await cleanupAsync();
       }, TIMEOUT_WHEN_USER_NEEDS_TO_INTERACT);
 
-      t.describe('Every return value has proper shape', async () => {
+      t.describe('Every return value has proper shape', () => {
         t.it('createAssetAsync', () => {
           const keys = Object.keys(testAssets[0]);
           ASSET_KEYS.forEach((key) => t.expect(keys).toContain(key));
@@ -211,7 +211,7 @@ export async function test(t) {
         });
       });
 
-      t.describe('Small tests', async () => {
+      t.describe('Small tests', () => {
         t.it('Function getAlbums returns test album', async () => {
           const albums = await MediaLibrary.getAlbumsAsync();
           t.expect(albums.filter((elem) => elem.id === album.id).length).toBe(1);
@@ -272,7 +272,7 @@ export async function test(t) {
         // });
       });
 
-      t.describe('Creating albums with initial assets', async () => {
+      t.describe('Creating albums with initial assets', () => {
         async function cleanupAsync() {
           const album = await MediaLibrary.getAlbumAsync(THIRD_ALBUM_NAME);
           await MediaLibrary.deleteAlbumsAsync([album], true);
@@ -304,7 +304,7 @@ export async function test(t) {
         });
       });
 
-      t.describe('getAssetsAsync', async () => {
+      t.describe('getAssetsAsync', () => {
         t.it('No arguments', async () => {
           const options = {};
           const { assets } = await MediaLibrary.getAssetsAsync(options);
@@ -434,7 +434,7 @@ export async function test(t) {
         });
       });
 
-      t.describe('getAssetInfoAsync', async () => {
+      t.describe('getAssetInfoAsync', () => {
         t.it('shouldDownloadFromNetwork: false, for photos', async () => {
           const mediaType = MediaLibrary.MediaType.photo;
           const options = { mediaType, album };
@@ -507,7 +507,7 @@ export async function test(t) {
       });
     });
 
-    t.describe('Delete tests', async () => {
+    t.describe('Delete tests', () => {
       t.it(
         'deleteAssetsAsync',
         async () => {
@@ -578,7 +578,7 @@ export async function test(t) {
       );
     });
 
-    t.describe('Listeners', async () => {
+    t.describe('Listeners', () => {
       const createdAssets = [];
 
       t.afterAll(async () => {

--- a/apps/test-suite/tests/MediaLibraryNext.ts
+++ b/apps/test-suite/tests/MediaLibraryNext.ts
@@ -58,7 +58,7 @@ export async function test(t) {
     }
   });
 
-  t.describe('Stress tests', async () => {
+  t.describe('Stress tests', () => {
     t.it('creating files with the same filename', async () => {
       for (let i = 0; i < 40; i++) {
         const asset = await Asset.create(pngFile.localUri);

--- a/apps/test-suite/tests/Network.js
+++ b/apps/test-suite/tests/Network.js
@@ -7,7 +7,7 @@ const Ipv4Regex =
 
 export async function test(t) {
   if (Platform.OS === 'android') {
-    t.describe(`Network.isAirplaneModeEnabledAsync()`, async () => {
+    t.describe(`Network.isAirplaneModeEnabledAsync()`, () => {
       t.it(`returns a boolean`, async () => {
         const isAirplaneModeOn = await Network.isAirplaneModeEnabledAsync();
         t.expect(isAirplaneModeOn).toBeDefined();

--- a/apps/test-suite/tests/Notifications.ts
+++ b/apps/test-suite/tests/Notifications.ts
@@ -155,7 +155,7 @@ export async function test(t) {
         }
       });
 
-      t.describe('if handler responds in time', async () => {
+      t.describe('if handler responds in time', () => {
         t.it(
           'calls `handleSuccess` callback of the notification handler',
           async () => {
@@ -167,7 +167,7 @@ export async function test(t) {
         );
       });
 
-      t.describe('if handler fails to respond in time', async () => {
+      t.describe('if handler fails to respond in time', () => {
         t.beforeAll(() => {
           handleFuncOverride = async () => {
             await waitFor(3000);

--- a/apps/test-suite/tests/TaskManager.js
+++ b/apps/test-suite/tests/TaskManager.js
@@ -23,7 +23,7 @@ export async function test(t) {
       });
     });
 
-    t.describe('isTaskRegisteredAsync()', async () => {
+    t.describe('isTaskRegisteredAsync()', () => {
       t.beforeAll(async () => {
         await BackgroundFetch.registerTaskAsync(DEFINED_TASK_NAME);
       });
@@ -41,7 +41,7 @@ export async function test(t) {
       });
     });
 
-    t.describe('getTaskOptionsAsync()', async () => {
+    t.describe('getTaskOptionsAsync()', () => {
       let taskOptions;
 
       t.it('returns null for unregistered tasks', async () => {
@@ -62,7 +62,7 @@ export async function test(t) {
       });
     });
 
-    t.describe('getRegisteredTasksAsync()', async () => {
+    t.describe('getRegisteredTasksAsync()', () => {
       let registeredTasks;
 
       t.it('returns empty array if there are no tasks', async () => {


### PR DESCRIPTION
# Why
fixes: 
<img width="125" height="273" alt="Screenshot_20260513_155034_BareExpo" src="https://github.com/user-attachments/assets/a8d4e622-41e4-4009-a07a-2349f434bf85" />
The problem is that Jasmine doesn't accept async callbacks in the describe function. This was hidden by the `@babel/plugin-transform-async-to-generator` plugin, which was removed in https://github.com/expo/expo/pull/45345, causing tests that use this construction to throw an error.


# How
Removes the `async` keyword fron describe callbacks. 

# Test Plan
BareExpo ✅