### PR TITLE
fix(cli): Limit `/message` client-originating messages [EXP-30]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Restrict `/message` client commands ([#45858](https://github.com/expo/expo/pull/45858) by [@kitten](https://github.com/kitten)
+
 ### 💡 Others
 
 ## 56.1.5 — 2026-05-15

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMessageSocket.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/createMessageSocket.test.ts
@@ -40,6 +40,41 @@ describe(createMessagesSocket, () => {
     });
   });
 
+  it('drops client-originated broadcasts of privileged methods', async () => {
+    const client1 = server.connect('/message');
+    const client2 = server.connect('/message');
+
+    await Promise.all([once(client1, 'open'), once(client2, 'open')]);
+
+    const client2Listener = jest.fn();
+    client2.on('message', client2Listener);
+
+    client1.send(
+      serializeMessage({
+        method: 'sendDevCommand',
+        params: { name: 'module-import', data: { id: 'x', code: '' } },
+      })
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(client2Listener).not.toHaveBeenCalled();
+  });
+
+  it('drops client-originated broadcasts from cross-origin clients', async () => {
+    const client1 = server.connect('/message', { headers: { Origin: 'http://evil.example' } });
+    const client2 = server.connect('/message');
+
+    await Promise.all([once(client1, 'open'), once(client2, 'open')]);
+
+    const client2Listener = jest.fn();
+    client2.on('message', client2Listener);
+
+    client1.send(serializeMessage({ method: 'reload' }));
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(client2Listener).not.toHaveBeenCalled();
+  });
+
   it('exported broadcast method broadcasts messages', async () => {
     const client1 = server.connect('/message');
     const client2 = server.connect('/message');

--- a/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/__tests__/utils.ts
@@ -12,7 +12,7 @@ export function withMetroServer(projectRoot = '/project'): {
   metro: ReturnType<typeof createMetroMiddleware>;
   server: ReturnType<typeof createServer> & {
     fetch: (url: string, init?: RequestInit) => Promise<Response>;
-    connect: (url: string) => WebSocket;
+    connect: (url: string, options?: ClientOptions) => WebSocket;
   };
 } {
   const metro = createMetroMiddleware(
@@ -22,6 +22,7 @@ export function withMetroServer(projectRoot = '/project'): {
         ({
           ready: () => Promise.resolve(),
         }) as any,
+      serverBaseUrl: 'http://localhost',
     }
   );
 
@@ -63,7 +64,7 @@ export function withMetroServer(projectRoot = '/project'): {
 
         Object.defineProperty(server, 'connect', {
           value: (url = '', options?: ClientOptions) =>
-            new WebSocket(`ws://${hostname}:${address.port}${url}`),
+            new WebSocket(`ws://${hostname}:${address.port}${url}`, options),
         });
 
         resolve();

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
@@ -13,6 +13,8 @@ type MessageSocketOptions = {
   serverBaseUrl: string;
 };
 
+const debug = require('debug')('expo:metro:devserver:messageSocket') as typeof console.log;
+
 const CLIENT_BROADCAST_ALLOWED_METHODS = new Set(['reload', 'devMenu']);
 
 /**
@@ -95,7 +97,10 @@ function createClientMessageHandler(
 
     // Handle broadcast messages
     if (messageIsBroadcast(message)) {
-      if (!isTrustedClient || !CLIENT_BROADCAST_ALLOWED_METHODS.has(message.method)) return;
+      if (!isTrustedClient || !CLIENT_BROADCAST_ALLOWED_METHODS.has(message.method)) {
+        debug(`Refused broadcast message from untrusted client (method: ${message.method})`);
+        return;
+      }
       return broadcast(null, data.toString());
     }
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
@@ -27,7 +27,8 @@ export function createMessagesSocket(options: MessageSocketOptions) {
 
   server.on('connection', (socket, req) => {
     const client = clients.registerSocket(socket);
-    const trusted = isLocalSocket(req.socket) && isMatchingOrigin(req, options.serverBaseUrl);
+    const isTrustedClient =
+      isLocalSocket(req.socket) && isMatchingOrigin(req, options.serverBaseUrl);
 
     // Assign the query parameters to the socket, used for `getpeers` requests
     // NOTE(cedric): this looks like a legacy feature, might be able to drop it
@@ -43,7 +44,7 @@ export function createMessagesSocket(options: MessageSocketOptions) {
     // Register message handler
     socket.on(
       'message',
-      createClientMessageHandler(socket, client.id, clients, broadcast, trusted)
+      createClientMessageHandler(socket, client.id, clients, broadcast, isTrustedClient)
     );
   });
 
@@ -67,7 +68,7 @@ function createClientMessageHandler(
   clientId: SocketId,
   clients: ReturnType<typeof createSocketMap>,
   broadcast: ReturnType<typeof createBroadcaster>,
-  trusted: boolean
+  isTrustedClient: boolean
 ) {
   function handleServerRequest(message: RequestMessage) {
     // Ignore messages without identifiers, unable to link responses
@@ -94,7 +95,7 @@ function createClientMessageHandler(
 
     // Handle broadcast messages
     if (messageIsBroadcast(message)) {
-      if (!trusted || !CLIENT_BROADCAST_ALLOWED_METHODS.has(message.method)) return;
+      if (!isTrustedClient || !CLIENT_BROADCAST_ALLOWED_METHODS.has(message.method)) return;
       return broadcast(null, data.toString());
     }
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMessageSocket.ts
@@ -4,12 +4,16 @@ import { type WebSocket, WebSocketServer, type RawData as WebSocketRawData } fro
 import { createBroadcaster } from './utils/createSocketBroadcaster';
 import { createSocketMap, type SocketId } from './utils/createSocketMap';
 import { parseRawMessage, serializeMessage } from './utils/socketMessages';
+import { isLocalSocket, isMatchingOrigin } from '../../../../utils/net';
 
 type MessageSocketOptions = {
   logger: {
     warn: (message: string) => any;
   };
+  serverBaseUrl: string;
 };
+
+const CLIENT_BROADCAST_ALLOWED_METHODS = new Set(['reload', 'devMenu']);
 
 /**
  * Client "command" server that dispatches basic commands to connected clients.
@@ -23,6 +27,7 @@ export function createMessagesSocket(options: MessageSocketOptions) {
 
   server.on('connection', (socket, req) => {
     const client = clients.registerSocket(socket);
+    const trusted = isLocalSocket(req.socket) && isMatchingOrigin(req, options.serverBaseUrl);
 
     // Assign the query parameters to the socket, used for `getpeers` requests
     // NOTE(cedric): this looks like a legacy feature, might be able to drop it
@@ -36,7 +41,10 @@ export function createMessagesSocket(options: MessageSocketOptions) {
     socket.on('close', client.terminate);
     socket.on('error', client.terminate);
     // Register message handler
-    socket.on('message', createClientMessageHandler(socket, client.id, clients, broadcast));
+    socket.on(
+      'message',
+      createClientMessageHandler(socket, client.id, clients, broadcast, trusted)
+    );
   });
 
   return {
@@ -58,7 +66,8 @@ function createClientMessageHandler(
   socket: WebSocket,
   clientId: SocketId,
   clients: ReturnType<typeof createSocketMap>,
-  broadcast: ReturnType<typeof createBroadcaster>
+  broadcast: ReturnType<typeof createBroadcaster>,
+  trusted: boolean
 ) {
   function handleServerRequest(message: RequestMessage) {
     // Ignore messages without identifiers, unable to link responses
@@ -80,11 +89,12 @@ function createClientMessageHandler(
   }
 
   return (data: WebSocketRawData, isBinary: boolean) => {
-    const message = parseRawMessage<IncomingMessage>(data, isBinary);
+    const message = parseRawMessage<IncomingClientMessage>(data, isBinary);
     if (!message) return;
 
     // Handle broadcast messages
     if (messageIsBroadcast(message)) {
+      if (!trusted || !CLIENT_BROADCAST_ALLOWED_METHODS.has(message.method)) return;
       return broadcast(null, data.toString());
     }
 
@@ -126,7 +136,7 @@ type MessageId = {
   clientId: SocketId;
 };
 
-type IncomingMessage = BroadcastMessage | RequestMessage | ResponseMessage;
+type IncomingClientMessage = BroadcastMessage | RequestMessage | ResponseMessage;
 
 type BroadcastMessage = {
   method: string;
@@ -146,7 +156,7 @@ type ResponseMessage = {
   id: MessageId;
 };
 
-function messageIsBroadcast(message: IncomingMessage): message is BroadcastMessage {
+function messageIsBroadcast(message: IncomingClientMessage): message is BroadcastMessage {
   return (
     'method' in message &&
     typeof message.method === 'string' &&
@@ -155,7 +165,7 @@ function messageIsBroadcast(message: IncomingMessage): message is BroadcastMessa
   );
 }
 
-function messageIsRequest(message: IncomingMessage): message is RequestMessage {
+function messageIsRequest(message: IncomingClientMessage): message is RequestMessage {
   return (
     'method' in message &&
     typeof message.method === 'string' &&
@@ -164,7 +174,7 @@ function messageIsRequest(message: IncomingMessage): message is RequestMessage {
   );
 }
 
-function messageIsResponse(message: IncomingMessage): message is ResponseMessage {
+function messageIsResponse(message: IncomingClientMessage): message is ResponseMessage {
   return (
     'id' in message &&
     typeof message.id === 'object' &&

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -14,6 +14,7 @@ import { openInEditorAsync } from '../../../../utils/editor';
 
 interface MetroMiddlewareOptions {
   getMetroBundler(): MetroBundler;
+  serverBaseUrl: string;
 }
 
 interface StackFrame {
@@ -25,7 +26,7 @@ export function createMetroMiddleware(
   metroConfig: Pick<MetroConfig, 'projectRoot'>,
   options: MetroMiddlewareOptions
 ) {
-  const messages = createMessagesSocket({ logger: Log });
+  const messages = createMessagesSocket({ logger: Log, serverBaseUrl: options.serverBaseUrl });
   const events = createEventsSocket(messages);
 
   const middleware = connect()

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -387,16 +387,16 @@ export async function instantiateMetroAsync(
     getMetroBundler,
   });
 
-  // Create the core middleware stack for Metro, including websocket listeners
-  const { middleware, messagesSocket, eventsSocket, websocketEndpoints } = createMetroMiddleware(
-    metroConfig,
-    { getMetroBundler }
-  );
-
   // Get local URL to Metro bundler server (typically configured as 127.0.0.1:8081)
   const serverBaseUrl = metroBundler
     .getUrlCreator()
     .constructUrl({ scheme: 'http', hostType: 'localhost' });
+
+  // Create the core middleware stack for Metro, including websocket listeners
+  const { middleware, messagesSocket, eventsSocket, websocketEndpoints } = createMetroMiddleware(
+    metroConfig,
+    { getMetroBundler, serverBaseUrl }
+  );
 
   if (!isExporting) {
     // Enable correct CORS headers for Expo Router features


### PR DESCRIPTION
## Summary

We should copy over the CDP websocket checks here, and restrict what messages clients may send explicitly.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
