### PR TITLE
[ci] Re-enable Development Client workflow

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -155,7 +155,7 @@ runs:
     - name: 🛠 Install NDK if cache not present
       if: inputs.ndk == 'true' && steps.cache-android-ndk.outputs.cache-hit != 'true'
       shell: bash
-      run: sudo $ANDROID_SDK_ROOT/tools/bin/sdkmanager --install "ndk;${{ inputs.ndk-version }}"
+      run: sudo $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager --install "ndk;${{ inputs.ndk-version }}"
 
     - name: 🔍️ Get Xcode version for iOS ccache key
       if: inputs.ccache == 'true' && runner.os == 'macOS'

--- a/.github/workflows/development-client-e2e.yml
+++ b/.github/workflows/development-client-e2e.yml
@@ -27,11 +27,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - name: 🍺 Install required tools
-        run: |
-          brew tap wix/brew
-          brew install applesimutils
-          brew install watchman
       - name: 💎 Setup Ruby and install gems
         uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
         with:

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -20,11 +20,6 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
-      - name: 🍺 Install required tools
-        run: |
-          brew tap wix/brew
-          brew install applesimutils
-          brew install watchman
       - name: 💎 Setup Ruby and install gems
         uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
         with:

--- a/.github/workflows/development-client.yml
+++ b/.github/workflows/development-client.yml
@@ -2,17 +2,17 @@ name: Development Client
 
 on:
   workflow_dispatch: {}
-  # This task will fail due to migration to `expo-modules-core`.
-  # We temporary disable it.
-  # pull_request:
-  #   paths:
-  #     - .github/workflows/development-client.yml
-  #     - packages/expo-dev-*/**
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - .github/workflows/development-client.yml
-  #     - packages/expo-dev-*/**
+  pull_request:
+    paths:
+      - .github/workflows/development-client.yml
+      - packages/expo-dev-*/**
+      - pnpm-lock.yaml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/development-client.yml
+      - packages/expo-dev-*/**
+      - pnpm-lock.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -21,9 +21,6 @@ concurrency:
 jobs:
   android:
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        ndk-version: [21.4.7075529]
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -41,14 +38,11 @@ jobs:
       - name: ♻️ Restore caches
         uses: ./.github/actions/expo-caches
         id: expo-caches
-        with:
-          ndk: 'true'
-          ndk-version: ${{ matrix.ndk-version }}
       - name: 📦 Install node modules
         run: pnpm install --frozen-lockfile
       - name: Init new expo app
         working-directory: ../
-        run: pnpm create expo-app ./development-client-android-test --yes
+        run: pnpm create expo -t blank@next --yes development-client-android-test
       - name: Make Yarn resolve expo-dev-client dependencies locally
         working-directory: ../development-client-android-test
         run: |
@@ -63,6 +57,12 @@ jobs:
               'expo-updates': 'file:${{ github.workspace }}/packages/expo-updates', \
               'expo-manifests': 'file:${{ github.workspace }}/packages/expo-manifests', \
               'expo-json-utils': 'file:${{ github.workspace }}/packages/expo-json-utils', \
+              '@expo/schema-utils': 'file:${{ github.workspace }}/packages/@expo/schema-utils', \
+              '@expo/plist': 'file:${{ github.workspace }}/packages/@expo/plist', \
+              'expo-eas-client': 'file:${{ github.workspace }}/packages/expo-eas-client', \
+              'expo-structured-headers': 'file:${{ github.workspace }}/packages/expo-structured-headers', \
+              'expo-modules-core': 'file:${{ github.workspace }}/packages/expo-modules-core', \
+              'expo-modules-jsi': 'file:${{ github.workspace }}/packages/expo-modules-jsi', \
             }; \
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
       - name: Add dependencies
@@ -71,18 +71,10 @@ jobs:
       - name: Setup app.config.json
         working-directory: ../development-client-android-test
         run: echo "{\"name\":\"development-client-android-test\",\"plugins\":[\"expo-dev-client\"],\"android\":{\"package\":\"com.devclient.test\"},\"ios\":{\"bundleIdentifier\":\"com.devclient.test\"}}" > app.config.json
-      - name: Prebuild Android
+      - name: 🛠 Prebuild Android
         working-directory: ../development-client-android-test
         run: pnpm expo prebuild --platform android
-      - name: Bump `build tools`
-        working-directory: ../development-client-android-test
-        run: sed -i -e 's/buildToolsVersion\ =\ \"29\..\..\"/buildToolsVersion\ = \"30\.0\.3\"/' ./android/build.gradle
-      - name: Bump `android build tools`
-        working-directory: ../development-client-android-test
-        run: sed -i -e 's/com\.android\.tools\.build:gradle:3\..\../com\.android\.tools\.build:gradle:3\.5\.4/' ./android/build.gradle
       - name: 🏗️ Build debug version
-        env:
-          ANDROID_NDK_HOME: /usr/local/lib/android/sdk/ndk/${{ matrix.ndk-version }}/
         working-directory: ../development-client-android-test/android
         run: ./gradlew assembleDebug
 
@@ -91,8 +83,17 @@ jobs:
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: 🔨 Switch to Xcode 26.2
+        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
+      - name: 💎 Setup Ruby and install gems
+        uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.2.2
+      - name: 💎 Install cocoapods
+        run: sudo gem install cocoapods
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
@@ -109,7 +110,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Init new expo app
         working-directory: ../
