### PR TITLE
[expo-image] [iOS] Fix `placeholder` failing to load images from the ios asset catalog (xcassets)

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `placeholder` failing to load images from the asset catalog (xcassets).
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-06

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -347,22 +347,26 @@ public final class ImageView: ExpoView {
   }
 
   private func maybeRenderLocalAsset(from source: ImageSource) -> Bool {
-    let path: String? = {
-      // .path() on iOS 16 would remove the leading slash, but it doesn't on tvOS 16 🙃
-      // It also crashes with EXC_BREAKPOINT when parsing data:image uris
-      // manually drop the leading slash below iOS 16
-      if let path = source.uri?.path {
-        return String(path.dropFirst())
-      }
-      return nil
-    }()
-
-    if let path, !path.isEmpty, let local = UIImage(named: path) {
+    if let local = localAssetImage(from: source) {
       renderSourceImage(local)
       return true
     }
 
     return false
+  }
+
+  private func localAssetImage(from source: ImageSource) -> UIImage? {
+    // .path() on iOS 16 would remove the leading slash, but it doesn't on tvOS 16 🙃
+    // It also crashes with EXC_BREAKPOINT when parsing data:image uris
+    // manually drop the leading slash below iOS 16
+    guard let path = source.uri?.path else {
+      return nil
+    }
+    let trimmed = String(path.dropFirst())
+    guard !trimmed.isEmpty else {
+      return nil
+    }
+    return UIImage(named: trimmed)
   }
 
   // MARK: - Placeholder
@@ -412,6 +416,14 @@ public final class ImageView: ExpoView {
     // Exit early if placeholder is not set or there is already an image attached to the view.
     // The placeholder is only used until the first image is loaded.
     guard canDisplayPlaceholder, let placeholder = bestPlaceholder else {
+      return
+    }
+
+    // Asset catalog (xcassets) images aren't resolvable by SDWebImage, so try the
+    // local lookup first — mirroring the proper source path in `maybeRenderLocalAsset`.
+    if let localImage = localAssetImage(from: placeholder) {
+      placeholderImage = localImage
+      displayPlaceholderIfNecessary()
       return
     }
 


### PR DESCRIPTION
Hi all, found a small issue in `expo-image`, with `placeholder` prop. 
This is a pretty small fix! Unfortunately I wasn't able to find a good tests for expo-image, and not sure how to cover properly this particular case, but if you can give me any tips, I can add tests.

Please find issue details below.

# Why

On iOS, passing an image from the asset catalog (xcassets) to `<Image source>` works correctly, but passing the same image to the `placeholder` prop silently fails, nothing renders.

# How

I used same logic as used for loading image source. 

# Test Plan

1. Add an image `my-placeholder` to the iOS asset catalog (xcassets).
2. Render:
```
<Image
  source={{ uri: 'corrupted-url' }}
  placeholder="my-placeholder"
/>
```
3. Before this change: the placeholder area stays empty until the remote image loads.
4. After this change: the xcassets image renders as the placeholder until the remote image loads, matching the behavior when the same asset is passed as source.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
