### PR TITLE
fix(tools): rebuild stale prebuild dependencies

### DIFF
--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -194,6 +194,55 @@ export const Frameworks = {
   },
 
   /**
+   * Finds an xcframework at either a non-versioned or versioned output path.
+   * Versioned paths have the format:
+   * output/<packageVersion>/<rnVersion>/<hermesVersion>/<flavor>/xcframeworks/
+   */
+  findFrameworkAtAnyVersion: (
+    buildPath: string,
+    productName: string,
+    buildType: BuildFlavor
+  ): string | null => {
+    const nonVersionedPath = Frameworks.getFrameworkPath(buildPath, productName, buildType);
+    if (fs.existsSync(nonVersionedPath)) {
+      return nonVersionedPath;
+    }
+
+    const outputDir = path.join(buildPath, 'output');
+    if (!fs.existsSync(outputDir)) {
+      return null;
+    }
+
+    const flavor = buildType.toLowerCase();
+    const xcframeworkName = `${productName}.xcframework`;
+
+    try {
+      for (const entry of fs.readdirSync(outputDir)) {
+        if (entry === 'debug' || entry === 'release') continue;
+
+        const verDir = path.join(outputDir, entry);
+        if (!fs.statSync(verDir).isDirectory()) continue;
+
+        for (const rnVer of fs.readdirSync(verDir)) {
+          const rnDir = path.join(verDir, rnVer);
+          if (!fs.statSync(rnDir).isDirectory()) continue;
+
+          for (const hermesVer of fs.readdirSync(rnDir)) {
+            const candidate = path.join(rnDir, hermesVer, flavor, 'xcframeworks', xcframeworkName);
+            if (fs.existsSync(candidate)) {
+              return candidate;
+            }
+          }
+        }
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
+  },
+
+  /**
    * Returns the full path to the tarball for the given product.
    * @param buildPath Package build path (centralized under packages/precompile/.build/<pkg>/)
    * @param productName SPM product name

--- a/tools/src/prebuilds/Frameworks.ts
+++ b/tools/src/prebuilds/Frameworks.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { execSync } from 'child_process';
 import fs from 'fs-extra';
+import { glob } from 'glob';
 import path from 'path';
 
 import { getPrecompileDir } from '../Directories';
@@ -203,43 +204,16 @@ export const Frameworks = {
     productName: string,
     buildType: BuildFlavor
   ): string | null => {
-    const nonVersionedPath = Frameworks.getFrameworkPath(buildPath, productName, buildType);
-    if (fs.existsSync(nonVersionedPath)) {
-      return nonVersionedPath;
+    const nonVersioned = Frameworks.getFrameworkPath(buildPath, productName, buildType);
+    if (fs.existsSync(nonVersioned)) {
+      return nonVersioned;
     }
 
-    const outputDir = path.join(buildPath, 'output');
-    if (!fs.existsSync(outputDir)) {
-      return null;
-    }
-
-    const flavor = buildType.toLowerCase();
-    const xcframeworkName = `${productName}.xcframework`;
-
-    try {
-      for (const entry of fs.readdirSync(outputDir)) {
-        if (entry === 'debug' || entry === 'release') continue;
-
-        const verDir = path.join(outputDir, entry);
-        if (!fs.statSync(verDir).isDirectory()) continue;
-
-        for (const rnVer of fs.readdirSync(verDir)) {
-          const rnDir = path.join(verDir, rnVer);
-          if (!fs.statSync(rnDir).isDirectory()) continue;
-
-          for (const hermesVer of fs.readdirSync(rnDir)) {
-            const candidate = path.join(rnDir, hermesVer, flavor, 'xcframeworks', xcframeworkName);
-            if (fs.existsSync(candidate)) {
-              return candidate;
-            }
-          }
-        }
-      }
-    } catch {
-      return null;
-    }
-
-    return null;
+    const matches = glob.sync(
+      `output/*/*/*/${buildType.toLowerCase()}/xcframeworks/${productName}.xcframework`,
+      { cwd: buildPath, absolute: true }
+    );
+    return matches[0] ?? null;
   },
 
   /**

--- a/tools/src/prebuilds/pipeline/RunSteps.test.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.test.ts
@@ -3,16 +3,20 @@
  *  - resolveFlavorTemplatedPath
  *  - sortPackagesByDependencies
  *  - collectSharedSPMDependencies
- *  - expandWithUnbuiltDependencies (with mocked fs/getPackageByName)
+ *  - expandWithUnbuiltDependencies
  */
+import fs from 'fs';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import os from 'os';
+import path from 'path';
 
 import {
   resolveFlavorTemplatedPath,
   sortPackagesByDependencies,
   collectSharedSPMDependencies,
   CACHE_DEPS,
+  expandWithUnbuiltDependencies,
 } from './RunSteps';
 import type { SPMPackageSource } from '../ExternalPackage';
 import type { SPMProduct, SPMPackageDependencyConfig } from '../SPMConfig.types';
@@ -48,6 +52,80 @@ function makeProduct(name: string, externalDeps: string[] = []): SPMProduct {
 
 function makeSourceOnlyProduct(name: string, externalDeps: string[] = []): SPMProduct {
   return { ...makeProduct(name, externalDeps), sourceOnly: true };
+}
+
+function makeSwiftProduct(
+  name: string,
+  externalDeps: string[] = [],
+  targetPath: string = 'ios'
+): SPMProduct {
+  return {
+    ...makeProduct(name, externalDeps),
+    targets: [
+      {
+        type: 'swift',
+        name,
+        path: targetPath,
+        pattern: '**/*.swift',
+      },
+    ],
+  };
+}
+
+function withTempDir<T>(fn: (dir: string) => T): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'runsteps-'));
+  try {
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeFileWithMtime(filePath: string, content: string, mtime: Date) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content);
+  fs.utimesSync(filePath, mtime, mtime);
+}
+
+function writeFrameworkWithMtime(
+  buildPath: string,
+  productName: string,
+  flavor: 'debug' | 'release',
+  mtime: Date
+) {
+  const frameworkPath = path.join(
+    buildPath,
+    'output',
+    flavor,
+    'xcframeworks',
+    `${productName}.xcframework`
+  );
+  writeFileWithMtime(path.join(frameworkPath, 'Info.plist'), '<plist />', mtime);
+}
+
+function makeTempPackage(
+  root: string,
+  name: string,
+  products: SPMProduct[],
+  sourceMtime: Date
+): SPMPackageSource {
+  const packagePath = path.join(root, name.replace('/', '__'));
+  const buildPath = path.join(root, '.build', name);
+  writeFileWithMtime(path.join(packagePath, 'package.json'), JSON.stringify({ name }), sourceMtime);
+  writeFileWithMtime(path.join(packagePath, 'spm.config.json'), '{}', sourceMtime);
+
+  for (const product of products) {
+    for (const target of product.targets) {
+      if (target.type === 'framework') continue;
+      writeFileWithMtime(
+        path.join(packagePath, target.path, `${target.name}.swift`),
+        'public struct Example {}',
+        sourceMtime
+      );
+    }
+  }
+
+  return makePkg(name, products, { path: packagePath, buildPath });
 }
 
 // ---------------------------------------------------------------------------
