### PR TITLE
[autolinking][iOS] Fix pod install for Unicode project paths

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `pod install` failing with `bad component (expected absolute path component)` for precompiled Expo modules when the project lives under a path containing non-ASCII characters (e.g. emoji). ([#45779](https://github.com/expo/expo/pull/45779) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-13

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -541,7 +541,7 @@ module Expo
 
         log_linking_status(spec.name, true, default_tarball)
 
-        spec.source = { :http => URI::File.build(path: default_tarball).to_s, :flatten => false }
+        spec.source = { :http => local_file_uri(default_tarball), :flatten => false }
         spec.vendored_frameworks = build_vendored_paths(product_name, pod_info, spec.name)
 
         extra_fw_paths = framework_search_paths_for_skipped_deps(spec.name, pod_info)
@@ -579,7 +579,7 @@ module Expo
         spec_json = JSON.parse(spec.to_pretty_json)
 
         # Override source to local tarball
-        spec_json['source'] = { 'http' => URI::File.build(path: default_tarball).to_s, 'flatten' => false }
+        spec_json['source'] = { 'http' => local_file_uri(default_tarball), 'flatten' => false }
         spec_json['vendored_frameworks'] = build_vendored_paths(product_name, pod_info, spec.name)
 
         # Clear source-build attributes
@@ -906,6 +906,14 @@ module Expo
       # Returns true when the prebuilt React.xcframework is in use.
       def prebuilt_react_active?
         ENV['RCT_USE_PREBUILT_RNCORE'] == '1'
+      end
+
+      # Builds a `file://` URI for a local filesystem path, percent-encoding
+      # any non-ASCII characters so paths with Unicode segments (e.g. emoji or
+      # accented characters) don't trip URI::File.build's RFC 3986 path
+      # validation.
+      def local_file_uri(path)
+        URI::File.build(path: URI::DEFAULT_PARSER.escape(path)).to_s
       end
 
       # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why

Reported in #45758 — when an Expo project lives under a filesystem path containing non-ASCII characters (e.g. `/Users/me/💻dev/my-app`), `pod install` fails with:

```
Invalid `ExpoModulesCore.podspec` file: bad component (expected absolute path component):
/.../💻dev/.../ExpoModulesCore.tar.gz
```

The cause is `URI::File.build(path:)` enforcing RFC 3986 path-component validation, which only allows a constrained ASCII subset. The raw filesystem path is fed in unencoded, and any byte outside that set raises before the URI is built.

## How

Add a small `local_file_uri` helper that percent-encodes the path via `URI::DEFAULT_PARSER.escape` before calling `URI::File.build`, and route both call sites in `precompiled_modules.rb` through it:

- `try_link_with_prebuilt_xcframework` — sets `spec.source` for `ExpoModulesCore` (the inline path)
- `patch_spec_for_prebuilt` — sets `spec_json['source']` for auto-patched specs

CocoaPods decodes the `file://` URI before opening the tarball, so the round-trip is lossless.

## Test plan

Reproduced and verified end-to-end against [@garretteklof](https://github.com/garretteklof)'s minimal repro (https://github.com/garretteklof/expo-unicode-path-bug):

1. Cloned the repro under `/tmp/unicode-repro/💻dev/expo-unicode-path-bug`.
2. Confirmed the original failure on stock `expo-modules-autolinking` (`bad component ... ExpoModulesCore.tar.gz`).
3. Applied this patch, re-ran `pod install`; the `ExpoModulesCore.podspec` error is gone and the precompiled-modules pipeline proceeds normally.

> [!NOTE]
> `react-native`'s `rncore.rb` / `rndependencies.rb` carry the same bug for the React-Core-prebuilt tarball and will still fail on Unicode paths until fixed upstream. That's out of scope for this PR — filing separately with the RN team.