### PR TITLE
[expo-app-metrics] fix concurrent access to AppStartupManager.metrics

### DIFF
--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/appstartup/AppStartupManager.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/appstartup/AppStartupManager.kt
@@ -17,6 +17,7 @@ import expo.modules.appmetrics.utils.TimeUtils.getCurrentTimeInMillis
 import expo.modules.appmetrics.utils.TimeUtils.getCurrentTimestampInISOFormat
 import expo.modules.appmetrics.utils.TimeUtils.getProcessStartTimeInMillis
 import org.json.JSONObject
+import java.util.concurrent.CopyOnWriteArrayList
 
 enum class AppStartType { COLD, WARM }
 
@@ -35,14 +36,20 @@ data class EASObserveAppStartupInfo(
 object AppStartupManager {
   private const val BACKGROUND_THRESHOLD_MS = 60_000L
 
-  private val _metrics: MutableList<Metric> = mutableListOf()
+  // CopyOnWriteArrayList: writes (addMetric) happen on the React/JS/main threads;
+  // reads (saveStartupMetricsIfNotSaved) happen on appContext.modulesQueue. Snapshot
+  // iteration on the read side means we never CME under concurrent add().
+  private val _metrics: MutableList<Metric> = CopyOnWriteArrayList()
   internal val metrics: List<Metric>
     get() = _metrics
 
-  private var bundleLoadStartTime: Long? = null
-  private var launchTimeInMillis: Long? = null
-  private var hasRecordedInteractive = false
-  private var hasRecordedFirstRender = false
+  // These fields are read and written across the React marker thread, the main thread,
+  // and the JS thread. @Volatile guarantees writes are visible across threads so the
+  // one-shot guards (hasRecorded*) don't spuriously fire twice.
+  @Volatile private var bundleLoadStartTime: Long? = null
+  @Volatile private var launchTimeInMillis: Long? = null
+  @Volatile private var hasRecordedInteractive = false
+  @Volatile private var hasRecordedFirstRender = false
 
   @Volatile
   var startupState: StartupState = StartupState.LAUNCHING

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameMetricsRecorder.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameMetricsRecorder.kt
@@ -9,6 +9,9 @@ import android.app.Activity
  * and retrieve the accumulated metrics.
  */
 class FrameMetricsRecorder {
+  // Reassigned from JS thread in stop() while dispatchFrame mutates it on the
+  // main thread. @Volatile gives stop() a stable visible reference to swap.
+  @Volatile
   private var record = FrameMetricsRecord()
 
   /** Starts recording frame metrics for the given activity's window. */

--- a/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameRateMonitor.kt
+++ b/packages/expo-app-metrics/android/src/main/java/expo/modules/appmetrics/frames/FrameRateMonitor.kt
@@ -5,24 +5,34 @@ import android.os.Handler
 import android.os.Looper
 import android.view.Window
 import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Internal singleton that manages the [Window.OnFrameMetricsAvailableListener].
  * Auto-attaches to the window when the first recorder is added and
  * auto-detaches when the last is removed.
+ *
+ * The frame callback runs on the main thread while [addRecorder] / [removeRecorder]
+ * are typically invoked from the JS thread, so [recorders] must be safe for
+ * concurrent iteration. [CopyOnWriteArrayList] gives lock-free iteration on the
+ * hot frame path; writes are rare (per record start/stop).
  */
 internal object FrameRateMonitor {
   private var listener: Window.OnFrameMetricsAvailableListener? = null
   private var currentActivity: WeakReference<Activity>? = null
-  private val recorders = mutableListOf<WeakReference<FrameMetricsRecorder>>()
+  private val recorders = CopyOnWriteArrayList<WeakReference<FrameMetricsRecorder>>()
 
+  @Synchronized
   fun addRecorder(recorder: FrameMetricsRecorder, activity: Activity) {
     recorders.add(WeakReference(recorder))
     startMonitoringIfNeeded(activity)
   }
 
+  @Synchronized
   fun removeRecorder(recorder: FrameMetricsRecorder) {
-    recorders.removeAll { it.get() === recorder || it.get() == null }
+    // Use CopyOnWriteArrayList's atomic removeIf — Kotlin's removeAll { } extension
+    // uses an indexed iterator that is not safe against concurrent add().
+    recorders.removeIf { ref -> ref.get().let { it === recorder || it == null } }
     stopMonitoringIfEmpty()
   }
 
@@ -33,11 +43,7 @@ internal object FrameRateMonitor {
     val newListener = Window.OnFrameMetricsAvailableListener { _, frameMetrics, _ ->
       val frameDurationMs =
         (frameMetrics.getMetric(android.view.FrameMetrics.TOTAL_DURATION) / 1_000_000.0).toLong()
-
-      removeReleasedRecorders()
-      for (ref in recorders) {
-        ref.get()?.processFrame(frameDurationMs)
-      }
+      dispatchFrame(frameDurationMs)
     }
     listener = newListener
 
@@ -57,6 +63,13 @@ internal object FrameRateMonitor {
   }
 
   private fun removeReleasedRecorders() {
-    recorders.removeAll { it.get() == null }
+    recorders.removeIf { it.get() == null }
+  }
+
+  internal fun dispatchFrame(frameDurationMs: Long) {
+    removeReleasedRecorders()
+    for (ref in recorders) {
+      ref.get()?.processFrame(frameDurationMs)
+    }
   }
 }

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/appstartup/AppStartupManagerTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/appstartup/AppStartupManagerTest.kt
@@ -1,0 +1,75 @@
+package expo.modules.appmetrics.appstartup
+
+import expo.modules.appmetrics.storage.Metric
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class AppStartupManagerTest {
+  @Test
+  fun `concurrent add and iterate on _metrics does not throw`() {
+    // Drive _metrics directly: the public mutators (markInteractive / markFirstRender)
+    // are one-shot guards, so they can't reliably reproduce sustained churn against
+    // a single iterator. Reflection lets us prove the underlying field is safe.
+    val field = AppStartupManager::class.java.getDeclaredField("_metrics").apply {
+      isAccessible = true
+    }
+    @Suppress("UNCHECKED_CAST")
+    val backing = field.get(AppStartupManager) as MutableList<Metric>
+    backing.clear()
+
+    val sample = Metric(
+      sessionId = "test",
+      timestamp = "2026-01-01T00:00:00Z",
+      category = "test",
+      name = "test",
+      value = 0.0
+    )
+
+    val running = AtomicBoolean(true)
+    val errors = ConcurrentLinkedQueue<Throwable>()
+
+    val readerThread = Thread({
+      while (running.get()) {
+        try {
+          // Iterate through the public getter, the same way saveStartupMetricsIfNotSaved does.
+          for (m in AppStartupManager.metrics) {
+            m.name.length
+          }
+        } catch (t: Throwable) {
+          errors.add(t)
+        }
+      }
+    }, "metrics-reader-thread")
+
+    val writerThread = Thread({
+      while (running.get()) {
+        try {
+          backing.add(sample)
+        } catch (t: Throwable) {
+          errors.add(t)
+        }
+      }
+    }, "metrics-writer-thread")
+
+    readerThread.start()
+    writerThread.start()
+    Thread.sleep(500)
+    running.set(false)
+    readerThread.join()
+    writerThread.join()
+
+    backing.clear()
+
+    assertTrue(
+      "Expected no exceptions, got ${errors.size}; first: ${errors.firstOrNull()?.let { "${it.javaClass.simpleName}: ${it.message}" }}",
+      errors.isEmpty()
+    )
+  }
+}

--- a/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/frames/FrameRateMonitorTest.kt
+++ b/packages/expo-app-metrics/android/src/test/java/expo/modules/appmetrics/frames/FrameRateMonitorTest.kt
@@ -1,0 +1,73 @@
+package expo.modules.appmetrics.frames
+
+import android.app.Activity
+import android.view.Window
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicBoolean
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [28])
+class FrameRateMonitorTest {
+  private val seed = FrameMetricsRecorder()
+
+  @After
+  fun tearDown() {
+    FrameRateMonitor.removeRecorder(seed)
+  }
+
+  @Test
+  fun `concurrent recorder churn during frame dispatch does not throw`() {
+    val window = mockk<Window>(relaxed = true)
+    val activity = mockk<Activity>(relaxed = true)
+    every { activity.window } returns window
+
+    // Seed with a long-lived recorder so the monitor attaches and stays attached
+    // throughout the test (otherwise the churn thread might briefly empty the list).
+    seed.start(activity)
+
+    val running = AtomicBoolean(true)
+    val errors = ConcurrentLinkedQueue<Throwable>()
+
+    val frameThread = Thread({
+      while (running.get()) {
+        try {
+          FrameRateMonitor.dispatchFrame(16L)
+        } catch (t: Throwable) {
+          errors.add(t)
+        }
+      }
+    }, "frame-dispatch-thread")
+
+    val recorderThread = Thread({
+      while (running.get()) {
+        try {
+          val r = FrameMetricsRecorder()
+          r.start(activity)
+          r.stop()
+        } catch (t: Throwable) {
+          errors.add(t)
+        }
+      }
+    }, "recorder-churn-thread")
+
+    frameThread.start()
+    recorderThread.start()
+    Thread.sleep(500)
+    running.set(false)
+    frameThread.join()
+    recorderThread.join()
+
+    assertTrue(
+      "Expected no exceptions, got ${errors.size}; first: ${errors.firstOrNull()?.let { "${it.javaClass.simpleName}: ${it.message}" }}",
+      errors.isEmpty()
+    )
+  }
+}


### PR DESCRIPTION
# Why

Follow-up to https://github.com/expo/expo/pull/45840

In a very unlikely scenario (for example, app goes to background in exactly same moment as markInteractive is called), there can be concurrent read and write to the `_metrics` list

# How

Change `mutableList` to `CopyOnWriteArrayList`

# Test Plan

1. CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
