### PR TITLE
fix(cli): Limit resources for network debugging CDP websocket [EXP-33]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fix missing await on bundle/assets output copies in `export:embed` ([#45883](https://github.com/expo/expo/pull/45883) by [@kitten](https://github.com/kitten))
 - Prevalidate `easProjectId` before using it as cache path ([#45879](https://github.com/expo/expo/pull/45879) by [@kitten](https://github.com/kitten))
 - Persist `~/.expo/state.json` with owner-only file permissions ([#45873](https://github.com/expo/expo/pull/45873) by [@kitten](https://github.com/kitten))
+- Limit payload sizes and recorded entries for network debugger CDP state ([#45864](https://github.com/expo/expo/pull/45864) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/createDebugMiddleware.ts
@@ -2,7 +2,7 @@ import type { NextHandleFunction } from 'connect';
 import { WebSocketServer } from 'ws';
 
 import { createHandlersFactory } from './createHandlersFactory';
-import { NETWORK_RESPONSE_STORAGE } from './messageHandlers/NetworkResponse';
+import { recordNetworkResponse } from './messageHandlers/NetworkResponse';
 import { env, envIsHeadless } from '../../../../utils/env';
 import { isLocalSocket, isMatchingOrigin } from '../../../../utils/net';
 import type { TerminalReporter } from '../TerminalReporter';
@@ -110,9 +110,10 @@ function createNetworkWebsocket(debuggerWebsocket: WebSocketServer) {
   const wss = new WebSocketServer({
     noServer: true,
     perMessageDeflate: true,
-    // Don't crash on exceptionally large messages - assume the device is
-    // well-behaved and the debugger is prepared to handle large messages.
-    maxPayload: 0,
+    // Bounded so an unauthenticated client cannot exhaust dev-server memory
+    // with one oversized frame. 16 MiB covers realistic response bodies
+    // (image previews, large JSON dumps, base64-inflated assets).
+    maxPayload: 16 * 1024 * 1024,
   });
 
   wss.on('connection', (networkSocket) => {
@@ -124,7 +125,7 @@ function createNetworkWebsocket(debuggerWebsocket: WebSocketServer) {
         if (message.method === 'Expo(Network.receivedResponseBody)' && message.params) {
           // If its a response body, write it to the global storage
           const { requestId, ...requestInfo } = message.params;
-          NETWORK_RESPONSE_STORAGE.set(requestId, requestInfo);
+          recordNetworkResponse(requestId, requestInfo);
         } else if (message.method.startsWith('Network.')) {
           // Otherwise, directly re-broadcast the Network events to all connected debuggers
           debuggerWebsocket.clients.forEach((debuggerSocket) => {

--- a/packages/@expo/cli/src/start/server/metro/debugging/messageHandlers/NetworkResponse.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/messageHandlers/NetworkResponse.ts
@@ -18,6 +18,24 @@ export const NETWORK_RESPONSE_STORAGE = new Map<
   DebuggerResponse<NetworkGetResponseBody>['result']
 >();
 
+// Bounded so an unauthenticated client on `/inspector/network` cannot grow this
+// map without limit. `Map` preserves insertion order, so the first key is the
+// oldest entry — drop it on overflow (FIFO).
+const MAX_NETWORK_RESPONSES = 512;
+
+export function recordNetworkResponse(
+  requestId: string,
+  info: DebuggerResponse<NetworkGetResponseBody>['result']
+) {
+  NETWORK_RESPONSE_STORAGE.set(requestId, info);
+  if (NETWORK_RESPONSE_STORAGE.size > MAX_NETWORK_RESPONSES) {
+    const oldestKey = NETWORK_RESPONSE_STORAGE.keys().next().value;
+    if (oldestKey !== undefined) {
+      NETWORK_RESPONSE_STORAGE.delete(oldestKey);
+    }
+  }
+}
+
 export class NetworkResponseHandler extends MessageHandler {
   /** All known responses, mapped by request id */
   storage = NETWORK_RESPONSE_STORAGE;
@@ -25,7 +43,7 @@ export class NetworkResponseHandler extends MessageHandler {
   handleDeviceMessage(message: DeviceRequest<NetworkReceivedResponseBody>) {
     if (message.method === 'Expo(Network.receivedResponseBody)') {
       const { requestId, ...requestInfo } = message.params;
-      this.storage.set(requestId, requestInfo);
+      recordNetworkResponse(requestId, requestInfo);
       return true;
     }
 

--- a/packages/@expo/cli/src/start/server/metro/debugging/messageHandlers/__tests__/NetworkResponse.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/debugging/messageHandlers/__tests__/NetworkResponse.test.ts
@@ -58,6 +58,23 @@ it('does not respond to non-existing response', () => {
   expect(connection.debugger.sendMessage).not.toHaveBeenCalled();
 });
 
+it('evicts the oldest entry once the storage exceeds its cap', () => {
+  const connection = mockConnection();
+  const handler = new NetworkResponseHandler(connection);
+
+  // 512 is the cap; pushing 513 entries should drop the oldest.
+  for (let i = 0; i < 513; i++) {
+    handler.handleDeviceMessage({
+      method: 'Expo(Network.receivedResponseBody)',
+      params: { requestId: String(i), body: '', base64Encoded: false },
+    });
+  }
+
+  expect(NETWORK_RESPONSE_STORAGE.size).toBe(512);
+  expect(NETWORK_RESPONSE_STORAGE.has('0')).toBe(false);
+  expect(NETWORK_RESPONSE_STORAGE.has('512')).toBe(true);
+});
+
 // Known issue of the collision and will be resolved later
 it('known to have response collision from global `NETWORK_RESPONSE_STORAGE`', () => {
   const connection = mockConnection();


### PR DESCRIPTION
## Summary

- Add payload size limit for CDP network messages
- Add storage limit on amount of network calls for CDP network messages

This seems appropriate until we're replacing this with the built-in socket.  

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)