### PR TITLE
[cli] invalidate session immediately on logout

### DIFF
--- a/packages/@expo/cli/src/api/user/__tests__/user-test.ts
+++ b/packages/@expo/cli/src/api/user/__tests__/user-test.ts
@@ -159,6 +159,8 @@ describe(logoutAsync, () => {
   resetEnv();
   it('removes the session secret', async () => {
     mockLoginRequest();
+    nock(getExpoApiBaseUrl()).post('/v2/auth/logout').reply(200, { data: {} });
+
     await loginAsync({ username: 'USERNAME', password: 'PASSWORD' });
     expect(getSession()?.sessionSecret).toBe('SESSION_SECRET');
 
@@ -168,6 +170,8 @@ describe(logoutAsync, () => {
 
   it('removes code signing data', async () => {
     mockLoginRequest();
+    nock(getExpoApiBaseUrl()).post('/v2/auth/logout').reply(200, { data: {} });
+
     await loginAsync({ username: 'USERNAME', password: 'PASSWORD' });
 
     await DevelopmentCodeSigningInfoFile.setAsync('test', {});
@@ -175,6 +179,39 @@ describe(logoutAsync, () => {
 
     await logoutAsync();
     expect(fs.existsSync(getDevelopmentCodeSigningDirectory())).toBe(false);
+  });
+
+  it('calls the server logout endpoint when session secret exists', async () => {
+    mockLoginRequest();
+    const logoutScope = nock(getExpoApiBaseUrl())
+      .post('/v2/auth/logout')
+      .matchHeader('expo-session', 'SESSION_SECRET')
+      .reply(200, { data: {} });
+
+    await loginAsync({ username: 'USERNAME', password: 'PASSWORD' });
+    await logoutAsync();
+
+    expect(logoutScope.isDone()).toBe(true);
+  });
+
+  it('clears the local session even if the server logout call fails', async () => {
+    mockLoginRequest();
+    nock(getExpoApiBaseUrl()).post('/v2/auth/logout').reply(500, 'Internal Server Error');
+
+    await loginAsync({ username: 'USERNAME', password: 'PASSWORD' });
+    expect(getSession()?.sessionSecret).toBe('SESSION_SECRET');
+
+    await logoutAsync();
+    expect(getSession()?.sessionSecret).toBeUndefined();
+  });
+
+  it('skips the server logout call when there is no session secret', async () => {
+    const logoutScope = nock(getExpoApiBaseUrl()).post('/v2/auth/logout').reply(200, { data: {} });
+
+    await logoutAsync();
+
+    expect(logoutScope.isDone()).toBe(false);
+    nock.cleanAll();
   });
 });
 

--- a/packages/@expo/cli/src/api/user/user.ts
+++ b/packages/@expo/cli/src/api/user/user.ts
@@ -9,6 +9,8 @@ import { getExpoWebsiteBaseUrl } from '../endpoint';
 import { UserQuery, type Actor } from '../graphql/queries/UserQuery';
 import { fetchAsync } from '../rest/client';
 
+const debug = require('debug')('expo:api:user') as typeof console.log;
+
 let currentUser: Actor | undefined;
 
 export const ANONYMOUS_USERNAME = 'anonymous';
@@ -83,6 +85,14 @@ export async function browserLoginAsync({ sso = false }): Promise<void> {
 }
 
 export async function logoutAsync(): Promise<void> {
+  const sessionSecret = getSession()?.sessionSecret;
+  if (sessionSecret) {
+    try {
+      await fetchAsync('auth/logout', { method: 'POST' });
+    } catch (error) {
+      debug('Failed to invalidate session secret on server:', error);
+    }
+  }
   currentUser = undefined;
   await Promise.all([
     fs.rm(getDevelopmentCodeSigningDirectory(), { recursive: true, force: true }),


### PR DESCRIPTION
# Why
Parity with https://github.com/expo/eas-cli/pull/3555

# How
Hit /v2/auth/logout endpoint on logout. If it fails, just remove credential locally (existing behavior) and credential will soon expire.

# Test Plan
Run updated tests.
Ran whoami -> login -> logout -> whoami -> login successfully
Verified manually session was invalidated.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
