### PR TITLE
fix(cli): Validate `EXPO_PUBLIC_FOLDER` to be in project root [EXP-38]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Enforce `routerRoot` to be within `projectRoot` to prevent unexpected errors ([#45892](https://github.com/expo/expo/pull/45892) by [@kitten](https://github.com/kitten))
 - Fix containment check in tar extraction to cover parallel folders with same prefix ([#45882](https://github.com/expo/expo/pull/45882) by [@kitten](https://github.com/kitten))
 - Forward the request HTTP method to the RSC renderer ([#45905](https://github.com/expo/expo/pull/45905) by [@kitten](https://github.com/kitten))
+- Add validation to check `EXPO_PUBLIC_FOLDER` is in project root ([#45866](https://github.com/expo/expo/pull/45866) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/export/__tests__/publicFolder.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/publicFolder.test.ts
@@ -1,6 +1,6 @@
 import { vol } from 'memfs';
 
-import { getUserDefinedFile } from '../publicFolder';
+import { getPublicFolderPath, getUserDefinedFile } from '../publicFolder';
 
 beforeEach(() => vol.reset());
 
@@ -8,7 +8,7 @@ describe(getUserDefinedFile, () => {
   it(`returns null when no favicon is defined`, () => {
     vol.fromJSON({}, '/');
 
-    const faviconFile = getUserDefinedFile('/', ['favicon.ico']);
+    const faviconFile = getUserDefinedFile('/project', ['favicon.ico']);
 
     expect(faviconFile).toBeNull();
   });
@@ -16,11 +16,43 @@ describe(getUserDefinedFile, () => {
   it(`returns the favicon file when defined`, () => {
     vol.fromJSON(
       {
-        'public/favicon.ico': '...',
+        'project/public/favicon.ico': '...',
       },
       '/'
     );
 
-    expect(getUserDefinedFile('/', ['favicon.ico'])).toBe('/public/favicon.ico');
+    expect(getUserDefinedFile('/project', ['favicon.ico'])).toBe('/project/public/favicon.ico');
+  });
+});
+
+describe(getPublicFolderPath, () => {
+  const projectRoot = '/project';
+
+  afterEach(() => {
+    delete process.env.EXPO_PUBLIC_FOLDER;
+  });
+
+  it('resolves the default "public" folder inside the project root', () => {
+    expect(getPublicFolderPath(projectRoot)).toBe('/project/public');
+  });
+
+  it('honors a relative override that stays inside the project root', () => {
+    process.env.EXPO_PUBLIC_FOLDER = 'static';
+    expect(getPublicFolderPath(projectRoot)).toBe('/project/static');
+  });
+
+  it('rejects parent-traversal values that escape the project root', () => {
+    process.env.EXPO_PUBLIC_FOLDER = '../other';
+    expect(() => getPublicFolderPath(projectRoot)).toThrow(/outside the project root/);
+  });
+
+  it('rejects absolute paths that escape the project root', () => {
+    process.env.EXPO_PUBLIC_FOLDER = '/etc';
+    expect(() => getPublicFolderPath(projectRoot)).toThrow(/outside the project root/);
+  });
+
+  it('rejects values that resolve to the project root itself', () => {
+    process.env.EXPO_PUBLIC_FOLDER = '.';
+    expect(() => getPublicFolderPath(projectRoot)).toThrow(/outside the project root/);
   });
 });

--- a/packages/@expo/cli/src/export/__tests__/publicFolder.test.ts
+++ b/packages/@expo/cli/src/export/__tests__/publicFolder.test.ts
@@ -41,6 +41,14 @@ describe(getPublicFolderPath, () => {
     expect(getPublicFolderPath(projectRoot)).toBe('/project/static');
   });
 
+  it('honors a relative override in non-canonical formats', () => {
+    process.env.EXPO_PUBLIC_FOLDER = './static';
+    expect(getPublicFolderPath(projectRoot)).toBe('/project/static');
+
+    process.env.EXPO_PUBLIC_FOLDER = './static/../static';
+    expect(getPublicFolderPath(projectRoot)).toBe('/project/static');
+  });
+
   it('rejects parent-traversal values that escape the project root', () => {
     process.env.EXPO_PUBLIC_FOLDER = '../other';
     expect(() => getPublicFolderPath(projectRoot)).toThrow(/outside the project root/);

--- a/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
+++ b/packages/@expo/cli/src/export/embed/exportEmbedAsync.ts
@@ -35,7 +35,7 @@ import { setNodeEnv, loadEnvFiles } from '../../utils/nodeEnv';
 import { exportDomComponentAsync } from '../exportDomComponents';
 import { isEnableHermesManaged } from '../exportHermes';
 import { persistMetroAssetsAsync } from '../persistMetroAssets';
-import { copyPublicFolderAsync } from '../publicFolder';
+import { copyPublicFolderAsync, getPublicFolderPath } from '../publicFolder';
 import type { BundleAssetWithFileHashes, ExportAssetMap } from '../saveAssets';
 import { persistMetroFilesAsync } from '../saveAssets';
 import { exportStandaloneServerAsync } from './exportServer';
@@ -148,7 +148,7 @@ export async function exportEmbedInternalAsync(projectRoot: string, options: Opt
     // Copy public folder for dom components only if
     hasDomComponents
       ? copyPublicFolderAsync(
-          path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER),
+          getPublicFolderPath(projectRoot),
           path.join(domComponentProxyOutputDir, DOM_COMPONENTS_BUNDLE_DIR)
         )
       : null,

--- a/packages/@expo/cli/src/export/embed/exportServer.ts
+++ b/packages/@expo/cli/src/export/embed/exportServer.ts
@@ -20,7 +20,7 @@ import { removeAsync } from '../../utils/dir';
 import { env } from '../../utils/env';
 import { CommandError } from '../../utils/errors';
 import { exportApiRoutesStandaloneAsync } from '../exportStaticAsync';
-import { copyPublicFolderAsync } from '../publicFolder';
+import { copyPublicFolderAsync, getPublicFolderPath } from '../publicFolder';
 import type { ExportAssetMap } from '../saveAssets';
 import { persistMetroFilesAsync } from '../saveAssets';
 import type { Options } from './resolveOptions';
@@ -67,7 +67,7 @@ export async function exportStandaloneServerAsync(
     apiRoutesOnly: true,
   });
 
-  const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);
+  const publicPath = getPublicFolderPath(projectRoot);
 
   // Copy over public folder items
   await copyPublicFolderAsync(publicPath, serverOutput);

--- a/packages/@expo/cli/src/export/exportApp.ts
+++ b/packages/@expo/cli/src/export/exportApp.ts
@@ -19,7 +19,7 @@ import { assertEngineMismatchAsync, isEnableHermesManaged } from './exportHermes
 import { exportApiRoutesStandaloneAsync, exportFromServerAsync } from './exportStaticAsync';
 import { getVirtualFaviconAssetsAsync } from './favicon';
 import { getPublicExpoManifestAsync } from './getPublicExpoManifest';
-import { copyPublicFolderAsync } from './publicFolder';
+import { copyPublicFolderAsync, getPublicFolderPath } from './publicFolder';
 import type { Options } from './resolveOptions';
 import type { ExportAssetMap, BundleOutput, BundleAssetWithFileHashes } from './saveAssets';
 import { getFilesFromSerialAssets, persistMetroFilesAsync } from './saveAssets';
@@ -110,7 +110,7 @@ export async function exportAppAsync(
   }
 
   const mode = dev ? 'development' : 'production';
-  const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);
+  const publicPath = getPublicFolderPath(projectRoot);
   const outputPath = path.resolve(projectRoot, outputDir);
 
   // Write the JS bundles to disk, and get the bundle file names (this could change with async chunk loading support).

--- a/packages/@expo/cli/src/export/publicFolder.ts
+++ b/packages/@expo/cli/src/export/publicFolder.ts
@@ -1,14 +1,33 @@
 import fs from 'fs';
 import path from 'path';
 
-import { copyAsync } from '../utils/dir';
+import { copyAsync, isPathInside } from '../utils/dir';
 import { env } from '../utils/env';
+import { CommandError } from '../utils/errors';
 
 const debug = require('debug')('expo:public-folder') as typeof console.log;
 
+/**
+ * Resolve `EXPO_PUBLIC_FOLDER` against the project root and ensure the result
+ * stays inside the project. An `EXPO_PUBLIC_FOLDER` value that escapes
+ * (e.g. `../etc`, `/absolute/path`) almost always indicates a misconfigured
+ * environment, and if honored would expose unrelated files via every consumer
+ * that serves or copies the public folder.
+ */
+export function getPublicFolderPath(projectRoot: string): string {
+  const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);
+  if (!isPathInside(publicPath, projectRoot)) {
+    throw new CommandError(
+      'EXPO_PUBLIC_FOLDER',
+      `EXPO_PUBLIC_FOLDER ("${env.EXPO_PUBLIC_FOLDER}") resolves to "${publicPath}", which is outside the project root "${projectRoot}". Set EXPO_PUBLIC_FOLDER to a path inside your project (e.g. "public").`
+    );
+  }
+  return publicPath;
+}
+
 /** @returns the file system path for a user-defined file in the public folder. */
 export function getUserDefinedFile(projectRoot: string, possiblePaths: string[]): string | null {
-  const publicPath = path.join(projectRoot, env.EXPO_PUBLIC_FOLDER);
+  const publicPath = getPublicFolderPath(projectRoot);
 
   for (const possiblePath of possiblePaths) {
     const fullPath = path.join(publicPath, possiblePath);

--- a/packages/@expo/cli/src/export/publicFolder.ts
+++ b/packages/@expo/cli/src/export/publicFolder.ts
@@ -7,6 +7,14 @@ import { CommandError } from '../utils/errors';
 
 const debug = require('debug')('expo:public-folder') as typeof console.log;
 
+const maybeRealpath = (target: string) => {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return target;
+  }
+};
+
 /**
  * Resolve `EXPO_PUBLIC_FOLDER` against the project root and ensure the result
  * stays inside the project. An `EXPO_PUBLIC_FOLDER` value that escapes
@@ -15,7 +23,7 @@ const debug = require('debug')('expo:public-folder') as typeof console.log;
  * that serves or copies the public folder.
  */
 export function getPublicFolderPath(projectRoot: string): string {
-  const publicPath = path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER);
+  const publicPath = maybeRealpath(path.resolve(projectRoot, env.EXPO_PUBLIC_FOLDER));
   if (!isPathInside(publicPath, projectRoot)) {
     throw new CommandError(
       'EXPO_PUBLIC_FOLDER',

--- a/packages/@expo/cli/src/start/server/middleware/ServeStaticMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/middleware/ServeStaticMiddleware.ts
@@ -1,10 +1,9 @@
-import path from 'path';
 import send from 'send';
 import { parse } from 'url';
 
 import { parsePlatformHeader } from './resolvePlatform';
 import type { ServerRequest, ServerResponse } from './server.types';
-import { env } from '../../../utils/env';
+import { getPublicFolderPath } from '../../../export/publicFolder';
 
 const debug = require('debug')('expo:start:server:middleware:serveStatic') as typeof console.log;
 
@@ -14,7 +13,7 @@ const debug = require('debug')('expo:start:server:middleware:serveStatic') as ty
 export class ServeStaticMiddleware {
   constructor(private projectRoot: string) {}
   getHandler() {
-    const publicPath = path.join(this.projectRoot, env.EXPO_PUBLIC_FOLDER);
+    const publicPath = getPublicFolderPath(this.projectRoot);
 
     debug(`Serving static files from:`, publicPath);
     const opts = {

--- a/packages/@expo/cli/src/start/server/webTemplate.ts
+++ b/packages/@expo/cli/src/start/server/webTemplate.ts
@@ -5,7 +5,7 @@ import path from 'path';
 
 import { TEMPLATES } from '../../customize/templates';
 import { appendLinkToHtml, appendScriptsToHtml } from '../../export/html';
-import { env } from '../../utils/env';
+import { getPublicFolderPath } from '../../export/publicFolder';
 
 /**
  * Create a static HTML for SPA styled websites.
@@ -35,9 +35,9 @@ export async function createTemplateHtmlFromExpoConfigAsync(
 
 function getFileFromLocalPublicFolder(
   projectRoot: string,
-  { publicFolder, filePath }: { publicFolder: string; filePath: string }
+  { filePath }: { filePath: string }
 ): string | null {
-  const localFilePath = path.resolve(projectRoot, publicFolder, filePath);
+  const localFilePath = path.resolve(getPublicFolderPath(projectRoot), filePath);
   if (!fs.existsSync(localFilePath)) {
     return null;
   }
@@ -47,8 +47,6 @@ function getFileFromLocalPublicFolder(
 /** Attempt to read the `index.html` from the local project before falling back on the template `index.html`. */
 async function getTemplateIndexHtmlAsync(projectRoot: string): Promise<string> {
   let filePath = getFileFromLocalPublicFolder(projectRoot, {
-    // TODO: Maybe use the app.json override.
-    publicFolder: env.EXPO_PUBLIC_FOLDER,
     filePath: 'index.html',
   });
   if (!filePath) {


### PR DESCRIPTION
## Summary

We were missing a check restricting users to only provide `EXPO_PUBLIC_FOLDER` inside the project root.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
