### PR TITLE
Fix static framework imports in expo-task-manager

### DIFF
--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix static framework builds with `useFrameworks: "static"` by importing `ExpoModulesCore` as a module from public task manager headers. ([#45274](https://github.com/expo/expo/issues/45274) by [@mvincentong](https://github.com/mvincentong)) ([#45822](https://github.com/expo/expo/pull/45822) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-21

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTask.h
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTask.h
@@ -1,8 +1,6 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <ExpoModulesCore/EXTaskManagerInterface.h>
-#import <ExpoModulesCore/EXTaskInterface.h>
-#import <ExpoModulesCore/EXTaskConsumerInterface.h>
+@import ExpoModulesCore;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskExecutionRequest.h
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskExecutionRequest.h
@@ -1,8 +1,9 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
 #import <Foundation/Foundation.h>
-#import <ExpoModulesCore/EXTaskInterface.h>
 #import <UMAppLoader/UMAppLoaderInterface.h>
+
+@import ExpoModulesCore;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.h
+++ b/packages/expo-task-manager/ios/EXTaskManager/EXTaskService.h
@@ -1,8 +1,9 @@
 // Copyright 2018-present 650 Industries. All rights reserved.
 
-#import <ExpoModulesCore/EXTaskServiceInterface.h>
 #import <ExpoTaskManager/EXTask.h>
 #import <ExpoTaskManager/EXTaskExecutionRequest.h>
+
+@import ExpoModulesCore;
 
 @interface EXTaskService : NSObject <EXTaskServiceInterface, EXTaskDelegate>
 


### PR DESCRIPTION
## Why

Fixes https://github.com/expo/expo/issues/45274.

`expo-task-manager` public headers imported individual `ExpoModulesCore` task-manager headers with quoted framework-style includes. When an app builds Expo packages as static frameworks with `useFrameworks: "static"`, those imports can be treated as non-modular includes from inside the `ExpoTaskManager` framework module.

## How

Changed the three `expo-task-manager` public headers that reference `ExpoModulesCore` task protocols to import the `ExpoModulesCore` module instead of individual subheaders. This keeps the fix package-scoped to the failing module and does not change task-manager runtime behavior.

## Test Plan

- `git diff --check`
- `pnpm --filter expo-task-manager lint`
- `pnpm --filter expo-task-manager build`
- `pnpm --filter expo-task-manager test -- --runInBand` (fails because the package has no Jest tests)
- `pnpm --filter expo-task-manager test -- --runInBand --passWithNoTests`

I did not run a full CocoaPods static-framework app build locally.

## Risk

Low. The diff only changes three iOS header imports and one changelog entry in `expo-task-manager`. The remaining risk is CocoaPods integration coverage, since the local package checks do not reproduce the exact static-framework app build from the issue.
