### PR TITLE
[JSI] Fix off-thread execute tests calling noasync overload from async context

### DIFF
--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import ExpoModulesJSI
+import Foundation
 
 @Suite
 @JavaScriptActor
@@ -122,28 +123,30 @@ struct JavaScriptRuntimeTests {
   // schedules the closure onto the JS thread and pumps the caller's run loop until it
   // completes. The tests above run on `@JavaScriptActor` (the JS thread), so they only
   // exercise the fast path. The next three hop off the JS thread first to cover the
-  // cross-thread scheduling + run-loop pump.
+  // cross-thread scheduling + run-loop pump. The sync overloads of `execute` are
+  // `@available(*, noasync)`, so the caller must be a real synchronous thread — wrapping
+  // in `Task.detached` would stay on the cooperative pool and trip the noasync diagnostic.
 
   @Test
   func `execute sync from off-thread caller`() async throws {
     let runtime = self.runtime
-    let result = try await Task.detached { @Sendable in
+    let result = try await onSyncOffThread {
       try runtime.execute { @JavaScriptActor in
-        runtime.global().hasProperty("Object") ? 1 : 0
+        return runtime.global().hasProperty("Object") ? 1 : 0
       }
-    }.value
+    }
     #expect(result == 1)
   }
 
   @Test
   func `execute blocking-async from off-thread caller`() async throws {
     let runtime = self.runtime
-    let result = try await Task.detached { @Sendable in
+    let result = try await onSyncOffThread {
       try runtime.execute { @JavaScriptActor () async in
         await Task.yield()
         return runtime.global().hasProperty("Object") ? 1 : 0
       }
-    }.value
+    }
     #expect(result == 1)
   }
 
@@ -151,11 +154,11 @@ struct JavaScriptRuntimeTests {
   func `execute sync rethrows from off-thread caller`() async throws {
     let runtime = self.runtime
     await #expect(throws: ScriptEvaluationError.self) {
-      try await Task.detached { @Sendable in
+      try await onSyncOffThread {
         try runtime.execute { @JavaScriptActor in
           try runtime.eval("invalid syntax +++")
         }
-      }.value
+      }
     }
   }
 
@@ -737,5 +740,21 @@ struct JavaScriptRuntimeTests {
     }
     let result = try newRuntime.eval("1 + 2")
     #expect(result.getInt() == 3)
+  }
+}
+
+/// Runs `body` on a freshly spawned synchronous thread and bridges the result back into the
+/// async test. The thread has a real run loop, which the cross-thread `execute` path pumps.
+private func onSyncOffThread<R: Sendable>(
+  _ body: @escaping @Sendable () throws -> R
+) async throws -> R {
+  return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<R, any Error>) in
+    Thread.detachNewThread {
+      do {
+        continuation.resume(returning: try body())
+      } catch {
+        continuation.resume(throwing: error)
+      }
+    }
   }
 }


### PR DESCRIPTION
## Why

The three "off-thread caller" tests added in #45478 wrap the sync `execute` calls in `Task.detached { ... }`. `Task.detached`'s operation closure is `async`, so calling the `@available(*, noasync)` sync `execute` overload from inside it raises `Instance method 'execute' is unavailable from asynchronous contexts`.

`Task.detached` also doesn't actually exercise what the test set out to cover — it stays on the cooperative thread pool rather than running on a genuinely synchronous off-thread caller.

Fixes CI failures: https://github.com/expo/expo/actions/runs/25871443841/job/76027541323
Successful run on this branch: https://github.com/expo/expo/actions/runs/25877899737/job/76049854992

## How

Replaced the `Task.detached` wrappers with `Thread.detachNewThread`, bridged back to the async test via a `CheckedContinuation`. The body now runs on a real synchronous thread with a real run loop — which is what the cross-thread `execute` path is designed for (e.g. a JSI host function on the RN bridge thread).

Factored the bridging into a file-private `onSyncOffThread` helper.

## Test Plan

- iOS unit tests pass locally for the `ExpoModulesJSI` test target.

<!-- disable:changelog-checks -->