### PR TITLE
[ui] fix precompile warning

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed precompile xcframework warning. ([#45762](https://github.com/expo/expo/pull/45762) by [@kudo](https://github.com/kudo))
+
 ## 56.0.7 — 2026-05-13
 
 _This version does not introduce any user-facing changes._
@@ -22,7 +24,6 @@ _This version does not introduce any user-facing changes._
 - Make `ChartView` public. ([#45674](https://github.com/expo/expo/pull/45674) by [@jakex7](https://github.com/jakex7))
 - Added `@expo/ui/community/menu`, a drop-in replacement for `@react-native-menu/menu`. ([#45670](https://github.com/expo/expo/pull/45670) by [@vonovak](https://github.com/vonovak))
 - [android] Added Compose `combinedClickable` modifier. ([#45670](https://github.com/expo/expo/pull/45670) by [@vonovak](https://github.com/vonovak))
-
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-ui/ios/ExpoUITouchHandlerHelper.h
+++ b/packages/expo-ui/ios/ExpoUITouchHandlerHelper.h
@@ -1,8 +1,11 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <ExpoModulesCore/Platform.h>
+
 NS_ASSUME_NONNULL_BEGIN
+
+@class UIGestureRecognizer;
+@class UIView;
 
 @interface ExpoUITouchHandlerHelper : NSObject
 

--- a/packages/expo-ui/ios/ExpoUITouchHandlerHelper.mm
+++ b/packages/expo-ui/ios/ExpoUITouchHandlerHelper.mm
@@ -1,6 +1,7 @@
 // Copyright 2015-present 650 Industries. All rights reserved.
 
 #import "ExpoUITouchHandlerHelper.h"
+#import <ExpoModulesCore/Platform.h>
 #import <React/RCTSurfaceTouchHandler.h>
 
 @implementation ExpoUITouchHandlerHelper


### PR DESCRIPTION
# Why

precompile expo-ui xcframework warning

```
  ⚠ Clang @import warning for ExpoUI.xcframework (ios-arm64, ios-arm64_x86_64-simulator)
      Headers may import React types not available during standalone verification
```

# How

because we have non-modular import to expo-modules-core and expose to expo-ui umbrella header. this pr uses forward declarations and keeps the dependency in implementation only.

# Test Plan

- ci passed
- `et prebuild -f Debug expo-ui -v` without warning

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
