### PR TITLE
Fix brownfield POM version replacement

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed brownfield POM rewriting so existing dependency versions are replaced instead of duplicated. ([#45785](https://github.com/expo/expo/pull/45785) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.9 — 2026-05-13

--- a/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
+++ b/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
   implementation("org.json:json:20250517")
   implementation(gradleApi())
   compileOnly("com.android.tools.build:gradle:8.5.0")
+  testImplementation(kotlin("test"))
 }
 
 java {

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/extensions.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/extensions.kt
@@ -105,7 +105,12 @@ internal fun Node.artifactId(): String? {
  * @param version The version to set.
  */
 internal fun Node.setVersion(version: String) {
-  val versionNode = this.children().firstOrNull { it is Node && it.name() == "version" } as? Node
+  val versionNode =
+    when (val v = get("version")) {
+      is Node -> v
+      is NodeList -> v.firstOrNull() as? Node ?: null
+      else -> null
+    }
 
   if (versionNode != null) {
     versionNode.setValue(version)

--- a/packages/expo-brownfield/gradle-plugins/publish/src/test/kotlin/expo/modules/plugin/ExtensionsTest.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/test/kotlin/expo/modules/plugin/ExtensionsTest.kt
@@ -1,0 +1,56 @@
+@file:Suppress("DEPRECATION")
+
+package expo.modules.plugin
+
+import groovy.util.Node
+import groovy.util.NodeList
+import groovy.util.XmlParser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ExtensionsTest {
+  @Test
+  fun setVersionReplacesExistingVersionNode() {
+    val dependency =
+      XmlParser()
+        .parseText(
+          """
+          <dependency>
+            <groupId>com.facebook.react</groupId>
+            <artifactId>react-android</artifactId>
+            <version>+</version>
+            <scope>runtime</scope>
+          </dependency>
+          """.trimIndent()
+        )
+
+    dependency.setVersion("0.83.6")
+
+    val versions = dependency.versionNodes()
+    assertEquals(1, versions.size)
+    assertEquals("0.83.6", (versions.first() as Node).text())
+  }
+
+  @Test
+  fun setVersionAppendsMissingVersionNode() {
+    val dependency =
+      XmlParser()
+        .parseText(
+          """
+          <dependency>
+            <groupId>com.facebook.hermes</groupId>
+            <artifactId>hermes-android</artifactId>
+            <scope>runtime</scope>
+          </dependency>
+          """.trimIndent()
+        )
+
+    dependency.setVersion("0.13.0")
+
+    val versions = dependency.versionNodes()
+    assertEquals(1, versions.size)
+    assertEquals("0.13.0", (versions.first() as Node).text())
+  }
+
+  private fun Node.versionNodes(): NodeList = get("version") as NodeList
+}


### PR DESCRIPTION
Why:

Fixes https://github.com/expo/expo/issues/45750. `expo-brownfield` rewrites generated POM dependencies to pin React Native and Hermes versions. `Node.setVersion()` looked for an existing `<version>` child by comparing `Node.name()` to the string `"version"`, which misses Groovy's QName-like node name and appends a second `<version>` element.

How:

Use the same `Node.get("version")` / `NodeList` lookup pattern already used by the neighboring `groupId()` and `artifactId()` helpers. The change replaces the existing version node when present and still appends one when missing.

This PR is limited to the `expo-brownfield` Gradle publish plugin, a focused regression test, and the package changelog.

Test Plan:

- `./gradlew -p /Users/mvincentong/projects/expo/packages/expo-brownfield/gradle-plugins --include-build /Users/mvincentong/projects/expo/packages/expo-modules-autolinking/android/expo-gradle-plugin :publish:test` from `apps/brownfield-tester/integrated/android`: passed.
- `./gradlew -p /Users/mvincentong/projects/expo/packages/expo-brownfield/gradle-plugins --include-build /Users/mvincentong/projects/expo/packages/expo-modules-autolinking/android/expo-gradle-plugin :publish:build` from `apps/brownfield-tester/integrated/android`: passed.

Risk:

Four files changed: one Kotlin helper, one Kotlin test file, one Gradle test dependency, and one changelog entry. The behavior change is limited to how an existing dependency `<version>` child is found before calling `setValue`; missing version nodes still use the previous append path.
