### PR TITLE
[ci] re-enable Development Client + extend fork-safety guards from #45782

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -155,7 +155,7 @@ runs:
     - name: 🛠 Install NDK if cache not present
       if: inputs.ndk == 'true' && steps.cache-android-ndk.outputs.cache-hit != 'true'
       shell: bash
-      run: sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;${{ inputs.ndk-version }}"
+      run: sudo $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "ndk;${{ inputs.ndk-version }}"
 
     - name: 🔍️ Get Xcode version for iOS ccache key
       if: inputs.ccache == 'true' && runner.os == 'macOS'

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -14,13 +14,15 @@ concurrency:
 
 jobs:
   code_review:
-    # Auto-run only on same-repo PRs. Fork PRs don't get EXPO_BOT_GITHUB_TOKEN
-    # under `pull_request`, so the review would fail anyway — skip cleanly
-    # instead of leaving a red check. Maintainers can review a fork PR
-    # manually via workflow_dispatch.
+    # Auto-run only on same-repo PRs to expo/expo. Fork PRs don't get
+    # EXPO_BOT_GITHUB_TOKEN under `pull_request`, so the review would fail
+    # anyway — skip cleanly instead of leaving a red check. Forks dispatching
+    # this workflow manually would also fail for the same reason; gate on
+    # `github.repository` to short-circuit.
     if: >-
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.repository == 'expo/expo' &&
+      (github.event_name == 'workflow_dispatch' ||
+       github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/.github/workflows/commentator.yml
+++ b/.github/workflows/commentator.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   comment:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   detox_e2e:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -27,11 +28,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - name: 🍺 Install required tools
-        run: |
-          brew tap wix/brew
-          brew install applesimutils
-          brew install watchman
       - name: 💎 Setup Ruby and install gems
         uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
         with:

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   detox_latest_e2e:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -20,11 +21,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - name: 🍺 Install required tools
-        run: |
-          brew tap wix/brew
-          brew install applesimutils
-          brew install watchman
       - name: 💎 Setup Ruby and install gems
         uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
         with:
@@ -74,7 +70,7 @@ jobs:
           path: packages/expo-dev-client/artifacts
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure()
+        if: failure() && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_dev_client }}
           channel: '#dev-clients'

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -2,17 +2,17 @@ name: Development Client
 
 on:
   workflow_dispatch: {}
-  # This task will fail due to migration to `expo-modules-core`.
-  # We temporary disable it.
-  # pull_request:
-  #   paths:
-  #     - .github/workflows/development-client.yml
-  #     - packages/expo-dev-*/**
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - .github/workflows/development-client.yml
-  #     - packages/expo-dev-*/**
+  pull_request:
+    paths:
+      - .github/workflows/development-client.yml
+      - packages/expo-dev-*/**
+      - pnpm-lock.yaml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/development-client.yml
+      - packages/expo-dev-*/**
+      - pnpm-lock.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -21,9 +21,6 @@ concurrency:
 jobs:
   android:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        ndk-version: [21.4.7075529]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -41,14 +38,11 @@ jobs:
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
-        with:
-          ndk: 'true'
-          ndk-version: ${{ matrix.ndk-version }}
       - name: 📦 Install node modules
         run: pnpm install --frozen-lockfile
       - name: Init new expo app
         working-directory: ../
-        run: pnpm create expo-app ./development-client-android-test --yes
+        run: pnpm create expo -t blank@next --yes development-client-android-test
       - name: Make Yarn resolve expo-dev-client dependencies locally
         working-directory: ../development-client-android-test
         run: |
@@ -63,6 +57,12 @@ jobs:
               'expo-updates': 'file:${{ github.workspace }}/packages/expo-updates', \
               'expo-manifests': 'file:${{ github.workspace }}/packages/expo-manifests', \
               'expo-json-utils': 'file:${{ github.workspace }}/packages/expo-json-utils', \
+              '@expo/schema-utils': 'file:${{ github.workspace }}/packages/@expo/schema-utils', \
+              '@expo/plist': 'file:${{ github.workspace }}/packages/@expo/plist', \
+              'expo-eas-client': 'file:${{ github.workspace }}/packages/expo-eas-client', \
+              'expo-structured-headers': 'file:${{ github.workspace }}/packages/expo-structured-headers', \
+              'expo-modules-core': 'file:${{ github.workspace }}/packages/expo-modules-core', \
+              'expo-modules-jsi': 'file:${{ github.workspace }}/packages/expo-modules-jsi', \
             }; \
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
       - name: Add dependencies
