### PR TITLE
fix(cli): Limit MCP env var URL value to original system env [EXP-18]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Replace inaccurate file-in-root checks with utility ([#45856](https://github.com/expo/expo/pull/45856) by [@kitten](https://github.com/kitten))
 - Add missing adb shell quoting where necessary ([#45853](https://github.com/expo/expo/pull/45853) by [@kitten](https://github.com/kitten))
 - Escape content inserted into interstitial page ([#45839](https://github.com/expo/expo/pull/45839) by [@kitten](https://github.com/kitten))
+- Read raw MCP URL env var only from original system env vars ([#45842](https://github.com/expo/expo/pull/45842) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/env.ts
+++ b/packages/@expo/cli/src/utils/env.ts
@@ -1,3 +1,4 @@
+import { getOriginalEnvValue } from '@expo/env';
 import { boolish, int, string } from 'getenv';
 import process from 'node:process';
 
@@ -293,7 +294,8 @@ class Env {
     if (value === '1' || value.toLowerCase() === 'true') {
       return this.EXPO_STAGING ? 'staging-mcp.expo.dev' : 'mcp.expo.dev';
     }
-    return value;
+    // Re-read from the pre-dotenv env — overrides dev server URL served to clients.
+    return getOriginalEnvValue('EXPO_UNSTABLE_MCP_SERVER') || '';
   }
 
   /** Enable Expo Log Box for iOS and Android (Web is enabled by default) */


### PR DESCRIPTION
## Summary

Stacked on #45831
Related to #45833

Limits `EXPO_UNSTABLE_MCP_SERVER` raw URL value to the original system env.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
