### PR TITLE
fix(precompile) cache calls to File.exist in pod install

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -20,7 +20,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
-[iOS] Added fallback to source for missing framework slice. ([#45664](https://github.com/expo/expo/pull/45664) by [@chrfalch](https://github.com/chrfalch))
+- [iOS] Cache prebuilt module status lookups to reduce repeated `File.exist?` calls during `pod install`.
 
 ## 56.0.4 — 2026-05-11
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -20,7 +20,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
-- [iOS] Cache prebuilt module status lookups to reduce repeated `File.exist?` calls during `pod install`.
+- [iOS] Cache prebuilt module status lookups to reduce repeated `File.exist?` calls during `pod install`. ([#45742](https://github.com/expo/expo/pull/45742) by [@chrfalch](https://github.com/chrfalch))
 
 ## 56.0.4 — 2026-05-11
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `pod install` failing with `bad component (expected absolute path component)` for precompiled Expo modules when the project lives under a path containing non-ASCII characters (e.g. emoji). ([#45779](https://github.com/expo/expo/pull/45779) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Cache prebuilt module status lookups to reduce repeated `File.exist?` calls during `pod install`. ([#45742](https://github.com/expo/expo/pull/45742) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 
@@ -20,7 +21,7 @@ _This version does not introduce any user-facing changes._
 
 ### 🐛 Bug fixes
 
-- [iOS] Cache prebuilt module status lookups to reduce repeated `File.exist?` calls during `pod install`. ([#45742](https://github.com/expo/expo/pull/45742) by [@chrfalch](https://github.com/chrfalch))
+[iOS] Added fallback to source for missing framework slice. ([#45664](https://github.com/expo/expo/pull/45664) by [@chrfalch](https://github.com/chrfalch))
 
 ## 56.0.4 — 2026-05-11
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -80,6 +80,7 @@ module Expo
     @warned_no_prebuilt_react = false
     @target_platform = nil
     @xcframework_slice_cache = nil
+    @status_cache = nil                 # Hash: pod_name -> resolve_prebuilt_status result
 
     class << self
       # Returns the build flavor (debug/release) for precompiled modules.
@@ -1818,6 +1819,11 @@ module Expo
       # A pod may use a prebuilt xcframework only when its own prebuilt artifact
       # exists and every local Expo dependency also uses prebuilt.
       def resolve_prebuilt_status(pod_name, visiting = Set.new)
+        return _resolve_prebuilt_status_uncached(pod_name, visiting) unless visiting.empty?
+        (@status_cache ||= {})[pod_name] ||= _resolve_prebuilt_status_uncached(pod_name, visiting)
+      end
+
+      def _resolve_prebuilt_status_uncached(pod_name, visiting)
         return { available: false, reason: :build_from_source } if build_from_source?(pod_name)
         return { available: true } if visiting.include?(pod_name)
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -80,7 +80,7 @@ module Expo
     @warned_no_prebuilt_react = false
     @target_platform = nil
     @xcframework_slice_cache = nil
-    @status_cache = nil                 # Hash: pod_name -> resolve_prebuilt_status result
+    @status_cache = {}                  # Hash: pod_name -> resolve_prebuilt_status result
 
     class << self
       # Returns the build flavor (debug/release) for precompiled modules.
@@ -125,6 +125,7 @@ module Expo
 
       def build_from_source=(patterns)
         @build_from_source_patterns = (patterns || []).map { |p| Regexp.new("^#{p}$") }
+        @status_cache = {}
       end
 
       def target_platform=(platform)
@@ -136,6 +137,7 @@ module Expo
         @claimed_vendored_frameworks = nil
         @framework_owner_map = nil
         @xcframework_slice_cache = nil
+        @status_cache = {}
       end
 
       # Checks if a pod is configured to be built from source via buildFromSource.
@@ -1820,7 +1822,7 @@ module Expo
       # exists and every local Expo dependency also uses prebuilt.
       def resolve_prebuilt_status(pod_name, visiting = Set.new)
         return _resolve_prebuilt_status_uncached(pod_name, visiting) unless visiting.empty?
-        (@status_cache ||= {})[pod_name] ||= _resolve_prebuilt_status_uncached(pod_name, visiting)
+        @status_cache[pod_name] ||= _resolve_prebuilt_status_uncached(pod_name, visiting)
       end
 
       def _resolve_prebuilt_status_uncached(pod_name, visiting)


### PR DESCRIPTION
## Why 

After the precompiled XCFramework feature shipped, pod install times in EAS Build regressed. Investigation pointed at Expo::PrecompiledModules.resolve_prebuilt_status — and the File.exist? calls inside resolve_own_prebuilt_info/resolve_prebuilt_tarball — being invoked many times per pod from ~10 different call sites.

With ~28 prebuilt pods × ~10 traversal sites, every install repeats hundreds of stat calls plus a recursive dependency walk per query.


## How

Memoized resolve_prebuilt_status by pod_name. The result is deterministic for the duration of one pod install:

- build_from_source? patterns are frozen after AutolinkingManager#initialize.
- pod_lookup_map[pod_name] is built once.
- resolve_prebuilt_tarball resolves to the same path on every subsequent call (downloads happen lazily but the returned path is stable).

The recursive call passes a non-empty visiting set for cycle detection; the cache only kicks in on top-level calls (visiting.empty?), so the cycle-break special case can't leak into the cache.

# Test Plan

  Three back-to-back runs of ./apps/bare-expo/ios/run-pod-install.sh 1 with warm CocoaPods caches:

| Sample | Baseline (no cache) | Cached |
| ------ | ------------------- | ------ |
| 1      | 54.25s              | 48.16s |
| 2      | 51.67s              | 45.78s |
| 3      | 49.38s              | 38.65s |

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