-        run: pnpm create expo-app ./development-client-ios-test --yes
+        run: pnpm create expo -t blank@next --yes development-client-ios-test
       - name: Make Yarn resolve expo-dev-client dependencies locally
         working-directory: ../development-client-ios-test
         run: |
@@ -124,6 +125,12 @@ jobs:
               'expo-updates': 'file:${{ github.workspace }}/packages/expo-updates', \
               'expo-manifests': 'file:${{ github.workspace }}/packages/expo-manifests', \
               'expo-json-utils': 'file:${{ github.workspace }}/packages/expo-json-utils', \
+              '@expo/schema-utils': 'file:${{ github.workspace }}/packages/@expo/schema-utils', \
+              '@expo/plist': 'file:${{ github.workspace }}/packages/@expo/plist', \
+              'expo-eas-client': 'file:${{ github.workspace }}/packages/expo-eas-client', \
+              'expo-structured-headers': 'file:${{ github.workspace }}/packages/expo-structured-headers', \
+              'expo-modules-core': 'file:${{ github.workspace }}/packages/expo-modules-core', \
+              'expo-modules-jsi': 'file:${{ github.workspace }}/packages/expo-modules-jsi', \
             }; \
             fs.writeFileSync('./package.json', JSON.stringify(pkg, null, 2) + '\n');"
       - name: Add dependencies
@@ -132,9 +139,12 @@ jobs:
       - name: Setup app.config.json
         working-directory: ../development-client-ios-test
         run: echo "{\"name\":\"development-client-ios-test\",\"plugins\":[\"expo-dev-client\"],\"android\":{\"package\":\"com.devclient.test\"},\"ios\":{\"bundleIdentifier\":\"com.devclient.test\"}}" > app.config.json
-      - name: Prebuild iOS
+      - name: 🛠 Prebuild iOS
         working-directory: ../development-client-ios-test
-        run: pnpm expo prebuild --platform ios
+        run: pnpm expo prebuild --platform ios --no-install
+      - name: 🥥 Install pods in `development-client-ios-test/ios`
+        working-directory: ../development-client-ios-test/ios
+        run: pod install
       - name: 🏗️ Build debug version
         working-directory: ../development-client-ios-test
-        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator -arch x86_64
+        run: xcodebuild -workspace ios/developmentclientiostest.xcworkspace -scheme developmentclientiostest -configuration debug -sdk iphonesimulator EXCLUDED_ARCHS=""


### PR DESCRIPTION
The `Development Client` workflow has been disabled by comment in its `on:` block since #14027 in 2021. The original note blamed migration to `expo-modules-core`, which was true at the time, but five years of platform drift left smaller mismatches in place that only surfaced once it started running again. This re-enables it and walks through each one.

On the Android side, the NDK install in `expo-caches/action.yml` was reaching for `$ANDROID_SDK_ROOT/tools/bin/sdkmanager`, a path retired from `ubuntu-latest` a while back. Switched to `cmdline-tools/latest/bin/sdkmanager` to match what `cleanup-linux-disk-space` already uses. The `ndk-version: [21.4.7075529]` matrix also went away. `ExpoRootProjectPlugin` pins 27.1.12297006 unconditionally now, so the matrix was downloading and discarding ~600 MB of NDK r21e every run.

The test app scaffolding was the bigger one. `pnpm create expo-app --yes` resolves to a stale `create-expo-app@3.5.3` and was pulling `expo-modules-core@3.0.30` from npm instead of the local 56.0.8. That mismatch surfaced as Kotlin compile errors that looked like bugs in `expo-dev-menu`:

```
e: .../expo-dev-menu/.../DevMenuPackage.kt:50:9
  'onDidCreateReactActivityDelegateNotification' overrides nothing.
e: .../expo-dev-menu/.../DevMenuModule.kt:14:34
  Unresolved reference 'OptimizedRecord'.
```

Both APIs exist in 56.0.8 but not 3.0.30. Switched init to `pnpm create expo -t blank@next --yes` (the unaliased name resolves to current `create-expo@3.6.14`) and expanded `pnpm.resolutions` from 7 to 13 entries to cover the transitive workspace deps of `expo-dev-launcher` and `expo-updates`. Also dropped two 2021 `sed` steps (`Bump build tools`, `Bump android build tools`). The regexes haven't matched modern Expo prebuild output in years.

The iOS half needed Ruby plus cocoapods setup, same shape `development-client-e2e` already uses, because the test app lives outside the monorepo workspace so bundler can't walk up to the root Gemfile. Split prebuild into `--no-install` followed by a bare `pod install` for deterministic ordering. Replaced hardcoded `-arch x86_64` with `EXCLUDED_ARCHS=""` since the `macos-15` runners are arm64. Switched to Xcode 26.2 to match every other macOS workflow.

Also drops the broken `🍺 Install required tools` step from `development-client-e2e.yml` and `development-client-latest-e2e.yml`. Both ran `brew tap wix/brew && brew install applesimutils && brew install watchman` on `ubuntu-24.04`. There's no brew on Linux and `applesimutils` is iOS-only, so step 4 has been exiting 127 every cycle. Both workflows run Android Detox, so the step never had a reason to be there.

# Test Plan

Fork validation on `ramonclaudio/expo-fork`: https://github.com/ramonclaudio/expo-fork/actions/runs/25880752777

```
Android: BUILD SUCCESSFUL in 7m 43s   (debug APK packaged)
iOS:     BUILD SUCCEEDED              (debug .app packaged)
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - Not applicable: workflow-only change.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - Not applicable: workflow-only change.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
  - Not applicable: no docs touched.
