### PR TITLE
[ci] Fix Windows check-package test failures

### DIFF
--- a/packages/expo-codemod/CHANGELOG.md
+++ b/packages/expo-codemod/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Fixed unit test failure on Windows. ([#45777](https://github.com/expo/expo/pull/45777) by [@kudo](https://github.com/kudo))
+
 ## 56.0.3 — 2026-05-11
 
 ### 🎉 New features

--- a/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
+++ b/packages/expo-codemod/src/transforms/__tests__/sdk-56-expo-router-react-navigation-replace-test.ts
@@ -453,7 +453,7 @@ describe('type imports', () => {
       `import { createStackNavigator, type StackScreenProps } from '@react-navigation/stack';`,
     ].join('\n');
     const output = runTS(input);
-    expect(output).toBe(
+    expect(output.replace(/\r\n/g, '\n')).toBe(
       [
         `import { useNavigation, type NavigationProp } from "expo-router/react-navigation";`,
         `import { createStackNavigator, type StackScreenProps } from "expo-router/js-stack";`,


### PR DESCRIPTION
# Why

Windows check-package CI is failing in a few packages because some tests assume POSIX paths/newlines ~,and `@expo/require-utils` drops POSIX-style source map file URLs on Windows.~

https://github.com/expo/expo/actions/runs/25807603817/job/75814670949

# How

- Normalize codemod test output newlines before assertions.

# Test Plan

- check-packages-windows ci passed: https://github.com/expo/expo/actions/runs/25880804574

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)