@@ -71,18 +71,10 @@ jobs:
       - name: Setup app.config.json
         working-directory: ../development-client-android-test
         run: echo "{\"name\":\"development-client-android-test\",\"plugins\":[\"expo-dev-client\"],\"android\":{\"package\":\"com.devclient.test\"},\"ios\":{\"bundleIdentifier\":\"com.devclient.test\"}}" > app.config.json
-      - name: Prebuild Android
+      - name: 🛠 Prebuild Android
         working-directory: ../development-client-android-test
         run: pnpm expo prebuild --platform android
-      - name: Bump `build tools`
-        working-directory: ../development-client-android-test
-        run: sed -i -e 's/buildToolsVersion\ =\ \"29\..\..\"/buildToolsVersion\ = \"30\.0\.3\"/' ./android/build.gradle
-      - name: Bump `android build tools`
-        working-directory: ../development-client-android-test
-        run: sed -i -e 's/com\.android\.tools\.build:gradle:3\..\../com\.android\.tools\.build:gradle:3\.5\.4/' ./android/build.gradle
       - name: 🏗️ Build debug version
-        env:
-          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/${{ matrix.ndk-version }}/
         working-directory: ../development-client-android-test/android
         run: ./gradlew assembleDebug
 
@@ -91,8 +83,17 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: 🔨 Switch to Xcode 26.2
+        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.2.2
+      - name: 💎 Install cocoapods
+        run: sudo gem install cocoapods
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
@@ -109,7 +110,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Init new expo app
         working-directory: ../
-        run: pnpm create expo-app ./development-client-ios-test --yes
+        run: pnpm create expo -t blank@next --yes development-client-ios-test
       - name: Make Yarn resolve expo-dev-client dependencies locally
         working-directory: ../development-client-ios-test
         run: |
@@ -124,6 +125,12 @@ jobs:
               'expo-updates': 'file:${{ github.workspace }}/packages/expo-updates', \
               'expo-manifests': 'file:${{ github.workspace }}/packages/expo-manifests', \
               'expo-json-utils': 'file:${{ github.workspace }}/packages/expo-json-utils', \
+              '@expo/schema-utils': 'file:${{ github.workspace }}/packages/@expo/schema-utils', \
+              '@expo/plist': 'file:${{ github.workspace }}/packages/@expo/plist', \
+              'expo-eas-client': 'file:${{ github.workspace }}/packages/expo-eas-client', \
+              'expo-structured-headers': 'file:${{ github.workspace }}/packages/expo-structured-headers', \
+              'expo-modules-core': 'file:${{ github.workspace }}/packages/expo-modules-core', \
+              'expo-modules-jsi': 'file:${{ github.workspace }}/packages/expo-modules-jsi', \
             }; \
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
       - name: Add dependencies
@@ -132,9 +139,12 @@ jobs:
       - name: Setup app.config.json
         working-directory: ../development-client-ios-test
         run: echo "{\"name\":\"development-client-ios-test\",\"plugins\":[\"expo-dev-client\"],\"android\":{\"package\":\"com.devclient.test\"},\"ios\":{\"bundleIdentifier\":\"com.devclient.test\"}}" > app.config.json
-      - name: Prebuild iOS
+      - name: 🛠 Prebuild iOS
         working-directory: ../development-client-ios-test
-        run: pnpm expo prebuild --platform ios
+        run: pnpm expo prebuild --platform ios --no-install
+      - name: 🥥 Install pods in `development-client-ios-test/ios`
+        working-directory: ../development-client-ios-test/ios
+        run: pod install
       - name: 🏗️ Build debug version
         working-directory: ../development-client-ios-test
-        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator -arch x86_64
+        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator EXCLUDED_ARCHS=""

--- a/.github/workflows/docs-pr-destroy.yml
+++ b/.github/workflows/docs-pr-destroy.yml
@@ -14,8 +14,9 @@ concurrency:
 
 jobs:
   docs-pr-destroy:
