### PR TITLE
[core][Android] Restructure some headers

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JSIContext.h
@@ -7,21 +7,12 @@
 #include "JavaScriptModuleObject.h"
 #include "JavaScriptValue.h"
 #include "JavaScriptObject.h"
-#include "JavaReferencesCache.h"
 #include "JSReferencesCache.h"
 #include "JNIDeallocator.h"
 #include "ThreadSafeJNIGlobalRef.h"
 #include "javaclasses/JSRunnable.h"
 
-#include <ReactCommon/CallInvokerHolder.h>
 #include <ReactCommon/CallInvoker.h>
-
-#if IS_NEW_ARCHITECTURE_ENABLED
-
-#include <ReactCommon/RuntimeExecutor.h>
-#include <react/jni/JRuntimeExecutor.h>
-
-#endif
 
 namespace jni = facebook::jni;
 namespace jsi = facebook::jsi;

--- a/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
+++ b/packages/expo-modules-core/android/src/main/cpp/JavaScriptValue.h
@@ -5,7 +5,6 @@
 #include "ExpoHeader.pch"
 #include "JSIObjectWrapper.h"
 #include "JavaScriptTypedArray.h"
-#include "JavaScriptArrayBuffer.h"
 #include "JNIDeallocator.h"
 
 namespace jni = facebook::jni;

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.cpp
@@ -2,10 +2,20 @@
 
 #include "JSDecoratorsBridgingObject.h"
 
+#include "JSFunctionsDecorator.h"
+#include "JSPropertiesDecorator.h"
+#include "JSConstantsDecorator.h"
+#include "JSObjectDecorator.h"
 #include "JSClassesDecorator.h"
 #include "../types/ReturnType.h"
 
 namespace expo {
+
+JSDecoratorsBridgingObject::~JSDecoratorsBridgingObject() = default;
+
+JSClassesDecorator* JSDecoratorsBridgingObject::getClassDecorator() const {
+  return classDecorator.get();
+}
 
 jni::local_ref<jni::HybridClass<JSDecoratorsBridgingObject>::jhybriddata>
 JSDecoratorsBridgingObject::initHybrid(jni::alias_ref<jhybridobject> jThis) {

--- a/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
+++ b/packages/expo-modules-core/android/src/main/cpp/decorators/JSDecoratorsBridgingObject.h
@@ -8,18 +8,20 @@
 #include "../JNIFunctionBody.h"
 #include "../types/ExpectedType.h"
 
-#include "JSFunctionsDecorator.h"
-#include "JSPropertiesDecorator.h"
-#include "JSConstantsDecorator.h"
-#include "JSObjectDecorator.h"
-#include "JSClassesDecorator.h"
-
 namespace jni = facebook::jni;
 
 namespace expo {
 
+class JSFunctionsDecorator;
+class JSPropertiesDecorator;
+class JSConstantsDecorator;
+class JSObjectDecorator;
+class JSClassesDecorator;
+
 class JSDecoratorsBridgingObject : public jni::HybridClass<JSDecoratorsBridgingObject> {
 public:
+  ~JSDecoratorsBridgingObject();
+
   static auto constexpr
     kJavaDescriptor = "Lexpo/modules/kotlin/jni/decorators/JSDecoratorsBridgingObject;";
   static auto constexpr TAG = "JSDecoratorsBridgingObject";
@@ -87,9 +89,7 @@ public:
   /**
    * Returns the class decorator, or nullptr if none was registered.
    */
-  JSClassesDecorator* getClassDecorator() const {
-    return classDecorator.get();
-  }
+  JSClassesDecorator* getClassDecorator() const;
 
 private:
   friend HybridBase;

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/NativeStatePropsGetter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/NativeStatePropsGetter.cpp
@@ -1,5 +1,6 @@
 #include "NativeStatePropsGetter.h"
 #include "AndroidExpoViewState.h"
+#include <react/fabric/StateWrapperImpl.h>
 
 #include <react/renderer/core/ConcreteState.h>
 

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/NativeStatePropsGetter.h
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/NativeStatePropsGetter.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../ExpoHeader.pch"
-#include <react/fabric/StateWrapperImpl.h>
 
 namespace jni = facebook::jni;
 namespace react = facebook::react;


### PR DESCRIPTION
# Why

Restructures some headers to improve compilation time.

# Test Plan

- unit tests ✅ 
- bare-expo ✅ 