### PR TITLE
fix(expo-router): Add missing attribute sanitization to react-helmet-async fork [EXP-25]

### DIFF
--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Preserve `headerTitleAlign` set on parent navigator options when `Stack.Title` does not specify `style.textAlign` ([#42110](https://github.com/expo/expo/pull/42110) by [@Quaid5050](https://github.com/Quaid5050))
 - [web] Fix loader HMR when streaming SSR is enabled in dev mode ([#45702](https://github.com/expo/expo/pull/45702) by [@hassankhan](https://github.com/hassankhan))
 - Pass `null` route params through `useLocalSearchParams` instead of stringifying them to `"null"` ([#34950](https://github.com/expo/expo/pull/34950) by [@hassankhan](https://github.com/hassankhan))
+- Add missing HTML attribute sanitization to vendored react-helmet-async ([#45851](https://github.com/expo/expo/pull/45851) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/expo-router/vendor/react-helmet-async/lib/index.esm.js
+++ b/packages/expo-router/vendor/react-helmet-async/lib/index.esm.js
@@ -256,7 +256,7 @@ var encodeSpecialCharacters = (str, encode = true) => {
   return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
 };
 var generateElementAttributesAsString = (attributes) => Object.keys(attributes).reduce((str, key) => {
-  const attr = typeof attributes[key] !== "undefined" ? `${key}="${attributes[key]}"` : `${key}`;
+  const attr = typeof attributes[key] !== "undefined" ? `${key}="${encodeSpecialCharacters(attributes[key])}"` : `${key}`;
   return str ? `${str} ${attr}` : attr;
 }, "");
 var generateTitleAsString = (type, title, attributes, encode) => {

--- a/packages/expo-router/vendor/react-helmet-async/lib/index.js
+++ b/packages/expo-router/vendor/react-helmet-async/lib/index.js
@@ -292,7 +292,7 @@ var encodeSpecialCharacters = (str, encode = true) => {
   return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#x27;");
 };
 var generateElementAttributesAsString = (attributes) => Object.keys(attributes).reduce((str, key) => {
-  const attr = typeof attributes[key] !== "undefined" ? `${key}="${attributes[key]}"` : `${key}`;
+  const attr = typeof attributes[key] !== "undefined" ? `${key}="${encodeSpecialCharacters(attributes[key])}"` : `${key}`;
   return str ? `${str} ${attr}` : attr;
 }, "");
 var generateTitleAsString = (type, title, attributes, encode) => {


### PR DESCRIPTION
## Summary

Minor fix to add some opportune sanitization code to the `react-helmet-async` fork. Values are trusted, so this isn't security-relevant, but a nice to have.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
