### PR TITLE
[expo-app-metrics] fix concurrent access to FrameMetricsRecorder

### DIFF
--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameMetricsRecorder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameMetricsRecorder.kt
@@ -9,6 +9,9 @@ import android.app.Activity
  * and retrieve the accumulated metrics.
  */
 class FrameMetricsRecorder {
+  // Reassigned from JS thread in stop() while dispatchFrame mutates it on the
+  // main thread. @Volatile gives stop() a stable visible reference to swap.
+  @Volatile
   private var record = FrameMetricsRecord()
 
   /** Starts recording frame metrics for the given activity's window. */

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameRateMonitor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameRateMonitor.kt
@@ -5,24 +5,34 @@ import android.os.Handler
 import android.os.Looper
 import android.view.Window
 import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Internal singleton that manages the [Window.OnFrameMetricsAvailableListener].
  * Auto-attaches to the window when the first recorder is added and
  * auto-detaches when the last is removed.
+ *
+ * The frame callback runs on the main thread while [addRecorder] / [removeRecorder]
+ * are typically invoked from the JS thread, so [recorders] must be safe for
+ * concurrent iteration. [CopyOnWriteArrayList] gives lock-free iteration on the
+ * hot frame path; writes are rare (per record start/stop).
  */
 internal object FrameRateMonitor {
   private var listener: Window.OnFrameMetricsAvailableListener? = null
   private var currentActivity: WeakReference<Activity>? = null
-  private val recorders = mutableListOf<WeakReference<FrameMetricsRecorder>>()
+  private val recorders = CopyOnWriteArrayList<WeakReference<FrameMetricsRecorder>>()
 
+  @Synchronized
   fun addRecorder(recorder: FrameMetricsRecorder, activity: Activity) {
     recorders.add(WeakReference(recorder))
     startMonitoringIfNeeded(activity)
   }
 
+  @Synchronized
   fun removeRecorder(recorder: FrameMetricsRecorder) {
-    recorders.removeAll { it.get() === recorder || it.get() == null }
+    // Use CopyOnWriteArrayList's atomic removeIf — Kotlin's removeAll { } extension
+    // uses an indexed iterator that is not safe against concurrent add().
+    recorders.removeIf { ref -> ref.get().let { it === recorder || it == null } }
     stopMonitoringIfEmpty()
   }
 
@@ -33,11 +43,7 @@ internal object FrameRateMonitor {
     val newListener = Window.OnFrameMetricsAvailableListener { _, frameMetrics, _ ->
       val frameDurationMs =
         (frameMetrics.getMetric(android.view.FrameMetrics.TOTAL_DURATION) / 1_000_000.0).toLong()
-
-      removeReleasedRecorders()
-      for (ref in recorders) {
-        ref.get()?.processFrame(frameDurationMs)
-      }
+      dispatchFrame(frameDurationMs)
     }
     listener = newListener
 
@@ -57,6 +63,13 @@ internal object FrameRateMonitor {
   }
 
   private fun removeReleasedRecorders() {
-    recorders.removeAll { it.get() == null }
+    recorders.removeIf { it.get() == null }
+  }
+
+  internal fun dispatchFrame(frameDurationMs: Long) {
+    removeReleasedRecorders()
+    for (ref in recorders) {
+      ref.get()?.processFrame(frameDurationMs)
+    }
   }
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/frames/FrameRateMonitorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/frames/FrameRateMonitorTest.kt
@@ -1,0 +1,73 @@
+package expo.modules.appmetrics.frames
+
+import android.app.Activity
+import android.view.Window
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class FrameRateMonitorTest {
+  private val seed = FrameMetricsRecorder()
+
+  @After
+  fun tearDown() {
+    FrameRateMonitor.removeRecorder(seed)
+  }
+
+  @Test
+  fun `concurrent recorder churn during frame dispatch does not throw`() {
+    val window = mockk<Window>(relaxed = true)
+    val activity = mockk<Activity>(relaxed = true)
+    every { activity.window } returns window
+
+    // Seed with a long-lived recorder so the monitor attaches and stays attached
+    // throughout the test (otherwise the churn thread might briefly empty the list).
+    seed.start(activity)
+
+    val running = AtomicBoolean(true)
+    val errors = ConcurrentLinkedQueue<Throwable>()
+
+    val frameThread = Thread({
+      while (running.get()) {
+        try {
+          FrameRateMonitor.dispatchFrame(16L)
+        } catch (t: Throwable) {
+          errors.add(t)
+        }
+      }
+    }, "frame-dispatch-thread")
+
+    val recorderThread = Thread({
+      while (running.get()) {
+        try {
+          val r = FrameMetricsRecorder()
+          r.start(activity)
+          r.stop()
+        } catch (t: Throwable) {
+          errors.add(t)
+        }
+      }
+    }, "recorder-churn-thread")
+
+    frameThread.start()
+    recorderThread.start()
+    Thread.sleep(500)
+    running.set(false)
+    frameThread.join()
+    recorderThread.join()
+
+    assertTrue(
+      "Expected no exceptions, got ${errors.size}; first: ${errors.firstOrNull()?.let { "${it.javaClass.simpleName}: ${it.message}" }}",
+      errors.isEmpty()
+    )
+  }
+}


### PR DESCRIPTION
# Why

https://linear.app/expo/issue/ENG-21273/fix-android-crash-in-frameratemonitor

# How

Change `mutableListOf` to `CopyOnWriteArrayList` - the recorders array is not muted often.

# Test Plan

1. CI - added concurrent access test
2. ObserveTester

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
