### PR TITLE
[core][Android] Extract component descriptor factory

### DIFF
--- a/packages/expo-modules-core/android/src/main/cpp/fabric/ExpoComponentDescriptorFactory.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/ExpoComponentDescriptorFactory.cpp
@@ -1,0 +1,31 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#include "ExpoComponentDescriptorFactory.h"
+#include "AndroidExpoViewComponentDescriptor.h"
+
+namespace react = facebook::react;
+
+namespace expo {
+
+StatePropMapType statePropMap = {};
+
+react::ComponentDescriptor::Unique concreteExpoComponentDescriptorConstructor(
+  const react::ComponentDescriptorParameters &parameters
+) {
+  auto descriptor = std::make_unique<AndroidExpoViewComponentDescriptor>(
+    parameters,
+    react::RawPropsParser(/*useRawPropsJsiValue=*/true)
+  );
+
+  if (statePropMap.contains(std::static_pointer_cast<std::string const>(parameters.flavor))) {
+    descriptor->setStateProps(
+      statePropMap.at(
+        std::static_pointer_cast<std::string const>(parameters.flavor)
+      )
+    );
+  }
+
+  return descriptor;
+}
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/ExpoComponentDescriptorFactory.h
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/ExpoComponentDescriptorFactory.h
@@ -1,0 +1,23 @@
+// Copyright 2018-present 650 Industries. All rights reserved.
+
+#pragma once
+
+#include <react/renderer/core/ComponentDescriptor.h>
+#include "../types/FrontendConverter.h"
+
+namespace react = facebook::react;
+
+namespace expo {
+
+using StatePropMapType = std::unordered_map<
+  react::ComponentDescriptor::Flavor,
+  std::unordered_map<std::string, std::shared_ptr<FrontendConverter>>
+>;
+
+extern StatePropMapType statePropMap;
+
+react::ComponentDescriptor::Unique concreteExpoComponentDescriptorConstructor(
+  const react::ComponentDescriptorParameters &parameters
+);
+
+} // namespace expo

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/FabricComponentsRegistry.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/FabricComponentsRegistry.cpp
@@ -1,37 +1,15 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #include "FabricComponentsRegistry.h"
+#include "ExpoComponentDescriptorFactory.h"
 #include "../types/FrontendConverterProvider.h"
+#include <CoreComponentsRegistry.h>
+#include <react/renderer/componentregistry/ComponentDescriptorProvider.h>
 
 namespace jni = facebook::jni;
 namespace react = facebook::react;
 
 namespace expo {
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wextern-initializer"
-// Clang think that we don't need to initialize the extern variable here, but we do.
-extern StatePropMapType statePropMap = {};
-#pragma clang diagnostic pop
-
-AndroidExpoViewComponentDescriptor::Unique concreteExpoComponentDescriptorConstructor(
-  const react::ComponentDescriptorParameters &parameters
-) {
-  auto descriptor = std::make_unique<AndroidExpoViewComponentDescriptor>(
-    parameters,
-    react::RawPropsParser(/*useRawPropsJsiValue=*/true)
-  );
-
-  if (statePropMap.contains(std::static_pointer_cast<std::string const>(parameters.flavor))) {
-    descriptor->setStateProps(
-      statePropMap.at(
-        std::static_pointer_cast<std::string const>(parameters.flavor)
-      )
-    );
-  }
-
-  return descriptor;
-}
 
 // static
 void FabricComponentsRegistry::registerNatives() {

--- a/packages/expo-modules-core/android/src/main/cpp/fabric/FabricComponentsRegistry.h
+++ b/packages/expo-modules-core/android/src/main/cpp/fabric/FabricComponentsRegistry.h
@@ -3,28 +3,11 @@
 #pragma once
 
 #include "../ExpoHeader.pch"
-#include <CoreComponentsRegistry.h>
-#include <react/renderer/componentregistry/ComponentDescriptorProvider.h>
-
 #include "../types/ExpectedType.h"
-#include "../types/FrontendConverter.h"
-#include "AndroidExpoViewComponentDescriptor.h"
 
 namespace jni = facebook::jni;
-namespace react = facebook::react;
 
 namespace expo {
-
-typedef std::unordered_map<
-  AndroidExpoViewComponentDescriptor::Flavor,
-  std::unordered_map<std::string, std::shared_ptr<FrontendConverter>>
-> StatePropMapType;
-
-extern StatePropMapType statePropMap;
-
-AndroidExpoViewComponentDescriptor::Unique concreteExpoComponentDescriptorConstructor(
-  const react::ComponentDescriptorParameters &parameters
-);
 
 class FabricComponentsRegistry : public jni::HybridClass<FabricComponentsRegistry> {
 public:


### PR DESCRIPTION
# Why

Extracts ExpoComponentDescriptorFactory from `FabricComponentsRegistry.h`.

# Test Plan

- bare-expo ✅ 