### PR TITLE
[tools] Fix prebuild packages lookup for scoped packages

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix module precompile.
+- Fix module precompile. ([#45715](https://github.com/expo/expo/pull/45715) by [@jakex7](https://github.com/jakex7))
 
 ### 💡 Others
 

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -15,7 +15,7 @@ import path from 'path';
 import { PACKAGES_DIR } from '../../Constants';
 import { getPrecompileDir } from '../../Directories';
 import logger from '../../Logger';
-import { getPackageByName } from '../../Packages';
+import { getListOfPackagesAsync, getPackageByName } from '../../Packages';
 import { Artifacts } from '../Artifacts';
 import { Dependencies } from '../Dependencies';
 import type { SPMPackageSource } from '../ExternalPackage';
@@ -380,6 +380,8 @@ export const prepareInputsStep: Step<PrebuildContext> = {
   shouldRun: () => true,
 
   async run(ctx) {
+    await getListOfPackagesAsync();
+
     const { request } = ctx;
 
     // Verbose widens what gets logged but doesn't change interactive vs.


### PR DESCRIPTION
# Why

`expo-widgets` precompile is still failing as `@expo/ui` packages is not being auto added, because it's not resolved properly.

# How

Prewarm packages cache in `tools/src/Packages.ts` by calling `getListOfPackagesAsync()` before calling `expandWithUnbuiltDependencies`

# Test plan

[Smoke Test Precompiled iOS XCFrameworks / Prebuild XCFrameworks (Debug)](https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/019e2751-843b-713e-b803-ffd5635b358e#job-019e2751-88cc-74fb-87d7-6f301a818580) should pass. 


```sh
❯ et prebuild -f Debug -v expo-modules-jsi expo-modules-core expo-widgets
📦 Prebuilding packages: expo-modules-jsi, expo-modules-core, expo-widgets
📎 Auto-adding @expo/ui (required by expo-widgets, xcframework not found)
📋 Build order (sorted by dependencies):
expo-modules-jsi, expo-modules-core, @expo/ui, expo-widgets

⚡ Building 4 packages with concurrency 4
```