### PR TITLE
fix(cli): Fix interstitial code being injected directly [EXP-16]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Add missing origin check to JS inspector middleware and add throttle to dev commands ([#45863](https://github.com/expo/expo/pull/45863) by [@kitten](https://github.com/kitten))
 - Replace inaccurate file-in-root checks with utility ([#45856](https://github.com/expo/expo/pull/45856) by [@kitten](https://github.com/kitten))
 - Add missing adb shell quoting where necessary ([#45853](https://github.com/expo/expo/pull/45853) by [@kitten](https://github.com/kitten))
+- Escape content inserted into interstitial page ([#45839](https://github.com/expo/expo/pull/45839) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/middleware/InterstitialPageMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/InterstitialPageMiddleware.ts
@@ -23,6 +23,15 @@ const debug = require('debug')(
   'expo:start:server:middleware:interstitialPage'
 ) as typeof console.log;
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export const LoadingEndpoint = '/_expo/loading';
 
 export class InterstitialPageMiddleware extends ExpoMiddleware {
@@ -48,14 +57,17 @@ export class InterstitialPageMiddleware extends ExpoMiddleware {
       path.resolve(__dirname, '../../../../../static/loading-page/index.html');
     let content = (await readFile(templatePath)).toString('utf-8');
 
-    content = content.replace(/{{\s*AppName\s*}}/, appName);
-    content = content.replace(/{{\s*Path\s*}}/, this.projectRoot);
-    content = content.replace(/{{\s*Scheme\s*}}/, this.options.scheme ?? 'Unknown');
+    content = content.replace(/{{\s*AppName\s*}}/, escapeHtml(appName));
+    content = content.replace(/{{\s*Path\s*}}/, escapeHtml(this.projectRoot));
+    content = content.replace(/{{\s*Scheme\s*}}/, escapeHtml(this.options.scheme ?? 'Unknown'));
     content = content.replace(
       /{{\s*ProjectVersionType\s*}}/,
       `${projectVersion.type === 'sdk' ? 'SDK' : 'Runtime'} version`
     );
-    content = content.replace(/{{\s*ProjectVersion\s*}}/, projectVersion.version ?? 'Undetected');
+    content = content.replace(
+      /{{\s*ProjectVersion\s*}}/,
+      escapeHtml(projectVersion.version ?? 'Undetected')
+    );
 
     return content;
   }

--- a/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/__tests__/InterstitialPageMiddleware-test.ts
@@ -142,6 +142,32 @@ describe('_getPageAsync', () => {
       })
     ).resolves.toEqual('AppName: "App", Runtime version "123", Path: /, Scheme: "testscheme"');
   });
+
+  it('escapes injected values so they cannot break out of the HTML template', async () => {
+    const projectRoot = '/';
+    vol.fromJSON(
+      {
+        'node_modules/expo/static/loading-page/index.html':
+          'AppName: "{{ AppName }}", {{ ProjectVersionType }} "{{ ProjectVersion }}", Path: {{ Path }}, Scheme: "{{ Scheme }}"',
+      },
+      projectRoot
+    );
+
+    const middleware = new InterstitialPageMiddleware(projectRoot, {
+      scheme: `"><script>alert('xss')</script>`,
+    });
+    await expect(
+      middleware._getPageAsync({
+        appName: `<img src=x onerror=alert(1)>`,
+        projectVersion: {
+          type: 'runtime',
+          version: `</p><script>1</script>`,
+        },
+      })
+    ).resolves.toEqual(
+      'AppName: "&lt;img src=x onerror=alert(1)&gt;", Runtime version "&lt;/p&gt;&lt;script&gt;1&lt;/script&gt;", Path: /, Scheme: "&quot;&gt;&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"'
+    );
+  });
 });
 
 describe('handleRequestAsync', () => {

--- a/packages/@expo/cli/static/loading-page/index.html
+++ b/packages/@expo/cli/static/loading-page/index.html
@@ -237,7 +237,7 @@
   <title>Expo Start | Loading Page</title>
 </head>
 <body>
-  <div id="alert"></div>
+  <div id="alert" data-scheme="{{ Scheme }}"></div>
   <div class="logo-box">
     <div class="logo-background-box">
 
@@ -297,12 +297,20 @@
   <script>
   const alertElement = document.getElementById("alert");
 
+  const escapeHtml = (value) => value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
   const showAlert = (isExpoGo) => {
     if (isExpoGo) {
       alertElement.innerHTML = 'Unable to open in Expo Go. Please install <b>Expo Go</b> to continue.' +
       '<br><a href="https://expo.dev/client">Learn more.</a>';
     } else {
-      alertElement.innerHTML = 'Unable to open in Development Build with the <b>{{ Scheme }}</b> scheme. Please build and install a compatible <b>Development Build</b> to continue.' +
+      const scheme = escapeHtml(alertElement.dataset.scheme || 'Unknown');
+      alertElement.innerHTML = 'Unable to open in Development Build with the <b>' + scheme + '</b> scheme. Please build and install a compatible <b>Development Build</b> to continue.' +
       '<br><a href="https://docs.expo.dev/development/build/">Learn more.</a>';
     }
 


### PR DESCRIPTION
## Summary

While the likelihood of this causing any unintended side-effects is low, it's cheap for us to sanitise the values we inject in the interstitial page template.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
