### PR TITLE
[ci] Fix scheduled workflow failures in forks

### DIFF
--- a/.github/workflows/check-issues-nightly.yml
+++ b/.github/workflows/check-issues-nightly.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   validate-pending-issues:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -56,18 +56,18 @@ jobs:
             const pkg = require('./package.json'); \
             pkg.resolutions = { \
               ...pkg.resolutions, \
-              'expo-dev-menu': 'file:../expo/packages/expo-dev-menu', \
-              'expo-dev-menu-interface': 'file:../expo/packages/expo-dev-menu-interface', \
-              'expo-dev-launcher': 'file:../expo/packages/expo-dev-launcher', \
-              'expo-updates-interface': 'file:../expo/packages/expo-updates-interface', \
-              'expo-updates': 'file:../expo/packages/expo-updates', \
-              'expo-manifests': 'file:../expo/packages/expo-manifests', \
-              'expo-json-utils': 'file:../expo/packages/expo-json-utils', \
+              'expo-dev-menu': 'file:${{ github.workspace }}/packages/expo-dev-menu', \
+              'expo-dev-menu-interface': 'file:${{ github.workspace }}/packages/expo-dev-menu-interface', \
+              'expo-dev-launcher': 'file:${{ github.workspace }}/packages/expo-dev-launcher', \
+              'expo-updates-interface': 'file:${{ github.workspace }}/packages/expo-updates-interface', \
+              'expo-updates': 'file:${{ github.workspace }}/packages/expo-updates', \
+              'expo-manifests': 'file:${{ github.workspace }}/packages/expo-manifests', \
+              'expo-json-utils': 'file:${{ github.workspace }}/packages/expo-json-utils', \
             }; \
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
       - name: Add dependencies
         working-directory: ../development-client-android-test
-        run: pnpm add file:../expo/packages/expo-dev-client
+        run: pnpm add file:${{ github.workspace }}/packages/expo-dev-client
       - name: Setup app.config.json
         working-directory: ../development-client-android-test
         run: echo "{\"name\":\"development-client-android-test\",\"plugins\":[\"expo-dev-client\"],\"android\":{\"package\":\"com.devclient.test\"},\"ios\":{\"bundleIdentifier\":\"com.devclient.test\"}}" > app.config.json
@@ -117,18 +117,18 @@ jobs:
             const pkg = require('./package.json'); \
             pkg.resolutions = { \
               ...pkg.resolutions, \
-              'expo-dev-menu': 'file:../expo/packages/expo-dev-menu', \
-              'expo-dev-menu-interface': 'file:../expo/packages/expo-dev-menu-interface', \
-              'expo-dev-launcher': 'file:../expo/packages/expo-dev-launcher', \
-              'expo-updates-interface': 'file:../expo/packages/expo-updates-interface', \
-              'expo-updates': 'file:../expo/packages/expo-updates', \
-              'expo-manifests': 'file:../expo/packages/expo-manifests', \
-              'expo-json-utils': 'file:../expo/packages/expo-json-utils', \
+              'expo-dev-menu': 'file:${{ github.workspace }}/packages/expo-dev-menu', \
+              'expo-dev-menu-interface': 'file:${{ github.workspace }}/packages/expo-dev-menu-interface', \
+              'expo-dev-launcher': 'file:${{ github.workspace }}/packages/expo-dev-launcher', \
+              'expo-updates-interface': 'file:${{ github.workspace }}/packages/expo-updates-interface', \
+              'expo-updates': 'file:${{ github.workspace }}/packages/expo-updates', \
+              'expo-manifests': 'file:${{ github.workspace }}/packages/expo-manifests', \
+              'expo-json-utils': 'file:${{ github.workspace }}/packages/expo-json-utils', \
             }; \
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
       - name: Add dependencies
         working-directory: ../development-client-ios-test
-        run: pnpm add file:../expo/packages/expo-dev-client
+        run: pnpm add file:${{ github.workspace }}/packages/expo-dev-client
       - name: Setup app.config.json
         working-directory: ../development-client-ios-test
         run: echo "{\"name\":\"development-client-ios-test\",\"plugins\":[\"expo-dev-client\"],\"android\":{\"package\":\"com.devclient.test\"},\"ios\":{\"bundleIdentifier\":\"com.devclient.test\"}}" > app.config.json

--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -87,9 +87,9 @@ jobs:
           EOF
 
           if [[ "${{ env.ACTIONS_STEP_DEBUG }}" == "true" ]]; then
