### PR TITLE
[modules-jsi] Adopt swift-format

### DIFF
--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -23,7 +23,9 @@ concurrency:
 env:
   # The version of swift-format used by CI and contributors. Keep in sync with
   # the EXPECTED_VERSION constants in scripts/swift-format.sh.
-  SWIFT_FORMAT_VERSION: '603.0.0'
+  # No final 603.0.0 release exists yet; track the latest 603 prerelease,
+  # which aligns with the swift-format Xcode 26.2 bundles.
+  SWIFT_FORMAT_VERSION: '603.0.0-prerelease-2026-02-09'
   SWIFT_VERSION: '6.3'
   SWIFT_PLATFORM: ubuntu24.04
 

--- a/.github/workflows/swift-format.yml
+++ b/.github/workflows/swift-format.yml
@@ -1,0 +1,70 @@
+name: Swift Format
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/swift-format.yml
+      - .swift-format
+      - scripts/swift-format.sh
+      - packages/expo-modules-jsi/**/*.swift
+  pull_request:
+    paths:
+      - .github/workflows/swift-format.yml
+      - .swift-format
+      - scripts/swift-format.sh
+      - packages/expo-modules-jsi/**/*.swift
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # The version of swift-format used by CI and contributors. Keep in sync with
+  # the EXPECTED_VERSION constants in scripts/swift-format.sh.
+  SWIFT_FORMAT_VERSION: '603.0.0'
+  SWIFT_VERSION: '6.3'
+  SWIFT_PLATFORM: ubuntu24.04
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: 👀 Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: 🐦 Install Swift ${{ env.SWIFT_VERSION }}
+        run: |
+          set -euo pipefail
+          tag="swift-${SWIFT_VERSION}-RELEASE"
+          slug="$(echo "$SWIFT_PLATFORM" | tr -d .)"
+          url="https://download.swift.org/swift-${SWIFT_VERSION}-release/${slug}/${tag}/${tag}-${SWIFT_PLATFORM}.tar.gz"
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-recommends \
+            binutils git gnupg2 libc6-dev libcurl4-openssl-dev libedit2 \
+            libgcc-13-dev libsqlite3-0 libstdc++-13-dev libxml2-dev \
+            libz3-dev pkg-config tzdata unzip zlib1g-dev
+          curl -fsSL "$url" -o /tmp/swift.tar.gz
+          sudo mkdir -p /opt/swift
+          sudo tar -xzf /tmp/swift.tar.gz -C /opt/swift --strip-components=1
+          echo "/opt/swift/usr/bin" >> "$GITHUB_PATH"
+      - name: ♻️ Cache swift-format binary
+        id: swift-format-cache
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        with:
+          path: ~/.local/bin/swift-format
+          key: swift-format-${{ runner.os }}-${{ env.SWIFT_FORMAT_VERSION }}
+      - name: 🔨 Build swift-format ${{ env.SWIFT_FORMAT_VERSION }}
+        if: steps.swift-format-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.local/bin
+          tmp=$(mktemp -d)
+          git clone --depth 1 --branch "$SWIFT_FORMAT_VERSION" https://github.com/swiftlang/swift-format.git "$tmp"
+          (cd "$tmp" && swift build -c release)
+          cp "$tmp/.build/release/swift-format" ~/.local/bin/swift-format
+      - name: ➕ Add swift-format to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: 🧹 Lint expo-modules-jsi
+        run: ../../scripts/swift-format.sh --lint
+        working-directory: packages/expo-modules-jsi

