### PR TITLE
fix(cli): Add missing adb shell quoting where needed [EXP-27]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Limit payload sizes and recorded entries for network debugger CDP state ([#45864](https://github.com/expo/expo/pull/45864) by [@kitten](https://github.com/kitten))
 - Add missing origin check to JS inspector middleware and add throttle to dev commands ([#45863](https://github.com/expo/expo/pull/45863) by [@kitten](https://github.com/kitten))
 - Replace inaccurate file-in-root checks with utility ([#45856](https://github.com/expo/expo/pull/45856) by [@kitten](https://github.com/kitten))
+- Add missing adb shell quoting where necessary ([#45853](https://github.com/expo/expo/pull/45853) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
+++ b/packages/@expo/cli/src/start/platforms/android/__tests__/adb-test.ts
@@ -26,20 +26,26 @@ const asDevice = (device: Partial<Device>): Device => device as Device;
 const device = asDevice({ name: 'Pixel 5', pid: '123' });
 
 describe(openUrlAsync, () => {
-  it(`escapes & in the url`, async () => {
+  it(`quotes the url`, async () => {
     await openUrlAsync(device, { url: 'acme://foo?bar=1&baz=2' });
     expect(getServer().runAsync).toHaveBeenCalledWith([
       '-s',
       '123',
       'shell',
-      'am',
-      'start',
-      '-a',
-      'android.intent.action.VIEW',
-      '-d',
-      // Ensure this is escaped
-      'acme://foo?bar=1\\&baz=2',
+      "'am'",
+      "'start'",
+      "'-a'",
+      "'android.intent.action.VIEW'",
+      "'-d'",
+      "'acme://foo?bar=1&baz=2'",
     ]);
+  });
+
+  it(`neutralizes shell-injection attempts in the url`, async () => {
+    await openUrlAsync(device, { url: 'acme://x; reboot' });
+    expect(getServer().runAsync).toHaveBeenCalledWith(
+      expect.arrayContaining(["'acme://x; reboot'"])
+    );
   });
 });
 
@@ -63,12 +69,12 @@ describe(launchActivityAsync, () => {
       '-s',
       '123',
       'shell',
-      'am',
-      'start',
-      '-f',
-      '0x20000000',
-      '-n',
-      'dev.bacon.app/.MainActivity',
+      "'am'",
+      "'start'",
+      "'-f'",
+      "'0x20000000'",
+      "'-n'",
+      "'dev.bacon.app/.MainActivity'",
     ]);
   });
   it(`launches activity with url`, async () => {
@@ -81,15 +87,24 @@ describe(launchActivityAsync, () => {
       '-s',
       '123',
       'shell',
-      'am',
-      'start',
-      '-f',
-      '0x20000000',
-      '-n',
-      'dev.expo.custom.appid/dev.bacon.app.MainActivity',
-      '-d',
-      'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081',
+      "'am'",
+      "'start'",
+      "'-f'",
+      "'0x20000000'",
+      "'-n'",
+      "'dev.expo.custom.appid/dev.bacon.app.MainActivity'",
+      "'-d'",
+      "'exp+expo-test://expo-development-client/?url=http%3A%2F%2F192.168.86.186%3A8081'",
     ]);
+  });
+  it(`neutralizes shell-injection attempts in the launch activity`, async () => {
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce('...');
+    await launchActivityAsync(device, {
+      launchActivity: 'dev.bacon.app/.MainActivity; reboot',
+    });
+    expect(getServer().runAsync).toHaveBeenCalledWith(
+      expect.arrayContaining(["'dev.bacon.app/.MainActivity; reboot'"])
+    );
   });
 });
 
@@ -109,17 +124,24 @@ describe(isPackageInstalledAsync, () => {
       '-s',
       '123',
       'shell',
-      'pm',
-      'list',
-      'packages',
-      '--user',
-      '0',
-      'com.google.android.youtube',
+      "'pm'",
+      "'list'",
+      "'packages'",
+      "'--user'",
+      "'0'",
+      "'com.google.android.youtube'",
     ]);
   });
   it(`returns false when a package is not isntalled`, async () => {
     jest.mocked(getServer().runAsync).mockResolvedValueOnce('');
     expect(await isPackageInstalledAsync(device, 'com.google.android.youtube')).toBe(false);
+  });
+  it(`neutralizes shell-injection attempts in the package name`, async () => {
+    jest.mocked(getServer().runAsync).mockResolvedValueOnce('');
+    await isPackageInstalledAsync(device, 'com.google.android.youtube; reboot');
+    expect(getServer().runAsync).toHaveBeenCalledWith(
+      expect.arrayContaining(["'com.google.android.youtube; reboot'"])
+    );
   });
 });
 

--- a/packages/@expo/cli/src/start/platforms/android/adb.ts
+++ b/packages/@expo/cli/src/start/platforms/android/adb.ts
@@ -78,16 +78,7 @@ export async function isPackageInstalledAsync(
   androidPackage: string
 ): Promise<boolean> {
   const packages = await getServer().runAsync(
-    adbArgs(
-      device.pid,
-      'shell',
-      'pm',
-      'list',
-      'packages',
-      '--user',
-      env.EXPO_ADB_USER,
-      androidPackage
-    )
+    adbShellArgs(device.pid, 'pm', 'list', 'packages', '--user', env.EXPO_ADB_USER, androidPackage)
   );
 
   const lines = packages.split(/\r?\n/);
@@ -115,8 +106,7 @@ export async function launchActivityAsync(
     url?: string;
   }
 ) {
-  const args: string[] = [
-    'shell',
+  const command: string[] = [
     'am',
     'start',
     // FLAG_ACTIVITY_SINGLE_TOP -- If set, the activity will not be launched if it is already running at the top of the history stack.
@@ -128,10 +118,10 @@ export async function launchActivityAsync(
   ];
 
   if (url) {
-    args.push('-d', url);
+    command.push('-d', url);
   }
 
-  return openAsync(adbArgs(device.pid, ...args));
+  return openAsync(adbShellArgs(device.pid, ...command));
 }
 
 /**
@@ -147,17 +137,7 @@ export async function openUrlAsync(
   }
 ) {
   return openAsync(
-    adbArgs(
-      device.pid,
-      'shell',
-      'am',
-      'start',
-      '-a',
-      'android.intent.action.VIEW',
-      '-d',
-      // ADB requires ampersands to be escaped.
-      url.replace(/&/g, String.raw`\&`)
-    )
+    adbShellArgs(device.pid, 'am', 'start', '-a', 'android.intent.action.VIEW', '-d', url)
   );
 }
 
@@ -188,7 +168,7 @@ export async function getPackageInfoAsync(
   device: DeviceContext,
   { appId }: { appId: string }
 ): Promise<string> {
-  return await getServer().runAsync(adbArgs(device.pid, 'shell', 'dumpsys', 'package', appId));
+  return await getServer().runAsync(adbShellArgs(device.pid, 'dumpsys', 'package', appId));
 }
 
 /** Install an app on a connected device. */
@@ -207,6 +187,18 @@ export function adbArgs(pid: Device['pid'], ...options: string[]): string[] {
   }
 
   return args.concat(options);
+}
+
+/**
+ * `adb shell` concatenates trailing args and runs the result through `sh -c` on
+ * the device, so unquoted metacharacters in tainted tokens execute on-device.
+ */
+export function adbShellArgs(pid: Device['pid'], ...command: string[]): string[] {
+  return adbArgs(pid, 'shell', ...command.map(shellQuote));
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 // TODO: This is very expensive for some operations.
@@ -359,8 +351,9 @@ export async function getPropertyDataForDeviceAsync(
   device: DeviceContext,
   prop?: string
 ): Promise<DeviceProperties> {
-  // @ts-ignore
-  const propCommand = adbArgs(...[device.pid, 'shell', 'getprop', prop].filter(Boolean));
+  const propCommand = prop
+    ? adbShellArgs(device.pid, 'getprop', prop)
+    : adbShellArgs(device.pid, 'getprop');
   try {
     // Prevent reading as UTF8.
     const results = await getServer().getFileOutputAsync(propCommand);


### PR DESCRIPTION
## Summary

The `adb shell` args weren't always quoted as needed. This could allow arbitrary command execution. While this is mostly in a trusted context against limited shells, it's unexpected and a slight security issue, especially in repros.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
