### PR TITLE
fix(cli): Fix MCP plugin schema filters and command assumptions [EXP-19]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -32,6 +32,8 @@
 - Serve an unsigned Expo Go manifest instead of failing with HTTP 500 when `expo start` is unauthenticated in a non-interactive shell. ([#45809](https://github.com/expo/expo/pull/45809) by [@EvanBacon](https://github.com/EvanBacon))
 - Add troubleshooting guide link to simulator boot failure errors. ([#43786](https://github.com/expo/expo/pull/43786) by [@kadikraman](https://github.com/kadikraman))
 - Disallow devtools plugins to point to `webpageRoot` outside of their own bounds ([#45841](https://github.com/expo/expo/pull/45841) by [@kitten](https://github.com/kitten))
+- Pre-filter MCP-exposed commands to exclude ones marked as CLI-only ([#45845](https://github.com/expo/expo/pull/45845) by [@kitten](https://github.com/kitten))
+- Tighten checks on MCP plugins and ran commands ([#45845](https://github.com/expo/expo/pull/45845) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionExecutor.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { spawn, type ChildProcessWithoutNullStreams } from 'child_process';
 import path from 'path';
 
 import type {
@@ -7,6 +7,7 @@ import type {
   DevToolsPluginOutput,
 } from './DevToolsPlugin.schema';
 import { DevToolsPluginCliExtensionResults } from './DevToolsPluginCliExtensionResults';
+import { isPathInside } from '../../utils/dir';
 
 const DEFAULT_TIMEOUT_MS = 10_000; // 10 seconds
 
@@ -25,6 +26,8 @@ const DEFAULT_TIMEOUT_MS = 10_000; // 10 seconds
  *  - Provides structured output with exit codes and error states
  */
 export class DevToolsPluginCliExtensionExecutor {
+  private readonly resolvedEntryPoint: string;
+
   constructor(
     private plugin: DevToolsPluginInfo,
     private projectRoot: string,
@@ -35,6 +38,15 @@ export class DevToolsPluginCliExtensionExecutor {
     if (!this.plugin.cliExtensions?.entryPoint) {
       throw new Error(`Plugin ${this.plugin.packageName} has no CLI extensions`);
     }
+    // Reject entryPoints that escape packageRoot (e.g. "../../other-pkg/dist/cli.js").
+    const resolved = path.resolve(this.plugin.packageRoot, this.plugin.cliExtensions.entryPoint);
+    if (!isPathInside(resolved, this.plugin.packageRoot)) {
+      throw new Error(
+        `Plugin ${this.plugin.packageName} entryPoint "${this.plugin.cliExtensions.entryPoint}" ` +
+          `escapes packageRoot (${this.plugin.packageRoot}); must be a relative path inside the package.`
+      );
+    }
+    this.resolvedEntryPoint = resolved;
   }
 
   public validate({ command, args }: Omit<DevToolsPluginExecutorArguments, 'metroServerOrigin'>) {
@@ -52,12 +64,20 @@ export class DevToolsPluginCliExtensionExecutor {
       );
     }
 
-    const argsKeys = Object.keys(args ?? {});
+    const argsObj = (args ?? {}) as Record<string, unknown>;
     for (const param of commandElement.parameters ?? []) {
-      const found = argsKeys.find((key) => key === param.name);
-      if (!found) {
+      if (!Object.prototype.hasOwnProperty.call(argsObj, param.name)) {
         throw new Error(
           `Parameter "${param.name}" not found in command "${command}" of plugin ${this.plugin.packageName}`
+        );
+      }
+      // Enforce declared parameter type; don't rely on upstream Zod validation alone.
+      const expected =
+        param.type === 'confirm' ? 'boolean' : param.type === 'number' ? 'number' : 'string';
+      const actual = typeof argsObj[param.name];
+      if (actual !== expected) {
+        throw new Error(
+          `Parameter "${param.name}" of "${command}" expected ${expected} (declared "${param.type}"), got ${actual}.`
         );
       }
     }
@@ -78,27 +98,50 @@ export class DevToolsPluginCliExtensionExecutor {
     onOutput,
   }: DevToolsPluginExecutorArguments): Promise<DevToolsPluginOutput> => {
     this.validate({ command, args });
-    return new Promise<DevToolsPluginOutput>(async (resolve) => {
-      // Set up the command and its arguments
-      const tool = path.join(this.plugin.packageRoot, this.plugin.cliExtensions!.entryPoint);
-      const child = this.spawnFunc(
-        'node',
-        [tool, command, `${JSON.stringify(args)}`, `${metroServerOrigin}`],
-        {
-          cwd: this.projectRoot,
-          env: { ...process.env },
-        }
-      );
-
+    return new Promise<DevToolsPluginOutput>((resolve) => {
       let finished = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
       const pluginResults = new DevToolsPluginCliExtensionResults(onOutput);
 
+      // process.execPath instead of 'node' so the child can't be redirected by a PATH shim.
+      let child: ChildProcessWithoutNullStreams;
+      try {
+        child = this.spawnFunc(
+          process.execPath,
+          [this.resolvedEntryPoint, command, `${JSON.stringify(args)}`, `${metroServerOrigin}`],
+          {
+            cwd: this.projectRoot,
+            env: { ...process.env },
+          }
+        );
+      } catch (err: any) {
+        // spawn can throw synchronously; resolve with an error result instead of hanging.
+        pluginResults.append(err?.toString?.() ?? String(err), 'error');
+        resolve(pluginResults.getOutput());
+        return;
+      }
+
+      const finishOnTruncation = () => {
+        if (pluginResults.isTruncated() && !finished) {
+          finished = true;
+          if (timeout) clearTimeout(timeout);
+          child.kill('SIGKILL');
+          resolve(pluginResults.getOutput());
+        }
+      };
+
       // Collect output/error data
-      child.stdout.on('data', (data) => pluginResults.append(data.toString()));
-      child.stderr.on('data', (data) => pluginResults.append(data.toString(), 'error'));
+      child.stdout.on('data', (data) => {
+        pluginResults.append(data.toString());
+        finishOnTruncation();
+      });
+      child.stderr.on('data', (data) => {
+        pluginResults.append(data.toString(), 'error');
+        finishOnTruncation();
+      });
 
       // Setup timeout
-      const timeout = setTimeout(() => {
+      timeout = setTimeout(() => {
         if (!finished) {
           finished = true;
           child.kill('SIGKILL');
@@ -109,7 +152,7 @@ export class DevToolsPluginCliExtensionExecutor {
 
       child.on('close', (code: number) => {
         if (finished) return;
-        clearTimeout(timeout);
+        if (timeout) clearTimeout(timeout);
         finished = true;
         pluginResults.exit(code);
         resolve(pluginResults.getOutput());
@@ -117,7 +160,7 @@ export class DevToolsPluginCliExtensionExecutor {
 
       child.on('error', (err: Error) => {
         if (finished) return;
-        clearTimeout(timeout);
+        if (timeout) clearTimeout(timeout);
         finished = true;
         pluginResults.append(err.toString(), 'error');
         resolve(pluginResults.getOutput());

--- a/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionResults.ts
+++ b/packages/@expo/cli/src/start/server/DevToolsPluginCliExtensionResults.ts
@@ -1,5 +1,10 @@
+import { constants as bufferConstants } from 'node:buffer';
+
 import type { DevToolsPluginOutput } from './DevToolsPlugin.schema';
 import { DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
+
+// Cap accumulated output at V8's max single-string length to bound heap growth.
+const MAX_OUTPUT_LENGTH = bufferConstants.MAX_STRING_LENGTH;
 
 /**
  * Class that collects and manages output from executed plugin commands
@@ -15,11 +20,30 @@ export class DevToolsPluginCliExtensionResults {
   constructor(private onOutput?: (output: DevToolsPluginOutput) => void) {}
 
   private _output: DevToolsPluginOutput = [];
+  private _totalLength = 0;
+  private _truncated = false;
 
   public append(output: string, level: 'info' | 'warning' | 'error' = 'info') {
+    if (this._truncated) return;
+    if (this._totalLength + output.length > MAX_OUTPUT_LENGTH) {
+      this._truncated = true;
+      const message = {
+        type: 'text' as const,
+        text: `Output truncated: plugin exceeded V8's max string length (${MAX_OUTPUT_LENGTH} chars). Reduce output, paginate, or write to a file.`,
+        level: 'error' as const,
+      };
+      this._output.push(message);
+      this.onOutput?.([message]);
+      return;
+    }
+    this._totalLength += output.length;
     const results = this.parseOutputText(output, level);
     this._output.push(...results);
     this.onOutput?.(results);
+  }
+
+  public isTruncated(): boolean {
+    return this._truncated;
   }
 
   public exit(code: number) {

--- a/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
+++ b/packages/@expo/cli/src/start/server/MCPDevToolsPluginCLIExtensions.ts
@@ -1,4 +1,5 @@
 import type { DevServerManager } from './DevServerManager';
+import type { DevToolsPluginInfo } from './DevToolsPlugin.schema';
 import { DevToolsPluginOutputSchema } from './DevToolsPlugin.schema';
 import { DevToolsPluginCliExtensionExecutor } from './DevToolsPluginCliExtensionExecutor';
 import type { McpServer } from './MCP';
@@ -12,17 +13,28 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
 
   for (const plugin of plugins) {
     if (plugin.cliExtensions) {
-      const commands = (plugin.cliExtensions.commands ?? []).filter((p) =>
+      const mcpCommands = (plugin.cliExtensions.commands ?? []).filter((p) =>
         p.environments?.includes('mcp')
       );
-      if (commands.length === 0) {
+      if (mcpCommands.length === 0) {
         continue;
       }
 
-      const schema = createMCPDevToolsExtensionSchema(plugin);
+      // Build an MCP-scoped descriptor so the schema enum and the executor's
+      // existence check both reject commands that were not declared MCP-enabled.
+      const mcpPlugin: DevToolsPluginInfo = {
+        packageName: plugin.packageName,
+        packageRoot: plugin.packageRoot,
+        cliExtensions: {
+          ...plugin.cliExtensions,
+          commands: mcpCommands,
+        },
+      };
+
+      const schema = createMCPDevToolsExtensionSchema(mcpPlugin);
 
       debug(
-        `Installing MCP CLI extension for plugin: ${plugin.packageName} - found ${commands.length} commands`
+        `Installing MCP CLI extension for plugin: ${plugin.packageName} - found ${mcpCommands.length} commands`
       );
 
       mcpServer.registerTool(
@@ -41,7 +53,7 @@ export async function addMcpCapabilities(mcpServer: McpServer, devServerManager:
               .getJsInspectorBaseUrl();
 
             const results = await new DevToolsPluginCliExtensionExecutor(
-              plugin,
+              mcpPlugin,
               devServerManager.projectRoot
             ).execute({ command, args, metroServerOrigin });
 

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionExecutor-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionExecutor-test.ts
@@ -8,6 +8,20 @@ describe('DevToolsPluginCliExtensionExecutor', () => {
     );
   });
 
+  it('should reject an entryPoint that escapes packageRoot', () => {
+    const pluginDescriptor = {
+      ...PLUGIN_DESCRIPTOR,
+      cliExtensions: {
+        commands: [COMMAND],
+        description: 'Test Plugin',
+        entryPoint: '../../etc/passwd',
+      },
+    };
+    expect(() => new DevToolsPluginCliExtensionExecutor(pluginDescriptor, PROJECT_ROOT)).toThrow(
+      /escapes packageRoot/
+    );
+  });
+
   describe('validation', () => {
     it('should validate that the command exists in the extension', async () => {
       const pluginDescriptor = {
@@ -61,6 +75,25 @@ describe('DevToolsPluginCliExtensionExecutor', () => {
           args: { invalidParam: 'value' },
         })
       ).toThrow();
+    });
+
+    it('should reject parameter values whose type does not match the declared type', () => {
+      const pluginDescriptor = {
+        ...PLUGIN_DESCRIPTOR,
+        cliExtensions: {
+          commands: [COMMAND_WITH_PARAMS],
+          description: 'Test Plugin',
+          entryPoint: 'index.js',
+        },
+      };
+      const executor = new DevToolsPluginCliExtensionExecutor(pluginDescriptor, PROJECT_ROOT);
+      // param1 is declared text → string; param2 is declared number. Pass number for both.
+      expect(() =>
+        executor.validate({
+          command: 'test-command',
+          args: { param1: 42 as any, param2: 42 },
+        })
+      ).toThrow(/expected string \(declared "text"\), got number/);
     });
   });
 

--- a/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionResults-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevToolsPluginCliExtensionResults-test.ts
@@ -50,4 +50,39 @@ describe('DevToolsPluginCliExtensionResults', () => {
       expect(valueToTest.getOutput()).toEqual(elements);
     });
   });
+
+  describe('output truncation', () => {
+    it('truncates output once accumulated length exceeds MAX_STRING_LENGTH and stops accepting more', () => {
+      jest.isolateModules(() => {
+        jest.doMock('node:buffer', () => ({
+          constants: { MAX_STRING_LENGTH: 100 },
+        }));
+        const {
+          DevToolsPluginCliExtensionResults: Results,
+        } = require('../DevToolsPluginCliExtensionResults');
+
+        const onOutput = jest.fn();
+        const results = new Results(onOutput);
+        results.append('a'.repeat(80));
+        expect(results.isTruncated()).toBe(false);
+
+        // Pushes total to 110 > 100 cap → truncation triggers.
+        results.append('b'.repeat(30));
+        expect(results.isTruncated()).toBe(true);
+
+        const output = results.getOutput();
+        expect(output[output.length - 1].text).toMatch(/Output truncated/);
+        expect(onOutput).toHaveBeenLastCalledWith([
+          expect.objectContaining({ text: expect.stringMatching(/Output truncated/) }),
+        ]);
+
+        // Subsequent appends are no-ops; output length and isTruncated stay put.
+        const lengthBefore = results.getOutput().length;
+        const onOutputCalls = onOutput.mock.calls.length;
+        results.append('c'.repeat(10));
+        expect(results.getOutput()).toHaveLength(lengthBefore);
+        expect(onOutput.mock.calls).toHaveLength(onOutputCalls);
+      });
+    });
+  });
 });

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -191,6 +191,58 @@ describe(addMcpCapabilities, () => {
     expect(registerTool).not.toHaveBeenCalled();
   });
 
+  it('blocks CLI-only command invocation through the handler even if the schema is bypassed', async () => {
+    // Restore the real executor for this test so we exercise the actual execute()/validate() path,
+    // not the mocked one. A bypassed-schema scenario (future MCP client variant, internal misuse,
+    // protocol-level smuggling) must still be rejected before any spawn occurs.
+    const { DevToolsPluginCliExtensionExecutor: ActualExecutor } = jest.requireActual<
+      typeof import('../DevToolsPluginCliExtensionExecutor')
+    >('../DevToolsPluginCliExtensionExecutor');
+    // Fake child that immediately fires `close(0)` so, if the executor IS reached without
+    // throwing at validate, the handler resolves and assertions run deterministically
+    // (instead of timing out the test).
+    const spawnSpy = jest.fn(() => ({
+      stdout: { on: jest.fn() },
+      stderr: { on: jest.fn() },
+      on: (event: string, cb: (code: number) => void) => {
+        if (event === 'close') setImmediate(() => cb(0));
+      },
+      kill: jest.fn(),
+    }));
+    MockedExecutor.mockImplementationOnce(
+      (plugin, projectRoot) =>
+        new ActualExecutor(plugin, projectRoot, spawnSpy as any) as InstanceType<
+          typeof DevToolsPluginCliExtensionExecutor
+        >
+    );
+
+    const mcpCommand = createCommand({ name: 'safe-read' });
+    const cliOnlyCommand: DevToolsPluginCommand = {
+      name: 'cli-only-mutate',
+      title: 'CLI-only mutate',
+      environments: ['cli'],
+      parameters: [{ name: 'target', type: 'text', description: 'Target' }],
+    };
+    const plugin = createPlugin('mixed-plugin', 'Mixed plugin', [mcpCommand, cliOnlyCommand]);
+
+    const { devServerManager } = createDevServerManager([plugin]);
+    const registerTool = jest.fn();
+    const mcpServer = { registerTool } as unknown as McpServer;
+
+    await addMcpCapabilities(mcpServer, devServerManager);
+    const [, , handler] = registerTool.mock.calls[0];
+
+    // Smuggle a CLI-only command name past the schema by invoking the handler directly.
+    const result = await handler({ parameters: { command: 'cli-only-mutate', target: 'value' } });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(
+      /Command "cli-only-mutate" not found in plugin mixed-plugin/
+    );
+    // The real validate() must throw before the executor ever reaches spawnFunc.
+    expect(spawnSpy).not.toHaveBeenCalled();
+  });
+
   it('omits CLI-only commands from the MCP schema and executor for mixed plugins', async () => {
     const mcpCommand = createCommand({
       name: 'safe-read',

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -243,6 +243,35 @@ describe(addMcpCapabilities, () => {
     expect(spawnSpy).not.toHaveBeenCalled();
   });
 
+  it('round-trips number and confirm parameters through schema and executor', async () => {
+    const command = createCommand({
+      name: 'configure',
+      parameters: [
+        { name: 'count', type: 'number', description: 'A count' },
+        { name: 'force', type: 'confirm', description: 'Whether to force' },
+      ],
+    });
+    const plugin = createPlugin('typed-plugin', 'Typed plugin', [command]);
+    const { devServerManager } = createDevServerManager([plugin]);
+    const registerTool = jest.fn();
+    const mcpServer = { registerTool } as unknown as McpServer;
+    executeMock.mockResolvedValue([]);
+
+    await addMcpCapabilities(mcpServer, devServerManager);
+
+    const [, toolDefinition, handler] = registerTool.mock.calls[0];
+    const schema = toolDefinition.inputSchema.parameters;
+
+    expect(schema.safeParse({ command: 'configure', count: 3, force: true }).success).toBe(true);
+    expect(schema.safeParse({ command: 'configure', count: '3', force: true }).success).toBe(false);
+
+    await handler({ parameters: { command: 'configure', count: 3, force: true } });
+
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'configure', args: { count: 3, force: true } })
+    );
+  });
+
   it('omits CLI-only commands from the MCP schema and executor for mixed plugins', async () => {
     const mcpCommand = createCommand({
       name: 'safe-read',

--- a/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/MCPDevToolsPluginCLIExtensions-test.ts
@@ -96,7 +96,18 @@ describe(addMcpCapabilities, () => {
     });
 
     expect(MockedExecutor).toHaveBeenCalledTimes(1);
-    expect(MockedExecutor).toHaveBeenLastCalledWith(plugin, PROJECT_ROOT);
+    expect(MockedExecutor).toHaveBeenLastCalledWith(
+      {
+        packageName: plugin.packageName,
+        packageRoot: plugin.packageRoot,
+        cliExtensions: {
+          description: plugin.cliExtensions!.description,
+          entryPoint: plugin.cliExtensions!.entryPoint,
+          commands: [command],
+        },
+      },
+      PROJECT_ROOT
+    );
     expect(executeMock).toHaveBeenCalledWith({
       command: 'run-analysis',
       args: { path: '/tmp/data' },
@@ -178,6 +189,44 @@ describe(addMcpCapabilities, () => {
 
     expect(queryPluginsAsync).toHaveBeenCalledTimes(1);
     expect(registerTool).not.toHaveBeenCalled();
+  });
+
+  it('omits CLI-only commands from the MCP schema and executor for mixed plugins', async () => {
+    const mcpCommand = createCommand({
+      name: 'safe-read',
+      parameters: [{ name: 'id', type: 'text', description: 'Record id' }],
+    });
+    const cliOnlyCommand: DevToolsPluginCommand = {
+      name: 'cli-only-mutate',
+      title: 'CLI-only mutate',
+      environments: ['cli'],
+      parameters: [{ name: 'target', type: 'text', description: 'Target' }],
+    };
+    const plugin = createPlugin('mixed-plugin', 'Mixed plugin', [mcpCommand, cliOnlyCommand]);
+
+    const { devServerManager } = createDevServerManager([plugin]);
+    const registerTool = jest.fn();
+    const mcpServer = { registerTool } as unknown as McpServer;
+
+    await addMcpCapabilities(mcpServer, devServerManager);
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    const [, toolDefinition, handler] = registerTool.mock.calls[0];
+
+    // The MCP schema enum must only accept MCP-enabled commands.
+    const schema = toolDefinition.inputSchema.parameters;
+    expect(schema.safeParse({ command: 'safe-read', id: 'abc' }).success).toBe(true);
+    expect(schema.safeParse({ command: 'cli-only-mutate', target: 'abc' }).success).toBe(false);
+
+    // The executor must also receive a descriptor that excludes CLI-only commands,
+    // so a request that bypasses the schema (e.g., a future client variant) still fails
+    // existence validation rather than running a CLI-only command.
+    executeMock.mockResolvedValue([]);
+    await handler({ parameters: { command: 'safe-read', id: 'abc' } });
+
+    expect(MockedExecutor).toHaveBeenCalledTimes(1);
+    const [executorPluginArg] = MockedExecutor.mock.calls[0];
+    expect(executorPluginArg.cliExtensions?.commands.map((c) => c.name)).toEqual(['safe-read']);
   });
 });
 

--- a/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
+++ b/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import type { DevToolsPlugin } from './DevToolsPlugin';
+import type { DevToolsPluginInfo } from './DevToolsPlugin.schema';
 
 /**
  * Creates an MCP-compatible JSON schema for a DevTools plugin's CLI extensions.
@@ -34,7 +34,7 @@ import type { DevToolsPlugin } from './DevToolsPlugin';
  * }
  * ```
  */
-export function createMCPDevToolsExtensionSchema(plugin: DevToolsPlugin) {
+export function createMCPDevToolsExtensionSchema(plugin: DevToolsPluginInfo) {
   if (plugin.cliExtensions == null || plugin.cliExtensions?.commands.length === 0) {
     throw new Error(
       `Plugin ${plugin.packageName} has no commands defined. Please define at least one command.`

--- a/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
+++ b/packages/@expo/cli/src/start/server/createMCPDevToolsExtensionSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import type { DevToolsPluginInfo } from './DevToolsPlugin.schema';
+import type { DevToolsPluginCommandParameter, DevToolsPluginInfo } from './DevToolsPlugin.schema';
 
 /**
  * Creates an MCP-compatible JSON schema for a DevTools plugin's CLI extensions.
@@ -58,6 +58,7 @@ export function createMCPDevToolsExtensionSchema(plugin: DevToolsPluginInfo) {
   // Track which commands use each parameter for documentation
   const parameterCommandMap: Record<string, string[]> = {};
   const parameterDescriptions: Record<string, string> = {};
+  const parameterTypes: Record<string, DevToolsPluginCommandParameter['type']> = {};
 
   for (const command of commands) {
     if (command.parameters && command.parameters.length > 0) {
@@ -67,6 +68,7 @@ export function createMCPDevToolsExtensionSchema(plugin: DevToolsPluginInfo) {
           commands = [];
           parameterCommandMap[param.name] = commands;
           parameterDescriptions[param.name] = param.description || '';
+          parameterTypes[param.name] = param.type;
         }
         commands.push(command.name);
       }
@@ -87,7 +89,9 @@ export function createMCPDevToolsExtensionSchema(plugin: DevToolsPluginInfo) {
       ? `${baseDescription} (Used by: ${commandsUsingParam})`
       : `Parameter for: ${commandsUsingParam}`;
 
-    allParameters[paramName] = z.string().optional().describe(fullDescription);
+    allParameters[paramName] = paramTypeToZod(parameterTypes[paramName]!)
+      .optional()
+      .describe(fullDescription);
   }
 
   // Build the command description with clear instructions for the LLM
@@ -108,4 +112,15 @@ export function createMCPDevToolsExtensionSchema(plugin: DevToolsPluginInfo) {
     .strict(); // .strict() adds additionalProperties: false
 
   return schema;
+}
+
+function paramTypeToZod(type: DevToolsPluginCommandParameter['type']) {
+  switch (type) {
+    case 'number':
+      return z.number();
+    case 'confirm':
+      return z.boolean();
+    case 'text':
+      return z.string();
+  }
 }


### PR DESCRIPTION
## Summary

Related to #45841

1. Adds the missing pre-filter that removes CLI-only commands from the exposed MCP schema (also validates that this effectively blocks the command). This is just a bug, I assume, in the exposed API surface
2. Tighten checks around command runner and plugin pre-validation

## Set of changes

- Exclude CLI-only commands from MCP schema
- Validate `args` types and don't trust input implicitly
- Valiate `entryPoint` to be within `packageRoot`
- Replace `node` with `process.execPath`
- Fix sync exec errors not being caught
- Fix output truncation/overflow against max string limit

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
