### PR TITLE
[expo-cli] Display warning when device from LAN network connects

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Display warning when device from LAN network connects ([#45751](https://github.com/expo/expo/pull/45751) by [@Ubax](https://github.com/Ubax))
+
 ### 🐛 Bug fixes
 
 - Fix loader HMR when streaming SSR is enabled in dev mode ([#45702](https://github.com/expo/expo/pull/45702) by [@hassankhan](https://github.com/hassankhan))

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -34,6 +34,7 @@ import { Log } from '../../../log';
 import { env } from '../../../utils/env';
 import { CommandError } from '../../../utils/errors';
 import { createCorsMiddleware } from '../middleware/CorsMiddleware';
+import { createRemotePeerWarning } from '../middleware/RemotePeerWarningMiddleware';
 import { createJsInspectorMiddleware } from '../middleware/inspector/createJsInspectorMiddleware';
 import { prependMiddleware } from '../middleware/mutations';
 import { getPlatformBundlers } from '../platformBundlers';
@@ -398,9 +399,17 @@ export async function instantiateMetroAsync(
     .getUrlCreator()
     .constructUrl({ scheme: 'http', hostType: 'localhost' });
 
+  // Warn the developer when a non-loopback peer (real device / another machine on the LAN)
+  // first talks to this dev server. HTTP requests go through the middleware; HMR/WebSocket
+  // upgrades bypass it, so the same deduplication state is shared with the WS upgrade handler below.
+  const remotePeerWarning = !isExporting ? createRemotePeerWarning() : null;
+
   if (!isExporting) {
     // Enable correct CORS headers for Expo Router features
     prependMiddleware(middleware, createCorsMiddleware(exp));
+    if (remotePeerWarning) {
+      prependMiddleware(middleware, remotePeerWarning.middleware);
+    }
 
     // Enable debug middleware for CDP-related debugging
     const { debugMiddleware, debugWebsocketEndpoints } = createDebugMiddleware({
@@ -464,6 +473,7 @@ export async function instantiateMetroAsync(
         websocketEndpoints,
         watch,
         secureServerOptions,
+        onRemotePeer: remotePeerWarning?.onRemotePeer,
       },
       {
         mockServer: isExporting,

--- a/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/runServer-fork.ts
@@ -12,6 +12,7 @@ import type { ConfigT } from '@expo/metro/metro-config';
 import assert from 'assert';
 import http from 'http';
 import https from 'https';
+import type { Socket } from 'node:net';
 import type { WebSocketServer } from 'ws';
 
 import type { MetroBundlerDevServer } from './MetroBundlerDevServer';
@@ -38,6 +39,11 @@ interface RunServerOptionsFork {
   onError?($$PARAM_0$$: Error & { code?: string }): void;
   onReady?(server: http.Server | https.Server): void;
   onClose?(): void;
+  /**
+   * Called when a WebSocket peer upgrades the connection. Used to detect remote
+   * (non-loopback) clients that bypass the HTTP middleware chain (HMR via `/hot`).
+   */
+  onRemotePeer?(socket: Socket | undefined, userAgent: string | undefined): void;
   websocketEndpoints?: RunServerOptions['websocketEndpoints'];
   secureServerOptions?: SecureServerOptions;
   waitForBundler?: boolean;
@@ -52,6 +58,7 @@ export const runServer = async (
     host,
     onError,
     onReady,
+    onRemotePeer,
     secureServerOptions,
     websocketEndpoints = {},
     watch,
@@ -181,6 +188,10 @@ export const runServer = async (
       httpServer.on('upgrade', (request, socket, head) => {
         const { pathname } = new URL(request.url!, 'http://localhost');
         if (pathname != null && websocketEndpoints[pathname]) {
+          if (onRemotePeer) {
+            const ua = request.headers['user-agent'];
+            onRemotePeer(request.socket, Array.isArray(ua) ? ua[0] : ua);
+          }
           websocketEndpoints[pathname].handleUpgrade(request, socket, head, (ws) => {
             websocketEndpoints[pathname]?.emit('connection', ws, request);
           });

--- a/packages/@expo/cli/src/start/server/middleware/RemotePeerWarningMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/RemotePeerWarningMiddleware.ts
@@ -1,0 +1,79 @@
+import chalk from 'chalk';
+import type { Socket } from 'node:net';
+
+import type { ServerNext, ServerRequest, ServerResponse } from './server.types';
+import { Log } from '../../../log';
+import { isLocalSocket } from '../../../utils/net';
+
+export interface RemotePeerWarning {
+  /** Connect-style HTTP middleware. Logs the first request from a non-loopback peer. */
+  middleware: (req: ServerRequest, res: ServerResponse, next: ServerNext) => void;
+  /** Call this from a WebSocket upgrade handler. Shares dedup state with `middleware`. */
+  onRemotePeer: (socket: Socket | undefined, userAgent: string | undefined) => void;
+}
+
+const IPV4_MAPPED_PREFIX = '::ffff:';
+
+/**
+ * Builds a one-shot, per-IP, per-server-session warning that fires when a non-loopback
+ * peer (e.g. a real device on the LAN) reaches the Metro dev server.
+ *
+ * HTTP and WebSocket entry points share the same `seen` set so a peer that opens both
+ * `/hot` and a bundle request only logs once.
+ */
+export function createRemotePeerWarning(): RemotePeerWarning {
+  const seen = new Set<string>();
+
+  const handlePeer = (socket: Socket | undefined, userAgent: string | undefined) => {
+    if (process.env.EXPO_SILENCE_REMOTE_PEER_WARNINGS) return;
+    if (!socket || isLocalSocket(socket)) return;
+
+    const remoteAddress = socket.remoteAddress;
+    if (!remoteAddress) return;
+
+    const ip = normalizeIp(remoteAddress);
+    if (seen.has(ip)) return;
+    seen.add(ip);
+
+    const label = recognizeUserAgent(userAgent);
+    const who = label ? `${chalk.bold(ip)} (${label})` : chalk.bold(ip);
+    Log.warn(
+      `A device at ${who} just connected to your dev server.\n` +
+        `  To restrict access to local simulators/emulators/USB devices, ` +
+        `restart with: ${chalk.bold('expo start --localhost')}\n` +
+        `  Silence: ${chalk.dim('EXPO_SILENCE_REMOTE_PEER_WARNINGS=1')}`
+    );
+  };
+
+  return {
+    middleware: (req, _res, next) => {
+      handlePeer(req.socket, asString(req.headers['user-agent']));
+      next();
+    },
+    onRemotePeer: handlePeer,
+  };
+}
+
+function normalizeIp(remoteAddress: string): string {
+  return remoteAddress.startsWith(IPV4_MAPPED_PREFIX)
+    ? remoteAddress.slice(IPV4_MAPPED_PREFIX.length)
+    : remoteAddress;
+}
+
+function asString(value: string | string[] | undefined): string | undefined {
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+/** Returns a friendly label for known user agents, or null if unrecognized. */
+function recognizeUserAgent(userAgent: string | undefined): string | null {
+  if (!userAgent) return null;
+  if (/Expo Go/i.test(userAgent)) return 'Expo Go';
+  if (/Expo\//i.test(userAgent)) return 'Expo dev client';
+  if (/okhttp/i.test(userAgent)) return 'Android';
+  if (/CFNetwork|Darwin/i.test(userAgent)) return 'iOS';
+  if (/Chrome|Firefox|Edg(e|iOS|A)|Safari/i.test(userAgent)) return 'browser';
+  const toolMatch = /^(curl|wget|HTTPie|httpie)\b/i.exec(userAgent);
+  if (toolMatch?.[1]) return toolMatch[1].toLowerCase();
+  return null;
+}

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/RemotePeerWarningMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/RemotePeerWarningMiddleware-test.ts
@@ -1,0 +1,205 @@
+import type { Socket } from 'node:net';
+
+import { Log } from '../../../../log';
+import { createRemotePeerWarning } from '../RemotePeerWarningMiddleware';
+import type { ServerNext, ServerRequest, ServerResponse } from '../server.types';
+
+const asSocket = (remoteAddress?: string): Socket | undefined => {
+  if (remoteAddress === undefined) return undefined;
+  return {
+    remoteAddress,
+    remoteFamily: remoteAddress.includes(':') ? 'IPv6' : 'IPv4',
+    // Loopback would have localAddress === remoteAddress; for these tests the peer
+    // is always considered distinct from the server.
+    localAddress: '0.0.0.0',
+  } as unknown as Socket;
+};
+
+const asRequest = (remoteAddress?: string, userAgent?: string): ServerRequest =>
+  ({
+    socket: asSocket(remoteAddress),
+    headers: userAgent ? { 'user-agent': userAgent } : {},
+  }) as unknown as ServerRequest;
+
+describe(createRemotePeerWarning, () => {
+  let warnSpy: jest.SpyInstance;
+  let res: ServerResponse;
+  let next: jest.Mock<ServerNext>;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(Log, 'warn').mockImplementation(() => {});
+    res = {} as ServerResponse;
+    next = jest.fn();
+    delete process.env.EXPO_SILENCE_REMOTE_PEER_WARNINGS;
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('warns once for a remote LAN peer (192.168.x)', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.83'), res, next);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('192.168.1.83');
+    expect(warnSpy.mock.calls[0][0]).toContain('expo start --localhost');
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('always calls next() regardless of warning', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('127.0.0.1'), res, next);
+    expect(next).toHaveBeenCalledWith();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('dedupes the same IP across requests', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.83'), res, next);
+    middleware(asRequest('192.168.1.83'), res, next);
+    middleware(asRequest('192.168.1.83'), res, next);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns once per distinct IP', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.83'), res, next);
+    middleware(asRequest('10.0.0.5'), res, next);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('normalizes IPv4-mapped IPv6 addresses', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('::ffff:192.168.1.83'), res, next);
+    // log should show the bare v4 form
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('192.168.1.83');
+    expect(warnSpy.mock.calls[0][0]).not.toContain('::ffff:');
+
+    // and the same v4 raw connection should be deduped
+    middleware(asRequest('192.168.1.83'), res, next);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('silences loopback peers (127.0.0.1, ::1, ::ffff:127.0.0.1)', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('127.0.0.1'), res, next);
+    middleware(asRequest('::1'), res, next);
+    middleware(asRequest('::ffff:127.0.0.1'), res, next);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('silences via EXPO_SILENCE_REMOTE_PEER_WARNINGS env var', () => {
+    process.env.EXPO_SILENCE_REMOTE_PEER_WARNINGS = '1';
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.83'), res, next);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('warns for pure IPv6 link-local LAN address', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('fe80::1ff:fe23:4567:890a'), res, next);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('fe80::');
+  });
+
+  it('handles missing remoteAddress', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest(undefined), res, next);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('appends "Expo Go" label for the Expo Go user agent', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.10', 'Expo/2.32.0 Expo Go/2.32.0 (iPhone)'), res, next);
+    expect(warnSpy.mock.calls[0][0]).toContain('(Expo Go)');
+  });
+
+  it('appends "Expo dev client" label when only Expo/ is present', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.11', 'Expo/1.0.0 (development client)'), res, next);
+    expect(warnSpy.mock.calls[0][0]).toContain('(Expo dev client)');
+  });
+
+  it('appends "Android" label for okhttp UA', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.12', 'okhttp/4.9.2'), res, next);
+    expect(warnSpy.mock.calls[0][0]).toContain('(Android)');
+  });
+
+  it('appends "iOS" label for CFNetwork/Darwin UA', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.13', 'MyApp/1.0 CFNetwork/1390 Darwin/22.0.0'), res, next);
+    expect(warnSpy.mock.calls[0][0]).toContain('(iOS)');
+  });
+
+  it('appends "browser" label for desktop browser UA', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(
+      asRequest(
+        '192.168.1.14',
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 Chrome/120.0.0.0 Safari/537.36'
+      ),
+      res,
+      next
+    );
+    expect(warnSpy.mock.calls[0][0]).toContain('(browser)');
+  });
+
+  it('appends tool name for curl/wget/httpie', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.15', 'curl/8.4.0'), res, next);
+    expect(warnSpy.mock.calls[0][0]).toContain('(curl)');
+  });
+
+  it('omits the parenthetical label for an unrecognized user agent', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.16', 'SomethingWeirdAndUnknown/1.2.3'), res, next);
+    const msg = warnSpy.mock.calls[0][0];
+    expect(msg).toContain('192.168.1.16');
+    expect(msg).not.toContain('SomethingWeirdAndUnknown');
+    // No parenthetical after the IP
+    expect(msg).not.toMatch(/192\.168\.1\.16[^\n]*\(/);
+  });
+
+  it('omits the parenthetical label when no user agent is provided', () => {
+    const { middleware } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.17'), res, next);
+    const msg = warnSpy.mock.calls[0][0];
+    expect(msg).toContain('192.168.1.17');
+    expect(msg).not.toMatch(/192\.168\.1\.17[^\n]*\(/);
+  });
+
+  it('onRemotePeer shares the same dedup state as the middleware', () => {
+    const { middleware, onRemotePeer } = createRemotePeerWarning();
+    middleware(asRequest('192.168.1.83', 'Expo Go/1.0'), res, next);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    // A subsequent WS upgrade from the same peer should NOT warn again.
+    onRemotePeer(asSocket('192.168.1.83'), 'Expo Go/1.0');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('onRemotePeer warns on first contact via WS even without an HTTP request', () => {
+    const { onRemotePeer } = createRemotePeerWarning();
+    onRemotePeer(asSocket('192.168.1.83'), 'okhttp/4.9.2');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('192.168.1.83');
+    expect(warnSpy.mock.calls[0][0]).toContain('(Android)');
+  });
+
+  it('silences peer when the request is a loopback (localAddress === remoteAddress)', () => {
+    // Simulates a request from the same machine to its own LAN IP (e.g., when --host lan
+    // is used and a local browser connects to the server's LAN address).
+    const loopbackSocket = {
+      remoteAddress: '192.168.1.83',
+      localAddress: '192.168.1.83',
+      remoteFamily: 'IPv4',
+    } as unknown as Socket;
+    const { onRemotePeer } = createRemotePeerWarning();
+    onRemotePeer(loopbackSocket, 'Expo Go/1.0');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Why

When using public network, expo server exposes the `8081` port to public. In order to increase awareness about possible privacy issues, we can add a warning when non-localhost device connects to the dev server, informing about `expo start --localhost` option

# How

Add a middleware which detects new connections to the server, detects wether they are from local network and if not prints a warning. When a warning is printed for an ip, it won't be displayed until the server is restarted.

# Test Plan

1. CI
2. Local server:
   - Android and iOS using Dev client - test wether warning appears and is displayed only once
   - Web browser from another machine - test wether warning appears and is displayed only once
   - Local browser/simulator - no warning should be displayed

<img width="733" height="49" alt="image" src="https://github.com/user-attachments/assets/dfcb4181-a38f-4152-a636-f298583198ff" />

<img width="732" height="53" alt="image" src="https://github.com/user-attachments/assets/0d417bd1-7466-44c9-9c5a-267f92af4e6c" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
