### PR TITLE
fix(cli): Add missing origin check to JS inspector middleware and throttle dev commands [EXP-31]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Prevalidate `easProjectId` before using it as cache path ([#45879](https://github.com/expo/expo/pull/45879) by [@kitten](https://github.com/kitten))
 - Persist `~/.expo/state.json` with owner-only file permissions ([#45873](https://github.com/expo/expo/pull/45873) by [@kitten](https://github.com/kitten))
 - Limit payload sizes and recorded entries for network debugger CDP state ([#45864](https://github.com/expo/expo/pull/45864) by [@kitten](https://github.com/kitten))
+- Add missing origin check to JS inspector middleware and add throttle to dev commands ([#45863](https://github.com/expo/expo/pull/45863) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -11,6 +11,7 @@ import { createEventsSocket } from './createEventSocket';
 import { createMessagesSocket } from './createMessageSocket';
 import { Log } from '../../../../log';
 import { openInEditorAsync } from '../../../../utils/editor';
+import { shouldThrottleRemoteDevCall } from '../../../../utils/net';
 
 interface MetroMiddlewareOptions {
   getMetroBundler(): MetroBundler;
@@ -99,6 +100,11 @@ function createMetroOpenStackFrameMiddleware(
     if (!file) {
       res.statusCode = 400;
       return res.end('Open stack frame requires target file to be in server root');
+    }
+
+    if (shouldThrottleRemoteDevCall()) {
+      res.statusCode = 429;
+      return res.end();
     }
 
     try {

--- a/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
+++ b/packages/@expo/cli/src/start/server/metro/instantiateMetro.ts
@@ -409,7 +409,7 @@ export async function instantiateMetroAsync(
     });
     Object.assign(websocketEndpoints, debugWebsocketEndpoints);
     middleware.use(debugMiddleware);
-    middleware.use('/_expo/debugger', createJsInspectorMiddleware());
+    middleware.use('/_expo/debugger', createJsInspectorMiddleware({ serverBaseUrl }));
 
     // TODO(cedric): `enhanceMiddleware` is deprecated, but is currently used to unify the middleware stacks
     // See: https://github.com/facebook/metro/commit/22e85fde85ec454792a1b70eba4253747a2587a9

--- a/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/createJsInspectorMiddleware-test.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/__tests__/createJsInspectorMiddleware-test.ts
@@ -20,7 +20,7 @@ describe('createJsInspectorMiddleware', () => {
       >
     ).mockReturnValue(Promise.resolve(app));
 
-    const middlewareAsync = createJsInspectorMiddleware();
+    const middlewareAsync = createJsInspectorMiddleware({ serverBaseUrl: 'http://localhost:8081' });
     await middlewareAsync(req, res as ServerResponse, next);
 
     expectMockedResponse(res, 200, JSON.stringify(app));
@@ -39,7 +39,7 @@ describe('createJsInspectorMiddleware', () => {
       >
     ).mockReturnValue(Promise.resolve(app));
 
-    const middlewareAsync = createJsInspectorMiddleware();
+    const middlewareAsync = createJsInspectorMiddleware({ serverBaseUrl: 'http://localhost:8081' });
     await middlewareAsync(req, res as ServerResponse, next);
 
     expectMockedResponse(res, 200, JSON.stringify(app));
@@ -55,7 +55,7 @@ describe('createJsInspectorMiddleware', () => {
       >
     ).mockReturnValue(Promise.resolve(null));
 
-    const middlewareAsync = createJsInspectorMiddleware();
+    const middlewareAsync = createJsInspectorMiddleware({ serverBaseUrl: 'http://localhost:8081' });
     await middlewareAsync(req, res as ServerResponse, next);
 
     expectMockedResponse(res, 404);
@@ -66,10 +66,46 @@ describe('createJsInspectorMiddleware', () => {
     const res = createMockedResponse();
     const next = jest.fn();
 
-    const middlewareAsync = createJsInspectorMiddleware();
+    const middlewareAsync = createJsInspectorMiddleware({ serverBaseUrl: 'http://localhost:8081' });
     await middlewareAsync(req, res as ServerResponse, next);
 
     expectMockedResponse(res, 400);
+  });
+
+  it('queries the local server origin even when the request URL is absolute-form', async () => {
+    const app = METRO_INSPECTOR_RESPONSE_FIXTURE[0];
+    const req = createRequest(
+      `http://localhost:8081/_expo/debugger?applicationId=${app.description}`
+    );
+    req.url = `http://192.0.2.66:9010/_expo/debugger?applicationId=${app.description}`;
+    const res = createMockedResponse();
+    const next = jest.fn();
+    (
+      JsInspector.queryInspectorAppAsync as jest.MockedFunction<
+        typeof JsInspector.queryInspectorAppAsync
+      >
+    ).mockReturnValue(Promise.resolve(app));
+
+    const middlewareAsync = createJsInspectorMiddleware({ serverBaseUrl: 'http://localhost:8081' });
+    await middlewareAsync(req, res as ServerResponse, next);
+
+    expect(JsInspector.queryInspectorAppAsync).toHaveBeenCalledWith(
+      'http://localhost:8081',
+      expect.anything()
+    );
+  });
+
+  it('rejects requests from a cross-origin browser page', async () => {
+    const req = createRequest('http://localhost:8081/_expo/debugger?applicationId=any');
+    req.headers.origin = 'http://evil.example';
+    const res = createMockedResponse();
+    const next = jest.fn();
+
+    const middlewareAsync = createJsInspectorMiddleware({ serverBaseUrl: 'http://localhost:8081' });
+    await middlewareAsync(req, res as ServerResponse, next);
+
+    expectMockedResponse(res, 403);
+    expect(JsInspector.queryInspectorAppAsync).not.toHaveBeenCalled();
   });
 
   it('should open browser for PUT request with given applicationId', async () => {
@@ -86,7 +122,7 @@ describe('createJsInspectorMiddleware', () => {
       >
     ).mockReturnValue(Promise.resolve(app));
 
-    const middlewareAsync = createJsInspectorMiddleware();
+    const middlewareAsync = createJsInspectorMiddleware({ serverBaseUrl: 'http://localhost:8081' });
     await middlewareAsync(req, res as ServerResponse, next);
 
     expectMockedResponse(res, 200);
@@ -94,7 +130,11 @@ describe('createJsInspectorMiddleware', () => {
   });
 });
 
-function createRequest(requestUrl: string, method?: 'GET' | 'POST' | 'PUT'): IncomingMessage {
+function createRequest(
+  requestUrl: string,
+  method?: 'GET' | 'POST' | 'PUT',
+  { remoteAddress = '127.0.0.1' }: { remoteAddress?: string } = {}
+): IncomingMessage {
   const url = new URL(requestUrl);
   const req: Partial<IncomingMessage> = {
     method: method || 'GET',
@@ -102,8 +142,10 @@ function createRequest(requestUrl: string, method?: 'GET' | 'POST' | 'PUT'): Inc
       host: url.host,
     },
     socket: {
-      localAddress: url.hostname,
+      localAddress: '127.0.0.1',
       localPort: Number(url.port || 80),
+      remoteAddress,
+      remoteFamily: 'IPv4',
     } as Socket,
     url: `${url.pathname}${url.search}`,
   };

--- a/packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/inspector/createJsInspectorMiddleware.ts
@@ -1,26 +1,37 @@
 import chalk from 'chalk';
 import type { NextHandleFunction } from 'connect';
 import type { IncomingMessage, ServerResponse } from 'http';
-import net from 'net';
-import { TLSSocket } from 'tls';
 import { URL } from 'url';
 
 import { openJsInspector, queryInspectorAppAsync } from './JsInspector';
+import { isMatchingOrigin, shouldThrottleRemoteDevCall } from '../../../../utils/net';
+
+interface JsInspectorMiddlewareOptions {
+  serverBaseUrl: string;
+}
 
 /**
  * Create a middleware that handles new requests to open the debugger from the dev menu.
  * @todo(cedric): delete this middleware once we fully swap over to the new React Native JS Inspector.
  */
-export function createJsInspectorMiddleware(): NextHandleFunction {
+export function createJsInspectorMiddleware({
+  serverBaseUrl,
+}: JsInspectorMiddlewareOptions): NextHandleFunction {
   return async function (req: IncomingMessage, res: ServerResponse, next: (err?: Error) => void) {
-    const { origin, searchParams } = new URL(req.url ?? '/', getServerBase(req));
+    if (!isMatchingOrigin(req, serverBaseUrl)) {
+      res.writeHead(403).end();
+      return;
+    }
+
+    // `req.url` may be absolute-form (HTTP/1.1) — only take search params from it.
+    const { searchParams } = new URL(req.url ?? '/', serverBaseUrl);
     const appId = searchParams.get('appId') || searchParams.get('applicationId');
     if (!appId) {
       res.writeHead(400).end('Missing application identifier ("?appId=...")');
       return;
     }
 
-    const app = await queryInspectorAppAsync(origin, appId);
+    const app = await queryInspectorAppAsync(serverBaseUrl, appId);
     if (!app) {
       res.writeHead(404).end('Unable to find inspector target from @react-native/dev-middleware');
       console.warn(
@@ -40,8 +51,12 @@ export function createJsInspectorMiddleware(): NextHandleFunction {
       });
       res.end(data);
     } else if (req.method === 'POST' || req.method === 'PUT') {
+      if (shouldThrottleRemoteDevCall()) {
+        res.writeHead(429).end();
+        return;
+      }
       try {
-        await openJsInspector(origin, app);
+        await openJsInspector(serverBaseUrl, app);
       } catch (error: any) {
         // abort(Error: Command failed: osascript -e POSIX path of (path to application "google chrome")
         // 15:50: execution error: Google Chrome got an error: Application isn’t running. (-600)
@@ -58,12 +73,4 @@ export function createJsInspectorMiddleware(): NextHandleFunction {
       res.writeHead(405);
     }
   };
-}
-
-function getServerBase(req: IncomingMessage): string {
-  const scheme =
-    req.socket instanceof TLSSocket && req.socket.encrypted === true ? 'https' : 'http';
-  const { localAddress, localPort } = req.socket;
-  const address = localAddress && net.isIPv6(localAddress) ? `[${localAddress}]` : localAddress;
-  return `${scheme}:${address}:${localPort}`;
 }

--- a/packages/@expo/cli/src/utils/net.ts
+++ b/packages/@expo/cli/src/utils/net.ts
@@ -42,3 +42,16 @@ export const isMatchingOrigin = (
   const expectedHost = new URL(serverBaseUrl).host;
   return actualHost === expectedHost;
 };
+
+const DEV_CALL_THROTTLE_MS = 2_000;
+let lastRemoteDevCallAt = 0;
+
+/** Process-wide throttle. Returns `true` if another call fired within the cooldown window. */
+export const shouldThrottleRemoteDevCall = (): boolean => {
+  const now = Date.now();
+  if (now - lastRemoteDevCallAt < DEV_CALL_THROTTLE_MS) {
+    return true;
+  }
+  lastRemoteDevCallAt = now;
+  return false;
+};


### PR DESCRIPTION
## Summary

Adds the missing origin check to the JS inspector middleware for symmetry with the other checked dev command endpoints, and adds a throttle to it and related endpoints to slow down dev command requests to avoid resource exhaustion.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
