### PR TITLE
fix(tools): resolve scoped packages without cache prewarm

### DIFF
--- a/tools/src/Packages.test.ts
+++ b/tools/src/Packages.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import Module from 'node:module';
 import { describe, it } from 'node:test';
 
 import { getPackageByName } from './Packages';
@@ -21,6 +22,24 @@ describe('getPackageByName', () => {
       const pkg = getPackageByName(name);
       assert.ok(pkg, `${name} should resolve`);
       assert.equal(pkg.packageName, name);
+    }
+  });
+
+  it('falls back to the workspace package list for scoped packages without a direct package path', () => {
+    const originalResolveFilename = Module._resolveFilename;
+    Module._resolveFilename = function (request, parent, isMain, options) {
+      if (request === '@expo/ui/package.json') {
+        throw new Error('Simulated missing direct package path');
+      }
+      return originalResolveFilename.call(this, request, parent, isMain, options);
+    };
+
+    try {
+      const pkg = getPackageByName('@expo/ui');
+      assert.ok(pkg);
+      assert.equal(pkg.packageName, '@expo/ui');
+    } finally {
+      Module._resolveFilename = originalResolveFilename;
     }
   });
 

--- a/tools/src/Packages.test.ts
+++ b/tools/src/Packages.test.ts
@@ -4,6 +4,15 @@ import { describe, it } from 'node:test';
 
 import { getPackageByName } from './Packages';
 
