### PR TITLE
Fix iOS recycled hash placeholder fit

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
 - [Android] Fixed `useImage` crashing on SVG sources, and made `maxWidth`/`maxHeight` preserve the SVG's aspect ratio. ([#46077](https://github.com/expo/expo/pull/46077) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fix recycled Blurhash and Thumbhash placeholders being redisplayed with the default `scaleDown` fit. ([#22206](https://github.com/expo/expo/issues/22206) by [@mvincentong](https://github.com/mvincentong)) ([#45823](https://github.com/expo/expo/pull/45823) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageModule.swift
+++ b/packages/expo-image/ios/ImageModule.swift
@@ -47,6 +47,7 @@ public final class ImageModule: Module {
 
       Prop("placeholderContentFit") { (view, placeholderContentFit: ContentFit?) in
         view.placeholderContentFit = placeholderContentFit ?? .scaleDown
+        view.usesDefaultPlaceholderContentFit = placeholderContentFit == nil
       }
 
       Prop("contentPosition") { (view, contentPosition: ContentPosition?) in

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -379,11 +379,21 @@ public final class ImageView: ExpoView {
   var placeholderImage: UIImage?
 
   /**
+   Whether the loaded placeholder image was generated from an image hash.
+   */
+  var isPlaceholderImageHash = false
+
+  /**
    Content fit for the placeholder. `scale-down` seems to be the best choice for spinners
    and that the placeholders are usually smaller than the proper image, but it doesn't
    apply to blurhash that by default could use the same fitting as the proper image.
    */
   var placeholderContentFit: ContentFit = .scaleDown
+
+  /**
+   Whether `placeholderContentFit` is using the default value rather than an explicit prop.
+   */
+  var usesDefaultPlaceholderContentFit = true
 
   /**
    Same as `bestSource`, but for placeholders.
@@ -425,7 +435,7 @@ public final class ImageView: ExpoView {
         return
       }
       self.placeholderImage = placeholder
-      self.placeholderContentFit = isPlaceholderHash ? self.contentFit : self.placeholderContentFit
+      self.isPlaceholderImageHash = isPlaceholderHash
       self.displayPlaceholderIfNecessary()
     }
   }
@@ -437,7 +447,16 @@ public final class ImageView: ExpoView {
     guard canDisplayPlaceholder, let placeholder = placeholderImage else {
       return
     }
-    setImage(placeholder, contentFit: placeholderContentFit, isPlaceholder: true)
+    setImage(
+      placeholder,
+      contentFit: placeholderContentFitForDisplay(
+        placeholderContentFit: placeholderContentFit,
+        contentFit: contentFit,
+        isPlaceholderHash: isPlaceholderImageHash,
+        usesDefaultPlaceholderContentFit: usesDefaultPlaceholderContentFit
+      ),
+      isPlaceholder: true
+    )
   }
 
   // MARK: - Processing
@@ -854,4 +873,13 @@ func localAssetName(from url: URL?) -> String? {
   }
 
   return path.isEmpty ? nil : path
+}
+
+func placeholderContentFitForDisplay(
+  placeholderContentFit: ContentFit,
+  contentFit: ContentFit,
+  isPlaceholderHash: Bool,
+  usesDefaultPlaceholderContentFit: Bool
+) -> ContentFit {
+  return isPlaceholderHash && usesDefaultPlaceholderContentFit ? contentFit : placeholderContentFit
 }

--- a/packages/expo-image/ios/Tests/ImageResizingSpec.swift
+++ b/packages/expo-image/ios/Tests/ImageResizingSpec.swift
@@ -142,5 +142,40 @@ class ImageResizingSpec: ExpoSpec {
         expect(localAssetName(from: URL(string: "sf:/star"))).to(beNil())
       }
     }
+
+    describe("placeholder content fit") {
+      it("uses source content fit for hash placeholders") {
+        let contentFit = placeholderContentFitForDisplay(
+          placeholderContentFit: .scaleDown,
+          contentFit: .cover,
+          isPlaceholderHash: true,
+          usesDefaultPlaceholderContentFit: true
+        )
+
+        expect(contentFit) == .cover
+      }
+
+      it("uses explicit placeholder content fit for hash placeholders") {
+        let contentFit = placeholderContentFitForDisplay(
+          placeholderContentFit: .contain,
+          contentFit: .cover,
+          isPlaceholderHash: true,
+          usesDefaultPlaceholderContentFit: false
+        )
+
+        expect(contentFit) == .contain
+      }
+
+      it("uses placeholder content fit for non-hash placeholders") {
+        let contentFit = placeholderContentFitForDisplay(
+          placeholderContentFit: .scaleDown,
+          contentFit: .cover,
+          isPlaceholderHash: false,
+          usesDefaultPlaceholderContentFit: true
+        )
+
+        expect(contentFit) == .scaleDown
+      }
+    }
   }
 }


### PR DESCRIPTION
## Why

Fixes https://github.com/expo/expo/issues/22206.

On iOS, hash placeholders are intended to use the source image `contentFit` when `placeholderContentFit` is left at its default. The current implementation only applies that choice when the placeholder finishes loading. If a recycled image view later clears the rendered image and redisplays the already-loaded Blurhash or Thumbhash placeholder, it can fall back to the default `scaleDown` fit and appear tiny.

## How

`ImageView` now tracks whether the loaded placeholder came from an image hash and resolves the placeholder fit at display time. Hash placeholders use `contentFit` only when `placeholderContentFit` is defaulted; explicit `placeholderContentFit` values are still respected.

I also added focused native coverage for the placeholder-fit resolution helper.

## Test Plan

- `git diff --check`
- `swiftc -parse packages/expo-image/ios/ImageView.swift packages/expo-image/ios/ImageModule.swift packages/expo-image/ios/Tests/ImageResizingSpec.swift`
- `pnpm --filter expo-image lint`
- `pnpm --filter expo-image build`
- `pnpm --filter expo-image test -- --runInBand` (fails because the package has no Jest tests)
- `pnpm --filter expo-image test -- --runInBand --passWithNoTests`

I did not run the native iOS test suite locally.

## Risk

Low. The behavior change is limited to iOS placeholder rendering in `expo-image`. The diff changes four files: native view logic, native prop tracking, one native spec, and the changelog. The main remaining risk is native UI integration coverage for the recycled-view sequence.
