### PR TITLE
[ios][ui] Apply Host modifiers prop

### DIFF
--- a/apps/native-component-list/src/screens/UI/ModifiersScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/ModifiersScreen.ios.tsx
@@ -68,6 +68,7 @@ import {
   contentShape,
   shapes,
   resizable,
+  tint,
 } from '@expo/ui/swift-ui/modifiers';
 import { useAssets } from 'expo-asset';
 import { useState } from 'react';
@@ -131,7 +132,12 @@ export default function ModifiersScreen() {
 
   return (
     <ScrollView>
-      <Host matchContents>
+      <Host
+        matchContents
+        modifiers={[
+          tint('#FF6B6B'),
+          font({ size: 16, weight: 'medium', design: 'rounded' }),
+        ]}>
         <Form
           modifiers={[
             scrollContentBackground(hideScrollBackground ? 'hidden' : 'visible'),

--- a/apps/native-component-list/src/screens/UI/ModifiersScreen.ios.tsx
+++ b/apps/native-component-list/src/screens/UI/ModifiersScreen.ios.tsx
@@ -134,10 +134,7 @@ export default function ModifiersScreen() {
     <ScrollView>
       <Host
         matchContents
-        modifiers={[
-          tint('#FF6B6B'),
-          font({ size: 16, weight: 'medium', design: 'rounded' }),
-        ]}>
+        modifiers={[tint('#FF6B6B'), font({ size: 16, weight: 'medium', design: 'rounded' })]}>
         <Form
           modifiers={[
             scrollContentBackground(hideScrollBackground ? 'hidden' : 'visible'),

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Unmount `BottomSheet` when it is dismissed. ([#45846](https://github.com/expo/expo/pull/45846) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Apply `modifiers` prop on `Host` instead of silently dropping it. ([#45872](https://github.com/expo/expo/pull/45872) by [@ramonclaudio](https://github.com/ramonclaudio))
 
 ### 💡 Others
 

--- a/packages/expo-ui/ios/ExpoUIModule.swift
+++ b/packages/expo-ui/ios/ExpoUIModule.swift
@@ -81,13 +81,16 @@ public final class ExpoUIModule: Module {
       }
     }
 
-    // MARK: - Views don't support common view modifiers
+    // MARK: - Views that apply common view modifiers internally
+
+    View(HostView.self)
+    View(TextView.self)
+
+    // MARK: - Views that don't support common view modifiers
 
     View(SlotView.self)
     View(NamespaceView.self)
     View(GridRowView.self)
-    View(HostView.self)
-    View(TextView.self)
 
     // MARK: - Expo UI Views
 

--- a/packages/expo-ui/ios/HostView.swift
+++ b/packages/expo-ui/ios/HostView.swift
@@ -38,6 +38,7 @@ internal final class HostViewProps: ExpoSwiftUI.ViewProps, ExpoSwiftUI.SafeAreaC
   @Field var matchContentsHorizontal = false
   @Field var matchContentsVertical = false
   @Field var ignoreSafeArea: ExpoSwiftUI.IgnoreSafeArea?
+  @Field var modifiers: ModifierArray?
   var onLayoutContent = EventDispatcher()
 }
 
@@ -45,38 +46,40 @@ struct HostView: ExpoSwiftUI.View, ExpoSwiftUI.WithHostingView {
   @ObservedObject var props: HostViewProps
 
   var body: some View {
-    var useViewportSizeMeasurement: Bool = props.useViewportSizeMeasurement
-    if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
-      useViewportSizeMeasurement = props.useViewportSizeMeasurement
-    } else {
-      log.warn("useViewportSizeMeasurement is not supported on iOS/tvOS < 16.0")
-      useViewportSizeMeasurement = false
-    }
-
     let layoutDirection = props.layoutDirection.toLayoutDirection()
     let alignment: Alignment = layoutDirection == .rightToLeft ? .topTrailing : .topLeading
 
     if #available(iOS 16.0, tvOS 16.0, macOS 13.0, *) {
       // swiftlint:disable:next identifier_name
-      let HostLayout = useViewportSizeMeasurement
+      let HostLayout = props.useViewportSizeMeasurement
         ? AnyLayout(ViewportSizeMeasurementLayout(layoutDirection: layoutDirection))
         : AnyLayout(ZStackLayout(alignment: alignment))
-      return HostLayout {
+      HostLayout {
         Children()
       }
       .fixedSize(horizontal: props.matchContentsHorizontal, vertical: props.matchContentsVertical)
       .modifier(LayoutDirectionModifier(layoutDirection: layoutDirection))
       .modifier(ColorSchemeModifier(colorScheme: props.colorScheme?.toColorScheme()))
+      .applyModifiers(
+        props.modifiers,
+        appContext: props.appContext,
+        globalEventDispatcher: props.globalEventDispatcher
+      )
+      .modifier(GeometryChangeModifier(props: props))
+    } else {
+      ZStack(alignment: alignment) {
+        Children()
+      }
+      .fixedSize(horizontal: props.matchContentsHorizontal, vertical: props.matchContentsVertical)
+      .modifier(LayoutDirectionModifier(layoutDirection: layoutDirection))
+      .modifier(ColorSchemeModifier(colorScheme: props.colorScheme?.toColorScheme()))
+      .applyModifiers(
+        props.modifiers,
+        appContext: props.appContext,
+        globalEventDispatcher: props.globalEventDispatcher
+      )
       .modifier(GeometryChangeModifier(props: props))
     }
-
-    return ZStack(alignment: alignment) {
-      Children()
-    }
-    .fixedSize(horizontal: props.matchContentsHorizontal, vertical: props.matchContentsVertical)
-    .modifier(LayoutDirectionModifier(layoutDirection: layoutDirection))
-    .modifier(ColorSchemeModifier(colorScheme: props.colorScheme?.toColorScheme()))
-    .modifier(GeometryChangeModifier(props: props))
   }
 
   private func safeAreaSize() -> CGSize {


### PR DESCRIPTION
Fixes `<Host modifiers={...}>` being silently dropped on iOS. `HostProps` (TS) already extends `CommonViewModifierProps` and `Host/index.tsx` already forwards `modifiers` to the native view, but `HostViewProps` (Swift) never declared the field. The prop got dropped during deserialization and every typechecked modifier on `Host` was a no-op no matter what you passed.

The fix is generic across the registered modifier surface. Once `HostViewProps` accepts the field and `HostView.body` chains `.applyModifiers(...)`, the same `ViewModifierRegistry` dispatch path that already handles every modifier on `UIBaseView` and `TextView` becomes available to `Host`. One field plus one chain restores the entire registered set in a single shot. Environment propagation (`tint`, `font`, `foregroundStyle`, `disabled`), layout (`frame`, `padding`), chrome (`background`, `clipShape`, `border`, `shadow`), transforms (`rotationEffect`, `scaleEffect`), filters (`blur`, `opacity`, `grayscale`), gestures (`onTapGesture`), and iOS 26 Liquid Glass (`glassEffect`).

```tsx
import { Host, Toggle, Slider, Button, VStack } from '@expo/ui/swift-ui';
import {
  tint, font, foregroundStyle, padding, background, clipShape, shadow,
} from '@expo/ui/swift-ui/modifiers';

<Host
  matchContents
  modifiers={[
    tint('#A78BFA'),
    font({ size: 16, weight: 'semibold', design: 'rounded' }),
    foregroundStyle('#0F172A'),
    padding({ all: 16 }),
    background('#FFF'),
    clipShape('roundedRectangle', 16),
    shadow({ radius: 12, y: 6, color: '#00000033' }),
  ]}>
  <VStack>
    <Toggle isOn={enabled} onIsOnChange={setEnabled} label="Notifications" />
    <Slider value={volume} onValueChange={setVolume} min={0} max={1} />
    <Button label="Save" onPress={save} />
    {/* every nested control inherits the cascade */}
  </VStack>
</Host>
```

# Test Plan

Test repro with screenshots here: [`ramonclaudio/expo-ui-host-modifiers-45872-repro`](https://github.com/ramonclaudio/expo-ui-host-modifiers-45872-repro). The README walks through all 15 cards so you can preview the demo without rebuilding.

Smoke-tested on iPhone 17 Pro simulator (iOS 26.5, Xcode 26.5) via `apps/native-component-list`:

- `pnpm build`, `pnpm lint --max-warnings 0`, and `pnpm test` (9 suites, 50 tests) all green in `packages/expo-ui`.
- `et generate-docs-api-data -p expo-ui` produces no diffs caused by this PR. The TypeScript surface is unchanged so there's nothing to regenerate. The only diffs it surfaced were unrelated drift from other PRs, which I discarded.
- Modifiers screen in `apps/native-component-list` renders descendant `Toggle`, `Picker`, `Slider`, and `Stepper` tinted in `#FF6B6B` and in `font({ size: 16, weight: 'medium', design: 'rounded' })` once the outer `Host` is wrapped in the two-modifier chain. Removing the `@Field var modifiers` from `HostViewProps` and rebuilding makes both effects vanish at once.
- Standalone repro renders 15 side-by-side cards covering every category against an unmodified Host. Environment (`tint`, `font`, `foregroundStyle`, `disabled`), chrome (`background`, `cornerRadius`, `border`, `shadow` stacked), transforms (`rotationEffect`, `scaleEffect`), filters (`blur`, `opacity`, `grayscale`), interaction (`onTapGesture`), and iOS 26 Liquid Glass (`glassEffect`). With the patch removed, every "WITH MODIFIER" column looks identical to the default.
