### PR TITLE
[JSI] Extract `PODS_ROOT` fallback logic into shared helper

### DIFF
--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -15,10 +15,11 @@
 #   - Cleans .swiftinterface files for cross-compiler compatibility
 #
 # Usage:
-#   PODS_ROOT=/path/to/Pods ./build-xcframework.sh [--clean]
+#   ./build-xcframework.sh [--clean]
 #
 # Environment:
-#   PODS_ROOT       (required) Path to the CocoaPods Pods directory
+#   PODS_ROOT       Path to the CocoaPods Pods directory. Defaults to
+#                   $EXPO_ROOT_DIR/apps/bare-expo/ios/Pods (set by direnv).
 #   PLATFORM_NAME   (optional) Build for a specific platform (e.g. iphoneos, iphonesimulator).
 #                   When unset, builds for both iphoneos and iphonesimulator.
 
@@ -35,6 +36,8 @@ SPM_WORKSPACE_PATH="${PACKAGE_DIR}/.swiftpm"
 BUILD_PRODUCTS_PATH="${DERIVED_DATA_PATH}/Build/Products"
 
 source "${PACKAGE_DIR}/scripts/xcframework-helpers.sh"
+
+resolve_pods_root "$PACKAGE_DIR"
 
 CLEAN=false
 

--- a/packages/expo-modules-jsi/apple/scripts/test.sh
+++ b/packages/expo-modules-jsi/apple/scripts/test.sh
@@ -29,26 +29,11 @@ set -eo pipefail
 
 PACKAGE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-# --- PODS_ROOT ---
-#
-# Prefer an explicit PODS_ROOT (e.g. to test against a different app's Pods).
-# Otherwise fall back to bare-expo under EXPO_ROOT_DIR (set by the repo's
-# direnv config). Without either, point at a likely repo root computed from
-# this script's location so the script still works outside a direnv shell.
+source "${PACKAGE_DIR}/scripts/xcframework-helpers.sh"
 
-if [[ -z "${PODS_ROOT:-}" ]]; then
-  : "${EXPO_ROOT_DIR:=$(cd "${PACKAGE_DIR}/../../.." && pwd)}"
-  PODS_ROOT="${EXPO_ROOT_DIR}/apps/bare-expo/ios/Pods"
-fi
-if [[ ! -d "$PODS_ROOT" ]]; then
-  echo "error: PODS_ROOT does not exist: $PODS_ROOT" >&2
-  echo "       Run \`pod install\` in apps/bare-expo/ios first, or set PODS_ROOT explicitly." >&2
-  exit 1
-fi
-PODS_ROOT="$(cd "$PODS_ROOT" && pwd)"
-# Export so xcodebuild forwards it to SwiftPM's manifest evaluation, where
-# Package.swift reads it via resolvePodsRoot().
-export PODS_ROOT
+# Resolve PODS_ROOT with fallback logic (from xcframework-helpers.sh).
+# Must be passed to subprocess calls, not exported, to avoid polluting the environment.
+resolve_pods_root "$PACKAGE_DIR"
 
 # --- Symlink xcframeworks for SwiftPM binary targets ---
 
@@ -79,7 +64,7 @@ link_xcframework "ReactNativeDependencies" \
 
 # --- Generate the jsi module map ---
 
-"${PACKAGE_DIR}/scripts/generate-modulemap.sh"
+env PODS_ROOT="$PODS_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
 
 # --- Pick a simulator destination ---
 
@@ -113,7 +98,7 @@ fi
 # --- Run the tests ---
 
 cd "$PACKAGE_DIR"
-exec xcodebuild test \
+exec env PODS_ROOT="$PODS_ROOT" xcodebuild test \
   -scheme ExpoModulesJSI \
   -destination "$DESTINATION" \
   -derivedDataPath "${PACKAGE_DIR}/.DerivedData" \

--- a/packages/expo-modules-jsi/apple/scripts/xcframework-helpers.sh
+++ b/packages/expo-modules-jsi/apple/scripts/xcframework-helpers.sh
@@ -4,6 +4,24 @@
 # canonical slice metadata and the Info.plist writer used by both scripts so
 # the manifest is produced from a single place.
 
+# resolve_pods_root PACKAGE_DIR
+# Sets PODS_ROOT, preferring an explicit value (e.g. from CocoaPods build phase)
+# over a fallback to bare-expo under EXPO_ROOT_DIR. Exits if PODS_ROOT doesn't exist.
+resolve_pods_root() {
+  local package_dir="$1"
+
+  if [[ -z "${PODS_ROOT:-}" ]]; then
+    : "${EXPO_ROOT_DIR:=$(cd "${package_dir}/../../.." && pwd)}"
+    PODS_ROOT="${EXPO_ROOT_DIR}/apps/bare-expo/ios/Pods"
+  fi
+  if [[ ! -d "$PODS_ROOT" ]]; then
+    echo "error: PODS_ROOT does not exist: $PODS_ROOT" >&2
+    echo "       Run \`pod install\` in apps/bare-expo/ios first, or set PODS_ROOT explicitly." >&2
+    exit 1
+  fi
+  PODS_ROOT="$(cd "$PODS_ROOT" && pwd)"
+}
+
 # All slice IDs known to the xcframework, mapped to their plist metadata.
 # CocoaPods reads Info.plist at `pod install` time and generates a per-slice
 # copy script; any slice missing from this table will be skipped by


### PR DESCRIPTION
# Why

Until now, `build-xcframework.sh` errored out with `PODS_ROOT: unbound variable` when run via `pnpm build` outside of a CocoaPods build phase. `test.sh` already had a fallback to `$EXPO_ROOT_DIR/apps/bare-expo/ios/Pods`, but the logic was inlined and not shared.

# How

- Extracted the `PODS_ROOT` resolution into a `resolve_pods_root()` helper in `xcframework-helpers.sh`.
- Both `build-xcframework.sh` and `test.sh` now source the helper and call it.
- Replaced `export PODS_ROOT` in `test.sh` with explicit `env PODS_ROOT=... cmd` passthrough to the two subprocess calls that need it (`generate-modulemap.sh` and `xcodebuild test`), so we don't leak the variable into the rest of the shell environment.

# Test plan

- [x] `pnpm build` works without an explicit `PODS_ROOT`
- [x] `pnpm test` still works (verified `generate-modulemap.sh` and `xcodebuild` both receive `PODS_ROOT`)