### PR TITLE
feat(cli): Accept `expo login -p -` to input password programmtically [EXP-52]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Add `/_expo/open` middleware for programmatically resolving deep links and disambiguation pages for the running dev server. ([#45804](https://github.com/expo/expo/pull/45804) by [@EvanBacon](https://github.com/EvanBacon))
 - Upgrade react-native-tvos to the correct version on install/fix. ([#45816](https://github.com/expo/expo/pull/45816) by [@douglowder](https://github.com/douglowder))
+- Accept `expo login -p -` argument to read password from stdin ([#45877](https://github.com/expo/expo/pull/45877) by [@kitten](https://github.com/kitten))
 
 ### 🐛 Bug fixes
 

--- a/packages/@expo/cli/e2e/__tests__/login-test.ts
+++ b/packages/@expo/cli/e2e/__tests__/login-test.ts
@@ -38,7 +38,7 @@ it('runs `npx expo login --help`', async () => {
 
       Options
         -u, --username <string>  Username
-        -p, --password <string>  Password
+        -p, --password <string>  Password ("-" for stdin)
         --otp <string>           One-time password from your 2FA device
         -s, --sso                Log in with SSO
         -b, --browser            Log in with a browser

--- a/packages/@expo/cli/src/login/__tests__/index-test.ts
+++ b/packages/@expo/cli/src/login/__tests__/index-test.ts
@@ -1,0 +1,46 @@
+import { Readable } from 'stream';
+
+import { readWordFromStdin } from '../index';
+
+const originalStdin = process.stdin;
+
+function withFakeStdin(chunks: string[]) {
+  Object.defineProperty(process, 'stdin', {
+    value: Readable.from(chunks.map((chunk) => Buffer.from(chunk))),
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'stdin', { value: originalStdin, configurable: true });
+});
+
+it('returns the first line of stdin', async () => {
+  withFakeStdin(['supersecret\nignored\n']);
+
+  expect(await readWordFromStdin()).toBe('supersecret');
+});
+
+it('reassembles a line split across chunks', async () => {
+  withFakeStdin(['super', 'sec', 'ret\n']);
+
+  expect(await readWordFromStdin()).toBe('supersecret');
+});
+
+it('strips a trailing CR for CRLF input', async () => {
+  withFakeStdin(['supersecret\r\n']);
+
+  expect(await readWordFromStdin()).toBe('supersecret');
+});
+
+it('returns the buffered content when EOF arrives without a newline', async () => {
+  withFakeStdin(['supersecret']);
+
+  expect(await readWordFromStdin()).toBe('supersecret');
+});
+
+it('returns an empty string when stdin is empty', async () => {
+  withFakeStdin([]);
+
+  expect(await readWordFromStdin()).toBe('');
+});

--- a/packages/@expo/cli/src/login/index.ts
+++ b/packages/@expo/cli/src/login/index.ts
@@ -29,7 +29,7 @@ export const expoLogin: Command = async (argv) => {
       `npx expo login`,
       [
         `-u, --username <string>  Username`,
-        `-p, --password <string>  Password`,
+        `-p, --password <string>  Password ("-" for stdin)`,
         `--otp <string>           One-time password from your 2FA device`,
         `-s, --sso                Log in with SSO`,
         `-b, --browser            Log in with a browser`,
@@ -38,13 +38,27 @@ export const expoLogin: Command = async (argv) => {
     );
   }
 
+  const password = args['--password'] === '-' ? await readWordFromStdin() : args['--password'];
+
   const { showLoginPromptAsync } = await import('../api/user/actions.js');
   return showLoginPromptAsync({
     // Parsed options
     username: args['--username'],
-    password: args['--password'],
+    password,
     otp: args['--otp'],
     sso: !!args['--sso'],
     browser: !!args['--browser'],
   }).catch(logCmdError);
 };
+
+export async function readWordFromStdin(): Promise<string> {
+  let buffer = '';
+  for await (const chunk of process.stdin) {
+    buffer += chunk;
+    const newlineIndex = buffer.indexOf('\n');
+    if (newlineIndex !== -1) {
+      return buffer.slice(0, newlineIndex).replace(/\r$/, '');
+    }
+  }
+  return buffer;
+}

--- a/tools/src/EASUpdate.ts
+++ b/tools/src/EASUpdate.ts
@@ -1,7 +1,8 @@
+import spawnAsync from '@expo/spawn-async';
 import process from 'process';
 
+import { EXPO_DIR } from './Constants';
 import * as EASCLI from './EASCLI';
-import * as ExpoCLI from './ExpoCLI';
 import * as Log from './Log';
 
 type Options = {
@@ -32,7 +33,14 @@ export async function setAuthAndPublishProjectWithEasCliAsync(
 
     if (username && password) {
       Log.collapsed('Logging in...');
-      await ExpoCLI.runExpoCliAsync('login', ['-u', username, '-p', password]);
+      // Pass the password via stdin instead of argv to keep it out of the process table.
+      const child = spawnAsync('npx', ['expo', 'login', '-u', username, '-p', '-'], {
+        cwd: EXPO_DIR,
+        stdio: ['pipe', 'inherit', 'inherit'],
+        env: { ...process.env, EXPO_NO_DOCTOR: 'true' },
+      });
+      child.child.stdin!.end(`${password}\n`);
+      await child;
     } else {
       Log.collapsed('Expo username and password not specified. Using currently logged-in account.');
     }


### PR DESCRIPTION
## Summary

Adds `expo login -p -` support to pass a password via stdin. This is mostly for our own uses to isolate the password input away from shell arguments, but is likely useful for users too.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
