### PR TITLE
[dev-menu] Fix FAB resizing on label disappearance

### DIFF
--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix FAB resizing on label disappearance ([#45869](https://github.com/expo/expo/pull/45869) by [@Wenszel](https://github.com/Wenszel))
+
 ### 💡 Others
 
 ## 56.0.10 — 2026-05-15

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FloatingActionButtonContent.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/FloatingActionButtonContent.kt
@@ -13,11 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
@@ -34,7 +30,6 @@ import androidx.compose.ui.unit.sp
 import com.composeunstyled.Icon
 import com.composeunstyled.Text
 import expo.modules.devmenu.R
-import kotlinx.coroutines.delay
 
 private val FabBlue = Color(0xFF007AFF)
 
@@ -43,7 +38,8 @@ fun FloatingActionButtonContent(
   modifier: Modifier = Modifier,
   isPressed: Boolean = false,
   isDragging: Boolean = false,
-  isIdle: Boolean = false
+  isIdle: Boolean = false,
+  showLabel: Boolean = true
 ) {
   val scale by animateFloatAsState(
     targetValue = if (isPressed && !isDragging) 0.9f else 1f,
@@ -59,13 +55,6 @@ fun FloatingActionButtonContent(
     targetValue = if (isIdle) 0f else 1f,
     label = "idleSaturation"
   )
-
-  var showLabel by remember { mutableStateOf(true) }
-
-  LaunchedEffect(Unit) {
-    delay(10_000)
-    showLabel = false
-  }
 
   Column(
     horizontalAlignment = Alignment.CenterHorizontally,

--- a/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
+++ b/packages/expo-dev-menu/android/src/debug/java/expo/modules/devmenu/fab/MovableFloatingActionButton.kt
@@ -18,7 +18,10 @@ import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
@@ -31,9 +34,11 @@ import androidx.compose.ui.unit.dp
 import expo.modules.devmenu.compose.DevMenuState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-private val FabDefaultSize = DpSize(72.dp, 94.dp)
+private val FabDefaultSize = DpSize(52.dp, 94.dp)
+private val FabContentSize = DpSize(52.dp, 52.dp)
 private val Margin = 16.dp
 private const val ClickDragTolerance = 40f
 
@@ -46,22 +51,38 @@ private const val ClickDragTolerance = 40f
 fun MovableFloatingActionButton(
   state: DevMenuState,
   modifier: Modifier = Modifier,
-  fabSize: DpSize = FabDefaultSize,
   margin: Dp = Margin,
   onPress: () -> Unit = {}
 ) {
+  var showLabel by remember { mutableStateOf(true) }
+
+  LaunchedEffect(Unit) {
+    delay(10_000)
+    showLabel = false
+  }
+
   BoxWithConstraints(
     modifier = modifier
       .safeDrawingPadding()
       .fillMaxSize()
   ) {
-    val totalFabSize = DpSize(fabSize.width + margin * 2, fabSize.height + margin * 2)
+    val effectiveFabSize = if (showLabel) {
+      FabDefaultSize
+    } else {
+      FabContentSize
+    }
+    val totalFabSize = DpSize(effectiveFabSize.width + margin * 2, effectiveFabSize.height + margin * 2)
     val totalFabSizePx = with(LocalDensity.current) {
       Offset(totalFabSize.width.toPx(), totalFabSize.height.toPx())
     }
+    val fabPressableSizeWithMargin = DpSize(FabContentSize.width + margin * 2, FabContentSize.height + margin * 2)
+    val fabPressableSizeWithMarginPx = with(LocalDensity.current) {
+      Offset(fabPressableSizeWithMargin.width.toPx(), fabPressableSizeWithMargin.height.toPx())
+    }
+
     val bounds = Offset(
-      x = constraints.maxWidth - totalFabSizePx.x,
-      y = constraints.maxHeight - totalFabSizePx.y
+      x = constraints.maxWidth - fabPressableSizeWithMarginPx.x,
+      y = constraints.maxHeight - fabPressableSizeWithMarginPx.y
     )
 
     val halfFab = Offset(totalFabSizePx.x / 2f, totalFabSizePx.y / 2f)
@@ -185,6 +206,7 @@ fun MovableFloatingActionButton(
           isPressed = fab.isPressed,
           isDragging = fab.isDragging,
           isIdle = fab.isIdle,
+          showLabel = showLabel,
           modifier = Modifier.fillMaxSize()
         )
       }


### PR DESCRIPTION
# Why

The FAB keeps the same size after the label disappears. This PR changes the FAB behavior so that it shrinks if there is no label

Before:
<img width="98" height="123" alt="Screenshot 2026-05-18 at 18 04 21" src="https://github.com/user-attachments/assets/c3bd4a8a-e475-46d9-a3e1-47465da2dbf4" />
After:
<img width="95" height="79" alt="Screenshot 2026-05-18 at 18 02 23" src="https://github.com/user-attachments/assets/be7cb39a-8d14-4914-a57b-784c1a30b94e" />

# How

- Moved `showLabel` higher to `MovableFloatingActionButton`
- Changed the bounds calculations so that they don't rely on the FAB size with the label
- Removed the `fabSize` prop from `MovableFloatingActionButton`. It was problematic because the icon size is hardcoded, it wasn't used anywhere, and changing it only impacted the margin

# Test Plan

BareExpo, ExpoGo  ✅