### PR TITLE
feat(doctor): Add check for `*.local` env files and pass original env to Expo CLI [EXP-11]

### DIFF
--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -6,7 +6,11 @@
 
 ### 🎉 New features
 
+- Add check for committed `*.local` env files ([#45832](https://github.com/expo/expo/pull/45832) by [@kitten](https://github.com/kitten))
+
 ### 🐛 Bug fixes
+
+- Pass original env to Expo sub-command ([#45832](https://github.com/expo/expo/pull/45832) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-doctor/src/checks/EnvLocalFilesCheck.ts
+++ b/packages/expo-doctor/src/checks/EnvLocalFilesCheck.ts
@@ -1,0 +1,44 @@
+import { getEnvFiles, KNOWN_MODES } from '@expo/env';
+import fs from 'fs';
+import path from 'path';
+
+import type { DoctorCheck, DoctorCheckParams, DoctorCheckResult } from './checks.types';
+import { isFileIgnoredAsync } from '../utils/files';
+
+export class EnvLocalFilesCheck implements DoctorCheck {
+  description = 'Check that local environment files are not committed';
+
+  sdkVersionRange = '*';
+
+  async runAsync({ projectRoot }: DoctorCheckParams): Promise<DoctorCheckResult> {
+    const issues: string[] = [];
+    const advice: string[] = [];
+
+    const localEnvFiles = Array.from(
+      new Set(KNOWN_MODES.flatMap((mode) => getEnvFiles({ mode, silent: true })))
+    ).filter((file) => file.endsWith('.local'));
+
+    const committedFiles: string[] = [];
+    for (const file of localEnvFiles) {
+      const filePath = path.join(projectRoot, file);
+      if (!fs.existsSync(filePath)) continue;
+      const isIgnored = await isFileIgnoredAsync(filePath, false);
+      // NOTE: skip if the ignore-status is undetermined (e.g. repo isn't a git
+      // checkout) to avoid false-positives, matching ProjectSetupCheck's pattern
+      if (isIgnored === false) {
+        committedFiles.push(file);
+      }
+    }
+
+    if (committedFiles.length > 0) {
+      issues.push(
+        `The following local environment file(s) exist in the project but are not ignored by Git: ${committedFiles.join(', ')}. Files matching ".env*.local" are intended as per-developer overrides — committing them risks leaking secrets, overriding secure defaults loaded from your committed ".env" files, or imposing your personal SDK paths on others who clone the project.`
+      );
+      advice.push(
+        `Add ".env*.local" to your .gitignore. If any of these files have already been committed, untrack them with "git rm --cached ${committedFiles.join(' ')}" and commit the change.`
+      );
+    }
+
+    return { isSuccessful: issues.length === 0, issues, advice };
+  }
+}

--- a/packages/expo-doctor/src/checks/__tests__/EnvLocalFilesCheck.test.ts
+++ b/packages/expo-doctor/src/checks/__tests__/EnvLocalFilesCheck.test.ts
@@ -1,0 +1,105 @@
+import { vol } from 'memfs';
+
+import { isFileIgnoredAsync } from '../../utils/files';
+import { EnvLocalFilesCheck } from '../EnvLocalFilesCheck';
+
+jest.mock('fs');
+jest.mock('../../utils/files');
+
+const projectRoot = '/tmp/project';
+
+const additionalProjectProps = {
+  exp: { name: 'name', slug: 'slug' },
+  projectRoot,
+  hasUnusedStaticConfig: false,
+  staticConfigPath: null,
+  dynamicConfigPath: null,
+};
+
+const mockIsFileIgnored = (value: boolean | null) =>
+  (isFileIgnoredAsync as jest.MockedFunction<typeof isFileIgnoredAsync>).mockResolvedValue(value);
+
+describe('runAsync', () => {
+  afterEach(() => {
+    vol.reset();
+    jest.resetAllMocks();
+  });
+
+  it('returns isSuccessful = true when no .local env files exist', async () => {
+    vol.fromJSON({ [`${projectRoot}/package.json`]: '{}' });
+    mockIsFileIgnored(false);
+
+    const result = await new EnvLocalFilesCheck().runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBe(true);
+    expect(isFileIgnoredAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns isSuccessful = true when a .local env file exists and is gitignored', async () => {
+    vol.fromJSON({ [`${projectRoot}/.env.local`]: 'FOO=bar' });
+    mockIsFileIgnored(true);
+
+    const result = await new EnvLocalFilesCheck().runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it('returns isSuccessful = true when the ignore status is undetermined (no git)', async () => {
+    vol.fromJSON({ [`${projectRoot}/.env.local`]: 'FOO=bar' });
+    mockIsFileIgnored(null);
+
+    const result = await new EnvLocalFilesCheck().runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBe(true);
+  });
+
+  it('returns isSuccessful = false when a .local env file exists and is not gitignored', async () => {
+    vol.fromJSON({ [`${projectRoot}/.env.local`]: 'FOO=bar' });
+    mockIsFileIgnored(false);
+
+    const result = await new EnvLocalFilesCheck().runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    expect(result.issues[0]).toContain('.env.local');
+    expect(result.issues[0]).toContain('not ignored by Git');
+    expect(result.advice[0]).toContain('git rm --cached .env.local');
+    expect(result.advice[0]).toContain('.env*.local');
+  });
+
+  it('flags every unignored .local variant', async () => {
+    vol.fromJSON({
+      [`${projectRoot}/.env.local`]: 'FOO=bar',
+      [`${projectRoot}/.env.development.local`]: 'FOO=dev',
+      [`${projectRoot}/.env.production.local`]: 'FOO=prod',
+      [`${projectRoot}/.env.test.local`]: 'FOO=test',
+    });
+    mockIsFileIgnored(false);
+
+    const result = await new EnvLocalFilesCheck().runAsync({
+      pkg: { name: 'name', version: '1.0.0' },
+      ...additionalProjectProps,
+    });
+
+    expect(result.isSuccessful).toBe(false);
+    for (const file of [
+      '.env.local',
+      '.env.development.local',
+      '.env.production.local',
+      '.env.test.local',
+    ]) {
+      expect(result.issues[0]).toContain(file);
+    }
+  });
+});

--- a/packages/expo-doctor/src/utils/checkResolver.ts
+++ b/packages/expo-doctor/src/utils/checkResolver.ts
@@ -11,6 +11,7 @@ import { AppConfigFieldsNotSyncedToNativeProjectsCheck } from '../checks/AppConf
 import { AutolinkingDependencyDuplicatesCheck } from '../checks/AutolinkingDependencyDuplicatesCheck';
 import { DependencyVersionOverrideCheck } from '../checks/DependencyVersionOverrideCheck';
 import { DirectPackageInstallCheck } from '../checks/DirectPackageInstallCheck';
+import { EnvLocalFilesCheck } from '../checks/EnvLocalFilesCheck';
 import { ExpoConfigCommonIssueCheck } from '../checks/ExpoConfigCommonIssueCheck';
 import { ExpoConfigSchemaCheck } from '../checks/ExpoConfigSchemaCheck';
 import { ExpoRouterReactNavigationCheck } from '../checks/ExpoRouterReactNavigationCheck';
@@ -41,6 +42,7 @@ export function resolveChecksInScope(exp: ExpoConfig, pkg: PackageJSONConfig): D
   const resolvedChecks: DoctorCheck[] = [
     // Project Structure Checks
     new ProjectSetupCheck(),
+    new EnvLocalFilesCheck(),
     new PackageJsonCheck(),
     new LockfileCheck(),
     new ExpoConfigSchemaCheck(),

--- a/packages/expo-doctor/src/utils/spawnExpoCLI.ts
+++ b/packages/expo-doctor/src/utils/spawnExpoCLI.ts
@@ -12,8 +12,8 @@ export async function spawnExpoCLI(
   // any project-controlled overrides the parent loaded.
   const spawnOptions: spawnAsync.SpawnOptions = {
     cwd: projectRoot,
-    env: getOriginalEnv(),
     ...options,
+    env: options.env ? { ...getOriginalEnv(), ...options.env } : getOriginalEnv(),
   };
   const expoCliPath = resolveFrom.silent(projectRoot, 'expo/bin/cli');
   if (expoCliPath) {

--- a/packages/expo-doctor/src/utils/spawnExpoCLI.ts
+++ b/packages/expo-doctor/src/utils/spawnExpoCLI.ts
@@ -1,3 +1,4 @@
+import { getOriginalEnv } from '@expo/env';
 import spawnAsync from '@expo/spawn-async';
 import resolveFrom from 'resolve-from';
 
@@ -6,16 +7,18 @@ export async function spawnExpoCLI(
   args: string[],
   options: Omit<spawnAsync.SpawnOptions, 'cwd'>
 ) {
+  // Spawn a child `node`/`npx` with the pre-dotenv env. expo-doctor itself
+  // loads `.env` files via @expo/env, so without this the child would inherit
+  // any project-controlled overrides the parent loaded.
+  const spawnOptions: spawnAsync.SpawnOptions = {
+    cwd: projectRoot,
+    env: getOriginalEnv(),
+    ...options,
+  };
   const expoCliPath = resolveFrom.silent(projectRoot, 'expo/bin/cli');
   if (expoCliPath) {
-    return await spawnAsync('node', [expoCliPath, ...args], {
-      cwd: projectRoot,
-      ...options,
-    });
+    return await spawnAsync('node', [expoCliPath, ...args], spawnOptions);
   } else {
-    return await spawnAsync('npx', ['expo', ...args], {
-      cwd: projectRoot,
-      ...options,
-    });
+    return await spawnAsync('npx', ['expo', ...args], spawnOptions);
   }
 }


### PR DESCRIPTION
## Summary

Stacked on #45831

We should use the new API in `@expo/env` to pass the original system env to the Expo CLI, since we're otherwise "upgrading" the loaded environment variables with the ones already loaded in `expo-doctor`.

Additionally, this PR adds a check to ensure that `*.local` env files aren't committed to source control, similar to the other checks for this. This is already recommended in the docs, but not captured: https://docs.expo.dev/guides/environment-variables/#using-multiple-env-files-to-define-separate-environments

## Set of changes

- Pass `env` as `getOriginalEnv()` to `expo` commands
- Add `EnvLocalFilesCheck`

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
