### PR TITLE
fix(cli): Fix Android launch activity ID for custom fully qualified activity names

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix containment check in tar extraction to cover parallel folders with same prefix ([#45882](https://github.com/expo/expo/pull/45882) by [@kitten](https://github.com/kitten))
 - Forward the request HTTP method to the RSC renderer ([#45905](https://github.com/expo/expo/pull/45905) by [@kitten](https://github.com/kitten))
 - Add validation to check `EXPO_PUBLIC_FOLDER` is in project root ([#45866](https://github.com/expo/expo/pull/45866) by [@kitten](https://github.com/kitten))
+- Fix launching Android activity when activity name is fully specified ([#45773](https://github.com/expo/expo/pull/45773) by [@sebryu](https://github.com/sebryu))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/run/android/__tests__/resolveLaunchProps-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveLaunchProps-test.ts
@@ -58,4 +58,26 @@ describe(resolveLaunchPropsAsync, () => {
       customAppId: 'dev.expo.test',
     });
   });
+
+  it(`resolves launch properties with fully qualified main activity`, async () => {
+    vol.fromJSON(
+      {
+        ...rnFixture,
+        'android/app/src/main/AndroidManifest.xml': rnFixture[
+          'android/app/src/main/AndroidManifest.xml'
+        ].replace(
+          'android:name=".MainActivity"',
+          'android:name="com.reactnativeproject.MainActivity"'
+        ),
+      },
+      '/'
+    );
+
+    expect(await resolveLaunchPropsAsync('/', { appId: 'dev.expo.test' })).toEqual({
+      launchActivity: 'dev.expo.test/com.reactnativeproject.MainActivity',
+      mainActivity: 'com.reactnativeproject.MainActivity',
+      packageName: 'com.bacon.mydevicefamilyproject',
+      customAppId: 'dev.expo.test',
+    });
+  });
 });

--- a/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
+++ b/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
@@ -28,6 +28,10 @@ export interface LaunchProps {
   launchActivity: string;
 }
 
+function resolveCustomLaunchActivity(packageName: string, mainActivity: string): string {
+  return mainActivity.startsWith('.') ? `${packageName}${mainActivity}` : mainActivity;
+}
+
 async function getMainActivityAsync(projectRoot: string): Promise<string> {
   const filePath = await AndroidConfig.Paths.getAndroidManifestAsync(projectRoot);
   const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(filePath);
@@ -55,7 +59,7 @@ export async function resolveLaunchPropsAsync(
 
   const launchActivity =
     customAppId && customAppId !== packageName
-      ? `${customAppId}/${packageName}${mainActivity}`
+      ? `${customAppId}/${resolveCustomLaunchActivity(packageName, mainActivity)}`
       : `${packageName}/${mainActivity}`;
 
   return {


### PR DESCRIPTION
## Summary

- fix Android launch activity resolution when a custom app id is paired with a fully-qualified activity name

## Test plan
- pnpm --filter @expo/cli test -- src/run/android/__tests__/resolveLaunchProps-test.ts --runInBand