### PR TITLE
[docs] Adds new template to splash screen and icon doc

### DIFF
--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -1,7 +1,6 @@
 ---
 title: Splash screen and app icon
 description: Learn how to add a splash screen and app icon to your Expo project.
-hasVideoLink: true
 ---
 
 import { DocsLogo } from '@expo/styleguide';
@@ -14,12 +13,6 @@ import { CODE } from '~/ui/components/Text';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
 A splash screen and an app icon are fundamental elements of a mobile app. They play an important role in the user experience and branding of the app. This guide provides steps on how to create and add them to your app.
-
-<VideoBoxLink
-  videoId="3Bsw8a1BJoQ"
-  title="Create an App Icon and Splash Screen"
-  description="See a detailed walkthrough on how to create an app icon and splash screen for an Expo project."
-/>
 
 ---
 
@@ -35,7 +28,7 @@ The [`expo-splash-screen`](/versions/latest/sdk/splash-screen) has a built-in [c
 
 ### Create a splash screen icon
 
-To create a splash screen icon, you can use this [Figma template](https://www.figma.com/community/file/1466490409418563617). It provides a bare minimum design for an icon and splash images for Android and iOS.
+To create a splash screen icon, you can use this [Figma template](https://www.figma.com/community/file/1637141012732584189). It provides a bare minimum design for an icon and splash images for Android and iOS.
 
 **Recommended:**
 
@@ -157,7 +150,7 @@ An app's icon is what your app users see on their device's home screen and app s
 
 ### Create an app icon
 
-To create an app icon, you can use this [Figma template](https://www.figma.com/community/file/1466490409418563617). It provides a bare minimum design for an icon and splash images for Android and iOS.
+To create an app icon, you can use this [Figma template](https://www.figma.com/community/file/1637141012732584189). It provides a bare minimum design for an icon and splash images for Android and iOS.
 
 </Step>
 


### PR DESCRIPTION
# Why

Closes #39601

The templates developers need to create Android and iOS icons has changed, and we needed to update our Figma template to reflect current standards.

This PR changes the Figma template link in the /develop/user-interface/splash-screen-and-app-icon/ doc to include the new Figma template link: https://www.figma.com/community/file/1637141012732584189.

I also removed the video at the top of the page, since it's no longer accurate/up-to-date. I'll need to re-record that video, which I can do at a later date. If anyone thinks I should keep it around, happy to add it back.

# Test Plan

Go to /develop/user-interface/splash-screen-and-app-icon/ and make sure that the Figma template links go to https://www.figma.com/community/file/1637141012732584189.