### PR TITLE
[widgets] Make errors more descriptive

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Support configurable widgets. ([#45726](https://github.com/expo/expo/pull/45726) by [@jakex7](https://github.com/jakex7))
+- Improve RedBox messages.
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - Support configurable widgets. ([#45726](https://github.com/expo/expo/pull/45726) by [@jakex7](https://github.com/jakex7))
-- Improve RedBox messages.
+- Improve RedBox messages. ([#45732](https://github.com/expo/expo/pull/45732) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/ios/Widgets/EntryView.swift
+++ b/packages/expo-widgets/ios/Widgets/EntryView.swift
@@ -25,13 +25,12 @@ public struct WidgetsEntryView: View {
   }
 
   public var body: some View {
-    let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\(entry.name)_layout") ?? ""
-    let node = evaluateLayout(layout: layout, props: entry.props ?? [:], environment: widgetEnvironment)
-
-    if let node {
+    if let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\(entry.name)_layout"),
+       !layout.isEmpty {
+      let node = evaluateLayout(layout: layout, props: entry.props ?? [:], environment: widgetEnvironment)
       WidgetsDynamicView(name: entry.name, kind: .widget, node: node, entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     } else {
-      EmptyView()
+      WidgetsDynamicView(name: entry.name, kind: .widget, node: createRedBox(message: "No layout found for \(WidgetsStorage.appGroupIdentifier ?? "")::\(entry.name)"), entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     }
   }
 }

--- a/packages/expo-widgets/ios/Widgets/Utils.swift
+++ b/packages/expo-widgets/ios/Widgets/Utils.swift
@@ -20,7 +20,7 @@ func parseTimeline(identifier: String, name: String, family: WidgetFamily) -> [W
   return entries.compactMap(\.self)
 }
 
-func createRedBox(message: String, stack: String? = nil) -> [String: Any] {
+public func createRedBox(message: String, stack: String? = nil) -> [String: Any] {
   var props: [String: Any] = ["message": message]
   if let stack {
     props["stack"] = stack
@@ -32,9 +32,9 @@ public func evaluateLayout(
   layout: String,
   props: [String: Any],
   environment: [String: Any]
-) -> [String: Any]? {
+) -> [String: Any] {
   guard let context = createWidgetContext(layout: layout) else {
-    return nil
+    return createRedBox(message: "Could not create context for layout evaluation.")
   }
 
   let result = context.objectForKeyedSubscript("__expoWidgetRender")?.call(
@@ -44,7 +44,7 @@ public func evaluateLayout(
     print("[ExpoWidgets] Layout evaluation failed: \(exception)")
     return createRedBox(message: exception.toString())
   }
-  return result?.toObject() as? [String: Any]
+  return result?.toObject() as? [String: Any] ?? createRedBox(message: "Expo widget render did not produce any results.")
 }
 
 func getLiveActivityNodes(forName name: String, props: String = "{}", environment: [String: Any]) -> [String: Any] {
@@ -52,7 +52,7 @@ func getLiveActivityNodes(forName name: String, props: String = "{}", environmen
   let propsData = props.data(using: .utf8)
   let propsDict = propsData.flatMap { try? JSONSerialization.jsonObject(with: $0, options: []) as? [String: Any] } ?? [:]
   guard let context = createWidgetContext(layout: layout) else {
-    return [:]
+    return ["banner": createRedBox(message: "Could not create context for layout evaluation.")]
   }
 
   var widgetEnvironment = environment
@@ -67,7 +67,7 @@ func getLiveActivityNodes(forName name: String, props: String = "{}", environmen
     return ["banner": createRedBox(message: exception.toString())]
   }
 
-  return result?.toObject() as? [String: Any] ?? [:]
+  return result?.toObject() as? [String: Any] ?? ["banner": createRedBox(message: "Expo widget render did not produce any results.")]
 }
 
 func getLiveActivityUrl(forName name: String) -> URL? {

--- a/packages/expo-widgets/ios/WidgetsStorage.swift
+++ b/packages/expo-widgets/ios/WidgetsStorage.swift
@@ -1,5 +1,5 @@
 public enum WidgetsStorage {
-  static var appGroupIdentifier: String? = Bundle.main.object(forInfoDictionaryKey: "ExpoWidgetsAppGroupIdentifier") as? String
+  public static var appGroupIdentifier: String? = Bundle.main.object(forInfoDictionaryKey: "ExpoWidgetsAppGroupIdentifier") as? String
   static let defaults = UserDefaults(suiteName: appGroupIdentifier)
 
   static func set(_ value: [String: Any], forKey key: String) {

--- a/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
+++ b/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
@@ -278,13 +278,12 @@ ${Object.entries(widget.configuration?.parameters ?? {})
   }
 
   public var body: some View {
-    let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\\(entry.name)_layout") ?? ""
-    let node = evaluateLayout(layout: layout, props: entry.props ?? [:], environment: widgetEnvironment)
-
-    if let node {
+    if let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\\(entry.name)_layout"),
+       !layout.isEmpty {
+      let node = evaluateLayout(layout: layout, props: entry.props ?? [:], environment: widgetEnvironment)
       WidgetsDynamicView(name: entry.name, kind: .widget, node: node, entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     } else {
-      EmptyView()
+      WidgetsDynamicView(name: entry.name, kind: .widget, node: createRedBox(message: "No layout found for \\(WidgetsStorage.appGroupIdentifier ?? "")::\\(entry.name)"), entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     }
   }
 }

--- a/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
@@ -282,13 +282,12 @@ ${Object.entries(widget.configuration?.parameters ?? {})
   }
 
   public var body: some View {
-    let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\\(entry.name)_layout") ?? ""
-    let node = evaluateLayout(layout: layout, props: entry.props ?? [:], environment: widgetEnvironment)
-
-    if let node {
+    if let layout = WidgetsStorage.getString(forKey: "__expo_widgets_\\(entry.name)_layout"),
+       !layout.isEmpty {
+      let node = evaluateLayout(layout: layout, props: entry.props ?? [:], environment: widgetEnvironment)
       WidgetsDynamicView(name: entry.name, kind: .widget, node: node, entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     } else {
-      EmptyView()
+      WidgetsDynamicView(name: entry.name, kind: .widget, node: createRedBox(message: "No layout found for \\(WidgetsStorage.appGroupIdentifier ?? "")::\\(entry.name)"), entryIndex: entry.entryIndex, environmentString: widgetEnvironmentString)
     }
   }
 }


### PR DESCRIPTION
# Why

To make RedBox errors more descriptive (and visible instead EmptyView)

# How

Change types and error messages.

# Test Plan

Show widget without layout defined.
<img width="322" height="170" alt="image" src="https://github.com/user-attachments/assets/435d1e90-a740-4b71-8927-f19d19d92eb8" />

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
