### PR TITLE
[gl] Install WebGL constructors and constants before any context exists

### DIFF
--- a/apps/test-suite/tests/GLView.js
+++ b/apps/test-suite/tests/GLView.js
@@ -10,7 +10,7 @@ export const name = 'GLView';
 const style = { width: 200, height: 200 };
 
 export async function test(
-  { it, describe, beforeAll, jasmine, afterAll, expect, afterEach, beforeEach },
+  { it, xit, describe, beforeAll, jasmine, afterAll, expect, afterEach, beforeEach },
   { setPortalChild, cleanupPortal }
 ) {
   let instance = null;
@@ -45,24 +45,40 @@ export async function test(
   }
 
   describe('GLView', () => {
-    it('gets a valid context', async () => {
-      const context = await getContextAsync();
-      expect(
-        context instanceof WebGLRenderingContext || context instanceof WebGL2RenderingContext
-      ).toBe(true);
-    });
+    // Regression test for https://github.com/expo/expo/issues/44637 — the
+    // WebGLRenderingContext / WebGL2RenderingContext globals and their numeric
+    // constants must exist before any GL context is created so module-level
+    // code (e.g. `enum X { LINEAR = WebGL2RenderingContext.LINEAR }`) doesn't
+    // crash at app startup. This `describe` must run before any GLView is
+    // mounted in this file so the assertions reflect the at-launch state, not
+    // the state after `createWebGLRenderer` has run.
+    describe('global bindings (no context created)', () => {
+      // `__EXGLContexts` is populated by `createWebGLRenderer`, so its
+      // presence means another test (or earlier mount) already ran the lazy
+      // install path and these assertions no longer prove the at-launch
+      // behavior. Skip them instead of asserting on tainted state.
+      const itAtLaunch =
+        Platform.OS === 'web' || globalThis.__EXGLContexts === undefined ? it : xit;
 
-    it('takes a snapshot', async () => {
-      await getContextAsync();
+      itAtLaunch('exposes the WebGLRenderingContext constructor on globalThis', () => {
+        expect(typeof WebGLRenderingContext).toBe('function');
+      });
 
-      const snapshot = await instance.takeSnapshotAsync({ format: 'png' });
-      expect(snapshot).toBeDefined();
-      if (Platform.OS === 'web') {
-        expect(snapshot.uri instanceof Blob).toBe(true);
-      } else {
-        expect(snapshot.uri).toMatch(/^file:\/\//);
-        expect(snapshot.localUri).toMatch(/^file:\/\//);
-      }
+      itAtLaunch('exposes the WebGL2RenderingContext constructor on globalThis', () => {
+        expect(typeof WebGL2RenderingContext).toBe('function');
+      });
+
+      itAtLaunch('exposes GL constants as static members of WebGLRenderingContext', () => {
+        expect(WebGLRenderingContext.COLOR_BUFFER_BIT).toBe(0x4000);
+        expect(WebGLRenderingContext.TEXTURE_2D).toBe(0x0de1);
+        expect(WebGLRenderingContext.NEAREST).toBe(0x2600);
+        expect(WebGLRenderingContext.LINEAR).toBe(0x2601);
+      });
+
+      itAtLaunch('exposes GL constants as static members of WebGL2RenderingContext', () => {
+        expect(WebGL2RenderingContext.NEAREST).toBe(0x2600);
+        expect(WebGL2RenderingContext.LINEAR).toBe(0x2601);
+      });
     });
 
     describe('context', () => {
@@ -82,6 +98,27 @@ export async function test(
       gl_FragColor = texture2D(texture, vec2(uv.x, uv.y));
     }
         `;
+
+      it('gets a valid context', async () => {
+        const context = await getContextAsync();
+        expect(
+          context instanceof WebGLRenderingContext || context instanceof WebGL2RenderingContext
+        ).toBe(true);
+      });
+
+      it('takes a snapshot', async () => {
+        await getContextAsync();
+
+        const snapshot = await instance.takeSnapshotAsync({ format: 'png' });
+        expect(snapshot).toBeDefined();
+        if (Platform.OS === 'web') {
+          expect(snapshot.uri instanceof Blob).toBe(true);
+        } else {
+          expect(snapshot.uri).toMatch(/^file:\/\//);
+          expect(snapshot.localUri).toMatch(/^file:\/\//);
+        }
+      });
+
       it('has Expo methods', async () => {
         const context = await getContextAsync();
         expect(typeof context.endFrameEXP).toBe('function');

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Install `WebGLRenderingContext` and `WebGL2RenderingContext` globals and their numeric constants at module init so libraries that read them before any GL context is created no longer crash. ([#45865](https://github.com/expo/expo/pull/45865) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-gl/android/src/main/cpp/EXGLJniApi.cpp
+++ b/packages/expo-gl/android/src/main/cpp/EXGLJniApi.cpp
@@ -17,6 +17,12 @@ Java_expo_modules_gl_cpp_EXGL_EXGLContextCreate
 }
 
 JNIEXPORT void JNICALL
+Java_expo_modules_gl_cpp_EXGL_EXGLInstallWebGLBindings
+(JNIEnv *env, jclass clazz, jlong jsiPtr) {
+  EXGLInstallWebGLBindings((void *) jsiPtr);
+}
+
+JNIEXPORT void JNICALL
 Java_expo_modules_gl_cpp_EXGL_EXGLContextPrepare
 (JNIEnv *env, jclass clazz, jlong jsiPtr, jint exglCtxId, jobject glContext) {
   threadLocalEnv = env;

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/GLModule.kt
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/GLModule.kt
@@ -5,12 +5,14 @@ import android.os.Bundle
 import android.util.SparseArray
 import android.view.View
 import expo.modules.interfaces.camera.CameraViewInterface
+import expo.modules.gl.cpp.EXGL
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.functions.Queues
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.runtime.MainRuntime
 
 private class InvalidCameraViewException :
   CodedException("Provided view tag don't point to valid instance of the camera view")
@@ -23,6 +25,16 @@ class GLModule : Module() {
   private val mGLContextMap = SparseArray<GLContext>()
   override fun definition() = ModuleDefinition {
     Name("ExpoGL")
+
+    OnCreate {
+      val runtime = appContext.runtime as? MainRuntime ?: return@OnCreate
+      val jsRuntimePointer = runtime.reactContext?.javaScriptContextHolder?.get() ?: 0L
+      if (jsRuntimePointer != 0L) {
+        runtime.schedule {
+          EXGL.EXGLInstallWebGLBindings(jsRuntimePointer)
+        }
+      }
+    }
 
     AsyncFunction("destroyObjectAsync") { exglObjId: Int ->
       val glObject = mGLObjects[exglObjId]

--- a/packages/expo-gl/android/src/main/java/expo/modules/gl/cpp/EXGL.java
+++ b/packages/expo-gl/android/src/main/java/expo/modules/gl/cpp/EXGL.java
@@ -8,6 +8,7 @@ public class EXGL {
     SoLoader.loadLibrary("expo-gl");
   }
   public static native int EXGLContextCreate();
+  public static native void EXGLInstallWebGLBindings(long jsCtxPtr);
   public static native void EXGLContextPrepare(long jsCtxPtr, int exglCtxId, Object glContext);
   public static native void EXGLContextPrepareWorklet(int exglCtxId);
 

--- a/packages/expo-gl/common/EXGLNativeApi.cpp
+++ b/packages/expo-gl/common/EXGLNativeApi.cpp
@@ -1,11 +1,16 @@
 #include "EXGLNativeApi.h"
 #include "EXGLContextManager.h"
 #include "EXGLNativeContext.h"
+#include "EXWebGLRenderer.h"
 
 using namespace expo::gl_cpp;
 
 EXGLContextId EXGLContextCreate() {
   return ContextCreate();
+}
+
+void EXGLInstallWebGLBindings(void *jsiPtr) {
+  installWebGLConstructorsAndConstants(*reinterpret_cast<jsi::Runtime *>(jsiPtr));
 }
 
 void EXGLContextPrepare(

--- a/packages/expo-gl/common/EXGLNativeApi.h
+++ b/packages/expo-gl/common/EXGLNativeApi.h
@@ -28,6 +28,11 @@ typedef unsigned int EXGLObjectId;
 
 EXGLContextId EXGLContextCreate();
 
+// [JS thread] Install the `WebGLRenderingContext` / `WebGL2RenderingContext`
+// global constructors and their numeric constants so they are reachable from
+// JS before any GL context is created. `runtime` is a raw `jsi::Runtime *`.
+void EXGLInstallWebGLBindings(void *runtime);
+
 #ifdef __cplusplus
 // [JS thread] Create an EXGL context and return its id number. Saves the
 // JavaScript interface object (has a WebGLRenderingContext-style API) at

--- a/packages/expo-gl/common/EXWebGLRenderer.cpp
+++ b/packages/expo-gl/common/EXWebGLRenderer.cpp
@@ -44,7 +44,8 @@ void createWebGLRenderer(
   glesContext viewport,
   jsi::Object &&global
 ) {
-  ensurePrototypes(runtime);
+  installWebGLConstructorsAndConstants(runtime);
+  installWebGLInstanceMethods(runtime);
   jsi::Object gl = ctx->supportsWebGL2
                    ? createWebGLObject(
       runtime, EXWebGLClass::WebGL2RenderingContext, {static_cast<double>(ctx->ctxId)})
@@ -172,7 +173,14 @@ void jsClassExtend(jsi::Runtime &runtime, jsi::Object &baseClass, jsi::PropNameI
     });
 }
 
-void ensurePrototypes(jsi::Runtime &runtime) {
+static jsi::Object getRenderingContextPrototype(jsi::Runtime &runtime, EXWebGLClass classEnum) {
+  return runtime.global()
+    .getProperty(runtime, jsi::PropNameID::forUtf8(runtime, getConstructorName(classEnum)))
+    .asObject(runtime)
+    .getPropertyAsObject(runtime, "prototype");
+}
+
+void installWebGLConstructorsAndConstants(jsi::Runtime &runtime) {
   if (runtime.global().hasProperty(runtime, "WebGLRenderingContext")) {
     return;
   }
@@ -181,37 +189,30 @@ void ensurePrototypes(jsi::Runtime &runtime) {
   auto evalBuffer = std::make_shared<jsi::StringBuffer>(evalStubConstructors);
   runtime.evaluateJavaScript(evalBuffer, "expo-gl");
 
-  auto inheritFromJsObject = [&runtime](EXWebGLClass classEnum) {
-    auto objectClass = runtime.global().getPropertyAsObject(runtime, "Object");
+  jsi::Object objectClass = runtime.global().getPropertyAsObject(runtime, "Object");
+  auto inheritFromJsObject = [&runtime, &objectClass](EXWebGLClass classEnum) {
     jsClassExtend(
       runtime, objectClass, jsi::PropNameID::forUtf8(runtime, getConstructorName(classEnum)));
   };
 
-  // configure WebGLRenderingContext
-  {
-    inheritFromJsObject(EXWebGLClass::WebGLRenderingContext);
-    auto prototype =
+  auto installConstantsOnConstructor = [&runtime](EXWebGLClass classEnum) {
+    auto constructor =
       runtime.global()
-        .getProperty(runtime, jsi::PropNameID::forUtf8(runtime, getConstructorName(
-          EXWebGLClass::WebGLRenderingContext)))
-        .asObject(runtime)
-        .getPropertyAsObject(runtime, "prototype");
-    installConstants(runtime, prototype);
-    installWebGLMethods(runtime, prototype);
-  }
+        .getProperty(runtime, jsi::PropNameID::forUtf8(runtime, getConstructorName(classEnum)))
+        .asObject(runtime);
+    // Per the WebGL spec, GL_* numeric constants are exposed both as static
+    // members of the interface (e.g. WebGLRenderingContext.LINEAR) and on the
+    // prototype (e.g. gl.LINEAR). Only the static members are needed before
+    // a context is created; the prototype copy is deferred to
+    // `installWebGLInstanceMethods` to keep module-init cheap.
+    installConstants(runtime, constructor);
+  };
 
-  // configure WebGL2RenderingContext
-  {
-    inheritFromJsObject(EXWebGLClass::WebGL2RenderingContext);
-    auto prototype =
-      runtime.global()
-        .getProperty(runtime, jsi::PropNameID::forUtf8(runtime, getConstructorName(
-          EXWebGLClass::WebGL2RenderingContext)))
-        .asObject(runtime)
-        .getPropertyAsObject(runtime, "prototype");
-    installConstants(runtime, prototype);
-    installWebGL2Methods(runtime, prototype);
-  }
+  inheritFromJsObject(EXWebGLClass::WebGLRenderingContext);
+  installConstantsOnConstructor(EXWebGLClass::WebGLRenderingContext);
+
+  inheritFromJsObject(EXWebGLClass::WebGL2RenderingContext);
+  installConstantsOnConstructor(EXWebGLClass::WebGL2RenderingContext);
 
   // Configure rest of WebGL objects
   inheritFromJsObject(EXWebGLClass::WebGLObject);
@@ -243,6 +244,21 @@ void ensurePrototypes(jsi::Runtime &runtime) {
   inheritFromWebGLObject(EXWebGLClass::WebGLSync);
   inheritFromWebGLObject(EXWebGLClass::WebGLTransformFeedback);
   inheritFromWebGLObject(EXWebGLClass::WebGLVertexArrayObject);
+}
+
+void installWebGLInstanceMethods(jsi::Runtime &runtime) {
+  if (runtime.global().hasProperty(runtime, "__EXGLPrototypeReady")) {
+    return;
+  }
+  runtime.global().setProperty(runtime, "__EXGLPrototypeReady", true);
+
+  auto webglPrototype = getRenderingContextPrototype(runtime, EXWebGLClass::WebGLRenderingContext);
+  installConstants(runtime, webglPrototype);
+  installWebGLMethods(runtime, webglPrototype);
+
+  auto webgl2Prototype = getRenderingContextPrototype(runtime, EXWebGLClass::WebGL2RenderingContext);
+  installConstants(runtime, webgl2Prototype);
+  installWebGL2Methods(runtime, webgl2Prototype);
 }
 
 void installConstants(jsi::Runtime &runtime, jsi::Object &gl) {

--- a/packages/expo-gl/common/EXWebGLRenderer.h
+++ b/packages/expo-gl/common/EXWebGLRenderer.h
@@ -36,7 +36,16 @@ enum class EXWebGLClass {
   WebGLVertexArrayObject,
 };
 
-void ensurePrototypes(jsi::Runtime &runtime);
+// Installs the WebGLRenderingContext and WebGL2RenderingContext constructors,
+// their numeric constants, and the inheritance chain for related interface
+// objects. Safe to call before any GL context exists; idempotent.
+void installWebGLConstructorsAndConstants(jsi::Runtime &runtime);
+
+// Installs WebGLRenderingContext and WebGL2RenderingContext instance methods
+// on their prototypes. Defers the heavier per-method binding work until a GL
+// context is created. Requires `installWebGLConstructorsAndConstants` to have
+// run; idempotent.
+void installWebGLInstanceMethods(jsi::Runtime &runtime);
 
 void createWebGLRenderer(jsi::Runtime &runtime, EXGLContext *, glesContext, jsi::Object &&global);
 

--- a/packages/expo-gl/ios/ExpoGLModule.swift
+++ b/packages/expo-gl/ios/ExpoGLModule.swift
@@ -6,6 +6,17 @@ public final class ExpoGLModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoGL")
 
+    OnCreate {
+      guard let runtime = try? appContext?.runtime else {
+        return
+      }
+      try! runtime.execute {
+        runtime.withUnsafePointee { runtimePtr in
+          EXGLInstallWebGLBindings(runtimePtr)
+        }
+      }
+    }
+
     AsyncFunction("takeSnapshotAsync") { (contextId: UInt, options: [String: Any], promise: Promise) in
       EXGLObjectManager.shared.takeSnapshot(
         withContextId: contextId as NSNumber,


### PR DESCRIPTION
## Why

Closes #44637. Module-level code that referenced `WebGL2RenderingContext.LINEAR` (or any other `WebGLRenderingContext` / `WebGL2RenderingContext` constant) crashed at app startup because `expo-gl` only installed those globals lazily, on first GL context creation. Any third-party library that reads these constants at bundle-eval time would `TypeError` before a `GLView` ever mounted.

The issue title says `[android]` but the same bug exists on iOS — the lazy install lives in shared C++.

## What

- Split `ensurePrototypes` into two: `installWebGLConstructorsAndConstants` (cheap, runs at module init) and `installWebGLInstanceMethods` (heavy per-method binding + prototype-side constants, deferred to first `createWebGLRenderer` call).
- Added a public C entry point `EXGLInstallWebGLBindings(void *)` that just runs the constructors-and-constants install. Exported via JNI on Android and called from Swift via the umbrella header on iOS.
- Wired it up in `ExpoGLModule`'s `OnCreate` on both platforms so the constructors and static constants exist before the JS bundle's top-level eval runs.
- Per the WebGL spec, GL constants live both as static members of the interface (`WebGL2RenderingContext.LINEAR`) and on the prototype (`gl.LINEAR`). The original code only installed onto the prototype, which is why static access broke. Static access is now eager; prototype access stays deferred to avoid doubling work at startup.

## Performance

Module init now does ~1,120 `setProperty` calls (560 constants × 2 constructors) plus the inheritance-chain setup. The heavier ~278 method bindings × 2 prototypes still happen lazily on first GL context creation, so users who never mount a `GLView` pay only the constants cost.

## Test plan

- [x] iOS: `BareExpo` builds and `apps/test-suite/tests/GLView.js` passes, including the new `global bindings (no context created)` describe block that asserts the constructors and `LINEAR` / `NEAREST` / `COLOR_BUFFER_BIT` / `TEXTURE_2D` are reachable before any GLView mounts.
- [x] Android: `BareExpo` builds and the same test-suite block passes.
- The test block skips itself (via `xit`) if `globalThis.__EXGLContexts` is defined, so cross-file test ordering can't produce a false positive.