--- a/.swift-format
+++ b/.swift-format
@@ -1,0 +1,6 @@
+{
+  "indentation": { "spaces": 2 },
+  "indentConditionalCompilationBlocks": false,
+  "lineLength": 120,
+  "version": 1
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,6 +128,7 @@ All modules should adhere to the style guides which can be found here:
 
 - [Expo Module Infrastructure](guides/Expo%20Module%20Infrastructure.md)
 - [Expo JS Style Guide](guides/Expo%20JavaScript%20Style%20Guide.md) (also mostly applies to TypeScript)
+- [Expo Swift Style Guide](guides/Swift%20Style%20Guide.md)
 - [Updating Changelogs](guides/contributing/Updating%20Changelogs.md)
 
 ### Extra Credit

--- a/guides/Swift Style Guide.md
+++ b/guides/Swift Style Guide.md
@@ -1,0 +1,98 @@
+# Expo Swift Style Guide
+
+We format Swift sources with [swift-format](https://github.com/swiftlang/swift-format) using the configuration at the repo root (`.swift-format`). swift-format is opinionated; rather than maintain a long list of in-house conventions, we accept its defaults with a few narrow overrides and rely on the formatter to keep the codebase consistent.
+
+## Scope
+
+Formatting is opt-in per package and rolled out gradually. Packages currently formatted with swift-format:
+
+- `expo-modules-jsi`
+
+Other packages are not yet formatted. To opt a package in, add the `swift-format` and `swift-format:check` scripts (see below) and update the path filters in `.github/workflows/swift-format.yml`.
+
+## Installing swift-format locally
+
+### macOS (Xcode 26.2 or newer)
+
+swift-format is bundled with the Swift toolchain. Run it via `xcrun`:
+
+```sh
+xcrun swift-format --version
+# 603.0.0
+```
+
+No extra install needed. The pnpm scripts pick this up automatically.
+
+### Linux (or non-Xcode macOS)
+
+Build from source at the version CI uses:
+
+```sh
+git clone --depth 1 --branch 603.0.0 https://github.com/swiftlang/swift-format.git /tmp/swift-format
+(cd /tmp/swift-format && swift build -c release)
+mkdir -p ~/.local/bin
+cp /tmp/swift-format/.build/release/swift-format ~/.local/bin/
+```
+
+Make sure `~/.local/bin` is on your `PATH`.
+
+The version must match the pin in `scripts/swift-format.sh` (`REQUIRED_GIT_TAG` / `REQUIRED_XCODE_VERSION`) and `SWIFT_FORMAT_VERSION` in `.github/workflows/swift-format.yml`. CI runs the version pinned there; mismatches can produce different output. Note: the swift-format Git tag uses the form `603.0.0`, but the same binary reports `6.3.0` when bundled with Xcode — both refer to the same release.
+
+## Running the formatter
+
+From inside a formatted package:
+
+```sh
+# Rewrite files in place
+pnpm swift:format
+
+# Check without modifying (matches what CI runs)
+pnpm swift:lint
+```
+
+The script only touches tracked `.swift` files, so Pods, `.build`, `DerivedData`, and untracked content are skipped automatically. If you need to format files outside a package, invoke the shared script directly:
+
+```sh
+./scripts/swift-format.sh path/to/dir
+./scripts/swift-format.sh --lint path/to/dir
+```
+
+## Configuration
+
+The repo-root `.swift-format` is intentionally minimal:
+
+```json
+{
+  "indentation": { "spaces": 2 },
+  "indentConditionalCompilationBlocks": false,
+  "lineLength": 120,
+  "version": 1
+}
+```
+
+Everything else uses swift-format's defaults. If you have a strong opinion about a rule, raise it with the team before changing the config — the goal of using a formatter is to stop relitigating style on a per-PR basis.
+
+## Things swift-format does not enforce
+
+A formatter handles whitespace, line breaks, and a handful of stylistic rewrites. It does not enforce semantic conventions. The following are still reviewer expectations:
+
+- Naming: prefer full words over abbreviations (`Prototype`, not `Proto`).
+- Use explicit `return` keywords in closures rather than relying on implicit returns.
+- Don't write `///` doc comments inline with a `/** */` block; the formatter rewrites blocks to `///`, but use `///` from the start in new files.
+- Place private helper methods at the end of the type, after public and internal API.
+- Prefer `nonisolated(unsafe) let` over `Unmanaged.passUnretained` for capturing non-`Sendable` references across isolation boundaries.
+
+## Opting a new package in
+
+1. Add the scripts to the package's `package.json`:
+   ```json
+   {
+     "scripts": {
+       "swift:format": "../../scripts/swift-format.sh",
+       "swift:lint": "../../scripts/swift-format.sh --lint"
+     }
+   }
+   ```
+2. Run `pnpm swift:format` once to bring existing files into shape. Land that as its own commit so it can be added to `.git-blame-ignore-revs` later.
+3. Update the path filters and lint steps in `.github/workflows/swift-format.yml` so CI starts enforcing the rule for that package.
+4. Add the package to the **Scope** section of this document.

--- a/guides/Swift Style Guide.md
+++ b/guides/Swift Style Guide.md
@@ -4,11 +4,14 @@ We format Swift sources with [swift-format](https://github.com/swiftlang/swift-f
 
 ## Scope
 
+> [!NOTE]
+> Adoption is experimental. We're piloting swift-format on a small set of packages before expanding. The configuration and rollout details below may change as we learn from the pilot, and the supported package list will grow over time.
+
 Formatting is opt-in per package and rolled out gradually. Packages currently formatted with swift-format:
 
 - `expo-modules-jsi`
 
-Other packages are not yet formatted. To opt a package in, add the `swift-format` and `swift-format:check` scripts (see below) and update the path filters in `.github/workflows/swift-format.yml`.
+Other packages are not yet formatted. To opt a package in, add the `swift:format` and `swift:lint` scripts (see below) and update the path filters in `.github/workflows/swift-format.yml`.
 
 ## Installing swift-format locally
 
@@ -72,15 +75,13 @@ The repo-root `.swift-format` is intentionally minimal:
 
 Everything else uses swift-format's defaults. If you have a strong opinion about a rule, raise it with the team before changing the config — the goal of using a formatter is to stop relitigating style on a per-PR basis.
 
-## Things swift-format does not enforce
+## Conventions not enforced by the formatter
 
-A formatter handles whitespace, line breaks, and a handful of stylistic rewrites. It does not enforce semantic conventions. The following are still reviewer expectations:
+A formatter handles whitespace, line breaks, and a handful of stylistic rewrites — it can't reason about meaning. The following are reviewer expectations:
 
 - Naming: prefer full words over abbreviations (`Prototype`, not `Proto`).
 - Use explicit `return` keywords in closures rather than relying on implicit returns.
-- Don't write `///` doc comments inline with a `/** */` block; the formatter rewrites blocks to `///`, but use `///` from the start in new files.
 - Place private helper methods at the end of the type, after public and internal API.
-- Prefer `nonisolated(unsafe) let` over `Unmanaged.passUnretained` for capturing non-`Sendable` references across isolation boundaries.
 
 ## Opting a new package in
 

--- a/guides/Swift Style Guide.md
+++ b/guides/Swift Style Guide.md
@@ -31,7 +31,7 @@ No extra install needed. The pnpm scripts pick this up automatically.
 Build from source at the version CI uses:
 
 ```sh
-git clone --depth 1 --branch 603.0.0 https://github.com/swiftlang/swift-format.git /tmp/swift-format
+git clone --depth 1 --branch 603.0.0-prerelease-2026-02-09 https://github.com/swiftlang/swift-format.git /tmp/swift-format
 (cd /tmp/swift-format && swift build -c release)
 mkdir -p ~/.local/bin
 cp /tmp/swift-format/.build/release/swift-format ~/.local/bin/
@@ -39,7 +39,7 @@ cp /tmp/swift-format/.build/release/swift-format ~/.local/bin/
 
 Make sure `~/.local/bin` is on your `PATH`.
 
-The version must match the pin in `scripts/swift-format.sh` (`REQUIRED_GIT_TAG` / `REQUIRED_XCODE_VERSION`) and `SWIFT_FORMAT_VERSION` in `.github/workflows/swift-format.yml`. CI runs the version pinned there; mismatches can produce different output. Note: the swift-format Git tag uses the form `603.0.0`, but the same binary reports `6.3.0` when bundled with Xcode — both refer to the same release.
+The version must match the pin in `scripts/swift-format.sh` (`EXPECTED_VERSION` / `EXPECTED_XCODE_VERSION`) and `SWIFT_FORMAT_VERSION` in `.github/workflows/swift-format.yml`. CI runs the version pinned there; mismatches can produce different output. Note: the swift-format Git tag is currently a 603 prerelease (no final `603.0.0` exists yet); the same binary reports `6.3.0` when bundled with Xcode — both refer to the same series.
 
 ## Running the formatter
 

--- a/packages/expo-modules-jsi/CLAUDE.md
+++ b/packages/expo-modules-jsi/CLAUDE.md
@@ -60,3 +60,7 @@ struct JavaScriptRuntimeTests {
 Tests are in `apple/Tests/` and each file covers one type. Some suites use the global actor `@JavaScriptActor` for executor isolation.
 
 Run them with `pnpm test` from the package root, which calls `apple/scripts/test.sh`. The script needs an installed host app's `Pods` directory (defaults to `$EXPO_ROOT_DIR/apps/bare-expo/ios/Pods`); override with `PODS_ROOT`. It symlinks React / hermesvm / ReactNativeDependencies xcframeworks into `apple/.test-frameworks/` so SPM can resolve them as relative-path binary targets, generates the `jsi` modulemap, and runs `xcodebuild test` against an iOS Simulator (override with `DESTINATION`). Extra args pass through to xcodebuild &mdash; e.g. `pnpm test -only-testing TestName`.
+
+## Formatting
+
+Swift sources are formatted with swift-format. From the package root, `pnpm swift:format` rewrites files in place and `pnpm swift:lint` checks without modifying; both delegate to the repo-root `scripts/swift-format.sh`, which reads the repo-root `.swift-format` config and only touches tracked `.swift` files. CI enforces this via `.github/workflows/swift-format.yml`, which pins a specific swift-format version &mdash; mismatched local versions can produce different output, so prefer the pinned one. Style conventions beyond what the formatter enforces live in [`guides/Swift Style Guide.md`](../../guides/Swift%20Style%20Guide.md) at the repo root.

--- a/packages/expo-modules-jsi/apple/Package.swift
+++ b/packages/expo-modules-jsi/apple/Package.swift
@@ -1,8 +1,8 @@
 // swift-tools-version: 6.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
-import PackageDescription
 import Foundation
+import PackageDescription
 
 let packageDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
 let podsRoot = resolvePodsRoot()
@@ -17,7 +17,8 @@ let podsRoot = resolvePodsRoot()
 // `REACT_NATIVE_PATH` is exported by Xcode for hosts that build RN from a
 // non-npm location, e.g. Expo Go.
 let publicHeaders = "\(podsRoot)/Headers/Public"
-let reactNative = ProcessInfo.processInfo.environment["RN_ROOT"]
+let reactNative =
+  ProcessInfo.processInfo.environment["RN_ROOT"]
   ?? ProcessInfo.processInfo.environment["REACT_NATIVE_PATH"]
   ?? "\(podsRoot)/../../node_modules/react-native"
 let headerSearchPaths = [
@@ -72,7 +73,7 @@ let package = Package(
       name: "ExpoModulesJSI",
       type: .dynamic,
       targets: ["ExpoModulesJSI"],
-    ),
+    )
   ],
   dependencies: [],
   targets: [
@@ -80,7 +81,7 @@ let package = Package(
     .target(
       name: "ExpoModulesJSI",
       dependencies: [
-        "ExpoModulesJSI-Cxx",
+        "ExpoModulesJSI-Cxx"
       ],
       swiftSettings: [
         .interoperabilityMode(.Cxx),
@@ -115,7 +116,7 @@ let package = Package(
         // builds without those static libs being available here.
         .unsafeFlags([
           "-Xlinker", "-undefined", "-Xlinker", "dynamic_lookup",
-        ]),
+        ])
       ],
     ),
 
@@ -124,7 +125,7 @@ let package = Package(
       name: "ExpoModulesJSI-Cxx",
       dependencies: [],
       cxxSettings: [
-        .unsafeFlags(cxxIncludeFlags),
+        .unsafeFlags(cxxIncludeFlags)
       ],
     ),
 
@@ -147,10 +148,12 @@ func resolvePodsRoot() -> String {
   if let explicit = env["PODS_ROOT"] {
     return explicit
   }
-  let repoRoot = env["EXPO_ROOT_DIR"] ?? URL(fileURLWithPath: packageDir)
-    .deletingLastPathComponent() // expo-modules-jsi
-    .deletingLastPathComponent() // packages
-    .deletingLastPathComponent() // repo root
+  let repoRoot =
+    env["EXPO_ROOT_DIR"]
+    ?? URL(fileURLWithPath: packageDir)
+    .deletingLastPathComponent()  // expo-modules-jsi
+    .deletingLastPathComponent()  // packages
+    .deletingLastPathComponent()  // repo root
     .path
   return "\(repoRoot)/apps/bare-expo/ios/Pods"
 }
@@ -171,7 +174,8 @@ func resolveTestFrameworks() -> (binaryTargets: [Target], dependencies: [Target.
   let binaryTargets: [Target] = available.map({
     .binaryTarget(name: $0, path: ".test-frameworks/\($0).xcframework")
   })
-  let dependencies: [Target.Dependency] = ["ExpoModulesJSI"]
+  let dependencies: [Target.Dependency] =
+    ["ExpoModulesJSI"]
     + available.map({ .target(name: $0) })
   return (binaryTargets, dependencies)
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/CleanupContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/CleanupContext.swift
@@ -1,9 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-/**
- A box that holds a cleanup closure and invokes it on deallocation.
- Used to bridge Swift closures to C++ cleanup callbacks via `Unmanaged` pointers.
- */
+/// A box that holds a cleanup closure and invokes it on deallocation.
+/// Used to bridge Swift closures to C++ cleanup callbacks via `Unmanaged` pointers.
 internal final class CleanupContext: Sendable {
   let cleanup: @Sendable () -> Void
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostFunctionContext.swift
@@ -1,6 +1,4 @@
-/**
- Context that captures Swift values to pass them to JSI host function as an unmanaged pointer for interoperability with C++.
- */
+/// Context that captures Swift values to pass them to JSI host function as an unmanaged pointer for interoperability with C++.
 internal final class HostFunctionContext: Sendable {
   weak let runtime: JavaScriptRuntime?
   let name: String?

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Contexts/HostObjectContext.swift
@@ -1,6 +1,4 @@
-/**
- Context that captures Swift types to pass them to JSI host object as an unmanaged pointer for interoperability with C++.
- */
+/// Context that captures Swift types to pass them to JSI host object as an unmanaged pointer for interoperability with C++.
 internal final class HostObjectContext: Sendable {
   typealias Getter = @JavaScriptActor (_ propertyName: String) throws -> JavaScriptValue
   typealias Setter = @JavaScriptActor (_ propertyName: String, _ value: JavaScriptValue) throws -> Void

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Extensions/Task+immediate.swift
@@ -1,3 +1,5 @@
+// swift-format-ignore-file: AlwaysUseLowerCamelCase
+
 // `Task.immediate` is a pretty useful API that lets us immediately switch from synchronous to asynchronous context.
 // Read the proposal for more: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0472-task-start-synchronously-on-caller-context.md
 // Unfortunately, it is available only as of Apple OS 26.0 and there are no plans to backport it yet.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
@@ -1,18 +1,12 @@
 import CoreGraphics
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
-/**
- A type whose values can be represented as `facebook.jsi.Value`.
- */
+/// A type whose values can be represented as `facebook.jsi.Value`.
 internal protocol JSIRepresentable: JavaScriptRepresentable, Sendable, ~Copyable {
-  /**
-   Creates an instance of this type from the given `facebook.jsi.Value` in `facebook.jsi.IRuntime`.
-   */
+  /// Creates an instance of this type from the given `facebook.jsi.Value` in `facebook.jsi.IRuntime`.
   static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Self
-  /**
-   Creates a JSI value representing this value in the given JSI runtime.
-   */
+  /// Creates a JSI value representing this value in the given JSI runtime.
   func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value
 }
 
@@ -52,11 +46,13 @@ extension Bool: JSIRepresentable {
 internal protocol JSIRepresentableNumber: JSIRepresentable {}
 
 extension JSIRepresentableNumber {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Int where Self: FixedWidthInteger {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Int
+  where Self: FixedWidthInteger {
     return Int(value.getNumber())
   }
 
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Double where Self: BinaryFloatingPoint {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Double
+  where Self: BinaryFloatingPoint {
     return value.getNumber()
   }
 
@@ -108,7 +104,7 @@ extension Optional: JSIRepresentable where Wrapped: JSIRepresentable {
 }
 
 extension Array: JSIRepresentable where Element: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Array<Element> {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> [Element] {
     let jsiArray = value.getObject(runtime).getArray(runtime)
     let size = jsiArray.size(runtime)
     var result: Self = []
@@ -132,7 +128,7 @@ extension Array: JSIRepresentable where Element: JSIRepresentable {
 }
 
 extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Dictionary<Key, Value> {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> [Key: Value] {
     let object = value.getObject(runtime)
     let propertyNames = object.getPropertyNames(runtime)
     let size = propertyNames.size(runtime)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptRepresentable.swift
@@ -2,17 +2,11 @@ internal import jsi
 
 // MARK: - JavaScriptRepresentable
 
-/**
- A type whose values can be represented in the JS runtime.
- */
+/// A type whose values can be represented in the JS runtime.
 public protocol JavaScriptRepresentable: Sendable, ~Copyable {
-  /**
-   Creates an instance of this type from the given JS value.
-   */
+  /// Creates an instance of this type from the given JS value.
   static func fromJavaScriptValue(_ value: JavaScriptValue) -> Self
-  /**
-   Creates a JS value representing this value in the given runtime.
-   */
+  /// Creates a JS value representing this value in the given runtime.
   func toJavaScriptValue(in runtime: JavaScriptRuntime) -> JavaScriptValue
 }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptThrowable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptThrowable.swift
@@ -1,33 +1,27 @@
-/**
- A protocol that native error types can conform to in order to control
- how they are represented when thrown into the JavaScript world.
-
- When a native function throws an error that conforms to this protocol,
- a JavaScript `Error` object is created with the specified `message`
- and `code`.
-
- Types that don't conform to this protocol are still throwable, but
- will use a generic error representation.
-
- ```swift
- struct MyError: JavaScriptThrowable {
-   var message: String { "Something went wrong" }
-   var code: String { "ERR_MY_ERROR" }
- }
- ```
- */
+/// A protocol that native error types can conform to in order to control
+/// how they are represented when thrown into the JavaScript world.
+///
+/// When a native function throws an error that conforms to this protocol,
+/// a JavaScript `Error` object is created with the specified `message`
+/// and `code`.
+///
+/// Types that don't conform to this protocol are still throwable, but
+/// will use a generic error representation.
+///
+/// ```swift
+/// struct MyError: JavaScriptThrowable {
+///   var message: String { "Something went wrong" }
+///   var code: String { "ERR_MY_ERROR" }
+/// }
+/// ```
 public protocol JavaScriptThrowable: Error, Sendable {
-  /**
-   The error message describing what went wrong. Defaults to the debug description of the
-   conforming type, which typically includes richer context (class name, origin, cause chain)
-   than a plain description. Override to provide a custom user-facing message.
-   */
+  /// The error message describing what went wrong. Defaults to the debug description of the
+  /// conforming type, which typically includes richer context (class name, origin, cause chain)
+  /// than a plain description. Override to provide a custom user-facing message.
   var message: String { get }
 
-  /**
-   An error code for programmatic error handling in JavaScript.
-   Return an empty string to omit the `code` property from the JS error.
-   */
+  /// An error code for programmatic error handling in JavaScript.
+  /// Return an empty string to omit the `code` property from the JS error.
   var code: String { get }
 }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptType.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptType.swift
@@ -1,35 +1,27 @@
-/**
- Protocol conformed by the types that represent any JavaScript values.
- */
+/// Protocol conformed by the types that represent any JavaScript values.
 public protocol JavaScriptType: Sendable, ~Copyable {
   associatedtype Ref
 
-  /**
-   Returns a value that this instance represents as a `JavaScriptValue`.
-   */
+  /// Returns a value that this instance represents as a `JavaScriptValue`.
   func asValue() -> JavaScriptValue
 
-  /**
-   Creates a reference to this non-copyable JS value. Ownership on the value is transferred (is consumed) to the reference.
-   The original type and value are preserved; Referencing `JavaScriptFunction` and then dereferencing returns exactly the same struct.
-   */
+  /// Creates a reference to this non-copyable JS value. Ownership on the value is transferred (is consumed) to the reference.
+  /// The original type and value are preserved; Referencing `JavaScriptFunction` and then dereferencing returns exactly the same struct.
   consuming func ref() -> JavaScriptRef<Self>
 
-  /**
-   Creates a reference to a copy of this JS value. Ownership is **not transferred** (is borrowed) as the ref owns its copy.
-   The original type and value are **not preserved**, meaning that dereferencing will return a `JavaScriptValue`.
-   */
+  /// Creates a reference to a copy of this JS value. Ownership is **not transferred** (is borrowed) as the ref owns its copy.
+  /// The original type and value are **not preserved**, meaning that dereferencing will return a `JavaScriptValue`.
   borrowing func refToValue() -> JavaScriptValue.Ref
 }
 
-public extension JavaScriptType where Self: ~Copyable {
-  typealias Ref = JavaScriptRef<Self>
+extension JavaScriptType where Self: ~Copyable {
+  public typealias Ref = JavaScriptRef<Self>
 
-  consuming func ref() -> JavaScriptRef<Self> {
+  public consuming func ref() -> JavaScriptRef<Self> {
     return JavaScriptRef(self)
   }
 
-  borrowing func refToValue() -> JavaScriptValue.Ref {
+  public borrowing func refToValue() -> JavaScriptValue.Ref {
     return JavaScriptRef(self.asValue())
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptActor.swift
@@ -1,17 +1,13 @@
 import Foundation
 
-/**
- Name of the JavaScript thread created by React Native. Copied from `RCTJSThreadManager.mm`.
- */
+/// Name of the JavaScript thread created by React Native. Copied from `RCTJSThreadManager.mm`.
 private let jsThreadName = "com.facebook.react.runtime.JavaScript"
 
-/**
- Global actor that is used to isolate the code that should only be executed from the JavaScript thread.
- Theoretically it does not act as a real actor; it uses a serial executor that executes jobs **synchronously**
- without hopping to the proper thread. Meaning that running these jobs on the JavaScript thread must be ensured
- externally before switching to the isolated context, e.g. using `schedule` function on `JavaScriptRuntime`
- or enforcing the isolation with `JavaScriptActor.assumeIsolated`.
- */
+/// Global actor that is used to isolate the code that should only be executed from the JavaScript thread.
+/// Theoretically it does not act as a real actor; it uses a serial executor that executes jobs **synchronously**
+/// without hopping to the proper thread. Meaning that running these jobs on the JavaScript thread must be ensured
+/// externally before switching to the isolated context, e.g. using `schedule` function on `JavaScriptRuntime`
+/// or enforcing the isolation with `JavaScriptActor.assumeIsolated`.
 @globalActor
 public actor JavaScriptActor: GlobalActor {
   public static let shared = JavaScriptActor()
@@ -24,13 +20,11 @@ public actor JavaScriptActor: GlobalActor {
     return executor.asUnownedSerialExecutor()
   }
 
-  /**
-   An equivalent of `MainActor.assumeIsolated`, but for the `JavaScriptActor`. Assumes that the currently executing
-   synchronous function is actually executing on the JavaScript thread and invokes an isolated version of the operation,
-   allowing synchronous access to JavaScript runtime state without hopping through asynchronous boundaries.
-
-   See https://stackoverflow.com/a/79346971 for more information about the implementation.
-   */
+  /// An equivalent of `MainActor.assumeIsolated`, but for the `JavaScriptActor`. Assumes that the currently executing
+  /// synchronous function is actually executing on the JavaScript thread and invokes an isolated version of the operation,
+  /// allowing synchronous access to JavaScript runtime state without hopping through asynchronous boundaries.
+  ///
+  /// See https://stackoverflow.com/a/79346971 for more information about the implementation.
   public static func assumeIsolated<T: ~Copyable>(_ operation: @JavaScriptActor () throws -> T) rethrows -> T {
     typealias YesActor = @JavaScriptActor () throws -> T
     typealias NoActor = () throws -> T
@@ -45,33 +39,25 @@ public actor JavaScriptActor: GlobalActor {
     }
   }
 
-  /**
-   Stops program execution if the actor's executor is not isolating the current context.
-   */
+  /// Stops program execution if the actor's executor is not isolating the current context.
   public static func checkIsolated() {
     shared.executor.checkIsolated()
   }
 }
 
-/**
- Executor for the `JavaScriptActor` that executes given jobs synchronously and immediately.
- - Note: It does not ensure that given jobs are executed on the JavaScript thread; it must be done externally.
- */
+/// Executor for the `JavaScriptActor` that executes given jobs synchronously and immediately.
+/// - Note: It does not ensure that given jobs are executed on the JavaScript thread; it must be done externally.
 internal class JavaScriptExecutor: SerialExecutor, @unchecked Sendable {
   func enqueue(_ job: UnownedJob) {
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }
 
-  /**
-   Converts the executor to the optimized form of borrowed executor reference.
-   */
+  /// Converts the executor to the optimized form of borrowed executor reference.
   func asUnownedSerialExecutor() -> UnownedSerialExecutor {
     return UnownedSerialExecutor(ordinary: self)
   }
 
-  /**
-   Stops program execution if the executor is not isolating the current context.
-   */
+  /// Stops program execution if the executor is not isolating the current context.
   func checkIsolated() {
     // Using `assert` instead of `precondition` because this check is a heuristic based on
     // thread name, not a precise isolation guarantee. Worklet runtimes legitimately run on
@@ -79,19 +65,16 @@ internal class JavaScriptExecutor: SerialExecutor, @unchecked Sendable {
     assert(isIsolatingCurrentContext() == true, "JavaScriptActor operations must be run on the JavaScript thread")
   }
 
-  /**
-   Checks whether the executor isolates the current context, i.e. the current thread is a JavaScript thread.
-   The condition is also met when running tests and in single threaded environments.
-   */
+  /// Checks whether the executor isolates the current context, i.e. the current thread is a JavaScript thread.
+  /// The condition is also met when running tests and in single threaded environments.
   func isIsolatingCurrentContext() -> Bool? {
     // We must be careful as it relies on the thread name given by React Native.
-    return Thread.current.name == jsThreadName || !Thread.isMultiThreaded() || ProcessInfo.processInfo.processName == "xctest"
+    return Thread.current.name == jsThreadName || !Thread.isMultiThreaded()
+      || ProcessInfo.processInfo.processName == "xctest"
   }
 }
 
-/**
- An actor that is dedicated for the specific runtime.
- */
+/// An actor that is dedicated for the specific runtime.
 internal actor JavaScriptRuntimeActor {
   private weak let runtime: JavaScriptRuntime?
   nonisolated private let executor: JavaScriptExecutor
@@ -110,9 +93,7 @@ internal actor JavaScriptRuntimeActor {
   }
 }
 
-/**
- Serial executor dedicated for the specific runtime.
- */
+/// Serial executor dedicated for the specific runtime.
 internal final class JavaScriptRuntimeExecutor: JavaScriptExecutor, @unchecked Sendable {
   private weak let runtime: JavaScriptRuntime?
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptNativeState.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptNativeState.swift
@@ -1,9 +1,7 @@
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
-/**
- Base class for JS object's native state.
- */
+/// Base class for JS object's native state.
 open class JavaScriptNativeState {
   // Stored as an opaque pointer to avoid ARC retaining the bridged C++ type,
   // which could cause memory leaks due to unbalanced reference counting.
@@ -43,17 +41,13 @@ open class JavaScriptNativeState {
     self.pointee = expo.NativeState(ptr, deallocate)
   }
 
-  /**
-   Checks whether the underlying native state has already been released.
-   */
+  /// Checks whether the underlying native state has already been released.
   public var isReleased: Bool {
     return pointee == nil
   }
 
-  /**
-   Sets a deallocator, a closure that is invoked when this native state is no longer attached to any JS object.
-   Replaces any previously set deallocator.
-   */
+  /// Sets a deallocator, a closure that is invoked when this native state is no longer attached to any JS object.
+  /// Replaces any previously set deallocator.
   public func setDeallocator(_ deallocator: @escaping Deallocator) throws(NativeStateReleasedError) {
     if isReleased {
       throw NativeStateReleasedError()
@@ -61,10 +55,8 @@ open class JavaScriptNativeState {
     self.deallocator = deallocator
   }
 
-  /**
-   Turns given C++ `expo.NativeState` into its Swift counterpart.
-   May return `nil` if the native state is of unrelated type.
-   */
+  /// Turns given C++ `expo.NativeState` into its Swift counterpart.
+  /// May return `nil` if the native state is of unrelated type.
   internal static func from(cxx nativeState: expo.NativeState) -> Self? {
     // Get the opaque pointer stored by the C++ native state.
     let context = nativeState.getContext()

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptPropNameID.swift
@@ -1,31 +1,23 @@
 internal import jsi
 
-/**
- Represents something that can be a JS property key.
- */
+/// Represents something that can be a JS property key.
 public final class JavaScriptPropNameID: JavaScriptType {
   private weak let runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.PropNameID
 
-  /**
-   Creates a PropNameID from existing `facebook.jsi.PropNameID`.
-   */
+  /// Creates a PropNameID from existing `facebook.jsi.PropNameID`.
   internal init(_ runtime: JavaScriptRuntime, _ pointee: consuming facebook.jsi.PropNameID) {
     self.runtime = runtime
     self.pointee = pointee
   }
 
-  /**
-   Creates a PropNameID from the string.
-   */
+  /// Creates a PropNameID from the string.
   public init(_ runtime: JavaScriptRuntime, string: String) {
     self.runtime = runtime
     self.pointee = facebook.jsi.PropNameID.forUtf8(runtime.pointee, string, string.count)
   }
 
-  /**
-   Copies the data in a PropNameID as UTF8 into a string.
-   */
+  /// Copies the data in a PropNameID as UTF8 into a string.
   public func utf8() -> String {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -33,9 +25,7 @@ public final class JavaScriptPropNameID: JavaScriptType {
     return String(pointee.utf8(runtime.pointee))
   }
 
-  /**
-   Copies the data in a PropNameID as UTF16 into a string.
-   */
+  /// Copies the data in a PropNameID as UTF16 into a string.
   public func utf16() -> String {
     guard let runtime else {
       FatalError.runtimeLost()

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRef.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRef.swift
@@ -1,60 +1,44 @@
 import Foundation
 internal import jsi
 
-/**
- Reference to a non-copyable JavaScript value. Use it only when you have to:
- - Switch from value semantics to reference semantics.
- - Send a value through different isolation contexts.
- - Capture by escaping closures.
- - Store in containers that do not support non-copyable types.
- Swift (v6.2 at the time of writing) still has very limited support for non-copyable types.
- Many built-in types (including collections, containers, tuples) and protocols are not supporting them.
- There is a new ``InlineArray`` that supports them, but it requires iOS 26.
- - TODO: Annotate `value` and friends with `@JavaScriptActor`.
- */
+/// Reference to a non-copyable JavaScript value. Use it only when you have to:
+/// - Switch from value semantics to reference semantics.
+/// - Send a value through different isolation contexts.
+/// - Capture by escaping closures.
+/// - Store in containers that do not support non-copyable types.
+/// Swift (v6.2 at the time of writing) still has very limited support for non-copyable types.
+/// Many built-in types (including collections, containers, tuples) and protocols are not supporting them.
+/// There is a new ``InlineArray`` that supports them, but it requires iOS 26.
+/// - TODO: Annotate `value` and friends with `@JavaScriptActor`.
 public final class JavaScriptRef<T: JavaScriptType & ~Copyable>: JavaScriptType, Sendable, Copyable, Escapable {
-  /**
-   The referenced non-copyable value. It is consumed by the ref until it is taken (see `take()`) by a new owner.
-   */
+  /// The referenced non-copyable value. It is consumed by the ref until it is taken (see `take()`) by a new owner.
   nonisolated(unsafe) private var value: T?
 
-  /**
-   Returns `true` if the reference does not reference any value, `false` otherwise.
-   */
+  /// Returns `true` if the reference does not reference any value, `false` otherwise.
   public var isEmpty: Bool {
     return value == nil
   }
 
-  /**
-   Initializes a ref without an initial value.
-   */
+  /// Initializes a ref without an initial value.
   public init() {}
 
-  /**
-   Makes a reference to the value. The value is consumed and cannot be used anymore in the calling scope.
-   */
+  /// Makes a reference to the value. The value is consumed and cannot be used anymore in the calling scope.
   public init(_ value: consuming sending T) {
     self.value = consume value
   }
 
-  /**
-   Replaces the referenced value with a new value.
-   */
+  /// Replaces the referenced value with a new value.
   public func reset(_ value: consuming sending T) {
     self.value = consume value
   }
 
-  /**
-   Releases the value. Any subsequent `take()` calls with throw or return `nil`.
-   */
+  /// Releases the value. Any subsequent `take()` calls with throw or return `nil`.
   public func release() {
     self.value = nil
   }
 
-  /**
-   Takes the value out of the reference and transfers the ownership to the caller.
-   Throws when the reference does not hold any value, i.e. it has already been taken or never set.
-   */
+  /// Takes the value out of the reference and transfers the ownership to the caller.
+  /// Throws when the reference does not hold any value, i.e. it has already been taken or never set.
   public func take() throws(InvalidRefError) -> sending T {
     guard let value = value.take() else {
       throw InvalidRefError()
@@ -62,24 +46,18 @@ public final class JavaScriptRef<T: JavaScriptType & ~Copyable>: JavaScriptType,
     return value
   }
 
-  /**
-   Takes the value out of the reference and transfers the ownership to the caller.
-   Returns `nil` if the reference does not hold any value, i.e. it has already been taken or never set.
-   */
+  /// Takes the value out of the reference and transfers the ownership to the caller.
+  /// Returns `nil` if the reference does not hold any value, i.e. it has already been taken or never set.
   public func take() -> sending T? {
     return value.take()
   }
 
-  /**
-   Takes the value as a `JavaScriptValue`. Returns `undefined` value if the reference does not hold any value.
-   */
+  /// Takes the value as a `JavaScriptValue`. Returns `undefined` value if the reference does not hold any value.
   public func asValue() -> JavaScriptValue {
     return take()?.asValue() ?? .undefined
   }
 
-  /**
-   An error thrown when attempting to `take()` a value from a ref that has already been taken, released, or was never set.
-   */
+  /// An error thrown when attempting to `take()` a value from a ref that has already been taken, released, or was never set.
   public struct InvalidRefError: Error, CustomStringConvertible {
     public init() {}
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -1,79 +1,66 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import Foundation
-
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+import Foundation
+internal import jsi
 
-/**
- A Swift wrapper around a JavaScript runtime. Provides access to a JavaScript execution environment, allowing you to evaluate
- JavaScript code, create and manipulate JavaScript objects, functions, and values, and bridge between Swift and JavaScript.
-
- ## Threading
-
- JavaScript runtimes are single-threaded. All operations must be performed on the JavaScript
- thread. Use `schedule()` or `execute()` methods to safely run code on the correct thread.
- The runtime uses `@JavaScriptActor` to enforce thread safety at compile time.
-
- ## Lifecycle
-
- The runtime maintains a weak reference pattern for values, objects, and arrays to prevent
- retain cycles. Ensure the runtime remains alive while any derived JavaScript objects are in use.
- */
+/// A Swift wrapper around a JavaScript runtime. Provides access to a JavaScript execution environment, allowing you to evaluate
+/// JavaScript code, create and manipulate JavaScript objects, functions, and values, and bridge between Swift and JavaScript.
+///
+/// ## Threading
+///
+/// JavaScript runtimes are single-threaded. All operations must be performed on the JavaScript
+/// thread. Use `schedule()` or `execute()` methods to safely run code on the correct thread.
+/// The runtime uses `@JavaScriptActor` to enforce thread safety at compile time.
+///
+/// ## Lifecycle
+///
+/// The runtime maintains a weak reference pattern for values, objects, and arrays to prevent
+/// retain cycles. Ensure the runtime remains alive while any derived JavaScript objects are in use.
 open class JavaScriptRuntime: Equatable, @unchecked Sendable {
-  /**
-   The underlying JSI runtime this `JavaScriptRuntime` points to, exposed as
-   `IRuntime` — the abstract base interface that virtually all JSI value/object/
-   function methods take (`Value::getString`, `Object::setProperty`,
-   `Function::call`, …) since RN 0.86 split the API. Stored as the upcast result
-   of `runtimePointee` because Swift's C++ interop does not auto-upcast between
-   two `SwiftImportAs: reference` types.
-
-   Use ``runtimePointee`` instead when you specifically need a `jsi::Runtime&`
-   (e.g. constructing an `expo.RuntimeScheduler` whose binding lookup is typed on
-   `Runtime&` upstream).
-
-   Note that `facebook.jsi.IRuntime` and `facebook.jsi.Runtime` are imported as
-   reference types so for the Swift compiler they are treated like classes.
-   This is important because they:
-   - are abstract classes with many virtual methods. Swift/C++ interop does not support calling pure virtual methods on value types.
-   - are non-copyable. As value types, we would have to "borrow" them from React Native in an unsafe manner.
-   */
+  /// The underlying JSI runtime this `JavaScriptRuntime` points to, exposed as
+  /// `IRuntime` — the abstract base interface that virtually all JSI value/object/
+  /// function methods take (`Value::getString`, `Object::setProperty`,
+  /// `Function::call`, …) since RN 0.86 split the API. Stored as the upcast result
+  /// of `runtimePointee` because Swift's C++ interop does not auto-upcast between
+  /// two `SwiftImportAs: reference` types.
+  ///
+  /// Use ``runtimePointee`` instead when you specifically need a `jsi::Runtime&`
+  /// (e.g. constructing an `expo.RuntimeScheduler` whose binding lookup is typed on
+  /// `Runtime&` upstream).
+  ///
+  /// Note that `facebook.jsi.IRuntime` and `facebook.jsi.Runtime` are imported as
+  /// reference types so for the Swift compiler they are treated like classes.
+  /// This is important because they:
+  /// - are abstract classes with many virtual methods. Swift/C++ interop does not support calling pure virtual methods on value types.
+  /// - are non-copyable. As value types, we would have to "borrow" them from React Native in an unsafe manner.
   internal let pointee: facebook.jsi.IRuntime
   internal let runtimePointee: facebook.jsi.Runtime
   internal let scheduler: expo.RuntimeScheduler
 
-  /**
-   Thread ID of the JavaScript thread, captured at construction time. Used by `isOnJavaScriptThread()`
-   for a fast integer comparison instead of `Thread.current.name == "..."`.
-   Assumes runtime initializers always run on the JS thread.
-   */
+  /// Thread ID of the JavaScript thread, captured at construction time. Used by `isOnJavaScriptThread()`
+  /// for a fast integer comparison instead of `Thread.current.name == "..."`.
+  /// Assumes runtime initializers always run on the JS thread.
   private let jsThreadID: UInt64 = {
     var id: UInt64 = 0
     pthread_threadid_np(nil, &id)
     return id
   }()
 
-  /**
-   Actor for running runtime work.
-   */
+  /// Actor for running runtime work.
   lazy var runtimeActor: JavaScriptRuntimeActor = JavaScriptRuntimeActor(runtime: self)
 
-  /**
-   Creates a runtime from the JSI runtime. The scheduler runs tasks synchronously
-   on the caller's thread — for the React-backed runtime, use
-   `init(unsafePointer:nativeScheduler:dispatch:)` instead.
-   */
+  /// Creates a runtime from the JSI runtime. The scheduler runs tasks synchronously
+  /// on the caller's thread — for the React-backed runtime, use
+  /// `init(unsafePointer:nativeScheduler:dispatch:)` instead.
   internal init(_ runtime: facebook.jsi.Runtime) {
     self.runtimePointee = runtime
     self.pointee = expo.iruntime(runtime)
     self.scheduler = expo.RuntimeScheduler()
   }
 
-  /**
-   Creates a standalone Hermes runtime. Scheduled tasks run synchronously —
-   no React scheduler is wired up.
-   */
+  /// Creates a standalone Hermes runtime. Scheduled tasks run synchronously —
+  /// no React scheduler is wired up.
   public init() {
     let runtime = expo.createHermesRuntime()
     self.runtimePointee = runtime
@@ -81,11 +68,9 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     self.scheduler = expo.RuntimeScheduler()
   }
 
-  /**
-   Creates a runtime from a raw pointer to the underlying `facebook.jsi.Runtime`.
-   Scheduled tasks run synchronously — for the React-backed runtime, use
-   `init(unsafePointer:nativeScheduler:dispatch:)` instead.
-   */
+  /// Creates a runtime from a raw pointer to the underlying `facebook.jsi.Runtime`.
+  /// Scheduled tasks run synchronously — for the React-backed runtime, use
+  /// `init(unsafePointer:nativeScheduler:dispatch:)` instead.
   public init(unsafePointer: UnsafeMutableRawPointer) {
     let runtime = unsafeBitCast(unsafePointer, to: facebook.jsi.Runtime.self)
     self.runtimePointee = runtime
@@ -93,17 +78,15 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     self.scheduler = expo.RuntimeScheduler()
   }
 
-  /**
-   Creates a runtime bound to a host-provided React `RuntimeScheduler`. Calls to
-   `schedule(...)` / `.execute(...)` dispatch through `dispatch`, which the host
-   implements against the real `react::RuntimeScheduler`. This is the path the
-   React Native factory uses.
-
-   - `unsafePointer`: raw pointer to the underlying `facebook::jsi::Runtime`.
-   - `scheduler`: raw pointer to the `react::RuntimeScheduler` instance.
-   - `dispatch`: raw pointer to a C function with signature
-     `void (*)(void *scheduler, int priority, void (^callback)())`.
-   */
+  /// Creates a runtime bound to a host-provided React `RuntimeScheduler`. Calls to
+  /// `schedule(...)` / `.execute(...)` dispatch through `dispatch`, which the host
+  /// implements against the real `react::RuntimeScheduler`. This is the path the
+  /// React Native factory uses.
+  ///
+  /// - `unsafePointer`: raw pointer to the underlying `facebook::jsi::Runtime`.
+  /// - `scheduler`: raw pointer to the `react::RuntimeScheduler` instance.
+  /// - `dispatch`: raw pointer to a C function with signature
+  ///   `void (*)(void *scheduler, int priority, void (^callback)())`.
   public init(
     unsafePointer: UnsafeMutableRawPointer,
     scheduler: UnsafeMutableRawPointer,
@@ -116,34 +99,26 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     self.scheduler = expo.RuntimeScheduler(scheduler, fn)
   }
 
-  /**
-   Provides scoped access to a raw pointer to the underlying `facebook.jsi.Runtime`.
-   The pointer is valid only for the duration of the closure and must not be stored or escaped.
-   */
+  /// Provides scoped access to a raw pointer to the underlying `facebook.jsi.Runtime`.
+  /// The pointer is valid only for the duration of the closure and must not be stored or escaped.
   public func withUnsafePointee<R>(_ body: (UnsafeMutableRawPointer) throws -> R) rethrows -> R {
     return try body(Unmanaged<facebook.jsi.Runtime>.passUnretained(runtimePointee).toOpaque())
   }
 
-  /**
-   Returns the runtime `global` object.
-   */
+  /// Returns the runtime `global` object.
   public func global() -> JavaScriptObject {
     return JavaScriptObject(self, pointee.global())
   }
 
   // MARK: - Creating objects
 
-  /**
-   Creates a plain JavaScript object.
-   */
+  /// Creates a plain JavaScript object.
   public func createObject() -> JavaScriptObject {
     return JavaScriptObject(self, facebook.jsi.Object(pointee))
   }
 
-  /**
-   Creates a new JavaScript object, using the provided object as the prototype.
-   Calls `Object.create(prototype)` under the hood.
-   */
+  /// Creates a new JavaScript object, using the provided object as the prototype.
+  /// Calls `Object.create(prototype)` under the hood.
   public func createObject(prototype: borrowing JavaScriptObject) -> JavaScriptObject {
     return try! global()
       .getPropertyAsObject("Object")
@@ -152,16 +127,14 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
       .getObject()
   }
 
-  /**
-   Creates a JavaScript host object with given implementations for property getter, property setter, property names getter and dealloc.
-
-   Errors thrown from `get` or `set` propagate to JavaScript as a thrown `Error`. Conform
-   the thrown type to `JavaScriptThrowable` to control the resulting `message` and `code`.
-
-   Pass `nil` for `set` to make the host object read-only — assignment from JavaScript
-   then throws an `Error` whose message names the property and explains how to make it
-   writable. `getPropertyNames` and `dealloc` default to no-ops.
-   */
+  /// Creates a JavaScript host object with given implementations for property getter, property setter, property names getter and dealloc.
+  ///
+  /// Errors thrown from `get` or `set` propagate to JavaScript as a thrown `Error`. Conform
+  /// the thrown type to `JavaScriptThrowable` to control the resulting `message` and `code`.
+  ///
+  /// Pass `nil` for `set` to make the host object read-only — assignment from JavaScript
+  /// then throws an `Error` whose message names the property and explains how to make it
+  /// writable. `getPropertyNames` and `dealloc` default to no-ops.
   public func createHostObject(
     get: @escaping @JavaScriptActor (_ propertyName: String) throws -> JavaScriptValue,
     set: (@JavaScriptActor (_ propertyName: String, _ value: JavaScriptValue) throws -> Void)? = nil,
@@ -182,7 +155,9 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
       }
     }
 
-    func setter(context: UnsafeMutableRawPointer, propertyName: UnsafePointer<CChar>, valuePointer: UnsafeMutableRawPointer) {
+    func setter(
+      context: UnsafeMutableRawPointer, propertyName: UnsafePointer<CChar>, valuePointer: UnsafeMutableRawPointer
+    ) {
       let context = Unmanaged<HostObjectContext>.fromOpaque(context).takeUnretainedValue()
 
       guard let runtime = context.runtime else {
@@ -236,10 +211,12 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
       }
     }
 
-    let context = Unmanaged.passRetained(HostObjectContext(runtime: self, get, set, getPropertyNames, dealloc)).toOpaque()
+    let context = Unmanaged.passRetained(HostObjectContext(runtime: self, get, set, getPropertyNames, dealloc))
+      .toOpaque()
     // Pass a null setter to C++ when the Swift setter is nil so that JS assignment
     // raises a `jsi::JSError` directly, without crossing the Swift boundary.
-    let callbacks = expo.HostObjectCallbacks(context, getter, set == nil ? nil : setter, propertyNamesGetter, deallocate)
+    let callbacks = expo.HostObjectCallbacks(
+      context, getter, set == nil ? nil : setter, propertyNamesGetter, deallocate)
     let hostObject = expo.HostObject.makeObject(pointee, consume callbacks)
 
     return JavaScriptObject(self, hostObject)
@@ -247,19 +224,17 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
   // MARK: - Creating array buffers
 
-  /**
-   Creates a new array buffer of the given size with zero-initialized memory.
-   */
+  /// Creates a new array buffer of the given size with zero-initialized memory.
   public func createArrayBuffer(size: Int) -> JavaScriptArrayBuffer {
     let jsiArrayBuffer = expo.createArrayBuffer(pointee, size)
     return JavaScriptArrayBuffer(self, jsiArrayBuffer)
   }
 
-  /**
-   Creates a new array buffer that wraps the given native data pointer.
-   The cleanup closure is called when the array buffer is garbage collected.
-   */
-  public func createArrayBuffer(data: UnsafeMutablePointer<UInt8>, size: Int, cleanup: @escaping @Sendable () -> Void) -> JavaScriptArrayBuffer {
+  /// Creates a new array buffer that wraps the given native data pointer.
+  /// The cleanup closure is called when the array buffer is garbage collected.
+  public func createArrayBuffer(data: UnsafeMutablePointer<UInt8>, size: Int, cleanup: @escaping @Sendable () -> Void)
+    -> JavaScriptArrayBuffer
+  {
     let context = Unmanaged.passRetained(CleanupContext(cleanup)).toOpaque()
     let jsiArrayBuffer = expo.createArrayBuffer(pointee, data, size, context) { context in
       Unmanaged<CleanupContext>.fromOpaque(context).release()
@@ -269,28 +244,26 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
   // MARK: - Creating arrays
 
-  /**
-   Creates a new Array instance.
-   */
+  /// Creates a new Array instance.
   public func createArray(length: Int = 0) -> JavaScriptArray {
     return JavaScriptArray(self, facebook.jsi.Array(pointee, length))
   }
 
   // MARK: - Creating functions
 
-  /**
-   Type of the closure that is passed to the `createFunction` function.
-   */
-  public typealias SyncFunctionClosure = @JavaScriptActor (
-    _ this: JavaScriptValue,
-    _ arguments: consuming JavaScriptValuesBuffer
-  ) throws -> JavaScriptValue
+  /// Type of the closure that is passed to the `createFunction` function.
+  public typealias SyncFunctionClosure =
+    @JavaScriptActor (
+      _ this: JavaScriptValue,
+      _ arguments: consuming JavaScriptValuesBuffer
+    ) throws -> JavaScriptValue
 
-  /**
-   Creates a class with the given name and native constructor.
-   */
+  /// Creates a class with the given name and native constructor.
   @JavaScriptActor
-  public func createClass(name: String, inheriting baseClass: consuming JavaScriptFunction? = nil, _ constructor: @escaping SyncFunctionClosure) throws -> JavaScriptFunction {
+  public func createClass(
+    name: String, inheriting baseClass: consuming JavaScriptFunction? = nil,
+    _ constructor: @escaping SyncFunctionClosure
+  ) throws -> JavaScriptFunction {
     // Host functions are not standard functions, thus cannot be used as class constructors.
     // We're creating one by evaluating a script that calls a "native constructor" that is a host function.
     let nativeConstructorKey = "__native_constructor__"
@@ -300,7 +273,9 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
       throw InvalidIdentifierError(identifier: name)
     }
 
-    let klassValue = try eval(label: "\(name).\(nativeConstructorKey)", "(function \(name)(...args) { return this.\(nativeConstructorKey)(...args); })")
+    let klassValue = try eval(
+      label: "\(name).\(nativeConstructorKey)",
+      "(function \(name)(...args) { return this.\(nativeConstructorKey)(...args); })")
     let klassObject = klassValue.getObject()
 
     // Create a host function that is called by the constructor
@@ -324,11 +299,9 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return klassValue.getFunction()
   }
 
-  /**
-   Creates a synchronous host function that runs the given closure when it's called.
-   The value returned by the closure is synchronously returned to JS.
-   - Returns: A JavaScript function represented as a `JavaScriptFunction`.
-   */
+  /// Creates a synchronous host function that runs the given closure when it's called.
+  /// The value returned by the closure is synchronously returned to JS.
+  /// - Returns: A JavaScript function represented as a `JavaScriptFunction`.
   @JavaScriptActor
   public func createFunction(_ name: String, _ function: sending @escaping SyncFunctionClosure) -> JavaScriptFunction {
     let closure = createFunctionClosure(runtime: self, name: name, function)
@@ -337,11 +310,9 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return JavaScriptFunction(self, hostFunction)
   }
 
-  /**
-   Creates a synchronous anonymous host function that runs the given closure when it's called.
-   The value returned by the closure is synchronously returned to JS.
-   - Returns: A JavaScript function represented as a `JavaScriptFunction`.
-   */
+  /// Creates a synchronous anonymous host function that runs the given closure when it's called.
+  /// The value returned by the closure is synchronously returned to JS.
+  /// - Returns: A JavaScript function represented as a `JavaScriptFunction`.
   @JavaScriptActor
   public func createFunction(_ function: sending @escaping SyncFunctionClosure) -> JavaScriptFunction {
     let closure = createFunctionClosure(runtime: self, name: nil, function)
@@ -350,22 +321,21 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return JavaScriptFunction(self, hostFunction)
   }
 
-  /**
-   Type of the closure that is passed to the `createAsyncFunction` function.
-   It is invoked from asynchronous context, so it can await and call other asynchronous functions.
-   */
-  public typealias AsyncFunctionClosure = @JavaScriptActor (
-    _ this: JavaScriptValue,
-    _ arguments: consuming JavaScriptValuesBuffer,
-  ) async throws -> JavaScriptValue
+  /// Type of the closure that is passed to the `createAsyncFunction` function.
+  /// It is invoked from asynchronous context, so it can await and call other asynchronous functions.
+  public typealias AsyncFunctionClosure =
+    @JavaScriptActor (
+      _ this: JavaScriptValue,
+      _ arguments: consuming JavaScriptValuesBuffer,
+    ) async throws -> JavaScriptValue
 
-  /**
-   Creates an asynchronous host function that runs given block when it's called.
-   The value returned by the closure is returned to JS asynchronously.
-   - Returns: A JavaScript function represented as a `JavaScriptFunction` that returns a promise.
-   */
+  /// Creates an asynchronous host function that runs given block when it's called.
+  /// The value returned by the closure is returned to JS asynchronously.
+  /// - Returns: A JavaScript function represented as a `JavaScriptFunction` that returns a promise.
   @JavaScriptActor
-  public func createAsyncFunction(_ name: String, _ function: sending @escaping AsyncFunctionClosure) -> JavaScriptFunction {
+  public func createAsyncFunction(_ name: String, _ function: sending @escaping AsyncFunctionClosure)
+    -> JavaScriptFunction
+  {
     return createFunction(name) { this, arguments in
       let promise = try JavaScriptPromise(self)
 
@@ -390,18 +360,17 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
   // MARK: - Runtime execution
 
-  /**
-   Whether the runtime scheduler can dispatch work asynchronously to the JS thread.
-   Returns false for standalone runtimes (e.g. in tests) where scheduled tasks run synchronously.
-   */
+  /// Whether the runtime scheduler can dispatch work asynchronously to the JS thread.
+  /// Returns false for standalone runtimes (e.g. in tests) where scheduled tasks run synchronously.
   public var supportsAsyncScheduling: Bool {
     return scheduler.supportsAsyncScheduling()
   }
 
-  /**
-   Schedules a closure to be executed with granted synchronized access to the runtime.
-   */
-  public func schedule(priority: SchedulerPriority = .normal, @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () -> sending Void) -> Void {
+  /// Schedules a closure to be executed with granted synchronized access to the runtime.
+  public func schedule(
+    priority: SchedulerPriority = .normal,
+    @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () -> sending Void
+  ) {
     let cxxPriority = expo.RuntimeScheduler.Priority(rawValue: priority.rawValue) ?? .NormalPriority
     scheduler.scheduleTask(cxxPriority) {
       JavaScriptActor.assumeIsolated(closure)
@@ -411,7 +380,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   public func schedule(
     priority: SchedulerPriority = .normal,
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () async throws -> Void
-  ) -> Void {
+  ) {
     schedule(priority: priority) {
       Task.immediate_polyfill {
         try await closure()
@@ -419,13 +388,13 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     }
   }
 
-  /**
-   Synchronously executes a closure on the JavaScript runtime thread, blocking the current thread until completion.
-   Not available in async contexts to prevent blocking the cooperative thread pool.
-   */
+  /// Synchronously executes a closure on the JavaScript runtime thread, blocking the current thread until completion.
+  /// Not available in async contexts to prevent blocking the cooperative thread pool.
   @available(*, noasync)
   @discardableResult
-  public func execute<R: Sendable>(@_implicitSelfCapture _ closure: @escaping @JavaScriptActor () throws -> R) throws -> sending R {
+  public func execute<R: Sendable>(@_implicitSelfCapture _ closure: @escaping @JavaScriptActor () throws -> R) throws
+    -> sending R
+  {
     if isOnJavaScriptThread() {
       return try JavaScriptActor.assumeIsolated(closure)
     }
@@ -460,10 +429,8 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return try result.get()
   }
 
-  /**
-   Synchronously executes an async closure on the JavaScript runtime thread, blocking the current thread until completion.
-   Not available in async contexts to prevent blocking the cooperative thread pool.
-   */
+  /// Synchronously executes an async closure on the JavaScript runtime thread, blocking the current thread until completion.
+  /// Not available in async contexts to prevent blocking the cooperative thread pool.
   @available(*, noasync)
   @discardableResult
   public func execute<R: Sendable>(
@@ -475,7 +442,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     // to work around a Swift 6.2.3 compiler bug.
     let callerRunLoop = NonisolatedUnsafeVar(CFRunLoopGetCurrent())
 
-    func body() -> Void {
+    func body() {
       Task.immediate_polyfill(priority: .high) {
         do {
           result.value = .success(try await closure())
@@ -503,9 +470,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return try result.value.get()
   }
 
-  /**
-   Asynchronously executes a sync closure on the JavaScript runtime thread, awaiting its completion without blocking.
-   */
+  /// Asynchronously executes a sync closure on the JavaScript runtime thread, awaiting its completion without blocking.
   @discardableResult
   public func execute<R: Sendable>(
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () throws -> R
@@ -524,9 +489,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     }
   }
 
-  /**
-   Asynchronously executes an async closure on the JavaScript runtime thread, awaiting its completion without blocking.
-   */
+  /// Asynchronously executes an async closure on the JavaScript runtime thread, awaiting its completion without blocking.
   @discardableResult
   public func execute<R: Sendable>(
     @_implicitSelfCapture _ closure: @escaping @JavaScriptActor () async throws -> R
@@ -547,9 +510,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     }
   }
 
-  /**
-   Checks whether the function is called on the JavaScript thread.
-   */
+  /// Checks whether the function is called on the JavaScript thread.
   @inline(__always)
   public final func isOnJavaScriptThread() -> Bool {
     var current: UInt64 = 0
@@ -557,18 +518,14 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     return current == jsThreadID
   }
 
-  /**
-   Asserts whether we are on the JavaScript thread. Helpful for debugging threading issues.
-   */
+  /// Asserts whether we are on the JavaScript thread. Helpful for debugging threading issues.
   @inline(__always)
   public final func assertThread(file: String = #file, function: String = #function, line: Int = #line) {
     assert(isOnJavaScriptThread(), "Function '\(function)' is not run on the JavaScript thread (\(file):\(line))")
   }
 
-  /**
-   Priority of the scheduled task.
-   - Note: Keep it in sync with the equivalent C++ enum from React Native (see `SchedulerPriority.h` from `React-callinvoker`).
-   */
+  /// Priority of the scheduled task.
+  /// - Note: Keep it in sync with the equivalent C++ enum from React Native (see `SchedulerPriority.h` from `React-callinvoker`).
   public enum SchedulerPriority: Int32 {
     case immediate = 1
     case userBlocking = 2
@@ -579,9 +536,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
 
   // MARK: - Script evaluation
 
-  /**
-   Evaluates given JavaScript source code.
-   */
+  /// Evaluates given JavaScript source code.
   @discardableResult
   @JavaScriptActor
   public func eval(label: String? = nil, _ source: String) throws -> JavaScriptValue {
@@ -597,9 +552,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     }
   }
 
-  /**
-   Evaluates the given JavaScript source code made by joining an array of strings with a newline separator.
-   */
+  /// Evaluates the given JavaScript source code made by joining an array of strings with a newline separator.
   @available(*, deprecated, message: "Spread the array into arguments instead")
   @discardableResult
   @JavaScriptActor
@@ -607,18 +560,14 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     try eval(label: label, lines.joined(separator: "\n"))
   }
 
-  /**
-   Evaluates the given JavaScript source code made by joining arguments with a newline separator.
-   */
+  /// Evaluates the given JavaScript source code made by joining arguments with a newline separator.
   @discardableResult
   @JavaScriptActor
   public func eval(label: String? = nil, _ lines: String...) throws -> JavaScriptValue {
     try eval(label: label, lines.joined(separator: "\n"))
   }
 
-  /**
-   Evaluates given JavaScript source code in an async context. If the evaluated source returns a Promise, it awaits until the promise is resolved/rejected.
-   */
+  /// Evaluates given JavaScript source code in an async context. If the evaluated source returns a Promise, it awaits until the promise is resolved/rejected.
   @discardableResult
   @JavaScriptActor
   public func evalAsync(label: String? = nil, _ source: String) async throws -> JavaScriptValue {
@@ -638,10 +587,15 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   internal var propNameIdsRegistry: [String: JavaScriptPropNameID] = [:]
 }
 
-private func createFunctionClosure(runtime: JavaScriptRuntime, name: String? = nil, _ closure: @escaping JavaScriptRuntime.SyncFunctionClosure) -> expo.HostFunctionClosure {
+private func createFunctionClosure(
+  runtime: JavaScriptRuntime, name: String? = nil, _ closure: @escaping JavaScriptRuntime.SyncFunctionClosure
+) -> expo.HostFunctionClosure {
   let context = Unmanaged.passRetained(HostFunctionContext(runtime: runtime, name: name, closure)).toOpaque()
 
-  func call(context: UnsafeMutableRawPointer, thisPtr: UnsafePointer<facebook.jsi.Value>, argumentsPtr: UnsafePointer<facebook.jsi.Value>, argumentsCount: Int) -> facebook.jsi.Value {
+  func call(
+    context: UnsafeMutableRawPointer, thisPtr: UnsafePointer<facebook.jsi.Value>,
+    argumentsPtr: UnsafePointer<facebook.jsi.Value>, argumentsCount: Int
+  ) -> facebook.jsi.Value {
     let context = Unmanaged<HostFunctionContext>.fromOpaque(context).takeUnretainedValue()
 
     guard let runtime = context.runtime else {
@@ -668,14 +622,10 @@ private func createFunctionClosure(runtime: JavaScriptRuntime, name: String? = n
 // MARK: - Errors
 
 extension JavaScriptRuntime {
-  /**
-   Thrown when an invalid JavaScript identifier is passed to APIs that interpolate
-   the name into evaluated JavaScript source, such as ``createClass(name:inheriting:_:)``.
-   */
+  /// Thrown when an invalid JavaScript identifier is passed to APIs that interpolate
+  /// the name into evaluated JavaScript source, such as ``createClass(name:inheriting:_:)``.
   public struct InvalidIdentifierError: Error, CustomStringConvertible {
-    /**
-     The identifier string that failed validation.
-     */
+    /// The identifier string that failed validation.
     public let identifier: String
 
     public var description: String {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift
@@ -1,10 +1,8 @@
 internal import jsi
 
-/**
- A buffer that stores instances of `facebook.jsi.Value` with the ability to convert them to `JavaScriptValue` on element access
- without the need to create a new container (e.g. `std.vector<facebook.jsi.Value>` or `[JavaScriptValue]`).
- Used mainly to pass function arguments from C++ to Swift.
- */
+/// A buffer that stores instances of `facebook.jsi.Value` with the ability to convert them to `JavaScriptValue` on element access
+/// without the need to create a new container (e.g. `std.vector<facebook.jsi.Value>` or `[JavaScriptValue]`).
+/// Used mainly to pass function arguments from C++ to Swift.
 public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   // Safe to use unowned — the buffer's lifetime is scoped to a host function call,
   // so the runtime is always alive while the buffer exists.
@@ -13,38 +11,37 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   internal nonisolated(unsafe) let bufferPointer: UnsafeMutableBufferPointer<facebook.jsi.Value>
   private let ownsMemory: Bool
 
-  /**
-   A pointer to the first value of the buffer.
-   If the baseAddress of this buffer is `nil`, the `count` is zero.
-   */
+  /// A pointer to the first value of the buffer.
+  /// If the baseAddress of this buffer is `nil`, the `count` is zero.
   internal var baseAddress: UnsafePointer<facebook.jsi.Value>? {
     return UnsafePointer(bufferPointer.baseAddress)
   }
 
-  /**
-   A type-erased raw pointer to the first value of the buffer, suitable for
-   passing across Swift/ObjC++ boundaries where `facebook.jsi.Value` cannot
-   appear in a public signature.
-   */
+  /// A type-erased raw pointer to the first value of the buffer, suitable for
+  /// passing across Swift/ObjC++ boundaries where `facebook.jsi.Value` cannot
+  /// appear in a public signature.
   public var rawBaseAddress: UnsafeRawPointer? {
     return baseAddress.map { UnsafeRawPointer($0) }
   }
 
-  /**
-   The number of values in the buffer.
-   */
+  /// The number of values in the buffer.
   public var count: Int {
     return bufferPointer.count
   }
 
-  internal init(_ runtime: JavaScriptRuntime, buffer: consuming UnsafeMutableBufferPointer<facebook.jsi.Value>, ownsMemory: Bool = false) {
+  internal init(
+    _ runtime: JavaScriptRuntime, buffer: consuming UnsafeMutableBufferPointer<facebook.jsi.Value>,
+    ownsMemory: Bool = false
+  ) {
     self.runtime = runtime
     self.bufferPointer = buffer
     self.ownsMemory = ownsMemory
   }
 
   internal init(_ runtime: JavaScriptRuntime, start: consuming UnsafePointer<facebook.jsi.Value>?, count: Int) {
-    self.init(runtime, buffer: UnsafeMutableBufferPointer(start: UnsafeMutablePointer(mutating: start), count: count), ownsMemory: false)
+    self.init(
+      runtime, buffer: UnsafeMutableBufferPointer(start: UnsafeMutablePointer(mutating: start), count: count),
+      ownsMemory: false)
   }
 
   internal init(_ runtime: JavaScriptRuntime, buffer: consuming UnsafeBufferPointer<facebook.jsi.Value>) {
@@ -65,7 +62,8 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   }
 
   @discardableResult
-  internal consuming func set<T: JSIRepresentable>(value: borrowing T, atIndex index: Int) -> JavaScriptValuesBuffer where T: ~Copyable {
+  internal consuming func set<T: JSIRepresentable>(value: borrowing T, atIndex index: Int) -> JavaScriptValuesBuffer
+  where T: ~Copyable {
     guard (0..<count).contains(index) else {
       FatalError.valuesBufferIndexOutRange(index: index, capacity: count)
     }
@@ -74,7 +72,8 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
   }
 
   @JavaScriptActor
-  public func map<T>(_ transform: @JavaScriptActor (_ value: JavaScriptValue, _ index: Int) throws -> T) rethrows -> [T] {
+  public func map<T>(_ transform: @JavaScriptActor (_ value: JavaScriptValue, _ index: Int) throws -> T) rethrows -> [T]
+  {
     var result: [T] = []
     result.reserveCapacity(count)
     for index in 0..<count {
@@ -85,9 +84,7 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
     return result
   }
 
-  /**
-   Allocates a new buffer of the same capacity with copies of `facebook.jsi.Value` it stores.
-   */
+  /// Allocates a new buffer of the same capacity with copies of `facebook.jsi.Value` it stores.
   @JavaScriptActor
   public func copy() -> JavaScriptValuesBuffer {
     let bufferCopy = JavaScriptValuesBuffer.copying(in: runtime, buffer: bufferPointer)
@@ -103,19 +100,18 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
 
   // MARK: - Allocation
 
-  /**
-   Allocates new values buffer with the given capacity. The buffer is in uninitialized state.
-   You must initialize all elements using `set(value:atIndex)` method.
-   */
+  /// Allocates new values buffer with the given capacity. The buffer is in uninitialized state.
+  /// You must initialize all elements using `set(value:atIndex)` method.
   public static func allocate(in runtime: JavaScriptRuntime, capacity: Int) -> JavaScriptValuesBuffer {
-    return JavaScriptValuesBuffer(runtime, buffer: UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: capacity), ownsMemory: true)
+    return JavaScriptValuesBuffer(
+      runtime, buffer: UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: capacity), ownsMemory: true)
   }
 
-  /**
-   Allocates new values buffer with the given JS representables.
-   Note that parameter packs still do not support non-copyable types so they need to be passed as `JavaScriptRef`.
-   */
-  public static func allocate<each T: JavaScriptRepresentable>(in runtime: JavaScriptRuntime, with values: repeat each T) -> JavaScriptValuesBuffer {
+  /// Allocates new values buffer with the given JS representables.
+  /// Note that parameter packs still do not support non-copyable types so they need to be passed as `JavaScriptRef`.
+  public static func allocate<each T: JavaScriptRepresentable>(
+    in runtime: JavaScriptRuntime, with values: repeat each T
+  ) -> JavaScriptValuesBuffer {
     // First we count parameters in a pack to find the proper buffer capacity. This is still the simplest way.
     var capacity = 0
     for _ in repeat each values {
@@ -138,7 +134,9 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
     return JavaScriptValuesBuffer(runtime, buffer: buffer, ownsMemory: true)
   }
 
-  internal static func copying(in runtime: JavaScriptRuntime, buffer: UnsafeMutableBufferPointer<facebook.jsi.Value>) -> UnsafeMutableBufferPointer<facebook.jsi.Value> {
+  internal static func copying(in runtime: JavaScriptRuntime, buffer: UnsafeMutableBufferPointer<facebook.jsi.Value>)
+    -> UnsafeMutableBufferPointer<facebook.jsi.Value>
+  {
     let copy = UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: buffer.count)
     for index in 0..<buffer.count {
       copy.initializeElement(at: index, to: facebook.jsi.Value(runtime.pointee, buffer[index]))
@@ -146,16 +144,15 @@ public struct JavaScriptValuesBuffer: JavaScriptType, ~Copyable {
     return copy
   }
 
-  /**
-   Allocates a new owning buffer holding a runtime-aware copy of each value's
-   underlying `facebook.jsi.Value`. The given `JavaScriptValue`s must all belong
-   to `runtime`; mixing runtimes will crash deep inside JSI.
-   */
+  /// Allocates a new owning buffer holding a runtime-aware copy of each value's
+  /// underlying `facebook.jsi.Value`. The given `JavaScriptValue`s must all belong
+  /// to `runtime`; mixing runtimes will crash deep inside JSI.
   @JavaScriptActor
   public static func copying(in runtime: JavaScriptRuntime, values: [JavaScriptValue]) -> JavaScriptValuesBuffer {
     let buffer = UnsafeMutableBufferPointer<facebook.jsi.Value>.allocate(capacity: values.count)
     for (index, value) in values.enumerated() {
-      assert(value.runtime === runtime, "JavaScriptValue belongs to a different runtime than the buffer being initialized")
+      assert(
+        value.runtime === runtime, "JavaScriptValue belongs to a different runtime than the buffer being initialized")
       buffer.initializeElement(at: index, to: facebook.jsi.Value(runtime.pointee, value.pointee))
     }
     return JavaScriptValuesBuffer(runtime, buffer: buffer, ownsMemory: true)

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArray.swift
@@ -1,98 +1,90 @@
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
-/**
- A Swift representation of a JavaScript array. `JavaScriptArray` provides a bridge between JavaScript arrays
- and Swift, allowing you to access and manipulate JavaScript array elements from Swift code. It maintains a reference
- to the underlying JavaScript array and provides Swift-friendly APIs for common array operations.
- */
+/// A Swift representation of a JavaScript array. `JavaScriptArray` provides a bridge between JavaScript arrays
+/// and Swift, allowing you to access and manipulate JavaScript array elements from Swift code. It maintains a reference
+/// to the underlying JavaScript array and provides Swift-friendly APIs for common array operations.
 public struct JavaScriptArray: JavaScriptType, ~Copyable {
   internal weak let runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.Array
 
-  /**
-   Creates a new JavaScript array with the specified length.
-
-   This is the primary initializer for creating empty or pre-sized JavaScript arrays.
-   If no length is provided, an empty array is created. When a length is specified,
-   the array is created with that many elements, each initialized to `undefined`.
-
-   - Parameters:
-     - runtime: The JavaScript runtime in which to create the array
-     - length: The initial length of the array. Defaults to 0 (empty array).
-
-   ## Examples
-
-   ```swift
-   // Create an empty array
-   let empty = JavaScriptArray(runtime)
-
-   // Create an array with specific length (all elements are undefined)
-   let sized = JavaScriptArray(runtime, length: 10)
-   print(sized.length)  // 10
-   print(sized[0])      // undefined
-   ```
-
-   - Note: This initializer creates a new JavaScript array object in the runtime's heap.
-     The array's length can be modified later using the `length` property.
-   - SeeAlso: `init(_:items:)` for creating arrays with initial values
-   */
+  /// Creates a new JavaScript array with the specified length.
+  ///
+  /// This is the primary initializer for creating empty or pre-sized JavaScript arrays.
+  /// If no length is provided, an empty array is created. When a length is specified,
+  /// the array is created with that many elements, each initialized to `undefined`.
+  ///
+  /// - Parameters:
+  ///   - runtime: The JavaScript runtime in which to create the array
+  ///   - length: The initial length of the array. Defaults to 0 (empty array).
+  ///
+  /// ## Examples
+  ///
+  /// ```swift
+  /// // Create an empty array
+  /// let empty = JavaScriptArray(runtime)
+  ///
+  /// // Create an array with specific length (all elements are undefined)
+  /// let sized = JavaScriptArray(runtime, length: 10)
+  /// print(sized.length)  // 10
+  /// print(sized[0])      // undefined
+  /// ```
+  ///
+  /// - Note: This initializer creates a new JavaScript array object in the runtime's heap.
+  ///   The array's length can be modified later using the `length` property.
+  /// - SeeAlso: `init(_:items:)` for creating arrays with initial values
   public init(_ runtime: JavaScriptRuntime, length: Int = 0) {
     self.init(runtime, facebook.jsi.Array(runtime.pointee, length))
   }
 
-  /**
-   Creates a Swift wrapper around an existing JSI array object.
-
-   This internal initializer is used to wrap a C++ JSI `Array` object with a Swift
-   `JavaScriptArray` interface. It takes ownership of the provided JSI array using
-   Swift's consuming parameter ownership, ensuring proper move semantics.
-
-   - Parameters:
-     - runtime: The JavaScript runtime that owns the array
-     - pointee: The underlying JSI `Array` object to wrap (consumed)
-
-   - Note: This initializer is internal and used by the library's implementation to
-     bridge between the C++ JSI layer and Swift. It should not be called directly
-     by library consumers.
-   - Note: The `pointee` parameter uses consuming ownership, meaning the JSI array
-     object is moved into this structure and the caller's copy is invalidated.
-   */
+  /// Creates a Swift wrapper around an existing JSI array object.
+  ///
+  /// This internal initializer is used to wrap a C++ JSI `Array` object with a Swift
+  /// `JavaScriptArray` interface. It takes ownership of the provided JSI array using
+  /// Swift's consuming parameter ownership, ensuring proper move semantics.
+  ///
+  /// - Parameters:
+  ///   - runtime: The JavaScript runtime that owns the array
+  ///   - pointee: The underlying JSI `Array` object to wrap (consumed)
+  ///
+  /// - Note: This initializer is internal and used by the library's implementation to
+  ///   bridge between the C++ JSI layer and Swift. It should not be called directly
+  ///   by library consumers.
+  /// - Note: The `pointee` parameter uses consuming ownership, meaning the JSI array
+  ///   object is moved into this structure and the caller's copy is invalidated.
   internal init(_ runtime: JavaScriptRuntime, _ pointee: consuming facebook.jsi.Array) {
     self.runtime = runtime
     self.pointee = pointee
   }
 
-  /**
-   Creates a new JavaScript array initialized with the provided array of values.
-
-   This initializer allows you to create a JavaScript array from a Swift array of
-   `JavaScriptValue` elements. This is particularly useful when you already have
-   a collection of values and want to avoid the syntactic overhead of spreading them
-   as variadic arguments.
-
-   - Parameters:
-     - runtime: The JavaScript runtime in which to create the array
-     - items: A Swift array of `JavaScriptValue` elements to populate the array with
-
-   ## Examples
-
-   ```swift
-   // Create from an existing array
-   let values = [JavaScriptValue.number(1), .number(2), .number(3)]
-   let array = JavaScriptArray(runtime, items: values)
-
-   // Create from a mapped collection
-   let numbers = [1, 2, 3, 4, 5]
-   let jsValues = numbers.map { JavaScriptValue.number(Double($0)) }
-   let array = JavaScriptArray(runtime, items: jsValues)
-   ```
-
-   - Note: Due to limitations in Swift/C++ interop with `std::initializer_list`, this
-     implementation creates an empty array first and then populates it element by element,
-     rather than using JSI's `createWithElements` method directly.
-   - SeeAlso: `init(_:items:)` for the variadic argument version
-   */
+  /// Creates a new JavaScript array initialized with the provided array of values.
+  ///
+  /// This initializer allows you to create a JavaScript array from a Swift array of
+  /// `JavaScriptValue` elements. This is particularly useful when you already have
+  /// a collection of values and want to avoid the syntactic overhead of spreading them
+  /// as variadic arguments.
+  ///
+  /// - Parameters:
+  ///   - runtime: The JavaScript runtime in which to create the array
+  ///   - items: A Swift array of `JavaScriptValue` elements to populate the array with
+  ///
+  /// ## Examples
+  ///
+  /// ```swift
+  /// // Create from an existing array
+  /// let values = [JavaScriptValue.number(1), .number(2), .number(3)]
+  /// let array = JavaScriptArray(runtime, items: values)
+  ///
+  /// // Create from a mapped collection
+  /// let numbers = [1, 2, 3, 4, 5]
+  /// let jsValues = numbers.map { JavaScriptValue.number(Double($0)) }
+  /// let array = JavaScriptArray(runtime, items: jsValues)
+  /// ```
+  ///
+  /// - Note: Due to limitations in Swift/C++ interop with `std::initializer_list`, this
+  ///   implementation creates an empty array first and then populates it element by element,
+  ///   rather than using JSI's `createWithElements` method directly.
+  /// - SeeAlso: `init(_:items:)` for the variadic argument version
   public init(_ runtime: JavaScriptRuntime, items: [JavaScriptValue]) {
     self.init(runtime, length: items.count)
 
@@ -101,76 +93,72 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     }
   }
 
-  /**
-   Creates a new JavaScript array initialized with the provided values.
-
-   This convenience initializer allows you to create a JavaScript array from a variable
-   number of `JavaScriptValue` arguments. The array is created with the appropriate length
-   and populated with the provided values in order.
-
-   - Parameters:
-     - runtime: The JavaScript runtime in which to create the array
-     - items: A variadic list of `JavaScriptValue` elements to populate the array with
-
-   ## Examples
-
-   ```swift
-   // Create an empty array
-   let empty = JavaScriptArray(runtime, items: )
-
-   // Create an array with values
-   let numbers = JavaScriptArray(runtime, items: .number(1), .number(2), .number(3))
-
-   // Mix different value types
-   let mixed = JavaScriptArray(runtime,
-     items: .string("hello"), .number(42), .bool(true))
-   ```
-
-   - Note: This variadic version internally creates a Swift array and delegates to the
-     array-based initializer. If you already have an array of values, consider using
-     `init(_:items:)` directly for cleaner syntax.
-   - SeeAlso: `init(_:items:)` for the array version
-   */
+  /// Creates a new JavaScript array initialized with the provided values.
+  ///
+  /// This convenience initializer allows you to create a JavaScript array from a variable
+  /// number of `JavaScriptValue` arguments. The array is created with the appropriate length
+  /// and populated with the provided values in order.
+  ///
+  /// - Parameters:
+  ///   - runtime: The JavaScript runtime in which to create the array
+  ///   - items: A variadic list of `JavaScriptValue` elements to populate the array with
+  ///
+  /// ## Examples
+  ///
+  /// ```swift
+  /// // Create an empty array
+  /// let empty = JavaScriptArray(runtime, items: )
+  ///
+  /// // Create an array with values
+  /// let numbers = JavaScriptArray(runtime, items: .number(1), .number(2), .number(3))
+  ///
+  /// // Mix different value types
+  /// let mixed = JavaScriptArray(runtime,
+  ///   items: .string("hello"), .number(42), .bool(true))
+  /// ```
+  ///
+  /// - Note: This variadic version internally creates a Swift array and delegates to the
+  ///   array-based initializer. If you already have an array of values, consider using
+  ///   `init(_:items:)` directly for cleaner syntax.
+  /// - SeeAlso: `init(_:items:)` for the array version
   public init(_ runtime: JavaScriptRuntime, items: JavaScriptValue...) {
     self.init(runtime, items: items)
   }
 
-  /**
-   Creates a new JavaScript array from variadic arguments of any types conforming to `JavaScriptRepresentable`.
-
-   This generic initializer uses Swift's parameter pack feature to accept a variable number of
-   arguments of potentially different types, as long as each type conforms to `JavaScriptRepresentable`.
-   This provides a type-safe and ergonomic way to create JavaScript arrays from Swift values without
-   needing to manually convert them to `JavaScriptValue` first.
-
-   - Parameters:
-     - runtime: The JavaScript runtime in which to create the array
-     - items: A variadic parameter pack of values conforming to `JavaScriptRepresentable`
-
-   ## Examples
-
-   ```swift
-   // Mix different Swift types directly
-   let array = JavaScriptArray(runtime, items: 42, "hello", true, 3.14)
-
-   // All same type works too
-   let numbers = JavaScriptArray(runtime, items: 1, 2, 3, 4, 5)
-
-   // Use with custom types that conform to JavaScriptRepresentable
-   struct Person: JavaScriptRepresentable {
-     let name: String
-     let age: Int
-   }
-   let people = [Person(name: "Alice", age: 30), Person(name: "Bob", age: 25)]
-   let array = JavaScriptArray(runtime, items: people[0], people[1])
-   ```
-
-   - Note: This initializer automatically converts each item to a `JavaScriptValue` using
-     its `toJavaScriptValue(in:)` method, providing compile-time type safety.
-   - Note: Unlike the `JavaScriptValue` variadic initializer, this version accepts heterogeneous
-     types directly without requiring explicit `JavaScriptValue` wrapping.
-   - SeeAlso: `init(_:items:)` for the `JavaScriptValue` array version
-   */
+  /// Creates a new JavaScript array from variadic arguments of any types conforming to `JavaScriptRepresentable`.
+  ///
+  /// This generic initializer uses Swift's parameter pack feature to accept a variable number of
+  /// arguments of potentially different types, as long as each type conforms to `JavaScriptRepresentable`.
+  /// This provides a type-safe and ergonomic way to create JavaScript arrays from Swift values without
+  /// needing to manually convert them to `JavaScriptValue` first.
+  ///
+  /// - Parameters:
+  ///   - runtime: The JavaScript runtime in which to create the array
+  ///   - items: A variadic parameter pack of values conforming to `JavaScriptRepresentable`
+  ///
+  /// ## Examples
+  ///
+  /// ```swift
+  /// // Mix different Swift types directly
+  /// let array = JavaScriptArray(runtime, items: 42, "hello", true, 3.14)
+  ///
+  /// // All same type works too
+  /// let numbers = JavaScriptArray(runtime, items: 1, 2, 3, 4, 5)
+  ///
+  /// // Use with custom types that conform to JavaScriptRepresentable
+  /// struct Person: JavaScriptRepresentable {
+  ///   let name: String
+  ///   let age: Int
+  /// }
+  /// let people = [Person(name: "Alice", age: 30), Person(name: "Bob", age: 25)]
+  /// let array = JavaScriptArray(runtime, items: people[0], people[1])
+  /// ```
+  ///
+  /// - Note: This initializer automatically converts each item to a `JavaScriptValue` using
+  ///   its `toJavaScriptValue(in:)` method, providing compile-time type safety.
+  /// - Note: Unlike the `JavaScriptValue` variadic initializer, this version accepts heterogeneous
+  ///   types directly without requiring explicit `JavaScriptValue` wrapping.
+  /// - SeeAlso: `init(_:items:)` for the `JavaScriptValue` array version
   public init<each T: JavaScriptRepresentable>(_ runtime: JavaScriptRuntime, items: repeat each T) {
     var length: Int = 0
     for _ in repeat each items {
@@ -186,42 +174,40 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     }
   }
 
-  /**
-   The length of the JavaScript array, equivalent to the `length` property in JavaScript.
-
-   This property provides direct access to the array's length, which can be both read and
-   modified. Changing the length affects the array size, matching JavaScript's behavior.
-
-   ## Getting the Length
-
-   Returns the current number of elements in the array:
-
-   ```swift
-   let array = try runtime.eval("[1, 2, 3]").getArray()
-   print(array.length) // 3
-   ```
-
-   ## Setting the Length
-
-   Modifying the length changes the array size:
-   - **Increasing** the length adds `undefined` elements to fill the gap
-   - **Decreasing** the length truncates the array, removing elements
-
-   ```swift
-   let array = try runtime.eval("[1, 2, 3, 4, 5]").getArray()
-
-   // Truncate the array
-   array.length = 3
-   // Array is now [1, 2, 3]
-
-   // Expand the array
-   array.length = 5
-   // Array is now [1, 2, 3, undefined, undefined]
-   ```
-
-   - Note: This property directly modifies the JavaScript array's `length` property,
-     providing the same semantics as `array.length = newValue` in JavaScript.
-   */
+  /// The length of the JavaScript array, equivalent to the `length` property in JavaScript.
+  ///
+  /// This property provides direct access to the array's length, which can be both read and
+  /// modified. Changing the length affects the array size, matching JavaScript's behavior.
+  ///
+  /// ## Getting the Length
+  ///
+  /// Returns the current number of elements in the array:
+  ///
+  /// ```swift
+  /// let array = try runtime.eval("[1, 2, 3]").getArray()
+  /// print(array.length) // 3
+  /// ```
+  ///
+  /// ## Setting the Length
+  ///
+  /// Modifying the length changes the array size:
+  /// - **Increasing** the length adds `undefined` elements to fill the gap
+  /// - **Decreasing** the length truncates the array, removing elements
+  ///
+  /// ```swift
+  /// let array = try runtime.eval("[1, 2, 3, 4, 5]").getArray()
+  ///
+  /// // Truncate the array
+  /// array.length = 3
+  /// // Array is now [1, 2, 3]
+  ///
+  /// // Expand the array
+  /// array.length = 5
+  /// // Array is now [1, 2, 3, undefined, undefined]
+  /// ```
+  ///
+  /// - Note: This property directly modifies the JavaScript array's `length` property,
+  ///   providing the same semantics as `array.length = newValue` in JavaScript.
   public var length: Int {
     get {
       guard let runtime else {
@@ -237,14 +223,12 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     }
   }
 
-  /**
-   Retrieves the value at the specified index in the array.
-
-   - Parameter index: The zero-based index of the element to retrieve
-   - Returns: The `JavaScriptValue` at the specified index
-   - Throws: `JavaScriptArray.Errors.indexOutOfRange` if the index is negative or
-     greater than or equal to the array's length
-   */
+  /// Retrieves the value at the specified index in the array.
+  ///
+  /// - Parameter index: The zero-based index of the element to retrieve
+  /// - Returns: The `JavaScriptValue` at the specified index
+  /// - Throws: `JavaScriptArray.Errors.indexOutOfRange` if the index is negative or
+  ///   greater than or equal to the array's length
   public func getValue(at index: Int) throws -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -256,24 +240,20 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     return JavaScriptValue(runtime, pointee.getValueAtIndex(runtime.pointee, index))
   }
 
-  /**
-   Returns the value at the given index without bounds-checking. Used by the iteration
-   helpers (`map`, `forEach`, `reduce`, `filter`, `enumerated`) which iterate
-   `0..<length` and never produce an out-of-range index. Skipping the redundant bounds
-   check avoids a weak-runtime load on every element on the hot path.
-   */
+  /// Returns the value at the given index without bounds-checking. Used by the iteration
+  /// helpers (`map`, `forEach`, `reduce`, `filter`, `enumerated`) which iterate
+  /// `0..<length` and never produce an out-of-range index. Skipping the redundant bounds
+  /// check avoids a weak-runtime load on every element on the hot path.
   internal func getValueUnchecked(at index: Int, in runtime: JavaScriptRuntime) -> JavaScriptValue {
     return JavaScriptValue(runtime, pointee.getValueAtIndex(runtime.pointee, index))
   }
 
-  /**
-   Sets the element at the specified index.
-
-   - Parameters:
-     - value: The value to set, conforming to `JavaScriptRepresentable`
-     - index: The zero-based index where the value should be set
-   - Throws: `JavaScriptArray.Errors.indexOutOfRange` if the index is out of bounds
-   */
+  /// Sets the element at the specified index.
+  ///
+  /// - Parameters:
+  ///   - value: The value to set, conforming to `JavaScriptRepresentable`
+  ///   - index: The zero-based index where the value should be set
+  /// - Throws: `JavaScriptArray.Errors.indexOutOfRange` if the index is out of bounds
   public func set<T: JavaScriptRepresentable & ~Copyable>(value: borrowing T, at index: Int) throws {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -286,42 +266,40 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     expo.setValueAtIndex(runtime.pointee, pointee, index, jsiValue)
   }
 
-  /**
-   Accesses array elements by numeric index with safe, non-throwing behavior.
-
-   This subscript provides a convenient way to read and write array elements without
-   explicit error handling. It mimics JavaScript's array behavior by automatically
-   handling out-of-bounds access and dynamic resizing.
-
-   - Parameter index: The zero-based index of the element to access or modify
-   - Returns: The `JavaScriptValue` at the specified index, or `undefined` if the index
-     is out of range
-
-   ## Getting Values
-
-   Returns `undefined` if the index is out of bounds (no error thrown):
-
-   ```swift
-   let array = try runtime.eval("[1, 2, 3]").getArray()
-   let value = array[1]           // JavaScriptValue(2)
-   let outOfRange = array[10]     // JavaScriptValue.undefined
-   ```
-
-   ## Setting Values
-
-   Automatically expands the array if the index is beyond the current length:
-
-   ```swift
-   let array = try runtime.eval("[1, 2, 3]").getArray()
-   array[1] = .number(99)         // Updates existing element
-   array[10] = .string("hello")   // Expands array to size 11
-   ```
-
-   - Note: This subscript never throws. For strict bounds checking with errors,
-     use `getValue(at:)` and `set(value:at:)` instead.
-   - Note: When setting an element beyond the current length, intermediate elements
-     are filled with `undefined`, matching JavaScript's behavior.
-   */
+  /// Accesses array elements by numeric index with safe, non-throwing behavior.
+  ///
+  /// This subscript provides a convenient way to read and write array elements without
+  /// explicit error handling. It mimics JavaScript's array behavior by automatically
+  /// handling out-of-bounds access and dynamic resizing.
+  ///
+  /// - Parameter index: The zero-based index of the element to access or modify
+  /// - Returns: The `JavaScriptValue` at the specified index, or `undefined` if the index
+  ///   is out of range
+  ///
+  /// ## Getting Values
+  ///
+  /// Returns `undefined` if the index is out of bounds (no error thrown):
+  ///
+  /// ```swift
+  /// let array = try runtime.eval("[1, 2, 3]").getArray()
+  /// let value = array[1]           // JavaScriptValue(2)
+  /// let outOfRange = array[10]     // JavaScriptValue.undefined
+  /// ```
+  ///
+  /// ## Setting Values
+  ///
+  /// Automatically expands the array if the index is beyond the current length:
+  ///
+  /// ```swift
+  /// let array = try runtime.eval("[1, 2, 3]").getArray()
+  /// array[1] = .number(99)         // Updates existing element
+  /// array[10] = .string("hello")   // Expands array to size 11
+  /// ```
+  ///
+  /// - Note: This subscript never throws. For strict bounds checking with errors,
+  ///   use `getValue(at:)` and `set(value:at:)` instead.
+  /// - Note: When setting an element beyond the current length, intermediate elements
+  ///   are filled with `undefined`, matching JavaScript's behavior.
   public subscript(index: Int) -> JavaScriptValue {
     get {
       return (try? self.getValue(at: index)) ?? .undefined
@@ -337,46 +315,44 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     }
   }
 
-  /**
-   Type-safe subscript for accessing and modifying array elements with automatic conversion.
-
-   This subscript provides a convenient way to work with JavaScript array elements using
-   Swift types that conform to `JavaScriptRepresentable`. It automatically converts between
-   JavaScript values and Swift types.
-
-   - Parameter index: The zero-based index of the element to access or modify
-   - Returns: An optional value of type `T` if the element exists and can be converted,
-     or `nil` if the index is out of range or conversion fails
-
-   ## Getting Values
-
-   When reading, returns `nil` if:
-   - The index is out of range
-   - The JavaScript value cannot be converted to type `T`
-
-   ```swift
-   let array = try runtime.eval("[1, 2, 3]").getArray()
-   let value: Int? = array[0]  // Returns 1
-   let outOfRange: Int? = array[10]  // Returns nil
-   ```
-
-   ## Setting Values
-
-   When writing:
-   - Automatically resizes the array if the index is beyond the current length (JavaScript behavior)
-   - Setting `nil` sets the element to `undefined`
-   - Accepts any value conforming to `JavaScriptRepresentable`
-
-   ```swift
-   array[0] = 42              // Sets element to number
-   array[5] = "hello"         // Resizes array and sets element
-   array[1] = nil             // Sets element to undefined
-   ```
-
-   - Note: Unlike `getValue(at:)` and `set(value:at:)`, this subscript mimics JavaScript's
-     dynamic array behavior by automatically expanding the array when setting elements beyond
-     the current length.
-   */
+  /// Type-safe subscript for accessing and modifying array elements with automatic conversion.
+  ///
+  /// This subscript provides a convenient way to work with JavaScript array elements using
+  /// Swift types that conform to `JavaScriptRepresentable`. It automatically converts between
+  /// JavaScript values and Swift types.
+  ///
+  /// - Parameter index: The zero-based index of the element to access or modify
+  /// - Returns: An optional value of type `T` if the element exists and can be converted,
+  ///   or `nil` if the index is out of range or conversion fails
+  ///
+  /// ## Getting Values
+  ///
+  /// When reading, returns `nil` if:
+  /// - The index is out of range
+  /// - The JavaScript value cannot be converted to type `T`
+  ///
+  /// ```swift
+  /// let array = try runtime.eval("[1, 2, 3]").getArray()
+  /// let value: Int? = array[0]  // Returns 1
+  /// let outOfRange: Int? = array[10]  // Returns nil
+  /// ```
+  ///
+  /// ## Setting Values
+  ///
+  /// When writing:
+  /// - Automatically resizes the array if the index is beyond the current length (JavaScript behavior)
+  /// - Setting `nil` sets the element to `undefined`
+  /// - Accepts any value conforming to `JavaScriptRepresentable`
+  ///
+  /// ```swift
+  /// array[0] = 42              // Sets element to number
+  /// array[5] = "hello"         // Resizes array and sets element
+  /// array[1] = nil             // Sets element to undefined
+  /// ```
+  ///
+  /// - Note: Unlike `getValue(at:)` and `set(value:at:)`, this subscript mimics JavaScript's
+  ///   dynamic array behavior by automatically expanding the array when setting elements beyond
+  ///   the current length.
   public subscript<T: JavaScriptRepresentable & ~Copyable>(index: Int) -> T? {
     get {
       return try? T.fromJavaScriptValue(self.getValue(at: index))
@@ -388,42 +364,41 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
       if index >= length {
         self.length = index + 1
       }
-      let jsiValue = if let newValue {
-        newValue.toJavaScriptValue(in: runtime).toJSIValue(in: runtime.pointee)
-      } else {
-        facebook.jsi.Value.undefined()
-      }
+      let jsiValue =
+        if let newValue {
+          newValue.toJavaScriptValue(in: runtime).toJSIValue(in: runtime.pointee)
+        } else {
+          facebook.jsi.Value.undefined()
+        }
       expo.setValueAtIndex(runtime.pointee, pointee, index, jsiValue)
     }
   }
 
-  /**
-   Accesses properties of the array using string keys.
-
-   Since JavaScript arrays are also objects, they can have named properties in addition
-   to numeric indices. This subscript allows you to access and modify these properties.
-
-   - Parameter key: The property name to access or modify
-   - Returns: The value of the property as a `JavaScriptValue`
-
-   ## Examples
-
-   ```swift
-   let array = try runtime.eval("[1, 2, 3]").getArray()
-
-   // Access built-in properties
-   let length = array["length"]  // JavaScriptValue(3)
-
-   // Set custom properties
-   array["customProperty"] = .string("custom value")
-
-   // Access custom properties
-   let custom = array["customProperty"]  // JavaScriptValue("custom value")
-   ```
-
-   - Note: This subscript accesses object properties, not array elements. To access
-     array elements by index, use the numeric subscript `array[0]` instead of `array["0"]`.
-   */
+  /// Accesses properties of the array using string keys.
+  ///
+  /// Since JavaScript arrays are also objects, they can have named properties in addition
+  /// to numeric indices. This subscript allows you to access and modify these properties.
+  ///
+  /// - Parameter key: The property name to access or modify
+  /// - Returns: The value of the property as a `JavaScriptValue`
+  ///
+  /// ## Examples
+  ///
+  /// ```swift
+  /// let array = try runtime.eval("[1, 2, 3]").getArray()
+  ///
+  /// // Access built-in properties
+  /// let length = array["length"]  // JavaScriptValue(3)
+  ///
+  /// // Set custom properties
+  /// array["customProperty"] = .string("custom value")
+  ///
+  /// // Access custom properties
+  /// let custom = array["customProperty"]  // JavaScriptValue("custom value")
+  /// ```
+  ///
+  /// - Note: This subscript accesses object properties, not array elements. To access
+  ///   array elements by index, use the numeric subscript `array[0]` instead of `array["0"]`.
   public subscript(key: String) -> JavaScriptValue {
     get {
       guard let runtime else {
@@ -441,20 +416,18 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     }
   }
 
-  /**
-   Transforms each element in the JavaScript array using the provided closure. This method creates a new Swift array
-   by calling the transform closure on each element of the JavaScript array.
-   The closure receives a `JavaScriptValue` for each element and returns a transformed value.
-
-   - Parameter transform: A closure that accepts a `JavaScriptValue` representing an element
-     from the array and returns a transformed value. The closure can throw an error, which
-     will be propagated to the caller.
-   - Returns: A Swift array containing the transformed elements in the same order as
-     the original JavaScript array.
-   - Throws: Any error thrown by the `transform` closure.
-   - Note: This method uses Swift's standard `map` semantics and follows the `rethrows`
-     pattern, meaning it only throws if the transform closure throws.
-   */
+  /// Transforms each element in the JavaScript array using the provided closure. This method creates a new Swift array
+  /// by calling the transform closure on each element of the JavaScript array.
+  /// The closure receives a `JavaScriptValue` for each element and returns a transformed value.
+  ///
+  /// - Parameter transform: A closure that accepts a `JavaScriptValue` representing an element
+  ///   from the array and returns a transformed value. The closure can throw an error, which
+  ///   will be propagated to the caller.
+  /// - Returns: A Swift array containing the transformed elements in the same order as
+  ///   the original JavaScript array.
+  /// - Throws: Any error thrown by the `transform` closure.
+  /// - Note: This method uses Swift's standard `map` semantics and follows the `rethrows`
+  ///   pattern, meaning it only throws if the transform closure throws.
   public func map<T>(_ transform: (_ value: JavaScriptValue) throws -> T) rethrows -> [T] {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -469,14 +442,12 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     return result
   }
 
-  /**
-   Converts the JavaScript array to a `JavaScriptValue`.
-
-   - Returns: A `JavaScriptValue` representing this array
-   - Note: The returned value maintains a reference to the same underlying JavaScript
-     array, so modifications to the array in JavaScript will be reflected in the value.
-   - SeeAlso: `JavaScriptValue.getArray()` for the inverse operation
-   */
+  /// Converts the JavaScript array to a `JavaScriptValue`.
+  ///
+  /// - Returns: A `JavaScriptValue` representing this array
+  /// - Note: The returned value maintains a reference to the same underlying JavaScript
+  ///   array, so modifications to the array in JavaScript will be reflected in the value.
+  /// - SeeAlso: `JavaScriptValue.getArray()` for the inverse operation
   public func asValue() -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -484,43 +455,37 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
     return JavaScriptValue(runtime, expo.valueFromArray(runtime.pointee, pointee))
   }
 
-  /**
-   Converts the array to a `JavaScriptObject`.
-
-   Since JavaScript arrays are also objects, this method allows you to access the array
-   as a generic object to use object-specific APIs like property enumeration or prototype
-   manipulation.
-
-   - Returns: A `JavaScriptObject` representing the same underlying array
-
-   ```swift
-   let array = try runtime.eval("[1, 2, 3]").getArray()
-   let object = array.toObject()
-
-   // Access array properties as an object
-   let length = object.getProperty("length")  // JavaScriptValue(3)
-   ```
-
-   - Note: The returned object maintains a reference to the same underlying JavaScript
-     array, so modifications through either the array or object interface will affect
-     the same data.
-   - SeeAlso: `asValue()` for converting to a `JavaScriptValue`
-   */
+  /// Converts the array to a `JavaScriptObject`.
+  ///
+  /// Since JavaScript arrays are also objects, this method allows you to access the array
+  /// as a generic object to use object-specific APIs like property enumeration or prototype
+  /// manipulation.
+  ///
+  /// - Returns: A `JavaScriptObject` representing the same underlying array
+  ///
+  /// ```swift
+  /// let array = try runtime.eval("[1, 2, 3]").getArray()
+  /// let object = array.toObject()
+  ///
+  /// // Access array properties as an object
+  /// let length = object.getProperty("length")  // JavaScriptValue(3)
+  /// ```
+  ///
+  /// - Note: The returned object maintains a reference to the same underlying JavaScript
+  ///   array, so modifications through either the array or object interface will affect
+  ///   the same data.
+  /// - SeeAlso: `asValue()` for converting to a `JavaScriptValue`
   public func toObject() -> JavaScriptObject {
     return asValue().getObject()
   }
 
-  /**
-   Errors that can occur when working with JavaScript arrays.
-   */
+  /// Errors that can occur when working with JavaScript arrays.
   public enum Errors: Error, Equatable, CustomStringConvertible {
-    /**
-     The specified index is out of the array's valid range.
-
-     - Parameters:
-       - index: The invalid index that was accessed
-       - length: The actual length of the array
-     */
+    /// The specified index is out of the array's valid range.
+    ///
+    /// - Parameters:
+    ///   - index: The invalid index that was accessed
+    ///   - length: The actual length of the array
     case indexOutOfRange(index: Int, length: Int)
 
     public var description: String {
@@ -540,11 +505,9 @@ public struct JavaScriptArray: JavaScriptType, ~Copyable {
 // equivalent functionality without requiring protocol conformance.
 
 extension JavaScriptArray {
-  /**
-   Returns an array of `(offset, element)` pairs, similar to `Sequence.enumerated()`.
-
-   - Note: Eagerly evaluates all elements. For large arrays, prefer `forEach(_:)`.
-   */
+  /// Returns an array of `(offset, element)` pairs, similar to `Sequence.enumerated()`.
+  ///
+  /// - Note: Eagerly evaluates all elements. For large arrays, prefer `forEach(_:)`.
   public func enumerated() -> [(offset: Int, element: JavaScriptValue)] {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -558,9 +521,7 @@ extension JavaScriptArray {
     return result
   }
 
-  /**
-   Calls the given closure on each element in the array.
-   */
+  /// Calls the given closure on each element in the array.
   public func forEach(_ body: (JavaScriptValue) throws -> Void) rethrows {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -571,9 +532,7 @@ extension JavaScriptArray {
     }
   }
 
-  /**
-   Returns an array of elements satisfying the given predicate.
-   */
+  /// Returns an array of elements satisfying the given predicate.
   public func filter(_ isIncluded: (JavaScriptValue) throws -> Bool) rethrows -> [JavaScriptValue] {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -589,10 +548,10 @@ extension JavaScriptArray {
     return result
   }
 
-  /**
-   Returns the result of combining the elements using the given closure.
-   */
-  public func reduce<Result>(_ initialResult: Result, _ nextPartialResult: (Result, JavaScriptValue) throws -> Result) rethrows -> Result {
+  /// Returns the result of combining the elements using the given closure.
+  public func reduce<Result>(_ initialResult: Result, _ nextPartialResult: (Result, JavaScriptValue) throws -> Result)
+    rethrows -> Result
+  {
     guard let runtime else {
       FatalError.runtimeLost()
     }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArrayBuffer.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptArrayBuffer.swift
@@ -1,12 +1,10 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
-/**
- A Swift representation of a JavaScript array buffer. Provides access to the
- underlying raw data pointer and size of the buffer.
- */
+/// A Swift representation of a JavaScript array buffer. Provides access to the
+/// underlying raw data pointer and size of the buffer.
 public struct JavaScriptArrayBuffer: ~Copyable {
   internal weak let runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.ArrayBuffer
@@ -16,10 +14,8 @@ public struct JavaScriptArrayBuffer: ~Copyable {
     self.pointee = arrayBuffer
   }
 
-  /**
-   Returns the size of the array buffer storage in bytes.
-   This is not affected by overriding the `byteLength` property.
-   */
+  /// Returns the size of the array buffer storage in bytes.
+  /// This is not affected by overriding the `byteLength` property.
   public var size: Int {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -27,14 +23,10 @@ public struct JavaScriptArrayBuffer: ~Copyable {
     return Int(expo.arrayBufferSize(runtime.pointee, pointee))
   }
 
-  /**
-   Alias for `size` that matches JavaScript's `ArrayBuffer.byteLength` property.
-   */
+  /// Alias for `size` that matches JavaScript's `ArrayBuffer.byteLength` property.
   public var byteLength: Int { size }
 
-  /**
-   Returns a pointer to the underlying data of the array buffer.
-   */
+  /// Returns a pointer to the underlying data of the array buffer.
   public func data() -> UnsafeMutablePointer<UInt8> {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -42,9 +34,7 @@ public struct JavaScriptArrayBuffer: ~Copyable {
     return expo.arrayBufferData(runtime.pointee, pointee)
   }
 
-  /**
-   Creates a new array buffer with a copy of this buffer's data.
-   */
+  /// Creates a new array buffer with a copy of this buffer's data.
   public func copy() -> JavaScriptArrayBuffer {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -57,9 +47,7 @@ public struct JavaScriptArrayBuffer: ~Copyable {
 
   // MARK: - Conversions
 
-  /**
-   Returns this array buffer as a `JavaScriptValue`.
-   */
+  /// Returns this array buffer as a `JavaScriptValue`.
   public func asValue() -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptBigInt.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptBigInt.swift
@@ -1,131 +1,122 @@
 internal import jsi
 
-/**
- A Swift representation of a JavaScript BigInt. BigInt is a built-in JavaScript object that provides
- a way to represent whole numbers larger than 2^53 - 1, which is the largest number JavaScript can
- reliably represent with the Number primitive.
-
- BigInts can be created from 64-bit integers (signed or unsigned) and can be converted back to
- 64-bit integers with optional validation to ensure no data loss.
-
- ## Example Usage
- ```swift
- let runtime = JavaScriptRuntime()
-
- // Create from Int64
- let bigInt = JavaScriptBigInt(runtime, fromInt64: 9007199254740991)
-
- // Create from UInt64
- let largeBigInt = JavaScriptBigInt(runtime, fromUint64: UInt64.max)
-
- // Convert to string with different radixes
- let decimal = bigInt.toString(radix: 10)  // "9007199254740991"
- let hex = bigInt.toString(radix: 16)      // "1fffffffffffff"
- let binary = bigInt.toString(radix: 2)    // "11111111111111111111111111111111111111111111111111111"
-
- // Safe conversion back to integers
- if bigInt.isInt64() {
-   let value = try bigInt.asInt64()  // Safe conversion
- }
-
- // Equality testing
- let another = JavaScriptBigInt(runtime, fromInt64: 9007199254740991)
- if bigInt == another {
-   print("BigInts are equal")
- }
- ```
-
- - Note: BigInt values cannot be mixed with Number values in arithmetic operations in JavaScript.
- You must explicitly convert between them.
- */
+/// A Swift representation of a JavaScript BigInt. BigInt is a built-in JavaScript object that provides
+/// a way to represent whole numbers larger than 2^53 - 1, which is the largest number JavaScript can
+/// reliably represent with the Number primitive.
+///
+/// BigInts can be created from 64-bit integers (signed or unsigned) and can be converted back to
+/// 64-bit integers with optional validation to ensure no data loss.
+///
+/// ## Example Usage
+/// ```swift
+/// let runtime = JavaScriptRuntime()
+///
+/// // Create from Int64
+/// let bigInt = JavaScriptBigInt(runtime, fromInt64: 9007199254740991)
+///
+/// // Create from UInt64
+/// let largeBigInt = JavaScriptBigInt(runtime, fromUint64: UInt64.max)
+///
+/// // Convert to string with different radixes
+/// let decimal = bigInt.toString(radix: 10)  // "9007199254740991"
+/// let hex = bigInt.toString(radix: 16)      // "1fffffffffffff"
+/// let binary = bigInt.toString(radix: 2)    // "11111111111111111111111111111111111111111111111111111"
+///
+/// // Safe conversion back to integers
+/// if bigInt.isInt64() {
+///   let value = try bigInt.asInt64()  // Safe conversion
+/// }
+///
+/// // Equality testing
+/// let another = JavaScriptBigInt(runtime, fromInt64: 9007199254740991)
+/// if bigInt == another {
+///   print("BigInts are equal")
+/// }
+/// ```
+///
+/// - Note: BigInt values cannot be mixed with Number values in arithmetic operations in JavaScript.
+/// You must explicitly convert between them.
 public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
   internal weak let runtime: JavaScriptRuntime?
   internal var pointee: facebook.jsi.BigInt
 
-  /**
-   Creates a BigInt from an existing JSI BigInt.
-   */
+  /// Creates a BigInt from an existing JSI BigInt.
   internal init(_ runtime: JavaScriptRuntime, _ bigInt: consuming facebook.jsi.BigInt) {
     self.runtime = runtime
     self.pointee = bigInt
   }
 
-  /**
-   Creates a BigInt from a signed 64-bit integer.
-
-   - Parameters:
-     - runtime: The JavaScript runtime
-     - value: The Int64 value to convert to BigInt
-   */
+  /// Creates a BigInt from a signed 64-bit integer.
+  ///
+  /// - Parameters:
+  ///   - runtime: The JavaScript runtime
+  ///   - value: The Int64 value to convert to BigInt
   public init(_ runtime: JavaScriptRuntime, fromInt64 value: Int64) {
     self.runtime = runtime
     self.pointee = facebook.jsi.BigInt.fromInt64(runtime.pointee, value)
   }
 
-  /**
-   Creates a BigInt from an unsigned 64-bit integer.
-
-   - Parameters:
-     - runtime: The JavaScript runtime
-     - value: The UInt64 value to convert to BigInt
-   */
+  /// Creates a BigInt from an unsigned 64-bit integer.
+  ///
+  /// - Parameters:
+  ///   - runtime: The JavaScript runtime
+  ///   - value: The UInt64 value to convert to BigInt
   public init(_ runtime: JavaScriptRuntime, fromUint64 value: UInt64) {
     self.runtime = runtime
     self.pointee = facebook.jsi.BigInt.fromUint64(runtime.pointee, value)
   }
 
-  /**
-   Creates a BigInt from a string representation.
-
-   This initializer parses a string to create a BigInt value. The string can be in decimal format
-   or use prefixes for other bases (e.g., "0x" for hexadecimal, "0o" for octal, "0b" for binary).
-   Unlike the numeric initializers which are limited to 64-bit ranges, this initializer can create
-   BigInt values of arbitrary size.
-
-   - Parameters:
-     - runtime: The JavaScript runtime
-     - string: A string representation of the number to parse. Can include:
-       - Decimal: "12345" or "-12345"
-       - Hexadecimal: "0xFF" or "0xff"
-       - Octal: "0o77"
-       - Binary: "0b1111"
-
-   - Throws: An error if the string cannot be parsed as a valid BigInt. This can occur if:
-     - The string is empty
-     - The string contains invalid characters
-     - The string format is not recognized by JavaScript's `BigInt()` constructor
-
-   - Note: This method calls JavaScript's `BigInt()` constructor internally, so it follows
-     the same parsing rules as JavaScript. Whitespace is trimmed automatically.
-
-   ## Examples
-   ```swift
-   // Create from decimal string
-   let bigInt1 = try JavaScriptBigInt(runtime, string: "123456789012345678901234567890")
-
-   // Create from hexadecimal string
-   let bigInt2 = try JavaScriptBigInt(runtime, string: "0xFFFFFFFFFFFFFFFF")
-
-   // Create from binary string
-   let bigInt3 = try JavaScriptBigInt(runtime, string: "0b11111111")
-
-   // Create from octal string
-   let bigInt4 = try JavaScriptBigInt(runtime, string: "0o777")
-
-   // Negative values
-   let bigInt5 = try JavaScriptBigInt(runtime, string: "-999999999999999999")
-
-   // Handle errors
-   do {
-     let bigInt = try JavaScriptBigInt(runtime, string: "invalid")
-   } catch {
-     print("Failed to parse BigInt: \(error)")
-   }
-   ```
-   */
+  /// Creates a BigInt from a string representation.
+  ///
+  /// This initializer parses a string to create a BigInt value. The string can be in decimal format
+  /// or use prefixes for other bases (e.g., "0x" for hexadecimal, "0o" for octal, "0b" for binary).
+  /// Unlike the numeric initializers which are limited to 64-bit ranges, this initializer can create
+  /// BigInt values of arbitrary size.
+  ///
+  /// - Parameters:
+  ///   - runtime: The JavaScript runtime
+  ///   - string: A string representation of the number to parse. Can include:
+  ///     - Decimal: "12345" or "-12345"
+  ///     - Hexadecimal: "0xFF" or "0xff"
+  ///     - Octal: "0o77"
+  ///     - Binary: "0b1111"
+  ///
+  /// - Throws: An error if the string cannot be parsed as a valid BigInt. This can occur if:
+  ///   - The string is empty
+  ///   - The string contains invalid characters
+  ///   - The string format is not recognized by JavaScript's `BigInt()` constructor
+  ///
+  /// - Note: This method calls JavaScript's `BigInt()` constructor internally, so it follows
+  ///   the same parsing rules as JavaScript. Whitespace is trimmed automatically.
+  ///
+  /// ## Examples
+  /// ```swift
+  /// // Create from decimal string
+  /// let bigInt1 = try JavaScriptBigInt(runtime, string: "123456789012345678901234567890")
+  ///
+  /// // Create from hexadecimal string
+  /// let bigInt2 = try JavaScriptBigInt(runtime, string: "0xFFFFFFFFFFFFFFFF")
+  ///
+  /// // Create from binary string
+  /// let bigInt3 = try JavaScriptBigInt(runtime, string: "0b11111111")
+  ///
+  /// // Create from octal string
+  /// let bigInt4 = try JavaScriptBigInt(runtime, string: "0o777")
+  ///
+  /// // Negative values
+  /// let bigInt5 = try JavaScriptBigInt(runtime, string: "-999999999999999999")
+  ///
+  /// // Handle errors
+  /// do {
+  ///   let bigInt = try JavaScriptBigInt(runtime, string: "invalid")
+  /// } catch {
+  ///   print("Failed to parse BigInt: \(error)")
+  /// }
+  /// ```
   public init(_ runtime: JavaScriptRuntime, string: String) throws {
     self.runtime = runtime
-    self.pointee = try runtime
+    self.pointee =
+      try runtime
       .global()
       .getPropertyAsFunction("BigInt")
       .call(arguments: string)
@@ -135,13 +126,11 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
 
   // MARK: - Conversions to Integer Types
 
-  /**
-   Returns whether this BigInt can be losslessly converted to a signed 64-bit integer.
-
-   If this returns `true`, calling `asInt64()` will succeed without throwing.
-
-   - Returns: `true` if the BigInt fits in an Int64 range, `false` otherwise
-   */
+  /// Returns whether this BigInt can be losslessly converted to a signed 64-bit integer.
+  ///
+  /// If this returns `true`, calling `asInt64()` will succeed without throwing.
+  ///
+  /// - Returns: `true` if the BigInt fits in an Int64 range, `false` otherwise
   public func isInt64() -> Bool {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -149,13 +138,11 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
     return pointee.isInt64(runtime.pointee)
   }
 
-  /**
-   Returns whether this BigInt can be losslessly converted to an unsigned 64-bit integer.
-
-   If this returns `true`, calling `asUint64()` will succeed without throwing.
-
-   - Returns: `true` if the BigInt fits in a UInt64 range, `false` otherwise
-   */
+  /// Returns whether this BigInt can be losslessly converted to an unsigned 64-bit integer.
+  ///
+  /// If this returns `true`, calling `asUint64()` will succeed without throwing.
+  ///
+  /// - Returns: `true` if the BigInt fits in a UInt64 range, `false` otherwise
   public func isUint64() -> Bool {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -163,14 +150,12 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
     return pointee.isUint64(runtime.pointee)
   }
 
-  /**
-   Returns this BigInt truncated to a signed 64-bit integer.
-
-   This method always succeeds but may lose data if the BigInt is outside the Int64 range.
-   Use `isInt64()` first to check if conversion is lossless, or use `asInt64()` for safe conversion.
-
-   - Returns: The truncated Int64 value
-   */
+  /// Returns this BigInt truncated to a signed 64-bit integer.
+  ///
+  /// This method always succeeds but may lose data if the BigInt is outside the Int64 range.
+  /// Use `isInt64()` first to check if conversion is lossless, or use `asInt64()` for safe conversion.
+  ///
+  /// - Returns: The truncated Int64 value
   public func getInt64() -> Int64 {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -178,14 +163,12 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
     return pointee.getInt64(runtime.pointee)
   }
 
-  /**
-   Returns this BigInt truncated to an unsigned 64-bit integer.
-
-   This method always succeeds but may lose data if the BigInt is outside the UInt64 range.
-   Use `isUint64()` first to check if conversion is lossless, or use `asUint64()` for safe conversion.
-
-   - Returns: The truncated UInt64 value
-   */
+  /// Returns this BigInt truncated to an unsigned 64-bit integer.
+  ///
+  /// This method always succeeds but may lose data if the BigInt is outside the UInt64 range.
+  /// Use `isUint64()` first to check if conversion is lossless, or use `asUint64()` for safe conversion.
+  ///
+  /// - Returns: The truncated UInt64 value
   public func getUint64() -> UInt64 {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -193,14 +176,12 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
     return pointee.getUint64(runtime.pointee)
   }
 
-  /**
-   Returns this BigInt as a signed 64-bit integer, throwing an error if the conversion is lossy.
-
-   Use this method when you need to ensure no data is lost during conversion.
-
-   - Returns: The Int64 value
-   - Throws: `BigIntConversionError` if the BigInt is outside the Int64 range
-   */
+  /// Returns this BigInt as a signed 64-bit integer, throwing an error if the conversion is lossy.
+  ///
+  /// Use this method when you need to ensure no data is lost during conversion.
+  ///
+  /// - Returns: The Int64 value
+  /// - Throws: `BigIntConversionError` if the BigInt is outside the Int64 range
   public func asInt64() throws -> Int64 {
     guard isInt64() else {
       throw BigIntConversionError.outOfInt64Range
@@ -208,14 +189,12 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
     return getInt64()
   }
 
-  /**
-   Returns this BigInt as an unsigned 64-bit integer, throwing an error if the conversion is lossy.
-
-   Use this method when you need to ensure no data is lost during conversion.
-
-   - Returns: The UInt64 value
-   - Throws: `BigIntConversionError` if the BigInt is outside the UInt64 range
-   */
+  /// Returns this BigInt as an unsigned 64-bit integer, throwing an error if the conversion is lossy.
+  ///
+  /// Use this method when you need to ensure no data is lost during conversion.
+  ///
+  /// - Returns: The UInt64 value
+  /// - Throws: `BigIntConversionError` if the BigInt is outside the UInt64 range
   public func asUint64() throws -> UInt64 {
     guard isUint64() else {
       throw BigIntConversionError.outOfUint64Range
@@ -225,28 +204,26 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
 
   // MARK: - String Conversion
 
-  /**
-   Converts this BigInt to a string representation in the specified radix (base).
-
-   The radix can be any value from 2 to 36. Common bases include:
-   - 2: Binary
-   - 8: Octal
-   - 10: Decimal (default)
-   - 16: Hexadecimal
-
-   - Parameter radix: The base to use for string conversion (2-36). Defaults to 10.
-   - Returns: A string representation of the BigInt
-   - Throws: `BigIntConversionError.invalidRadix` if radix is not in the valid range
-
-   ## Examples
-   ```swift
-   let bigInt = JavaScriptBigInt(runtime, fromInt64: 255)
-   bigInt.toString(radix: 2)   // "11111111"
-   bigInt.toString(radix: 8)   // "377"
-   bigInt.toString(radix: 10)  // "255"
-   bigInt.toString(radix: 16)  // "ff"
-   ```
-   */
+  /// Converts this BigInt to a string representation in the specified radix (base).
+  ///
+  /// The radix can be any value from 2 to 36. Common bases include:
+  /// - 2: Binary
+  /// - 8: Octal
+  /// - 10: Decimal (default)
+  /// - 16: Hexadecimal
+  ///
+  /// - Parameter radix: The base to use for string conversion (2-36). Defaults to 10.
+  /// - Returns: A string representation of the BigInt
+  /// - Throws: `BigIntConversionError.invalidRadix` if radix is not in the valid range
+  ///
+  /// ## Examples
+  /// ```swift
+  /// let bigInt = JavaScriptBigInt(runtime, fromInt64: 255)
+  /// bigInt.toString(radix: 2)   // "11111111"
+  /// bigInt.toString(radix: 8)   // "377"
+  /// bigInt.toString(radix: 10)  // "255"
+  /// bigInt.toString(radix: 16)  // "ff"
+  /// ```
   public func toString(radix: Int = 10) throws -> String {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -267,9 +244,7 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptValue(runtime, facebook.jsi.Value(runtime.pointee, pointee))
   }
 
-  /**
-   Returns the BigInt as a `facebook.jsi.Value` instance.
-   */
+  /// Returns the BigInt as a `facebook.jsi.Value` instance.
   internal func asJSIValue() -> facebook.jsi.Value {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -279,16 +254,14 @@ public struct JavaScriptBigInt: JavaScriptType, Sendable, ~Copyable {
 
   // MARK: - Equality
 
-  /**
-   Tests whether two BigInts are strictly equal (represent the same numeric value).
-
-   This performs a strict equality check as defined by JavaScript's `===` operator for BigInts.
-
-   - Parameters:
-     - lhs: The first BigInt to compare
-     - rhs: The second BigInt to compare
-   - Returns: `true` if the BigInts represent the same value, `false` otherwise
-   */
+  /// Tests whether two BigInts are strictly equal (represent the same numeric value).
+  ///
+  /// This performs a strict equality check as defined by JavaScript's `===` operator for BigInts.
+  ///
+  /// - Parameters:
+  ///   - lhs: The first BigInt to compare
+  ///   - rhs: The second BigInt to compare
+  /// - Returns: `true` if the BigInts represent the same value, `false` otherwise
   public static func == (lhs: borrowing JavaScriptBigInt, rhs: borrowing JavaScriptBigInt) -> Bool {
     guard let runtime = lhs.runtime else {
       FatalError.runtimeLost()
@@ -308,7 +281,8 @@ extension JavaScriptBigInt: JavaScriptRepresentable {
 }
 
 extension JavaScriptBigInt: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptBigInt {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptBigInt
+  {
     fatalError("Not implemented: Use JavaScriptValue.getBigInt() instead")
   }
 
@@ -319,9 +293,7 @@ extension JavaScriptBigInt: JSIRepresentable {
 
 // MARK: - Errors
 
-/**
- Errors that can occur when working with BigInt conversions.
- */
+/// Errors that can occur when working with BigInt conversions.
 public enum BigIntConversionError: Error, CustomStringConvertible {
   /// The BigInt value is outside the valid Int64 range (-2^63 to 2^63-1)
   case outOfInt64Range

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptError.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptError.swift
@@ -1,5 +1,5 @@
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
 public struct JavaScriptError: JavaScriptType, ~Copyable {
   private weak let runtime: JavaScriptRuntime?
@@ -15,11 +15,9 @@ public struct JavaScriptError: JavaScriptType, ~Copyable {
     self.pointee = facebook.jsi.JSError(runtime.pointee, message)
   }
 
-  /**
-   Creates a JavaScript error from a native error conforming to `JavaScriptThrowable`.
-   Creates a proper JavaScript `Error` instance with `message` set, then attaches
-   the optional `code` property to the error object.
-   */
+  /// Creates a JavaScript error from a native error conforming to `JavaScriptThrowable`.
+  /// Creates a proper JavaScript `Error` instance with `message` set, then attaches
+  /// the optional `code` property to the error object.
   public init(_ runtime: JavaScriptRuntime, from error: any JavaScriptThrowable) {
     self.runtime = runtime
     self.pointee = facebook.jsi.JSError(runtime.pointee, error.message)
@@ -67,7 +65,8 @@ extension JavaScriptError: JavaScriptRepresentable {
 }
 
 extension JavaScriptError: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptError {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptError
+  {
     FatalError.unimplemented()
   }
 
@@ -76,14 +75,12 @@ extension JavaScriptError: JSIRepresentable {
   }
 }
 
-/**
- Makes `expo.CppError` conform to Swift's `Error` protocol so it can be caught
- with `try/catch`, and exposes its message as a native Swift `String`.
-
- The C++ `message` field is bridged to Swift as `_message` (a `std.string`)
- via the `SWIFT_NAME(_message)` annotation in `CppError.h`. This extension
- wraps it in a Swift `String` for cleaner call-site usage.
- */
+/// Makes `expo.CppError` conform to Swift's `Error` protocol so it can be caught
+/// with `try/catch`, and exposes its message as a native Swift `String`.
+///
+/// The C++ `message` field is bridged to Swift as `_message` (a `std.string`)
+/// via the `SWIFT_NAME(_message)` annotation in `CppError.h`. This extension
+/// wraps it in a Swift `String` for cleaner call-site usage.
 extension expo.CppError: Error {
   public var message: String {
     return String(_getMessage())

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptFunction.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptFunction.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
 public struct JavaScriptFunction: JavaScriptType, ~Copyable {
   internal weak let runtime: JavaScriptRuntime?
@@ -17,37 +17,39 @@ public struct JavaScriptFunction: JavaScriptType, ~Copyable {
   /// however it would require consuming `this` that we rather want to avoid (unwrapping is consuming).
   /// If `this` is consumed, something obvious like `object.getPropertyAsFunction("fn").call(this: object)` would be impossible.
 
-  /**
-   Calls the function with the given `this` object and buffer of arguments.
-   */
+  /// Calls the function with the given `this` object and buffer of arguments.
   @discardableResult
-  public func call(this: borrowing JavaScriptObject, arguments: consuming JavaScriptValuesBuffer? = nil) throws -> JavaScriptValue {
+  public func call(this: borrowing JavaScriptObject, arguments: consuming JavaScriptValuesBuffer? = nil) throws
+    -> JavaScriptValue
+  {
     guard let runtime else {
       FatalError.runtimeLost()
     }
     return try capturingCppErrors {
-      return JavaScriptValue(runtime, expo.callFunctionWithThis(runtime.pointee, pointee, this.pointee, arguments?.baseAddress, arguments?.count ?? 0))
+      return JavaScriptValue(
+        runtime,
+        expo.callFunctionWithThis(runtime.pointee, pointee, this.pointee, arguments?.baseAddress, arguments?.count ?? 0)
+      )
     }
   }
 
-  /**
-   Calls the function with the given buffer of arguments.
-   */
+  /// Calls the function with the given buffer of arguments.
   @discardableResult
   public func call(arguments: consuming JavaScriptValuesBuffer? = nil) throws -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()
     }
     return try capturingCppErrors {
-      return JavaScriptValue(runtime, expo.callFunction(runtime.pointee, pointee, arguments?.baseAddress, arguments?.count ?? 0))
+      return JavaScriptValue(
+        runtime, expo.callFunction(runtime.pointee, pointee, arguments?.baseAddress, arguments?.count ?? 0))
     }
   }
 
-  /**
-   Calls the function with the given `this` object and JS-representable arguments.
-   */
+  /// Calls the function with the given `this` object and JS-representable arguments.
   @discardableResult
-  public func call<each T: JavaScriptRepresentable>(this: borrowing JavaScriptObject, arguments: repeat each T) throws -> JavaScriptValue {
+  public func call<each T: JavaScriptRepresentable>(this: borrowing JavaScriptObject, arguments: repeat each T) throws
+    -> JavaScriptValue
+  {
     guard let runtime else {
       FatalError.runtimeLost()
     }
@@ -55,9 +57,7 @@ public struct JavaScriptFunction: JavaScriptType, ~Copyable {
     return try self.call(this: this, arguments: argumentsBuffer)
   }
 
-  /**
-   Calls the function with the given JS-representable arguments.
-   */
+  /// Calls the function with the given JS-representable arguments.
   @discardableResult
   public func call<each T: JavaScriptRepresentable>(arguments: repeat each T) throws -> JavaScriptValue {
     guard let runtime else {
@@ -67,9 +67,7 @@ public struct JavaScriptFunction: JavaScriptType, ~Copyable {
     return try self.call(arguments: argumentsBuffer)
   }
 
-  /**
-   Calls the function as a constructor with the given buffer of arguments. It's like calling a function with the `new` keyword.
-   */
+  /// Calls the function as a constructor with the given buffer of arguments. It's like calling a function with the `new` keyword.
   public func callAsConstructor(_ arguments: consuming JavaScriptValuesBuffer? = nil) throws -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -80,9 +78,7 @@ public struct JavaScriptFunction: JavaScriptType, ~Copyable {
     }
   }
 
-  /**
-   Calls the function as a constructor with the given arguments. It's like calling a function with the `new` keyword.
-   */
+  /// Calls the function as a constructor with the given arguments. It's like calling a function with the `new` keyword.
   public func callAsConstructor<each T: JavaScriptRepresentable>(_ arguments: repeat each T) throws -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -100,9 +96,7 @@ public struct JavaScriptFunction: JavaScriptType, ~Copyable {
     return JavaScriptValue(runtime, expo.valueFromFunction(jsiRuntime, pointee))
   }
 
-  /**
-   Returns the function as a `facebook.jsi.Value` instance.
-   */
+  /// Returns the function as a `facebook.jsi.Value` instance.
   internal func asJSIValue() -> facebook.jsi.Value {
     guard let jsiRuntime = runtime?.pointee else {
       FatalError.runtimeLost()
@@ -130,7 +124,9 @@ extension JavaScriptFunction: JavaScriptRepresentable {
 }
 
 extension JavaScriptFunction: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptFunction {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime)
+    -> JavaScriptFunction
+  {
     FatalError.unimplemented()
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -1,42 +1,32 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
-/**
- A Swift representation of a JavaScript object. Provides access to JavaScript object properties and methods,
- supporting property access, modification, enumeration, prototype manipulation, and function calling.
- */
+/// A Swift representation of a JavaScript object. Provides access to JavaScript object properties and methods,
+/// supporting property access, modification, enumeration, prototype manipulation, and function calling.
 public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
   internal weak let runtime: JavaScriptRuntime?
   internal var pointee: facebook.jsi.Object
 
-  /**
-   Creates a new object in the given runtime.
-   */
+  /// Creates a new object in the given runtime.
   public init(_ runtime: JavaScriptRuntime) {
     self.init(runtime, facebook.jsi.Object(runtime.pointee))
   }
 
-  /**
-   Creates a new object from the dictionary whose values are representable in JS.
-   */
+  /// Creates a new object from the dictionary whose values are representable in JS.
   public init<DictValue: JavaScriptRepresentable>(_ runtime: JavaScriptRuntime, _ dictionary: [String: DictValue]) {
     self.runtime = runtime
     self.pointee = dictionary.toJavaScriptValue(in: runtime).getObject().pointee
   }
 
-  /**
-   Creates a new object from existing JSI object.
-   */
+  /// Creates a new object from existing JSI object.
   internal init(_ runtime: JavaScriptRuntime, _ object: consuming facebook.jsi.Object) {
     self.runtime = runtime
     self.pointee = object
   }
 
-  /**
-   Result of `object instanceof constructor`, which tests if the prototype property of a constructor appears anywhere in the prototype chain of an object.
-   */
+  /// Result of `object instanceof constructor`, which tests if the prototype property of a constructor appears anywhere in the prototype chain of an object.
   public func instanceOf(_ constructor: borrowing JavaScriptFunction) -> Bool {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -44,16 +34,12 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return pointee.instanceOf(runtime.pointee, constructor.pointee)
   }
 
-  /**
-   Result of `object instanceof constructor`, which tests if the prototype property of a constructor appears anywhere in the prototype chain of an object.
-   */
+  /// Result of `object instanceof constructor`, which tests if the prototype property of a constructor appears anywhere in the prototype chain of an object.
   public func instanceOf(_ constructor: JavaScriptValue) -> Bool {
     return instanceOf(constructor.getFunction())
   }
 
-  /**
-   Equivalent to `Array.isArray()` in JS. If it returns `true`, then `getArray()` will succeed.
-   */
+  /// Equivalent to `Array.isArray()` in JS. If it returns `true`, then `getArray()` will succeed.
   public func isArray() -> Bool {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -61,9 +47,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return pointee.isArray(runtime.pointee)
   }
 
-  /**
-   Returns `true` if the object is callable. If so, then `getFunction()` will succeed.
-   */
+  /// Returns `true` if the object is callable. If so, then `getFunction()` will succeed.
   public func isFunction() -> Bool {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -71,10 +55,8 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return pointee.isFunction(runtime.pointee)
   }
 
-  /**
-   Returns `true` if the object is backed by a `jsi::HostObject`, including host objects
-   created via `JavaScriptRuntime.createHostObject` and ones produced by other native code.
-   */
+  /// Returns `true` if the object is backed by a `jsi::HostObject`, including host objects
+  /// created via `JavaScriptRuntime.createHostObject` and ones produced by other native code.
   public func isHostObject() -> Bool {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -89,9 +71,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return pointee.isArrayBuffer(runtime.pointee)
   }
 
-  /**
-   Returns the object as an array buffer, or asserts if not an array buffer.
-   */
+  /// Returns the object as an array buffer, or asserts if not an array buffer.
   public func getArrayBuffer() -> JavaScriptArrayBuffer {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -100,9 +80,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptArrayBuffer(runtime, pointee.getArrayBuffer(runtime.pointee))
   }
 
-  /**
-   Returns the object as an array, or asserts if not an array.
-   */
+  /// Returns the object as an array, or asserts if not an array.
   public func getArray() -> JavaScriptArray {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -111,9 +89,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptArray(runtime, pointee.getArray(runtime.pointee))
   }
 
-  /**
-   Returns the object as a function, or asserts if not a function.
-   */
+  /// Returns the object as a function, or asserts if not a function.
   public func getFunction() -> JavaScriptFunction {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -124,9 +100,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
 
   // MARK: - Accessing object properties
 
-  /**
-   Checks whether the object has a property with the given name.
-   */
+  /// Checks whether the object has a property with the given name.
   public func hasProperty(_ name: String) -> Bool {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -134,10 +108,8 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return pointee.hasProperty(runtime.pointee, name)
   }
 
-  /**
-   Returns the property of the object with the given name,
-   or `undefined` value if the name is not a property of the object.
-   */
+  /// Returns the property of the object with the given name,
+  /// or `undefined` value if the name is not a property of the object.
   public func getProperty(_ name: String) -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -145,19 +117,17 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptValue(runtime, pointee.getProperty(runtime.pointee, name))
   }
 
-  /**
-   Accesses nested properties in a single subscript operation by traversing the object chain.
-   This subscript provides a convenient way to access deeply nested properties without
-   multiple chained calls to `getProperty()`. Each key in the chain is accessed sequentially,
-   treating intermediate values as objects.
-
-   - Parameters:
-     - key: The first property name to access on this object
-     - nestedKeys: Variadic list of subsequent property names to access on nested objects
-   - Returns: The `JavaScriptValue` at the end of the property chain
-   - Note: Each intermediate value in the chain (except the last) must be an object.
-     If any intermediate value is not an object, the behavior is undefined and may crash.
-   */
+  /// Accesses nested properties in a single subscript operation by traversing the object chain.
+  /// This subscript provides a convenient way to access deeply nested properties without
+  /// multiple chained calls to `getProperty()`. Each key in the chain is accessed sequentially,
+  /// treating intermediate values as objects.
+  ///
+  /// - Parameters:
+  ///   - key: The first property name to access on this object
+  ///   - nestedKeys: Variadic list of subsequent property names to access on nested objects
+  /// - Returns: The `JavaScriptValue` at the end of the property chain
+  /// - Note: Each intermediate value in the chain (except the last) must be an object.
+  ///   If any intermediate value is not an object, the behavior is undefined and may crash.
   public subscript(_ key: String, _ nestedKeys: String...) -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -171,13 +141,11 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptValue(runtime, value)
   }
 
-  /**
-   Returns an array of the object's own enumerable property names.
-   This method is equivalent to JavaScript's `Object.keys()`, returning only properties
-   that are enumerable and directly owned by the object (not inherited from the prototype chain).
-
-   - Returns: An array of property names as strings
-   */
+  /// Returns an array of the object's own enumerable property names.
+  /// This method is equivalent to JavaScript's `Object.keys()`, returning only properties
+  /// that are enumerable and directly owned by the object (not inherited from the prototype chain).
+  ///
+  /// - Returns: An array of property names as strings
   public func getPropertyNames() -> [String] {
     guard let jsiRuntime = runtime?.pointee else {
       FatalError.runtimeLost()
@@ -190,9 +158,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     }
   }
 
-  /**
-   Same as `getProperty(name).getObject()`.
-   */
+  /// Same as `getProperty(name).getObject()`.
   public func getPropertyAsObject(_ name: String) -> JavaScriptObject {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -200,9 +166,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptObject(runtime, pointee.getPropertyAsObject(runtime.pointee, name))
   }
 
-  /**
-   Same as `getProperty(propName).getObject()`.
-   */
+  /// Same as `getProperty(propName).getObject()`.
   public func getPropertyAsObject(_ propName: JavaScriptPropNameID) -> JavaScriptObject {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -210,9 +174,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptObject(runtime, pointee.getProperty(runtime.pointee, propName.pointee).getObject(runtime.pointee))
   }
 
-  /**
-   Same as `getProperty(name).getObject().getFunction()`.
-   */
+  /// Same as `getProperty(name).getObject().getFunction()`.
   public func getPropertyAsFunction(_ name: String) -> JavaScriptFunction {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -220,20 +182,17 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptFunction(runtime, pointee.getPropertyAsFunction(runtime.pointee, name))
   }
 
-  /**
-   Same as `getProperty(propName).getObject().getFunction()`.
-   */
+  /// Same as `getProperty(propName).getObject().getFunction()`.
   public func getPropertyAsFunction(_ propName: JavaScriptPropNameID) -> JavaScriptFunction {
     guard let runtime else {
       FatalError.runtimeLost()
     }
-    let jsiFunction = pointee.getProperty(runtime.pointee, propName.pointee).getObject(runtime.pointee).getFunction(runtime.pointee)
+    let jsiFunction = pointee.getProperty(runtime.pointee, propName.pointee).getObject(runtime.pointee).getFunction(
+      runtime.pointee)
     return JavaScriptFunction(runtime, jsiFunction)
   }
 
-  /**
-   Returns a prototype of the object. Same as `Object.getPrototypeOf(object)` in JS.
-   */
+  /// Returns a prototype of the object. Same as `Object.getPrototypeOf(object)` in JS.
   public func getPrototype() -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -241,9 +200,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptValue(runtime, pointee.getPrototype(runtime.pointee))
   }
 
-  /**
-   Sets a prototype of the object. Same as `Object.setPrototypeOf(object, prototype)` in JS.
-   */
+  /// Sets a prototype of the object. Same as `Object.setPrototypeOf(object, prototype)` in JS.
   public func setPrototype(_ prototype: JavaScriptValue) {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -284,10 +241,8 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     expo.setProperty(runtime.pointee, pointee, name, facebook.jsi.Value(runtime.pointee, object.pointee))
   }
 
-  /**
-   Deletes a property with the given name. After calling this function,
-   `hasProperty` will return `false`, and `getProperty` will return `undefined` value.
-   */
+  /// Deletes a property with the given name. After calling this function,
+  /// `hasProperty` will return `false`, and `getProperty` will return `undefined` value.
   public func deleteProperty(_ name: String) {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -314,7 +269,9 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     defineProperty(name, descriptor: descriptorObject)
   }
 
-  public func defineProperty<T: JavaScriptRepresentable & ~Copyable>(_ name: String, value: borrowing T, options: PropertyOptions = []) {
+  public func defineProperty<T: JavaScriptRepresentable & ~Copyable>(
+    _ name: String, value: borrowing T, options: PropertyOptions = []
+  ) {
     guard let runtime else {
       FatalError.runtimeLost()
     }
@@ -329,21 +286,21 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
 
   // MARK: - Calling owned functions
 
-  /**
-   Compact form of `object.getPropertyAsFunction(functionName).call(this: object, arguments: ...)`.
-   */
+  /// Compact form of `object.getPropertyAsFunction(functionName).call(this: object, arguments: ...)`.
   @discardableResult
   @JavaScriptActor
-  public func callFunction<each T: JavaScriptRepresentable>(_ functionName: String, arguments: repeat each T) throws -> JavaScriptValue {
+  public func callFunction<each T: JavaScriptRepresentable>(_ functionName: String, arguments: repeat each T) throws
+    -> JavaScriptValue
+  {
     return try getPropertyAsFunction(functionName).call(this: self, arguments: repeat each arguments)
   }
 
-  /**
-   Compact form of `object.getPropertyAsFunction(functionName).call(this: object, arguments: ...)`.
-   */
+  /// Compact form of `object.getPropertyAsFunction(functionName).call(this: object, arguments: ...)`.
   @discardableResult
   @JavaScriptActor
-  public func callFunction<each T: JavaScriptRepresentable>(_ functionName: JavaScriptPropNameID, arguments: repeat each T) throws -> JavaScriptValue {
+  public func callFunction<each T: JavaScriptRepresentable>(
+    _ functionName: JavaScriptPropNameID, arguments: repeat each T
+  ) throws -> JavaScriptValue {
     return try getPropertyAsFunction(functionName).call(this: self, arguments: repeat each arguments)
   }
 
@@ -356,9 +313,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptValue(runtime, facebook.jsi.Value(runtime.pointee, pointee))
   }
 
-  /**
-   Returns the object as a `facebook.jsi.Value` instance.
-   */
+  /// Returns the object as a `facebook.jsi.Value` instance.
   internal func asJSIValue() -> facebook.jsi.Value {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -366,29 +321,23 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return facebook.jsi.Value(runtime.pointee, pointee)
   }
 
-  /**
-   Provides scoped access to a raw pointer to the underlying `facebook.jsi.Object`.
-   The pointer is valid only for the duration of the closure and must not be stored or escaped.
-   */
+  /// Provides scoped access to a raw pointer to the underlying `facebook.jsi.Object`.
+  /// The pointer is valid only for the duration of the closure and must not be stored or escaped.
   public func withUnsafePointee<R>(_ body: (UnsafeRawPointer) throws -> R) rethrows -> R {
     return try withUnsafeBytes(of: pointee) { bytes in
       return try body(bytes.baseAddress!)
     }
   }
 
-  /**
-   Provides scoped mutable access to a raw pointer to the underlying `facebook.jsi.Object`.
-   The pointer is valid only for the duration of the closure and must not be stored or escaped.
-   */
+  /// Provides scoped mutable access to a raw pointer to the underlying `facebook.jsi.Object`.
+  /// The pointer is valid only for the duration of the closure and must not be stored or escaped.
   public mutating func withUnsafeMutablePointee<R>(_ body: (UnsafeMutableRawPointer) throws -> R) rethrows -> R {
     return try withUnsafeMutableBytes(of: &pointee) { bytes in
       return try body(bytes.baseAddress!)
     }
   }
 
-  /**
-   Creates a weak reference to the object. If the only references to an object are these, the object is eligible for GC.
-   */
+  /// Creates a weak reference to the object. If the only references to an object are these, the object is eligible for GC.
   public func createWeak() -> JavaScriptWeakObject {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -398,9 +347,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
 
   // MARK: - Native state
 
-  /**
-   Returns whether this object has native state previously set by `setNativeState`.
-   */
+  /// Returns whether this object has native state previously set by `setNativeState`.
   public func hasNativeState() -> Bool {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -408,10 +355,8 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return expo.hasNativeState(runtime.pointee, pointee)
   }
 
-  /**
-   Returns a native state previously set by `setNativeState`.
-   If `hasNativeState()` is false or object's native state is of unrelated type, this will return `nil`.
-   */
+  /// Returns a native state previously set by `setNativeState`.
+  /// If `hasNativeState()` is false or object's native state is of unrelated type, this will return `nil`.
   public func getNativeState<T: JavaScriptNativeState>(as: T.Type = JavaScriptNativeState.self) -> T? {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -422,12 +367,12 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return T.from(cxx: cxxNativeState)
   }
 
-  /**
-   Sets the internal native state property of this object, overwriting any old value.
-   Creates a new shared_ptr to the object managed by state, which will live until the value at this property becomes unreachable.
-   - TODO: throw a type error if this object is a proxy or host object.
-   */
-  public func setNativeState<T: JavaScriptNativeState>(_ nativeState: T) throws(JavaScriptNativeState.NativeStateReleasedError) {
+  /// Sets the internal native state property of this object, overwriting any old value.
+  /// Creates a new shared_ptr to the object managed by state, which will live until the value at this property becomes unreachable.
+  /// - TODO: throw a type error if this object is a proxy or host object.
+  public func setNativeState<T: JavaScriptNativeState>(_ nativeState: T) throws(JavaScriptNativeState
+    .NativeStateReleasedError)
+  {
     guard let runtime else {
       FatalError.runtimeLost()
     }
@@ -437,9 +382,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     expo.setNativeState(runtime.pointee, pointee, nativeStatePointee)
   }
 
-  /**
-   Unsets the native state of this object.
-   */
+  /// Unsets the native state of this object.
   public func unsetNativeState() {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -458,9 +401,7 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
 
   // MARK: - Equality
 
-  /**
-   Compares whether the two `JavaScriptObject`s are pointing to the same underlying JS object.
-   */
+  /// Compares whether the two `JavaScriptObject`s are pointing to the same underlying JS object.
   public static func == (lhs: borrowing JavaScriptObject, rhs: borrowing JavaScriptObject) -> Bool {
     // Note that we implement comparison operator, but we don't add conformance to `Equatable` because it requires types to be copyable.
     // This proposal solves it: https://github.com/swiftlang/swift-evolution/blob/main/proposals/0499-support-non-copyable-simple-protocols.md
@@ -469,55 +410,45 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
 
   // MARK: - Property options and descriptor
 
-  /**
-   Options for defining property attributes on JavaScript objects. These options correspond to the property
-   descriptor attributes in JavaScript's `Object.defineProperty()` method. They control how a property behaves when
-   accessed, enumerated, or modified.
-
-   - SeeAlso: `PropertyDescriptor` for more fine-grained control over property definitions
-   */
+  /// Options for defining property attributes on JavaScript objects. These options correspond to the property
+  /// descriptor attributes in JavaScript's `Object.defineProperty()` method. They control how a property behaves when
+  /// accessed, enumerated, or modified.
+  ///
+  /// - SeeAlso: `PropertyDescriptor` for more fine-grained control over property definitions
   public struct PropertyOptions: OptionSet, Sendable {
     public let rawValue: Int
 
     public init(rawValue: Int) {
       self.rawValue = rawValue
     }
-    /**
-     When `true`, the property descriptor may be changed and the property may be deleted.
-     Default is `false` when not specified.
-
-     Corresponds to JavaScript's `configurable` property attribute. A configurable property
-     can have its descriptor redefined or be deleted from the object.
-     */
+    /// When `true`, the property descriptor may be changed and the property may be deleted.
+    /// Default is `false` when not specified.
+    ///
+    /// Corresponds to JavaScript's `configurable` property attribute. A configurable property
+    /// can have its descriptor redefined or be deleted from the object.
     public static let configurable = PropertyOptions(rawValue: 1 << 0)
-    /**
-     When `true`, the property shows up during enumeration of properties.
-     Default is `false` when not specified.
-
-     Corresponds to JavaScript's `enumerable` property attribute. Enumerable properties
-     appear in `for...in` loops and `Object.keys()` results.
-     */
+    /// When `true`, the property shows up during enumeration of properties.
+    /// Default is `false` when not specified.
+    ///
+    /// Corresponds to JavaScript's `enumerable` property attribute. Enumerable properties
+    /// appear in `for...in` loops and `Object.keys()` results.
     public static let enumerable = PropertyOptions(rawValue: 1 << 1)
-    /**
-     When `true`, the property's value can be changed with an assignment operator.
-     Default is `false` when not specified.
-
-     Corresponds to JavaScript's `writable` property attribute. Writable properties
-     can be modified after they are defined.
-     */
+    /// When `true`, the property's value can be changed with an assignment operator.
+    /// Default is `false` when not specified.
+    ///
+    /// Corresponds to JavaScript's `writable` property attribute. Writable properties
+    /// can be modified after they are defined.
     public static let writable = PropertyOptions(rawValue: 1 << 2)
   }
-  /**
-   A descriptor that defines the characteristics of a property on a JavaScript object.
-   Property descriptors provide fine-grained control over how properties behave,
-   corresponding directly to JavaScript's property descriptor objects used with
-   `Object.defineProperty()`. Each descriptor specifies whether the property is
-   configurable, enumerable, writable, and what value it should hold.
-
-   - Note: All boolean properties default to `false`, matching JavaScript's behavior
-     when properties are defined via `Object.defineProperty()`.
-   - SeeAlso: `PropertyOptions` for a simpler option-set based approach
-   */
+  /// A descriptor that defines the characteristics of a property on a JavaScript object.
+  /// Property descriptors provide fine-grained control over how properties behave,
+  /// corresponding directly to JavaScript's property descriptor objects used with
+  /// `Object.defineProperty()`. Each descriptor specifies whether the property is
+  /// configurable, enumerable, writable, and what value it should hold.
+  ///
+  /// - Note: All boolean properties default to `false`, matching JavaScript's behavior
+  ///   when properties are defined via `Object.defineProperty()`.
+  /// - SeeAlso: `PropertyOptions` for a simpler option-set based approach
   public struct PropertyDescriptor: ~Copyable {
     /// When `true`, the property descriptor may be changed and the property may be deleted from the object.
     let configurable: Bool
@@ -531,32 +462,30 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     /// The value associated with the property. Can be any JavaScript value or `nil`.
     let value: JavaScriptValue?
 
-    /**
-     Creates a new property descriptor with the specified attributes.
-
-     - Parameters:
-       - configurable: Whether the property can be deleted or have its descriptor modified. Defaults to `false`.
-       - enumerable: Whether the property appears during enumeration. Defaults to `false`.
-       - writable: Whether the property's value can be changed. Defaults to `false`.
-       - value: The value to assign to the property. Defaults to `nil`.
-     - Note: When all parameters use their default values, this creates a non-configurable,
-       non-enumerable, non-writable property with no value (undefined in JavaScript).
-     */
-    public init(configurable: Bool = false, enumerable: Bool = false, writable: Bool = false, value: JavaScriptValue? = nil) {
+    /// Creates a new property descriptor with the specified attributes.
+    ///
+    /// - Parameters:
+    ///   - configurable: Whether the property can be deleted or have its descriptor modified. Defaults to `false`.
+    ///   - enumerable: Whether the property appears during enumeration. Defaults to `false`.
+    ///   - writable: Whether the property's value can be changed. Defaults to `false`.
+    ///   - value: The value to assign to the property. Defaults to `nil`.
+    /// - Note: When all parameters use their default values, this creates a non-configurable,
+    ///   non-enumerable, non-writable property with no value (undefined in JavaScript).
+    public init(
+      configurable: Bool = false, enumerable: Bool = false, writable: Bool = false, value: JavaScriptValue? = nil
+    ) {
       self.configurable = configurable
       self.enumerable = enumerable
       self.writable = writable
       self.value = value
     }
-    /**
-     Converts the descriptor to a JavaScript object that can be used with `Object.defineProperty()`.
-     This method creates a JavaScript object with the descriptor's attributes set as properties.
-     Only attributes that are `true` or non-nil are included in the resulting object,
-     following JavaScript conventions.
-
-     - Parameter runtime: The JavaScript runtime in which to create the descriptor object
-     - Returns: A JavaScript object representing this property descriptor
-     */
+    /// Converts the descriptor to a JavaScript object that can be used with `Object.defineProperty()`.
+    /// This method creates a JavaScript object with the descriptor's attributes set as properties.
+    /// Only attributes that are `true` or non-nil are included in the resulting object,
+    /// following JavaScript conventions.
+    ///
+    /// - Parameter runtime: The JavaScript runtime in which to create the descriptor object
+    /// - Returns: A JavaScript object representing this property descriptor
     public consuming func toObject(_ runtime: borrowing JavaScriptRuntime) -> JavaScriptObject {
       let object = runtime.createObject()
       if configurable {
@@ -587,7 +516,8 @@ extension JavaScriptObject: JavaScriptRepresentable {
 }
 
 extension JavaScriptObject: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptObject {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptObject
+  {
     FatalError.unimplemented()
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -1,14 +1,12 @@
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
-/**
- A Swift representation of a JavaScript Promise.
-
- `JavaScriptPromise` bridges JavaScript promises with Swift's async/await, allowing you to create
- deferred promises that can be resolved or rejected from Swift, or wrap existing JavaScript promises
- to await their results. It provides type-safe access to promise resolution and rejection, integrating
- JavaScript's asynchronous patterns with Swift's concurrency model.
- */
+/// A Swift representation of a JavaScript Promise.
+///
+/// `JavaScriptPromise` bridges JavaScript promises with Swift's async/await, allowing you to create
+/// deferred promises that can be resolved or rejected from Swift, or wrap existing JavaScript promises
+/// to await their results. It provides type-safe access to promise resolution and rejection, integrating
+/// JavaScript's asynchronous patterns with Swift's concurrency model.
 public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   private typealias PromiseContinuation = CheckedContinuation<JavaScriptValue.Ref, any Error>
 
@@ -21,10 +19,8 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   private let resolveFunction = JavaScriptValue.Ref()
   private let rejectFunction = JavaScriptValue.Ref()
 
-  /**
-   Initializes a promise from the existing object. The promise may already be settled.
-   It cannot be resolved/rejected from the outside, i.e. `resolve` and `reject` functions are no-op.
-   */
+  /// Initializes a promise from the existing object. The promise may already be settled.
+  /// It cannot be resolved/rejected from the outside, i.e. `resolve` and `reject` functions are no-op.
   @JavaScriptActor
   public init(_ runtime: JavaScriptRuntime, _ object: consuming JavaScriptObject) throws {
     self.runtime = runtime
@@ -32,9 +28,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
     try setUpCallbacks()
   }
 
-  /**
-   Creates a new promise whose resolver or rejecter must be called from the outside (also known as a deferred promise).
-   */
+  /// Creates a new promise whose resolver or rejecter must be called from the outside (also known as a deferred promise).
   @JavaScriptActor
   public init(_ runtime: JavaScriptRuntime) throws {
     self.runtime = runtime
@@ -49,7 +43,8 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       return .undefined
     }
 
-    self.object = try runtime
+    self.object =
+      try runtime
       .global()
       .getPropertyAsFunction(.cached(runtime, "Promise"))
       .callAsConstructor(setup.asValue())

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
@@ -1,5 +1,9 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
+// swift-format-ignore-file: AlwaysUseLowerCamelCase
+// `Kind` enum cases mirror the JavaScript TypedArray constructor names verbatim
+// (`Int8Array`, `Uint8ClampedArray`, etc.) and must not be lowercased.
+
 internal import jsi
 internal import ExpoModulesJSI_Cxx
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptTypedArray.swift
@@ -4,18 +4,16 @@
 // `Kind` enum cases mirror the JavaScript TypedArray constructor names verbatim
 // (`Int8Array`, `Uint8ClampedArray`, etc.) and must not be lowercased.
 
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
 public struct JavaScriptTypedArray: ~Copyable {
   internal weak let runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.Object
 
-  /**
-   The underlying `ArrayBuffer` backing this typed array. Stored alongside `pointee`
-   so that holding the Swift value keeps the backing store alive on the JS side —
-   the JS garbage collector cannot free the buffer while this reference exists.
-   */
+  /// The underlying `ArrayBuffer` backing this typed array. Stored alongside `pointee`
+  /// so that holding the Swift value keeps the backing store alive on the JS side —
+  /// the JS garbage collector cannot free the buffer while this reference exists.
   internal let arrayBuffer: facebook.jsi.ArrayBuffer
 
   public let kind: Kind
@@ -30,48 +28,41 @@ public struct JavaScriptTypedArray: ~Copyable {
     self.pointee = object
   }
 
-  /**
-   Invokes the closure with a raw buffer pointer covering the typed array's bytes.
-   The pointer is valid only for the duration of the closure and must not escape it.
-   */
+  /// Invokes the closure with a raw buffer pointer covering the typed array's bytes.
+  /// The pointer is valid only for the duration of the closure and must not escape it.
   public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
     return try body(UnsafeRawBufferPointer(start: startPointer(), count: byteLength))
   }
 
-  /**
-   Invokes the closure with a mutable raw buffer pointer covering the typed array's bytes.
-   Writes through the buffer are visible to JavaScript. The pointer is valid only for the duration of the closure.
-   */
+  /// Invokes the closure with a mutable raw buffer pointer covering the typed array's bytes.
+  /// Writes through the buffer are visible to JavaScript. The pointer is valid only for the duration of the closure.
   public func withUnsafeMutableBytes<R>(_ body: (UnsafeMutableRawBufferPointer) throws -> R) rethrows -> R {
     return try body(UnsafeMutableRawBufferPointer(start: startPointer(), count: byteLength))
   }
 
-  /**
-   Invokes the closure with a typed buffer pointer over the elements of the typed array.
-   The generic type must match the array's element type (e.g. `UInt8` for `Uint8Array`, `Int32` for `Int32Array`);
-   passing a mismatched type reinterprets the bytes and is a programmer error.
-   */
-  public func withUnsafeBufferPointer<T, R>(as type: T.Type, _ body: (UnsafeBufferPointer<T>) throws -> R) rethrows -> R {
+  /// Invokes the closure with a typed buffer pointer over the elements of the typed array.
+  /// The generic type must match the array's element type (e.g. `UInt8` for `Uint8Array`, `Int32` for `Int32Array`);
+  /// passing a mismatched type reinterprets the bytes and is a programmer error.
+  public func withUnsafeBufferPointer<T, R>(as type: T.Type, _ body: (UnsafeBufferPointer<T>) throws -> R) rethrows -> R
+  {
     return try withUnsafeBytes { bytes in
       try body(bytes.bindMemory(to: T.self))
     }
   }
 
-  /**
-   Invokes the closure with a mutable typed buffer pointer over the elements of the typed array.
-   The generic type must match the array's element type. Writes through the buffer are visible to JavaScript.
-   */
-  public func withUnsafeMutableBufferPointer<T, R>(as type: T.Type, _ body: (UnsafeMutableBufferPointer<T>) throws -> R) rethrows -> R {
+  /// Invokes the closure with a mutable typed buffer pointer over the elements of the typed array.
+  /// The generic type must match the array's element type. Writes through the buffer are visible to JavaScript.
+  public func withUnsafeMutableBufferPointer<T, R>(as type: T.Type, _ body: (UnsafeMutableBufferPointer<T>) throws -> R)
+    rethrows -> R
+  {
     return try withUnsafeMutableBytes { bytes in
       try body(bytes.bindMemory(to: T.self))
     }
   }
 
-  /**
-   Returns a pointer to the first byte of the typed array's data — the beginning of the underlying
-   ArrayBuffer, advanced by `byteOffset`. The pointer is tied to the ArrayBuffer retained by this
-   value; it is only valid while this `JavaScriptTypedArray` is alive.
-   */
+  /// Returns a pointer to the first byte of the typed array's data — the beginning of the underlying
+  /// ArrayBuffer, advanced by `byteOffset`. The pointer is tied to the ArrayBuffer retained by this
+  /// value; it is only valid while this `JavaScriptTypedArray` is alive.
   private func startPointer() -> UnsafeMutablePointer<UInt8> {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -97,30 +88,22 @@ public struct JavaScriptTypedArray: ~Copyable {
 
   // MARK: - Expose JS properties
 
-  /**
-   The length in bytes from the start of the underlying ArrayBuffer.
-   Fixed at construction time and thus read-only.
-   */
+  /// The length in bytes from the start of the underlying ArrayBuffer.
+  /// Fixed at construction time and thus read-only.
   public let byteLength: Int
 
-  /**
-   The offset in bytes from the start of the underlying ArrayBuffer.
-   Fixed at construction time and thus read-only.
-   */
+  /// The offset in bytes from the start of the underlying ArrayBuffer.
+  /// Fixed at construction time and thus read-only.
   public let byteOffset: Int
 
-  /**
-   Returns the number of elements held in the typed array.
-   Fixed at construction time and thus read only.
-   */
+  /// Returns the number of elements held in the typed array.
+  /// Fixed at construction time and thus read only.
   public let length: Int
 
   // MARK: - Conversions
 
-  /**
-   Returns the underlying `ArrayBuffer` that this typed array is a view of.
-   Equivalent to the JavaScript `.buffer` property.
-   */
+  /// Returns the underlying `ArrayBuffer` that this typed array is a view of.
+  /// Equivalent to the JavaScript `.buffer` property.
   public func getArrayBuffer() -> JavaScriptArrayBuffer {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -129,9 +112,7 @@ public struct JavaScriptTypedArray: ~Copyable {
     return JavaScriptArrayBuffer(runtime, buffer)
   }
 
-  /**
-   Returns the typed array as a `JavaScriptValue`.
-   */
+  /// Returns the typed array as a `JavaScriptValue`.
   public func asValue() -> JavaScriptValue {
     guard let runtime else {
       FatalError.runtimeLost()

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -1,76 +1,58 @@
+internal import ExpoModulesJSI_Cxx
 import Foundation
 internal import jsi
-internal import ExpoModulesJSI_Cxx
 
-/**
- Represents any JS value (undefined, null, boolean, number, bigint, symbol, string, or object).
- As opposed to other concrete types (e.g. `JavaScriptObject`, `JavaScriptFunction`),
- this one is a reference type so can be safely captured in closures, passed to other isolation context,
- and stored in containers that don't support non-copyable types etc.
- */
+/// Represents any JS value (undefined, null, boolean, number, bigint, symbol, string, or object).
+/// As opposed to other concrete types (e.g. `JavaScriptObject`, `JavaScriptFunction`),
+/// this one is a reference type so can be safely captured in closures, passed to other isolation context,
+/// and stored in containers that don't support non-copyable types etc.
 public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error {
   internal weak let runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.Value
 
-  /**
-   Initializer from the existing JSI value.
-   */
+  /// Initializer from the existing JSI value.
   internal init(_ runtime: JavaScriptRuntime?, _ pointee: consuming facebook.jsi.Value) {
     self.runtime = runtime
     self.pointee = pointee
   }
 
-  /**
-   Copy initializer from the existing JSI value.
-   */
+  /// Copy initializer from the existing JSI value.
   internal init(_ runtime: JavaScriptRuntime, _ pointee: borrowing facebook.jsi.Value) {
     self.runtime = runtime
     self.pointee = facebook.jsi.Value(runtime.pointee, pointee)
   }
 
-  /**
-   Creates a boolean JS value.
-   */
+  /// Creates a boolean JS value.
   public init(_ runtime: JavaScriptRuntime, _ bool: Bool) {
     self.runtime = runtime
     self.pointee = facebook.jsi.Value(bool)
   }
 
-  /**
-   Creates a BigInt JS value from an Int64.
-   */
+  /// Creates a BigInt JS value from an Int64.
   public init(_ runtime: JavaScriptRuntime, bigInt: Int64) {
     self.runtime = runtime
     self.pointee = facebook.jsi.Value(runtime.pointee, facebook.jsi.BigInt.fromInt64(runtime.pointee, bigInt))
   }
 
-  /**
-   Creates a BigInt JS value from a UInt64.
-   */
+  /// Creates a BigInt JS value from a UInt64.
   public init(_ runtime: JavaScriptRuntime, bigInt: UInt64) {
     self.runtime = runtime
     self.pointee = facebook.jsi.Value(runtime.pointee, facebook.jsi.BigInt.fromUint64(runtime.pointee, bigInt))
   }
 
-  /**
-   Creates a JS value from a JS representable.
-   */
+  /// Creates a JS value from a JS representable.
   public init(_ runtime: JavaScriptRuntime, _ value: JavaScriptRepresentable) {
     self.runtime = runtime
     self.pointee = value.toJavaScriptValue(in: runtime).toJSIValue(in: runtime.pointee)
   }
 
-  /**
-   Creates a JS value from a JSI representable.
-   */
+  /// Creates a JS value from a JSI representable.
   internal init(_ runtime: JavaScriptRuntime, _ value: JSIRepresentable) {
     self.runtime = runtime
     self.pointee = value.toJSIValue(in: runtime.pointee)
   }
 
-  /**
-   Copies the value.
-   */
+  /// Copies the value.
   public func copy() -> JavaScriptValue {
     if let runtime {
       return JavaScriptValue(runtime, facebook.jsi.Value(runtime.pointee, pointee))
@@ -90,10 +72,8 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     }
   }
 
-  /**
-   Provides scoped access to a raw pointer to the underlying `facebook.jsi.Value`.
-   The pointer is valid only for the duration of the closure and must not be stored or escaped.
-   */
+  /// Provides scoped access to a raw pointer to the underlying `facebook.jsi.Value`.
+  /// The pointer is valid only for the duration of the closure and must not be stored or escaped.
   public func withUnsafePointee<R>(_ body: (UnsafeRawPointer) throws -> R) rethrows -> R {
     // Using `withUnsafePointer(to:)` crashes the SIL optimizer in release builds
     // due to a Swift compiler bug with C++ interop value types.
@@ -159,9 +139,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return pointee.isObject() && expo.isTypedArray(jsiRuntime, pointee.getObject(jsiRuntime))
   }
 
-  /**
-   Checks whether the value is an `ArrayBuffer`.
-   */
+  /// Checks whether the value is an `ArrayBuffer`.
   public func isArrayBuffer() -> Bool {
     guard let jsiRuntime = runtime?.pointee else {
       FatalError.runtimeLost()
@@ -169,10 +147,8 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return pointee.isObject() && pointee.getObject(jsiRuntime).isArrayBuffer(jsiRuntime)
   }
 
-  /**
-   Checks whether the value is an instance of a global class of the given name.
-   For example `value.is("Promise")` checks whether the value is a promise.
-   */
+  /// Checks whether the value is an instance of a global class of the given name.
+  /// For example `value.is("Promise")` checks whether the value is a promise.
   @JavaScriptActor
   public func `is`(_ typeName: String) -> Bool {
     guard let runtime else {
@@ -230,33 +206,25 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     fatalError("Unsupported value kind: \(kind)")
   }
 
-  /**
-   Returns the value as a boolean, or asserts if not a boolean.
-   */
+  /// Returns the value as a boolean, or asserts if not a boolean.
   public func getBool() -> Bool {
     assert(isBool(), "Value is not a boolean")
     return pointee.getBool()
   }
 
-  /**
-   Returns the value as an integer, or asserts if not a number.
-   */
+  /// Returns the value as an integer, or asserts if not a number.
   public func getInt() -> Int {
     assert(isNumber(), "Value is not a number")
     return Int(pointee.getNumber())
   }
 
-  /**
-   Returns the value as a double, or asserts if not a number.
-   */
+  /// Returns the value as a double, or asserts if not a number.
   public func getDouble() -> Double {
     assert(isNumber(), "Value is not a number")
     return pointee.getNumber()
   }
 
-  /**
-   Returns the value as a string, or asserts if not a string.
-   */
+  /// Returns the value as a string, or asserts if not a string.
   public func getString() -> String {
     guard let jsiRuntime = runtime?.pointee else {
       FatalError.runtimeLost()
@@ -265,9 +233,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return String(pointee.getString(jsiRuntime).utf8(jsiRuntime))
   }
 
-  /**
-   Returns the value as a BigInt, or asserts if not a BigInt.
-   */
+  /// Returns the value as a BigInt, or asserts if not a BigInt.
   public func getBigInt() -> JavaScriptBigInt {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -276,9 +242,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return JavaScriptBigInt(runtime, pointee.getBigInt(runtime.pointee))
   }
 
-  /**
-   Returns the value as an object, or asserts if not an object.
-   */
+  /// Returns the value as an object, or asserts if not an object.
   public func getObject() -> JavaScriptObject {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -287,9 +251,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return JavaScriptObject(runtime, pointee.getObject(runtime.pointee))
   }
 
-  /**
-   Returns the value as an array, or asserts if not an array.
-   */
+  /// Returns the value as an array, or asserts if not an array.
   public func getArray() -> JavaScriptArray {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -298,9 +260,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return JavaScriptArray(runtime, pointee.getObject(runtime.pointee).getArray(runtime.pointee))
   }
 
-  /**
-   Returns the value as a function, or asserts if not a function.
-   */
+  /// Returns the value as a function, or asserts if not a function.
   public func getFunction() -> JavaScriptFunction {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -309,9 +269,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return JavaScriptFunction(runtime, pointee.getObject(runtime.pointee).getFunction(runtime.pointee))
   }
 
-  /**
-   Returns the value as a typed array, or asserts if it is not a typed array.
-   */
+  /// Returns the value as a typed array, or asserts if it is not a typed array.
   public func getTypedArray() -> JavaScriptTypedArray {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -320,9 +278,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return JavaScriptTypedArray(runtime, pointee.getObject(runtime.pointee))
   }
 
-  /**
-   Returns the value as an array buffer, or asserts if it is not an array buffer.
-   */
+  /// Returns the value as an array buffer, or asserts if it is not an array buffer.
   public func getArrayBuffer() -> JavaScriptArrayBuffer {
     guard let runtime else {
       FatalError.runtimeLost()
@@ -331,9 +287,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return JavaScriptArrayBuffer(runtime, pointee.getObject(runtime.pointee).getArrayBuffer(runtime.pointee))
   }
 
-  /**
-   Returns the value as a promise, or asserts if it is not a promise.
-   */
+  /// Returns the value as a promise, or asserts if it is not a promise.
   @JavaScriptActor
   public func getPromise() throws -> JavaScriptPromise {
     guard let runtime else {
@@ -425,10 +379,8 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return try getPromise()
   }
 
-  /**
-   Returns the value as a `JavaScriptArrayBuffer`.
-   Throws `TypeError` if the value is not an object or not an `ArrayBuffer`.
-   */
+  /// Returns the value as a `JavaScriptArrayBuffer`.
+  /// Throws `TypeError` if the value is not an object or not an `ArrayBuffer`.
   @JavaScriptActor
   public func asArrayBuffer() throws(TypeError) -> JavaScriptArrayBuffer {
     let object = try asObject()
@@ -440,9 +392,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
 
   // MARK: - Serializing
 
-  /**
-   Returns a string representing the value. Same as calling `toString()` in JS.
-   */
+  /// Returns a string representing the value. Same as calling `toString()` in JS.
   public func toString() -> String {
     guard let jsiRuntime = runtime?.pointee else {
       FatalError.runtimeLost()
@@ -450,61 +400,59 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     return String(pointee.toString(jsiRuntime).utf8(jsiRuntime))
   }
 
-  /**
-   Converts the JavaScript value to a JSON string representation.
-
-   This method is equivalent to calling `JSON.stringify()` in JavaScript with this value
-   as the first argument. It serializes the value into a JSON-formatted string, with
-   optional control over the serialization process through the replacer and space parameters.
-
-   - Parameters:
-     - replacer: An optional function or array that alters the behavior of the stringification process.
-       - If a function: Called for each property, receiving the key and value as arguments.
-       - If an array: Only properties whose names are in the array will be included in the result.
-       - If `nil`: All properties are included.
-     - space: An optional string or number that controls the indentation and spacing in the output.
-       - If a number: Indicates the number of spaces to use for indentation (clamped to 10).
-       - If a string: Used as the indentation string (truncated to 10 characters).
-       - If `nil`: No whitespace is added, resulting in compact output.
-
-   - Returns: A JSON string representation of the value, or `nil` if the value cannot be
-     serialized (e.g., functions, symbols, or undefined values in object properties).
-
-   - Throws: An error if the serialization fails (e.g., circular references, or if a
-     replacer function throws an error).
-
-   ## Examples
-   ```swift
-   let runtime = JavaScriptRuntime()
-
-   // Simple value
-   let number = JavaScriptValue(runtime, 42)
-   try number.jsonStringify() // "42"
-
-   // Object with pretty printing
-   let obj = runtime.eval("({ name: 'Alice', age: 30 })")
-   try obj.jsonStringify(space: JavaScriptValue(runtime, 2))
-   // Returns:
-   // {
-   //   "name": "Alice",
-   //   "age": 30
-   // }
-
-   // Using a replacer to filter properties
-   let replacer = runtime.eval("['name']") // Only include 'name' property
-   try obj.jsonStringify(replacer: replacer) // {"name":"Alice"}
-
-   // Undefined returns nil
-   let undefined = JavaScriptValue.undefined
-   try undefined.jsonStringify() // nil
-   ```
-
-   - Note: For simple values (undefined, null, boolean, number) that don't have an associated
-     runtime, this method can still produce a JSON representation without invoking JavaScript's
-     `JSON.stringify()`.
-
-   - SeeAlso: [MDN: JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
-   */
+  /// Converts the JavaScript value to a JSON string representation.
+  ///
+  /// This method is equivalent to calling `JSON.stringify()` in JavaScript with this value
+  /// as the first argument. It serializes the value into a JSON-formatted string, with
+  /// optional control over the serialization process through the replacer and space parameters.
+  ///
+  /// - Parameters:
+  ///   - replacer: An optional function or array that alters the behavior of the stringification process.
+  ///     - If a function: Called for each property, receiving the key and value as arguments.
+  ///     - If an array: Only properties whose names are in the array will be included in the result.
+  ///     - If `nil`: All properties are included.
+  ///   - space: An optional string or number that controls the indentation and spacing in the output.
+  ///     - If a number: Indicates the number of spaces to use for indentation (clamped to 10).
+  ///     - If a string: Used as the indentation string (truncated to 10 characters).
+  ///     - If `nil`: No whitespace is added, resulting in compact output.
+  ///
+  /// - Returns: A JSON string representation of the value, or `nil` if the value cannot be
+  ///   serialized (e.g., functions, symbols, or undefined values in object properties).
+  ///
+  /// - Throws: An error if the serialization fails (e.g., circular references, or if a
+  ///   replacer function throws an error).
+  ///
+  /// ## Examples
+  /// ```swift
+  /// let runtime = JavaScriptRuntime()
+  ///
+  /// // Simple value
+  /// let number = JavaScriptValue(runtime, 42)
+  /// try number.jsonStringify() // "42"
+  ///
+  /// // Object with pretty printing
+  /// let obj = runtime.eval("({ name: 'Alice', age: 30 })")
+  /// try obj.jsonStringify(space: JavaScriptValue(runtime, 2))
+  /// // Returns:
+  /// // {
+  /// //   "name": "Alice",
+  /// //   "age": 30
+  /// // }
+  ///
+  /// // Using a replacer to filter properties
+  /// let replacer = runtime.eval("['name']") // Only include 'name' property
+  /// try obj.jsonStringify(replacer: replacer) // {"name":"Alice"}
+  ///
+  /// // Undefined returns nil
+  /// let undefined = JavaScriptValue.undefined
+  /// try undefined.jsonStringify() // nil
+  /// ```
+  ///
+  /// - Note: For simple values (undefined, null, boolean, number) that don't have an associated
+  ///   runtime, this method can still produce a JSON representation without invoking JavaScript's
+  ///   `JSON.stringify()`.
+  ///
+  /// - SeeAlso: [MDN: JSON.stringify()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)
   public func jsonStringify(replacer: JavaScriptValue? = nil, space: JavaScriptValue? = nil) throws -> String? {
     guard let runtime else {
       // Some types do not need the runtime. Handle them before crashing due to missing runtime.
@@ -521,7 +469,8 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
         FatalError.runtimeLost()
       }
     }
-    let value = try runtime
+    let value =
+      try runtime
       .global()
       .getPropertyAsObject("JSON")
       .getPropertyAsFunction("stringify")
@@ -596,9 +545,7 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
 
   // MARK: - Equality
 
-  /**
-   Tests whether two values are strictly equal, according to https://262.ecma-international.org/11.0/#sec-strict-equality-comparison
-   */
+  /// Tests whether two values are strictly equal, according to https://262.ecma-international.org/11.0/#sec-strict-equality-comparison
   public func isEqual(to another: JavaScriptValue) -> Bool {
     if let jsiRuntime = runtime?.pointee ?? another.runtime?.pointee {
       return facebook.jsi.Value.strictEquals(jsiRuntime, pointee, another.pointee)
@@ -620,61 +567,47 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     }
   }
 
-  /**
-   Same as `isEqual(to:)`.
-   */
+  /// Same as `isEqual(to:)`.
   public static func == (lhs: JavaScriptValue, rhs: JavaScriptValue) -> Bool {
     return lhs.isEqual(to: rhs)
   }
 
-  /**
-   Negates the result of `isEqual(to:)`.
-   */
+  /// Negates the result of `isEqual(to:)`.
   public static func != (lhs: JavaScriptValue, rhs: JavaScriptValue) -> Bool {
     return !lhs.isEqual(to: rhs)
   }
 
   // MARK: - Runtime-free initializers
 
-  /**
-   This is a lightweight way to create an undefined value that can be used in contexts
-   where a runtime is not available or needed. The resulting value can be passed to
-   JavaScript functions or used in comparisons.
-   */
+  /// This is a lightweight way to create an undefined value that can be used in contexts
+  /// where a runtime is not available or needed. The resulting value can be passed to
+  /// JavaScript functions or used in comparisons.
   public static var undefined: JavaScriptValue {
     JavaScriptValue(nil, facebook.jsi.Value.undefined())
   }
 
-  /**
-   This is a lightweight way to create a null value that can be used in contexts
-   where a runtime is not available or needed. The resulting value represents
-   JavaScript's `null`, which is distinct from `undefined`.
-   */
+  /// This is a lightweight way to create a null value that can be used in contexts
+  /// where a runtime is not available or needed. The resulting value represents
+  /// JavaScript's `null`, which is distinct from `undefined`.
   public static var null: JavaScriptValue {
     JavaScriptValue(nil, facebook.jsi.Value.null())
   }
 
-  /**
-   This is a lightweight way to create a boolean true value that can be used in contexts
-   where a runtime is not available or needed.
-   */
+  /// This is a lightweight way to create a boolean true value that can be used in contexts
+  /// where a runtime is not available or needed.
   public static func `true`() -> JavaScriptValue {
     return JavaScriptValue(nil, facebook.jsi.Value(true))
   }
 
-  /**
-   This is a lightweight way to create a boolean false value that can be used in contexts
-   where a runtime is not available or needed.
-   */
+  /// This is a lightweight way to create a boolean false value that can be used in contexts
+  /// where a runtime is not available or needed.
   public static func `false`() -> JavaScriptValue {
     return JavaScriptValue(nil, facebook.jsi.Value(false))
   }
 
-  /**
-   This is a lightweight way to create a numeric value that can be used in contexts
-   where a runtime is not available or needed. JavaScript numbers are represented
-   as double-precision floating-point values following the IEEE 754 standard.
-   */
+  /// This is a lightweight way to create a numeric value that can be used in contexts
+  /// where a runtime is not available or needed. JavaScript numbers are represented
+  /// as double-precision floating-point values following the IEEE 754 standard.
   public static func number(_ number: Double) -> JavaScriptValue {
     return JavaScriptValue(nil, facebook.jsi.Value(number))
   }
@@ -704,7 +637,8 @@ extension JavaScriptValue: JavaScriptRepresentable {
 }
 
 extension JavaScriptValue: JSIRepresentable {
-  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptValue {
+  static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptValue
+  {
     FatalError.unimplemented()
   }
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptWeakObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptWeakObject.swift
@@ -2,34 +2,26 @@
 
 internal import jsi
 
-/**
- Represents a weak reference to an object. If the only references to an object are these,
- the object is eligible for GC. Method names are inspired by C++ `std::weak_ptr`.
- */
+/// Represents a weak reference to an object. If the only references to an object are these,
+/// the object is eligible for GC. Method names are inspired by C++ `std::weak_ptr`.
 public struct JavaScriptWeakObject: JavaScriptType, ~Copyable {
   internal weak let runtime: JavaScriptRuntime?
   internal let pointee: facebook.jsi.WeakObject
 
-  /**
-   Initializes a weak object with the underlying JSI weak object.
-   */
+  /// Initializes a weak object with the underlying JSI weak object.
   internal init(_ runtime: JavaScriptRuntime, _ object: consuming facebook.jsi.WeakObject) {
     self.runtime = runtime
     self.pointee = object
   }
 
-  /**
-   Creates `JavaScriptWeakObject` from `JavaScriptObject`. Same as `createWeak()` called on the object.
-   */
+  /// Creates `JavaScriptWeakObject` from `JavaScriptObject`. Same as `createWeak()` called on the object.
   public init(_ runtime: JavaScriptRuntime, _ object: borrowing JavaScriptObject) {
     self.runtime = runtime
     self.pointee = facebook.jsi.WeakObject(runtime.pointee, object.pointee)
   }
 
-  /**
-   Returns the underlying `JavaScriptObject` if it is still valid; otherwise returns `nil`.
-   Note that this method has nothing to do with threads or concurrency. The name is based on `std::weak_ptr::lock()` which serves a similar purpose.
-   */
+  /// Returns the underlying `JavaScriptObject` if it is still valid; otherwise returns `nil`.
+  /// Note that this method has nothing to do with threads or concurrency. The name is based on `std::weak_ptr::lock()` which serves a similar purpose.
   public func lock() -> JavaScriptObject? {
     guard let runtime else {
       FatalError.runtimeLost()

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/ErrorHandling.swift
@@ -1,9 +1,7 @@
-internal import jsi
 internal import ExpoModulesJSI_Cxx
+internal import jsi
 
-/**
- Gets the recently thrown `expo.CppError` that was not handled by Swift yet.
- */
+/// Gets the recently thrown `expo.CppError` that was not handled by Swift yet.
 private func getCurrentCppError() -> expo.CppError? {
   if let current = expo.CppError.getCurrent() {
     return current.move()
@@ -11,10 +9,8 @@ private func getCurrentCppError() -> expo.CppError? {
   return nil
 }
 
-/**
- Executes given block (calling potentially throwing C++ functions) and captures C++ exceptions
- thrown within the block passed to `expo::CppError::tryCatch` call in C++.
- */
+/// Executes given block (calling potentially throwing C++ functions) and captures C++ exceptions
+/// thrown within the block passed to `expo::CppError::tryCatch` call in C++.
 internal func capturingCppErrors<R: ~Copyable>(_ block: () throws -> R) throws -> R {
   let result: R = try block()
   if let cppError = getCurrentCppError() {
@@ -23,14 +19,12 @@ internal func capturingCppErrors<R: ~Copyable>(_ block: () throws -> R) throws -
   return result
 }
 
-/**
- Runs a Swift trampoline body called from a C++ host callback and forwards any thrown error
- to `expo::CppError`'s thread-local storage so the C++ side can rethrow it as a `jsi::JSError`.
- On the failure branch returns `undefined`, since the C++ side will overwrite it by throwing
- the rethrown `jsi::JSError` before the value is observed by JS. Used by host function and
- host object getter trampolines on a hot path, hence `@_transparent` to inline into the
- caller and avoid a function-call boundary.
- */
+/// Runs a Swift trampoline body called from a C++ host callback and forwards any thrown error
+/// to `expo::CppError`'s thread-local storage so the C++ side can rethrow it as a `jsi::JSError`.
+/// On the failure branch returns `undefined`, since the C++ side will overwrite it by throwing
+/// the rethrown `jsi::JSError` before the value is observed by JS. Used by host function and
+/// host object getter trampolines on a hot path, hence `@_transparent` to inline into the
+/// caller and avoid a function-call boundary.
 @_transparent
 internal func forwardingSwiftErrorsToJS(
   runtime: JavaScriptRuntime,
@@ -50,10 +44,8 @@ internal func forwardingSwiftErrorsToJS(
   return .undefined()
 }
 
-/**
- Void overload of `forwardingSwiftErrorsToJS` for host object setter trampolines, which
- have no return value to propagate.
- */
+/// Void overload of `forwardingSwiftErrorsToJS` for host object setter trampolines, which
+/// have no return value to propagate.
 @_transparent
 internal func forwardingSwiftErrorsToJS(
   runtime: JavaScriptRuntime,

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/Errors.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/Errors.swift
@@ -1,45 +1,33 @@
-/**
- Contains specialized functions that execute fatal errors that terminate the program and print the message to the console.
- */
+/// Contains specialized functions that execute fatal errors that terminate the program and print the message to the console.
 internal struct FatalError {
-  /**
-   Signals that a function or one of its case is not implemented (intentionally or not).
-   */
+  /// Signals that a function or one of its case is not implemented (intentionally or not).
   internal static func unimplemented() -> Never {
     fatalError("Unimplemented")
   }
 
-  /**
-   Stops program execution when the JS runtime is not available but required to proceed.
-   */
+  /// Stops program execution when the JS runtime is not available but required to proceed.
   internal static func runtimeLost() -> Never {
     fatalError("The JavaScript runtime has been deallocated")
   }
 
-  /**
-   Stops program execution when trying to access buffer's elements out of its range.
-   */
+  /// Stops program execution when trying to access buffer's elements out of its range.
   internal static func valuesBufferIndexOutRange(index: Int, capacity: Int) -> Never {
     fatalError("Index \(index) is out of range of values buffer capacity \(capacity), valid range is 0..<\(capacity)")
   }
 
-  /**
-   Stops program execution when trying to represent a `JavaScriptValuesBuffer` as a single JS value.
-   */
+  /// Stops program execution when trying to represent a `JavaScriptValuesBuffer` as a single JS value.
   internal static func valuesBufferNotRepresentable() -> Never {
     fatalError("JavaScript values buffer cannot be represented as a single value")
   }
 
-  /**
-   Stops program execution when the Swift setter trampoline runs for a host object that
-   was created with `set: nil`. The C++ `HostObjectCallbacks::set` is supposed to throw a
-   `jsi::JSError` for read-only host objects without re-entering Swift, so reaching this
-   means that contract has drifted — check its null-setter short-circuit.
-   */
+  /// Stops program execution when the Swift setter trampoline runs for a host object that
+  /// was created with `set: nil`. The C++ `HostObjectCallbacks::set` is supposed to throw a
+  /// `jsi::JSError` for read-only host objects without re-entering Swift, so reaching this
+  /// means that contract has drifted — check its null-setter short-circuit.
   internal static func readOnlyHostObjectSetterInvoked() -> Never {
     fatalError(
       "createHostObject setter trampoline ran despite set: nil — HostObjectCallbacks::set should throw a jsi::JSError for read-only host objects without re-entering Swift. "
-      + "Check that its null-setter short-circuit is still in place."
+        + "Check that its null-setter short-circuit is still in place."
     )
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/NonisolatedUnsafeVar.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Utilities/NonisolatedUnsafeVar.swift
@@ -1,7 +1,5 @@
-/**
- Unsafe wrapper to make non-Sendable types shareable across concurrency domains without compiler enforcement.
- Use with extreme caution as it bypasses Swift's concurrency safety checks.
- */
+/// Unsafe wrapper to make non-Sendable types shareable across concurrency domains without compiler enforcement.
+/// Use with extreme caution as it bypasses Swift's concurrency safety checks.
 internal final class NonisolatedUnsafeVar<VarType>: Sendable {
   nonisolated(unsafe) var value: VarType! = nil
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptActorTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptActorTests.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 struct JavaScriptActorTests {
@@ -125,7 +125,7 @@ struct JavaScriptActorTests {
     // async outside, async inside
     try await runtime.execute {
       JavaScriptActor.assertIsolated()
-      try await Task.sleep(nanoseconds: 0) // makes the closure async
+      try await Task.sleep(nanoseconds: 0)  // makes the closure async
       JavaScriptActor.assertIsolated()
     }
   }
@@ -135,7 +135,7 @@ struct JavaScriptActorTests {
     // sync outside, async inside
     try runtime.execute {
       JavaScriptActor.assertIsolated()
-      try await Task.sleep(nanoseconds: 0) // makes the closure async
+      try await Task.sleep(nanoseconds: 0)  // makes the closure async
       JavaScriptActor.assertIsolated()
     }
   }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayBufferTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayBufferTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayTests.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor
@@ -139,7 +139,7 @@ struct JavaScriptArrayTests {
     #expect(try array.getValue(at: 1).getBool() == true)
     #expect(try array.getValue(at: 2).isNull() == true)
     #expect(try array.getValue(at: 3).isUndefined() == true)
-    #expect(try array.getValue(at: 4).getInt() == 5) // Unchanged
+    #expect(try array.getValue(at: 4).getInt() == 5)  // Unchanged
   }
 
   @Test
@@ -462,6 +462,7 @@ struct JavaScriptArrayTests {
     let array = try runtime.eval("[10, 20, 30]").getArray()
     var values: [Int] = []
 
+    // swift-format-ignore: ReplaceForEachWithForLoop
     array.forEach { values.append($0.getInt()) }
     #expect(values == [10, 20, 30])
   }
@@ -471,6 +472,7 @@ struct JavaScriptArrayTests {
     let array = try runtime.eval("[]").getArray()
     var count = 0
 
+    // swift-format-ignore: ReplaceForEachWithForLoop
     array.forEach { _ in count += 1 }
     #expect(count == 0)
   }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptBigIntTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptBigIntTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor
@@ -10,16 +10,16 @@ struct JavaScriptBigIntTests {
 
   @Test
   func `create from Int64`() {
-    let bigInt = JavaScriptBigInt(runtime, fromInt64: 9007199254740991)
+    let bigInt = JavaScriptBigInt(runtime, fromInt64: 9_007_199_254_740_991)
     #expect(bigInt.isInt64() == true)
-    #expect(bigInt.getInt64() == 9007199254740991)
+    #expect(bigInt.getInt64() == 9_007_199_254_740_991)
   }
 
   @Test
   func `create from negative Int64`() {
-    let bigInt = JavaScriptBigInt(runtime, fromInt64: -9007199254740991)
+    let bigInt = JavaScriptBigInt(runtime, fromInt64: -9_007_199_254_740_991)
     #expect(bigInt.isInt64() == true)
-    #expect(bigInt.getInt64() == -9007199254740991)
+    #expect(bigInt.getInt64() == -9_007_199_254_740_991)
   }
 
   @Test
@@ -137,7 +137,7 @@ struct JavaScriptBigIntTests {
 
   @Test
   func `create from string beyond Int64 range`() throws {
-    let bigInt = try JavaScriptBigInt(runtime, string: "9223372036854775808") // Int64.max + 1
+    let bigInt = try JavaScriptBigInt(runtime, string: "9223372036854775808")  // Int64.max + 1
     #expect(bigInt.isInt64() == false)
     let str = try bigInt.toString()
     #expect(str == "9223372036854775808")
@@ -169,7 +169,7 @@ struct JavaScriptBigIntTests {
 
   @Test
   func `asInt64 throws when beyond Int64 range`() throws {
-    let bigInt = try JavaScriptBigInt(runtime, string: "9223372036854775808") // Int64.max + 1
+    let bigInt = try JavaScriptBigInt(runtime, string: "9223372036854775808")  // Int64.max + 1
     #expect(throws: BigIntConversionError.self) {
       try bigInt.asInt64()
     }
@@ -235,7 +235,7 @@ struct JavaScriptBigIntTests {
 
   @Test
   func `toString with base 36`() throws {
-    let bigInt = JavaScriptBigInt(runtime, fromInt64: 1234567890)
+    let bigInt = JavaScriptBigInt(runtime, fromInt64: 1_234_567_890)
     let str = try bigInt.toString(radix: 36)
     #expect(str == "kf12oi")
   }
@@ -282,7 +282,7 @@ struct JavaScriptBigIntTests {
 
   @Test
   func `equality of large values`() {
-    let value = Int64(9007199254740991)
+    let value = Int64(9_007_199_254_740_991)
     let bigInt1 = JavaScriptBigInt(runtime, fromInt64: value)
     let bigInt2 = JavaScriptBigInt(runtime, fromInt64: value)
     #expect((bigInt1 == bigInt2) == true)
@@ -439,11 +439,11 @@ struct JavaScriptBigIntTests {
 
   @Test
   func `round-trip through JavaScript property`() throws {
-    let original = JavaScriptBigInt(runtime, fromInt64: 9007199254740991)
-    
+    let original = JavaScriptBigInt(runtime, fromInt64: 9_007_199_254_740_991)
+
     let global = runtime.global()
     global.setProperty("testBigInt", value: original.asValue())
-    
+
     let retrieved = try runtime.eval("testBigInt").getBigInt()
     #expect((original == retrieved) == true)
   }
@@ -451,26 +451,26 @@ struct JavaScriptBigIntTests {
   @Test
   func `round-trip through JavaScript function`() throws {
     try runtime.eval("globalThis.identity = (x) => x")
-    
+
     let bigInt = JavaScriptBigInt(runtime, fromInt64: 42)
     let result = try runtime.global()
       .getPropertyAsFunction("identity")
       .call(arguments: bigInt.asValue())
       .getBigInt()
-    
+
     #expect((result == bigInt) == true)
   }
 
   @Test
   func `pass BigInt to JavaScript function and operate`() throws {
     try runtime.eval("globalThis.double = (x) => x * 2n")
-    
+
     let bigInt = JavaScriptBigInt(runtime, fromInt64: 21)
     let result = try runtime.global()
       .getPropertyAsFunction("double")
       .call(arguments: bigInt.asValue())
       .getBigInt()
-    
+
     #expect(result.getInt64() == 42)
   }
 
@@ -479,7 +479,7 @@ struct JavaScriptBigIntTests {
     let obj = runtime.createObject()
     let bigInt = JavaScriptBigInt(runtime, fromInt64: 42)
     obj.setProperty("value", value: bigInt.asValue())
-    
+
     let retrieved = obj.getProperty("value").getBigInt()
     #expect((retrieved == bigInt) == true)
   }
@@ -489,7 +489,7 @@ struct JavaScriptBigIntTests {
     let array = JavaScriptArray(runtime, length: 1)
     let bigInt = JavaScriptBigInt(runtime, fromInt64: 42)
     array[0] = bigInt.asValue()
-    
+
     let retrieved = try array.getValue(at: 0).getBigInt()
     #expect((retrieved == bigInt) == true)
   }
@@ -554,10 +554,10 @@ struct JavaScriptBigIntTests {
   func `BigIntConversionError has descriptive messages`() {
     let error1 = BigIntConversionError.outOfInt64Range
     #expect(error1.description.contains("Int64"))
-    
+
     let error2 = BigIntConversionError.outOfUint64Range
     #expect(error2.description.contains("UInt64"))
-    
+
     let error3 = BigIntConversionError.invalidRadix(50)
     #expect(error3.description.contains("50"))
     #expect(error3.description.contains("2"))

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptErrorTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptErrorTests.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor
@@ -49,9 +49,11 @@ struct JavaScriptErrorTests {
     }
     runtime.global().setProperty("failing", value: fn)
 
-    let result = try runtime.eval("""
-      try { failing(); null } catch (e) { [e.message, e.code] }
-    """).getArray()
+    let result = try runtime.eval(
+      """
+        try { failing(); null } catch (e) { [e.message, e.code] }
+      """
+    ).getArray()
     #expect(result[0].getString() == "Boom")
     #expect(result[1].getString() == "ERR_BOOM")
   }
@@ -60,9 +62,10 @@ struct JavaScriptErrorTests {
   func `nested host function errors are independent`() throws {
     let outer = runtime.createFunction("outer") { [self] _, _ in
       // Call inner from JS, which throws; JS catches it, then we throw our own error.
-      let innerResult = try runtime.eval("""
-        try { inner(); 'no error' } catch (e) { e.message }
-      """)
+      let innerResult = try runtime.eval(
+        """
+          try { inner(); 'no error' } catch (e) { e.message }
+        """)
       #expect(innerResult.getString() == "inner boom")
 
       throw CodedError(message: "outer boom", code: "ERR_OUTER")
@@ -74,9 +77,11 @@ struct JavaScriptErrorTests {
     runtime.global().setProperty("outer", value: outer)
     runtime.global().setProperty("inner", value: inner)
 
-    let result = try runtime.eval("""
-      try { outer(); null } catch (e) { [e.message, e.code] }
-    """).getArray()
+    let result = try runtime.eval(
+      """
+        try { outer(); null } catch (e) { [e.message, e.code] }
+      """
+    ).getArray()
     #expect(result[0].getString() == "outer boom")
     #expect(result[1].getString() == "ERR_OUTER")
   }
@@ -92,4 +97,3 @@ private struct CodedError: JavaScriptThrowable {
   var message: String
   var code: String
 }
-

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptFunctionTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptFunctionTests.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptNativeStateTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptNativeStateTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor
@@ -242,7 +242,7 @@ struct JavaScriptObjectTests {
       object.defineProperty("test", descriptor: .init(value: JavaScriptValue(runtime, true)))
       #expect(object.hasProperty("test") == true)
       #expect(object.getProperty("test").getBool() == true)
-      #expect(object.getPropertyNames().contains("test") == false) // non-enumerable by default
+      #expect(object.getPropertyNames().contains("test") == false)  // non-enumerable by default
     }
 
     @Test
@@ -283,14 +283,14 @@ struct JavaScriptObjectTests {
     func `define property with all options`() {
       let object = JavaScriptObject(runtime)
       object.defineProperty("fullAccess", value: 100, options: [.configurable, .enumerable, .writable])
-      
+
       #expect(object.getProperty("fullAccess").getInt() == 100)
       #expect(object.getPropertyNames().contains("fullAccess") == true)
-      
+
       // Can modify
       object.setProperty("fullAccess", value: 200.0)
       #expect(object.getProperty("fullAccess").getInt() == 200)
-      
+
       // Can reconfigure
       object.defineProperty("fullAccess", descriptor: .init(value: JavaScriptValue(runtime, 300)))
       #expect(object.getProperty("fullAccess").getInt() == 300)
@@ -436,7 +436,7 @@ struct JavaScriptObjectTests {
     func `call function that throws error`() throws {
       let obj = try runtime.eval("({ throwError() { throw new Error('test error'); } })")
       let jsObject = obj.getObject()
-      
+
       #expect(throws: Error.self) {
         try jsObject.callFunction("throwError")
       }
@@ -492,7 +492,8 @@ struct JavaScriptObjectTests {
     @Test
     func `PropertyDescriptor with all properties`() {
       let value = JavaScriptValue(runtime, "test")
-      let descriptor = JavaScriptObject.PropertyDescriptor(configurable: true, enumerable: true, writable: true, value: value)
+      let descriptor = JavaScriptObject.PropertyDescriptor(
+        configurable: true, enumerable: true, writable: true, value: value)
       let object = descriptor.toObject(runtime)
       #expect(object.hasProperty("configurable") == true)
       #expect(object.getProperty("configurable").getBool() == true)
@@ -506,7 +507,8 @@ struct JavaScriptObjectTests {
 
     @Test
     func `PropertyDescriptor to object conversion`() {
-      let descriptor = JavaScriptObject.PropertyDescriptor(configurable: false, enumerable: true, writable: false, value: JavaScriptValue(runtime, 42))
+      let descriptor = JavaScriptObject.PropertyDescriptor(
+        configurable: false, enumerable: true, writable: false, value: JavaScriptValue(runtime, 42))
       let object = descriptor.toObject(runtime)
       #expect(object.getProperty("enumerable").getBool() == true)
       #expect(object.getProperty("value").getInt() == 42)

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor
@@ -96,11 +96,12 @@ struct JavaScriptPromiseTests {
   @Test
   func `wrapped promise setup throws when then is unavailable`() throws {
     let runtime = JavaScriptRuntime()
-    let promiseValue = try runtime.eval("""
-    const promise = Promise.resolve(42);
-    promise.then = undefined;
-    promise;
-    """)
+    let promiseValue = try runtime.eval(
+      """
+      const promise = Promise.resolve(42);
+      promise.then = undefined;
+      promise;
+      """)
 
     #expect(throws: Error.self) {
       _ = try promiseValue.getPromise()
@@ -223,7 +224,8 @@ struct JavaScriptPromiseTests {
   @Test
   func `promise from async JavaScript function`() async throws {
     let runtime = JavaScriptRuntime()
-    let result = try await runtime
+    let result =
+      try await runtime
       .eval("(async function() { return 42; })")
       .getFunction()
       .call()
@@ -236,7 +238,8 @@ struct JavaScriptPromiseTests {
   @Test
   func `promise from async JavaScript function with arguments`() async throws {
     let runtime = JavaScriptRuntime()
-    let result = try await runtime
+    let result =
+      try await runtime
       .eval("(async function(a, b) { return a + b; })")
       .getFunction()
       .call(arguments: 15, 27)
@@ -249,7 +252,8 @@ struct JavaScriptPromiseTests {
   @Test
   func `promise catches JavaScript errors`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try runtime
+    let promise =
+      try runtime
       .eval("(async function() { throw new Error('async error'); })")
       .getFunction()
       .call()
@@ -267,7 +271,7 @@ struct JavaScriptPromiseTests {
 
     // Resolve from a task
     Task.detached {
-      try await Task.sleep(nanoseconds: 10_000_000) // 10ms
+      try await Task.sleep(nanoseconds: 10_000_000)  // 10ms
       promise.resolve(JavaScriptValue(runtime, 99))
     }
 
@@ -287,7 +291,8 @@ struct JavaScriptPromiseTests {
     runtime.global().setProperty("p2", value: promise2.asValue())
     runtime.global().setProperty("p3", value: promise3.asValue())
 
-    let promiseAll = try runtime
+    let promiseAll =
+      try runtime
       .eval("Promise.all([globalThis.p1, globalThis.p2, globalThis.p3])")
       .getPromise()
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRefTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRefTests.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -1,6 +1,6 @@
-import Testing
 import ExpoModulesJSI
 import Foundation
+import Testing
 
 @Suite
 @JavaScriptActor
@@ -281,9 +281,10 @@ struct JavaScriptRuntimeTests {
 
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
 
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.foo = 1; 'no error' } catch (e) { e.message }
-    """)
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.foo = 1; 'no error' } catch (e) { e.message }
+      """)
 
     #expect(result.getString().contains("set failed"))
   }
@@ -302,9 +303,11 @@ struct JavaScriptRuntimeTests {
 
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
 
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.foo = 1; null } catch (e) { [e.message, e.code] }
-    """).getArray()
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.foo = 1; null } catch (e) { [e.message, e.code] }
+      """
+    ).getArray()
 
     #expect(result[0].getString() == "read only")
     #expect(result[1].getString() == "ERR_READ_ONLY")
@@ -322,9 +325,10 @@ struct JavaScriptRuntimeTests {
 
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
 
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.foo; 'no error' } catch (e) { e.message }
-    """)
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.foo; 'no error' } catch (e) { e.message }
+      """)
 
     #expect(result.getString().contains("get failed"))
   }
@@ -342,9 +346,11 @@ struct JavaScriptRuntimeTests {
 
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
 
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.foo; null } catch (e) { [e.message, e.code] }
-    """).getArray()
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.foo; null } catch (e) { [e.message, e.code] }
+      """
+    ).getArray()
 
     #expect(result[0].getString() == "missing")
     #expect(result[1].getString() == "ERR_MISSING")
@@ -372,17 +378,19 @@ struct JavaScriptRuntimeTests {
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
 
     // First write throws and is caught in JS.
-    let firstAttempt = try runtime.eval("""
-      try { globalThis.hostObj.value = 1; 'no error' } catch (e) { e.message }
-    """)
+    let firstAttempt = try runtime.eval(
+      """
+        try { globalThis.hostObj.value = 1; 'no error' } catch (e) { e.message }
+      """)
     #expect(firstAttempt.getString().contains("boom"))
 
     // Subsequent write must succeed — verifies the C++ thread-local error
     // state is cleared after being rethrown, not leaked to the next call.
     shouldThrow = false
-    let secondAttempt = try runtime.eval("""
-      try { globalThis.hostObj.value = 7; globalThis.hostObj.value } catch (e) { -1 }
-    """)
+    let secondAttempt = try runtime.eval(
+      """
+        try { globalThis.hostObj.value = 7; globalThis.hostObj.value } catch (e) { -1 }
+      """)
     #expect(secondAttempt.getInt() == 7)
   }
 
@@ -407,10 +415,11 @@ struct JavaScriptRuntimeTests {
 
     // A failing set followed by a successful get must not surface the
     // earlier set error — checks the thread-local error slot is cleared.
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.value = 1 } catch (e) {}
-      globalThis.hostObj.ok
-    """)
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.value = 1 } catch (e) {}
+        globalThis.hostObj.ok
+      """)
 
     #expect(result.getInt() == 123)
   }
@@ -425,9 +434,10 @@ struct JavaScriptRuntimeTests {
 
     // No `set` was provided — the C++ side raises a `jsi::JSError` directly,
     // without crossing the Swift boundary.
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.foo = 1; 'no error' } catch (e) { e.message }
-    """)
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.foo = 1; 'no error' } catch (e) { e.message }
+      """)
     let message = result.getString()
 
     #expect(message.contains("read-only host object"))
@@ -445,22 +455,24 @@ struct JavaScriptRuntimeTests {
 
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
 
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.value = 7; globalThis.hostObj.value } catch (e) { -1 }
-    """)
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.value = 7; globalThis.hostObj.value } catch (e) { -1 }
+      """)
 
     #expect(result.getInt() == 7)
   }
 
   @Test
   func `host getter that calls failing JS preserves the original error`() throws {
-    try runtime.eval("""
-      globalThis.throwTagged = function () {
-        const e = new Error('inner failure');
-        e.code = 'ERR_INNER';
-        throw e;
-      };
-    """)
+    try runtime.eval(
+      """
+        globalThis.throwTagged = function () {
+          const e = new Error('inner failure');
+          e.code = 'ERR_INNER';
+          throw e;
+        };
+      """)
     let throwTagged = runtime.global().getPropertyAsFunction("throwTagged")
 
     let hostObject = runtime.createHostObject(
@@ -473,9 +485,11 @@ struct JavaScriptRuntimeTests {
     )
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
 
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.foo; null } catch (e) { [e.message, e.code] }
-    """).getArray()
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.foo; null } catch (e) { [e.message, e.code] }
+      """
+    ).getArray()
 
     #expect(result[0].getString() == "inner failure")
     #expect(result[1].getString() == "ERR_INNER")
@@ -483,13 +497,14 @@ struct JavaScriptRuntimeTests {
 
   @Test
   func `host setter that calls failing JS preserves the original error`() throws {
-    try runtime.eval("""
-      globalThis.throwTagged = function () {
-        const e = new Error('inner setter failure');
-        e.code = 'ERR_SETTER';
-        throw e;
-      };
-    """)
+    try runtime.eval(
+      """
+        globalThis.throwTagged = function () {
+          const e = new Error('inner setter failure');
+          e.code = 'ERR_SETTER';
+          throw e;
+        };
+      """)
     let throwTagged = runtime.global().getPropertyAsFunction("throwTagged")
 
     let hostObject = runtime.createHostObject(
@@ -500,9 +515,11 @@ struct JavaScriptRuntimeTests {
     )
     runtime.global().setProperty("hostObj", value: hostObject.asValue())
 
-    let result = try runtime.eval("""
-      try { globalThis.hostObj.foo = 1; null } catch (e) { [e.message, e.code] }
-    """).getArray()
+    let result = try runtime.eval(
+      """
+        try { globalThis.hostObj.foo = 1; null } catch (e) { [e.message, e.code] }
+      """
+    ).getArray()
 
     #expect(result[0].getString() == "inner setter failure")
     #expect(result[1].getString() == "ERR_SETTER")
@@ -522,9 +539,10 @@ struct JavaScriptRuntimeTests {
 
     runtime.global().setProperty("failing", value: fn.asValue())
 
-    let result = try runtime.eval("""
-      try { failing(); 'no error' } catch (e) { e.message }
-    """)
+    let result = try runtime.eval(
+      """
+        try { failing(); 'no error' } catch (e) { e.message }
+      """)
 
     #expect(result.getString().contains("something went wrong"))
   }
@@ -541,12 +559,14 @@ struct JavaScriptRuntimeTests {
 
     runtime.global().setProperty("throwIt", value: fn.asValue())
 
-    let result = try runtime.eval("""
-      var caught = false;
-      var message = '';
-      try { throwIt(); } catch (e) { caught = true; message = e.message; }
-      [caught, message]
-    """).getArray()
+    let result = try runtime.eval(
+      """
+        var caught = false;
+        var message = '';
+        try { throwIt(); } catch (e) { caught = true; message = e.message; }
+        [caught, message]
+      """
+    ).getArray()
 
     #expect(result[0].getBool() == true)
     #expect(result[1].getString().contains("custom error message"))

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptTypedArrayTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptTypedArrayTests.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor
@@ -107,10 +107,12 @@ struct JavaScriptTypedArrayTests {
 
   @Test
   func `properties with offset and length`() throws {
-    let typedArray = try runtime.eval("""
-      var buf = new ArrayBuffer(16);
-      new Int32Array(buf, 4, 2)
-    """).getTypedArray()
+    let typedArray = try runtime.eval(
+      """
+        var buf = new ArrayBuffer(16);
+        new Int32Array(buf, 4, 2)
+      """
+    ).getTypedArray()
 
     #expect(typedArray.length == 2)
     #expect(typedArray.byteOffset == 4)
@@ -210,11 +212,13 @@ struct JavaScriptTypedArrayTests {
 
   @Test
   func `withUnsafeBytes covers view range, not full buffer`() throws {
-    let typedArray = try runtime.eval("""
-      var buf = new ArrayBuffer(16);
-      new Uint8Array(buf).fill(0xAA);
-      new Uint8Array(buf, 4, 8)
-    """).getTypedArray()
+    let typedArray = try runtime.eval(
+      """
+        var buf = new ArrayBuffer(16);
+        new Uint8Array(buf).fill(0xAA);
+        new Uint8Array(buf, 4, 8)
+      """
+    ).getTypedArray()
 
     #expect(typedArray.byteOffset == 4)
     #expect(typedArray.byteLength == 8)
@@ -271,10 +275,12 @@ struct JavaScriptTypedArrayTests {
 
   @Test
   func `getArrayBuffer respects offset`() throws {
-    let typedArray = try runtime.eval("""
-      var buf = new ArrayBuffer(8);
-      new Uint8Array(buf, 2, 4)
-    """).getTypedArray()
+    let typedArray = try runtime.eval(
+      """
+        var buf = new ArrayBuffer(8);
+        new Uint8Array(buf, 2, 4)
+      """
+    ).getTypedArray()
     let buffer = typedArray.getArrayBuffer()
 
     #expect(typedArray.byteOffset == 2)

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptValueTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptValuesBufferTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptValuesBufferTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptWeakObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptWeakObjectTests.swift
@@ -1,7 +1,7 @@
 // Copyright 2025-present 650 Industries. All rights reserved.
 
-import Testing
 import ExpoModulesJSI
+import Testing
 
 @Suite
 @JavaScriptActor

--- a/packages/expo-modules-jsi/package.json
+++ b/packages/expo-modules-jsi/package.json
@@ -12,6 +12,8 @@
   },
   "scripts": {
     "build": "apple/scripts/build-xcframework.sh",
+    "swift:format": "../../scripts/swift-format.sh",
+    "swift:lint": "../../scripts/swift-format.sh --lint",
     "test": "apple/scripts/test.sh"
   },
   "keywords": [

--- a/scripts/swift-format.sh
+++ b/scripts/swift-format.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Run swift-format against tracked .swift files under the given paths
+# (or the current directory if none are given). Pass --lint to check
+# without modifying. Reads .swift-format at the repo root.
+
+set -euo pipefail
+
+if command -v swift-format >/dev/null 2>&1; then
+  bin=(swift-format)
+else
+  bin=(xcrun swift-format)
+fi
+
+# Keep in sync with SWIFT_FORMAT_VERSION in .github/workflows/swift-format.yml.
+# The same binary reports the Git tag (603.0.0) when built from source and the
+# Xcode-style version (6.3.0) when bundled with the toolchain.
+readonly EXPECTED_VERSION=603.0.0
+readonly EXPECTED_XCODE_VERSION=6.3.0
+got_version=$("${bin[@]}" --version 2>/dev/null || true)
+if [[ "$got_version" != "$EXPECTED_VERSION" && "$got_version" != "$EXPECTED_XCODE_VERSION" ]]; then
+  echo "warning: swift-format $got_version found, CI uses $EXPECTED_VERSION ($EXPECTED_XCODE_VERSION). Output may differ." >&2
+fi
+
+mode=format
+extra=(--in-place)
+if [[ "${1-}" == "--lint" ]]; then
+  mode=lint
+  extra=(--strict)
+  shift
+fi
+
+paths=("$@")
+[[ ${#paths[@]} -eq 0 ]] && paths=(".")
+
+git ls-files -z -- "${paths[@]}" \
+  | tr '\0' '\n' \
+  | grep '\.swift$' \
+  | xargs "${bin[@]}" "$mode" "${extra[@]}" --parallel

--- a/scripts/swift-format.sh
+++ b/scripts/swift-format.sh
@@ -12,9 +12,9 @@ else
 fi
 
 # Keep in sync with SWIFT_FORMAT_VERSION in .github/workflows/swift-format.yml.
-# The same binary reports the Git tag (603.0.0) when built from source and the
-# Xcode-style version (6.3.0) when bundled with the toolchain.
-readonly EXPECTED_VERSION=603.0.0
+# The Xcode-bundled binary reports `6.3.0`; the swift-format Git tag is a 603
+# prerelease (no final 603.0.0 has been cut). Both refer to the same series.
+readonly EXPECTED_VERSION=603.0.0-prerelease-2026-02-09
 readonly EXPECTED_XCODE_VERSION=6.3.0
 got_version=$("${bin[@]}" --version 2>/dev/null || true)
 if [[ "$got_version" != "$EXPECTED_VERSION" && "$got_version" != "$EXPECTED_XCODE_VERSION" ]]; then


### PR DESCRIPTION
# Why

To stop relitigating Swift style on a per-PR basis and let an opinionated formatter own whitespace, indentation, import order, line wrapping, and doc-comment shape. Piloting on `expo-modules-jsi` first — if it works well, more packages can opt in later.

# How

- Added [swift-format](https://github.com/swiftlang/swift-format) (Swift 6.3 series — currently pinned to the latest 603 prerelease since no final 603.0.0 has been cut) as the formatter, configured via a minimal `.swift-format` at the repo root (2-space indent, no `#if` body indent, `lineLength: 120`, otherwise defaults).
- New **Swift Format** CI workflow lints opted-in packages on Ubuntu, building swift-format from source and caching the binary across runs.
- Opt-in is per package via `swift:format` / `swift:lint` pnpm scripts wired to a thin shared wrapper at `scripts/swift-format.sh`. `expo-modules-jsi` is opted in.
- Existing sources were mass-reformatted. That commit is intended for `.git-blame-ignore-revs` post-merge so `git blame` walks through it.
- A handful of identifiers and constructs that intentionally mirror JS names or otherwise don't fit a generic lint are silenced with targeted `swift-format-ignore` markers.
- Documented the rollout process and conventions in `guides/Swift Style Guide.md` (linked from `CONTRIBUTING.md`).

# Test Plan

- New **Swift Format** CI job passes.
- iOS unit tests still pass against the reformatted code.
- Local: `pnpm swift:lint` in `packages/expo-modules-jsi` exits clean; `pnpm test` on macOS still green.

<!-- disable:changelog-checks -->