### PR TITLE
fix(cli): prevent path overflow on dev server interstitial page

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix loader HMR when streaming SSR is enabled in dev mode ([#45702](https://github.com/expo/expo/pull/45702) by [@hassankhan](https://github.com/hassankhan))
+- Fix long project paths overflowing the dev server interstitial page by making the path scroll horizontally. ([#45808](https://github.com/expo/expo/pull/45808) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/static/loading-page/index.html
+++ b/packages/@expo/cli/static/loading-page/index.html
@@ -115,6 +115,8 @@
       display: flex;
       flex-direction: row;
       justify-content: space-between;
+      align-items: flex-start;
+      gap: 12px;
       margin-right: 8px;
       padding: 4px 8px;
       border-radius: 8px;
@@ -127,6 +129,36 @@
       font-size: 12px;
       font-weight: 400;
       line-height: 150%;
+    }
+
+    .info-box-details-record > p:first-child {
+      flex-shrink: 0;
+    }
+
+    .info-box-details-record > p:last-child {
+      min-width: 0;
+      text-align: right;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .info-box-details-scroll {
+      min-width: 0;
+      flex: 1;
+      overflow-x: auto;
+      overflow-y: hidden;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: none;
+    }
+
+    .info-box-details-scroll::-webkit-scrollbar {
+      display: none;
+    }
+
+    .info-box-details-scroll p {
+      white-space: nowrap;
+      padding-right: 8px;
     }
 
     .info-box-details-record:nth-child(odd) {
@@ -242,7 +274,9 @@
         </div> -->
         <div class="info-box-details-record">
           <p>Path</p>
-          <p>{{ Path }}</p>
+          <div class="info-box-details-scroll">
+            <p>{{ Path }}</p>
+          </div>
         </div>
         <!-- <div class="info-box-details-record">
           <p>Last commit</p>


### PR DESCRIPTION
# Why

The dev server interstitial page (`/_expo/loading`) renders the project's absolute path inside a small fixed-width info card. With long project paths, the text collided with the "Path" label and wrapped awkwardly, making the value unreadable.

## Before

<img width="591" height="520" alt="Screenshot 2026-05-14 at 2 06 34 PM" src="https://github.com/user-attachments/assets/83afaefc-0eee-4304-acbd-c789e67363e1" />

## After

<img width="469" height="239" alt="Screenshot 2026-05-14 at 2 50 30 PM" src="https://github.com/user-attachments/assets/a213ca78-1af0-48b4-9e43-a9ef303bbe22" />


# How

- Reworked the path row so the "Path" label sits outside the value container.
- The value now lives in a horizontally scrollable container with `white-space: nowrap`, so long paths scroll instead of wrapping or overlapping the label.
- Scoped the existing single-line ellipsis behavior to the direct `<p>` children only, so the SDK/Runtime version row still truncates while the path row scrolls.
- Added a small end-padding on the scrollable value so the text doesn't sit flush against the rounded card edge, and hid the scrollbar to keep the pill clean.

# Test Plan

- Ran `InterstitialPageMiddleware` unit tests (7/7 passing).
- Manually rendered the templated HTML with a long project path and verified in the browser that:
  - The "Path" label stays in place.
  - The value scrolls horizontally without wrapping.
  - The SDK / Runtime version row still uses the right-aligned single-line behavior.