### PR TITLE
[docs] Add non-null assertion to Supabase URL and key

### DIFF
--- a/docs/pages/guides/using-supabase.mdx
+++ b/docs/pages/guides/using-supabase.mdx
@@ -50,8 +50,8 @@ Create a helper file to initialize the Supabase client (`@supabase/supabase-js`)
 import 'expo-sqlite/localStorage/install';
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = YOUR_REACT_NATIVE_SUPABASE_URL;
-const supabasePublishableKey = YOUR_REACT_NATIVE_SUPABASE_PUBLISHABLE_KEY;
+const supabaseUrl = YOUR_REACT_NATIVE_SUPABASE_URL!;
+const supabasePublishableKey = YOUR_REACT_NATIVE_SUPABASE_PUBLISHABLE_KEY!;
 
 export const supabase = createClient(supabaseUrl, supabasePublishableKey, {
   auth: {


### PR DESCRIPTION
### Summary

Following the [documentation](https://docs.expo.dev/guides/using-supabase/), specifically the second step in the `Using the Supabase TypeScript SDK` section, the example for `supabaseUrl `and `supabasePublishableKey` can lead to a TypeScript error after being copied into the editor.


<img width="789" height="131" alt="Image" src="https://github.com/user-attachments/assets/c9e5421d-29d9-4b93-ad10-0962344d393a" />

******


To avoid this issue and align the example with the official Supabase documentation, I suggest adding the non-null assertion operator (!) to both constants:

```typescript
const supabaseUrl = YOUR_REACT_NATIVE_SUPABASE_URL!;
const supabasePublishableKey = YOUR_REACT_NATIVE_SUPABASE_PUBLISHABLE_KEY!;
``` 

This change would help prevent TypeScript errors and keep the example consistent with the recommended [Supabase setup](https://supabase.com/docs/guides/getting-started/tutorials/with-expo-react-native?utm_source=expo&utm_medium=referral&utm_term=expo-react-native&queryGroups=auth-store&auth-store=local-storage). You can find the example in `supabse.ts` 