### PR TITLE
fix(cli): Read selected env vars only from original system env [EXP-11]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Add missing adb shell quoting where necessary ([#45853](https://github.com/expo/expo/pull/45853) by [@kitten](https://github.com/kitten))
 - Escape content inserted into interstitial page ([#45839](https://github.com/expo/expo/pull/45839) by [@kitten](https://github.com/kitten))
 - Read raw MCP URL env var only from original system env vars ([#45842](https://github.com/expo/expo/pull/45842) by [@kitten](https://github.com/kitten))
+- Read selected env vars only from original system env vars, not from `@expo/env` env files ([#45833](https://github.com/expo/expo/pull/45833) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/api/user/UserSettings.ts
+++ b/packages/@expo/cli/src/api/user/UserSettings.ts
@@ -1,3 +1,4 @@
+import { getOriginalEnvValue } from '@expo/env';
 import JsonFile from '@expo/json-file';
 import crypto from 'crypto';
 import { boolish } from 'getenv';
@@ -26,8 +27,12 @@ export type UserSettingsData = {
 export function getExpoHomeDirectory() {
   const home = homedir();
 
-  if (process.env.__UNSAFE_EXPO_HOME_DIRECTORY) {
-    return process.env.__UNSAFE_EXPO_HOME_DIRECTORY;
+  // Read from the pre-dotenv env — this redirects the directory used for the
+  // auth-token cache and other settings. The `__UNSAFE_` prefix marks it as a
+  // shell-only escape hatch; a project `.env` setting it would hijack credentials.
+  const unsafeHome = getOriginalEnvValue('__UNSAFE_EXPO_HOME_DIRECTORY');
+  if (unsafeHome) {
+    return unsafeHome;
   } else if (boolish('EXPO_STAGING', false)) {
     return path.join(home, '.expo-staging');
   } else if (boolish('EXPO_LOCAL', false)) {

--- a/packages/@expo/cli/src/start/server/UrlCreator.ts
+++ b/packages/@expo/cli/src/start/server/UrlCreator.ts
@@ -1,3 +1,4 @@
+import { getOriginalEnvValue } from '@expo/env';
 import assert from 'assert';
 import { URL } from 'url';
 
@@ -195,7 +196,9 @@ function joinUrlComponents({ protocol, hostname, port }: Partial<UrlComponents>)
 
 /** @deprecated */
 function getProxyUrl(): string | undefined {
-  return process.env.EXPO_PACKAGER_PROXY_URL;
+  // Read from the pre-dotenv env — overriding this would redirect connected dev
+  // clients through an attacker-controlled URL.
+  return getOriginalEnvValue('EXPO_PACKAGER_PROXY_URL');
 }
 
 // TODO: Drop the undocumented env variables:

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -233,7 +233,7 @@ class Env {
 
   /** Internal key used to pass eager bundle data from the CLI to the native run scripts during `npx expo run` commands. */
   get __EXPO_EAGER_BUNDLE_OPTIONS() {
-    return string('__EXPO_EAGER_BUNDLE_OPTIONS', '');
+    return getOriginalEnvValue('__EXPO_EAGER_BUNDLE_OPTIONS') || '';
   }
 
   /** Disable server deployment during production builds (during `expo export:embed`). This is useful for testing API routes and server components against a local server. */

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -54,7 +54,9 @@ class Env {
 
   /** local directory to the universe repo for testing locally */
   get EXPO_UNIVERSE_DIR() {
-    return string('EXPO_UNIVERSE_DIR', '');
+    // Read from the pre-dotenv env — this is a filesystem path used by internal
+    // tooling; a project `.env` overriding it could redirect file access.
+    return getOriginalEnvValue('EXPO_UNIVERSE_DIR') || '';
   }
 
   /** @deprecated Default Webpack host string */
@@ -114,7 +116,8 @@ class Env {
    * This is useful for browser editors that require custom proxy URLs.
    */
   get EXPO_PACKAGER_PROXY_URL(): string {
-    return string('EXPO_PACKAGER_PROXY_URL', '');
+    // Read from the pre-dotenv env — overrides dev server URL served to clients.
+    return getOriginalEnvValue('EXPO_PACKAGER_PROXY_URL') || '';
   }
 
   /**
@@ -159,7 +162,9 @@ class Env {
    * @internal
    */
   get EXPO_OVERRIDE_METRO_CONFIG(): string | undefined {
-    return process.env.EXPO_OVERRIDE_METRO_CONFIG?.trim() || undefined;
+    // Read from the pre-dotenv env — this path is `require()`d as Metro config,
+    // so a project `.env` overriding it would execute attacker code in-process.
+    return getOriginalEnvValue('EXPO_OVERRIDE_METRO_CONFIG')?.trim() || undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary

Stacked on https://github.com/expo/expo/pull/45831

Limits `__UNSAFE_EXPO_HOME_DIRECTORY`, `EXPO_PACKAGER_PROXY_URL`, `EXPO_UNIVERSE_DIR`, and `EXPO_OVERRIDE_METRO_CONFIG` to be read from original system env only.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
