### PR TITLE
[expo-router] Mark expo-image as optional dependency

### DIFF
--- a/packages/expo-router/package.json
+++ b/packages/expo-router/package.json
@@ -93,6 +93,7 @@
     "@testing-library/react-native": ">= 13.2.0",
     "expo": "*",
     "expo-constants": "workspace:^56.0.11",
+    "expo-image": "workspace:^56.0.4",
     "expo-linking": "workspace:^56.0.8",
     "react": "*",
     "react-dom": "*",
@@ -106,6 +107,9 @@
   },
   "peerDependenciesMeta": {
     "@testing-library/react-native": {
+      "optional": true
+    },
+    "expo-image": {
       "optional": true
     },
     "react-dom": {
@@ -139,6 +143,7 @@
     "@types/react-is": "^19.0.0",
     "@types/react-test-renderer": "^19.1.0",
     "expo": "workspace:*",
+    "expo-image": "workspace:*",
     "immer": "^10.1.1",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-reanimated": "~4.3.1",
@@ -163,7 +168,6 @@
     "debug": "^4.3.4",
     "escape-string-regexp": "^4.0.0",
     "expo-glass-effect": "workspace:^56.0.4",
-    "expo-image": "workspace:^56.0.4",
     "expo-server": "workspace:^56.0.2",
     "expo-symbols": "workspace:^56.0.5",
     "fast-deep-equal": "^3.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5131,9 +5131,6 @@ importers:
       expo-glass-effect:
         specifier: workspace:^56.0.4
         version: link:../expo-glass-effect
-      expo-image:
-        specifier: workspace:^56.0.4
-        version: link:../expo-image
       expo-linking:
         specifier: workspace:^56.0.8
         version: link:../expo-linking
@@ -5231,6 +5228,9 @@ importers:
       expo:
         specifier: workspace:*
         version: link:../expo
+      expo-image:
+        specifier: workspace:*
+        version: link:../expo-image
       immer:
         specifier: ^10.1.1
         version: 10.2.0


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