@@ -244,6 +322,160 @@ describe('sortPackagesByDependencies', () => {
     const { dependsOn } = sortPackagesByDependencies([a, b]);
     assert.equal(dependsOn.get('a')!.size, 0);
     assert.equal(dependsOn.get('b')!.size, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// expandWithUnbuiltDependencies
+// ---------------------------------------------------------------------------
+
+describe('expandWithUnbuiltDependencies', () => {
+  it('skips a dependency when requested flavor output is fresh', () => {
+    withTempDir((dir) => {
+      const old = new Date('2026-01-01T00:00:00Z');
+      const newer = new Date('2026-01-02T00:00:00Z');
+      const consumer = makeTempPackage(
+        dir,
+        'consumer',
+        [makeSwiftProduct('Consumer', ['dep/DepProduct'])],
+        old
+      );
+      const dep = makeTempPackage(dir, 'dep', [makeSwiftProduct('DepProduct')], old);
+      writeFrameworkWithMtime(dep.buildPath, 'DepProduct', 'debug', newer);
+      writeFrameworkWithMtime(dep.buildPath, 'DepProduct', 'release', newer);
+
+      const result = expandWithUnbuiltDependencies([consumer], {
+        buildFlavors: ['Debug', 'Release'],
+        resolvePackageByName: (name) => (name === 'dep' ? dep : null),
+      });
+
+      assert.deepEqual(
+        result.map((pkg) => pkg.packageName),
+        ['consumer']
+      );
+    });
+  });
+
+  it('auto-adds a dependency when requested flavor output is missing', () => {
+    withTempDir((dir) => {
+      const mtime = new Date('2026-01-01T00:00:00Z');
+      const consumer = makeTempPackage(
+        dir,
+        'consumer',
+        [makeSwiftProduct('Consumer', ['dep/DepProduct'])],
+        mtime
+      );
+      const dep = makeTempPackage(dir, 'dep', [makeSwiftProduct('DepProduct')], mtime);
+
+      const result = expandWithUnbuiltDependencies([consumer], {
+        buildFlavors: ['Debug'],
+        resolvePackageByName: (name) => (name === 'dep' ? dep : null),
+      });
+
+      assert.deepEqual(
+        result.map((pkg) => pkg.packageName),
+        ['consumer', 'dep']
+      );
+    });
+  });
+
+  it('auto-adds a scoped dependency when requested flavor output is missing', () => {
+    withTempDir((dir) => {
+      const mtime = new Date('2026-01-01T00:00:00Z');
+      const consumer = makeTempPackage(
+        dir,
+        'consumer',
+        [makeSwiftProduct('Consumer', ['@expo/ui/ExpoUI'])],
+        mtime
+      );
+      const ui = makeTempPackage(dir, '@expo/ui', [makeSwiftProduct('ExpoUI')], mtime);
+
+      const result = expandWithUnbuiltDependencies([consumer], {
+        buildFlavors: ['Debug'],
+        resolvePackageByName: (name) => (name === '@expo/ui' ? ui : null),
+      });
+
+      assert.deepEqual(
+        result.map((pkg) => pkg.packageName),
+        ['consumer', '@expo/ui']
+      );
+    });
+  });
+
+  it('auto-adds a dependency when requested flavor output is stale', () => {
+    withTempDir((dir) => {
+      const old = new Date('2026-01-01T00:00:00Z');
+      const newer = new Date('2026-01-02T00:00:00Z');
+      const consumer = makeTempPackage(
+        dir,
+        'consumer',
+        [makeSwiftProduct('Consumer', ['dep/DepProduct'])],
+        old
+      );
+      const dep = makeTempPackage(dir, 'dep', [makeSwiftProduct('DepProduct')], newer);
+      writeFrameworkWithMtime(dep.buildPath, 'DepProduct', 'debug', old);
+
+      const result = expandWithUnbuiltDependencies([consumer], {
+        buildFlavors: ['Debug'],
+        resolvePackageByName: (name) => (name === 'dep' ? dep : null),
+      });
+
+      assert.deepEqual(
+        result.map((pkg) => pkg.packageName),
+        ['consumer', 'dep']
+      );
+    });
+  });
+
+  it('auto-adds a fresh dependency when clean is requested', () => {
+    withTempDir((dir) => {
+      const old = new Date('2026-01-01T00:00:00Z');
+      const newer = new Date('2026-01-02T00:00:00Z');
+      const consumer = makeTempPackage(
+        dir,
+        'consumer',
+        [makeSwiftProduct('Consumer', ['dep/DepProduct'])],
+        old
+      );
+      const dep = makeTempPackage(dir, 'dep', [makeSwiftProduct('DepProduct')], old);
+      writeFrameworkWithMtime(dep.buildPath, 'DepProduct', 'debug', newer);
+
+      const result = expandWithUnbuiltDependencies([consumer], {
+        buildFlavors: ['Debug'],
+        clean: true,
+        resolvePackageByName: (name) => (name === 'dep' ? dep : null),
+      });
+
+      assert.deepEqual(
+        result.map((pkg) => pkg.packageName),
+        ['consumer', 'dep']
+      );
+    });
+  });
+
+  it('only requires requested flavors', () => {
+    withTempDir((dir) => {
+      const old = new Date('2026-01-01T00:00:00Z');
+      const newer = new Date('2026-01-02T00:00:00Z');
+      const consumer = makeTempPackage(
+        dir,
+        'consumer',
+        [makeSwiftProduct('Consumer', ['dep/DepProduct'])],
+        old
+      );
+      const dep = makeTempPackage(dir, 'dep', [makeSwiftProduct('DepProduct')], old);
+      writeFrameworkWithMtime(dep.buildPath, 'DepProduct', 'debug', newer);
+
+      const result = expandWithUnbuiltDependencies([consumer], {
+        buildFlavors: ['Debug'],
+        resolvePackageByName: (name) => (name === 'dep' ? dep : null),
+      });
+
+      assert.deepEqual(
+        result.map((pkg) => pkg.packageName),
+        ['consumer']
+      );
+    });
   });
 });
 

--- a/tools/src/prebuilds/pipeline/RunSteps.test.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.test.ts
@@ -477,6 +477,81 @@ describe('expandWithUnbuiltDependencies', () => {
       );
     });
   });
