### PR TITLE
[modules-core][ios] Introduce experimental `@JS` / `@ExpoModule` / `@SharedObject` macros

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `pod install` failing with `bad component (expected absolute path component)` for precompiled Expo modules when the project lives under a path containing non-ASCII characters (e.g. emoji). ([#45779](https://github.com/expo/expo/pull/45779) by [@tsapeta](https://github.com/tsapeta))
-- [iOS] Wire the macro plugin flag into `ExpoModulesCore`'s own xcconfig so SourceKit can resolve `#externalMacro` references in core source files. ([#45775](https://github.com/expo/expo/pull/45775) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Wire the macro plugin flag into `ExpoModulesCore`'s own xcconfig so SourceKit can resolve `#externalMacro` references in core source files. ([#45778](https://github.com/expo/expo/pull/45778) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `pod install` failing with `bad component (expected absolute path component)` for precompiled Expo modules when the project lives under a path containing non-ASCII characters (e.g. emoji). ([#45779](https://github.com/expo/expo/pull/45779) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Wire the macro plugin flag into `ExpoModulesCore`'s own xcconfig so SourceKit can resolve `#externalMacro` references in core source files. ([#45775](https://github.com/expo/expo/pull/45775) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/project_integrator.rb
@@ -145,8 +145,9 @@ module Expo
         end
 
         target.pod_targets.each do |pod_target|
+          is_core = pod_target.name == 'ExpoModulesCore'
           has_core_dependency = pod_target.dependencies.find { |dependency| dependency == 'ExpoModulesCore' }
-          next unless has_core_dependency
+          next unless is_core || has_core_dependency
           pod_target.build_settings.each do |build_configuration_name, build_settings|
             xcconfig = build_settings.xcconfig
             swift_flags = xcconfig.attributes[SWIFT_FLAGS] || '$(inherited)'

--- a/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
@@ -1,8 +1,5 @@
-
-/**
- Declares macro signatures whose implementations are provided by the `@expo/expo-modules-macros-plugin` binary.
- Keep in sync with `@expo/expo-modules-macros-plugin/apple/Sources/ExpoModulesOptimized/ExpoModulesOptimized.swift`.
- */
+// Declares macro signatures whose implementations are provided by the `@expo/expo-modules-macros-plugin` binary.
+// Keep in sync with the macro declarations in the `@expo/expo-modules-macros-plugin` package.
 
 // MARK: - Macro declarations
 
@@ -25,3 +22,64 @@
 @attached(peer, names: arbitrary)
 public macro OptimizedFunction() =
   #externalMacro(module: "ExpoModulesMacros", type: "OptimizedFunctionAttachedMacro")
+
+/// Marker macro applied to module / shared-object members that should be exposed to JavaScript.
+/// The accompanying `@ExpoModule` and `@SharedObject` macros discover `@JS`-marked declarations
+/// and generate the matching `Function` / `AsyncFunction` / `Property` / `Constructor` registrations.
+///
+/// Usage:
+///
+///     @JS
+///     func greet(name: String) -> String { ... }
+///
+///     @JS("doWork")
+///     func performWork() async throws { ... }
+///
+///     @JS
+///     var status: String { "ok" }
+@attached(peer)
+public macro JS(_ jsName: String? = nil) =
+  #externalMacro(module: "ExpoModulesMacros", type: "JSMacro")
+
+/// Member macro applied to a `Module` subclass. Scans the class body for declarations
+/// marked with `@JS` and synthesizes a framework-internal `_exposedDefinition()` method.
+/// `expo-modules-core` calls it automatically and merges the result into the module's
+/// definition, so the user doesn't have to reference it from `definition()`.
+///
+/// Usage:
+///
+///     @ExpoModule
+///     public final class MyModule: Module {
+///       public func definition() -> ModuleDefinition {
+///         Name("MyModule")
+///       }
+///
+///       @JS
+///       func greet(name: String) -> String { "Hi, \(name)" }
+///     }
+@attached(member, names: named(_exposedDefinition), named(appContext), named(init))
+public macro ExpoModule(_ name: String? = nil, classes: [Any.Type] = []) =
+  #externalMacro(module: "ExpoModulesMacros", type: "ExpoModuleMacro")
+
+/// Member macro applied to a `SharedObject` subclass. Scans the class body for declarations
+/// marked with `@JS` (including a single `@JS init(...)` for the JS constructor) and
+/// synthesizes a `_exposedClassDefinition()` static method returning a `ClassDefinition`.
+/// The companion `@ExpoModule(classes: [Foo.self])` wires the class into the module's
+/// exposed surface.
+///
+/// Usage:
+///
+///     @SharedObject
+///     final class Cache: SharedObject {
+///       @JS
+///       init(name: String) { self.name = name }
+///
+///       @JS
+///       func get(_ key: String) -> String? { ... }
+///
+///       @JS
+///       var size: Int { 42 }
+///     }
+@attached(member, names: named(_exposedClassDefinition))
+public macro SharedObject(_ name: String? = nil) =
+  #externalMacro(module: "ExpoModulesMacros", type: "SharedObjectMacro")

--- a/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
+++ b/packages/expo-modules-core/ios/Core/ExpoModulesMacros.swift
@@ -1,5 +1,6 @@
-// Declares macro signatures whose implementations are provided by the `@expo/expo-modules-macros-plugin` binary.
-// Keep in sync with the macro declarations in the `@expo/expo-modules-macros-plugin` package.
+// Declares macro signatures whose implementations are provided by the `ExpoModulesMacros` compiler
+// plugin shipped in the `@expo/expo-modules-macros-plugin` package. Keep the `#externalMacro`
+// module/type names below in sync with the macro implementations in that package.
 
 // MARK: - Macro declarations
 

--- a/packages/expo-modules-core/ios/Core/ModuleHolder.swift
+++ b/packages/expo-modules-core/ios/Core/ModuleHolder.swift
@@ -46,8 +46,26 @@ public final class ModuleHolder {
     self.appContext = appContext
     self._name = name
     self.module = module
-    self.definition = module.definition()
+    self.definition = ModuleHolder.buildDefinition(for: module)
     post(event: .moduleCreate)
+  }
+
+  /// Combines the user-authored definition with the entries synthesized by the
+  /// `@ExpoModule` macro on this module's class (if any). The macro emits a
+  /// `_exposedDefinition()` method returning an `[AnyDefinition]` array of the
+  /// `Function` / `Property` / `Constructor` entries it generated from `@JS`
+  /// members. Those entries are prepended to the user's definitions and the
+  /// whole list is fed back through `ModuleDefinition.init` so the merged
+  /// result is rebucketed (into `functions`, `properties`, etc.) just like a
+  /// hand-written definition. Modules that don't use the macro fall through
+  /// the empty-exposed fast path and return the user's definition unchanged.
+  private static func buildDefinition(for module: AnyModule) -> ModuleDefinition {
+    let userDefinition = module.definition()
+    let exposed = module._exposedDefinition()
+    if exposed.isEmpty {
+      return userDefinition
+    }
+    return ModuleDefinition(definitions: exposed + userDefinition.rawDefinitions)
   }
 
   // MARK: Constants

--- a/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Modules/ModuleDefinition.swift
@@ -29,10 +29,17 @@ public final class ModuleDefinition: ObjectDefinition {
 
   let eventObservers: [AnyEventObservingDefinition]
 
+  /// The raw list of definitions used to construct this module. Retained so
+  /// that `ModuleHolder` can merge in the entries synthesized by the
+  /// `@ExpoModule` macro without losing the user-authored ones.
+  let rawDefinitions: [AnyDefinition]
+
   /**
    Initializer that is called by the `ModuleDefinitionBuilder` results builder.
    */
   override init(definitions: [AnyDefinition]) {
+    self.rawDefinitions = definitions
+
     self.name = definitions
       .compactMap { $0 as? ModuleNameDefinition }
       .last?

--- a/packages/expo-modules-core/ios/Core/Protocols/AnyModule.swift
+++ b/packages/expo-modules-core/ios/Core/Protocols/AnyModule.swift
@@ -14,4 +14,16 @@ public protocol AnyModule: AnyObject, AnyArgument {
    */
   @ModuleDefinitionBuilder
   func definition() -> ModuleDefinition
+
+  /// Returns definitions synthesized from `@JS`-annotated members by the `@ExpoModule` macro.
+  /// Framework-internal: the leading underscore signals this is not part of the public API and
+  /// should only be called by `expo-modules-core` itself. Modules that don't use the macro fall
+  /// back to the default empty implementation.
+  func _exposedDefinition() -> [AnyDefinition]
+}
+
+public extension AnyModule {
+  func _exposedDefinition() -> [AnyDefinition] {
+    return []
+  }
 }

--- a/packages/expo-modules-core/package.json
+++ b/packages/expo-modules-core/package.json
@@ -55,7 +55,7 @@
     "preset": "expo-module-scripts"
   },
   "dependencies": {
-    "@expo/expo-modules-macros-plugin": "~0.0.8",
+    "@expo/expo-modules-macros-plugin": "~0.0.9",
     "expo-modules-jsi": "workspace:~56.0.4",
     "invariant": "^2.2.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4876,8 +4876,8 @@ importers:
   packages/expo-modules-core:
     dependencies:
       '@expo/expo-modules-macros-plugin':
-        specifier: ~0.0.8
-        version: 0.0.8
+        specifier: ~0.0.9
+        version: 0.0.9
       expo-modules-jsi:
         specifier: workspace:~56.0.4
         version: link:../expo-modules-jsi
@@ -7520,8 +7520,8 @@ packages:
   '@expo/devcert@1.2.1':
     resolution: {integrity: sha512-qC4eaxmKMTmJC2ahwyui6ud8f3W60Ss7pMkpBq40Hu3zyiAaugPXnZ24145U7K36qO9UHdZUVxsCvIpz2RYYCA==}
 
-  '@expo/expo-modules-macros-plugin@0.0.8':
-    resolution: {integrity: sha512-ZHH+Hgle/ZyVfTSd9L+ON/0a7BouMEQ3wJKGmOilPLYMTjx5NOcbNZVaJ3iAHKCplvDIHHjPdmqVPorWMHm19A==}
+  '@expo/expo-modules-macros-plugin@0.0.9':
+    resolution: {integrity: sha512-odai6D7ng/gA7At8ukFcWcauNEeDdyVqzVPbQxDkyU2NTJ4kgphA4I5iigS5C4LXFicSIzEt2nzdlLM8sjsTdA==}
 
   '@expo/material-symbols@0.1.1':
     resolution: {integrity: sha512-ruA6hZATOPKxo1qSd1NE3HI9FrmEDwcMDhsvzTAdMkP9AapdHfJ/0tKmBMWFJir85voxs1twYxLVrGW9OLGaOg==}
@@ -17367,7 +17367,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/expo-modules-macros-plugin@0.0.8': {}
+  '@expo/expo-modules-macros-plugin@0.0.9': {}
 
   '@expo/material-symbols@0.1.1': {}
 


### PR DESCRIPTION
# Why

Bumps `@expo/expo-modules-macros-plugin` to `0.0.9`, which adds the new `@JS`, `@ExpoModule`, and `@SharedObject` Swift macros for declaring JS-exposed members directly on Swift members rather than inside the `definition()` DSL. These are experimental and intentionally **not** advertised in the public CHANGELOG.

This PR is the core-side scaffolding that makes those macros actually wire up at runtime — the plugin alone only synthesizes code, the framework has to call into it.

# How

Three logical commits:

1. **Declare the macros + bump the plugin** — exposes `@JS` / `@ExpoModule` / `@SharedObject` signatures via `ExpoModulesMacros.swift` so modules can reference them by importing `ExpoModulesCore` alone.

2. **Merge `@ExpoModule`-synthesized definitions into modules** — adds a framework-internal `_exposedDefinition() -> [AnyDefinition]` requirement on `AnyModule` (default empty) and has `ModuleHolder` prepend its entries to the user-authored `ModuleDefinition`. Without this, the macro-generated array would be dead code. `ModuleDefinition` retains the raw input list so the merge round-trips through `init(definitions:)` cleanly.

3. **Load the macro plugin in `ExpoModulesCore` too** — `expo-modules-autolinking` previously wired the plugin xcconfig flag only into pods that *depend on* `ExpoModulesCore`. Now that core itself contains `#externalMacro` references, SourceKit warns when editing files inside core. Including core in the same loop fixes it.

# Test Plan

- `pnpm install` resolves `@expo/expo-modules-macros-plugin@0.0.9` from npm (no local symlink).
- In a module that adopts `@ExpoModule` + `@JS`, the methods become callable from JavaScript (verified locally with `expo-app-metrics`, migration tracked separately).
- Modules that don't adopt the macros take the empty-exposed fast path — no behavior change.
- After `pod install`, `ExpoModulesCore`'s xcconfig contains `-load-plugin-executable …#ExpoModulesMacros` and SourceKit no longer warns inside `ExpoModulesMacros.swift`.

<!-- disable:changelog-checks -->