### PR TITLE
fix(expo-ui): unmount iOS bottom sheet after programmatic close

### DIFF
--- a/packages/expo-ui/ios/BottomSheetView.swift
+++ b/packages/expo-ui/ios/BottomSheetView.swift
@@ -7,6 +7,7 @@ final class BottomSheetProps: UIBaseViewProps {
   @Field var isPresented: Bool = false
   @Field var fitToContents: Bool = false
   var onIsPresentedChange = EventDispatcher()
+  var onDismissed = EventDispatcher()
 }
 
 struct SizePreferenceKey: PreferenceKey {
@@ -88,6 +89,9 @@ struct BottomSheetView: ExpoSwiftUI.View {
     Rectangle().hidden()
       .sheet(isPresented: $isPresented) {
         sheetContent
+          .onDisappear {
+            props.onDismissed([:])
+          }
       }
       .onChange(of: isPresented, perform: { newIsPresented in
         if props.isPresented == newIsPresented {

--- a/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
+++ b/packages/expo-ui/src/community/bottom-sheet/BottomSheet.ios.tsx
@@ -92,6 +92,7 @@ export function BottomSheet(props: BottomSheetProps) {
   const [isMounted, setIsMounted] = useState(indexProp >= 0);
   const [isPresented, setIsPresented] = useState(indexProp >= 0);
   const [currentIndex, setCurrentIndex] = useState(Math.max(indexProp, 0));
+  const isPresentedRef = useRef(isPresented);
   // Ref mirrors currentIndex for use in handleDetentChange without adding it as a useCallback dep
   const currentIndexRef = useRef(currentIndex);
   // Guards fireCloseCallbacks against double-firing.
@@ -122,30 +123,53 @@ export function BottomSheet(props: BottomSheetProps) {
     onChangeRef.current?.(-1);
   }, []);
 
+  const setPresented = useCallback((presented: boolean) => {
+    isPresentedRef.current = presented;
+    setIsPresented(presented);
+  }, []);
+
   // Sync with external index prop changes
   useEffect(() => {
     if (indexProp === -1) {
-      setIsPresented(false);
+      setPresented(false);
       fireCloseCallbacks();
     } else if (indexProp >= 0) {
       closedRef.current = false;
       setIsMounted(true);
-      setIsPresented(true);
+      setPresented(true);
       const clampedIndex = Math.min(indexProp, detents.length - 1);
       setCurrentIndex(clampedIndex);
       currentIndexRef.current = clampedIndex;
     }
-  }, [indexProp, detents.length, fireCloseCallbacks]);
+  }, [indexProp, detents.length, fireCloseCallbacks, setPresented]);
 
   const handlePresentedChange = useCallback(
     (presented: boolean) => {
       if (!presented) {
-        setIsPresented(false);
-        setIsMounted(false);
+        setPresented(false);
         fireCloseCallbacks();
       }
     },
-    [fireCloseCallbacks]
+    [fireCloseCallbacks, setPresented]
+  );
+
+  const handleDismissed = useCallback(() => {
+    if (isPresentedRef.current) return;
+    setIsMounted(false);
+    fireCloseCallbacks();
+  }, [fireCloseCallbacks]);
+
+  const openAtIndex = useCallback(
+    (index: number) => {
+      const clampedIndex = Math.min(Math.max(index, 0), detents.length - 1);
+      closedRef.current = false;
+      setIsMounted(true);
+      setPresented(true);
+      currentIndexRef.current = clampedIndex;
+      setCurrentIndex(clampedIndex);
+      onChangeRef.current?.(clampedIndex);
+    },
+    [detents.length, setPresented]
   );
 
   const handleDetentChange = useCallback(
@@ -163,17 +187,11 @@ export function BottomSheet(props: BottomSheetProps) {
   const methods: BottomSheetMethods = useMemo(() => {
     const snapToIndex = (index: number) => {
       if (index === -1) {
-        setIsPresented(false);
+        setPresented(false);
         fireCloseCallbacks();
         return;
       }
-      const clampedIndex = Math.min(Math.max(index, 0), detents.length - 1);
-      closedRef.current = false;
-      setIsMounted(true);
-      setIsPresented(true);
-      currentIndexRef.current = clampedIndex;
-      setCurrentIndex(clampedIndex);
-      onChangeRef.current?.(clampedIndex);
+      openAtIndex(index);
     };
 
     // Fire close callbacks immediately: the native `onIsPresentedChange` event is
@@ -181,8 +199,10 @@ export function BottomSheet(props: BottomSheetProps) {
     // the feedback loop), so we can't rely on handlePresentedChange here. The
     // closedRef guard inside fireCloseCallbacks prevents double-firing if a
     // native user-dismiss event also arrives during the animation.
+    // The native `onDismissed` event unmounts the native sheet host once SwiftUI
+    // has actually removed the sheet content.
     const close = () => {
-      setIsPresented(false);
+      setPresented(false);
       fireCloseCallbacks();
     };
 
@@ -194,10 +214,10 @@ export function BottomSheet(props: BottomSheetProps) {
       collapse: () => snapToIndex(0),
       close,
       forceClose: close,
-      present: () => snapToIndex(0),
+      present: () => openAtIndex(0),
       dismiss: close,
     };
-  }, [detents, fireCloseCallbacks]);
+  }, [detents, fireCloseCallbacks, openAtIndex, setPresented]);
 
   useImperativeHandle(ref, () => methods, [methods]);
 
@@ -239,6 +259,7 @@ export function BottomSheet(props: BottomSheetProps) {
           <NativeBottomSheet
             isPresented={isPresented}
             onIsPresentedChange={handlePresentedChange}
+            onDismissed={handleDismissed}
             fitToContents={fitToContents}>
             <Group modifiers={modifiers}>
               <RNHostView matchContents={fitToContents}>

--- a/packages/expo-ui/src/swift-ui/BottomSheet/index.tsx
+++ b/packages/expo-ui/src/swift-ui/BottomSheet/index.tsx
@@ -22,6 +22,10 @@ export type BottomSheetProps = {
    */
   onIsPresentedChange: (isPresented: boolean) => void;
   /**
+   * Callback function that is called after the native sheet content disappears.
+   */
+  onDismissed?: () => void;
+  /**
    * When `true`, the sheet will automatically size itself to fit its content.
    * This sets the presentation detent to match the height of the children.
    * @default false
@@ -31,6 +35,7 @@ export type BottomSheetProps = {
 
 type NativeBottomSheetProps = Omit<BottomSheetProps, 'onIsPresentedChange'> & {
   onIsPresentedChange: (event: NativeSyntheticEvent<{ isPresented: boolean }>) => void;
+  onDismissed?: (event: NativeSyntheticEvent<Record<string, never>>) => void;
 };
 
 const BottomSheetNativeView: ComponentType<NativeBottomSheetProps> = requireNativeView(
@@ -46,6 +51,9 @@ function transformBottomSheetProps(props: BottomSheetProps): NativeBottomSheetPr
     ...restProps,
     onIsPresentedChange: ({ nativeEvent: { isPresented } }) => {
       props?.onIsPresentedChange?.(isPresented);
+    },
+    onDismissed: () => {
+      props?.onDismissed?.();
     },
   };
 }


### PR DESCRIPTION
### Summary

Fixes #45812.

The iOS implementation of `@expo/ui/community/bottom-sheet` uses separate `isPresented` and `isMounted` state so native SwiftUI sheets can animate closed before their host is removed from the React tree.

Native/backdrop dismissal already reaches `handlePresentedChange(false)`, which eventually clears both states. Programmatic close paths (`dismiss()`, `close()`, and `snapToIndex(-1)`) only set `isPresented` to false. The Swift layer suppresses `onIsPresentedChange` for JS-driven state changes, so `isMounted` can stay true after the visible sheet disappears.

This adds a native `onDismissed` event from the SwiftUI sheet content's `onDisappear` lifecycle and uses that to unmount the native sheet host after SwiftUI has actually removed the sheet. That avoids guessing the system close animation duration in JS.

### Testing

- Reproduced in an Expo SDK 56 repro app on iOS Simulator with `@expo/ui@56.0.7`.
- Minimal repro: https://github.com/gruckion/expo-ui-bottom-sheet-dismiss-repro
- Confirmed the existing JS-only timeout workaround fixes the repro locally in an Expo Go app.
- Could not run the native Swift event fix end-to-end in Expo Go because the fix requires a new native `expo-ui` binary.
