### PR TITLE
[JSI] Hash JSI headers for cache invalidation

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed xcframework build cache not invalidating when React-jsi headers change. ([#45735](https://github.com/expo/expo/pull/45735) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Added support for `facebook::jsi::IRuntime` so the package builds against React Native 0.86+, while staying compatible with 0.85 and react-native-tvos. ([#45728](https://github.com/expo/expo/pull/45728) by [@zoontek](https://github.com/zoontek))
 
 ### 💡 Others

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -74,6 +74,10 @@ SOURCE_FILES=(
   "${PACKAGE_DIR}/scripts/build-xcframework.sh"
   "${PACKAGE_DIR}/scripts/create-stub-xcframework.sh"
   "${PACKAGE_DIR}/scripts/xcframework-helpers.sh"
+  # JSI headers we compile against. `cat` follows the symlinks CocoaPods
+  # installs into Pods/Headers/Public so the real header contents get hashed.
+  "${PODS_ROOT}/Headers/Public/React-jsi/jsi/jsi.h"
+  "${PODS_ROOT}/Headers/Public/React-jsi/jsi/jsi-inl.h"
 )
 
 compute_hash() {


### PR DESCRIPTION
## Summary

Include `jsi.h` and `jsi-inl.h` in the build cache hash so the xcframework is rebuilt when React-jsi headers change. This ensures the compiled code always matches the headers being compiled against.

## Test plan

- [x] Build succeeds with `pnpm build`
- [x] xcframework is rebuilt when JSI headers change