### PR TITLE
[core][Android] Improve complation time of `JavaCallback`

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -60,10 +60,8 @@ jni::local_ref<JavaCallback::javaobject> JavaCallback::newInstance(
   return object;
 }
 
-template<typename T>
-void JavaCallback::invokeJSFunction(
-  ArgsConverter<typename std::remove_const<T>::type> argsConverter,
-  T arg
+void JavaCallback::invokeWithResolver(
+  std::function<void(jsi::Runtime &rt, jsi::Function &jsFunction)> resolver
 ) {
   const auto strongCallbackContext = this->callbackContext.lock();
   // The context were deallocated before the callback was invoked.
@@ -80,8 +78,7 @@ void JavaCallback::invokeJSFunction(
   jsInvoker->invokeAsync(
     [
       context = callbackContext,
-      argsConverter = std::move(argsConverter),
-      arg = std::move(arg)
+      resolver = std::move(resolver)
     ]() -> void {
       auto strongContext = context.lock();
       // The context were deallocated before the callback was invoked.
@@ -98,23 +95,9 @@ void JavaCallback::invokeJSFunction(
       jsi::Function &jsFunction = strongContext->resolveHolder.value();
       jsi::Runtime &rt = strongContext->rt;
 
-      argsConverter(rt, jsFunction, std::move(arg));
+      resolver(rt, jsFunction);
       strongContext->invalidate();
     });
-}
-
-template<class T>
-void JavaCallback::invokeJSFunction(T arg) {
-  invokeJSFunction<T>(
-    [](
-      jsi::Runtime &rt,
-      jsi::Function &jsFunction,
-      T arg
-    ) {
-      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::forward<T>(arg)));
-    },
-    arg
-  );
 }
 
 template<class T>
@@ -125,38 +108,51 @@ void JavaCallback::invokeJSFunctionForArray(T &arg) {
   rawArray.size = size;
   rawArray.data = std::move(region);
 
-  invokeJSFunction<decltype(rawArray)>(
-    std::move(rawArray)
+  invokeWithResolver(
+    [rawArray = std::move(rawArray)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::move(rawArray)));
+    }
   );
 }
 
 void JavaCallback::invoke() {
-  invokeJSFunction<nullptr_t>(
-    [](
-      jsi::Runtime &rt,
-      jsi::Function &jsFunction,
-      nullptr_t arg
-    ) {
+  invokeWithResolver(
+    [](jsi::Runtime &rt, jsi::Function &jsFunction) {
       jsFunction.call(rt, {jsi::Value::null()});
-    },
-    nullptr
+    }
   );
 }
 
 void JavaCallback::invokeBool(bool result) {
-  invokeJSFunction(result);
+  invokeWithResolver(
+    [result](jsi::Runtime &rt, jsi::Function &jsFunction) {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, result));
+    }
+  );
 }
 
 void JavaCallback::invokeInt(int result) {
-  invokeJSFunction(result);
+  invokeWithResolver(
+    [result](jsi::Runtime &rt, jsi::Function &jsFunction) {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, result));
+    }
+  );
 }
 
 void JavaCallback::invokeDouble(double result) {
-  invokeJSFunction(result);
+  invokeWithResolver(
+    [result](jsi::Runtime &rt, jsi::Function &jsFunction) {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, result));
+    }
+  );
 }
 
 void JavaCallback::invokeFloat(float result) {
-  invokeJSFunction(result);
+  invokeWithResolver(
+    [result](jsi::Runtime &rt, jsi::Function &jsFunction) {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, result));
+    }
+  );
 }
 
 void JavaCallback::invokeString(jni::alias_ref<jstring> result) {
@@ -164,41 +160,92 @@ void JavaCallback::invokeString(jni::alias_ref<jstring> result) {
   const char *rawValue = env->GetStringUTFChars(result.get(), nullptr);
   std::string parsedResult = rawValue;
   env->ReleaseStringUTFChars(result.get(), rawValue);
-  invokeJSFunction(parsedResult);
+  invokeWithResolver(
+    [parsedResult = std::move(parsedResult)](jsi::Runtime &rt, jsi::Function &jsFunction) {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, parsedResult));
+    }
+  );
 }
 
 void JavaCallback::invokeCollection(jni::alias_ref<jni::JCollection<jobject>> result) {
-  invokeJSFunction<
-    jni::global_ref<jni::JCollection<jobject>>
-  >(jni::make_global(result));
+  auto globalResult = jni::make_global(result);
+  invokeWithResolver(
+    [globalResult = std::move(globalResult)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
+      JNIEnv *env = jni::Environment::current();
+      size_t size = globalResult->size();
+      auto jsArray = jsi::Array(rt, size);
+      size_t index = 0;
+      for (const auto &item : *globalResult) {
+        jsArray.setValueAtIndex(rt, index++, convert(env, rt, item));
+      }
+      jsFunction.call(rt, std::move(jsArray));
+    }
+  );
 }
 
 void JavaCallback::invokeMap(jni::alias_ref<jni::JMap<jstring, jobject>> result) {
-  invokeJSFunction<
-    jni::global_ref<jni::JMap<jstring, jobject>>
-  >(jni::make_global(result));
+  auto globalResult = jni::make_global(result);
+  invokeWithResolver(
+    [globalResult = std::move(globalResult)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
+      JNIEnv *env = jni::Environment::current();
+      jsi::Object jsObject(rt);
+      for (const auto &entry : *globalResult) {
+        jsObject.setProperty(
+          rt,
+          entry.first->toStdString().c_str(),
+          convert(env, rt, entry.second)
+        );
+      }
+      jsFunction.call(rt, std::move(jsObject));
+    }
+  );
 }
 
 void
 JavaCallback::invokeWritableArray(jni::alias_ref<react::WritableNativeArray::javaobject> result) {
-  invokeJSFunction(result->cthis()->consume());
+  auto consumed = result->cthis()->consume();
+  invokeWithResolver(
+    [consumed = std::move(consumed)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::move(consumed)));
+    }
+  );
 }
 
 void JavaCallback::invokeWritableMap(jni::alias_ref<react::WritableNativeMap::javaobject> result) {
-  invokeJSFunction(result->cthis()->consume());
+  auto consumed = result->cthis()->consume();
+  invokeWithResolver(
+    [consumed = std::move(consumed)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::move(consumed)));
+    }
+  );
 }
 
 void JavaCallback::invokeSharedObject(jni::alias_ref<JSharedObject::javaobject> result) {
-  invokeJSFunction(jni::make_global(result));
+  auto globalResult = jni::make_global(result);
+  invokeWithResolver(
+    [globalResult = std::move(globalResult)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::move(globalResult)));
+    }
+  );
 }
 
 void JavaCallback::invokeJavaScriptArrayBuffer(
   jni::alias_ref<JavaScriptArrayBuffer::javaobject> result) {
-  invokeJSFunction(jni::make_global(result));
+  auto globalResult = jni::make_global(result);
+  invokeWithResolver(
+    [globalResult = std::move(globalResult)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::move(globalResult)));
+    }
+  );
 }
 
 void JavaCallback::invokeNativeArrayBuffer(jni::alias_ref<NativeArrayBuffer::javaobject> result) {
-  invokeJSFunction(jni::make_global(result));
+  auto globalResult = jni::make_global(result);
+  invokeWithResolver(
+    [globalResult = std::move(globalResult)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::move(globalResult)));
+    }
+  );
 }
 
 void JavaCallback::invokeIntArray(jni::alias_ref<jni::JArrayInt> result) {

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.cpp
@@ -168,35 +168,19 @@ void JavaCallback::invokeString(jni::alias_ref<jstring> result) {
 }
 
 void JavaCallback::invokeCollection(jni::alias_ref<jni::JCollection<jobject>> result) {
-  auto globalResult = jni::make_global(result);
+  jni::global_ref<jni::JCollection<jobject>> globalResult = jni::make_global(result);
   invokeWithResolver(
     [globalResult = std::move(globalResult)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
-      JNIEnv *env = jni::Environment::current();
-      size_t size = globalResult->size();
-      auto jsArray = jsi::Array(rt, size);
-      size_t index = 0;
-      for (const auto &item : *globalResult) {
-        jsArray.setValueAtIndex(rt, index++, convert(env, rt, item));
-      }
-      jsFunction.call(rt, std::move(jsArray));
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::move(globalResult)));
     }
   );
 }
 
 void JavaCallback::invokeMap(jni::alias_ref<jni::JMap<jstring, jobject>> result) {
-  auto globalResult = jni::make_global(result);
+  jni::global_ref<jni::JMap<jstring, jobject>> globalResult = jni::make_global(result);
   invokeWithResolver(
     [globalResult = std::move(globalResult)](jsi::Runtime &rt, jsi::Function &jsFunction) mutable {
-      JNIEnv *env = jni::Environment::current();
-      jsi::Object jsObject(rt);
-      for (const auto &entry : *globalResult) {
-        jsObject.setProperty(
-          rt,
-          entry.first->toStdString().c_str(),
-          convert(env, rt, entry.second)
-        );
-      }
-      jsFunction.call(rt, std::move(jsObject));
+      jsFunction.call(rt, convertToJS(jni::Environment::current(), rt, std::move(globalResult)));
     }
   );
 }

