### PR TITLE
[expo-router][docs] Document how to use @expo/material-symbols in toolbar

### DIFF
--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -109,6 +109,43 @@ You can browse available symbols in Apple's SF Symbols app.
 
 > **info** SF Symbols are an iOS-only feature.
 
+### Material Symbols (Android only)
+
+The easiest way to add icons on Android is to use Google's [Material Symbols](https://fonts.google.com/icons) via the [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) package, which ships pre-built XML vector drawables as individual asset subpaths — Metro only bundles the icons you actually import. Install it with:
+
+```sh
+npx expo install @expo/material-symbols
+```
+
+Import any icon directly from its own subpath and pass it to the `icon` prop:
+
+```tsx
+import Star from '@expo/material-symbols/star.xml';
+import Share from '@expo/material-symbols/share.xml';
+import MoreVert from '@expo/material-symbols/more_vert.xml';
+
+<Stack.Toolbar.Button icon={Star} onPress={() => {}} />
+<Stack.Toolbar.Button icon={Share} onPress={() => {}} />
+<Stack.Toolbar.Menu icon={MoreVert}>{/* ... */}</Stack.Toolbar.Menu>
+```
+
+Vector drawables are tinted with the toolbar's tint color by default. Pass `iconRenderingMode="original"` to preserve the source colors.
+
+> **info** Material Symbols XML drawables are an Android-only feature. On iOS, use SF Symbols instead.
+
+#### Using the same icon on Android and iOS
+
+`Stack.Toolbar.Button`'s `icon` prop accepts both an SF Symbol name (iOS) and an `ImageSourcePropType` (Android), so a `process.env.EXPO_OS` check covers both platforms from a single component. Metro replaces the value at build time and removes the unused branch, so the other platform's asset never ships:
+
+```tsx
+import Star from '@expo/material-symbols/star.xml';
+
+<Stack.Toolbar.Button
+  icon={process.env.EXPO_OS === 'ios' ? 'star.fill' : Star}
+  onPress={() => {}}
+/>
+```
+
 ### Custom images
 
 You can also use custom images. The API for passing them differs by platform:
@@ -711,7 +748,7 @@ export default function Home() {
 
 </Collapsible>
 
-<Collapsible summary="Custom icons are the only supported icon type on Android">
+<Collapsible summary="Android icons must be image sources">
 
 On Android, `icon` must be an `ImageSourcePropType`. For example `require('./icon.png')` or `{ uri: '...' }`.
 

--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -4,6 +4,7 @@ description: Learn how to use the native toolbar in Stack navigation with Expo R
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';
+import { Terminal } from '~/ui/components/Snippet';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
 > **important** `Stack.Toolbar` is an [alpha](/more/release-statuses/#alpha) API available on Android in **Expo SDK 56** and later, and on iOS in **Expo SDK 55** and later. The API is subject to breaking changes.
@@ -111,11 +112,9 @@ You can browse available symbols in Apple's SF Symbols app.
 
 ### Material Symbols (Android only)
 
-The easiest way to add icons on Android is to use Google's [Material Symbols](https://fonts.google.com/icons) via the [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) package, which ships pre-built XML vector drawables as individual asset subpaths — Metro only bundles the icons you actually import. Install it with:
+The recommended source of icons for Android is [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) library. It ships Google's [Material Symbols](https://fonts.google.com/icons) as individual asset subpaths, so Metro only bundles the icons you actually import.
 
-```sh
-npx expo install @expo/material-symbols
-```
+<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
 
 Import any icon directly from its own subpath and pass it to the `icon` prop:
 
@@ -135,7 +134,7 @@ Vector drawables are tinted with the toolbar's tint color by default. Pass `icon
 
 #### Using the same icon on Android and iOS
 
-`Stack.Toolbar.Button`'s `icon` prop accepts both an SF Symbol name (iOS) and an `ImageSourcePropType` (Android), so a `process.env.EXPO_OS` check covers both platforms from a single component. Metro replaces the value at build time and removes the unused branch, so the other platform's asset never ships:
+`Stack.Toolbar.Button`'s `icon` prop accepts both an `ImageSourcePropType` (Android) and an SF Symbol name (iOS). To use a single component for both platforms, branch on `process.env.EXPO_OS` and pass the platform-appropriate value. Metro replaces `process.env.EXPO_OS` with a string literal at build time, then tree-shakes the branch that doesn't match the current platform — so the Material Symbols XML drawable never ships in the iOS bundle, and the SF Symbol name never ships in the Android bundle:
 
 ```tsx
 import Star from '@expo/material-symbols/star.xml';
@@ -143,7 +142,7 @@ import Star from '@expo/material-symbols/star.xml';
 <Stack.Toolbar.Button
   icon={process.env.EXPO_OS === 'ios' ? 'star.fill' : Star}
   onPress={() => {}}
-/>
+/>;
 ```
 
 ### Custom images


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