-            ../expo/packages/@expo/fingerprint/bin/cli.js fingerprint:generate --debug > ../expo/fingerprint-${{ matrix.os }}.json
+            ${{ github.workspace }}/packages/@expo/fingerprint/bin/cli.js fingerprint:generate --debug > ${{ github.workspace }}/fingerprint-${{ matrix.os }}.json
           else
-            ../expo/packages/@expo/fingerprint/bin/cli.js fingerprint:generate > ../expo/fingerprint-${{ matrix.os }}.json
+            ${{ github.workspace }}/packages/@expo/fingerprint/bin/cli.js fingerprint:generate > ${{ github.workspace }}/fingerprint-${{ matrix.os }}.json
           fi
       - name: 💾 Create fingerprint from the temp project (Windows)
         if: ${{ startsWith(matrix.os, 'windows') }}
@@ -119,9 +119,9 @@ jobs:
           "@ | Set-Content fingerprint.config.js
 
           if ($env:ACTIONS_STEP_DEBUG -eq "true") {
-            node ../expo/packages/@expo/fingerprint/bin/cli.js fingerprint:generate --debug > ../expo/fingerprint-${{ matrix.os }}.json
+            node ${{ github.workspace }}/packages/@expo/fingerprint/bin/cli.js fingerprint:generate --debug > ${{ github.workspace }}/fingerprint-${{ matrix.os }}.json
           } else {
-            node ../expo/packages/@expo/fingerprint/bin/cli.js fingerprint:generate > ../expo/fingerprint-${{ matrix.os }}.json
+            node ${{ github.workspace }}/packages/@expo/fingerprint/bin/cli.js fingerprint:generate > ${{ github.workspace }}/fingerprint-${{ matrix.os }}.json
           }
       - name: 📤 Upload fingerprint
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/publish-canaries.yml
+++ b/.github/workflows/publish-canaries.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   publish-canaries:
+    if: github.repository == 'expo/expo'
     runs-on: macos-15
     timeout-minutes: 120
     env:

--- a/.github/workflows/validate-npm-owners.yml
+++ b/.github/workflows/validate-npm-owners.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   validate-npm-owners:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout


### PR DESCRIPTION
Makes the five auto-firing scheduled workflows fork-safe. Three of them fail every cycle on forks of `expo/expo`, one burns up to 120 minutes of fork CI nightly producing no useful output, and one has a latent path bug that would fail the moment the workflow gets re-enabled. Follows the workflow audit in #45694, which pinned action SHAs across the board but didn't touch fork-side behavior.

`fingerprint.yml` and `development-client.yml` reach into the checkout from a sibling temp project with `../expo/...`. The runner mounts the repo at `/home/runner/work/<repo-name>/<repo-name>/`, so `<repo-name>` is `expo` only on upstream. Any fork named anything else, `expo-fork`, `expo-contributions`, anything, hits `No such file or directory` at the write step. Failure log from `ramonclaudio/expo-fork` run `24841784951`:

```
/home/runner/work/_temp/520d0efe.sh: line 25: ../expo/fingerprint-ubuntu-latest.json: No such file or directory
##[error]Process completed with exit code 1.
```

Swapping `../expo/` for `${{ github.workspace }}/` (the GitHub-provided absolute checkout root) gets the same physical path on `expo/expo` and a correct path on any fork. Strict no-op upstream.

`validate-npm-owners.yml`, `check-issues-nightly.yml`, and `publish-canaries.yml` are org-maintenance jobs that reference secrets which don't exist outside `expo/expo` (`NPM_TOKEN_READ_ONLY`, `EXPO_BOT_GITHUB_TOKEN`, `EXPO_BOT_NPM_TOKEN`). Adding `if: github.repository == 'expo/expo'` to the job skips them on forks instead of letting them fail or burn CI. Same pattern as `codemention.yaml` (#34190).

`Development Client` is currently disabled via comment in `on:` but has the same `../expo/` path bug as `Fingerprint` in 16 places. Fixing now means it's ready the moment the team re-enables it, no follow-up needed.

# Test Plan

Inspect. `${{ github.workspace }}` evaluates to `/home/runner/work/expo/expo/` on upstream, which is exactly where `../expo/` from `/home/runner/work/expo/my-app/` already pointed. Identical behavior. The three `if:` guards are strict no-ops on `expo/expo` and a skip on every fork.

This PR's own `Fingerprint` and `Publish Canaries` runs both fire on `pull_request` and exercise the path change in upstream context. `actionlint` is clean, every warning is pre-existing `SC2086` on `echo "$(pwd)/bin" >> $GITHUB_PATH` lines this diff doesn't touch.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - Not applicable: workflow-only change.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - Not applicable: workflow-only change.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
  - Not applicable: no docs touched.
