### PR TITLE
[docs] add a check for `Set` and `Map` to not create links to them

### DIFF
--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -150,7 +150,7 @@ const renderWithLink = ({
 
 const renderUnion = (types: TypeDefinitionData[], { sdkVersion }: { sdkVersion: string }) =>
   types
-    .map((type) => resolveTypeName(type, sdkVersion))
+    .map(type => resolveTypeName(type, sdkVersion))
     .map((valueToRender, index) => (
       <span key={`union-type-${index}`}>
         {valueToRender}
@@ -413,7 +413,7 @@ export const parseParamName = (name: string) => (name.startsWith('__') ? name.sl
 export const listParams = (parameters: MethodParamData[]) =>
   parameters
     ? parameters
-        ?.map((param) => {
+        ?.map(param => {
           if (param.flags?.isRest) {
             return `...${parseParamName(param.name)}`;
           }
@@ -457,7 +457,7 @@ export const getTagData = (tagName: string, comment?: CommentData) =>
 
 export const getAllTagData = (tagName: string, comment?: CommentData) =>
   [...(comment?.blockTags ?? []), ...(comment?.modifierTags ?? [])]
-    .map((tag) => {
+    .map(tag => {
       if (typeof tag === 'string') {
         return {
           tag,
@@ -481,11 +481,11 @@ export const getAllTagData = (tagName: string, comment?: CommentData) =>
       }
       return tag;
     })
-    .filter((tag) => tag.tag.slice(1) === tagName);
+    .filter(tag => tag.tag.slice(1) === tagName);
 
 export const getTagNamesList = (comment?: CommentData) =>
   comment && [
-    ...(getAllTagData('platform', comment)?.map((platformData) =>
+    ...(getAllTagData('platform', comment)?.map(platformData =>
       getCommentContent(platformData.content)
     ) || []),
     ...(getTagData('deprecated', comment) ? ['deprecated'] : []),
@@ -494,7 +494,7 @@ export const getTagNamesList = (comment?: CommentData) =>
 
 export function getTypeParametersNames(typeParameters?: TypeParameterData[]) {
   if (typeParameters?.length) {
-    return `<${typeParameters.map((param) => param.name).join(', ')}>`;
+    return `<${typeParameters.map(param => param.name).join(', ')}>`;
   }
   return '';
 }
@@ -521,7 +521,7 @@ export const getMethodName = (
 
 export const getCommentContent = (content: CommentContentData[]) => {
   return content
-    .map((entry) => {
+    .map(entry => {
       if (entry.tag === '@link' && !entry.text.includes('/')) {
         return `[\`${entry.tsLinkText?.length ? entry.tsLinkText : entry.text}\`](#${slug(entry.text)})`;
       }
@@ -594,7 +594,7 @@ export function defineLiteralType(types: TypeDefinitionData[]) {
   if (uniqueTypes.length === 1) {
     return <CODE>{uniqueTypes[0]}</CODE>;
   }
-  if (uniqueTypes.filter(Boolean).every((type) => typeof type === 'string')) {
+  if (uniqueTypes.filter(Boolean).every(type => typeof type === 'string')) {
     return <CODE>union</CODE>;
   }
   return null;

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -150,7 +150,7 @@ const renderWithLink = ({
 
 const renderUnion = (types: TypeDefinitionData[], { sdkVersion }: { sdkVersion: string }) =>
   types
-    .map(type => resolveTypeName(type, sdkVersion))
+    .map((type) => resolveTypeName(type, sdkVersion))
     .map((valueToRender, index) => (
       <span key={`union-type-${index}`}>
         {valueToRender}
@@ -185,11 +185,12 @@ export const resolveTypeName = (
     tail,
   } = typeDefinition;
 
+  const builtinTypes = new Set(['Record', 'React.ComponentProps', 'Set', 'Map']);
   try {
     if (name) {
       if (type === 'reference') {
         if (typeArguments) {
-          if (name === 'Record' || name === 'React.ComponentProps') {
+          if (builtinTypes.has(name)) {
             return (
               <>
                 {name}
@@ -412,7 +413,7 @@ export const parseParamName = (name: string) => (name.startsWith('__') ? name.sl
 export const listParams = (parameters: MethodParamData[]) =>
   parameters
     ? parameters
-        ?.map(param => {
+        ?.map((param) => {
           if (param.flags?.isRest) {
             return `...${parseParamName(param.name)}`;
           }
@@ -456,7 +457,7 @@ export const getTagData = (tagName: string, comment?: CommentData) =>
 
 export const getAllTagData = (tagName: string, comment?: CommentData) =>
   [...(comment?.blockTags ?? []), ...(comment?.modifierTags ?? [])]
-    .map(tag => {
+    .map((tag) => {
       if (typeof tag === 'string') {
         return {
           tag,
@@ -480,11 +481,11 @@ export const getAllTagData = (tagName: string, comment?: CommentData) =>
       }
       return tag;
     })
-    .filter(tag => tag.tag.slice(1) === tagName);
+    .filter((tag) => tag.tag.slice(1) === tagName);
 
 export const getTagNamesList = (comment?: CommentData) =>
   comment && [
-    ...(getAllTagData('platform', comment)?.map(platformData =>
+    ...(getAllTagData('platform', comment)?.map((platformData) =>
       getCommentContent(platformData.content)
     ) || []),
     ...(getTagData('deprecated', comment) ? ['deprecated'] : []),
@@ -493,7 +494,7 @@ export const getTagNamesList = (comment?: CommentData) =>
 
 export function getTypeParametersNames(typeParameters?: TypeParameterData[]) {
   if (typeParameters?.length) {
-    return `<${typeParameters.map(param => param.name).join(', ')}>`;
+    return `<${typeParameters.map((param) => param.name).join(', ')}>`;
   }
   return '';
 }
@@ -520,7 +521,7 @@ export const getMethodName = (
 
 export const getCommentContent = (content: CommentContentData[]) => {
   return content
-    .map(entry => {
+    .map((entry) => {
       if (entry.tag === '@link' && !entry.text.includes('/')) {
         return `[\`${entry.tsLinkText?.length ? entry.tsLinkText : entry.text}\`](#${slug(entry.text)})`;
       }
@@ -593,7 +594,7 @@ export function defineLiteralType(types: TypeDefinitionData[]) {
   if (uniqueTypes.length === 1) {
     return <CODE>{uniqueTypes[0]}</CODE>;
   }
-  if (uniqueTypes.filter(Boolean).every(type => typeof type === 'string')) {
+  if (uniqueTypes.filter(Boolean).every((type) => typeof type === 'string')) {
     return <CODE>union</CODE>;
   }
   return null;


### PR DESCRIPTION
# Why
Currently when autogenerating the type which has Set or Map
 properties it adds link to nonexisting place on the page.

Before the update:
<img width="855" height="104" alt="image" src="https://github.com/user-attachments/assets/6c1d57eb-9c10-4a92-a8ab-095de06e1ad8" />

 
After the update:
 
<img width="842" height="97" alt="image" src="https://github.com/user-attachments/assets/41e04a41-f424-4f74-8fbd-ece8c3b46e64" />

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
