### PR TITLE
[docs][router] Fix typo in screen-tracking page description

### DIFF
--- a/docs/pages/router/reference/screen-tracking.mdx
+++ b/docs/pages/router/reference/screen-tracking.mdx
@@ -1,6 +1,6 @@
 ---
 title: Screen tracking for analytics
-description: Learn how to enable screen tracking for analytic when using Expo Router.
+description: Learn how to enable screen tracking for analytics when using Expo Router.
 hideTOC: true
 ---
 


### PR DESCRIPTION
# Why

The frontmatter description in `docs/pages/router/reference/screen-tracking.mdx` reads "screen tracking for **analytic**" (singular), while the page title on the same file uses the correct plural "Screen tracking for **analytics**".

This description appears in HTML `<meta>` tags and search hover previews, so the typo is visible to users browsing the docs index.

# How

Single-character fix: added the missing `s` to match the page title.

### Diff

```diff
  ---
  title: Screen tracking for analytics
- description: Learn how to enable screen tracking for analytic when using Expo Router.
+ description: Learn how to enable screen tracking for analytics when using Expo Router.
  hideTOC: true
  ---
```

# Test Plan

- Ran `pnpm lint` in `docs/` — all four checks pass (`oxfmt`, `oxlint`, `tsc`, `eslint`).
- Frontmatter-only change; no rendered content shifts.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources — N/A (docs-only change)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — N/A (docs-only change)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
