### PR TITLE
[ui][android] flush Host layout state update synchronously

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 🐛 Bug fixes
 
 - Fix `useNativeState` recreating the `ObservableState` when initial value changes; the seed is now captured once via `useRef`. ([#45623](https://github.com/expo/expo/pull/45623) by [@nishan](https://github.com/intergalacticspacehighway))
+- [Android] Fix layout shift in `Host` with `matchContents`. ([#45775](https://github.com/expo/expo/pull/45775) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ExpoUIModule.kt
@@ -86,7 +86,8 @@ class ExpoUIModule : Module() {
     //region Views use expo-modules-core DSL for uncommon features
 
     View(HostView::class) {
-      Events("onLayoutContent")
+      // See ShadowNodeSyncFlush.kt for why onExpoUISyncFlush is needed.
+      Events("onLayoutContent", "onExpoUISyncFlush")
 
       OnViewDidUpdateProps { view ->
         view.onViewDidUpdateProps()
@@ -123,7 +124,10 @@ class ExpoUIModule : Module() {
       colorScheme.toTokenMap()
     }
 
-    View(RNHostView::class)
+    View(RNHostView::class) {
+      // See ShadowNodeSyncFlush.kt for why this internal phantom event is needed.
+      Events("onExpoUISyncFlush")
+    }
 
     View(SlotView::class) {
       Events("onSlotEvent")

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/HostView.kt
@@ -193,6 +193,7 @@ internal class HostView(context: Context, appContext: AppContext) :
             if (constraints.maxWidth == 0) widthDp else Double.NaN,
             if (constraints.maxHeight == 0) heightDp else Double.NaN
           )
+          flushPendingStateUpdates()
         }
       }
 
@@ -221,6 +222,7 @@ internal class HostView(context: Context, appContext: AppContext) :
         val styleWidth = if (matchContentsHorizontal == true && width > 0) width else null
         val styleHeight = if (matchContentsVertical == true && height > 0) height else null
         shadowNodeProxy.setStyleSize(styleWidth?.toDouble(), styleHeight?.toDouble())
+        flushPendingStateUpdates()
       }
 
       onLayoutContent(LayoutContentEvent(width.toDouble(), height.toDouble()))

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/RNHostView.kt
@@ -154,6 +154,7 @@ internal class RNHostView(context: Context, appContext: AppContext) :
           size.width.toDp().value.toDouble(),
           size.height.toDp().value.toDouble()
         )
+        flushPendingStateUpdates()
       }
     }
   }

--- a/packages/expo-ui/android/src/main/java/expo/modules/ui/ShadowNodeSyncFlush.kt
+++ b/packages/expo-ui/android/src/main/java/expo/modules/ui/ShadowNodeSyncFlush.kt
@@ -1,0 +1,28 @@
+package expo.modules.ui
+
+import android.view.View
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
+
+// Workaround helper that triggers a synchronous event to flush a pending
+// shadow-node state update in the current event beat. Mirrors iOS's
+// `EventQueue::UpdateMode::unstable_Immediate`, which Android does not expose
+// to Java/Kotlin as of now.
+// TODO: Remove when a synchronous state update API is exposed on Android.
+// https://github.com/facebook/react-native/pull/56311
+internal fun View.flushPendingStateUpdates() {
+  val reactContext = context as? ReactContext ?: return
+  val surfaceId = UIManagerHelper.getSurfaceId(this)
+  UIManagerHelper.getEventDispatcherForReactTag(reactContext, id)
+    ?.dispatchEvent(SyncFlushEvent(surfaceId, id))
+}
+
+private class SyncFlushEvent(surfaceId: Int, viewTag: Int) : Event<SyncFlushEvent>(surfaceId, viewTag) {
+  override fun getEventName(): String = "topExpoUISyncFlush"
+  override fun getEventData(): WritableMap = Arguments.createMap()
+  override fun canCoalesce(): Boolean = true
+  override fun experimental_isSynchronous(): Boolean = true
+}


### PR DESCRIPTION
# Why

Below code snippet can cause layout shift on android on first mount.

```jsx
import { Box } from '@expo/ui/jetpack-compose';
import { size } from '@expo/ui/jetpack-compose/modifiers';
import { Host } from '@expo/ui/swift-ui';
import { background } from '@expo/ui/swift-ui/modifiers';
import { View } from 'react-native';

export default function ImageSymbolEffectExample() {
  return (
    <View style={{ flex: 1 }}>
      <Host matchContents>
        <Box modifiers={[size(100, 100), background('blue')]}></Box>
      </Host>
      <View style={{ width: 100, height: 100, backgroundColor: 'red' }}></View>
    </View>
  );
}
```

### Before and after the fix (left is before)
https://github.com/user-attachments/assets/b1b93781-0517-414d-90d0-7df14332652e



iOS had the same issue, it was fixed here - https://github.com/expo/expo/pull/40017

Issue is currently `Host` with `matchContents` uses updateState API to update shadow node size, this can cause layout shift as the current dispatch is async on android. On iOS, we're using experimental sync flag provided by RN. On Android, the flag is not exposed. We made a PR to enable it for android - https://github.com/facebook/react-native/pull/56311. Until it gets merged or any alternate API is provided by RN, we need a workaround that can enable sync state updates on Android.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

- Android has a solution to dispatch sync event from Kotlin (or cpp) to JS (via event emitter) (this is used by VirtualView in RN to send sync event from native to JS). So the approach in this PR relies on the behavior that both state update queue and events are flushed in the same tick when a sync event is dispatched. This allows us to dispatch a state update (which is async) but then immediately trigger a sync event which will flush our state update synchronously 😅. 
- The API had been in the core for quite some time (2024 - https://github.com/facebook/react-native/pull/44489) 

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- Tested the above repro with changes in this PR, layout shift gets fixed.
- Tested all the examples in NCL and confirmed there are no regressions.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
