### PR TITLE
[screen-orientation][iOS] fix infinite recursion in supportedInterfaceOrientations

### DIFF
--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `EXC_BAD_ACCESS` crash from recursive `supportedInterfaceOrientations` when `react-native-screens` per-screen orientation is set.                                   
+  ([#45733](https://github.com/expo/expo/pull/45733) by [@rayabelcode](https://github.com/rayabelcode))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
+++ b/packages/expo-screen-orientation/ios/ScreenOrientationViewController.swift
@@ -65,9 +65,13 @@ class ScreenOrientationViewController: UIViewController {
 
   override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
     if let vc = vcWithRNScreenOrientation() {
-      // react-native-screens has per-screen orientation set. Return that VC's
-      // supportedInterfaceOrientations — which RNScreens has swizzled to resolve
-      // the active screen's orientation mask.
+      // react-native-screens has per-screen orientation set. Defer to that VC's
+      // supportedInterfaceOrientations so RNScreens' swizzled implementation can
+      // resolve the active screen's orientation mask. When the matching VC is
+      // self, call super to avoid recursing into this override.
+      if vc === self {
+        return super.supportedInterfaceOrientations
+      }
       return vc.supportedInterfaceOrientations
     }
 


### PR DESCRIPTION
# Why

Fixes #45479.

`ScreenOrientationViewController.supportedInterfaceOrientations` infinite-recurses and crashes release builds with `EXC_BAD_ACCESS` (stack overflow) whenever `react-native-screens` per-screen orientation is set on a screen below the root VC. The regression was introduced by #44181 and ships in 55.0.14, 55.0.15, and current `main`.

In production (without `expo-dev-client`), `vcWithRNScreenOrientation()` returns `self` because `RNSScreenWindowTraits.shouldAskScreensForScreenOrientation(in: self)` is true for the root VC. The override then evaluates `vc.supportedInterfaceOrientations` on that same instance, which dynamic-dispatches back into this override and never terminates. The previous implementation called `super.supportedInterfaceOrientations` in this branch, which is why 55.0.13 did not crash.

The crash fires once a `<Stack.Screen options={{ orientation: ... }}>` mounts. The orientation value does not matter; the presence of the trait on the active screen is what makes `shouldAskScreensForScreenOrientation` return true. `expo-dev-client` builds do not reproduce because `DevLauncherViewController` sits between the window and `ScreenOrientationViewController`, so `shouldAskScreensForScreenOrientation(in: self)` returns false for the root VC and the child-search branch from #44181 takes over (returning a non-self VC, which does not recurse). This is why the regression was not caught when #44181 was tested.

# How

When `vcWithRNScreenOrientation()` returns `self`, fall through to `super.supportedInterfaceOrientations` (UIKit's default resolution, matching 55.0.13 behavior). When it returns a child VC (the `expo-dev-client` case that #44181 was written for), keep the existing call into the child's getter — that path was never recursive.

```swift
override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
  if let vc = vcWithRNScreenOrientation() {
    if vc === self {
      return super.supportedInterfaceOrientations
    }
    return vc.supportedInterfaceOrientations
  }
  let mask = screenOrientationRegistry.requiredOrientationMask()
  return !mask.isEmpty ? mask : defaultOrientationMask
}
```

Three lines of behavioral change; the rest of the diff is a comment update describing the new branch. Helper `vcWithRNScreenOrientation()` is unchanged.

# Test Plan

Reproduction from #45479: https://github.com/CacaoRick/expo-screen-orientation-55014-repro

1. `git clone https://github.com/CacaoRick/expo-screen-orientation-55014-repro && cd expo-screen-orientation-55014-repro`
2. Point `expo-screen-orientation` at this branch (or `yarn link` a local build).
3. `yarn install && npx expo prebuild --clean && npx expo run:ios --configuration Release -d`

Expected: app launches without crashing; the orientation-locked `<Stack.Screen>` mounts and applies its orientation.

Also verified that the `expo-dev-client` path from #44181 still works: when an intermediate VC blocks the single-level traversal, `vcWithRNScreenOrientation()` returns a child VC (not `self`), the new guard is skipped, and the existing call into `child.supportedInterfaceOrientations` runs as before.

# Notes

- Regression was introduced when #44181 replaced `return super.supportedInterfaceOrientations` with `return vc.supportedInterfaceOrientations`. Restoring `super` for the `vc === self` branch is the minimal fix.
- Affects 55.0.14, 55.0.15, and `main` (any release that shipped #44181). Maintainers may want to backport to the 55.x line.
- No CHANGELOG entry included; happy to add one in the requested format if maintainers prefer.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - Skipped pending maintainer guidance on which version section the entry belongs in (55.x backport vs. unpublished 56.x). Will add on request.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)