--- a/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaCallback.h
@@ -90,19 +90,9 @@ private:
   void invokeDoubleArray(jni::alias_ref<jni::JArrayDouble> result);
   void invokeFloatArray(jni::alias_ref<jni::JArrayFloat> result);
 
-  template<class T>
-  using ArgsConverter = std::function<void(jsi::Runtime &rt, jsi::Function &jsFunction, T arg)>;
-
-  template<class T>
-  inline void invokeJSFunction(
-    ArgsConverter<typename std::remove_const<T>::type> argsConverter,
-    T arg
-  );
+  void invokeWithResolver(std::function<void(jsi::Runtime &rt, jsi::Function &jsFunction)> resolver);
 
   template<class T>
   void invokeJSFunctionForArray(T &arg);
-
-  template<class T>
-  inline void invokeJSFunction(T arg);
 };
 } // namespace expo


### PR DESCRIPTION
# Why

Improves the compilation time of `JavaCallback` by reducing the number of templates that need to be resolved. 
This change shouldn't affect runtime performance.

# Test Plan

- unit tests ✅ 
- bare-expo ✅ 

<img width="501" height="239" alt="Screenshot 2026-05-13 at 16 20 26" src="https://github.com/user-attachments/assets/bb78306c-336f-42e5-bf27-e62da6c1adc4" />
