### PR TITLE
Fix infinite follow-up loop in expo install --fix when package manager age gate blocks expo update

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix infinite follow-up loop in `expo install --fix` when a package manager minimum release age policy (e.g., pnpm `minimumReleaseAge`, npm `minimum-release-age`, or Yarn `npmMinimalAgeGate`) silently blocks the expo package update.
+
 ### 💡 Others
 
 - Add general `eslint-disable` comment to Router's type-gen output ([#41637](https://github.com/expo/expo/pull/41637) by [@matinzd](https://github.com/matinzd))

--- a/packages/@expo/cli/src/install/__tests__/installExpoPackage-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/installExpoPackage-test.ts
@@ -1,5 +1,6 @@
 import * as PackageManager from '@expo/package-manager';
 import spawnAsync from '@expo/spawn-async';
+import fs from 'node:fs';
 
 import { Log } from '../../log';
 import { installExpoPackageAsync } from '../installExpoPackage';
@@ -83,5 +84,59 @@ describe(installExpoPackageAsync, () => {
     });
     expect(packageManager.addAsync).toHaveBeenCalledWith(['expo@latest']);
     expect(spawnAsync).not.toHaveBeenCalled();
+  });
+
+  it(`Does not spawn follow-up command when installed version does not satisfy expected range`, async () => {
+    // Simulate a package manager age gate (e.g., pnpm minimumReleaseAge / Yarn npmMinimalAgeGate)
+    // that silently blocks the installation, leaving the old version in place.
+    jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(JSON.stringify({ version: '53.0.9' }));
+
+    const packageManager = PackageManager.createForProject('/path/to/project');
+    await expect(
+      installExpoPackageAsync('/path/to/project', {
+        packageManager,
+        packageManagerArguments: [],
+        expoPackageToInstall: 'expo@53.0.10',
+        followUpCommandArgs: ['--fix'],
+      })
+    ).rejects.toThrow('Failed to update');
+
+    expect(packageManager.addAsync).toHaveBeenCalledWith(['expo@53.0.10']);
+    expect(spawnAsync).not.toHaveBeenCalled();
+  });
+
+  it(`Spawns follow-up command when installed version satisfies expected range`, async () => {
+    jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(JSON.stringify({ version: '53.0.10' }));
+
+    const packageManager = PackageManager.createForProject('/path/to/project');
+    await installExpoPackageAsync('/path/to/project', {
+      packageManager,
+      packageManagerArguments: [],
+      expoPackageToInstall: 'expo@~53.0.10',
+      followUpCommandArgs: ['--fix'],
+    });
+
+    expect(packageManager.addAsync).toHaveBeenCalledWith(['expo@~53.0.10']);
+    expect(spawnAsync).toHaveBeenCalledWith(
+      'npx',
+      ['expo', 'install', '--fix'],
+      expect.objectContaining({ cwd: '/path/to/project' })
+    );
+  });
+
+  it(`Spawns follow-up command when installed version cannot be determined`, async () => {
+    jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
+      throw new Error('ENOENT');
+    });
+
+    const packageManager = PackageManager.createForProject('/path/to/project');
+    await installExpoPackageAsync('/path/to/project', {
+      packageManager,
+      packageManagerArguments: [],
+      expoPackageToInstall: 'expo@53.0.10',
+      followUpCommandArgs: ['--fix'],
+    });
+
+    expect(spawnAsync).toHaveBeenCalled();
   });
 });

--- a/packages/@expo/cli/src/install/__tests__/installExpoPackage-test.ts
+++ b/packages/@expo/cli/src/install/__tests__/installExpoPackage-test.ts
@@ -1,6 +1,7 @@
 import * as PackageManager from '@expo/package-manager';
 import spawnAsync from '@expo/spawn-async';
 import fs from 'node:fs';
+import resolveFrom from 'resolve-from';
 
 import { Log } from '../../log';
 import { installExpoPackageAsync } from '../installExpoPackage';