-    if: (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview')) ||
-        (github.event.action == 'unlabeled' && github.event.label.name == 'preview')
+    if: github.repository == 'expo/expo' &&
+        ((github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview')) ||
+         (github.event.action == 'unlabeled' && github.event.label.name == 'preview'))
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -22,6 +22,7 @@ concurrency:
 
 jobs:
   docs-pr:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   docs:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/issue-closed.yml
+++ b/.github/workflows/issue-closed.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   run-on-issue-accepted:
     runs-on: ubuntu-24.04
-    if: contains(github.event.issue.labels.*.name, 'Issue accepted')
+    if: github.repository == 'expo/expo' && contains(github.event.issue.labels.*.name, 'Issue accepted')
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   check-if-trusted:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - uses: ./.github/actions/slack-notify
@@ -16,7 +17,6 @@ jobs:
         with:
           webhook: ${{ secrets.slack_webhook_expo_support }}
           channel: '#support'
-          text: 'This issue should be triaged ASAP: ${{ github.event.issue.html_url }}'
           author_name: ${{ github.event.issue.user.login }}
           fields: repo
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -32,6 +32,7 @@ jobs:
             })
 
   validate:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   needs-repro:
     runs-on: ubuntu-24.04
-    if: "${{ contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
+    if: "${{ github.repository == 'expo/expo' && contains(github.event.label.name, 'incomplete issue: missing or invalid repro') }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -58,7 +58,7 @@ jobs:
 
   needs-info:
     runs-on: ubuntu-24.04
-    if: "${{ contains(github.event.label.name, 'incomplete issue: missing info') }}"
+    if: "${{ github.repository == 'expo/expo' && contains(github.event.label.name, 'incomplete issue: missing info') }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -93,7 +93,7 @@ jobs:
     # expotools with EXPO_BOT_GITHUB_TOKEN, LINEAR_API_KEY, and OPENAI_API_KEY
     # in env. Without the guard, applying an "issue accepted" label to a PR
     # would trigger the same flow on a pull_request_target event.
-    if: github.event_name == 'issues' && github.event.label.name == 'issue accepted'
+    if: github.repository == 'expo/expo' && github.event_name == 'issues' && github.event.label.name == 'issue accepted'
     steps:
       - name: Comment on issue
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
@@ -151,7 +151,7 @@ jobs:
 
   question:
     runs-on: ubuntu-24.04
-    if: "${{ contains(github.event.label.name, 'invalid issue: question') }}"
+    if: "${{ github.repository == 'expo/expo' && contains(github.event.label.name, 'invalid issue: question') }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -179,7 +179,7 @@ jobs:
 
   feature-request:
     runs-on: ubuntu-24.04
-    if: "${{ contains(github.event.label.name, 'invalid issue: feature request') }}"
+    if: "${{ github.repository == 'expo/expo' && contains(github.event.label.name, 'invalid issue: feature request') }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -202,7 +202,7 @@ jobs:
 
   third-party:
     runs-on: ubuntu-24.04
-    if: "${{ contains(github.event.label.name, 'invalid issue: third-party library') }}"
+    if: "${{ github.repository == 'expo/expo' && contains(github.event.label.name, 'invalid issue: third-party library') }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -229,7 +229,7 @@ jobs:
             })
   react-native-core:
     runs-on: ubuntu-24.04
-    if: "${{ contains(github.event.label.name, 'invalid issue: react-native-core') }}"
+    if: "${{ github.repository == 'expo/expo' && contains(github.event.label.name, 'invalid issue: react-native-core') }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -251,7 +251,7 @@ jobs:
             })
   comments-on-closed:
     runs-on: ubuntu-24.04
-    if: "${{ github.event.label.name == 'Comments on closed issue' }}"
+    if: "${{ github.repository == 'expo/expo' && github.event.label.name == 'Comments on closed issue' }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -273,7 +273,7 @@ jobs:
             })
   eas-build-troubleshooting:
     runs-on: ubuntu-24.04
-    if: "${{ github.event.label.name == 'invalid issue: EAS Build troubleshooting' }}"
+    if: "${{ github.repository == 'expo/expo' && github.event.label.name == 'invalid issue: EAS Build troubleshooting' }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
@@ -295,7 +295,7 @@ jobs:
             })
   version-bump:
     runs-on: ubuntu-24.04
-    if: "${{ github.event.label.name == 'Version bump PR' }}"
+    if: "${{ github.repository == 'expo/expo' && github.event.label.name == 'Version bump PR' }}"
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:

