### PR TITLE
feat(cli): Allow Android app IDs from Expo config in start

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Forward the request HTTP method to the RSC renderer ([#45905](https://github.com/expo/expo/pull/45905) by [@kitten](https://github.com/kitten))
 - Add validation to check `EXPO_PUBLIC_FOLDER` is in project root ([#45866](https://github.com/expo/expo/pull/45866) by [@kitten](https://github.com/kitten))
 - Fix launching Android activity when activity name is fully specified ([#45773](https://github.com/expo/expo/pull/45773) by [@sebryu](https://github.com/sebryu))
+- Prefer Expo config app IDs over native files in `expo start` when `EXPO_RUN_PREFER_APP_CONFIG_ID` is enabled. ([#45774](https://github.com/expo/expo/pull/45774) by [@sebryu](https://github.com/sebryu))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add `/_expo/open` middleware for programmatically resolving deep links and disambiguation pages for the running dev server. ([#45804](https://github.com/expo/expo/pull/45804) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade react-native-tvos to the correct version on install/fix. ([#45816](https://github.com/expo/expo/pull/45816) by [@douglowder](https://github.com/douglowder))
 - Accept `expo login -p -` argument to read password from stdin ([#45877](https://github.com/expo/expo/pull/45877) by [@kitten](https://github.com/kitten))
+- Add `EXPO_RUN_PREFER_APP_CONFIG_ID=1` to prefer Expo config app IDs over native files when running apps ([#45774](https://github.com/expo/expo/pull/45774) by [@sebryu](https://github.com/sebryu))
 
 ### 🐛 Bug fixes
 
@@ -18,7 +19,6 @@
 - Forward the request HTTP method to the RSC renderer ([#45905](https://github.com/expo/expo/pull/45905) by [@kitten](https://github.com/kitten))
 - Add validation to check `EXPO_PUBLIC_FOLDER` is in project root ([#45866](https://github.com/expo/expo/pull/45866) by [@kitten](https://github.com/kitten))
 - Fix launching Android activity when activity name is fully specified ([#45773](https://github.com/expo/expo/pull/45773) by [@sebryu](https://github.com/sebryu))
-- Prefer Expo config app IDs over native files in `expo start` when `EXPO_RUN_PREFER_APP_CONFIG_ID` is enabled. ([#45774](https://github.com/expo/expo/pull/45774) by [@sebryu](https://github.com/sebryu))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/AppIdResolver.ts
+++ b/packages/@expo/cli/src/start/platforms/AppIdResolver.ts
@@ -1,5 +1,6 @@
 import { getConfig, getProjectConfigDescriptionWithPaths } from '@expo/config';
 
+import { env } from '../../utils/env';
 import { CommandError, UnimplementedError } from '../../utils/errors';
 import { get } from '../../utils/obj';
 
@@ -15,6 +16,9 @@ export class AppIdResolver {
 
   /** Resolve the application ID for the project. */
   async getAppIdAsync(): Promise<string> {
+    if (env.EXPO_RUN_PREFER_APP_CONFIG_ID) {
+      return this.getAppIdFromConfigAsync();
+    }
     if (await this.hasNativeProjectAsync()) {
       return this.getAppIdFromNativeAsync();
     }

--- a/packages/@expo/cli/src/start/platforms/__tests__/AppIdResolver-test.ts
+++ b/packages/@expo/cli/src/start/platforms/__tests__/AppIdResolver-test.ts
@@ -18,6 +18,17 @@ function createAppIdResolver() {
   return new AppIdResolver('/', 'ios', 'foo.bar');
 }
 
+const preferAppConfigIdEnvVar = 'EXPO_RUN_PREFER_APP_CONFIG_ID';
+const originalEnvValue = process.env[preferAppConfigIdEnvVar];
+
+afterEach(() => {
+  if (originalEnvValue == null) {
+    delete process.env[preferAppConfigIdEnvVar];
+  } else {
+    process.env[preferAppConfigIdEnvVar] = originalEnvValue;
+  }
+});
+
 describe('getAppIdAsync', () => {
   it('resolves the app id from native files', async () => {
     const resolver = createAppIdResolver();
@@ -52,6 +63,40 @@ describe('getAppIdAsync', () => {
     } as any);
     expect(await resolver.getAppIdAsync()).toBe('dev.bacon.myapp');
     expect(resolver.getAppIdFromConfigAsync).toHaveBeenCalledTimes(1);
+    expect(resolver.hasNativeProjectAsync).toHaveBeenCalledTimes(1);
+  });
+  it('resolves the app id from project config when EXPO_RUN_PREFER_APP_CONFIG_ID is enabled', async () => {
+    process.env[preferAppConfigIdEnvVar] = '1';
+
+    const resolver = createAppIdResolver();
+    resolver.hasNativeProjectAsync = jest.fn(async () => true);
+    resolver.getAppIdFromNativeAsync = jest.fn(async () => 'dev.bacon.myapp');
+    resolver.getAppIdFromConfigAsync = jest.fn(resolver.getAppIdFromConfigAsync);
+
+    jest.mocked(getConfig).mockReturnValueOnce({
+      exp: {
+        foo: {
+          bar: 'dev.bacon.myapp.dev',
+        },
+      },
+    } as any);
+
+    expect(await resolver.getAppIdAsync()).toBe('dev.bacon.myapp.dev');
+    expect(resolver.getAppIdFromConfigAsync).toHaveBeenCalledTimes(1);
+    expect(resolver.getAppIdFromNativeAsync).not.toHaveBeenCalled();
+    expect(resolver.hasNativeProjectAsync).not.toHaveBeenCalled();
+  });
+  it('resolves the app id from native files when EXPO_RUN_PREFER_APP_CONFIG_ID is disabled', async () => {
+    process.env[preferAppConfigIdEnvVar] = '0';
+
+    const resolver = createAppIdResolver();
+    resolver.hasNativeProjectAsync = jest.fn(async () => true);
+    resolver.getAppIdFromNativeAsync = jest.fn(async () => 'dev.bacon.myapp');
+    resolver.getAppIdFromConfigAsync = jest.fn(resolver.getAppIdFromConfigAsync);
+
+    expect(await resolver.getAppIdAsync()).toBe('dev.bacon.myapp');
+    expect(resolver.getAppIdFromConfigAsync).not.toHaveBeenCalled();
+    expect(resolver.getAppIdFromNativeAsync).toHaveBeenCalledTimes(1);
     expect(resolver.hasNativeProjectAsync).toHaveBeenCalledTimes(1);
   });
   it('throws when the app id is missing in the project config and there are no native files', async () => {

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -85,6 +85,10 @@ class Env {
   get EXPO_NO_QR_CODE(): boolean {
     return boolish('EXPO_NO_QR_CODE', false);
   }
+  /** Resolve application IDs from Expo app config before native files in `expo start`. */
+  get EXPO_RUN_PREFER_APP_CONFIG_ID(): boolean {
+    return boolish('EXPO_RUN_PREFER_APP_CONFIG_ID', false);
+  }
   /** The React Metro port that's baked into react-native scripts and tools. */
   get RCT_METRO_PORT() {
     return int('RCT_METRO_PORT', 0);


### PR DESCRIPTION
## Summary
- add `EXPO_USE_APP_CONFIG_ANDROID_PACKAGE` as an escape hatch for Android app id resolution
- when enabled, `AndroidAppIdResolver.getAppIdAsync()` reads `android.package` from Expo config before native files
- keep default native-first behavior and add coverage for enabled/disabled env behavior

## Test plan
- pnpm --filter @expo/cli test -- src/start/platforms/android/__tests__/AndroidAppIdResolver-test.ts --runInBand