+type ModuleWithResolveFilename = typeof Module & {
+  _resolveFilename: (
+    request: string,
+    parent: NodeJS.Module | undefined,
+    isMain: boolean,
+    options: unknown
+  ) => string;
+};
+
 describe('getPackageByName', () => {
   it('resolves packages whose directory matches their name', () => {
     const pkg = getPackageByName('expo-router');
@@ -26,8 +35,9 @@ describe('getPackageByName', () => {
   });
 
   it('falls back to the workspace package list for scoped packages without a direct package path', () => {
-    const originalResolveFilename = Module._resolveFilename;
-    Module._resolveFilename = function (request, parent, isMain, options) {
+    const moduleWithResolveFilename = Module as ModuleWithResolveFilename;
+    const originalResolveFilename = moduleWithResolveFilename._resolveFilename;
+    moduleWithResolveFilename._resolveFilename = function (request, parent, isMain, options) {
       if (request === '@expo/ui/package.json') {
         throw new Error('Simulated missing direct package path');
       }
@@ -39,7 +49,7 @@ describe('getPackageByName', () => {
       assert.ok(pkg);
       assert.equal(pkg.packageName, '@expo/ui');
     } finally {
-      Module._resolveFilename = originalResolveFilename;
+      moduleWithResolveFilename._resolveFilename = originalResolveFilename;
     }
   });
 

--- a/tools/src/Packages.ts
+++ b/tools/src/Packages.ts
@@ -92,6 +92,22 @@ export type ExpoModuleConfig = {
 };
 
 const SPMConfigFileName = 'spm.config.json';
+const PACKAGE_JSON_GLOB = '**/package.json';
+const PACKAGE_GLOB_IGNORE = [
+  '**/example/**',
+  '**/node_modules/**',
+  '**/static/**',
+  '**/__tests__/**',
+  '**/__mocks__/**',
+  '**/__fixtures__/**',
+  '**/e2e/**',
+];
+const TEMPLATE_GLOB_IGNORE = [
+  '**/node_modules/**',
+  '**/__tests__/**',
+  '**/__mocks__/**',
+  '**/__fixtures__/**',
+];
 
 /**
  * Represents a package in the monorepo.
@@ -429,7 +445,8 @@ export function getPackageByName(packageName: string): Package | null {
     const packageJson = require(packageJsonPath);
     return new Package(path.dirname(packageJsonPath), packageJson);
   } catch {
-    return cachedPackages?.find((pkg) => pkg.packageName === packageName) ?? null;
+    cachedPackages ??= getListOfPackagesSync();
+    return cachedPackages.find((pkg) => pkg.packageName === packageName) ?? null;
   }
 }
 
@@ -438,42 +455,45 @@ export function getPackageByName(packageName: string): Package | null {
  */
 export async function getListOfPackagesAsync(): Promise<Package[]> {
   if (!cachedPackages) {
-    const paths = await glob('**/package.json', {
+    const paths = await glob(PACKAGE_JSON_GLOB, {
       cwd: PACKAGES_DIR,
-      ignore: [
-        '**/example/**',
-        '**/node_modules/**',
-        '**/static/**',
-        '**/__tests__/**',
-        '**/__mocks__/**',
-        '**/__fixtures__/**',
-        '**/e2e/**',
-      ],
+      ignore: PACKAGE_GLOB_IGNORE,
     });
-    const templatesPaths = await glob('**/package.json', {
+    const templatesPaths = await glob(PACKAGE_JSON_GLOB, {
       cwd: TEMPLATES_DIR,
-      ignore: ['**/node_modules/**', '**/__tests__/**', '**/__mocks__/**', '**/__fixtures__/**'],
+      ignore: TEMPLATE_GLOB_IGNORE,
     });
-    cachedPackages = paths
-      .map((packageJsonPath) => {
-        const fullPackageJsonPath = path.join(PACKAGES_DIR, packageJsonPath);
-        const packagePath = path.dirname(fullPackageJsonPath);
-        const packageJson = require(fullPackageJsonPath);
-
-        return new Package(packagePath, packageJson);
-      })
-      .concat(
-        templatesPaths.map((packageJsonPath) => {
-          const fullPackageJsonPath = path.join(TEMPLATES_DIR, packageJsonPath);
-          const packagePath = path.dirname(fullPackageJsonPath);
-          const packageJson = require(fullPackageJsonPath);
-
-          return new Package(packagePath, packageJson);
-        })
-      )
-      .filter((pkg) => !!pkg.packageName);
+    cachedPackages = createPackagesFromPaths(PACKAGES_DIR, paths).concat(
+      createPackagesFromPaths(TEMPLATES_DIR, templatesPaths)
+    );
   }
   return cachedPackages;
+}
+
+function getListOfPackagesSync(): Package[] {
+  const paths = glob.sync(PACKAGE_JSON_GLOB, {
+    cwd: PACKAGES_DIR,
+    ignore: PACKAGE_GLOB_IGNORE,
+  });
+  const templatesPaths = glob.sync(PACKAGE_JSON_GLOB, {
+    cwd: TEMPLATES_DIR,
+    ignore: TEMPLATE_GLOB_IGNORE,
+  });
+  return createPackagesFromPaths(PACKAGES_DIR, paths).concat(
+    createPackagesFromPaths(TEMPLATES_DIR, templatesPaths)
+  );
+}
+
+function createPackagesFromPaths(rootDir: string, packageJsonPaths: string[]): Package[] {
+  return packageJsonPaths
+    .map((packageJsonPath) => {
+      const fullPackageJsonPath = path.join(rootDir, packageJsonPath);
+      const packagePath = path.dirname(fullPackageJsonPath);
+      const packageJson = require(fullPackageJsonPath);
+
+      return new Package(packagePath, packageJson);
+    })
+    .filter((pkg) => !!pkg.packageName);
 }
 
 function readExpoModuleConfigJson(expoModuleConfigJsonPath: string) {


### PR DESCRIPTION
## Why

Prebuild dependency expansion resolves local dependencies by package name, including scoped names like `@expo/ui`. Scoped workspace packages whose directory differs from their package name may not be reachable through the direct package path, so callers had to prewarm the package list before getPackageByName could find them.

This PR supersedes #45787

## How

Make `getPackageByName` populate the cached workspace package list synchronously on direct lookup miss, then resolve from that list. Share `package.json` glob patterns and package construction between the async and sync package scans.

Add a test that simulates `@expo/ui/package.json` being unavailable through direct resolution and verifies `getPackageByName('@expo/ui')` still resolves from the workspace list.

## Test-plan

`pnpm --dir tools test`