@@ -89,6 +90,7 @@ describe(installExpoPackageAsync, () => {
   it(`Does not spawn follow-up command when installed version does not satisfy expected range`, async () => {
     // Simulate a package manager age gate (e.g., pnpm minimumReleaseAge / Yarn npmMinimalAgeGate)
     // that silently blocks the installation, leaving the old version in place.
+    jest.spyOn(resolveFrom, 'silent').mockReturnValueOnce('/path/to/project/node_modules/expo/package.json');
     jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(JSON.stringify({ version: '53.0.9' }));
 
     const packageManager = PackageManager.createForProject('/path/to/project');
@@ -106,6 +108,7 @@ describe(installExpoPackageAsync, () => {
   });
 
   it(`Spawns follow-up command when installed version satisfies expected range`, async () => {
+    jest.spyOn(resolveFrom, 'silent').mockReturnValueOnce('/path/to/project/node_modules/expo/package.json');
     jest.spyOn(fs, 'readFileSync').mockReturnValueOnce(JSON.stringify({ version: '53.0.10' }));
 
     const packageManager = PackageManager.createForProject('/path/to/project');
@@ -125,9 +128,7 @@ describe(installExpoPackageAsync, () => {
   });
 
   it(`Spawns follow-up command when installed version cannot be determined`, async () => {
-    jest.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
-      throw new Error('ENOENT');
-    });
+    jest.spyOn(resolveFrom, 'silent').mockReturnValueOnce(null);
 
     const packageManager = PackageManager.createForProject('/path/to/project');
     await installExpoPackageAsync('/path/to/project', {

--- a/packages/@expo/cli/src/install/installExpoPackage.ts
+++ b/packages/@expo/cli/src/install/installExpoPackage.ts
@@ -2,7 +2,7 @@ import type * as PackageManager from '@expo/package-manager';
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
 import fs from 'node:fs';
-import path from 'node:path';
+import resolveFrom from 'resolve-from';
 import semver from 'semver';
 
 import * as Log from '../log';
@@ -60,11 +60,9 @@ export async function installExpoPackageAsync(
 
   // Spawn a new process to install the rest of the packages if there are any, as only then will the latest Expo package be used
   if (followUpCommandArgs.length) {
-    // Verify the installed expo version satisfies the expected range before spawning the
-    // follow-up command. Without this check, an infinite loop can occur when a package
-    // manager age gate (e.g., pnpm's `minimumReleaseAge`, npm's `minimum-release-age`, or
-    // Yarn's `npmMinimalAgeGate`) silently rejects the installation without throwing \u2014
-    // the follow-up `expo install --fix` would restart the cycle indefinitely.
+    // Guard against an infinite follow-up loop: if a package manager age gate (e.g., pnpm
+    // `minimumReleaseAge`, Yarn `npmMinimalAgeGate`) silently rejects the install without
+    // throwing, the old version remains and the respawned `expo install --fix` would loop.
     const expectedRange = expoPackageToInstall.replace(/^expo@/, '');
     if (semver.validRange(expectedRange)) {
       const installedVersion = getInstalledPackageVersion(projectRoot, 'expo');
@@ -100,9 +98,10 @@ export async function installExpoPackageAsync(
 
 function getInstalledPackageVersion(projectRoot: string, packageName: string): string | null {
   try {
-    const pkgJsonPath = path.join(projectRoot, 'node_modules', packageName, 'package.json');
-    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-    return pkgJson.version ?? null;
+    const pkgJsonPath = resolveFrom.silent(projectRoot, `${packageName}/package.json`);
+    if (!pkgJsonPath) return null;
+    const { version } = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    return version ?? null;
   } catch {
     return null;
   }

--- a/packages/@expo/cli/src/install/installExpoPackage.ts
+++ b/packages/@expo/cli/src/install/installExpoPackage.ts
@@ -1,9 +1,13 @@
 import type * as PackageManager from '@expo/package-manager';
 import spawnAsync from '@expo/spawn-async';
 import chalk from 'chalk';
+import fs from 'node:fs';
+import path from 'node:path';
+import semver from 'semver';
 
 import * as Log from '../log';
 import type { Options } from './resolveOptions';
+import { CommandError } from '../utils/errors';
 import { getRunningProcess } from '../utils/getRunningProcess';
 
 /**
@@ -56,6 +60,26 @@ export async function installExpoPackageAsync(
 
   // Spawn a new process to install the rest of the packages if there are any, as only then will the latest Expo package be used
   if (followUpCommandArgs.length) {
+    // Verify the installed expo version satisfies the expected range before spawning the
+    // follow-up command. Without this check, an infinite loop can occur when a package
+    // manager age gate (e.g., pnpm's `minimumReleaseAge`, npm's `minimum-release-age`, or
+    // Yarn's `npmMinimalAgeGate`) silently rejects the installation without throwing \u2014
+    // the follow-up `expo install --fix` would restart the cycle indefinitely.
+    const expectedRange = expoPackageToInstall.replace(/^expo@/, '');
+    if (semver.validRange(expectedRange)) {
+      const installedVersion = getInstalledPackageVersion(projectRoot, 'expo');
+      if (installedVersion && !semver.satisfies(installedVersion, expectedRange)) {
+        throw new CommandError(
+          'EXPO_PACKAGE_NOT_INSTALLED',
+          chalk`Failed to update {bold expo} to {bold ${expoPackageToInstall}} \u2014 installed version is {bold ${installedVersion}}. ` +
+            `Your package manager may be configured with a minimum release age policy ` +
+            chalk`(e.g., {bold minimumReleaseAge} in pnpm or npm, or {bold npmMinimalAgeGate} in Yarn) ` +
+            `that blocks newly-published versions. Run {bold npx expo install --fix} again once the quarantine period has passed, ` +
+            `or check your package manager configuration.`
+        );
+      }
+    }
+
     let commandSegments = ['expo', 'install', dev ? '--dev' : '', ...followUpCommandArgs].filter(
       Boolean
     );
@@ -71,5 +95,15 @@ export async function installExpoPackageAsync(
       cwd: projectRoot,
       env: { ...process.env },
     });
+  }
+}
+
+function getInstalledPackageVersion(projectRoot: string, packageName: string): string | null {
+  try {
+    const pkgJsonPath = path.join(projectRoot, 'node_modules', packageName, 'package.json');
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    return pkgJson.version ?? null;
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

- `expo install --fix` spawns a follow-up `npx expo install --fix` process after installing a new `expo` version (to run under the freshly-installed CLI)
- Package managers with a minimum release age policy (pnpm [`minimumReleaseAge`](https://pnpm.io/npmrc#minimum-release-age), npm [`minimum-release-age`](https://docs.npmjs.com/cli/v11/commands/npm-install), Yarn [`npmMinimalAgeGate`](https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate)) can silently block the installation without throwing — leaving the old `expo` version in place
- The spawned follow-up process sees the same version mismatch and re-enters the same cycle, causing an **infinite download loop**

Fix: after installing `expo`, verify the installed version satisfies the expected semver range before spawning the follow-up. If the version does not match (because the install was silently blocked), throw a clear `CommandError` that names the age gate as the likely cause and tells the user to try again after the quarantine period.

Closes #44479

## Test Plan

- [ ] Added unit tests in `installExpoPackage-test.ts` covering:
  - Follow-up is **not** spawned and a helpful error is thrown when the installed version doesn't satisfy the expected range (simulating a silent age gate block)
  - Follow-up **is** spawned when the installed version satisfies a semver range (e.g., `~53.0.10`)
  - Follow-up **is** spawned when `node_modules/expo/package.json` cannot be read (graceful degradation — no regression for environments without a readable node_modules)
- [ ] All existing tests continue to pass (`pnpm test` in `packages/@expo/cli`)
- [ ] TypeScript compiles without errors
- [ ] `pnpm lint` passes without errors