--- a/.github/workflows/pr-contributor-labeler.yml
+++ b/.github/workflows/pr-contributor-labeler.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   label:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   test-suite-fingerprint:
     runs-on: ubuntu-24.04
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
+    if: ${{ github.repository == 'expo/expo' && (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push') }}
     # REQUIRED: limit concurrency when pushing main(default) branch to prevent conflict for this action to update its fingerprint database
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     permissions:

--- a/.github/workflows/sync-template.yml
+++ b/.github/workflows/sync-template.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout


### PR DESCRIPTION
Re-enables the `Development Client` workflow after a long-standing disable in #14027 and extends #45782's fork-safety pattern to the rest of the workflows that need org-only secrets. Also fixes `development-client-e2e.yml` and `development-client-latest-e2e.yml`, which have been silently failing on `main` for some time.

The original disable comment said this would fail due to migration to `expo-modules-core`. This led to mismatches the workflow couldn't see while it was off.

The Android NDK install was pointing at `$ANDROID_SDK_ROOT/tools/bin/sdkmanager`, a path retired from `ubuntu-latest` a while back. Switched to `cmdline-tools/latest/bin/sdkmanager` to match the repo's own `cleanup-linux-disk-space` action. Also dropped the NDK 21.4.7075529 matrix, `ExpoRootProjectPlugin` defaults `ndkVersion` to 27.1.12297006 anyway, so the matrix was downloading and discarding ~600 MB of NDK r21e every run.

The test app was scaffolded by `pnpm create expo-app --yes`, which resolves to the stale `create-expo-app@3.5.3` on npm. The mismatch pulled an old `expo-modules-core@3.0.30` from npm instead of the local 56.0.8, and produced Kotlin compile errors that looked like bugs in `expo-dev-menu`:

```
e: .../expo-dev-menu/.../DevMenuPackage.kt:50:9
  'onDidCreateReactActivityDelegateNotification' overrides nothing.
e: .../expo-dev-menu/.../DevMenuModule.kt:14:34
  Unresolved reference 'OptimizedRecord'.
```

Both APIs exist in `expo-modules-core@56.0.8` but not `3.0.30`. Switched init to `pnpm create expo -t blank@next --yes` (the unaliased `pnpm create expo` resolves to current `create-expo@3.6.14`) and expanded `pnpm.resolutions` from 7 entries to 13 to cover the transitive workspace deps of `expo-dev-launcher` and `expo-updates`.

The test iOS app lives outside the monorepo, so bundler can't walk up to the root Gemfile, added `ruby/setup-ruby` + `sudo gem install cocoapods`, same shape `development-client-e2e` uses for the same reason. Split `pnpm expo prebuild --platform ios` into `--no-install` plus a bare `pod install` so the order is deterministic. Replaced hardcoded `-arch x86_64` with `EXCLUDED_ARCHS=""` because `macos-15` runners are arm64 now. Switched to Xcode 26.2 to match every other macOS workflow.

The two e2e files were running `brew install applesimutils` on `ubuntu-24.04`. There's no brew on Linux, so step 4 has been exiting 127 every cycle. `applesimutils` is iOS-only and these run Android Detox anyway, dropped the step. Added job-level `if: github.repository == 'expo/expo'` to both so they skip cleanly on forks.

Extends #45782's fork-safety pattern to the rest of the workflows that need org-only secrets or bot tokens: `docs-pr`, `docs`, `docs-pr-destroy`, `sync-template`, `commentator`, `pr-contributor-labeler`, `pr-labeler`, `code-review`, `issue-closed`, `issue-opened`, `issue-triage`. Each one fails on forks today because the secret evaluates to empty. The guard turns red into skipped. Same shape #45782 used.

# Test Plan

Validated on `ramonclaudio/expo-fork`: https://github.com/ramonclaudio/expo-fork/actions/runs/25880752777

```
Android: BUILD SUCCESSFUL in 7m 43s   (debug APK packaged)
iOS:     BUILD SUCCEEDED              (debug .app packaged)
```

Every fork-guarded workflow that fired on the fork reported `skipped`. `actionlint` clean on every changed file (also dropped a dead `text:` input in `issue-opened.yml`'s slack-notify call that actionlint flagged once the file was touched).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - Not applicable: workflow-only change. Same precedent as #34190, #45694, and the recently-merged #45782.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - Not applicable: workflow-only change.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
  - Not applicable: no docs touched.
