### PR TITLE
[docs][router] Match Color API cross-platform usage prose to Platform.select example

### DIFF
--- a/docs/pages/router/reference/color.mdx
+++ b/docs/pages/router/reference/color.mdx
@@ -140,7 +140,7 @@ iOS colors automatically adapt to the system appearance (light/dark mode) and ac
 
 ## Cross-platform usage
 
-The `Color` API is platform-specific. Use `useMemo` to select the appropriate color for each platform:
+The `Color` API is platform-specific. Use `Platform.select` to select the appropriate color for each platform:
 
 ```tsx
 import { Platform, View, Text } from 'react-native';


### PR DESCRIPTION
# Why

The `Cross-platform usage` section in `docs/pages/router/reference/color.mdx` introduces the example with: _"Use `useMemo` to select the appropriate color for each platform"_ — but the example immediately below uses `Platform.select`, not `useMemo`. The prose describes a different API than the one demonstrated.

# How

Updated the prose to match the example:

### Diff

```diff
- The `Color` API is platform-specific. Use `useMemo` to select the appropriate color for each platform:
+ The `Color` API is platform-specific. Use `Platform.select` to select the appropriate color for each platform:
```

The example below the line continues to use `Platform.select` unchanged.

# Test Plan

- Ran `pnpm lint` in `docs/` — all four checks pass (`oxfmt`, `oxlint`, `tsc`, `eslint`).
- Single-line prose change; no rendering or behavior impact.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources — N/A (docs-only change)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — N/A (docs-only change)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
