### PR TITLE
[brownfield][Android] Fix POM rewriter appending duplicate <version>

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed POM rewriter appending a duplicate `<version>` element instead of replacing the existing one, which caused `publish*PublicationToMavenLocal` to fail with `POM file is invalid` for dependencies declared with a placeholder version. ([#45783](https://github.com/expo/expo/pull/45783) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.9 — 2026-05-13

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/extensions.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/extensions.kt
@@ -105,7 +105,12 @@ internal fun Node.artifactId(): String? {
  * @param version The version to set.
  */
 internal fun Node.setVersion(version: String) {
-  val versionNode = this.children().firstOrNull { it is Node && it.name() == "version" } as? Node
+  val versionNode =
+    when (val v = get("version")) {
+      is Node -> v
+      is NodeList -> v.firstOrNull() as? Node
+      else -> null
+    }
 
   if (versionNode != null) {
     versionNode.setValue(version)


### PR DESCRIPTION
## Why

Reported in #45750 (thanks [@Mathbl](https://github.com/Mathbl) for the full diagnosis).

`Node.setVersion` in the brownfield POM rewriter used:

```kotlin
this.children().firstOrNull { it is Node && it.name() == "version" }
```

…to find an existing `<version>` element. Groovy's `Node.name()` returns a `QName`-like object, **not** a `String`, so the `== "version"` comparison always evaluated to `false`. The lookup returned `null` every time and `appendNode("version", version)` ran unconditionally — producing **two** `<version>` elements inside any dependency that already declared one.

Subprojects that depend on `react-android` with the placeholder version (e.g. `implementation "com.facebook.react:react-android:$reactNativeVersion"` or `"+"`) end up emitting:

```xml
<dependency>
  <groupId>com.facebook.react</groupId>
  <artifactId>react-android</artifactId>
  <version>+</version>
  <scope>runtime</scope>
  <version>0.83.6</version>   <!-- duplicate appended by setVersion -->
</dependency>
```

Maven rejects the POM:

```
> Failed to publish publication 'brownfieldRelease' to repository 'mavenLocal'
   > Invalid publication 'brownfieldRelease': POM file is invalid.
```

Any RN community library following the common pattern (e.g. `react-native-keyboard-controller` in the repro) trips it.

## How

Mirror the sibling `groupId()` / `artifactId()` helpers in the same file, which already use the correct `get("version")` + `Node` / `NodeList` branching:

```kotlin
internal fun Node.setVersion(version: String) {
  val versionNode =
    when (val v = get("version")) {
      is Node -> v
      is NodeList -> v.firstOrNull() as? Node
      else -> null
    }
  if (versionNode != null) versionNode.setValue(version) else this.appendNode("version", version)
}
```

This brings the helper in line with conventions already established in `extensions.kt`.

## Test plan

- Inspected the sibling `groupId()` / `artifactId()` helpers in the same file — the new implementation uses the identical pattern they already use successfully.
- Verified the only callers (`setReactNativeVersionPom` in `utils.kt`) hit `react-android` and `hermes-android` dependencies, exactly the case the reporter exercised.
- Repro from the issue: `bunx expo-brownfield build:android --repo MavenLocal -r` against an SDK 55 default template with `react-native-keyboard-controller` should now succeed.
