### PR TITLE
[docs] TV doc improvements for SDK 56

### DIFF
--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -18,7 +18,7 @@ React Native is supported on Android TV and Apple TV through the [React Native T
 
 Using the React Native TV library as the `react-native` dependency in an Expo project, it becomes capable of targeting both mobile (Android, iOS) and TV (Android TV, Apple TV) devices.
 
-## Project changes required
+## Native project changes required
 
 The necessary changes to the native Android and iOS files are minimal and can be automated with a [config plugin](https://github.com/react-native-tvos/config-tv/tree/main/packages/config-tv) if you use [prebuild](/more/glossary-of-terms/#prebuild). Below is a list of changes made by the config plugins, which you can alternatively apply manually:
 
@@ -147,15 +147,18 @@ The following walkthrough describes the steps required to modify an Expo project
 
 In **package.json**, modify the `react-native` dependency to use the TV repo, and exclude this dependency from [`npx expo install` version validation](/more/expo-cli/#configuring-dependency-validation).
 
-> **Warning** The `react-native-tvos` version should match the Expo SDK you are using. For example, Expo SDK 54 uses React Native 0.81, so you should use `react-native-tvos@0.81-stable` (the latest 0.81 version) as shown below. See the [SDK compatibility table](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version) for the correct version to use for older SDKs.
+> **Warning** The `react-native-tvos` version must match the Expo SDK you are using. For example, Expo SDK 56 uses React Native 0.85, so you should use `react-native-tvos@0.85-stable` (the latest 0.85 version) as shown below. See the [SDK compatibility table](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version) for the correct version to use for older SDKs.
 
+> **Warning** When upgrading an Expo TV project to a new version of the SDK, the `react-native-tvos` version **must be upgraded manually**. It will not be automatically updated by `npx expo install expo@latest --fix`.
+
+> **Warning** If you have more than one Expo project in a monorepo, and one of them is modified for TV, then all of them should be modified to use the React Native TV package as described here, even if some of the projects are not configured to target TV. This avoids possible conflicts between the project dependencies, while still supporting mobile development fully on all the projects.
 {/* prettier-ignore */}
 ```json package.json
 {
   /* @hide ... */ /* @end */
   "dependencies": {
     /* @hide ... */ /* @end */
-    "react-native": "npm:react-native-tvos@0.81-stable",
+    "react-native": "npm:react-native-tvos@0.85-stable",
     /* @hide ... */ /* @end */
   },
   "expo": {

--- a/docs/pages/guides/building-for-tv.mdx
+++ b/docs/pages/guides/building-for-tv.mdx
@@ -152,20 +152,19 @@ In **package.json**, modify the `react-native` dependency to use the TV repo, an
 > **Warning** When upgrading an Expo TV project to a new version of the SDK, the `react-native-tvos` version **must be upgraded manually**. It will not be automatically updated by `npx expo install expo@latest --fix`.
 
 > **Warning** If you have more than one Expo project in a monorepo, and one of them is modified for TV, then all of them should be modified to use the React Native TV package as described here, even if some of the projects are not configured to target TV. This avoids possible conflicts between the project dependencies, while still supporting mobile development fully on all the projects.
-{/* prettier-ignore */}
+> {/* prettier-ignore */}
+
 ```json package.json
 {
   /* @hide ... */ /* @end */
   "dependencies": {
     /* @hide ... */ /* @end */
-    "react-native": "npm:react-native-tvos@0.85-stable",
+    "react-native": "npm:react-native-tvos@0.85-stable"
     /* @hide ... */ /* @end */
   },
   "expo": {
     "install": {
-      "exclude": [
-        "react-native"
-      ]
+      "exclude": ["react-native"]
     }
   }
 }

--- a/docs/pages/guides/expo-ui-swift-ui/index.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/index.mdx
@@ -534,7 +534,7 @@ Because React's promise of _"learn once, write anywhere"_, it now extends to Swi
 
 <BoxLink
   title="Expo UI multiplatform demo"
-  description="A project demonstrating the production-ready Expo UI package available in SDK 56 and later. The project works on both TV (Apple TV, Android TV) and mobile (iOS, Android). Demo screens include most of the available components for both Swift UI and Jetpack Compose."
+  description="A project demonstrating the production-ready Expo UI package available in SDK 56 and later. The project works on both TV (Android TV, Apple TV) and mobile (Android, iOS). Demo screens include most of the available components for both Jetpack Compose and Swift UI."
   Icon={GithubIcon}
   href="https://github.com/react-native-tvos/ExpoUITV"
 />

--- a/docs/pages/guides/expo-ui-swift-ui/index.mdx
+++ b/docs/pages/guides/expo-ui-swift-ui/index.mdx
@@ -533,8 +533,8 @@ Because React's promise of _"learn once, write anywhere"_, it now extends to Swi
 />
 
 <BoxLink
-  title="Expo UI example replicate to TV"
-  description="TVOS support to Expo UI."
+  title="Expo UI multiplatform demo"
+  description="A project demonstrating the production-ready Expo UI package available in SDK 56 and later. The project works on both TV (Apple TV, Android TV) and mobile (iOS, Android). Demo screens include most of the available components for both Swift UI and Jetpack Compose."
   Icon={GithubIcon}
-  href="https://github.com/douglowder/ExpoUITV"
+  href="https://github.com/react-native-tvos/ExpoUITV"
 />

--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -246,6 +246,10 @@ From **SDK 54**, you can set `experiments.autolinkingModuleResolution` to `true`
 
 From **SDK 55**, this is enabled automatically for apps in monorepos.
 
+#### Monorepos with TV projects
+
+See the [Building for TV](/guides/building-for-tv/#modify-dependencies-for-tv) dependencies section for the special `react-native` dependency requirements when a TV project is contained in a monorepo with other Expo projects.
+
 ### Script '...' does not exist
 
 React Native uses packages to ship both JavaScript and native files. These native files also need to be linked, like the [**react-native/react.Gradle**](https://github.com/facebook/react-native/blob/v0.70.6/react.gradle) file from **android/app/build.Gradle**. Usually, this path is hardcoded to something like:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Add necessary changes for Expo TV.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Document the requirement for manual upgrade of react-native dependency in TV projects
- Document dependency requirements for monorepos
- Fix link to demo TV project in Expo UI docs

# Test Plan

Docs CI should pass

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)