### PR TITLE
[test-core] Pin expo-type-information version

### DIFF
--- a/packages/expo-modules-test-core/package.json
+++ b/packages/expo-modules-test-core/package.json
@@ -36,6 +36,6 @@
     "prettier": "^3.0.3",
     "xml-js": "^1.6.11",
     "yaml": "^2.8.3",
-    "expo-type-information": "workspace:*"
+    "expo-type-information": "workspace:^0.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4919,7 +4919,7 @@ importers:
         specifier: ^22.14.0
         version: 22.19.15
       expo-type-information:
-        specifier: workspace:*
+        specifier: workspace:^0.0.1
         version: link:../expo-type-information
       glob:
         specifier: ^13.0.0


### PR DESCRIPTION
# Why

A follow-up to the https://github.com/expo/expo/pull/45719#discussion_r3234798535
