### PR TITLE
[gl] Make WebGL2RenderingContext extend WebGLRenderingContext

### DIFF
--- a/apps/test-suite/tests/GLView.js
+++ b/apps/test-suite/tests/GLView.js
@@ -106,6 +106,24 @@ export async function test(
         ).toBe(true);
       });
 
+      it('WebGL2 contexts inherit from WebGLRenderingContext', async () => {
+        if (Platform.OS === 'web') {
+          // On web the context comes from the browser's `canvas.getContext`,
+          // and despite what the WebIDL spec calls for, browser engines
+          // (Chrome, Safari, and historically Firefox) all expose WebGL2
+          // contexts whose prototype chain does not include
+          // WebGLRenderingContext. This test verifies expo-gl's native
+          // inheritance fix, not browser behavior.
+          return;
+        }
+        const context = await getContextAsync();
+        // Per the WebGL spec WebGL2RenderingContext extends
+        // WebGLRenderingContext, so a WebGL2 instance must satisfy both
+        // `instanceof` checks.
+        expect(context instanceof WebGL2RenderingContext).toBe(true);
+        expect(context instanceof WebGLRenderingContext).toBe(true);
+      });
+
       it('takes a snapshot', async () => {
         await getContextAsync();
 

--- a/packages/expo-gl/CHANGELOG.md
+++ b/packages/expo-gl/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Install `WebGLRenderingContext` and `WebGL2RenderingContext` globals and their numeric constants at module init so libraries that read them before any GL context is created no longer crash. ([#45865](https://github.com/expo/expo/pull/45865) by [@tsapeta](https://github.com/tsapeta))
+- Make `WebGL2RenderingContext` inherit from `WebGLRenderingContext`, matching the WebGL spec. `gl2 instanceof WebGLRenderingContext` now returns `true` for WebGL2 contexts, and shared constants and methods are no longer duplicated on the WebGL2 prototype. ([#45871](https://github.com/expo/expo/pull/45871) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-gl/common/EXJsiUtils.h
+++ b/packages/expo-gl/common/EXJsiUtils.h
@@ -60,6 +60,22 @@ inline void setFunctionOnObject(
     runtime, jsName, jsi::Function::createFromHostFunction(runtime, jsName, 0, func));
 }
 
+// Sets `derived.__proto__ = base`, equivalent to `Object.setPrototypeOf` in
+// JS. For two constructor functions A and B, this is the static-side half of
+// `class B extends A {}` — property lookups on B fall through to A.
+inline void setObjectPrototypeOf(
+  jsi::Runtime &runtime,
+  jsi::Object &derived,
+  jsi::Object &base) {
+  jsi::Object objectClass = runtime.global().getPropertyAsObject(runtime, "Object");
+  objectClass
+    .getPropertyAsFunction(runtime, "setPrototypeOf")
+    .callWithThis(
+      runtime,
+      objectClass,
+      {jsi::Value(runtime, derived), jsi::Value(runtime, base)});
+}
+
 inline void jsConsoleLog(jsi::Runtime &runtime, std::initializer_list<jsi::Value> args) {
   runtime.global()
     .getProperty(runtime, "console")

--- a/packages/expo-gl/common/EXWebGLRenderer.cpp
+++ b/packages/expo-gl/common/EXWebGLRenderer.cpp
@@ -124,14 +124,6 @@ std::string getConstructorName(EXWebGLClass value) {
   }
 }
 
-void attachClass(
-  jsi::Runtime &runtime,
-  EXWebGLClass webglClass,
-  std::function<void(EXWebGLClass webglClass)> installPrototypes) {
-  jsi::PropNameID name = jsi::PropNameID::forUtf8(runtime, getConstructorName(webglClass));
-  installPrototypes(webglClass);
-}
-
 // https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Inheritance#setting_teachers_prototype_and_constructor_reference
 //
 // Below implementation is equivalent of `class WebGLBuffer extends WebGLObject {}`
@@ -211,8 +203,28 @@ void installWebGLConstructorsAndConstants(jsi::Runtime &runtime) {
   inheritFromJsObject(EXWebGLClass::WebGLRenderingContext);
   installConstantsOnConstructor(EXWebGLClass::WebGLRenderingContext);
 
-  inheritFromJsObject(EXWebGLClass::WebGL2RenderingContext);
-  installConstantsOnConstructor(EXWebGLClass::WebGL2RenderingContext);
+  // Make WebGL2RenderingContext extend WebGLRenderingContext on both sides,
+  // matching the WebGL spec and what `class WebGL2RenderingContext extends
+  // WebGLRenderingContext {}` would produce. Saves duplicating constants and
+  // WebGL1 methods on the WebGL2 prototype, and gives `instanceof
+  // WebGLRenderingContext` the right answer for WebGL2 instances.
+  auto webglRenderingContext =
+    runtime.global()
+      .getProperty(
+        runtime,
+        jsi::PropNameID::forUtf8(runtime, getConstructorName(EXWebGLClass::WebGLRenderingContext)))
+      .asObject(runtime);
+  jsClassExtend(
+    runtime,
+    webglRenderingContext,
+    jsi::PropNameID::forUtf8(runtime, getConstructorName(EXWebGLClass::WebGL2RenderingContext)));
+  jsi::Object webgl2RenderingContext =
+    runtime.global()
+      .getProperty(
+        runtime,
+        jsi::PropNameID::forUtf8(runtime, getConstructorName(EXWebGLClass::WebGL2RenderingContext)))
+      .asObject(runtime);
+  setObjectPrototypeOf(runtime, webgl2RenderingContext, webglRenderingContext);
 
   // Configure rest of WebGL objects
   inheritFromJsObject(EXWebGLClass::WebGLObject);
@@ -256,8 +268,9 @@ void installWebGLInstanceMethods(jsi::Runtime &runtime) {
   installConstants(runtime, webglPrototype);
   installWebGLMethods(runtime, webglPrototype);
 
+  // Constants and WebGL1 methods reach the WebGL2 prototype via inheritance;
+  // only the WebGL2-exclusive methods need installing here.
   auto webgl2Prototype = getRenderingContextPrototype(runtime, EXWebGLClass::WebGL2RenderingContext);
-  installConstants(runtime, webgl2Prototype);
   installWebGL2Methods(runtime, webgl2Prototype);
 }
 
@@ -280,17 +293,17 @@ void installWebGLMethods(jsi::Runtime &runtime, jsi::Object &gl) {
 #undef NATIVE_METHOD
 }
 
+// Installs only WebGL2-exclusive methods. WebGL1 methods reach WebGL2
+// instances via the prototype chain (WebGL2RenderingContext.prototype
+// inherits from WebGLRenderingContext.prototype).
 void installWebGL2Methods(jsi::Runtime &runtime, jsi::Object &gl) {
-#define CREATE_METHOD(name) setFunctionOnObject(runtime, gl, #name, method::glNativeMethod_##name);
-
-#define NATIVE_METHOD(name) CREATE_METHOD(name)
-#define NATIVE_WEBGL2_METHOD(name) CREATE_METHOD(name)
+#define NATIVE_METHOD(name) ;
+#define NATIVE_WEBGL2_METHOD(name) setFunctionOnObject(runtime, gl, #name, method::glNativeMethod_##name);
 
 #include "EXWebGLMethods.def"
 
 #undef NATIVE_WEBGL2_METHOD
 #undef NATIVE_METHOD
-#undef CREATE_METHOD
 }
 
 } // namespace gl_cpp


### PR DESCRIPTION
Stacked on top of #45865.

## Why

`WebGL2RenderingContext` previously inherited from `Object`, which diverged from the WebGL spec (and from what `class WebGL2RenderingContext extends WebGLRenderingContext {}` would produce in plain ES):

- `gl2 instanceof WebGLRenderingContext` returned `false`.
- Static GL constants on `WebGL2RenderingContext.LINEAR` and shared WebGL1 methods had to be installed twice — once on each prototype, once on each constructor — to make instance and static access work.

The existing test in `apps/test-suite/tests/GLView.js` even works around this: `context instanceof WebGLRenderingContext || context instanceof WebGL2RenderingContext`.

## What

Wire both halves of ES-style inheritance:

- **Prototype chain:** `WebGL2RenderingContext.prototype.__proto__ === WebGLRenderingContext.prototype` (via `jsClassExtend`).
- **Constructor chain:** `WebGL2RenderingContext.__proto__ === WebGLRenderingContext` (via a new `setObjectPrototypeOf` helper in `EXJsiUtils.h`).

With inheritance in place, drop:

- The 560 static-constant install on the WebGL2 constructor.
- The 560 prototype-constant install on the WebGL2 prototype.
- The 138 WebGL1 method install on the WebGL2 prototype.

These all reach WebGL2 instances and the WebGL2 constructor via the prototype chain.

Also removed a dead `attachClass` helper that was defined but never called.

## Perf measurements

Measured by wrapping the two install functions with `std::chrono::steady_clock` and reporting microseconds via `EXGLSysLog`. Multiple runs each, medians reported.

### iOS device (debug build)

| Step | Before | After | Δ |
|---|---|---|---|
| `installWebGLConstructorsAndConstants` | ~607 µs | ~514 µs | **−15%** |
| `installWebGLInstanceMethods` | ~900 µs | ~534 µs | **−41%** |
| Total per-context | ~1,507 µs | ~1,048 µs | **−30%** |

### Android emulator (debug build)

| Step | Before | After | Δ |
|---|---|---|---|
| `installWebGLConstructorsAndConstants` | ~580 µs (520–1,257 µs range, noisy) | ~650 µs (477–822 µs) | flat-to-modest |
| `installWebGLInstanceMethods` | ~580 µs (450–1,290 µs range) | ~347 µs (343–350 µs) | **~−40%** |
| Total per-context | ~1,160 µs | ~997 µs | **~−14%** |

Android emulator step-1 numbers are too noisy to call precisely (host CPU contention), but the lower bound (477 µs) sits comfortably under the prior median. Step 2 dropped consistently on both platforms, in line with the workload removed (half of it disappears with the inheritance fix).

Step 1's smaller win is because the new `setObjectPrototypeOf` call costs some of what the dropped constants install saved; step 2's larger win is because nearly half of its prior work (constants + WebGL1 methods on the WebGL2 prototype) is gone.

## Test plan

- [x] iOS device: `apps/test-suite/tests/GLView.js` passes, including the new `'WebGL2 contexts inherit from WebGLRenderingContext'` assertion.
- [x] Android device: same.
- New test asserts both `instanceof WebGLRenderingContext` and `instanceof WebGL2RenderingContext` hold for a WebGL2 context. On the vanishing tail of devices that only support OpenGL ES 2.0, this assertion will fail — which is the right signal that the device doesn't meet expo-gl's WebGL2 baseline.