### PR TITLE
[cli] Serve unsigned Expo Go manifest when unauthenticated in non-interactive shells

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix loader HMR when streaming SSR is enabled in dev mode ([#45702](https://github.com/expo/expo/pull/45702) by [@hassankhan](https://github.com/hassankhan))
+- Serve an unsigned Expo Go manifest instead of failing with HTTP 500 when `expo start` is unauthenticated in a non-interactive shell. ([#45809](https://github.com/expo/expo/pull/45809) by [@EvanBacon](https://github.com/EvanBacon))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/user/actions.ts
+++ b/packages/@expo/cli/src/api/user/actions.ts
@@ -7,6 +7,7 @@ import { getUserAsync, loginAsync, browserLoginAsync } from './user';
 import * as Log from '../../log';
 import { env } from '../../utils/env';
 import { CommandError } from '../../utils/errors';
+import { isInteractive } from '../../utils/interactive';
 import { learnMore } from '../../utils/link';
 import type { Question } from '../../utils/prompts';
 import promptAsync, { selectAsync } from '../../utils/prompts';
@@ -100,6 +101,13 @@ export async function tryGetUserAsync(): Promise<Actor | null> {
 
   if (user) {
     return user;
+  }
+
+  // In non-interactive environments (CI, non-TTY) we can't prompt for login. Proceed
+  // anonymously so callers like the Expo Go manifest code-signing flow degrade
+  // gracefully instead of bubbling a NON_INTERACTIVE error to the client.
+  if (!isInteractive()) {
+    return null;
   }
 
   const choices = [

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts
@@ -9,6 +9,8 @@ import {
   mockExpoRootChain,
   mockSelfSigned,
 } from '../../../../utils/__tests__/fixtures/certificates';
+import { isInteractive } from '../../../../utils/interactive';
+import { selectAsync } from '../../../../utils/prompts';
 import {
   ExpoGoManifestHandlerMiddleware,
   ResponseContentType,
@@ -18,6 +20,10 @@ import { resolveRuntimeVersionWithExpoUpdatesAsync } from '../resolveRuntimeVers
 import type { ServerRequest } from '../server.types';
 
 jest.mock('../../../../api/user/user');
+jest.mock('../../../../utils/prompts');
+jest.mock('../../../../utils/interactive', () => ({
+  isInteractive: jest.fn(() => true),
+}));
 jest.mock('../../../../log');
 jest.mock('../../../../api/graphql/queries/AppQuery', () => ({
   AppQuery: {
@@ -276,6 +282,40 @@ describe('_getManifestResponseAsync', () => {
       }
     }
 
+    expect(partsSeen.has('manifest')).toBeTruthy();
+  });
+
+  it('returns an anon manifest when not signed in and running in a non-interactive shell', async () => {
+    // Simulate `expo start` running in CI / non-TTY: no cached credentials and
+    // no way to prompt the user. Previously this surfaced as HTTP 500 in Expo Go
+    // because the code-signing flow tried to prompt for login.
+    jest.mocked(getUserAsync).mockImplementation(async () => undefined);
+    jest.mocked(isInteractive).mockReturnValue(false);
+    jest.mocked(selectAsync).mockImplementation(() => {
+      throw new Error('selectAsync must not be called in non-interactive mode');
+    });
+
+    const middleware = createMiddleware();
+
+    const response = await middleware._getManifestResponseAsync({
+      responseContentType: ResponseContentType.MULTIPART_MIXED,
+      platform: 'android',
+      expectSignature: 'sig, keyid="expo-root", alg="rsa-v1_5-sha256"',
+      hostname: 'localhost',
+    });
+
+    expect(selectAsync).not.toHaveBeenCalled();
+
+    const partsSeen = new Set<string>();
+    const contentType = response.headers.get('content-type')!;
+    for await (const part of parseMultipart(response.body!, { contentType })) {
+      partsSeen.add(part.name);
+      if (part.name === 'manifest') {
+        expect(part.headers['expo-signature']).toBe(undefined);
+        const manifest = (await part.json()) as { extra: { scopeKey: string } };
+        expect(manifest.extra.scopeKey).toMatch(/@anonymous\/.*/);
+      }
+    }
     expect(partsSeen.has('manifest')).toBeTruthy();
   });
 

--- a/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
@@ -4,9 +4,13 @@ import { mockExpoRootChain, mockSelfSigned } from './fixtures/certificates';
 import { getProjectDevelopmentCertificateAsync } from '../../api/getProjectDevelopmentCertificate';
 import { getUserAsync } from '../../api/user/user';
 import { getCodeSigningInfoAsync, signManifestString } from '../codesigning';
+import { isInteractive } from '../interactive';
 import { selectAsync } from '../prompts';
 
 jest.mock('../../utils/prompts');
+jest.mock('../../utils/interactive', () => ({
+  isInteractive: jest.fn(() => true),
+}));
 jest.mock('../../api/user/user');
 jest.mock('../../api/graphql/queries/AppQuery', () => ({
   AppQuery: {
@@ -46,6 +50,9 @@ jest.mock('../../api/getExpoGoIntermediateCertificate', () => ({
 
 beforeEach(() => {
   vol.reset();
+
+  jest.mocked(isInteractive).mockReturnValue(true);
+  jest.mocked(selectAsync).mockReset();
 
   jest.mocked(getUserAsync).mockImplementation(async () => ({
     __typename: 'User',


### PR DESCRIPTION
# Why

When `expo start` runs in a non-TTY environment (CI, piped output, certain editor terminals) and the user is not signed in, opening the project in Expo Go fails with:

```
HTTP response error 500: {"error":"CommandError: Input is required, but 'npx expo' is in non-interactive mode.
Use the EXPO_TOKEN environment variable to authenticate in CI ..."}
```

The Expo Go manifest handler serves a manifest, which (when the client requests `keyid="expo-root"`) calls into the dev code-signing flow. That flow falls through to `tryGetUserAsync`, which tries to prompt "Log in / Proceed anonymously". The prompt throws `NON_INTERACTIVE` in a non-TTY shell, the error bubbles up to the HTTP layer, and the client sees a 500 instead of a usable (anonymous) manifest.

# How

In `tryGetUserAsync`, if the process is not interactive, short-circuit and return `null` (the same outcome the user would get by selecting "Proceed anonymously"). Its lone caller, `fetchAndCacheNewDevelopmentCodeSigningInfoAsync`, already treats `null` as "no signing actor" and the manifest middleware falls through to serving an unsigned anonymous manifest.

# Test Plan

- New test in `ExpoGoManifestHandlerMiddleware-test.ts` exercises the user-visible boundary: with `getUserAsync` returning `undefined` and `isInteractive` mocked to `false`, the middleware returns an anonymous manifest and `selectAsync` is never invoked. Verified the test fails against the unfixed code.
- Adjusted the existing `codesigning-test.ts` "returns null when user is not logged in" case to mock `isInteractive` to `true` so its existing assertion that `selectAsync` is reached continues to hold.
- Full suite passes: `pnpm jest src/start/server/middleware/__tests__/ExpoGoManifestHandlerMiddleware-test.ts src/utils/__tests__/codesigning-test.ts src/api/user/__tests__/actions-test.ts` -> 38 passing.