### PR TITLE
fix(cli): Check API URL for `wrapFetchWithCredentials` and detach `resolveTemplate` [EXP-50]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### 💡 Others
 
 - Use `osascript.escapeString` utility in `open.ts` ([#45890](https://github.com/expo/expo/pull/45890) by [@kitten](https://github.com/kitten))
+- [Internal] Isolate `expo-session` requests to Expo API and update `resolveTemplate ([#45875](https://github.com/expo/expo/pull/45875) by [@kitten](https://github.com/kitten))
 
 ## 56.1.6 — 2026-05-19
 

--- a/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
+++ b/packages/@expo/cli/src/api/rest/__tests__/client-test.ts
@@ -163,6 +163,24 @@ it('makes an authenticated request with session secret', async () => {
   expect(await fetchAsync('get-me', { method: 'GET' })).toMatchObject({ status: 200 });
 });
 
+it('does not attach Expo credentials to absolute non-Expo URLs', async () => {
+  jest.mocked(getAccessToken).mockClear().mockReturnValue('my-access-token');
+  jest.mocked(getSession).mockClear().mockReturnValue({
+    sessionSecret: 'my-secret-token',
+    userId: '',
+    username: '',
+    currentConnection: 'Username-Password-Authentication',
+  });
+
+  nock('https://api.github.com')
+    .matchHeader('authorization', (val) => !val)
+    .matchHeader('expo-session', (val) => !val)
+    .get('/repos/expo/expo')
+    .reply(200, '{}');
+
+  expect(await fetchAsync('https://api.github.com/repos/expo/expo')).toMatchObject({ status: 200 });
+});
+
 it('only uses access token when both authentication methods are available', async () => {
   jest.mocked(getAccessToken).mockClear().mockReturnValue('my-access-token');
   jest.mocked(getSession).mockClear().mockReturnValue({

--- a/packages/@expo/cli/src/api/rest/client.ts
+++ b/packages/@expo/cli/src/api/rest/client.ts
@@ -74,8 +74,17 @@ export function getResponseDataOrThrow<T = any>(json: unknown): T {
 
 /**
  * @returns a `fetch` function that will inject user authentication information and handle errors from the Expo API.
+ *
+ * Credentials are only attached to requests targeting `expoApiBaseUrl`'s origin (including relative
+ * URLs, which the downstream base-URL wrapper resolves against the Expo API). Absolute URLs to any
+ * other host pass through without Expo credentials.
  */
-export function wrapFetchWithCredentials(fetchFunction: FetchLike): FetchLike {
+export function wrapFetchWithCredentials(
+  fetchFunction: FetchLike,
+  expoApiBaseUrl: string
+): FetchLike {
+  const expoApiOrigin = new URL(expoApiBaseUrl).origin;
+
   return async function fetchWithCredentials(url, options = {}) {
     if (Array.isArray(options.headers)) {
       throw new Error('request headers must be in object form');
@@ -83,13 +92,15 @@ export function wrapFetchWithCredentials(fetchFunction: FetchLike): FetchLike {
 
     const resolvedHeaders = options.headers ?? ({} as any);
 
-    const token = getAccessToken();
-    if (token) {
-      resolvedHeaders.authorization = `Bearer ${token}`;
-    } else {
-      const sessionSecret = getSession()?.sessionSecret;
-      if (sessionSecret) {
-        resolvedHeaders['expo-session'] = sessionSecret;
+    if (isExpoApiUrl(url, expoApiBaseUrl, expoApiOrigin)) {
+      const token = getAccessToken();
+      if (token) {
+        resolvedHeaders.authorization = `Bearer ${token}`;
+      } else {
+        const sessionSecret = getSession()?.sessionSecret;
+        if (sessionSecret) {
+          resolvedHeaders['expo-session'] = sessionSecret;
+        }
       }
     }
 
@@ -133,6 +144,18 @@ export function wrapFetchWithCredentials(fetchFunction: FetchLike): FetchLike {
   };
 }
 
+function isExpoApiUrl(url: unknown, expoApiBaseUrl: string, expoApiOrigin: string): boolean {
+  if (typeof url !== 'string') {
+    return false;
+  }
+  try {
+    // Relative URLs resolve against the Expo API base, so they always match the Expo origin.
+    return new URL(url, expoApiBaseUrl).origin === expoApiOrigin;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Determine if the provided error is related to a network issue.
  * When this returns true, offline mode should be enabled.
@@ -153,9 +176,13 @@ function isNetworkError(error: Error & { code?: string }) {
 
 const fetchWithOffline = wrapFetchWithOffline(wrapFetchWithUserAgent(fetch));
 
-const fetchWithBaseUrl = wrapFetchWithBaseUrl(fetchWithOffline, getExpoApiBaseUrl() + '/v2/');
+const expoApiBaseUrl = getExpoApiBaseUrl() + '/v2/';
 
-const fetchWithCredentials = wrapFetchWithProgress(wrapFetchWithCredentials(fetchWithBaseUrl));
+const fetchWithBaseUrl = wrapFetchWithBaseUrl(fetchWithOffline, expoApiBaseUrl);
+
+const fetchWithCredentials = wrapFetchWithProgress(
+  wrapFetchWithCredentials(fetchWithBaseUrl, expoApiBaseUrl)
+);
 
 /**
  * Create an instance of the fully qualified fetch command (auto authentication and api) but with caching in the '~/.expo' directory.
@@ -190,4 +217,6 @@ export function createCachedFetch({
 }
 
 /** Instance of fetch with automatic base URL pointing to the Expo API, user credential injection, and API error handling. Caching not included.  */
-export const fetchAsync = wrapFetchWithProgress(wrapFetchWithCredentials(fetchWithBaseUrl));
+export const fetchAsync = wrapFetchWithProgress(
+  wrapFetchWithCredentials(fetchWithBaseUrl, expoApiBaseUrl)
+);

--- a/packages/@expo/cli/src/prebuild/resolveTemplate.ts
+++ b/packages/@expo/cli/src/prebuild/resolveTemplate.ts
@@ -4,17 +4,16 @@ import type { Ora } from 'ora';
 import semver from 'semver';
 
 import type { ResolvedTemplateOption } from './resolveOptions';
-import { fetchAsync } from '../api/rest/client';
 import * as Log from '../log';
 import { resolveLocalTemplateAsync } from './resolveLocalTemplate';
 import { createGlobFilter } from '../utils/createFileTransform';
 import { AbortCommandError } from '../utils/errors';
+import { fetch } from '../utils/fetch';
 import {
   downloadAndExtractNpmModuleAsync,
   extractLocalNpmTarballAsync,
   extractNpmTarballFromUrlAsync,
 } from '../utils/npm';
-import { isUrlOk } from '../utils/url';
 
 const debug = require('debug')('expo:prebuild:resolveTemplate') as typeof console.log;
 
@@ -83,8 +82,9 @@ async function getRepoInfo(url: any, examplePath?: string): Promise<RepoInfo | u
 
   // Support repos whose entire purpose is to be an example, e.g.
   // https://github.com/:username/:my-cool-example-repo-name.
+  // Use the plain unauthenticated `fetch` so Expo credentials aren't forwarded to GitHub.
   if (t === undefined) {
-    const infoResponse = await fetchAsync(`https://api.github.com/repos/${username}/${name}`);
+    const infoResponse = await fetch(`https://api.github.com/repos/${username}/${name}`);
     if (infoResponse.status !== 200) {
       return;
     }
@@ -103,11 +103,16 @@ async function getRepoInfo(url: any, examplePath?: string): Promise<RepoInfo | u
   return undefined;
 }
 
-function hasRepo({ username, name, branch, filePath }: RepoInfo) {
+async function hasRepo({ username, name, branch, filePath }: RepoInfo): Promise<boolean> {
   const contentsUrl = `https://api.github.com/repos/${username}/${name}/contents`;
   const packagePath = `${filePath ? `/${filePath}` : ''}/package.json`;
 
-  return isUrlOk(contentsUrl + packagePath + `?ref=${branch}`);
+  try {
+    const response = await fetch(contentsUrl + packagePath + `?ref=${branch}`);
+    return response.ok;
+  } catch {
+    return false;
+  }
 }
 
 async function downloadAndExtractRepoAsync(

--- a/packages/@expo/cli/src/utils/__tests__/url-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/url-test.ts
@@ -17,19 +17,6 @@ describe(validateUrl, () => {
   });
 });
 
-describe(isUrlOk, () => {
-  it(`returns false when the URL returns non-200`, async () => {
-    const scope = nock('http://example.com').get('/').reply(504, '');
-    expect(await isUrlOk('http://example.com')).toBe(false);
-    expect(scope.isDone()).toBe(true);
-  });
-  it(`returns true when the URL returns 200`, async () => {
-    const scope = nock('http://example.com').get('/').reply(200, '');
-    expect(await isUrlOk('http://example.com')).toBe(true);
-    expect(scope.isDone()).toBe(true);
-  });
-});
-
 describe(stripPort, () => {
   // Used in the manifest handler when the Expo Go app requests the given hostname to use.
   it(`removes the port from a host string`, async () => {

--- a/packages/@expo/cli/src/utils/url.ts
+++ b/packages/@expo/cli/src/utils/url.ts
@@ -1,8 +1,6 @@
 import dns from 'dns';
 import { URL } from 'url';
 
-import { fetchAsync } from '../api/rest/client';
-
 /** Check if a server is available based on the URL. */
 export function isUrlAvailableAsync(url: string): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
@@ -10,16 +8,6 @@ export function isUrlAvailableAsync(url: string): Promise<boolean> {
       resolve(!err);
     });
   });
-}
-
-/** Check if a request to the given URL is `ok` (status 200). */
-export async function isUrlOk(url: string): Promise<boolean> {
-  try {
-    const res = await fetchAsync(url);
-    return res.ok;
-  } catch {
-    return false;
-  }
 }
 
 /** Determine if a string is a valid URL, can optionally ensure certain protocols (like `https` or `exp`) are adhered to. */


### PR DESCRIPTION
## Summary

We accidentally started using the `fetch` call with credentials for calls that shouldn't use it. We can switch those over to plain `fetch` one-by-one. The most important one for now is the call in `resolveTemplate`.

This doesn't so far cause issues, but we can check the `origin` before setting `expo-session` to defend from this happening again.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