+
+  it('auto-adds a dependency when a bundled resource is newer than the framework', () => {
+    withTempDir((dir) => {
+      const old = new Date('2026-01-01T00:00:00Z');
+      const newer = new Date('2026-01-02T00:00:00Z');
+      const consumer = makeTempPackage(
+        dir,
+        'consumer',
+        [makeSwiftProduct('Consumer', ['dep/DepProduct'])],
+        old
+      );
+      const depProduct: SPMProduct = {
+        ...makeProduct('DepProduct'),
+        targets: [
+          {
+            type: 'swift',
+            name: 'DepProduct',
+            path: 'ios',
+            pattern: '**/*.swift',
+            resources: [{ path: 'ios/Resources/**/*', rule: 'process' }],
+          },
+        ],
+      };
+      const dep = makeTempPackage(dir, 'dep', [depProduct], old);
+      writeFrameworkWithMtime(dep.buildPath, 'DepProduct', 'debug', old);
+      // A bundled resource was modified after the framework was last built.
+      writeFileWithMtime(path.join(dep.path, 'ios/Resources/icon.png'), 'x', newer);
+
+      const result = expandWithUnbuiltDependencies([consumer], {
+        buildFlavors: ['Debug'],
+        resolvePackageByName: (name) => (name === 'dep' ? dep : null),
+      });
+
+      assert.deepEqual(
+        result.map((pkg) => pkg.packageName),
+        ['consumer', 'dep']
+      );
+    });
+  });
+
+  it('treats a framework with no Info.plist as stale', () => {
+    withTempDir((dir) => {
+      const mtime = new Date('2026-01-02T00:00:00Z');
+      const frameworkDirMtime = new Date('2026-01-03T00:00:00Z');
+      const consumer = makeTempPackage(
+        dir,
+        'consumer',
+        [makeSwiftProduct('Consumer', ['dep/DepProduct'])],
+        mtime
+      );
+      const dep = makeTempPackage(dir, 'dep', [makeSwiftProduct('DepProduct')], mtime);
+      // Create the xcframework directory but omit Info.plist — even though the
+      // directory mtime is newer than sources, freshness must not be inferred
+      // from the bundle dir mtime alone.
+      const frameworkPath = path.join(
+        dep.buildPath,
+        'output',
+        'debug',
+        'xcframeworks',
+        'DepProduct.xcframework'
+      );
+      fs.mkdirSync(frameworkPath, { recursive: true });
+      fs.utimesSync(frameworkPath, frameworkDirMtime, frameworkDirMtime);
+
+      const result = expandWithUnbuiltDependencies([consumer], {
+        buildFlavors: ['Debug'],
+        resolvePackageByName: (name) => (name === 'dep' ? dep : null),
+      });
+
+      assert.deepEqual(
+        result.map((pkg) => pkg.packageName),
+        ['consumer', 'dep']
+      );
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -224,13 +224,19 @@ function getPathMtimeMs(filePath: string): number {
   try {
     return fs.statSync(filePath).mtimeMs;
   } catch {
-    return 0;
+    // Unreadable input → force a rebuild rather than silently passing as fresh.
+    return Number.POSITIVE_INFINITY;
   }
 }
 
 function getFrameworkMtimeMs(frameworkPath: string): number {
+  // Info.plist is rewritten on each build; without it the bundle is stale.
   const infoPlistPath = path.join(frameworkPath, 'Info.plist');
-  return getPathMtimeMs(fs.existsSync(infoPlistPath) ? infoPlistPath : frameworkPath);
+  try {
+    return fs.statSync(infoPlistPath).mtimeMs;
+  } catch {
+    return 0;
+  }
 }
 
 function getSourceTargetPath(pkg: SPMPackageSource, target: SPMTarget): string | null {
@@ -282,7 +288,7 @@ function getNewestProductInputMtimeMs(pkg: SPMPackageSource, product: SPMProduct
     }
   }
 
-  return Math.max(0, ...inputPaths.map(getPathMtimeMs));
+  return Math.max(...inputPaths.map(getPathMtimeMs));
 }
 
 function getDependencyFrameworkStatus(
@@ -409,9 +415,7 @@ export function expandWithUnbuiltDependencies(
           }
 
           logger.info(
-            `📎 Auto-adding ${chalk.cyan(depPackageName)} (required by ${chalk.green(pkg.packageName)}${
-              ', ' + reason
-            })`
+            `📎 Auto-adding ${chalk.cyan(depPackageName)} (required by ${chalk.green(pkg.packageName)}, ${reason})`
           );
           added.set(depPackageName, depPkg);
           changed = true;

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -10,10 +10,10 @@
 import chalk from 'chalk';
 import fs from 'fs';
 import fsExtra from 'fs-extra';
+import { glob } from 'glob';
 import path from 'path';
 
 import { PACKAGES_DIR } from '../../Constants';
-import { getPrecompileDir } from '../../Directories';
 import logger from '../../Logger';
 import { getPackageByName } from '../../Packages';
 import { Artifacts } from '../Artifacts';
@@ -23,7 +23,7 @@ import { getExternalPackageByProductName, isExternalPackage } from '../ExternalP
 import { Frameworks } from '../Frameworks';
 import type { BuildFlavor } from '../Prebuilder.types';
 import { buildSharedSPMDependencyAsync } from '../SPMBuild';
-import type { SPMPackageDependencyConfig } from '../SPMConfig.types';
+import type { SPMPackageDependencyConfig, SPMProduct, SPMTarget } from '../SPMConfig.types';
 import {
   getVersionsInfoAsync,
   setForceNonInteractive,
@@ -212,61 +212,109 @@ export function sortPackagesByDependencies(packages: SPMPackageSource[]): Topolo
 }
 
 // ---------------------------------------------------------------------------
-// Helper: frameworkExistsAtAnyVersion
+// Helper: dependency framework status
 // ---------------------------------------------------------------------------
 
-/**
- * Checks if an xcframework exists at either a non-versioned or versioned output path.
- * Versioned paths have the format: output/<packageVersion>/<rnVersion>/<hermesVersion>/<flavor>/xcframeworks/
- * Non-versioned paths have the format: output/<flavor>/xcframeworks/
- */
-function frameworkExistsAtAnyVersion(
-  buildPath: string,
-  productName: string,
-  buildType: BuildFlavor
-): boolean {
-  // Check non-versioned path first (quick check)
-  if (fs.existsSync(Frameworks.getFrameworkPath(buildPath, productName, buildType))) {
-    return true;
-  }
+type DependencyFrameworkStatus =
+  | { status: 'fresh' }
+  | { status: 'missing'; flavor: BuildFlavor }
+  | { status: 'stale'; flavor: BuildFlavor };
 
-  // Check versioned paths by scanning the output directory
-  const outputDir = path.join(buildPath, 'output');
-  if (!fs.existsSync(outputDir)) {
-    return false;
-  }
-
-  const flavor = buildType.toLowerCase();
-  const xcframeworkName = `${productName}.xcframework`;
-
-  // Scan top-level entries in output/ — version directories are non-flavor names
+function getPathMtimeMs(filePath: string): number {
   try {
-    for (const entry of fs.readdirSync(outputDir)) {
-      if (entry === 'debug' || entry === 'release') continue;
-      // Walk a known depth: <ver>/<rnVer>/<hermesVer>/<flavor>/xcframeworks/
-      const verDir = path.join(outputDir, entry);
-      if (!fs.statSync(verDir).isDirectory()) continue;
-      for (const rnVer of fs.readdirSync(verDir)) {
-        const rnDir = path.join(verDir, rnVer);
-        if (!fs.statSync(rnDir).isDirectory()) continue;
-        for (const hermesVer of fs.readdirSync(rnDir)) {
-          const candidate = path.join(rnDir, hermesVer, flavor, 'xcframeworks', xcframeworkName);
-          if (fs.existsSync(candidate)) {
-            return true;
-          }
-        }
+    return fs.statSync(filePath).mtimeMs;
+  } catch {
+    return 0;
+  }
+}
+
+function getFrameworkMtimeMs(frameworkPath: string): number {
+  const infoPlistPath = path.join(frameworkPath, 'Info.plist');
+  return getPathMtimeMs(fs.existsSync(infoPlistPath) ? infoPlistPath : frameworkPath);
+}
+
+function getSourceTargetPath(pkg: SPMPackageSource, target: SPMTarget): string | null {
+  if (target.type === 'framework') {
+    return path.resolve(pkg.path, target.path);
+  }
+
+  const isBuildArtifact = target.path.startsWith('.build/');
+  const targetRoot = isBuildArtifact ? pkg.buildPath : pkg.path;
+  const targetPath = isBuildArtifact ? target.path.slice('.build/'.length) : target.path;
+  return path.resolve(targetRoot, targetPath);
+}
+
+function collectTargetInputPaths(pkg: SPMPackageSource, target: SPMTarget): string[] {
+  const targetSourcePath = getSourceTargetPath(pkg, target);
+  if (!targetSourcePath || !fs.existsSync(targetSourcePath)) {
+    return [];
+  }
+
+  if (target.type === 'framework') {
+    return [targetSourcePath];
+  }
+
+  return glob
+    .sync('**/*', {
+      cwd: targetSourcePath,
+      ignore: target.exclude ?? [],
+      nodir: true,
+    })
+    .map((file) => path.join(targetSourcePath, file));
+}
+
+function getNewestProductInputMtimeMs(pkg: SPMPackageSource, product: SPMProduct): number {
+  const inputPaths = [
+    path.join(pkg.path, 'package.json'),
+    path.join(pkg.path, 'spm.config.json'),
+    ...product.targets.flatMap((target) => collectTargetInputPaths(pkg, target)),
+  ];
+
+  for (const target of product.targets) {
+    if (target.type === 'framework') continue;
+    for (const resource of target.resources ?? []) {
+      for (const file of glob.sync(resource.path, {
+        cwd: pkg.path,
+        nodir: true,
+      })) {
+        inputPaths.push(path.join(pkg.path, file));
       }
     }
-  } catch {
-    // If we can't read the directory, assume not found
   }
 
-  return false;
+  return Math.max(0, ...inputPaths.map(getPathMtimeMs));
+}
+
+function getDependencyFrameworkStatus(
+  pkg: SPMPackageSource,
+  product: SPMProduct,
+  buildFlavors: BuildFlavor[]
+): DependencyFrameworkStatus {
+  const newestInputMtimeMs = getNewestProductInputMtimeMs(pkg, product);
+
+  for (const flavor of buildFlavors) {
+    const frameworkPath = Frameworks.findFrameworkAtAnyVersion(pkg.buildPath, product.name, flavor);
+    if (!frameworkPath) {
+      return { status: 'missing', flavor };
+    }
+
+    if (getFrameworkMtimeMs(frameworkPath) < newestInputMtimeMs) {
+      return { status: 'stale', flavor };
+    }
+  }
+
+  return { status: 'fresh' };
 }
 
 // ---------------------------------------------------------------------------
 // Helper: expandWithUnbuiltDependencies
 // ---------------------------------------------------------------------------
+
+type DependencyExpansionOptions = {
+  buildFlavors?: BuildFlavor[];
+  clean?: boolean;
+  resolvePackageByName?: (packageName: string) => SPMPackageSource | null;
+};
 
 /**
  * Expands the package list to include unbuilt dependencies.
@@ -274,7 +322,12 @@ function frameworkExistsAtAnyVersion(
  * and that dependency's xcframework doesn't exist yet, it's automatically added
  * to the build set so the build can succeed without manual intervention.
  */
-export function expandWithUnbuiltDependencies(packages: SPMPackageSource[]): SPMPackageSource[] {
+export function expandWithUnbuiltDependencies(
+  packages: SPMPackageSource[],
+  options: DependencyExpansionOptions = {}
+): SPMPackageSource[] {
+  const buildFlavors = options.buildFlavors ?? ['Debug', 'Release'];
+  const resolvePackageByName = options.resolvePackageByName ?? getPackageByName;
   const packagesByName = new Map(packages.map((p) => [p.packageName, p]));
   const added = new Map<string, SPMPackageSource>();
 
@@ -323,35 +376,41 @@ export function expandWithUnbuiltDependencies(packages: SPMPackageSource[]): SPM
 
           // Resolve the dep package once — needed for both the customBuild check
           // and the auto-add below.
-          const depPkg = getPackageByName(depPackageName);
-          if (!depPkg || !depPkg.hasSwiftPMConfiguration()) continue;
+          const depPkg = resolvePackageByName(depPackageName);
+          if (!depPkg) continue;
+          let depConfig;
+          try {
+            depConfig = depPkg.getSwiftPMConfiguration();
+          } catch {
+            continue;
+          }
 
           // customBuild products own their staleness signal (their build script
           // hashes its own inputs and no-ops on cache hit). Always include them
           // so the script runs and can detect source changes the existence
           // check below cannot.
-          const depProduct = depPkg
-            .getSwiftPMConfiguration()
-            .products.find((p) => p.name === depProductName);
+          const depProduct = depConfig.products.find((p) => p.name === depProductName);
           const isCustomBuild = !!depProduct?.customBuild;
 
-          if (!isCustomBuild) {
-            // Standard SPM products: skip if both flavors are already on disk.
-            // Check both non-versioned and versioned paths (versioned: output/<ver>/<rn>/<hermes>/<flavor>/xcframeworks/)
-            const depBuildPath = path.join(getPrecompileDir(), '.build', depPackageName);
-            const debugExists = frameworkExistsAtAnyVersion(depBuildPath, depProductName, 'Debug');
-            const releaseExists = frameworkExistsAtAnyVersion(
-              depBuildPath,
-              depProductName,
-              'Release'
-            );
+          let reason = 'xcframework not found';
 
-            if (debugExists && releaseExists) continue;
+          if (options.clean) {
+            reason = 'clean requested';
+          } else if (isCustomBuild) {
+            reason = 'customBuild — script decides cache';
+          } else if (depProduct) {
+            const status = getDependencyFrameworkStatus(depPkg, depProduct, buildFlavors);
+            if (status.status === 'fresh') continue;
+
+            reason =
+              status.status === 'stale'
+                ? `${status.flavor} xcframework stale`
+                : `${status.flavor} xcframework not found`;
           }
 
           logger.info(
             `📎 Auto-adding ${chalk.cyan(depPackageName)} (required by ${chalk.green(pkg.packageName)}${
-              isCustomBuild ? ', customBuild — script decides cache' : ', xcframework not found'
+              ', ' + reason
             })`
           );
           added.set(depPackageName, depPkg);
@@ -410,7 +469,10 @@ export const prepareInputsStep: Step<PrebuildContext> = {
     );
 
     // 2. Auto-add unbuilt dependencies to the build set
-    const unsortedPackages = expandWithUnbuiltDependencies(requestedPackages);
+    const unsortedPackages = expandWithUnbuiltDependencies(requestedPackages, {
+      buildFlavors: request.buildFlavors,
+      clean: request.clean,
+    });
 
     // 3. Validate podName in spm.config.json matches actual .podspec files
     await validateAllPodNamesAsync(unsortedPackages);


### PR DESCRIPTION
## Why

Prebuild dependency expansion only checks whether a dependency xcframework existed - this works well in a CI environment.

If a local dependency such as `@expo/ui` had changed after its xcframework was built, dependent packages like expo-widgets could still compile against the stale binary and fail.

## How

Compare each local dependency product's newest package input mtime against the requested flavor's xcframework mtime before deciding to skip it. Auto-add the dependency when the requested output is missing or stale, and include fresh dependencies when --clean is requested.

Move versioned/non-versioned xcframework lookup into Frameworks so path discovery lives with the rest of the framework path helpers.

## Test-plan

✅ pnpm --dir tools test

```
touch packages/expo-ui/ios/ChartView.swift
et prebuild -f Debug --skip-artifacts --skip-generate --skip-build --skip-compose --skip-verify -j 1 expo-widgets
```

Expo/UI should be included in the list of targets to build 👆