### PR TITLE
docs(expo-router): add note about custom suspense fallbacks only being available in SDK 56 and later

### DIFF
--- a/docs/pages/router/error-handling.mdx
+++ b/docs/pages/router/error-handling.mdx
@@ -84,6 +84,8 @@ React Native LogBox needs to be presented less aggressively to develop with erro
 
 ## Loading states with Suspense fallback
 
+> **important** Custom suspense fallbacks are available in SDK 56 and later.
+
 Expo Router wraps each route in a [React Suspense](https://react.dev/reference/react/Suspense) boundary. You can export a [`SuspenseFallback`](/versions/unversioned/sdk/router/#suspensefallback) component from a layout file to customize the loading UI shown while any child route is suspended:
 
 ```tsx src/app/_layout.tsx


### PR DESCRIPTION
# Why

Fixes #45710

# How

Added warning callout under "Loading states with Suspense fallback"

# Test Plan

Docs-only change

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
