### PR TITLE
[template] Auto-remove reset-project script entry from package.json

### DIFF
--- a/templates/expo-template-default/scripts/reset-project.js
+++ b/templates/expo-template-default/scripts/reset-project.js
@@ -3,7 +3,7 @@
 /**
  * This script is used to reset the project to a blank state.
  * It deletes or moves the /src and /scripts directories to /example based on user input and creates a new /src/app directory with an index.tsx and _layout.tsx file.
- * You can remove the `reset-project` script from package.json and safely delete this file after running it.
+ * The `reset-project` entry is automatically removed from package.json. You can safely delete this file after running it.
  */
 
 const fs = require("fs");
@@ -47,6 +47,27 @@ const rl = readline.createInterface({
   output: process.stdout,
 });
 
+const removePackageJsonScript = async () => {
+  const packageJsonPath = path.join(root, "package.json");
+  try {
+    const raw = await fs.promises.readFile(packageJsonPath, "utf8");
+    const pkg = JSON.parse(raw);
+    if (pkg.scripts && "reset-project" in pkg.scripts) {
+      delete pkg.scripts["reset-project"];
+      const trailingNewline = raw.endsWith("\n") ? "\n" : "";
+      await fs.promises.writeFile(
+        packageJsonPath,
+        JSON.stringify(pkg, null, 2) + trailingNewline
+      );
+      console.log("🧹 Removed `reset-project` script from package.json.");
+    }
+  } catch (error) {
+    console.warn(
+      `⚠️  Could not update package.json automatically: ${error.message}\n   You can safely remove the "reset-project" entry from the "scripts" block manually.`
+    );
+  }
+};
+
 const moveDirectories = async (userInput) => {
   try {
     if (userInput === "y") {
@@ -86,6 +107,8 @@ const moveDirectories = async (userInput) => {
     const layoutPath = path.join(newAppDirPath, "_layout.tsx");
     await fs.promises.writeFile(layoutPath, layoutContent);
     console.log("📄 src/app/_layout.tsx created.");
+
+    await removePackageJsonScript();
 
     console.log("\n✅ Project reset complete. Next steps:");
     console.log(


### PR DESCRIPTION
# Why

After `npm run reset-project` runs, the `/scripts` directory is moved or deleted — which means `reset-project.js` itself no longer exists at the path referenced in `package.json`:

```json
"reset-project": "node ./scripts/reset-project.js"
```

This leaves the user's freshly-reset project with a dead script entry pointing to a missing file. The script's own JSDoc has long acknowledged this and asked users to clean it up manually:

> "You can remove the `reset-project` script from package.json and safely delete this file after running it."

Earlier, #34200 introduced a follow-up prompt that handled this cleanup when answered "Y". That behavior was dropped during the `/src` template refactor in #41983, so the manual-cleanup gap returned. This PR restores the cleanup automatically, finishing what the original script always told users to do themselves.

# How

Adds a small `removePackageJsonScript()` helper to `templates/expo-template-default/scripts/reset-project.js`. After the directory operations succeed, it:

1. Reads `package.json` from the project root.
2. Deletes the `reset-project` key from the `scripts` object if present (idempotent — safe if the user has already removed it).
3. Writes the file back with 2-space indentation, preserving the original trailing newline.
4. On any failure (missing or malformed `package.json`), prints a friendly `console.warn` with a manual-cleanup hint and lets the reset complete — the destructive work is already done by this point, so an unrelated JSON error shouldn't surface as a stack trace.

The JSDoc at the top of the script is also updated to reflect that the `package.json` entry is now removed automatically.

Compared to #34200's prior implementation:
- No second interactive prompt — the existing primary "move vs delete" prompt already governs the user's intent, and the `package.json` entry is dead either way once the script removes itself, so unconditional cleanup is strictly better than leaving a broken reference.

# Test Plan

In a fresh project created from the template:

\`\`\`bash
npx create-expo-app testreset --template expo-template-default
cd testreset
grep reset-project package.json   # baseline: present
npm run reset-project             # answer \"y\" or \"n\"
\`\`\`

Expected console output now includes:

\`\`\`
🧹 Removed \`reset-project\` script from package.json.

✅ Project reset complete. Next steps:
...
\`\`\`

Verify cleanup:

\`\`\`bash
grep reset-project package.json   # empty
node -e \"JSON.parse(require('fs').readFileSync('package.json','utf8'))\"
tail -c 1 package.json | xxd      # 0a (trailing newline preserved)
\`\`\`

Negative-path: deliberately corrupting `package.json` before running prints the friendly `⚠️` warning and the rest of the reset still completes — no stack trace.

# Checklist

- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (no module plugins or native code touched).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).