### PR TITLE
[brownfield][android] Add support Fused Library

### DIFF
--- a/apps/brownfield-tester/expo-app/app.json
+++ b/apps/brownfield-tester/expo-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "expo-app",
     "slug": "expo-app",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "expo-app",
@@ -40,6 +40,18 @@
         {
           "ios": {
             "buildReactNativeFromSource": false
+          },
+          "android": {
+            "publishing": [
+              { "type": "localMaven" },
+              {
+                "type": "remotePrivate",
+                "name": "GitHubPackages",
+                "url": "https://maven.pkg.github.com/gabrieldonadel/brownfield-fused-test",
+                "username": "gabrieldonadel",
+                "password": { "variable": "GITHUB_TOKEN" }
+              }
+            ]
           }
         }
       ]

--- a/apps/brownfield-tester/expo-app/app.json
+++ b/apps/brownfield-tester/expo-app/app.json
@@ -43,14 +43,7 @@
           },
           "android": {
             "publishing": [
-              { "type": "localMaven" },
-              {
-                "type": "remotePrivate",
-                "name": "GitHubPackages",
-                "url": "https://maven.pkg.github.com/<owner>/<repo>",
-                "username": { "variable": "GITHUB_ACTOR" },
-                "password": { "variable": "GITHUB_TOKEN" }
-              }
+              { "type": "localMaven" }
             ]
           }
         }

--- a/apps/brownfield-tester/expo-app/app.json
+++ b/apps/brownfield-tester/expo-app/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "expo-app",
     "slug": "expo-app",
-    "version": "1.0.1",
+    "version": "1.0.0",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "expo-app",
@@ -47,8 +47,8 @@
               {
                 "type": "remotePrivate",
                 "name": "GitHubPackages",
-                "url": "https://maven.pkg.github.com/gabrieldonadel/brownfield-fused-test",
-                "username": "gabrieldonadel",
+                "url": "https://maven.pkg.github.com/<owner>/<repo>",
+                "username": { "variable": "GITHUB_ACTOR" },
                 "password": { "variable": "GITHUB_TOKEN" }
               }
             ]

--- a/apps/brownfield-tester/isolated/android/app/build.gradle.kts
+++ b/apps/brownfield-tester/isolated/android/app/build.gradle.kts
@@ -18,20 +18,20 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-        packagingOptions {
-            pickFirsts.addAll(
-                listOf(
-                    "lib/arm64-v8a/libc++_shared.so",
-                    "lib/armeabi-v7a/libc++_shared.so",
-                    "lib/x86/libc++_shared.so",
-                    "lib/x86_64/libc++_shared.so",
-                    "**/libworklets.so",
-                    // libfbjni.so ships in both the fused brownfield AAR (via expo-modules-core)
-                    // and `com.facebook.react:react-android`. Same library, picking either copy.
-                    "**/libfbjni.so"
-                )
+    packagingOptions {
+        pickFirsts.addAll(
+            listOf(
+                "lib/arm64-v8a/libc++_shared.so",
+                "lib/armeabi-v7a/libc++_shared.so",
+                "lib/x86/libc++_shared.so",
+                "lib/x86_64/libc++_shared.so",
+                "**/libworklets.so",
+                // libfbjni.so ships in both the fused brownfield AAR (via expo-modules-core)
+                // and `com.facebook.react:react-android`. Same library, picking either copy.
+                "**/libfbjni.so"
             )
-        }
+        )
+    }
 
     buildTypes {
         release {

--- a/apps/brownfield-tester/isolated/android/app/build.gradle.kts
+++ b/apps/brownfield-tester/isolated/android/app/build.gradle.kts
@@ -18,17 +18,20 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    packagingOptions {
-        pickFirsts.addAll(
-            listOf(
-                "lib/arm64-v8a/libc++_shared.so",
-                "lib/armeabi-v7a/libc++_shared.so",
-                "lib/x86/libc++_shared.so",
-                "lib/x86_64/libc++_shared.so",
-                "**/libworklets.so"
+        packagingOptions {
+            pickFirsts.addAll(
+                listOf(
+                    "lib/arm64-v8a/libc++_shared.so",
+                    "lib/armeabi-v7a/libc++_shared.so",
+                    "lib/x86/libc++_shared.so",
+                    "lib/x86_64/libc++_shared.so",
+                    "**/libworklets.so",
+                    // libfbjni.so ships in both the fused brownfield AAR (via expo-modules-core)
+                    // and `com.facebook.react:react-android`. Same library, picking either copy.
+                    "**/libfbjni.so"
+                )
             )
-        )
-    }
+        }
 
     buildTypes {
         release {
@@ -62,8 +65,11 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
-    implementation(libs.brownfield)
-    implementation(libs.expo.brownfield)
+    // Single fat AAR per buildType — `brownfield-fused-release` strips dev tooling
+    // (expo-dev-menu / launcher / client); `brownfield-fused-debug` keeps them so
+    // the dev menu, Metro reload, and red-box error overlay work locally.
+    releaseImplementation(libs.brownfield.release)
+    debugImplementation(libs.brownfield.debug)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/BrownfieldTestActivity.kt
+++ b/apps/brownfield-tester/isolated/android/app/src/main/java/dev/expo/brownfieldintegratedtester/BrownfieldTestActivity.kt
@@ -3,7 +3,6 @@ package dev.expo.brownfieldintegratedtester
 import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
-import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 import expo.modules.brownfield.BrownfieldMessage
 import expo.modules.brownfield.BrownfieldMessaging
 import expo.modules.brownfield.BrownfieldState
@@ -12,7 +11,7 @@ import host.exp.exponent.brownfield.BrownfieldActivity
 import java.util.Timer
 import kotlin.concurrent.timerTask
 
-open class BrownfieldTestActivity : BrownfieldActivity(), DefaultHardwareBackBtnHandler {
+open class BrownfieldTestActivity : BrownfieldActivity() {
   // Listeners
   private var messagingListenerId: String? = null
   private var stateListeners: MutableList<Removable?> = mutableListOf()
@@ -140,9 +139,5 @@ open class BrownfieldTestActivity : BrownfieldActivity(), DefaultHardwareBackBtn
         java.time.LocalDateTime.now()
             .format(java.time.format.DateTimeFormatter.ofPattern("HH:mm:ss"))
     BrownfieldState.set("time", timeString)
-  }
-
-  override fun invokeDefaultOnBackPressed() {
-    TODO("Not yet implemented")
   }
 }

--- a/apps/brownfield-tester/isolated/android/gradle/libs.versions.toml
+++ b/apps/brownfield-tester/isolated/android/gradle/libs.versions.toml
@@ -24,8 +24,8 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
-brownfield = { group = "host.exp.exponent", name = "brownfield", version = "1.0.0" }
-expo-brownfield = { group = "expo.modules.brownfield", name = "expo.modules.brownfield", version = "0.1.0" }
+brownfield-release = { group = "host.exp.exponent", name = "brownfield-fused-release", version = "1.0.0" }
+brownfield-debug = { group = "host.exp.exponent", name = "brownfield-fused-debug", version = "1.0.0" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/apps/brownfield-tester/isolated/android/settings.gradle.kts
+++ b/apps/brownfield-tester/isolated/android/settings.gradle.kts
@@ -18,6 +18,14 @@ dependencyResolutionManagement {
         mavenCentral()
         mavenLocal()
         maven { url = uri("https://www.jitpack.io") }
+        // maven {
+        //     url = uri("https://maven.pkg.github.com/gabrieldonadel/brownfield-fused-test")
+        //     credentials {
+        //         username = System.getenv("GITHUB_ACTOR") ?: "gabrieldonadel"
+        //         password = System.getenv("GITHUB_TOKEN") ?: ""
+        //     }
+        // }
+
     }
 }
 

--- a/apps/brownfield-tester/isolated/android/settings.gradle.kts
+++ b/apps/brownfield-tester/isolated/android/settings.gradle.kts
@@ -18,14 +18,6 @@ dependencyResolutionManagement {
         mavenCentral()
         mavenLocal()
         maven { url = uri("https://www.jitpack.io") }
-        // maven {
-        //     url = uri("https://maven.pkg.github.com/gabrieldonadel/brownfield-fused-test")
-        //     credentials {
-        //         username = System.getenv("GITHUB_ACTOR") ?: "gabrieldonadel"
-        //         password = System.getenv("GITHUB_TOKEN") ?: ""
-        //     }
-        // }
-
     }
 }
 

--- a/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
+++ b/apps/expo-workflow-testing/.eas/workflows/test-suite-brownfield-isolated.yml
@@ -77,7 +77,7 @@ jobs:
         working_directory: ../brownfield-tester/expo-app
         run: |
           npx expo prebuild --clean -p android
-          npx expo-brownfield build:android --repo MavenLocal --verbose
+          npx expo-brownfield build:android --fused --repo MavenLocal --verbose
       - uses: eas/start_android_emulator
         with:
           device_name: pixel_4

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -244,6 +244,7 @@ Builds and publishes the brownfield library and its dependencies to Maven reposi
 | `-d, --debug`          | Build in debug mode                            |
 | `-r, --release`        | Build in release mode                          |
 | `-a, --all`            | Build in both debug and release mode (default) |
+| `--fused`              | Publish a single fat AAR via AGP Fused Library |
 | `-l, --library`        | Specify brownfield library name                |
 | `--repo, --repository` | Specify Maven repositories to publish to       |
 | `-t, --task`           | Specify Gradle publish tasks to run            |

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -225,6 +225,137 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
   ]}
 />
 
+## Publishing artifacts
+
+Brownfield Android artifacts are pushed to one or more Maven repositories declared via `android.publishing` in your app config. The repository types supported are:
+
+| `type`            | Description                                                                                                              |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `localMaven`      | Publishes to `~/.m2/repository`. Default. Useful for local host-app integration during development.                       |
+| `localDirectory`  | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.        |
+| `remotePublic`    | Publishes to a public Maven repository with no authentication.                                                            |
+| `remotePrivate`   | Publishes to an authenticated remote Maven repository (GitHub Packages, JFrog Artifactory, AWS CodeArtifact, Sonatype Nexus…). Credentials can be inline strings or environment-variable references. |
+
+`url`, `username`, and `password` on `remotePrivate` accept either a plain string or an `EnvValue` object — `{ "variable": "SOME_ENV_VAR" }` — that resolves the value at build time via Gradle's `providers.environmentVariable(...)`. Pin secrets to env vars so they don't end up in your committed app config.
+
+### Publishing to GitHub Packages
+
+GitHub Packages hosts a private Maven repository scoped to a GitHub repo. Authentication is `GITHUB_ACTOR` (the user/bot name) + a [personal access token](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages) with `write:packages` and `read:packages` scopes (in GitHub Actions, the workflow's `GITHUB_TOKEN` already has the right scopes for the workflow's own repo).
+
+Add a `remotePrivate` entry to `android.publishing` pointing at the GitHub Packages URL for your test repository:
+
+```json app.json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-brownfield",
+        {
+          "android": {
+            "group": "com.example",
+            "libraryName": "brownfield",
+            "publishing": [
+              { "type": "localMaven" },
+              {
+                "type": "remotePrivate",
+                "name": "GitHubPackages",
+                "url": "https://maven.pkg.github.com/<owner>/<repo>",
+                "username": { "variable": "GITHUB_ACTOR" },
+                "password": { "variable": "GITHUB_TOKEN" }
+              }
+            ]
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+The `name` field controls both the Gradle Maven repo name and the `--repo` CLI flag value. With `"name": "GitHubPackages"`, the publish task becomes `publishBrownfieldReleasePublicationToGitHubPackagesRepository`, invoked via:
+
+<Terminal cmd={['$ npx expo-brownfield build:android --fused --repo GitHubPackages']} />
+
+### Publishing only the fused artifacts
+
+The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20–40 artifacts per release). To publish a small, curated set instead, use `--fused` — the fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat-AAR sibling(s):
+
+| Invocation                                   | Coordinates published                                                                                                   |
+| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `--fused --release`                          | `<group>:<libraryName>-fused-release:<version>`                                                                          |
+| `--fused --debug`                            | `<group>:<libraryName>-fused-debug:<version>`                                                                            |
+| `--fused --all` (default with `--fused`)     | Both of the above (two Gradle invocations under the hood, one per variant)                                              |
+
+That's at most two Maven coordinates published per release — independent of how many Expo modules your project autolinks. Everything else (per-module AARs, transitive Maven deps) stays out of your remote repo. Foundational libraries (AndroidX, RN runtime, Kotlin stdlib, Glide alternatives the host already has) stay external in the POM rather than fusing into the AAR; see [Fused mode](#fused-mode) for the full denylist + allowlist.
+
+### Sample GitHub Actions workflow
+
+```yaml .github/workflows/publish-brownfield.yml
+name: Publish brownfield fused AAR
+
+on:
+  push:
+    tags:
+      - 'brownfield-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+      - run: npm ci
+      - run: npx expo prebuild --platform android
+      - run: npx expo-brownfield build:android --fused --release --repo GitHubPackages
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Trigger via `git tag brownfield-v1.0.0 && git push --tags` (or manually via the Actions tab). The workflow's built-in `GITHUB_TOKEN` is scoped to the workflow's own repo, so publishing to a third-party repo requires a PAT in a repo secret instead.
+
+### Consumer setup (host Android app)
+
+The host app's `settings.gradle.kts` (or per-module `build.gradle.kts`) declares the same GitHub Packages URL + credentials. The host app's CI/local builds must have `GITHUB_ACTOR` + `GITHUB_TOKEN` env vars set or pulled from `~/.gradle/gradle.properties`.
+
+```kotlin android/settings.gradle.kts
+dependencyResolutionManagement {
+  repositories {
+    google()
+    mavenCentral()
+    maven {
+      url = uri("https://maven.pkg.github.com/<owner>/<repo>")
+      credentials {
+        username = providers.environmentVariable("GITHUB_ACTOR").orNull
+          ?: providers.gradleProperty("gpr.user").get()
+        password = providers.environmentVariable("GITHUB_TOKEN").orNull
+          ?: providers.gradleProperty("gpr.token").get()
+      }
+    }
+  }
+}
+```
+
+```kotlin android/app/build.gradle.kts
+dependencies {
+  releaseImplementation("com.example:brownfield-fused-release:1.0.0")
+  debugImplementation("com.example:brownfield-fused-debug:1.0.0")
+}
+```
+
+`releaseImplementation` / `debugImplementation` pair the variants automatically — Gradle picks the matching sibling per host build type. If your host only ships release builds, you can drop the `debugImplementation` line and just publish the release sibling with `--fused --release`.
+
 ## CLI
 
 The `expo-brownfield` library includes a CLI for building and publishing to Maven repositories (Android) and XCFrameworks (iOS).

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -229,12 +229,12 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
 
 The `expo-brownfield` CLI pushes Android artifacts to one or more Maven repositories, declared via `android.publishing` in your app config. The supported repository types are:
 
-| `type`            | Description                                                                                                              |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `localMaven`      | Publishes to **~/.m2/repository**. Default. Useful for local host-app integration during development.                       |
-| `localDirectory`  | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.        |
-| `remotePublic`    | Publishes to a public Maven repository with no authentication.                                                            |
-| `remotePrivate`   | Publishes to an authenticated remote Maven repository (GitHub Packages, JFrog Artifactory, AWS CodeArtifact, Sonatype Nexus…). Credentials can be inline strings or environment-variable references. |
+| `type`           | Description                                                                                                                                                                                          |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `localMaven`     | Publishes to **~/.m2/repository**. Default. Useful for local host-app integration during development.                                                                                                |
+| `localDirectory` | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.                                                                                    |
+| `remotePublic`   | Publishes to a public Maven repository with no authentication.                                                                                                                                       |
+| `remotePrivate`  | Publishes to an authenticated remote Maven repository (GitHub Packages, JFrog Artifactory, AWS CodeArtifact, etc). Credentials can be inline strings or environment-variable references. |
 
 `url`, `username`, and `password` on `remotePrivate` accept either a plain string or an `EnvValue` object (`{ "variable": "SOME_ENV_VAR" }`) that resolves the value at build time via Gradle's `providers.environmentVariable(...)`. Pin secrets to env vars so they don't end up in your committed app config.
 
@@ -280,11 +280,11 @@ The `name` field controls both the Gradle Maven repo name and the `--repo` CLI f
 
 The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20 to 40 artifacts per release). To publish a small, curated set instead, use `--fused`. The fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat AAR sibling(s). A repository (`--repo`) or an explicit task (`-t`) is always required, as there is no default:
 
-| Invocation                                              | Coordinates published                                                       |
-| ------------------------------------------------------- | --------------------------------------------------------------------------- |
-| `--fused --release --repo <name>`                       | `<group>:<libraryName>-fused-release:<version>`                              |
-| `--fused --debug --repo <name>`                         | `<group>:<libraryName>-fused-debug:<version>`                                |
-| `--fused --all --repo <name>` (default with `--fused`)  | Both of the above (two Gradle invocations under the hood, one per variant)  |
+| Invocation                                             | Coordinates published                                                      |
+| ------------------------------------------------------ | -------------------------------------------------------------------------- |
+| `--fused --release --repo <name>`                      | `<group>:<libraryName>-fused-release:<version>`                            |
+| `--fused --debug --repo <name>`                        | `<group>:<libraryName>-fused-debug:<version>`                              |
+| `--fused --all --repo <name>` (default with `--fused`) | Both of the above (two Gradle invocations under the hood, one per variant) |
 
 That's at most two Maven coordinates published per release, independent of how many Expo modules your project autolinks. Everything else (per-module AARs, transitive Maven deps) stays out of your remote repo. Foundational libraries (AndroidX, RN runtime, Kotlin stdlib, Glide alternatives the host already has) stay external in the POM rather than fusing into the AAR.
 
@@ -300,12 +300,12 @@ Not everything is fused into the AAR. The build keeps three kinds of dependencie
 
 Four Gradle properties tune this behavior when a project's dependency graph needs it:
 
-| Property                                     | Effect                                                                                                                                  |
-| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `brownfield.fused.skip`                      | Comma-separated Gradle project names to leave out of the fat AAR entirely.                                                               |
-| `brownfield.fused.strip-packages`            | Comma-separated package prefixes to remove from the generated `ExpoModulesPackageList`. Pair with `skip` to avoid `NoClassDefFoundError` for skipped modules at startup. |
-| `brownfield.fused.androidx-fuse`             | Extra `androidx.*` group prefixes to fuse into the AAR instead of keeping external.                                                      |
-| `brownfield.fused.exclude-transitive`        | Extra dependency groups to keep external (declared in the POM instead of fused).                                                          |
+| Property                              | Effect                                                                                                                                                                   |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `brownfield.fused.skip`               | Comma-separated Gradle project names to leave out of the fat AAR entirely.                                                                                               |
+| `brownfield.fused.strip-packages`     | Comma-separated package prefixes to remove from the generated `ExpoModulesPackageList`. Pair with `skip` to avoid `NoClassDefFoundError` for skipped modules at startup. |
+| `brownfield.fused.androidx-fuse`      | Extra `androidx.*` group prefixes to fuse into the AAR instead of keeping external.                                                                                      |
+| `brownfield.fused.exclude-transitive` | Extra dependency groups to keep external (declared in the POM instead of fused).                                                                                         |
 
 Pass them as `-P` Gradle properties when invoking a fused publish task directly from the **android** directory:
 
@@ -400,16 +400,16 @@ Builds and publishes the brownfield library and its dependencies to Maven reposi
 
 <Terminal cmd={['$ npx expo-brownfield build:android [options]']} />
 
-| Option                 | Description                                    |
-| ---------------------- | ---------------------------------------------- |
-| `-d, --debug`          | Build in debug mode                            |
-| `-r, --release`        | Build in release mode                          |
-| `-a, --all`            | Build in both debug and release mode (default) |
+| Option                 | Description                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------------- |
+| `-d, --debug`          | Build in debug mode                                                                       |
+| `-r, --release`        | Build in release mode                                                                     |
+| `-a, --all`            | Build in both debug and release mode (default)                                            |
 | `--fused`              | Publish a single fat AAR per variant via AGP Fused Library. See [Fused mode](#fused-mode) |
-| `-l, --library`        | Specify brownfield library name                |
-| `--repo, --repository` | Specify Maven repositories to publish to       |
-| `-t, --task`           | Specify Gradle publish tasks to run            |
-| `--verbose`            | Include all logs from subprocesses             |
+| `-l, --library`        | Specify brownfield library name                                                           |
+| `--repo, --repository` | Specify Maven repositories to publish to                                                  |
+| `-t, --task`           | Specify Gradle publish tasks to run                                                       |
+| `--verbose`            | Include all logs from subprocesses                                                        |
 
 #### `build:ios`
 

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -229,12 +229,12 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
 
 The `expo-brownfield` CLI pushes Android artifacts to one or more Maven repositories, declared via `android.publishing` in your app config. The supported repository types are:
 
-| `type`           | Description                                                                                                                                                                                          |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `localMaven`     | Publishes to **~/.m2/repository**. Default. Useful for local host-app integration during development.                                                                                                |
-| `localDirectory` | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.                                                                                    |
-| `remotePublic`   | Publishes to a public Maven repository with no authentication.                                                                                                                                       |
-| `remotePrivate`  | Publishes to an authenticated remote Maven repository (GitHub Packages, JFrog Artifactory, AWS CodeArtifact, etc). Credentials can be inline strings or environment-variable references. |
+| `type`           | Description                                                                                                                  |
+| ---------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `localMaven`     | Publishes to **~/.m2/repository**. Default. Useful for local host-app integration during development.                        |
+| `localDirectory` | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.            |
+| `remotePublic`   | Publishes to a public Maven repository with no authentication.                                                               |
+| `remotePrivate`  | Publishes to an authenticated remote Maven repository. Credentials can be inline strings or environment-variable references. |
 
 `url`, `username`, and `password` on `remotePrivate` accept either a plain string or an `EnvValue` object (`{ "variable": "SOME_ENV_VAR" }`) that resolves the value at build time via Gradle's `providers.environmentVariable(...)`. Pin secrets to env vars so they don't end up in your committed app config.
 

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -227,20 +227,20 @@ The `expo-brownfield` package provides a [config plugin](/config-plugins/introdu
 
 ## Publishing artifacts
 
-Brownfield Android artifacts are pushed to one or more Maven repositories declared via `android.publishing` in your app config. The repository types supported are:
+The `expo-brownfield` CLI pushes Android artifacts to one or more Maven repositories, declared via `android.publishing` in your app config. The supported repository types are:
 
 | `type`            | Description                                                                                                              |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `localMaven`      | Publishes to `~/.m2/repository`. Default. Useful for local host-app integration during development.                       |
+| `localMaven`      | Publishes to **~/.m2/repository**. Default. Useful for local host-app integration during development.                       |
 | `localDirectory`  | Publishes to a local filesystem path (`path` field). Useful for checking artifacts into a sibling git repository.        |
 | `remotePublic`    | Publishes to a public Maven repository with no authentication.                                                            |
 | `remotePrivate`   | Publishes to an authenticated remote Maven repository (GitHub Packages, JFrog Artifactory, AWS CodeArtifact, Sonatype Nexus…). Credentials can be inline strings or environment-variable references. |
 
-`url`, `username`, and `password` on `remotePrivate` accept either a plain string or an `EnvValue` object — `{ "variable": "SOME_ENV_VAR" }` — that resolves the value at build time via Gradle's `providers.environmentVariable(...)`. Pin secrets to env vars so they don't end up in your committed app config.
+`url`, `username`, and `password` on `remotePrivate` accept either a plain string or an `EnvValue` object (`{ "variable": "SOME_ENV_VAR" }`) that resolves the value at build time via Gradle's `providers.environmentVariable(...)`. Pin secrets to env vars so they don't end up in your committed app config.
 
 ### Publishing to GitHub Packages
 
-GitHub Packages hosts a private Maven repository scoped to a GitHub repo. Authentication is `GITHUB_ACTOR` (the user/bot name) + a [personal access token](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages) with `write:packages` and `read:packages` scopes (in GitHub Actions, the workflow's `GITHUB_TOKEN` already has the right scopes for the workflow's own repo).
+GitHub Packages hosts a private Maven repository scoped to a GitHub repo. Authentication uses `GITHUB_ACTOR` (the user or bot name) and a [personal access token (PAT)](https://docs.github.com/en/packages/learn-github-packages/introduction-to-github-packages#authenticating-to-github-packages) with the `write:packages` and `read:packages` scopes. In GitHub Actions, the workflow's `GITHUB_TOKEN` already has the right scopes for the workflow's own repo.
 
 Add a `remotePrivate` entry to `android.publishing` pointing at the GitHub Packages URL for your test repository:
 
@@ -278,7 +278,7 @@ The `name` field controls both the Gradle Maven repo name and the `--repo` CLI f
 
 ### Publishing only the fused artifacts
 
-The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20–40 artifacts per release). To publish a small, curated set instead, use `--fused` — the fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat-AAR sibling(s):
+The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20 to 40 artifacts per release). To publish a small, curated set instead, use `--fused`. The fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat AAR sibling(s):
 
 | Invocation                                   | Coordinates published                                                                                                   |
 | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
@@ -286,7 +286,7 @@ The non-fused publish flow emits one Maven coordinate per autolinked Expo Androi
 | `--fused --debug`                            | `<group>:<libraryName>-fused-debug:<version>`                                                                            |
 | `--fused --all` (default with `--fused`)     | Both of the above (two Gradle invocations under the hood, one per variant)                                              |
 
-That's at most two Maven coordinates published per release — independent of how many Expo modules your project autolinks. Everything else (per-module AARs, transitive Maven deps) stays out of your remote repo. Foundational libraries (AndroidX, RN runtime, Kotlin stdlib, Glide alternatives the host already has) stay external in the POM rather than fusing into the AAR; see [Fused mode](#fused-mode) for the full denylist + allowlist.
+That's at most two Maven coordinates published per release, independent of how many Expo modules your project autolinks. Everything else (per-module AARs, transitive Maven deps) stays out of your remote repo. Foundational libraries (AndroidX, RN runtime, Kotlin stdlib, Glide alternatives the host already has) stay external in the POM rather than fusing into the AAR.
 
 ### Sample GitHub Actions workflow
 
@@ -327,7 +327,7 @@ Trigger via `git tag brownfield-v1.0.0 && git push --tags` (or manually via the 
 
 ### Consumer setup (host Android app)
 
-The host app's `settings.gradle.kts` (or per-module `build.gradle.kts`) declares the same GitHub Packages URL + credentials. The host app's CI/local builds must have `GITHUB_ACTOR` + `GITHUB_TOKEN` env vars set or pulled from `~/.gradle/gradle.properties`.
+The host app's **settings.gradle.kts** (or per-module **build.gradle.kts**) declares the same GitHub Packages URL and credentials. The host app's CI/local builds must have the `GITHUB_ACTOR` and `GITHUB_TOKEN` env vars set or pulled from **~/.gradle/gradle.properties**.
 
 ```kotlin android/settings.gradle.kts
 dependencyResolutionManagement {
@@ -354,7 +354,7 @@ dependencies {
 }
 ```
 
-`releaseImplementation` / `debugImplementation` pair the variants automatically — Gradle picks the matching sibling per host build type. If your host only ships release builds, you can drop the `debugImplementation` line and just publish the release sibling with `--fused --release`.
+`releaseImplementation`/`debugImplementation` pair the variants automatically. Gradle picks the matching sibling per host build type. If your host only ships release builds, you can drop the `debugImplementation` line and publish only the release sibling with `--fused --release`.
 
 ## CLI
 

--- a/docs/pages/versions/unversioned/sdk/brownfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/brownfield.mdx
@@ -272,21 +272,51 @@ Add a `remotePrivate` entry to `android.publishing` pointing at the GitHub Packa
 }
 ```
 
-The `name` field controls both the Gradle Maven repo name and the `--repo` CLI flag value. With `"name": "GitHubPackages"`, the publish task becomes `publishBrownfieldReleasePublicationToGitHubPackagesRepository`, invoked via:
+The `name` field controls both the Gradle Maven repo name and the `--repo` CLI flag value. With `"name": "GitHubPackages"`, the release publish task becomes `publishBrownfieldReleasePublicationToGitHubPackagesRepository` (and `publishBrownfieldDebugPublicationToGitHubPackagesRepository` for the debug sibling). The default invocation runs both:
 
 <Terminal cmd={['$ npx expo-brownfield build:android --fused --repo GitHubPackages']} />
 
 ### Publishing only the fused artifacts
 
-The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20 to 40 artifacts per release). To publish a small, curated set instead, use `--fused`. The fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat AAR sibling(s):
+The non-fused publish flow emits one Maven coordinate per autolinked Expo Android module (typically 20 to 40 artifacts per release). To publish a small, curated set instead, use `--fused`. The fused mode short-circuits the publish plugin's per-module re-publish loop and only emits the fat AAR sibling(s). A repository (`--repo`) or an explicit task (`-t`) is always required, as there is no default:
 
-| Invocation                                   | Coordinates published                                                                                                   |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `--fused --release`                          | `<group>:<libraryName>-fused-release:<version>`                                                                          |
-| `--fused --debug`                            | `<group>:<libraryName>-fused-debug:<version>`                                                                            |
-| `--fused --all` (default with `--fused`)     | Both of the above (two Gradle invocations under the hood, one per variant)                                              |
+| Invocation                                              | Coordinates published                                                       |
+| ------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `--fused --release --repo <name>`                       | `<group>:<libraryName>-fused-release:<version>`                              |
+| `--fused --debug --repo <name>`                         | `<group>:<libraryName>-fused-debug:<version>`                                |
+| `--fused --all --repo <name>` (default with `--fused`)  | Both of the above (two Gradle invocations under the hood, one per variant)  |
 
 That's at most two Maven coordinates published per release, independent of how many Expo modules your project autolinks. Everything else (per-module AARs, transitive Maven deps) stays out of your remote repo. Foundational libraries (AndroidX, RN runtime, Kotlin stdlib, Glide alternatives the host already has) stay external in the POM rather than fusing into the AAR.
+
+### Fused mode
+
+`--fused` publishes through two extra Gradle subprojects that prebuild always generates — `:<libraryName>-fused-release` and `:<libraryName>-fused-debug` — each producing one fat AAR via [AGP's Fused Library plugin](https://developer.android.com/build/publish-library/fused-library) (a Preview feature; the CLI temporarily forces AGP 8.13 for these builds). The subprojects are inert during normal builds: their build scripts only activate when the CLI passes `-Pbrownfield.fused=true`, so `npx expo run:android` and IDE sync pay no extra configuration cost. If you invoke a fused Gradle task directly instead of through the CLI, pass `-Pbrownfield.fused=true` yourself.
+
+Not everything is fused into the AAR. The build keeps three kinds of dependencies external and declares them as ordinary Maven dependencies in the published POM and Gradle Module Metadata, where the host app resolves them itself:
+
+- **The brownfield host baseline** — the React Native runtime (`react-android`, `hermes-android`, `fbjni`, `soloader`, `yoga`), the Kotlin stdlib, and host-provided commons (Material Components, Guava, Fresco, OkHttp, Okio). Fusing these would duplicate classes the host already ships.
+- **`androidx.*` libraries** — AGP Fused Library's class rewriter can't resolve `android:` framework attributes in their styleables, so all of AndroidX stays external except chains that must be fused for validation reasons (`androidx.camera`, `androidx.media3` by default).
+- **Auto-detected KMP umbrella modules** — pom-only coordinates whose variants all redirect to a platform module.
+
+Four Gradle properties tune this behavior when a project's dependency graph needs it:
+
+| Property                                     | Effect                                                                                                                                  |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `brownfield.fused.skip`                      | Comma-separated Gradle project names to leave out of the fat AAR entirely.                                                               |
+| `brownfield.fused.strip-packages`            | Comma-separated package prefixes to remove from the generated `ExpoModulesPackageList`. Pair with `skip` to avoid `NoClassDefFoundError` for skipped modules at startup. |
+| `brownfield.fused.androidx-fuse`             | Extra `androidx.*` group prefixes to fuse into the AAR instead of keeping external.                                                      |
+| `brownfield.fused.exclude-transitive`        | Extra dependency groups to keep external (declared in the POM instead of fused).                                                          |
+
+Pass them as `-P` Gradle properties when invoking a fused publish task directly from the **android** directory:
+
+<Terminal
+  cmd={[
+    '$ ./gradlew :brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal \\',
+    '    -Pbrownfield.fused=true \\',
+    '    -Pbrownfield.fused.skip=expo-camera \\',
+    '    -Pbrownfield.fused.strip-packages=expo.modules.camera.',
+  ]}
+/>
 
 ### Sample GitHub Actions workflow
 
@@ -338,9 +368,9 @@ dependencyResolutionManagement {
       url = uri("https://maven.pkg.github.com/<owner>/<repo>")
       credentials {
         username = providers.environmentVariable("GITHUB_ACTOR").orNull
-          ?: providers.gradleProperty("gpr.user").get()
+          ?: providers.gradleProperty("gpr.user").orNull
         password = providers.environmentVariable("GITHUB_TOKEN").orNull
-          ?: providers.gradleProperty("gpr.token").get()
+          ?: providers.gradleProperty("gpr.token").orNull
       }
     }
   }
@@ -375,7 +405,7 @@ Builds and publishes the brownfield library and its dependencies to Maven reposi
 | `-d, --debug`          | Build in debug mode                            |
 | `-r, --release`        | Build in release mode                          |
 | `-a, --all`            | Build in both debug and release mode (default) |
-| `--fused`              | Publish a single fat AAR via AGP Fused Library |
+| `--fused`              | Publish a single fat AAR per variant via AGP Fused Library. See [Fused mode](#fused-mode) |
 | `-l, --library`        | Specify brownfield library name                |
 | `--repo, --repository` | Specify Maven repositories to publish to       |
 | `-t, --task`           | Specify Gradle publish tasks to run            |

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Add hostProvidedFrameworks option to skip Frameworks provided by the host app ([#46355](https://github.com/expo/expo/pull/46355) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Add support Fused Library ([#45878](https://github.com/expo/expo/pull/45878) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### 🎉 New features
 
 - [iOS] Add hostProvidedFrameworks option to skip Frameworks provided by the host app ([#46355](https://github.com/expo/expo/pull/46355) by [@gabrieldonadel](https://github.com/gabrieldonadel))
-- [android] Add support Fused Library ([#45878](https://github.com/expo/expo/pull/45878) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [android] Add support for publishing a single fused AAR via AGP Fused Library ([#45878](https://github.com/expo/expo/pull/45878) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/cli/src/commands/build-android.ts
+++ b/packages/expo-brownfield/cli/src/commands/build-android.ts
@@ -17,8 +17,11 @@ const buildAndroid = async (command: Command) => {
   }
   printAndroidConfig(config);
 
+  // In `--fused` mode the publish plugin needs to short-circuit its per-module re-publish
+  // loop — otherwise every Expo module's AAR would publish redundantly next to the fat AAR.
+  const extraGradleArgs = config.fused ? ['-Pbrownfield.fused=true'] : [];
   for (const task of config.tasks) {
-    await runTask(task, config.verbose, config.dryRun);
+    await runTask(task, config.verbose, config.dryRun, extraGradleArgs);
   }
 };
 

--- a/packages/expo-brownfield/cli/src/commands/build-android.ts
+++ b/packages/expo-brownfield/cli/src/commands/build-android.ts
@@ -17,8 +17,6 @@ const buildAndroid = async (command: Command) => {
   }
   printAndroidConfig(config);
 
-  // In `--fused` mode the publish plugin needs to short-circuit its per-module re-publish
-  // loop — otherwise every Expo module's AAR would publish redundantly next to the fat AAR.
   const extraGradleArgs = config.fused ? ['-Pbrownfield.fused=true'] : [];
   for (const task of config.tasks) {
     await runTask(task, config.verbose, config.dryRun, extraGradleArgs);

--- a/packages/expo-brownfield/cli/src/index.ts
+++ b/packages/expo-brownfield/cli/src/index.ts
@@ -16,6 +16,10 @@ program
   .option('-d, --debug', 'build debug variant')
   .option('-r, --release', 'build release variant')
   .option('-a, --all', 'build both debug and release variants')
+  .option(
+    '--fused',
+    'publish a single fat AAR with every Expo module merged in via AGP Fused Library (forces release variant)'
+  )
   .option('--verbose', 'forward all output to the terminal')
   .option('-l, --library <library>', 'name of the brownfield library')
   .option('-t, --task <task...>', 'publishing task to be run (multiple can be passed)')

--- a/packages/expo-brownfield/cli/src/index.ts
+++ b/packages/expo-brownfield/cli/src/index.ts
@@ -18,7 +18,7 @@ program
   .option('-a, --all', 'build both debug and release variants')
   .option(
     '--fused',
-    'publish a single fat AAR with every Expo module merged in via AGP Fused Library (forces release variant)'
+    'publish a single fat AAR with every Expo module merged in via AGP Fused Library; release-only (AGP fused-library is single-variant)'
   )
   .option('--verbose', 'forward all output to the terminal')
   .option('-l, --library <library>', 'name of the brownfield library')

--- a/packages/expo-brownfield/cli/src/index.ts
+++ b/packages/expo-brownfield/cli/src/index.ts
@@ -16,10 +16,7 @@ program
   .option('-d, --debug', 'build debug variant')
   .option('-r, --release', 'build release variant')
   .option('-a, --all', 'build both debug and release variants')
-  .option(
-    '--fused',
-    'publish a single fat AAR with every Expo module merged in via AGP Fused Library; release-only (AGP fused-library is single-variant)'
-  )
+  .option('--fused', 'publish a single fat AAR per variant via AGP Fused Library')
   .option('--verbose', 'forward all output to the terminal')
   .option('-l, --library <library>', 'name of the brownfield library')
   .option('-t, --task <task...>', 'publishing task to be run (multiple can be passed)')

--- a/packages/expo-brownfield/cli/src/utils/android.ts
+++ b/packages/expo-brownfield/cli/src/utils/android.ts
@@ -14,13 +14,8 @@ export const buildPublishingTask = (
 ): string => {
   const repositoryName = repository === 'MavenLocal' ? repository : `${repository}Repository`;
   const task = `publishBrownfield${variant}PublicationTo${repositoryName}`;
-  // In `--fused` mode each variant has its own sibling Gradle subproject (AGP
-  // fused-library is single-variant per module). Route the task to the matching
-  // sibling — `:<lib>-fused-release` for Release, `:<lib>-fused-debug` for Debug.
-  // `--fused --all` is handled upstream by emitting both Release and Debug task
-  // names; this function sees them one at a time.
-  // `-Pbrownfield.fused=true` (passed in `runTask`'s extraGradleArgs) short-circuits
-  // the publish plugin's per-module re-publish loop.
+  // In `--fused` mode, route the task to the matching sibling subproject:
+  // `:<lib>-fused-release` for Release, `:<lib>-fused-debug` for Debug.
   if (fusedOpts.fused) {
     const siblingSuffix = variant === 'Debug' ? 'debug' : 'release';
     return `:${fusedOpts.library}-fused-${siblingSuffix}:${task}`;
@@ -115,12 +110,8 @@ export const runTask = async (
   dryRun: boolean,
   extraGradleArgs: string[] = []
 ) => {
-  // For fused tasks (path starts with `:<lib>-fused-<variant>:`), forward the
-  // variant as a Gradle property so `setupFusedModeStripping` in the
-  // brownfield-setup plugin applies the right strip prefixes — strip dev-module
-  // refs from the generated `ExpoModulesPackageList.kt` on release builds, no-op
-  // on debug. Each fused-mode task runs in its own Gradle invocation, so the
-  // property is correctly scoped per-task.
+  // For fused tasks, forward the variant as a Gradle property so
+  // `setupFusedModeStripping` applies the right strip prefixes.
   const fusedVariantMatch = task.match(/:[^:]+-fused-(release|debug):/);
   const perTaskArgs = fusedVariantMatch
     ? [...extraGradleArgs, `-Pbrownfield.fused.variant=${fusedVariantMatch[1]}`]

--- a/packages/expo-brownfield/cli/src/utils/android.ts
+++ b/packages/expo-brownfield/cli/src/utils/android.ts
@@ -14,13 +14,16 @@ export const buildPublishingTask = (
 ): string => {
   const repositoryName = repository === 'MavenLocal' ? repository : `${repository}Repository`;
   const task = `publishBrownfield${variant}PublicationTo${repositoryName}`;
-  // In `--fused` mode only the fused sibling subproject should publish — every other
-  // expo module subproject also has this publication on its own setup plugin and would
-  // publish redundant per-module AARs next to the fat AAR. The `:project:task` form
-  // restricts Gradle to that one subproject. `-Pbrownfield.fused=true` (passed in
-  // `runTask`) additionally short-circuits the publish plugin's prebuilts re-publish loop.
+  // In `--fused` mode each variant has its own sibling Gradle subproject (AGP
+  // fused-library is single-variant per module). Route the task to the matching
+  // sibling — `:<lib>-fused-release` for Release, `:<lib>-fused-debug` for Debug.
+  // `--fused --all` is handled upstream by emitting both Release and Debug task
+  // names; this function sees them one at a time.
+  // `-Pbrownfield.fused=true` (passed in `runTask`'s extraGradleArgs) short-circuits
+  // the publish plugin's per-module re-publish loop.
   if (fusedOpts.fused) {
-    return `:${fusedOpts.library}-fused:${task}`;
+    const siblingSuffix = variant === 'Debug' ? 'debug' : 'release';
+    return `:${fusedOpts.library}-fused-${siblingSuffix}:${task}`;
   }
   return task;
 };
@@ -112,7 +115,18 @@ export const runTask = async (
   dryRun: boolean,
   extraGradleArgs: string[] = []
 ) => {
-  const args = [task, ...extraGradleArgs];
+  // For fused tasks (path starts with `:<lib>-fused-<variant>:`), forward the
+  // variant as a Gradle property so `setupFusedModeStripping` in the
+  // brownfield-setup plugin applies the right strip prefixes — strip dev-module
+  // refs from the generated `ExpoModulesPackageList.kt` on release builds, no-op
+  // on debug. Each fused-mode task runs in its own Gradle invocation, so the
+  // property is correctly scoped per-task.
+  const fusedVariantMatch = task.match(/:[^:]+-fused-(release|debug):/);
+  const perTaskArgs = fusedVariantMatch
+    ? [...extraGradleArgs, `-Pbrownfield.fused.variant=${fusedVariantMatch[1]}`]
+    : extraGradleArgs;
+
+  const args = [task, ...perTaskArgs];
   if (dryRun) {
     console.log(`./gradlew ${args.join(' ')}`);
     return;

--- a/packages/expo-brownfield/cli/src/utils/android.ts
+++ b/packages/expo-brownfield/cli/src/utils/android.ts
@@ -70,6 +70,7 @@ export const printAndroidConfig = (config: AndroidConfig) => {
   console.log(chalk.bold('Resolved build configuration'));
   console.log(` - Build variant: ${chalk.blue(config.variant)}`);
   console.log(` - Library: ${chalk.blue(config.library)}`);
+  console.log(` - Fused: ${chalk.blue(config.fused)}`);
   console.log(` - Verbose: ${chalk.blue(config.verbose)}`);
   console.log(` - Dry run: ${chalk.blue(config.dryRun)}`);
   console.log(` - Tasks:`);
@@ -110,12 +111,17 @@ export const runTask = async (
   dryRun: boolean,
   extraGradleArgs: string[] = []
 ) => {
-  // For fused tasks, forward the variant as a Gradle property so
-  // `setupFusedModeStripping` applies the right strip prefixes.
-  const fusedVariantMatch = task.match(/:[^:]+-fused-(release|debug):/);
-  const perTaskArgs = fusedVariantMatch
-    ? [...extraGradleArgs, `-Pbrownfield.fused.variant=${fusedVariantMatch[1]}`]
-    : extraGradleArgs;
+  // Fused-shaped tasks (e.g. passed manually via -t without --fused) must still
+  // activate fused mode in Gradle: without `-Pbrownfield.fused=true` the fused
+  // sibling subprojects are inert (no publications) and the conditional AGP
+  // force-bump in the root build.gradle never applies, so the build would fail
+  // mid-execution under the version catalog's AGP.
+  const fusedProperty = '-Pbrownfield.fused=true';
+  const isFusedTask = /(?:^|:)[^:\s]+-fused-(?:release|debug):/.test(task);
+  const perTaskArgs =
+    isFusedTask && !extraGradleArgs.includes(fusedProperty)
+      ? [...extraGradleArgs, fusedProperty]
+      : extraGradleArgs;
 
   const args = [task, ...perTaskArgs];
   if (dryRun) {

--- a/packages/expo-brownfield/cli/src/utils/android.ts
+++ b/packages/expo-brownfield/cli/src/utils/android.ts
@@ -7,9 +7,22 @@ import CLIError from './error';
 import { withSpinner } from './spinner';
 import type { AndroidConfig, BuildVariant } from './types';
 
-export const buildPublishingTask = (variant: BuildVariant, repository: string): string => {
+export const buildPublishingTask = (
+  variant: BuildVariant,
+  repository: string,
+  fusedOpts: { fused: boolean; library: string } = { fused: false, library: '' }
+): string => {
   const repositoryName = repository === 'MavenLocal' ? repository : `${repository}Repository`;
-  return `publishBrownfield${variant}PublicationTo${repositoryName}`;
+  const task = `publishBrownfield${variant}PublicationTo${repositoryName}`;
+  // In `--fused` mode only the fused sibling subproject should publish — every other
+  // expo module subproject also has this publication on its own setup plugin and would
+  // publish redundant per-module AARs next to the fat AAR. The `:project:task` form
+  // restricts Gradle to that one subproject. `-Pbrownfield.fused=true` (passed in
+  // `runTask`) additionally short-circuits the publish plugin's prebuilts re-publish loop.
+  if (fusedOpts.fused) {
+    return `:${fusedOpts.library}-fused:${task}`;
+  }
+  return task;
 };
 
 export const findBrownfieldLibrary = (): string | undefined => {
@@ -93,15 +106,21 @@ export const processTasks = (stdout: string): string[] => {
   );
 };
 
-export const runTask = async (task: string, verbose: boolean, dryRun: boolean) => {
+export const runTask = async (
+  task: string,
+  verbose: boolean,
+  dryRun: boolean,
+  extraGradleArgs: string[] = []
+) => {
+  const args = [task, ...extraGradleArgs];
   if (dryRun) {
-    console.log(`./gradlew ${task}`);
+    console.log(`./gradlew ${args.join(' ')}`);
     return;
   }
 
   return withSpinner({
     operation: () =>
-      spawnAsync('./gradlew', [task], {
+      spawnAsync('./gradlew', args, {
         cwd: path.join(process.cwd(), 'android'),
         stdio: verbose ? 'inherit' : 'pipe',
       }),

--- a/packages/expo-brownfield/cli/src/utils/config.ts
+++ b/packages/expo-brownfield/cli/src/utils/config.ts
@@ -18,12 +18,18 @@ import type {
 const HOST_PROVIDED_FRAMEWORKS_KEY = 'ios.brownfieldHostProvidedFrameworks';
 
 export const resolveBuildConfigAndroid = (options: OptionValues): AndroidConfig => {
-  const variant = resolveVariant(options);
+  const fused = !!options.fused;
+  // The fused sibling subproject only registers a `brownfieldRelease` publication
+  // (single-variant by design — fused libraries can't carry multiple AGP variants),
+  // so `--debug` / `--all` alongside `--fused` falls through to Release.
+  const variant: BuildVariant = fused ? 'Release' : resolveVariant(options);
+  const library = resolveLibrary(options);
   return {
     ...resolveCommonConfig(options),
-    library: resolveLibrary(options),
-    tasks: resolveTaskArray(options, variant),
+    library,
+    tasks: resolveTaskArray(options, variant, { fused, library }),
     variant,
+    fused,
   };
 };
 
@@ -159,10 +165,14 @@ const resolveLibrary = (options: OptionValues): string => {
   return options.library || findBrownfieldLibrary();
 };
 
-const resolveTaskArray = (options: OptionValues, variant: BuildVariant): string[] => {
+const resolveTaskArray = (
+  options: OptionValues,
+  variant: BuildVariant,
+  fusedOpts: { fused: boolean; library: string }
+): string[] => {
   const tasks: string[] = options.task ?? [];
   const repoTasks = (options.repository ?? []).map((repo: string) =>
-    buildPublishingTask(variant, repo)
+    buildPublishingTask(variant, repo, fusedOpts)
   );
 
   return Array.from(new Set([...tasks, ...repoTasks]));

--- a/packages/expo-brownfield/cli/src/utils/config.ts
+++ b/packages/expo-brownfield/cli/src/utils/config.ts
@@ -169,11 +169,8 @@ const resolveTaskArray = (
 ): string[] => {
   const tasks: string[] = options.task ?? [];
   const repositories: string[] = options.repository ?? [];
-  // Each fused sibling is single-variant (AGP fused-library constraint), so
-  // `--fused --all` expands into separate `Debug` and `Release` task invocations
-  // — each runs against the matching sibling (`:<lib>-fused-debug` or
-  // `:<lib>-fused-release`). Default (non-fused) `--all` continues to use AGP's
-  // built-in multi-variant publishing in a single task.
+  // In `--fused` mode, `--all` expands to separate Debug + Release task
+  // invocations against the matching sibling subprojects.
   const variantsForRepoTasks: BuildVariant[] =
     fusedOpts.fused && variant === 'All' ? ['Debug', 'Release'] : [variant];
   const repoTasks = repositories.flatMap((repo) =>

--- a/packages/expo-brownfield/cli/src/utils/config.ts
+++ b/packages/expo-brownfield/cli/src/utils/config.ts
@@ -19,9 +19,12 @@ const HOST_PROVIDED_FRAMEWORKS_KEY = 'ios.brownfieldHostProvidedFrameworks';
 
 export const resolveBuildConfigAndroid = (options: OptionValues): AndroidConfig => {
   const fused = !!options.fused;
-  // The fused sibling subproject only registers a `brownfieldRelease` publication
-  // (single-variant by design — fused libraries can't carry multiple AGP variants),
-  // so `--debug` / `--all` alongside `--fused` falls through to Release.
+
+  if (fused && (options.debug || options.all)) {
+    throw new Error(
+      '`--fused` only supports release builds. Drop `--debug`/`--all` or run without `--fused`.'
+    );
+  }
   const variant: BuildVariant = fused ? 'Release' : resolveVariant(options);
   const library = resolveLibrary(options);
   return {

--- a/packages/expo-brownfield/cli/src/utils/config.ts
+++ b/packages/expo-brownfield/cli/src/utils/config.ts
@@ -19,13 +19,7 @@ const HOST_PROVIDED_FRAMEWORKS_KEY = 'ios.brownfieldHostProvidedFrameworks';
 
 export const resolveBuildConfigAndroid = (options: OptionValues): AndroidConfig => {
   const fused = !!options.fused;
-
-  if (fused && (options.debug || options.all)) {
-    throw new Error(
-      '`--fused` only supports release builds. Drop `--debug`/`--all` or run without `--fused`.'
-    );
-  }
-  const variant: BuildVariant = fused ? 'Release' : resolveVariant(options);
+  const variant: BuildVariant = resolveVariant(options);
   const library = resolveLibrary(options);
   return {
     ...resolveCommonConfig(options),
@@ -174,8 +168,16 @@ const resolveTaskArray = (
   fusedOpts: { fused: boolean; library: string }
 ): string[] => {
   const tasks: string[] = options.task ?? [];
-  const repoTasks = (options.repository ?? []).map((repo: string) =>
-    buildPublishingTask(variant, repo, fusedOpts)
+  const repositories: string[] = options.repository ?? [];
+  // Each fused sibling is single-variant (AGP fused-library constraint), so
+  // `--fused --all` expands into separate `Debug` and `Release` task invocations
+  // — each runs against the matching sibling (`:<lib>-fused-debug` or
+  // `:<lib>-fused-release`). Default (non-fused) `--all` continues to use AGP's
+  // built-in multi-variant publishing in a single task.
+  const variantsForRepoTasks: BuildVariant[] =
+    fusedOpts.fused && variant === 'All' ? ['Debug', 'Release'] : [variant];
+  const repoTasks = repositories.flatMap((repo) =>
+    variantsForRepoTasks.map((v) => buildPublishingTask(v, repo, fusedOpts))
   );
 
   return Array.from(new Set([...tasks, ...repoTasks]));

--- a/packages/expo-brownfield/cli/src/utils/types.ts
+++ b/packages/expo-brownfield/cli/src/utils/types.ts
@@ -20,6 +20,7 @@ export interface AndroidConfig extends CommonConfig {
   library: string;
   tasks: string[];
   variant: BuildVariant;
+  fused: boolean;
 }
 
 export interface PackageConfiguration {

--- a/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
+++ b/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
@@ -4,6 +4,7 @@ exports[`build:android command with prebuild should infer and print build config
 "Resolved build configuration
  - Build variant: All
  - Library: brownfield
+ - Fused: false
  - Verbose: false
  - Dry run: true
  - Tasks:

--- a/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
+++ b/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
@@ -21,6 +21,9 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
+  --fused                               publish a single fat AAR with every Expo
+                                        module merged in via AGP Fused Library
+                                        (forces release variant)
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can
@@ -41,6 +44,9 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
+  --fused                               publish a single fat AAR with every Expo
+                                        module merged in via AGP Fused Library
+                                        (forces release variant)
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can
@@ -61,6 +67,9 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
+  --fused                               publish a single fat AAR with every Expo
+                                        module merged in via AGP Fused Library
+                                        (forces release variant)
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can

--- a/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
+++ b/packages/expo-brownfield/e2e/cli/__tests__/__snapshots__/build-android.test.ts.snap
@@ -21,9 +21,8 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
-  --fused                               publish a single fat AAR with every Expo
-                                        module merged in via AGP Fused Library
-                                        (forces release variant)
+  --fused                               publish a single fat AAR per variant via
+                                        AGP Fused Library
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can
@@ -44,9 +43,8 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
-  --fused                               publish a single fat AAR with every Expo
-                                        module merged in via AGP Fused Library
-                                        (forces release variant)
+  --fused                               publish a single fat AAR per variant via
+                                        AGP Fused Library
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can
@@ -67,9 +65,8 @@ Options:
   -d, --debug                           build debug variant
   -r, --release                         build release variant
   -a, --all                             build both debug and release variants
-  --fused                               publish a single fat AAR with every Expo
-                                        module merged in via AGP Fused Library
-                                        (forces release variant)
+  --fused                               publish a single fat AAR per variant via
+                                        AGP Fused Library
   --verbose                             forward all output to the terminal
   -l, --library <library>               name of the brownfield library
   -t, --task <task...>                  publishing task to be run (multiple can

--- a/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
+++ b/packages/expo-brownfield/e2e/cli/__tests__/build-android.test.ts
@@ -363,6 +363,54 @@ describe('build:android command', () => {
     });
 
     /**
+     * Command: npx expo-brownfield build:android --repo MavenLocal --fused --dry-run
+     * Expected behavior: With --fused, repo tasks are routed to the per-variant
+     * fused sibling subprojects and -Pbrownfield.fused=true is forwarded to Gradle
+     */
+    it('should properly handle --fused option', async () => {
+      // Default variant (--all) expands to one task per fused sibling
+      await buildAndroidTest({
+        directory: TEMP_DIR_PREBUILD,
+        args: ['--repo', 'MavenLocal', '--fused', '--dry-run'],
+        stdout: [
+          BUILD_ANDROID.FUSED,
+          `./gradlew :brownfield-fused-debug:publishBrownfieldDebugPublicationToMavenLocal -Pbrownfield.fused=true`,
+          `./gradlew :brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal -Pbrownfield.fused=true`,
+        ],
+      });
+
+      // Single variant targets a single sibling
+      await buildAndroidTest({
+        directory: TEMP_DIR_PREBUILD,
+        args: ['--repo', 'MavenLocal', '--fused', '--release', '--dry-run'],
+        stdout: [
+          BUILD_ANDROID.BUILD_VARIANT_RELEASE,
+          `./gradlew :brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal -Pbrownfield.fused=true`,
+        ],
+      });
+    });
+
+    /**
+     * Command: npx expo-brownfield build:android -t <fused task> --dry-run (no --fused)
+     * Expected behavior: A fused task passed manually still activates fused mode in
+     * Gradle — without -Pbrownfield.fused=true the fused subprojects are inert and
+     * the AGP force-bump never applies
+     */
+    it('should forward the fused property for manually passed fused tasks', async () => {
+      await buildAndroidTest({
+        directory: TEMP_DIR_PREBUILD,
+        args: [
+          '-t',
+          ':brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal',
+          '--dry-run',
+        ],
+        stdout: [
+          `./gradlew :brownfield-fused-release:publishBrownfieldReleasePublicationToMavenLocal -Pbrownfield.fused=true`,
+        ],
+      });
+    });
+
+    /**
      * Command: npx expo-brownfield build:android
      * Expected behavior: The CLI should print an error message and exit
      */

--- a/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
+++ b/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
@@ -50,6 +50,64 @@ describe('plugin templates', () => {
 
   /**
    * Expected behavior:
+   * - Both fused sibling subprojects are emitted, one per variant, with
+   *   interpolated values resolved and the inert-by-default property guard
+   * - settings.gradle includes the fused siblings
+   * - gradle.properties contains the Fused Library preview opt-ins
+   * - The root build.gradle contains the conditional AGP force-bump
+   */
+  it('emits inert fused sibling projects for android', async () => {
+    const PACKAGE = 'com.example.test.mybrownfield';
+    const GROUP = 'io.example.test';
+    const VERSION = '2.56.173';
+    await setupAndroidPlugin(TEMP_DIR, {
+      package: PACKAGE,
+      group: GROUP,
+      version: VERSION,
+    });
+
+    for (const variant of ['release', 'debug']) {
+      expectFile({
+        projectRoot: TEMP_DIR,
+        filePath: `android/brownfield-fused-${variant}/build.gradle.kts`,
+        content: [
+          `group = "${GROUP}"`,
+          `version = "${VERSION}"`,
+          `namespace = "${PACKAGE}.fused.${variant}"`,
+          `val fusedVariant = "${variant}"`,
+          // Inert unless the CLI passes -Pbrownfield.fused=true — a plain
+          // `expo run:android` must not resolve the fused dependency graph
+          `findProperty("brownfield.fused") == "true"`,
+        ],
+      });
+    }
+
+    expectFile({
+      projectRoot: TEMP_DIR,
+      filePath: 'android/settings.gradle',
+      content: [
+        `include ':brownfield'`,
+        `include ':brownfield-fused-release'`,
+        `include ':brownfield-fused-debug'`,
+      ],
+    });
+    expectFile({
+      projectRoot: TEMP_DIR,
+      filePath: 'android/gradle.properties',
+      content: [
+        'android.experimental.fusedLibrarySupport=true',
+        'android.experimental.fusedLibrarySupport.publicationOnly=false',
+      ],
+    });
+    expectFile({
+      projectRoot: TEMP_DIR,
+      filePath: 'android/build.gradle',
+      content: [`findProperty('brownfield.fused') == 'true'`, 'com.android.tools.build:gradle'],
+    });
+  });
+
+  /**
+   * Expected behavior:
    * - All interpolated values are resolved in the templates for ios
    */
   it('resolves all interpolated values in templates for ios', async () => {

--- a/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
+++ b/packages/expo-brownfield/e2e/plugin/__tests__/templates.test.ts
@@ -33,7 +33,7 @@ describe('plugin templates', () => {
 
     expectFile({
       projectRoot: TEMP_DIR,
-      fileName: 'build.gradle.kts',
+      filePath: 'android/brownfield/build.gradle.kts',
       content: [`group = "${GROUP}"`, `version = "${VERSION}"`, `namespace = "${PACKAGE}"`],
     });
     expectFiles({

--- a/packages/expo-brownfield/e2e/utils/output.ts
+++ b/packages/expo-brownfield/e2e/utils/output.ts
@@ -24,6 +24,7 @@ export const BUILD_ANDROID = {
   BUILD_VARIANT_ALL: `- Build variant: All`,
   BUILD_VARIANT_DEBUG: `- Build variant: Debug`,
   BUILD_VARIANT_RELEASE: `- Build variant: Release`,
+  FUSED: `- Fused: true`,
   LIBRARY: `- Library: brownfieldlib`,
   TASK: [`- Tasks:`, `- task1`],
   TASKS: [`- Tasks:`, `- task1`, `- task2`, `- task3`],

--- a/packages/expo-brownfield/e2e/utils/test.ts
+++ b/packages/expo-brownfield/e2e/utils/test.ts
@@ -144,7 +144,7 @@ export const buildTestCommon = async ({
 /**
  * Expects the prebuild to be successful at the given project root and platform
  */
-export const expectPrebuild = async (projectRoot: string, platform: 'android' | 'ios') => {
+export const expectPrebuild = (projectRoot: string, platform: 'android' | 'ios') => {
   const prebuildDir = path.join(projectRoot, platform);
   expect(fs.existsSync(prebuildDir)).toBe(true);
 
@@ -162,12 +162,10 @@ interface ExpectFileOptions {
   content?: string[] | string;
 }
 
-export const expectFile = async ({
-  projectRoot,
-  fileName,
-  filePath,
-  content,
-}: ExpectFileOptions) => {
+// NOTE: deliberately synchronous — callers don't await this helper, so if it were
+// async, failed expect()s would surface as unhandled rejections that Jest ignores
+// instead of failing the test.
+export const expectFile = ({ projectRoot, fileName, filePath, content }: ExpectFileOptions) => {
   let fullFilePath: string;
 
   if (fileName) {
@@ -219,7 +217,7 @@ type ExpectFilesOptions =
       expected: ExpectedFileName[];
     };
 
-export const expectFiles = async (options: ExpectFilesOptions) => {
+export const expectFiles = (options: ExpectFilesOptions) => {
   if ('content' in options) {
     options.fileNames.forEach((fileName) => {
       expectFile({ projectRoot: options.projectRoot, fileName, content: options.content });

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -25,41 +25,20 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
   }
 
   /**
-   * In `--fused` mode (CLI passes `-Pbrownfield.fused=true`), the fat AAR built by the
-   * `:<library>-fused` sibling deliberately excludes a handful of Expo modules whose
-   * classes reference resources from EXTERNAL Maven deps (ExoPlayer for `expo-video`,
-   * CameraX for `expo-camera`, etc.) — AGP Fused Library's `rewriteClasses` can't
-   * resolve those references and fails. The skip-list lives in
-   * `templates/android/fused/build.gradle.kts` (`externalResourceExpoProjects`).
+   * In `--fused` mode, strips entries from the autolinking-generated
+   * `ExpoModulesPackageList.kt` for modules excluded from the fat AAR, so the host
+   * app doesn't hit `NoClassDefFoundError` at load time.
    *
-   * The autolinking-generated `ExpoModulesPackageList.kt` on the `:expo` project still
-   * references the skipped modules' Package / Module / Service classes by FQN. The fat
-   * AAR carries that file's compiled output, so when the host app loads it the static
-   * initializer hits a `NoClassDefFoundError` for the skipped classes.
-   *
-   * Workaround: hook the `:expo:generatePackagesList` task with a `doLast` that, when
-   * fused mode is active, strips every line in the generated file matching the skipped
-   * modules' package prefixes. Inert in default (non-fused) builds.
-   *
-   * MIRROR: the prefixes here correspond to the Gradle project names in
-   * `externalResourceExpoProjects` (in the fused template). Keep them aligned.
-   * Extend at invocation time via `-Pbrownfield.fused.strip-packages=foo.,bar.`.
-   *
-   * @param brownfieldProject The brownfield library project.
+   * Strip prefixes are passed via `-Pbrownfield.fused.strip-packages=foo.,bar.`.
+   * Inert in non-fused builds.
    */
   private fun setupFusedModeStripping(brownfieldProject: Project) {
     if (brownfieldProject.findProperty("brownfield.fused") != "true") return
 
     val expoProject = brownfieldProject.rootProject.findProject(":expo") ?: return
 
-    // Empty by default — heavy modules (expo-video, expo-camera, expo-image,
-    // expo-maps, ...) now fuse into the fat AAR via the transitive-AAR
-    // enumeration in the fused template, so their classes ARE present and the
-    // autolinking references in ExpoModulesPackageList.kt resolve cleanly. The
-    // strip hook stays in place as a safety net for any module the user
-    // explicitly skips via `-Pbrownfield.fused.skip=...` — pair that with
-    // `-Pbrownfield.fused.strip-packages=...` listing the package prefixes to
-    // strip so the runtime doesn't crash on a dangling reference.
+    // Empty by default; opt-in via `-Pbrownfield.fused.strip-packages=...` when
+    // pairing with `-Pbrownfield.fused.skip=...` to drop dangling references.
     val defaultStripPrefixes = emptySet<String>()
     val extraStrip =
       (brownfieldProject.findProperty("brownfield.fused.strip-packages") as? String)

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -25,21 +25,10 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
   }
 
   /**
-   * In `--fused` mode, strips entries from the autolinking-generated
-   * `ExpoModulesPackageList.kt` for modules excluded from the fat AAR, so the host
-   * app doesn't hit `NoClassDefFoundError` at load time.
-   *
-   * Variant-aware: on the RELEASE sibling build (CLI passes
-   * `-Pbrownfield.fused.variant=release`), dev-only Expo modules
-   * (`expo-dev-menu` / `-launcher` / `-client`) are excluded from the fat AAR by
-   * the fused template's `devOnlySkipProjects` set, so this strips their
-   * `ExpoModulesPackageList` references too. On the DEBUG sibling build, dev
-   * modules ARE included, so no stripping is needed.
-   *
-   * Extra prefixes can be passed via `-Pbrownfield.fused.strip-packages=foo.,bar.`
-   * to handle ad-hoc skip-list additions.
-   *
-   * Inert in non-fused builds.
+   * In `--fused` release builds, strips dev-only entries from the autolinking-generated
+   * `ExpoModulesPackageList.kt` so the host app doesn't hit `NoClassDefFoundError`
+   * for modules excluded from the fat AAR. Extra prefixes via
+   * `-Pbrownfield.fused.strip-packages=foo.,bar.`. Inert otherwise.
    */
   private fun setupFusedModeStripping(brownfieldProject: Project) {
     if (brownfieldProject.findProperty("brownfield.fused") != "true") return

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -12,6 +12,7 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     project.evaluationDependsOn(":expo")
     setupDependencySubstitution(project)
+    setupFusedModeStripping(project)
 
     project.afterEvaluate { project ->
       setupSourceSets(project)
@@ -20,6 +21,80 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
       setupCopyingNativeLibsForType(project, "Debug")
       setupHostAppArtifactForwardingForRelease(project)
       wireDevLauncherTasks(project)
+    }
+  }
+
+  /**
+   * In `--fused` mode (CLI passes `-Pbrownfield.fused=true`), the fat AAR built by the
+   * `:<library>-fused` sibling deliberately excludes a handful of Expo modules whose
+   * classes reference resources from EXTERNAL Maven deps (ExoPlayer for `expo-video`,
+   * CameraX for `expo-camera`, etc.) — AGP Fused Library's `rewriteClasses` can't
+   * resolve those references and fails. The skip-list lives in
+   * `templates/android/fused/build.gradle.kts` (`externalResourceExpoProjects`).
+   *
+   * The autolinking-generated `ExpoModulesPackageList.kt` on the `:expo` project still
+   * references the skipped modules' Package / Module / Service classes by FQN. The fat
+   * AAR carries that file's compiled output, so when the host app loads it the static
+   * initializer hits a `NoClassDefFoundError` for the skipped classes.
+   *
+   * Workaround: hook the `:expo:generatePackagesList` task with a `doLast` that, when
+   * fused mode is active, strips every line in the generated file matching the skipped
+   * modules' package prefixes. Inert in default (non-fused) builds.
+   *
+   * MIRROR: the prefixes here correspond to the Gradle project names in
+   * `externalResourceExpoProjects` (in the fused template). Keep them aligned.
+   * Extend at invocation time via `-Pbrownfield.fused.strip-packages=foo.,bar.`.
+   *
+   * @param brownfieldProject The brownfield library project.
+   */
+  private fun setupFusedModeStripping(brownfieldProject: Project) {
+    if (brownfieldProject.findProperty("brownfield.fused") != "true") return
+
+    val expoProject = brownfieldProject.rootProject.findProject(":expo") ?: return
+
+    val defaultStripPrefixes = setOf(
+      "expo.modules.video.",
+      "expo.modules.camera.",
+      "expo.modules.image.",
+      "expo.modules.imagepicker.",
+      "expo.modules.documentpicker.",
+      "expo.modules.maps.",
+      "expo.av.",
+    )
+    val extraStrip =
+      (brownfieldProject.findProperty("brownfield.fused.strip-packages") as? String)
+        ?.split(',')
+        ?.map { it.trim() }
+        ?.filter { it.isNotEmpty() }
+        ?.toSet()
+        ?: emptySet()
+    val stripPrefixes = defaultStripPrefixes + extraStrip
+
+    // `:expo` is already evaluated (forced by `evaluationDependsOn(":expo")` at the
+    // top of `apply`), so we read the task directly — no afterEvaluate needed.
+    val task = expoProject.tasks.findByName("generatePackagesList") ?: return
+    task.doLast {
+      val outputFile =
+        expoProject.layout.buildDirectory
+          .file("generated/expo/src/main/java/expo/modules/ExpoModulesPackageList.kt")
+          .get()
+          .asFile
+      if (!outputFile.exists()) {
+        expoProject.logger.warn(
+          "brownfield.fused: ExpoModulesPackageList.kt not found at ${outputFile.path}; nothing to strip"
+        )
+        return@doLast
+      }
+      val original = outputFile.readText()
+      val stripped =
+        original
+          .lineSequence()
+          .filter { line -> stripPrefixes.none { prefix -> line.contains(prefix) } }
+          .joinToString("\n")
+      outputFile.writeText(stripped)
+      expoProject.logger.lifecycle(
+        "brownfield.fused: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"
+      )
     }
   }
 

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -29,7 +29,16 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
    * `ExpoModulesPackageList.kt` for modules excluded from the fat AAR, so the host
    * app doesn't hit `NoClassDefFoundError` at load time.
    *
-   * Strip prefixes are passed via `-Pbrownfield.fused.strip-packages=foo.,bar.`.
+   * Variant-aware: on the RELEASE sibling build (CLI passes
+   * `-Pbrownfield.fused.variant=release`), dev-only Expo modules
+   * (`expo-dev-menu` / `-launcher` / `-client`) are excluded from the fat AAR by
+   * the fused template's `devOnlySkipProjects` set, so this strips their
+   * `ExpoModulesPackageList` references too. On the DEBUG sibling build, dev
+   * modules ARE included, so no stripping is needed.
+   *
+   * Extra prefixes can be passed via `-Pbrownfield.fused.strip-packages=foo.,bar.`
+   * to handle ad-hoc skip-list additions.
+   *
    * Inert in non-fused builds.
    */
   private fun setupFusedModeStripping(brownfieldProject: Project) {
@@ -37,9 +46,23 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
 
     val expoProject = brownfieldProject.rootProject.findProject(":expo") ?: return
 
-    // Empty by default; opt-in via `-Pbrownfield.fused.strip-packages=...` when
-    // pairing with `-Pbrownfield.fused.skip=...` to drop dangling references.
-    val defaultStripPrefixes = emptySet<String>()
+    // Strip prefixes that mirror the `devOnlySkipProjects` set in the release
+    // fused sibling. Kept in sync manually — if you add a module to the release
+    // skip list in `templates/android/fused/build.gradle.kts`, add its package
+    // prefix here too.
+    val fusedVariant =
+      (brownfieldProject.findProperty("brownfield.fused.variant") as? String)?.lowercase()
+    val variantStripPrefixes: Set<String> =
+      if (fusedVariant == "release") {
+        setOf(
+          "expo.modules.devmenu.",
+          "expo.modules.devlauncher.",
+          "expo.modules.devclient.",
+          "expo.interfaces.devmenu.",
+        )
+      } else {
+        emptySet()
+      }
     val extraStrip =
       (brownfieldProject.findProperty("brownfield.fused.strip-packages") as? String)
         ?.split(',')
@@ -47,7 +70,9 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
         ?.filter { it.isNotEmpty() }
         ?.toSet()
         ?: emptySet()
-    val stripPrefixes = defaultStripPrefixes + extraStrip
+    val stripPrefixes = variantStripPrefixes + extraStrip
+
+    if (stripPrefixes.isEmpty()) return
 
     // `:expo` is already evaluated (forced by `evaluationDependsOn(":expo")` at the
     // top of `apply`), so we read the task directly — no afterEvaluate needed.
@@ -72,7 +97,7 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
           .joinToString("\n")
       outputFile.writeText(stripped)
       expoProject.logger.lifecycle(
-        "brownfield.fused: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"
+        "brownfield.fused[${fusedVariant ?: "?"}]: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"
       )
     }
   }

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -52,15 +52,15 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
 
     val expoProject = brownfieldProject.rootProject.findProject(":expo") ?: return
 
-    val defaultStripPrefixes = setOf(
-      "expo.modules.video.",
-      "expo.modules.camera.",
-      "expo.modules.image.",
-      "expo.modules.imagepicker.",
-      "expo.modules.documentpicker.",
-      "expo.modules.maps.",
-      "expo.av.",
-    )
+    // Empty by default — heavy modules (expo-video, expo-camera, expo-image,
+    // expo-maps, ...) now fuse into the fat AAR via the transitive-AAR
+    // enumeration in the fused template, so their classes ARE present and the
+    // autolinking references in ExpoModulesPackageList.kt resolve cleanly. The
+    // strip hook stays in place as a safety net for any module the user
+    // explicitly skips via `-Pbrownfield.fused.skip=...` — pair that with
+    // `-Pbrownfield.fused.strip-packages=...` listing the package prefixes to
+    // strip so the runtime doesn't crash on a dangling reference.
+    val defaultStripPrefixes = emptySet<String>()
     val extraStrip =
       (brownfieldProject.findProperty("brownfield.fused.strip-packages") as? String)
         ?.split(',')

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -41,17 +41,11 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
     // prefix here too.
     val fusedVariant =
       (brownfieldProject.findProperty("brownfield.fused.variant") as? String)?.lowercase()
-    val variantStripPrefixes: Set<String> =
-      if (fusedVariant == "release") {
-        setOf(
-          "expo.modules.devmenu.",
-          "expo.modules.devlauncher.",
-          "expo.modules.devclient.",
-          "expo.interfaces.devmenu.",
-        )
-      } else {
-        emptySet()
-      }
+    // EXPERIMENT: skip variant-based stripping entirely to test whether the
+    // "all modules physically present" tolerance also holds for the brownfield
+    // fused AAR. `-Pbrownfield.fused.strip-packages=...` still works for ad-hoc
+    // overrides.
+    val variantStripPrefixes: Set<String> = emptySet()
     val extraStrip =
       (brownfieldProject.findProperty("brownfield.fused.strip-packages") as? String)
         ?.split(',')

--- a/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
+++ b/packages/expo-brownfield/gradle-plugins/brownfield/src/main/kotlin/expo/modules/plugin/ExpoBrownfieldSetupPlugin.kt
@@ -25,35 +25,29 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
   }
 
   /**
-   * In `--fused` release builds, strips dev-only entries from the autolinking-generated
-   * `ExpoModulesPackageList.kt` so the host app doesn't hit `NoClassDefFoundError`
-   * for modules excluded from the fat AAR. Extra prefixes via
-   * `-Pbrownfield.fused.strip-packages=foo.,bar.`. Inert otherwise.
+   * In `--fused` builds, strips entries from the autolinking-generated
+   * `ExpoModulesPackageList.kt` by package prefix, via
+   * `-Pbrownfield.fused.strip-packages=expo.modules.foo.,expo.modules.bar.`.
+   *
+   * This is the companion escape hatch to `-Pbrownfield.fused.skip=<project,...>`
+   * in the fused sibling's build script: a module excluded from the fat AAR still
+   * has its `Package` class referenced by `ExpoModulesPackageList.<clinit>`, which
+   * would crash the host with `NoClassDefFoundError` at startup — stripping the
+   * matching entries here keeps the package list consistent with the AAR contents.
+   * Inert unless both properties are set.
    */
   private fun setupFusedModeStripping(brownfieldProject: Project) {
     if (brownfieldProject.findProperty("brownfield.fused") != "true") return
 
     val expoProject = brownfieldProject.rootProject.findProject(":expo") ?: return
 
-    // Strip prefixes that mirror the `devOnlySkipProjects` set in the release
-    // fused sibling. Kept in sync manually — if you add a module to the release
-    // skip list in `templates/android/fused/build.gradle.kts`, add its package
-    // prefix here too.
-    val fusedVariant =
-      (brownfieldProject.findProperty("brownfield.fused.variant") as? String)?.lowercase()
-    // EXPERIMENT: skip variant-based stripping entirely to test whether the
-    // "all modules physically present" tolerance also holds for the brownfield
-    // fused AAR. `-Pbrownfield.fused.strip-packages=...` still works for ad-hoc
-    // overrides.
-    val variantStripPrefixes: Set<String> = emptySet()
-    val extraStrip =
+    val stripPrefixes =
       (brownfieldProject.findProperty("brownfield.fused.strip-packages") as? String)
         ?.split(',')
         ?.map { it.trim() }
         ?.filter { it.isNotEmpty() }
         ?.toSet()
         ?: emptySet()
-    val stripPrefixes = variantStripPrefixes + extraStrip
 
     if (stripPrefixes.isEmpty()) return
 
@@ -80,7 +74,7 @@ class ExpoBrownfieldSetupPlugin : Plugin<Project> {
           .joinToString("\n")
       outputFile.writeText(stripped)
       expoProject.logger.lifecycle(
-        "brownfield.fused[${fusedVariant ?: "?"}]: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"
+        "brownfield.fused: stripped ExpoModulesPackageList entries matching ${stripPrefixes.joinToString(", ")}"
       )
     }
   }

--- a/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
+++ b/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
   implementation("expo.modules:expo-autolinking-plugin-shared")
   implementation("org.json:json:20250517")
   implementation(gradleApi())
-  compileOnly("com.android.tools.build:gradle:8.5.0")
+  compileOnly("com.android.tools.build:gradle:9.0.0")
 }
 
 java {

--- a/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
+++ b/packages/expo-brownfield/gradle-plugins/publish/build.gradle.kts
@@ -14,7 +14,10 @@ dependencies {
   implementation("expo.modules:expo-autolinking-plugin-shared")
   implementation("org.json:json:20250517")
   implementation(gradleApi())
-  compileOnly("com.android.tools.build:gradle:9.0.0")
+  // Matches FUSED_AGP_VERSION in the config plugin — the newest AGP the plugin can
+  // run against (forced in fused mode). Compiling against a newer major than the
+  // runtime AGP risks NoSuchMethodError on changed APIs.
+  compileOnly("com.android.tools.build:gradle:8.13.0")
 }
 
 java {

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/prebuilts.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/prebuilts.kt
@@ -13,6 +13,15 @@ import org.gradle.api.tasks.TaskProvider
  */
 internal fun setupPrebuiltsCopying(rootProject: Project) {
   rootProject.afterEvaluate {
+    // In `--fused` mode the user is publishing a single fat AAR via Fused Library that
+    // already merges every Expo module's classes/resources/jni inside it — the
+    // per-module mavenLocal/remote re-publish loop below would emit redundant
+    // coordinates next to the fat AAR. Skip the whole setup when the CLI sets this
+    // property (`-Pbrownfield.fused=true`).
+    if (rootProject.findProperty("brownfield.fused") == "true") {
+      return@afterEvaluate
+    }
+
     val configExtension = getConfigExtension(rootProject)
 
     if (configExtension.publications.isEmpty) {

--- a/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/prebuilts.kt
+++ b/packages/expo-brownfield/gradle-plugins/publish/src/main/kotlin/expo/modules/plugin/prebuilts.kt
@@ -16,8 +16,7 @@ internal fun setupPrebuiltsCopying(rootProject: Project) {
     // In `--fused` mode the user is publishing a single fat AAR via Fused Library that
     // already merges every Expo module's classes/resources/jni inside it — the
     // per-module mavenLocal/remote re-publish loop below would emit redundant
-    // coordinates next to the fat AAR. Skip the whole setup when the CLI sets this
-    // property (`-Pbrownfield.fused=true`).
+    // coordinates next to the fat AAR. Skip.
     if (rootProject.findProperty("brownfield.fused") == "true") {
       return@afterEvaluate
     }

--- a/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
@@ -14,8 +14,62 @@ const withGradlePropertiesPlugin: ConfigPlugin = (config) => {
       }
     }
 
+    // AGP's Fused Library plugin is in Preview and refuses to apply without an explicit
+    // opt-in. The second flag lets `include(project(...))` resolve sibling Gradle
+    // subprojects directly instead of forcing a per-module mavenLocal round-trip.
+    // Emit both unconditionally — they're no-ops in default (non-fused) mode.
+    const hasFusedOptIn = config.modResults.some(
+      (item) =>
+        item.type === 'property' && item.key === 'android.experimental.fusedLibrarySupport'
+    );
+    const hasFusedPubFlag = config.modResults.some(
+      (item) =>
+        item.type === 'property' &&
+        item.key === 'android.experimental.fusedLibrarySupport.publicationOnly'
+    );
+    if (!hasFusedOptIn || !hasFusedPubFlag) {
+      config.modResults = [
+        ...config.modResults,
+        ...getFusedLibrarySupportConfiguration(hasFusedOptIn, hasFusedPubFlag),
+      ];
+    }
+
     return config;
   });
+};
+
+const getFusedLibrarySupportConfiguration = (
+  hasFusedOptIn: boolean,
+  hasFusedPubFlag: boolean
+): AndroidConfig.Properties.PropertiesItem[] => {
+  const items: AndroidConfig.Properties.PropertiesItem[] = [];
+  if (!hasFusedOptIn) {
+    items.push(
+      {
+        type: 'comment',
+        value: "Acknowledge AGP Fused Library Preview status (required to apply the plugin)",
+      },
+      {
+        type: 'property',
+        key: 'android.experimental.fusedLibrarySupport',
+        value: 'true',
+      }
+    );
+  }
+  if (!hasFusedPubFlag) {
+    items.push(
+      {
+        type: 'comment',
+        value: 'Allow `com.android.fused-library` to include sibling project deps directly',
+      },
+      {
+        type: 'property',
+        key: 'android.experimental.fusedLibrarySupport.publicationOnly',
+        value: 'false',
+      }
+    );
+  }
+  return items;
 };
 
 const getDevMenuReleaseConfiguration = (): AndroidConfig.Properties.PropertiesItem[] => {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withGradlePropertiesPlugin.ts
@@ -14,10 +14,9 @@ const withGradlePropertiesPlugin: ConfigPlugin = (config) => {
       }
     }
 
-    // AGP's Fused Library plugin is in Preview and refuses to apply without an explicit
-    // opt-in. The second flag lets `include(project(...))` resolve sibling Gradle
-    // subprojects directly instead of forcing a per-module mavenLocal round-trip.
-    // Emit both unconditionally — they're no-ops in default (non-fused) mode.
+    // Opt into AGP's Fused Library Preview. The `.publicationOnly=false` flag lets
+    // `include(project(...))` resolve sibling subprojects directly (no mavenLocal
+    // round-trip). No-op in non-fused mode.
     const hasFusedOptIn = config.modResults.some(
       (item) =>
         item.type === 'property' && item.key === 'android.experimental.fusedLibrarySupport'

--- a/packages/expo-brownfield/plugin/src/android/plugins/withProjectBuildGradlePlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withProjectBuildGradlePlugin.ts
@@ -7,25 +7,61 @@ const EXPO_APPLY_STATEMENT = 'apply plugin: "expo-root-project"';
 const PLUGIN_CLASSPATH = 'expo.modules:publish';
 const PLUGIN_NAME = 'expo-brownfield-publish';
 
+// AGP 8.12.0's Fused Library plugin's `rewriteClasses` task uses an ASM API version
+// below 9 at the call site and can't read `PermittedSubclasses` bytecode attributes
+// emitted for every Kotlin `sealed class`. AGP 8.13.0+ raises the hardcoded API
+// version. Bump only when the user opts into fused mode via `--fused` (which passes
+// `-Pbrownfield.fused=true`), so default builds keep using the version catalog's AGP.
+const FUSED_AGP_VERSION = '8.13.0';
+const FUSED_AGP_MARKER = 'brownfield.fused';
+
 const withProjectBuildGradlePlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig) => {
   return withProjectBuildGradle(config, (config) => {
-    if (config.modResults.contents.includes(PLUGIN_CLASSPATH)) {
-      return config;
+    let lines = config.modResults.contents.split('\n');
+
+    if (!config.modResults.contents.includes(FUSED_AGP_MARKER)) {
+      lines = addFusedAgpResolutionStrategy(lines);
     }
 
-    let lines = config.modResults.contents.split('\n');
-    lines = addPluginClasspathStatement(lines);
-    lines = addApplyStatement(lines);
-    lines = addPublicationConfiguration(
-      lines,
-      pluginConfig.publishing,
-      pluginConfig.projectRoot,
-      pluginConfig.libraryName
-    );
+    if (!config.modResults.contents.includes(PLUGIN_CLASSPATH)) {
+      lines = addPluginClasspathStatement(lines);
+      lines = addApplyStatement(lines);
+      lines = addPublicationConfiguration(
+        lines,
+        pluginConfig.publishing,
+        pluginConfig.projectRoot,
+        pluginConfig.libraryName
+      );
+    }
+
     config.modResults.contents = lines.join('\n');
 
     return config;
   });
+};
+
+const addFusedAgpResolutionStrategy = (lines: string[]): string[] => {
+  // Appended as a sibling top-level `buildscript { ... }` block. Gradle merges multiple
+  // top-level buildscript blocks, so this composes with the project's existing one
+  // without clobbering it. The `findProperty` check makes the override conditional on
+  // `-Pbrownfield.fused=true` (set by `expo-brownfield build:android --fused`); without
+  // the flag the resolution-strategy block never runs and AGP stays at the catalog
+  // version.
+  const block = [
+    '',
+    'buildscript {',
+    '  // expo-brownfield: bump AGP only when `--fused` is active (CLI passes',
+    `  // -P${FUSED_AGP_MARKER}=true). AGP 8.12.0's Fused Library can't read Kotlin`,
+    '  // sealed-class bytecode (PermittedSubclasses requires ASM API >= 9, fixed',
+    `  // in AGP ${FUSED_AGP_VERSION}).`,
+    `  if (findProperty('${FUSED_AGP_MARKER}') == 'true') {`,
+    '    configurations.classpath {',
+    `      resolutionStrategy.force 'com.android.tools.build:gradle:${FUSED_AGP_VERSION}'`,
+    '    }',
+    '  }',
+    '}',
+  ];
+  return [...lines, ...block];
 };
 
 const addPluginClasspathStatement = (lines: string[]): string[] => {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
@@ -15,19 +15,26 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     const brownfieldMainPath = path.join(brownfieldPath, 'src/main/');
     const brownfieldSourcesPath = path.join(brownfieldMainPath, pluginConfig.packagePath);
 
-    // The fused sibling sits next to the brownfield library so AGP's
+    // The fused siblings sit next to the brownfield library so AGP's
     // `com.android.fused-library` plugin can `include(project(":<expoModule>"))` from
-    // the same Gradle build. It carries no sources — only an `include()` list. Built
-    // only when the user opts in via `expo-brownfield build:android --fused`.
-    const fusedPath = path.join(
+    // the same Gradle build. Two siblings — one per variant — because AGP fused-library
+    // is single-variant per module by design. Each carries no sources, only an
+    // `include()` list. Only assembled when the user opts in via
+    // `expo-brownfield build:android --fused` (+ `--debug`/`--release`/`--all`).
+    const fusedReleasePath = path.join(
       pluginConfig.projectRoot,
-      `android/${pluginConfig.libraryName}-fused`
+      `android/${pluginConfig.libraryName}-fused-release`
+    );
+    const fusedDebugPath = path.join(
+      pluginConfig.projectRoot,
+      `android/${pluginConfig.libraryName}-fused-debug`
     );
 
     // Create directory for the brownfield library sources
     // (and all intermediate directories)
     mkdir(brownfieldSourcesPath, true);
-    mkdir(fusedPath, true);
+    mkdir(fusedReleasePath, true);
+    mkdir(fusedDebugPath, true);
 
     // Add files from templates to the brownfield library:
     // - AndroidManifest.xml
@@ -59,20 +66,26 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     createFileFromTemplate('proguard-rules.pro', brownfieldPath);
     createFileFromTemplate('consumer-rules.pro', brownfieldPath);
 
-    // Emit the fused sibling's build.gradle.kts. The template lives at
-    // packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts.
-    // It is only assembled when the user runs `expo-brownfield build:android --fused`.
-    createFileFromTemplateAs(
-      path.join('fused', 'build.gradle.kts'),
-      fusedPath,
-      'build.gradle.kts',
-      {
-        packageId: pluginConfig.package,
-        groupId: pluginConfig.group,
-        version: pluginConfig.version,
-        libraryName: pluginConfig.libraryName,
-      }
-    );
+    // Emit the fused siblings' build.gradle.kts files. Same template at
+    // packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts —
+    // `fusedVariant` is the only difference: substituted as "release" or "debug",
+    // the script then branches on `isReleaseVariant` for the few places the two
+    // siblings differ (dev-only skip, namespace suffix, publication name).
+    const fusedTemplate = path.join('fused', 'build.gradle.kts');
+    const fusedBaseVars = {
+      packageId: pluginConfig.package,
+      groupId: pluginConfig.group,
+      version: pluginConfig.version,
+      libraryName: pluginConfig.libraryName,
+    };
+    createFileFromTemplateAs(fusedTemplate, fusedReleasePath, 'build.gradle.kts', {
+      ...fusedBaseVars,
+      fusedVariant: 'release',
+    });
+    createFileFromTemplateAs(fusedTemplate, fusedDebugPath, 'build.gradle.kts', {
+      ...fusedBaseVars,
+      fusedVariant: 'debug',
+    });
 
     // Adjust ReactNativeHostManager and BrownfieldActivity to initialize dev menu
     if (checkPlugin(config, 'expo-dev-menu')) {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
@@ -15,12 +15,6 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     const brownfieldMainPath = path.join(brownfieldPath, 'src/main/');
     const brownfieldSourcesPath = path.join(brownfieldMainPath, pluginConfig.packagePath);
 
-    // The fused siblings sit next to the brownfield library so AGP's
-    // `com.android.fused-library` plugin can `include(project(":<expoModule>"))` from
-    // the same Gradle build. Two siblings — one per variant — because AGP fused-library
-    // is single-variant per module by design. Each carries no sources, only an
-    // `include()` list. Only assembled when the user opts in via
-    // `expo-brownfield build:android --fused` (+ `--debug`/`--release`/`--all`).
     const fusedReleasePath = path.join(
       pluginConfig.projectRoot,
       `android/${pluginConfig.libraryName}-fused-release`

--- a/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
@@ -63,8 +63,8 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     // Emit the fused siblings' build.gradle.kts files. Same template at
     // packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts —
     // `fusedVariant` is the only difference: substituted as "release" or "debug",
-    // the script then branches on `isReleaseVariant` for the few places the two
-    // siblings differ (dev-only skip, namespace suffix, publication name).
+    // it drives the namespace suffix, publication name, and which build type the
+    // sibling resolves and fuses.
     const fusedTemplate = path.join('fused', 'build.gradle.kts');
     const fusedBaseVars = {
       packageId: pluginConfig.package,

--- a/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withProjectFilesPlugin.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { applyPatchToFile, checkPlugin, mkdir } from '../../common';
 import type { PluginConfig } from '../types';
-import { createFileFromTemplate } from '../utils';
+import { createFileFromTemplate, createFileFromTemplateAs } from '../utils';
 
 const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig) => {
   return withAndroidManifest(config, (config) => {
@@ -15,9 +15,19 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     const brownfieldMainPath = path.join(brownfieldPath, 'src/main/');
     const brownfieldSourcesPath = path.join(brownfieldMainPath, pluginConfig.packagePath);
 
+    // The fused sibling sits next to the brownfield library so AGP's
+    // `com.android.fused-library` plugin can `include(project(":<expoModule>"))` from
+    // the same Gradle build. It carries no sources — only an `include()` list. Built
+    // only when the user opts in via `expo-brownfield build:android --fused`.
+    const fusedPath = path.join(
+      pluginConfig.projectRoot,
+      `android/${pluginConfig.libraryName}-fused`
+    );
+
     // Create directory for the brownfield library sources
     // (and all intermediate directories)
     mkdir(brownfieldSourcesPath, true);
+    mkdir(fusedPath, true);
 
     // Add files from templates to the brownfield library:
     // - AndroidManifest.xml
@@ -48,6 +58,21 @@ const withProjectFilesPlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig
     });
     createFileFromTemplate('proguard-rules.pro', brownfieldPath);
     createFileFromTemplate('consumer-rules.pro', brownfieldPath);
+
+    // Emit the fused sibling's build.gradle.kts. The template lives at
+    // packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts.
+    // It is only assembled when the user runs `expo-brownfield build:android --fused`.
+    createFileFromTemplateAs(
+      path.join('fused', 'build.gradle.kts'),
+      fusedPath,
+      'build.gradle.kts',
+      {
+        packageId: pluginConfig.package,
+        groupId: pluginConfig.group,
+        version: pluginConfig.version,
+        libraryName: pluginConfig.libraryName,
+      }
+    );
 
     // Adjust ReactNativeHostManager and BrownfieldActivity to initialize dev menu
     if (checkPlugin(config, 'expo-dev-menu')) {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
@@ -10,13 +10,15 @@ const withSettingsGradlePlugin: ConfigPlugin<PluginConfig> = (config, pluginConf
   });
 };
 
-// The fused sibling Gradle subproject (sourceless, applies `com.android.fused-library`)
-// is always emitted so it can be targeted on demand by `expo-brownfield build:android --fused`.
-// It's idle in default mode — no tasks run, nothing is built.
+// Two fused sibling Gradle subprojects (sourceless, applies `com.android.fused-library`)
+// are always emitted — one per variant — so each can be targeted on demand by
+// `expo-brownfield build:android --fused --release` / `--debug` / `--all`. They're
+// idle in default mode — no tasks run, nothing is built.
 const getBrownfieldIncludeStatement = (libraryName: string) => {
   return [
     `include ':${libraryName}'`,
-    `include ':${libraryName}-fused'`,
+    `include ':${libraryName}-fused-release'`,
+    `include ':${libraryName}-fused-debug'`,
     '',
   ].join('\n');
 };

--- a/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
@@ -4,23 +4,32 @@ import type { PluginConfig } from '../types';
 
 const withSettingsGradlePlugin: ConfigPlugin<PluginConfig> = (config, pluginConfig) => {
   return withSettingsGradle(config, (config) => {
-    config.modResults.contents += getBrownfieldIncludeStatement(pluginConfig.libraryName);
-    config.modResults.contents += getBrownfieldPluginIncludeStatement();
+    // Append line-by-line so re-running prebuild without --clean (or after
+    // upgrading from a version without the fused siblings) adds only what's
+    // missing instead of duplicating the whole block.
+    for (const line of getBrownfieldIncludeStatements(pluginConfig.libraryName)) {
+      if (!config.modResults.contents.includes(line)) {
+        config.modResults.contents += `${line}\n`;
+      }
+    }
+    if (!config.modResults.contents.includes('includeBuild(brownfieldPluginsPath)')) {
+      config.modResults.contents += getBrownfieldPluginIncludeStatement();
+    }
     return config;
   });
 };
 
 // Two fused sibling Gradle subprojects (sourceless, applies `com.android.fused-library`)
 // are always emitted — one per variant — so each can be targeted on demand by
-// `expo-brownfield build:android --fused --release` / `--debug` / `--all`. They're
-// idle in default mode — no tasks run, nothing is built.
-const getBrownfieldIncludeStatement = (libraryName: string) => {
+// `expo-brownfield build:android --fused --release` / `--debug` / `--all`. Their
+// build scripts are inert unless the CLI passes `-Pbrownfield.fused=true`, so in
+// default mode they register no publications and resolve nothing.
+const getBrownfieldIncludeStatements = (libraryName: string) => {
   return [
     `include ':${libraryName}'`,
     `include ':${libraryName}-fused-release'`,
     `include ':${libraryName}-fused-debug'`,
-    '',
-  ].join('\n');
+  ];
 };
 
 const getBrownfieldPluginIncludeStatement = () => {

--- a/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
+++ b/packages/expo-brownfield/plugin/src/android/plugins/withSettingsGradlePlugin.ts
@@ -10,8 +10,15 @@ const withSettingsGradlePlugin: ConfigPlugin<PluginConfig> = (config, pluginConf
   });
 };
 
+// The fused sibling Gradle subproject (sourceless, applies `com.android.fused-library`)
+// is always emitted so it can be targeted on demand by `expo-brownfield build:android --fused`.
+// It's idle in default mode — no tasks run, nothing is built.
 const getBrownfieldIncludeStatement = (libraryName: string) => {
-  return `include ':${libraryName}'\n`;
+  return [
+    `include ':${libraryName}'`,
+    `include ':${libraryName}-fused'`,
+    '',
+  ].join('\n');
 };
 
 const getBrownfieldPluginIncludeStatement = () => {

--- a/packages/expo-brownfield/plugin/src/common/filesystem.ts
+++ b/packages/expo-brownfield/plugin/src/common/filesystem.ts
@@ -15,6 +15,11 @@ const interpolateVariables = (str: string, variables: Record<string, unknown>): 
   let match = variableRegex.exec(str);
   while (match) {
     const variable = match[0].slice(3, -2);
+    if (!(variable in variables)) {
+      throw new Error(
+        `The expo-brownfield template variable "${variable}" has no value, so the generated file would contain the literal string "undefined" and fail to build. This usually means the plugin passed an incomplete variable set for this template — report this at https://github.com/expo/expo/issues.`
+      );
+    }
     str = str.replace(match[0], String(variables[variable]));
     match = variableRegex.exec(str);
   }

--- a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
+++ b/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
@@ -1,8 +1,11 @@
 package ${{packageId}}
 
+import android.app.Activity
 import android.app.Application
 import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatActivity
+import com.facebook.react.ReactPackage
+import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
 import expo.modules.ApplicationLifecycleDispatcher
 
 object BrownfieldLifecycleDispatcher {
@@ -15,9 +18,24 @@ object BrownfieldLifecycleDispatcher {
   }
 }
 
-open class BrownfieldActivity : AppCompatActivity() {
+// DefaultHardwareBackBtnHandler is declared here because ReactDelegate.onHostResume()
+// hard-casts the host Activity to it — without the interface on the base class, every
+// subclass would crash with ClassCastException on first resume.
+open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
   override fun onConfigurationChanged(newConfig: Configuration) {
     super.onConfigurationChanged(newConfig)
     BrownfieldLifecycleDispatcher.onConfigurationChanged(this.application, newConfig)
+  }
+
+  open fun showReactNativeFragment(
+    rootComponent: String = "main",
+    additionalPackages: List<ReactPackage> = emptyList(),
+  ) {
+    (this as Activity).showReactNativeFragment(rootComponent, additionalPackages)
+  }
+
+  @Suppress("DEPRECATION")
+  override fun invokeDefaultOnBackPressed() {
+    super.onBackPressed()
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
+++ b/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
@@ -34,8 +34,13 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandl
     (this as Activity).showReactNativeFragment(rootComponent, additionalPackages)
   }
 
-  @Suppress("DEPRECATION")
+  // React Native calls this when JS has no back handler. Don't call
+  // super.onBackPressed() here: it re-dispatches through the
+  // OnBackPressedDispatcher, whose RN callback (setUpNativeBackHandling)
+  // forwards back to JS — an infinite native <-> JS ping-pong that makes the
+  // back button dead. Finishing the activity is the default back action for a
+  // brownfield React Native screen: it returns to the previous host screen.
   override fun invokeDefaultOnBackPressed() {
-    super.onBackPressed()
+    finish()
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
+++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
@@ -58,9 +58,15 @@ class ReactNativeHostManager {
     loadReactNative(application)
     BrownfieldLifecycleDispatcher.onApplicationCreate(application)
 
+    // Pass `useDevSupport` explicitly (default is `ReactBuildConfig.DEBUG`). The
+    // brownfield's own `BuildConfig.DEBUG` follows the fused sibling's variant
+    // (true in `-fused-debug`, false in `-fused-release`) — using it ensures
+    // dev support fires correctly regardless of which RN variant the consumer
+    // resolves.
     reactHost = ExpoReactHostFactory.getDefaultReactHost(
       context = application.applicationContext,
-      packageList = PackageList(application).packages + additionalPackages
+      packageList = PackageList(application).packages + additionalPackages,
+      useDevSupport = BuildConfig.DEBUG
     )
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/consumer-rules.pro
+++ b/packages/expo-brownfield/plugin/templates/android/consumer-rules.pro
@@ -41,6 +41,7 @@
 -keepclassmembers class * {
     @expo.modules.core.interfaces.DoNotStrip *;
 }
+-keep interface expo.modules.kotlin.records.Record
 -keep class * implements expo.modules.kotlin.records.Record { *; }
 -keep class * extends expo.modules.kotlin.sharedobjects.SharedObject
 -keep enum * implements expo.modules.kotlin.types.Enumerable { *; }

--- a/packages/expo-brownfield/plugin/templates/android/consumer-rules.pro
+++ b/packages/expo-brownfield/plugin/templates/android/consumer-rules.pro
@@ -1,0 +1,66 @@
+# Consumer ProGuard rules shipped inside the brownfield AAR (and aggregated into the
+# fused AAR via AGP Fused Library). The host app's R8/ProGuard reads these rules to
+# avoid stripping classes that the runtime loads via reflection.
+#
+# Mirrors the relevant subset of expo-modules-core/android/proguard-rules.pro and
+# adds keep rules for ReactActivityLifecycleListener (silently disabled features
+# like edge-to-edge depend on it).
+
+# Expo Module Services — reflection-loaded via Service.construct() in
+# expo.modules.kotlin.services.ServicesRegistry. Stripping their constructors
+# causes `NoSuchMethodException` / `Array is empty` at startup.
+-keep interface expo.modules.kotlin.services.Service
+-keep class * implements expo.modules.kotlin.services.Service {
+    <init>(...);
+}
+
+# Expo Module Package classes — referenced by FQN in the autolinking-generated
+# `ExpoModulesPackageList.<clinit>`. Stripping causes `NoClassDefFoundError`.
+-keep class * implements expo.modules.core.interfaces.Package {
+    public <init>(...);
+}
+
+# Expo Modules — public constructors + the `definition()` method must survive
+# obfuscation/minification for the registry to instantiate them.
+-keep,allowoptimization,allowobfuscation class * extends expo.modules.kotlin.modules.Module {
+    public <init>();
+    public expo.modules.kotlin.modules.ModuleDefinitionData definition();
+}
+
+# ReactActivityLifecycleListener implementations — Expo modules return these from
+# `createReactActivityLifecycleListeners()` (e.g. `EdgeToEdgePackage` enables
+# edge-to-edge via its lifecycle hook). Lost listeners = silently disabled
+# features in the host app.
+-keep class * implements expo.modules.core.interfaces.ReactActivityLifecycleListener
+-keepclassmembers class * implements expo.modules.core.interfaces.ReactActivityLifecycleListener {
+    public <init>(...);
+}
+
+# DoNotStrip + Record + Enumerable patterns from expo-modules-core.
+-keep @expo.modules.core.interfaces.DoNotStrip class *
+-keepclassmembers class * {
+    @expo.modules.core.interfaces.DoNotStrip *;
+}
+-keep class * implements expo.modules.kotlin.records.Record { *; }
+-keep class * extends expo.modules.kotlin.sharedobjects.SharedObject
+-keep enum * implements expo.modules.kotlin.types.Enumerable { *; }
+-keepnames class kotlin.Pair
+
+# ExpoView constructors — Expo view modules call these via reflection from the
+# kotlin view registry.
+-keepclassmembers class * implements expo.modules.kotlin.views.ExpoView {
+    public <init>(android.content.Context);
+    public <init>(android.content.Context, expo.modules.kotlin.AppContext);
+}
+-keepnames class * implements expo.modules.kotlin.views.ExpoView { *; }
+
+# View event delegation fields read via reflection from the kotlin view runtime.
+-keepclassmembers class * {
+    expo.modules.kotlin.viewevent.ViewEventCallback *;
+}
+-keepclassmembers class * {
+    expo.modules.kotlin.viewevent.ViewEventDelegate *;
+}
+
+# ComposeProps implementations loaded reflectively for Compose-based views.
+-keep class * implements expo.modules.kotlin.views.ComposeProps { *; }

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -1,16 +1,9 @@
-// Single fat AAR that merges every autolinked Android module (Expo + RN community)
-// plus the brownfield library's own classes/resources/jni into one publishable
-// artifact via AGP's `com.android.fused-library` plugin (Preview in AGP 8.13+).
+// Fuses every autolinked Android module + the brownfield library into a single
+// publishable AAR via AGP's `com.android.fused-library` (Preview, AGP 8.13+).
 //
-// Two sibling subprojects are emitted by the brownfield config plugin:
-//   `:<libraryName>-fused-release` and `:<libraryName>-fused-debug`.
-// They share THIS template — `{{fusedVariant}}` is substituted at prebuild time to
-// `"release"` or `"debug"` and the script branches on `isReleaseVariant` for the
-// few places the two siblings actually differ.
-//
-// `android.experimental.fusedLibrarySupport.publicationOnly=false` in gradle.properties
-// lets `include(project(...))` resolve sibling Gradle subprojects directly without
-// first publishing them to mavenLocal.
+// One sibling subproject per variant — `:<libraryName>-fused-release` and
+// `-fused-debug` — both rendered from this template; `{{fusedVariant}}` is the
+// only delta.
 
 plugins {
   id("com.android.fused-library")
@@ -21,7 +14,6 @@ group = "${{groupId}}"
 
 version = "${{version}}"
 
-// Substituted by the config plugin: "release" or "debug".
 val fusedVariant = "${{fusedVariant}}"
 val isReleaseVariant = fusedVariant == "release"
 val fusedVariantCapitalized = fusedVariant.replaceFirstChar { it.uppercase() }
@@ -32,20 +24,10 @@ androidFusedLibrary {
   aarMetadata { minCompileSdk = 36 }
 }
 
-// Modules that must NOT land in the release fat AAR. Dev tooling
-// (`expo-dev-menu` / `-launcher` / `-client` / `-menu-interface`) is wired as
-// `debugImplementation` on the brownfield library by `templates/patches/build.gradle.patch`
-// — leaking it into release shipped to consumers contradicts that policy. The debug
-// sibling intentionally includes them so devs get dev-menu, etc.
-//
-// `setupFusedModeStripping` in the brownfield-setup Gradle plugin strips the matching
-// references from the autolinking-generated `ExpoModulesPackageList.kt` when the
-// release sibling builds — otherwise the host crashes at startup with
-// `NoClassDefFoundError` on the dangling Package class references.
-//
-// Extend at invocation via `-Pbrownfield.fused.skip=foo,bar` if a specific module
-// trips a build (e.g. a new Expo module introduces an external library that needs a
-// manual coord override).
+// Dev tooling is `debugImplementation`-only on the brownfield library, so the
+// release fat AAR must skip it. `setupFusedModeStripping` strips matching entries
+// from the generated `ExpoModulesPackageList.kt` to avoid `NoClassDefFoundError`
+// at host startup. Extend ad-hoc via `-Pbrownfield.fused.skip=foo,bar`.
 val devOnlySkipProjects: Set<String> = if (isReleaseVariant) {
   setOf("expo-dev-client", "expo-dev-launcher", "expo-dev-menu", "expo-dev-menu-interface")
 } else {
@@ -59,25 +41,19 @@ val extraSkip: Set<String> = (project.findProperty("brownfield.fused.skip") as? 
   ?: emptySet()
 val fusedSkipProjects = devOnlySkipProjects + extraSkip
 
-// Force every sibling Android module to evaluate its build script before we resolve
-// `include()` targets and walk their `releaseRuntimeClasspath`/`debugRuntimeClasspath`.
-// Without this, the `hasPlugin(...)` check and the classpath resolution both see
-// incomplete state.
+// Force sibling evaluation before resolving include() targets and walking their
+// runtime classpaths — without this, plugin detection and classpath resolution
+// see incomplete state. Skip self and the OTHER fused sibling to avoid a cycle.
 rootProject.subprojects.forEach {
-  // Skip self AND the sibling fused module — both fused siblings declare
-  // `evaluationDependsOn(rootProject.subprojects)`, so depending on each other
-  // creates a cycle. The siblings are independent (one per build type), so
-  // neither needs the other's evaluation.
   if (it.path == project.path) return@forEach
   if (it.name == "${{libraryName}}-fused-release") return@forEach
   if (it.name == "${{libraryName}}-fused-debug") return@forEach
   evaluationDependsOn(it.path)
 }
 
-// Group prefixes for non-AndroidX coords that MUST stay external in the published POM.
-// The consumer's host app provides these foundational libraries; bundling them inside
-// the fused AAR triggers duplicate-class errors at dex merge time. Extend at
-// invocation via `-Pbrownfield.fused.exclude-transitive=foo,bar`.
+// Foundational libraries the host app already provides — bundling them in the
+// fused AAR causes duplicate-class errors at dex merge. Stay external in the POM.
+// Extend via `-Pbrownfield.fused.exclude-transitive=foo,bar`.
 val transitiveIncludeDenylistNonAndroidX = setOf(
   "org.jetbrains.kotlin",
   "org.jetbrains.kotlinx",
@@ -92,12 +68,9 @@ val transitiveIncludeDenylistNonAndroidX = setOf(
   "com.squareup.okhttp3",
   "com.squareup.okio",
 )
-// AndroidX subgroups we DO want fused — these provide the heavy library code Android
-// modules wrap (ExoPlayer for expo-video, CameraX for expo-camera). All other
-// `androidx.*` groups stay external because the consumer's host app already provides
-// them, and Fused Library's validation refuses partially-included transitive-dep
-// chains (one allowed transitive's parent must also be in the fat AAR — easy to
-// trip when AndroidX modules cross-depend).
+// AndroidX subgroups we DO want fused (ExoPlayer for expo-video, CameraX for
+// expo-camera). All other `androidx.*` stays external — Fused Library rejects
+// partial transitive chains, easy to trip with cross-depending AndroidX modules.
 val androidxFuseAllowlist = setOf(
   "androidx.camera",
   "androidx.media3",
@@ -110,23 +83,20 @@ val extraDenylist: Set<String> =
     ?.toSet()
     ?: emptySet()
 val effectiveDenylist = transitiveIncludeDenylistNonAndroidX + extraDenylist
-// Helper that decides if a group should stay external (in POM, not in the fat AAR).
+// True → coord stays external in the POM. AndroidX uses an allowlist, everything
+// else uses the denylist above.
 fun isGroupDenied(group: String): Boolean {
   if (effectiveDenylist.any { group == it || group.startsWith("$it.") }) return true
-  // AndroidX: deny everything EXCEPT the explicit allowlist.
   if (group == "androidx" || group.startsWith("androidx.")) {
     return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
   }
   return false
 }
 
-// AGP Fused Library rejects ANY `androidx.databinding:*` dep — including
-// `viewbinding`, which is pulled transitively by `react { autolinkLibrariesWithApp() }`
-// on the brownfield library and by some autolinked modules. We don't use binding
-// in the fused AAR, so strip it from every configuration before validation runs.
-// This MUST be registered BEFORE the aggregator below is resolved — `configureEach`
-// fires for every configuration including future ones, and adding excludes after
-// resolution throws "Cannot mutate after resolved".
+// AGP Fused Library rejects any `androidx.databinding:*` dep (including
+// `viewbinding`, pulled transitively by `react { autolinkLibrariesWithApp() }`).
+// Strip them from every configuration. MUST be registered BEFORE the aggregator
+// resolves, otherwise `configureEach` throws "Cannot mutate after resolved".
 configurations.configureEach {
   exclude(group = "androidx.databinding", module = "viewbinding")
   exclude(group = "androidx.databinding", module = "databinding-common")
@@ -137,11 +107,9 @@ configurations.configureEach {
   fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
 }
 
-// Create an aggregator configuration on THIS project that depends on every autolinked
-// Android module. Resolving another project's configuration directly fails under
-// Gradle 8+ parallel execution with "attempted without an exclusive lock"; resolving
-// our own configuration is always safe. `BuildTypeAttr=${{fusedVariant}}` picks the
-// matching variant of every Expo / RN community module.
+// Aggregator configuration: depends on every autolinked module, resolved locally
+// to avoid Gradle 8+'s "attempted without an exclusive lock" on cross-project
+// resolution. `BuildTypeAttr` picks the matching variant per module.
 val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
   isCanBeResolved = true
   isCanBeConsumed = false
@@ -163,35 +131,20 @@ val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
       project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
     )
   }
-  // Two autolinked modules pin different `-android`-suffixed Guava versions which
-  // Gradle's version comparator can't reconcile (the suffix throws off SemVer
-  // ordering). The conflict cascades and lenient resolution returns ZERO artifacts.
-  // Neither `force(...)` nor `eachDependency` resolves it cleanly. Excluding Guava
-  // from the aggregator entirely is the pragmatic fix — Guava is foundational and
-  // stays external in the POM via the denylist above, so the consumer's host app
-  // provides it.
+  // Conflicting `-android`-suffixed Guava versions confuse Gradle's SemVer
+  // comparator and cascade into lenient resolution returning zero artifacts.
+  // Guava is denylisted anyway (host provides it), so just drop it here.
   exclude(group = "com.google.guava", module = "guava")
 }
 
-// Heuristic for "this is an autolinked Android module we should fuse in":
-// * applies `com.android.library`
-// * isn't this fused sibling, isn't the brownfield library itself
-// * isn't the host `:app` (com.android.application)
-// * isn't the OTHER fused sibling (avoid the debug sibling trying to include the
-//   release one or vice versa)
-// This catches BOTH Expo modules (via `expo-module-gradle-plugin`) AND React Native
-// community modules (which only apply `com.android.library`), fixing the previous
-// expo-only filter that silently excluded `react-native-screens` etc.
-// `project` inside a `Project` extension function resolves to the RECEIVER (since
-// `Project.getProject()` returns `this`), not the script's project. Capture the
-// script project's path in an outer `val` so the self-check actually compares the
-// iterated subproject against THIS fused module.
+// `project.path` inside a `Project` extension function resolves to the RECEIVER
+// (Project.getProject() returns `this`), not the script's project. Capture it in
+// an outer `val` so the self-check compares against THIS fused module.
 val thisProjectPath: String = project.path
 
 // `plugins.hasPlugin("com.android.library")` returns false on Expo modules because
-// `expo-module-gradle-plugin` applies AGP via `pluginManager.apply(LibraryPlugin::class.java)`
-// (programmatic class apply), which doesn't register the plugin ID in the ID lookup
-// table. We match by class FQN instead, catching both apply-by-class and apply-by-id.
+// `expo-module-gradle-plugin` applies AGP via `pluginManager.apply(LibraryPlugin::class.java)`,
+// which doesn't register the plugin ID. Match by class FQN to catch both apply paths.
 fun Project.hasAndroidLibraryPlugin(): Boolean {
   if (plugins.hasPlugin("com.android.library")) return true
   if (plugins.toList().any { p ->
@@ -225,15 +178,10 @@ dependencies {
   }
 }
 
-// Walk the aggregator's resolved artifacts to collect external AAR coordinates the
-// fused AAR should `include()`. Auto-discovers ExoPlayer for expo-video, CameraX
-// for expo-camera, Glide for expo-image, etc. without hardcoding per-module coord
-// lists. Foundational coords from the denylist stay out; sibling Android projects are
-// already include()'d as projects below.
-//
-// Uses the modern `incoming.artifactView { lenient(true) }` API rather than
-// `resolvedConfiguration.lenientConfiguration` — the latter throws on any failure
-// before you can access the lenient surface, masking the underlying error.
+// Walk the aggregator's resolved artifacts to collect external AAR coords for
+// `include()`. Auto-discovers ExoPlayer, CameraX, Glide, etc. Lenient via the
+// modern `artifactView` API — the legacy `lenientConfiguration` throws before
+// you can read the lenient surface, masking the real failure.
 val transitiveAarIncludes: Set<String> = run {
   val collected = mutableSetOf<String>()
   val artifactView = expoAggregator.incoming.artifactView {
@@ -252,11 +200,9 @@ val transitiveAarIncludes: Set<String> = run {
     val group = id.group
     if (isGroupDenied(group)) return@forEach
     if (rootProject.findProject(":${id.module}") != null) return@forEach
-    // Drop per-build-type Maven coords (e.g. `com.composables:core-android-debug`).
-    // These have variant baked into the artifactId and have no cross-variant
-    // counterpart, so AGP fused-library's internal release-hardcoded `fusedRuntime`
-    // configuration trips trying to resolve "release" of a "-debug" coord. Leave
-    // them external in the POM; the consumer's build resolves the matching variant.
+    // Drop per-build-type coords (e.g. `com.composables:core-android-debug`):
+    // AGP fused-library's internal release-hardcoded resolution trips on
+    // cross-variant lookups. Leave them external; the host resolves them.
     if (id.module.endsWith("-debug") || id.module.endsWith("-release")) return@forEach
     collected += "${group}:${id.module}:${id.version}"
   }
@@ -267,7 +213,7 @@ val transitiveAarIncludes: Set<String> = run {
 }
 
 dependencies {
-  // The brownfield library carries the user's BrownfieldActivity / Fragment / Host code.
+  // User's BrownfieldActivity / Fragment / Host code.
   include(project(":${{libraryName}}"))
 
   // Every autolinked Android module (Expo + RN community).
@@ -276,21 +222,15 @@ dependencies {
     include(project(sub.path))
   }
 
-  // External Maven AARs reachable from each fused module's runtime classpath
-  // (ExoPlayer for expo-video, CameraX for expo-camera, Glide for expo-image, etc.).
-  // Bringing them in as `include()` targets merges their R.txt + resources into the
-  // fused AAR so `rewriteClasses` can resolve the FQNs modules reference.
+  // External heavy libs (ExoPlayer, CameraX, Glide, ...). Including them merges
+  // R.txt + resources so `rewriteClasses` can resolve the FQNs modules reference.
   transitiveAarIncludes.forEach { coord -> include(coord) }
 }
 
 publishing {
-  // Mirror the repositories declared on the root project's `expoBrownfieldPublishPlugin`
-  // extension onto THIS fused sibling. The publish plugin's `setupRepositories` runs
-  // via `setupPublishing`, which is gated by `shouldBeSkipped()` — that returns true
-  // for fused modules (no `LibraryExtension`), so the wiring would otherwise stop at
-  // the publication and never create the `publishBrownfield<V>PublicationTo<X>Repository`
-  // tasks. Re-implement the repo loop here against the SAME `ExpoPublishExtension`
-  // config so `--repo <Name>` on the CLI resolves identically for fused and non-fused.
+  // Mirror the root project's `expoBrownfieldPublishPlugin` repositories. The
+  // publish plugin skips fused modules (no `LibraryExtension`), so without this
+  // loop no `publishBrownfield<V>PublicationTo<X>Repository` tasks are created.
   repositories {
     val rootPublishConfig =
       rootProject.extensions.findByType(expo.modules.plugin.ExpoPublishExtension::class.java)
@@ -318,13 +258,10 @@ publishing {
   publications {
     register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
       afterEvaluate { from(components["fusedLibraryComponent"]) }
-      // The Fused Library plugin externalizes every transitive dep it saw (RN, AndroidX,
-      // Kotlin, and — relevant here — every skip-list module reachable via
-      // `:${{libraryName}}`'s `react { autolinkLibrariesWithApp() }`). It uses Gradle
-      // project names (`expo-camera`) as artifactIds rather than the real published coords
-      // (`expo.modules.camera`), so consumers can't resolve them. Configuration-level
-      // excludes don't reach the component's POM emission. Strip the broken nodes
-      // here after Gradle generates the POM.
+      // Fused Library emits skip-list modules into the POM using Gradle project
+      // names (`expo-camera`) instead of the real coords (`expo.modules.camera`),
+      // breaking consumer resolution. Configuration-level excludes don't reach
+      // the POM, so strip them post-generation.
       pom.withXml {
         val deps = (asNode().get("dependencies") as? groovy.util.NodeList)?.firstOrNull() as? groovy.util.Node
           ?: return@withXml

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -1,11 +1,12 @@
-// Single fat AAR that merges every autolinked Expo Android module + the brownfield
-// library's own classes/resources/jni into one publishable artifact via AGP's
-// `com.android.fused-library` plugin (Preview in AGP 9.0+).
+// Single fat AAR that merges every autolinked Android module (Expo + RN community)
+// plus the brownfield library's own classes/resources/jni into one publishable
+// artifact via AGP's `com.android.fused-library` plugin (Preview in AGP 8.13+).
 //
-// Built only when the user opts in via `expo-brownfield build:android --fused`,
-// which routes Gradle to `:${{libraryName}}-fused:publishBrownfieldReleasePublicationTo...`
-// and passes `-Pbrownfield.fused=true` so the publish plugin's per-module re-publish
-// loop is skipped (everything is already inside this AAR).
+// Two sibling subprojects are emitted by the brownfield config plugin:
+//   `:<libraryName>-fused-release` and `:<libraryName>-fused-debug`.
+// They share THIS template — `{{fusedVariant}}` is substituted at prebuild time to
+// `"release"` or `"debug"` and the script branches on `isReleaseVariant` for the
+// few places the two siblings actually differ.
 //
 // `android.experimental.fusedLibrarySupport.publicationOnly=false` in gradle.properties
 // lets `include(project(...))` resolve sibling Gradle subprojects directly without
@@ -20,41 +21,57 @@ group = "${{groupId}}"
 
 version = "${{version}}"
 
+// Substituted by the config plugin: "release" or "debug".
+val fusedVariant = "${{fusedVariant}}"
+val isReleaseVariant = fusedVariant == "release"
+val fusedVariantCapitalized = fusedVariant.replaceFirstChar { it.uppercase() }
+
 androidFusedLibrary {
-  namespace = "${{packageId}}.fused"
+  namespace = "${{packageId}}.fused.${{fusedVariant}}"
   minSdk = 24
   aarMetadata { minCompileSdk = 36 }
 }
 
-// Every autolinked Expo Android module fuses in by default. Earlier iterations
-// skipped "heavy" modules (expo-video, expo-camera, expo-image, expo-maps, etc.)
-// because their classes reference R.* values from EXTERNAL Maven deps (ExoPlayer
-// for expo-video, CameraX for expo-camera, Glide for expo-image, Google Maps SDK
-// for expo-maps, ...) — AGP Fused Library's `rewriteClasses` step couldn't resolve
-// those references because the external libraries came in as POM deps, not as
-// included `include()` targets. The fix below: at Gradle time, walk each Expo
-// module's `releaseRuntimeClasspath`, collect every resolved external AAR, and
-// `include()` it alongside the project. The external library's R.txt + resources
-// end up merged into the fused AAR and `rewriteClasses` resolves cleanly.
+// Modules that must NOT land in the release fat AAR. Dev tooling
+// (`expo-dev-menu` / `-launcher` / `-client` / `-menu-interface`) is wired as
+// `debugImplementation` on the brownfield library by `templates/patches/build.gradle.patch`
+// — leaking it into release shipped to consumers contradicts that policy. The debug
+// sibling intentionally includes them so devs get dev-menu, etc.
 //
-// Override at invocation via `-Pbrownfield.fused.skip=foo,bar` if a specific
-// module still trips a build (e.g. a new Expo module introduces an external
-// library that needs a manual coord override).
+// `setupFusedModeStripping` in the brownfield-setup Gradle plugin strips the matching
+// references from the autolinking-generated `ExpoModulesPackageList.kt` when the
+// release sibling builds — otherwise the host crashes at startup with
+// `NoClassDefFoundError` on the dangling Package class references.
+//
+// Extend at invocation via `-Pbrownfield.fused.skip=foo,bar` if a specific module
+// trips a build (e.g. a new Expo module introduces an external library that needs a
+// manual coord override).
+val devOnlySkipProjects: Set<String> = if (isReleaseVariant) {
+  setOf("expo-dev-client", "expo-dev-launcher", "expo-dev-menu", "expo-dev-menu-interface")
+} else {
+  emptySet()
+}
 val extraSkip: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
   ?.split(',')
   ?.map { it.trim() }
   ?.filter { it.isNotEmpty() }
   ?.toSet()
   ?: emptySet()
-val fusedSkipProjects = extraSkip
+val fusedSkipProjects = devOnlySkipProjects + extraSkip
 
-// Force every sibling expo module to evaluate its build script before we resolve
-// `include()` targets and walk their `releaseRuntimeClasspath`. Without this, the
-// `hasPlugin(...)` check and the classpath resolution both see incomplete state.
+// Force every sibling Android module to evaluate its build script before we resolve
+// `include()` targets and walk their `releaseRuntimeClasspath`/`debugRuntimeClasspath`.
+// Without this, the `hasPlugin(...)` check and the classpath resolution both see
+// incomplete state.
 rootProject.subprojects.forEach {
-  if (it.path != project.path) {
-    evaluationDependsOn(it.path)
-  }
+  // Skip self AND the sibling fused module — both fused siblings declare
+  // `evaluationDependsOn(rootProject.subprojects)`, so depending on each other
+  // creates a cycle. The siblings are independent (one per build type), so
+  // neither needs the other's evaluation.
+  if (it.path == project.path) return@forEach
+  if (it.name == "${{libraryName}}-fused-release") return@forEach
+  if (it.name == "${{libraryName}}-fused-debug") return@forEach
+  evaluationDependsOn(it.path)
 }
 
 // Group prefixes for non-AndroidX coords that MUST stay external in the published POM.
@@ -75,7 +92,7 @@ val transitiveIncludeDenylistNonAndroidX = setOf(
   "com.squareup.okhttp3",
   "com.squareup.okio",
 )
-// AndroidX subgroups we DO want fused — these provide the heavy library code Expo
+// AndroidX subgroups we DO want fused — these provide the heavy library code Android
 // modules wrap (ExoPlayer for expo-video, CameraX for expo-camera). All other
 // `androidx.*` groups stay external because the consumer's host app already provides
 // them, and Fused Library's validation refuses partially-included transitive-dep
@@ -120,13 +137,11 @@ configurations.configureEach {
   fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
 }
 
-// Create an aggregator configuration on THIS project that depends on every Expo
-// module. Resolving another project's configuration directly fails under Gradle 8+
-// parallel execution with "attempted without an exclusive lock"; resolving our own
-// configuration is always safe. Attributes pin the consumer side to
-// `java-runtime` + `BuildTypeAttr=release` so Gradle's variant matcher picks each
-// Expo module's release runtime variant rather than emitting "no matching variants"
-// or silently resolving nothing.
+// Create an aggregator configuration on THIS project that depends on every autolinked
+// Android module. Resolving another project's configuration directly fails under
+// Gradle 8+ parallel execution with "attempted without an exclusive lock"; resolving
+// our own configuration is always safe. `BuildTypeAttr=${{fusedVariant}}` picks the
+// matching variant of every Expo / RN community module.
 val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
   isCanBeResolved = true
   isCanBeConsumed = false
@@ -139,34 +154,47 @@ val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
       org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE,
       project.objects.named(org.gradle.api.attributes.Category::class.java, org.gradle.api.attributes.Category.LIBRARY)
     )
-    // AGP's `releaseRuntimeElements` exposes multiple sub-variants under one
-    // configuration (`android-aar`, `android-aar-metadata`, `android-classes`,
-    // `android-jni`, ...). Without LibraryElements=aar Gradle can't pick which
-    // sub-variant to give us and emits "cannot choose between the following variants".
     attribute(
       org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
       project.objects.named(org.gradle.api.attributes.LibraryElements::class.java, "aar")
     )
     attribute(
       com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
-      project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, "release")
+      project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
     )
   }
-  // Two Expo modules pin different `-android`-suffixed Guava versions which Gradle's
-  // version comparator can't reconcile (the suffix throws off SemVer ordering). The
-  // conflict cascades and lenient resolution returns ZERO artifacts. Neither
-  // `force(...)` nor `eachDependency` resolves it cleanly. Excluding Guava from the
-  // aggregator entirely is the pragmatic fix — Guava is foundational and stays
-  // external in the POM via the denylist above, so the consumer's host app provides
-  // it. Add more `exclude(...)` lines here if another dep introduces a similar
-  // suffix-conflict that the aggregator can't reconcile.
+  // Two autolinked modules pin different `-android`-suffixed Guava versions which
+  // Gradle's version comparator can't reconcile (the suffix throws off SemVer
+  // ordering). The conflict cascades and lenient resolution returns ZERO artifacts.
+  // Neither `force(...)` nor `eachDependency` resolves it cleanly. Excluding Guava
+  // from the aggregator entirely is the pragmatic fix — Guava is foundational and
+  // stays external in the POM via the denylist above, so the consumer's host app
+  // provides it.
   exclude(group = "com.google.guava", module = "guava")
 }
+
+// Heuristic for "this is an autolinked Android module we should fuse in":
+// * applies `com.android.library`
+// * isn't this fused sibling, isn't the brownfield library itself
+// * isn't the host `:app` (com.android.application)
+// * isn't the OTHER fused sibling (avoid the debug sibling trying to include the
+//   release one or vice versa)
+// This catches BOTH Expo modules (via `expo-module-gradle-plugin`) AND React Native
+// community modules (which only apply `com.android.library`), fixing the previous
+// expo-only filter that silently excluded `react-native-screens` etc.
+fun Project.isFusableAndroidLibrary(): Boolean {
+  if (path == project.path) return false
+  if (name == "${{libraryName}}") return false
+  if (name == "${{libraryName}}-fused-release") return false
+  if (name == "${{libraryName}}-fused-debug") return false
+  if (name in fusedSkipProjects) return false
+  if (!plugins.hasPlugin("com.android.library")) return false
+  return true
+}
+
 dependencies {
   rootProject.subprojects.forEach { sub ->
-    if (sub.path == project.path) return@forEach
-    if (sub.name in fusedSkipProjects) return@forEach
-    if (!sub.plugins.hasPlugin("expo-module-gradle-plugin")) return@forEach
+    if (!sub.isFusableAndroidLibrary()) return@forEach
     add("brownfieldFusedExpoAggregator", sub)
   }
 }
@@ -174,7 +202,7 @@ dependencies {
 // Walk the aggregator's resolved artifacts to collect external AAR coordinates the
 // fused AAR should `include()`. Auto-discovers ExoPlayer for expo-video, CameraX
 // for expo-camera, Glide for expo-image, etc. without hardcoding per-module coord
-// lists. Foundational coords from the denylist stay out; sibling Expo projects are
+// lists. Foundational coords from the denylist stay out; sibling Android projects are
 // already include()'d as projects below.
 //
 // Uses the modern `incoming.artifactView { lenient(true) }` API rather than
@@ -182,10 +210,6 @@ dependencies {
 // before you can access the lenient surface, masking the underlying error.
 val transitiveAarIncludes: Set<String> = run {
   val collected = mutableSetOf<String>()
-  // Request `artifactType=aar` on the view. For external Maven AARs that's the
-  // file-extension type. For AGP project deps, Gradle's built-in artifact transforms
-  // converts the `android-aar` sub-variant to a plain `aar` file. Both targets match,
-  // sidestepping the "cannot choose between sub-variants" ambiguity.
   val artifactView = expoAggregator.incoming.artifactView {
     isLenient = true
     attributes {
@@ -202,9 +226,17 @@ val transitiveAarIncludes: Set<String> = run {
     val group = id.group
     if (isGroupDenied(group)) return@forEach
     if (rootProject.findProject(":${id.module}") != null) return@forEach
+    // Drop per-build-type Maven coords (e.g. `com.composables:core-android-debug`).
+    // These have variant baked into the artifactId and have no cross-variant
+    // counterpart, so AGP fused-library's internal release-hardcoded `fusedRuntime`
+    // configuration trips trying to resolve "release" of a "-debug" coord. Leave
+    // them external in the POM; the consumer's build resolves the matching variant.
+    if (id.module.endsWith("-debug") || id.module.endsWith("-release")) return@forEach
     collected += "${group}:${id.module}:${id.version}"
   }
-  logger.lifecycle("brownfield.fused: collected ${collected.size} external AAR coords")
+  logger.lifecycle(
+    "brownfield.fused[${fusedVariant}]: collected ${collected.size} external AAR coords"
+  )
   collected
 }
 
@@ -212,32 +244,25 @@ dependencies {
   // The brownfield library carries the user's BrownfieldActivity / Fragment / Host code.
   include(project(":${{libraryName}}"))
 
-  // Every autolinked Expo Android module. `expo-module-gradle-plugin` is applied by
-  // expo-modules-core's autolinking integration on Android modules only, so it's a
-  // reliable marker for "this is an Expo module we should fuse in" vs an unrelated
-  // `com.android.library` subproject (e.g. the host app's own library modules).
+  // Every autolinked Android module (Expo + RN community).
   rootProject.subprojects.forEach { sub ->
-    if (sub.name in fusedSkipProjects) return@forEach
-    if (sub.path == project.path) return@forEach
-    if (!sub.plugins.hasPlugin("expo-module-gradle-plugin")) return@forEach
+    if (!sub.isFusableAndroidLibrary()) return@forEach
     include(project(sub.path))
   }
 
-  // External Maven AARs reachable from each fused Expo module's release runtime
-  // classpath (ExoPlayer for expo-video, CameraX for expo-camera, Glide for
-  // expo-image, etc.). Bringing them in as `include()` targets merges their R.txt
-  // + resources into the fused AAR so `rewriteClasses` can resolve the FQNs Expo
-  // modules reference. The denylist above keeps foundational coords (kotlin-stdlib,
-  // androidx.core, RN runtime) external in the POM.
+  // External Maven AARs reachable from each fused module's runtime classpath
+  // (ExoPlayer for expo-video, CameraX for expo-camera, Glide for expo-image, etc.).
+  // Bringing them in as `include()` targets merges their R.txt + resources into the
+  // fused AAR so `rewriteClasses` can resolve the FQNs modules reference.
   transitiveAarIncludes.forEach { coord -> include(coord) }
 }
 
 publishing {
   publications {
-    register<MavenPublication>("brownfieldRelease") {
+    register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
       afterEvaluate { from(components["fusedLibraryComponent"]) }
       // The Fused Library plugin externalizes every transitive dep it saw (RN, AndroidX,
-      // Kotlin, and — relevant here — every skip-list Expo module reachable via
+      // Kotlin, and — relevant here — every skip-list module reachable via
       // `:${{libraryName}}`'s `react { autolinkLibrariesWithApp() }`). It uses Gradle
       // project names (`expo-camera`) as artifactIds rather than the real published coords
       // (`expo.modules.camera`), so consumers can't resolve them. Configuration-level

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -1,0 +1,138 @@
+// Single fat AAR that merges every autolinked Expo Android module + the brownfield
+// library's own classes/resources/jni into one publishable artifact via AGP's
+// `com.android.fused-library` plugin (Preview in AGP 9.0+).
+//
+// Built only when the user opts in via `expo-brownfield build:android --fused`,
+// which routes Gradle to `:${{libraryName}}-fused:publishBrownfieldReleasePublicationTo...`
+// and passes `-Pbrownfield.fused=true` so the publish plugin's per-module re-publish
+// loop is skipped (everything is already inside this AAR).
+//
+// `android.experimental.fusedLibrarySupport.publicationOnly=false` in gradle.properties
+// lets `include(project(...))` resolve sibling Gradle subprojects directly without
+// first publishing them to mavenLocal.
+
+plugins {
+  id("com.android.fused-library")
+  id("maven-publish")
+}
+
+group = "${{groupId}}"
+
+version = "${{version}}"
+
+androidFusedLibrary {
+  namespace = "${{packageId}}.fused"
+  minSdk = 24
+  aarMetadata { minCompileSdk = 36 }
+}
+
+// Originally we skipped dev-only modules (expo-dev-menu, expo-dev-launcher, etc.)
+// to keep dev tooling out of release. But the autolinking-generated
+// `ExpoModulesPackageList.kt` baked into `:${{libraryName}}` references every
+// autolinked module's Package class with a hard static reference — skipping a
+// module from the fused AAR leaves a dangling reference that crashes the host
+// at app startup with `NoClassDefFoundError`. We accept the trade-off: dev
+// modules ship inside the fused AAR (their classes exist, autolinking resolves),
+// but the host still only invokes dev features in debug-side flows. ViewBinding/
+// DataBinding from these modules is stripped by the `configurations.configureEach`
+// block below.
+val devOnlyExpoProjects = emptySet<String>()
+
+// Modules whose classes reference resources from EXTERNAL Maven deps (ExoPlayer for
+// expo-video, CameraX for expo-camera, Google Maps SDK for expo-maps, etc.). AGP
+// Fused Library's `rewriteClasses` step can't rewrite R.id/R.string references to
+// resources it never saw — only the included projects' own R.txt is merged. Including
+// these modules makes the build fail with "unknown symbol of type X and name Y" at
+// `rewriteClasses`. Consumers can still depend on them as regular Maven coords next
+// to the fused AAR.
+//
+// Extend at invocation time with `-Pbrownfield.fused.skip=foo,bar` (comma-separated
+// project names) if you hit additional `rewriteClasses` failures with other modules.
+val externalResourceExpoProjects = setOf(
+  "expo-video",
+  "expo-camera",
+  "expo-maps",
+  "expo-image",
+  "expo-av",
+  "expo-image-picker",
+  "expo-document-picker",
+)
+val extraSkip: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
+  ?.split(',')
+  ?.map { it.trim() }
+  ?.filter { it.isNotEmpty() }
+  ?.toSet()
+  ?: emptySet()
+val fusedSkipProjects = devOnlyExpoProjects + externalResourceExpoProjects + extraSkip
+
+// Force every sibling expo module to evaluate its build script before we resolve
+// `include()` targets. Without this, `sub.plugins.hasPlugin(...)` returns false for
+// any project Gradle hasn't reached yet and the fused AAR ships empty.
+rootProject.subprojects.forEach {
+  if (it.path != project.path) {
+    evaluationDependsOn(it.path)
+  }
+}
+
+// AGP Fused Library rejects ANY `androidx.databinding:*` dep — including
+// `viewbinding`, which is pulled transitively by `react { autolinkLibrariesWithApp() }`
+// on the brownfield library and by some autolinked modules. We don't use binding
+// in the fused AAR, so strip it from every configuration before validation runs.
+//
+// Plus: skip-list modules (dev-only + external-resource) leak into the fused POM as
+// transitive deps from `:brownfield`'s `react { autolinkLibrariesWithApp() }`, and
+// the Fused Library plugin externalizes them using Gradle project names
+// (`expo-camera`) rather than their real published artifactIds (`expo.modules.camera`).
+// The resulting coords don't resolve at consume time. Strip them from every
+// configuration so they never make it into the published POM — consumers add the
+// modules they actually need as separate deps in their host app.
+configurations.configureEach {
+  exclude(group = "androidx.databinding", module = "viewbinding")
+  exclude(group = "androidx.databinding", module = "databinding-common")
+  exclude(group = "androidx.databinding", module = "databinding-runtime")
+  exclude(group = "androidx.databinding", module = "databinding-adapters")
+  exclude(group = "androidx.databinding", module = "databinding-ktx")
+
+  fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
+}
+
+dependencies {
+  // The brownfield library carries the user's BrownfieldActivity / Fragment / Host code.
+  include(project(":${{libraryName}}"))
+
+  // Every autolinked Expo Android module. `expo-module-gradle-plugin` is applied by
+  // expo-modules-core's autolinking integration on Android modules only, so it's a
+  // reliable marker for "this is an Expo module we should fuse in" vs an unrelated
+  // `com.android.library` subproject (e.g. the host app's own library modules).
+  rootProject.subprojects.forEach { sub ->
+    if (sub.name in fusedSkipProjects) return@forEach
+    if (sub.path == project.path) return@forEach
+    if (!sub.plugins.hasPlugin("expo-module-gradle-plugin")) return@forEach
+    include(project(sub.path))
+  }
+}
+
+publishing {
+  publications {
+    register<MavenPublication>("brownfieldRelease") {
+      afterEvaluate { from(components["fusedLibraryComponent"]) }
+      // The Fused Library plugin externalizes every transitive dep it saw (RN, AndroidX,
+      // Kotlin, and — relevant here — every skip-list Expo module reachable via
+      // `:${{libraryName}}`'s `react { autolinkLibrariesWithApp() }`). It uses Gradle
+      // project names (`expo-camera`) as artifactIds rather than the real published coords
+      // (`expo.modules.camera`), so consumers can't resolve them. Configuration-level
+      // excludes don't reach the component's POM emission. Strip the broken nodes
+      // here after Gradle generates the POM.
+      pom.withXml {
+        val deps = (asNode().get("dependencies") as? groovy.util.NodeList)?.firstOrNull() as? groovy.util.Node
+          ?: return@withXml
+        val toRemove = deps.children().filterIsInstance<groovy.util.Node>().filter { dep ->
+          val artifactId = (dep.get("artifactId") as? groovy.util.NodeList)?.firstOrNull()
+            ?.let { (it as? groovy.util.Node)?.text() }
+          artifactId in fusedSkipProjects
+        }
+        toRemove.forEach { deps.remove(it) }
+      }
+    }
+  }
+}

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -4,6 +4,14 @@
 // One sibling subproject per variant — `:<libraryName>-fused-release` and
 // `-fused-debug` — both rendered from this template; `{{fusedVariant}}` is the
 // only delta.
+//
+// INERT BY DEFAULT: everything below the `brownfield.fused` guard only runs when
+// the CLI passes `-Pbrownfield.fused=true` (`expo-brownfield build:android --fused`).
+// Without the property this project registers no publications and resolves no
+// dependencies, so plain builds (`expo run:android`, IDE sync) pay no configuration
+// cost and non-fused `publishBrownfield<V>PublicationTo<X>` invocations can't
+// accidentally trigger a fat-AAR build through Gradle's cross-project task-name
+// matching.
 
 plugins {
   id("com.android.fused-library")
@@ -14,491 +22,528 @@ group = "${{groupId}}"
 
 version = "${{version}}"
 
-val fusedVariant = "${{fusedVariant}}"
-val fusedVariantCapitalized = fusedVariant.replaceFirstChar { it.uppercase() }
-
 androidFusedLibrary {
   namespace = "${{packageId}}.fused.${{fusedVariant}}"
   minSdk = 24
   aarMetadata { minCompileSdk = 36 }
 }
 
-// No hardcoded skip list. Dev tooling (`expo-dev-menu` / `-launcher` / `-client` /
-// `-menu-interface`) is included in BOTH variants:
-//   - For `-fused-release`, AGP fused-library compiles each module's release source
-//     set. `expo-dev-menu` / `expo-dev-launcher` swap their `src/debug` for a tiny
-//     `src/disableInRelease` source set in release builds — it provides STUB
-//     `DevMenuPackage` / `DevLauncherPackageDelegate` classes so `ExpoModulesPackageList`
-//     references resolve at runtime, but with no functional dev tooling. Footprint
-//     stays small and no manual entry-stripping is needed.
-//   - For `-fused-debug`, our `fusedRuntime` attribute override picks the debug
-//     source set → real dev tooling, Metro reload, red-box overlay, etc.
-// `expo-dev-client` and `expo-dev-menu-interface` have no Kotlin/Java sources at
-// all; including them adds nothing to the AAR.
-val extraSkip: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
-  ?.split(',')
-  ?.map { it.trim() }
-  ?.filter { it.isNotEmpty() }
-  ?.toSet()
-  ?: emptySet()
-val fusedSkipProjects = extraSkip
-
-// Force sibling evaluation before resolving include() targets and walking their
-// runtime classpaths — without this, plugin detection and classpath resolution
-// see incomplete state. Skip self and the OTHER fused sibling to avoid a cycle.
-rootProject.subprojects.forEach {
-  if (it.path == project.path) return@forEach
-  if (it.name == "${{libraryName}}-fused-release") return@forEach
-  if (it.name == "${{libraryName}}-fused-debug") return@forEach
-  evaluationDependsOn(it.path)
+// AGP `com.android.fused-library` auto-registers a `maven` publication at the same
+// coords as our explicit `brownfield<V>` one. `publishToMavenLocal` runs both — the
+// `maven` one overwrites our annotated metadata. Disable it unconditionally so a
+// manual `./gradlew publishToMavenLocal` in non-fused mode can't build the fat AAR
+// either.
+tasks.matching { it.name.startsWith("publishMavenPublicationTo") }.configureEach {
+  enabled = false
 }
 
-// `androidx.*` allowlist — these must be fused because their transitive chains
-// span non-AndroidX groups (e.g. `androidx.camera:camera-mlkit-vision` depends
-// on `com.google.mlkit:vision-interfaces`; the latter gets pulled into the AAR
-// as a side-effect of fusing an Expo module, and AGP fused-library's "parent
-// dependency not included" validation then demands its AndroidX parent be
-// fused too — which requires the whole `androidx.camera` chain to be fused).
-// Auto-detection can't see these because they're regular Maven parent links,
-// not KMP `available-at` redirects.
-//
-// Extend via `-Pbrownfield.fused.androidx-fuse=androidx.foo,androidx.bar` if
-// another autolinked module pulls a new AndroidX chain with the same pattern.
-val androidxFuseAllowlistDefaults = setOf("androidx.camera", "androidx.media3")
-val androidxFuseAllowlistExtra: Set<String> =
-  (project.findProperty("brownfield.fused.androidx-fuse") as? String)
-    ?.split(',')
-    ?.map { it.trim() }
-    ?.filter { it.isNotEmpty() }
-    ?.toSet()
-    ?: emptySet()
-val androidxFuseAllowlist = androidxFuseAllowlistDefaults + androidxFuseAllowlistExtra
+if (findProperty("brownfield.fused") == "true") {
+  val fusedVariant = "${{fusedVariant}}"
+  val fusedVariantCapitalized = fusedVariant.replaceFirstChar { it.uppercase() }
 
-// Android brownfield host platform baseline — NOT a list of application
-// libraries. These are the foundational pieces that, by definition of being a
-// React Native Android brownfield host, the integrating app already provides
-// on its classpath:
-//
-//   • RN runtime — `react-android`, `hermes-android`, `fbjni`, `soloader`,
-//     `yoga`. The host links variant-specific `.so` files against these;
-//     fusing them either duplicate-classes with the host's copies or pins
-//     the wrong variant's native libs. AGP fused-library's "parent
-//     dependency not included" validation also enforces this transitively
-//     (e.g. `fbjni`'s parent is `hermes-android`).
-//
-//   • Kotlin stdlib — `org.jetbrains.kotlin`, `org.jetbrains.kotlinx`. Every
-//     modern Android app pulls these via its own build.
-//
-//   • Host-provided commons — `com.google.android.material`, `com.google.guava`,
-//     `com.facebook.fresco`, `com.squareup.okhttp3`, `com.squareup.okio`.
-//     Beyond duplication risk, AGP fused-library's class rewriter can't
-//     resolve `android:*` framework-attr references in styleables (Material's
-//     `AppBarLayout_android_background` etc.), so fusing Material Design fails
-//     `rewriteClasses` outright.
-//
-// This list encodes structural facts about the brownfield host — not
-// application-specific library choices. If you're adding a NEW group here,
-// it should be because every brownfield host inherently has it (e.g. AGP
-// raised the minimum platform baseline), not because a specific app uses it.
-val hostPlatformBaseline = setOf(
-  "com.facebook.react",
-  "com.facebook.hermes",
-  "com.facebook.fbjni",
-  "com.facebook.soloader",
-  "com.facebook.yoga",
-  "com.facebook.fresco",
-  "org.jetbrains.kotlin",
-  "org.jetbrains.kotlinx",
-  "com.google.android.material",
-  "com.google.guava",
-  "com.squareup.okhttp3",
-  "com.squareup.okio",
-)
-
-// Extra groups the user wants kept OUT of the fused AAR — auto-detection below
-// handles the common KMP-umbrella case, this is only for edge cases:
-//   brownfield.fused.exclude-transitive=some.group,another.group
-val excludedGroupsExtra: Set<String> =
-  (project.findProperty("brownfield.fused.exclude-transitive") as? String)
+  // No hardcoded skip list. Dev tooling (`expo-dev-menu` / `-launcher` / `-client` /
+  // `-menu-interface`) is included in BOTH variants:
+  //   - For `-fused-release`, AGP fused-library compiles each module's release source
+  //     set. `expo-dev-menu` / `expo-dev-launcher` swap their `src/debug` for a tiny
+  //     `src/disableInRelease` source set in release builds — it provides STUB
+  //     `DevMenuPackage` / `DevLauncherPackageDelegate` classes so `ExpoModulesPackageList`
+  //     references resolve at runtime, but with no functional dev tooling. Footprint
+  //     stays small and no manual entry-stripping is needed.
+  //   - For `-fused-debug`, our `fusedRuntime` attribute override picks the debug
+  //     source set → real dev tooling, Metro reload, red-box overlay, etc.
+  // `expo-dev-client` and `expo-dev-menu-interface` have no Kotlin/Java sources at
+  // all; including them adds nothing to the AAR.
+  //
+  // Modules skipped via `-Pbrownfield.fused.skip` stay referenced by the autolinking-
+  // generated `ExpoModulesPackageList` — pair the skip with
+  // `-Pbrownfield.fused.strip-packages=<package prefixes>` so the host doesn't hit
+  // `NoClassDefFoundError` at startup.
+  val fusedSkipProjects: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
     ?.split(',')
     ?.map { it.trim() }
     ?.filter { it.isNotEmpty() }
     ?.toSet()
     ?: emptySet()
 
-// Populated below by walking the aggregator's resolution and detecting KMP-style
-// pom-only umbrellas that trip AGP fused-library's "parent dependency not
-// included" validation.
-val autoExcludedGroups = mutableSetOf<String>()
-val effectiveExcludedGroups: Set<String> get() =
-  hostPlatformBaseline + excludedGroupsExtra + autoExcludedGroups
-
-// True → coord stays external in the POM. AndroidX uses an allowlist; the
-// RN runtime baseline + user-excluded + auto-detected KMP umbrellas form the
-// denylist.
-fun isGroupDenied(group: String): Boolean {
-  val denylist = effectiveExcludedGroups
-  if (denylist.any { group == it || group.startsWith("$it.") }) return true
-  if (group == "androidx" || group.startsWith("androidx.")) {
-    return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
+  // Force sibling evaluation before resolving include() targets and walking their
+  // runtime classpaths — without this, plugin detection and classpath resolution
+  // see incomplete state. Skip self and the OTHER fused sibling to avoid a cycle.
+  rootProject.subprojects.forEach {
+    if (it.path == project.path) return@forEach
+    if (it.name == "${{libraryName}}-fused-release") return@forEach
+    if (it.name == "${{libraryName}}-fused-debug") return@forEach
+    evaluationDependsOn(it.path)
   }
-  return false
-}
 
-// Override AGP fused-library's internal `fusedRuntime` BuildTypeAttr=release →
-// match the sibling's `fusedVariant`. Makes `-fused-debug` actually fuse debug-
-// compiled bytecode (correct `BuildConfig.DEBUG=true`, dev-only code paths active).
-configurations.all {
-  if (name.startsWith("fusedRuntime")) {
+  // `androidx.*` allowlist — these must be fused because their transitive chains
+  // span non-AndroidX groups (e.g. `androidx.camera:camera-mlkit-vision` depends
+  // on `com.google.mlkit:vision-interfaces`; the latter gets pulled into the AAR
+  // as a side-effect of fusing an Expo module, and AGP fused-library's "parent
+  // dependency not included" validation then demands its AndroidX parent be
+  // fused too — which requires the whole `androidx.camera` chain to be fused).
+  // Auto-detection can't see these because they're regular Maven parent links,
+  // not KMP `available-at` redirects.
+  //
+  // Extend via `-Pbrownfield.fused.androidx-fuse=androidx.foo,androidx.bar` if
+  // another autolinked module pulls a new AndroidX chain with the same pattern.
+  val androidxFuseAllowlistDefaults = setOf("androidx.camera", "androidx.media3")
+  val androidxFuseAllowlistExtra: Set<String> =
+    (project.findProperty("brownfield.fused.androidx-fuse") as? String)
+      ?.split(',')
+      ?.map { it.trim() }
+      ?.filter { it.isNotEmpty() }
+      ?.toSet()
+      ?: emptySet()
+  val androidxFuseAllowlist = androidxFuseAllowlistDefaults + androidxFuseAllowlistExtra
+
+  // Android brownfield host platform baseline — NOT a list of application
+  // libraries. These are the foundational pieces that, by definition of being a
+  // React Native Android brownfield host, the integrating app already provides
+  // on its classpath:
+  //
+  //   • RN runtime — `react-android`, `hermes-android`, `fbjni`, `soloader`,
+  //     `yoga`. The host links variant-specific `.so` files against these;
+  //     fusing them either duplicate-classes with the host's copies or pins
+  //     the wrong variant's native libs. AGP fused-library's "parent
+  //     dependency not included" validation also enforces this transitively
+  //     (e.g. `fbjni`'s parent is `hermes-android`).
+  //
+  //   • Kotlin stdlib — `org.jetbrains.kotlin`, `org.jetbrains.kotlinx`. Every
+  //     modern Android app pulls these via its own build.
+  //
+  //   • Host-provided commons — `com.google.android.material`, `com.google.guava`,
+  //     `com.facebook.fresco`, `com.squareup.okhttp3`, `com.squareup.okio`.
+  //     Beyond duplication risk, AGP fused-library's class rewriter can't
+  //     resolve `android:*` framework-attr references in styleables (Material's
+  //     `AppBarLayout_android_background` etc.), so fusing Material Design fails
+  //     `rewriteClasses` outright.
+  //
+  // This list encodes structural facts about the brownfield host — not
+  // application-specific library choices. If you're adding a NEW group here,
+  // it should be because every brownfield host inherently has it (e.g. AGP
+  // raised the minimum platform baseline), not because a specific app uses it.
+  val hostPlatformBaseline = setOf(
+    "com.facebook.react",
+    "com.facebook.hermes",
+    "com.facebook.fbjni",
+    "com.facebook.soloader",
+    "com.facebook.yoga",
+    "com.facebook.fresco",
+    "org.jetbrains.kotlin",
+    "org.jetbrains.kotlinx",
+    "com.google.android.material",
+    "com.google.guava",
+    "com.squareup.okhttp3",
+    "com.squareup.okio",
+  )
+
+  // Extra groups the user wants kept OUT of the fused AAR — auto-detection below
+  // handles the common KMP-umbrella case, this is only for edge cases:
+  //   brownfield.fused.exclude-transitive=some.group,another.group
+  val excludedGroupsExtra: Set<String> =
+    (project.findProperty("brownfield.fused.exclude-transitive") as? String)
+      ?.split(',')
+      ?.map { it.trim() }
+      ?.filter { it.isNotEmpty() }
+      ?.toSet()
+      ?: emptySet()
+
+  // Populated below by walking the aggregator's resolution and detecting KMP-style
+  // pom-only umbrellas that trip AGP fused-library's "parent dependency not
+  // included" validation. A function rather than a val: `autoExcludedGroups` keeps
+  // growing during the walk and lazy consumers (configureEach) need the live view.
+  val autoExcludedGroups = mutableSetOf<String>()
+  fun effectiveExcludedGroups(): Set<String> =
+    hostPlatformBaseline + excludedGroupsExtra + autoExcludedGroups
+
+  // True → coord stays external in the POM. AndroidX uses an allowlist; the
+  // RN runtime baseline + user-excluded + auto-detected KMP umbrellas form the
+  // denylist.
+  fun isGroupDenied(group: String): Boolean {
+    val denylist = effectiveExcludedGroups()
+    if (denylist.any { group == it || group.startsWith("$it.") }) return true
+    if (group == "androidx" || group.startsWith("androidx.")) {
+      return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
+    }
+    return false
+  }
+
+  // Override AGP fused-library's internal `fusedRuntime` BuildTypeAttr=release →
+  // match the sibling's `fusedVariant`. Makes `-fused-debug` actually fuse debug-
+  // compiled bytecode (correct `BuildConfig.DEBUG=true`, dev-only code paths active).
+  configurations.all {
+    if (name.startsWith("fusedRuntime")) {
+      attributes {
+        attribute(
+          com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
+          project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
+        )
+      }
+    }
+  }
+
+  // Aggregator configuration: depends on every autolinked module, resolved locally
+  // to avoid Gradle 8+'s "attempted without an exclusive lock" on cross-project
+  // resolution. `BuildTypeAttr` picks the matching variant per module.
+  val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
+    isCanBeResolved = true
+    isCanBeConsumed = false
     attributes {
+      attribute(
+        org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
+        project.objects.named(org.gradle.api.attributes.Usage::class.java, org.gradle.api.attributes.Usage.JAVA_RUNTIME)
+      )
+      attribute(
+        org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE,
+        project.objects.named(org.gradle.api.attributes.Category::class.java, org.gradle.api.attributes.Category.LIBRARY)
+      )
+      attribute(
+        org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+        project.objects.named(org.gradle.api.attributes.LibraryElements::class.java, "aar")
+      )
       attribute(
         com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
         project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
       )
     }
+    // Conflicting `-android`-suffixed Guava versions confuse Gradle's SemVer
+    // comparator and cascade into lenient resolution returning zero artifacts.
+    // Guava is denylisted anyway (host provides it), so just drop it here.
+    exclude(group = "com.google.guava", module = "guava")
   }
-}
 
-// Aggregator configuration: depends on every autolinked module, resolved locally
-// to avoid Gradle 8+'s "attempted without an exclusive lock" on cross-project
-// resolution. `BuildTypeAttr` picks the matching variant per module.
-val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
-  isCanBeResolved = true
-  isCanBeConsumed = false
-  attributes {
-    attribute(
-      org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
-      project.objects.named(org.gradle.api.attributes.Usage::class.java, org.gradle.api.attributes.Usage.JAVA_RUNTIME)
-    )
-    attribute(
-      org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE,
-      project.objects.named(org.gradle.api.attributes.Category::class.java, org.gradle.api.attributes.Category.LIBRARY)
-    )
-    attribute(
-      org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
-      project.objects.named(org.gradle.api.attributes.LibraryElements::class.java, "aar")
-    )
-    attribute(
-      com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
-      project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
-    )
+  // `project.path` inside a `Project` extension function resolves to the RECEIVER
+  // (Project.getProject() returns `this`), not the script's project. Capture it in
+  // an outer `val` so the self-check compares against THIS fused module.
+  val thisProjectPath: String = project.path
+
+  // `plugins.hasPlugin("com.android.library")` returns false on Expo modules because
+  // `expo-module-gradle-plugin` applies AGP via `pluginManager.apply(LibraryPlugin::class.java)`,
+  // which doesn't register the plugin ID. Match by class FQN to catch both apply paths.
+  fun Project.hasAndroidLibraryPlugin(): Boolean {
+    if (plugins.hasPlugin("com.android.library")) return true
+    if (plugins.toList().any { p ->
+          val n = p.javaClass.name
+          (n.startsWith("com.android.build.gradle.") || n.startsWith("com.android.build.api.")) &&
+            n.endsWith("LibraryPlugin")
+        }) return true
+    val android = extensions.findByName("android") ?: return false
+    return android.javaClass.name.contains("Library", ignoreCase = true)
   }
-  // Conflicting `-android`-suffixed Guava versions confuse Gradle's SemVer
-  // comparator and cascade into lenient resolution returning zero artifacts.
-  // Guava is denylisted anyway (host provides it), so just drop it here.
-  exclude(group = "com.google.guava", module = "guava")
-}
 
-// `project.path` inside a `Project` extension function resolves to the RECEIVER
-// (Project.getProject() returns `this`), not the script's project. Capture it in
-// an outer `val` so the self-check compares against THIS fused module.
-val thisProjectPath: String = project.path
-
-// `plugins.hasPlugin("com.android.library")` returns false on Expo modules because
-// `expo-module-gradle-plugin` applies AGP via `pluginManager.apply(LibraryPlugin::class.java)`,
-// which doesn't register the plugin ID. Match by class FQN to catch both apply paths.
-fun Project.hasAndroidLibraryPlugin(): Boolean {
-  if (plugins.hasPlugin("com.android.library")) return true
-  if (plugins.toList().any { p ->
-        val n = p.javaClass.name
-        (n.startsWith("com.android.build.gradle.") || n.startsWith("com.android.build.api.")) &&
-          n.endsWith("LibraryPlugin")
-      }) return true
-  val android = extensions.findByName("android") ?: return false
-  return android.javaClass.name.contains("Library", ignoreCase = true)
-}
-
-fun Project.isFusableAndroidLibrary(): Boolean {
-  if (path == thisProjectPath) return false
-  if (name == "${{libraryName}}") return false
-  if (name == "${{libraryName}}-fused-release") return false
-  if (name == "${{libraryName}}-fused-debug") return false
-  if (name in fusedSkipProjects) return false
-  if (!hasAndroidLibraryPlugin()) return false
-  return true
-}
-
-val fusableSubprojects: List<Project> = rootProject.subprojects.filter { it.isFusableAndroidLibrary() }
-logger.lifecycle(
-  "brownfield.fused[${fusedVariant}]: fusing ${fusableSubprojects.size} subprojects: " +
-    fusableSubprojects.joinToString(", ") { it.name }
-)
-
-dependencies {
-  fusableSubprojects.forEach { sub ->
-    add("brownfieldFusedExpoAggregator", sub)
+  fun Project.isFusableAndroidLibrary(): Boolean {
+    if (path == thisProjectPath) return false
+    if (name == "${{libraryName}}") return false
+    if (name == "${{libraryName}}-fused-release") return false
+    if (name == "${{libraryName}}-fused-debug") return false
+    if (name in fusedSkipProjects) return false
+    if (!hasAndroidLibraryPlugin()) return false
+    return true
   }
-}
 
-// Recorded by the aggregator walk: coords whose group is in `effectiveExcludedGroups`
-// — the consumer-side resolution needs to declare these as transitive deps even
-// though we don't fuse them into the AAR. Used by the metadata + POM post-
-// processors below.
-val externalDepsForConsumer = mutableListOf<Triple<String, String, String>>()
-
-// AUTO-DETECT groups that must stay external. Walks the aggregator's resolution
-// graph once and records two cases:
-//
-//   1. Pom-only KMP umbrellas — components where EVERY variant is a redirect
-//      (`available-at`) to another module. The umbrella has no content of its
-//      own, only a pointer; fusing the `-android` child while the umbrella
-//      stays external trips AGP's "parent dependency not included" validation.
-//      Catches `com.composables:core`, `io.github.lukmccall:radix-ui-colors`,
-//      etc. without naming them. Facade umbrellas (Compose, AndroidX) have a
-//      mix of redirect and content variants — they don't match and stay
-//      fusable.
-//
-//   2. Non-allowlisted `androidx.*` groups — `androidx.core` and friends bring
-//      in styleables that reference `android:*` framework attrs (e.g.
-//      `ColorStateListItem` → `android:alpha`). AGP fused-library's class
-//      rewriter can't resolve framework attrs in the merged R, so fusing them
-//      makes `rewriteClasses` fail. Excluding at the configuration level here
-//      stops them from being pulled in via project-dep transitive walks.
-expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
-  val id = component.id
-  if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
-  val group = id.group
-  if (group == "androidx" || group.startsWith("androidx.")) {
-    val inAllowlist = androidxFuseAllowlist.any { group == it || group.startsWith("$it.") }
-    if (!inAllowlist) autoExcludedGroups.add(group)
-    return@forEach
-  }
-  val variants = component.variants
-  if (variants.isEmpty()) return@forEach
-  val isPureUmbrella = variants.all { variant -> variant.externalVariant.isPresent }
-  if (isPureUmbrella) autoExcludedGroups.add(group)
-}
-if (autoExcludedGroups.isNotEmpty()) {
+  val fusableSubprojects: List<Project> = rootProject.subprojects.filter { it.isFusableAndroidLibrary() }
   logger.lifecycle(
-    "brownfield.fused[${fusedVariant}]: auto-detected ${autoExcludedGroups.size} groups to " +
-      "keep external (KMP umbrellas + non-allowlisted androidx.*): " +
-      autoExcludedGroups.sorted().joinToString(", ")
+    "brownfield.fused[${fusedVariant}]: fusing ${fusableSubprojects.size} subprojects: " +
+      fusableSubprojects.joinToString(", ") { it.name }
   )
-}
 
-// Excludes that must reach EVERY configuration the fused-library plugin walks,
-// including the runtime classpaths of `include(project(...))` targets. Scoping
-// to just `fusedRuntime` isn't enough — fused-library reads from included
-// projects' own configs which a scoped exclude can't touch. The aggregator is
-// intentionally exempt so the transitive-AAR walk below can still record the
-// resolved versions of excluded groups for POM/.module injection.
-configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configureEach {
-  // AGP Fused Library rejects any `androidx.databinding:*` dep, including
-  // `viewbinding` pulled transitively by `react { autolinkLibrariesWithApp() }`.
-  exclude(group = "androidx.databinding", module = "viewbinding")
-  exclude(group = "androidx.databinding", module = "databinding-common")
-  exclude(group = "androidx.databinding", module = "databinding-runtime")
-  exclude(group = "androidx.databinding", module = "databinding-adapters")
-  exclude(group = "androidx.databinding", module = "databinding-ktx")
-
-  fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
-  effectiveExcludedGroups.forEach { g -> exclude(group = g) }
-}
-
-// Walk the aggregator's resolved artifacts to collect external AAR coords for
-// `include()`. Auto-discovers ExoPlayer, CameraX, Glide, etc. Lenient via the
-// modern `artifactView` API — the legacy `lenientConfiguration` throws before
-// you can read the lenient surface, masking the real failure.
-val transitiveAarIncludes: Set<String> = run {
-  val collected = mutableSetOf<String>()
-  val excludedGroups = effectiveExcludedGroups
-  val artifactView = expoAggregator.incoming.artifactView {
-    isLenient = true
-    attributes {
-      attribute(
-        org.gradle.api.attributes.Attribute.of("artifactType", String::class.java),
-        "aar"
-      )
+  dependencies {
+    fusableSubprojects.forEach { sub ->
+      add("brownfieldFusedExpoAggregator", sub)
     }
   }
-  artifactView.artifacts.artifacts.forEach { result ->
-    val id = result.id.componentIdentifier
+
+  // Coords whose group is excluded from fusing — the consumer-side resolution needs
+  // these declared as transitive deps in the published POM/.module even though they
+  // aren't fused into the AAR. LinkedHashSet: insertion order for stable output,
+  // set semantics so a coord reachable through several modules is recorded once.
+  val externalDepsForConsumer = linkedSetOf<Triple<String, String, String>>()
+
+  // Pure-umbrella coords recorded during auto-detection: the umbrella itself has no
+  // content (every variant redirects elsewhere), so it must not be re-declared for
+  // consumers — its `-android` child is recorded instead.
+  val pureUmbrellaComponents = mutableSetOf<Pair<String, String>>()
+
+  // AUTO-DETECT groups that must stay external. Walks the aggregator's resolution
+  // graph once and records two cases:
+  //
+  //   1. Pom-only KMP umbrellas — components where EVERY variant is a redirect
+  //      (`available-at`) to another module. The umbrella has no content of its
+  //      own, only a pointer; fusing the `-android` child while the umbrella
+  //      stays external trips AGP's "parent dependency not included" validation.
+  //      Catches `com.composables:core`, `io.github.lukmccall:radix-ui-colors`,
+  //      etc. without naming them. Facade umbrellas (Compose, AndroidX) have a
+  //      mix of redirect and content variants — they don't match and stay
+  //      fusable.
+  //
+  //   2. Non-allowlisted `androidx.*` groups — `androidx.core` and friends bring
+  //      in styleables that reference `android:*` framework attrs (e.g.
+  //      `ColorStateListItem` → `android:alpha`). AGP fused-library's class
+  //      rewriter can't resolve framework attrs in the merged R, so fusing them
+  //      makes `rewriteClasses` fail. Excluding at the configuration level here
+  //      stops them from being pulled in via project-dep transitive walks.
+  expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
+    val id = component.id
     if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
-    if (result.file.extension != "aar") return@forEach
     val group = id.group
-    // Record coords from excluded groups so we can inject them as transitive
-    // deps in the published POM/.module — must happen before any filter rejects them.
-    if (group in excludedGroups) {
-      externalDepsForConsumer.add(Triple(group, id.module, id.version))
+    if (group == "androidx" || group.startsWith("androidx.")) {
+      val inAllowlist = androidxFuseAllowlist.any { group == it || group.startsWith("$it.") }
+      if (!inAllowlist) autoExcludedGroups.add(group)
+      return@forEach
     }
-    if (isGroupDenied(group)) return@forEach
-    if (rootProject.findProject(":${id.module}") != null) return@forEach
-    // Drop variant-suffixed Maven coords (e.g. `com.composables:core-android-debug`).
-    // These coords bake the build type into the artifactId, so they have no
-    // cross-variant counterpart and AGP fused-library's internal resolution trips
-    // trying to look them up. The consumer's own resolution picks the matching
-    // variant naturally via Gradle Module Metadata.
-    if (id.module.endsWith("-debug") || id.module.endsWith("-release")) return@forEach
-    collected += "${group}:${id.module}:${id.version}"
+    val variants = component.variants
+    if (variants.isEmpty()) return@forEach
+    val isPureUmbrella = variants.all { variant -> variant.externalVariant.isPresent }
+    if (isPureUmbrella) {
+      autoExcludedGroups.add(group)
+      pureUmbrellaComponents.add(group to id.module)
+    }
   }
-  logger.lifecycle(
-    "brownfield.fused[${fusedVariant}]: collected ${collected.size} external AAR coords"
-  )
-  collected
-}
-
-dependencies {
-  // User's BrownfieldActivity / Fragment / Host code.
-  include(project(":${{libraryName}}"))
-
-  // Every autolinked Android module (Expo + RN community).
-  rootProject.subprojects.forEach { sub ->
-    if (!sub.isFusableAndroidLibrary()) return@forEach
-    include(project(sub.path))
+  if (autoExcludedGroups.isNotEmpty()) {
+    logger.lifecycle(
+      "brownfield.fused[${fusedVariant}]: auto-detected ${autoExcludedGroups.size} groups to " +
+        "keep external (KMP umbrellas + non-allowlisted androidx.*): " +
+        autoExcludedGroups.sorted().joinToString(", ")
+    )
   }
 
-  // External heavy libs (ExoPlayer, CameraX, Glide, ...). Including them merges
-  // R.txt + resources so `rewriteClasses` can resolve the FQNs modules reference.
-  transitiveAarIncludes.forEach { coord -> include(coord) }
-}
+  // Second pass, after `autoExcludedGroups` is complete: record every excluded-group
+  // coordinate for the POM/.module injection — at the component level so JAR-only
+  // modules (okhttp, okio, kotlin-stdlib, annotation artifacts) are captured too;
+  // the AAR-filtered artifactView walk below never sees them. Pure umbrellas are
+  // skipped (their `-android` children carry the content) and so are BOM/platform
+  // modules, which aren't plain runtime dependencies.
+  expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
+    val id = component.id
+    if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
+    if (id.group !in effectiveExcludedGroups()) return@forEach
+    if ((id.group to id.module) in pureUmbrellaComponents) return@forEach
+    if (id.module.endsWith("-bom")) return@forEach
+    externalDepsForConsumer.add(Triple(id.group, id.module, id.version))
+  }
 
-publishing {
-  // Mirror the root project's `expoBrownfieldPublishPlugin` repositories. The
-  // publish plugin skips fused modules (no `LibraryExtension`), so without this
-  // loop no `publishBrownfield<V>PublicationTo<X>Repository` tasks are created.
-  repositories {
-    val rootPublishConfig =
-      rootProject.extensions.findByType(expo.modules.plugin.ExpoPublishExtension::class.java)
-    rootPublishConfig?.publications?.forEach { pubConfig ->
-      when (pubConfig.type.get()) {
-        "localMaven" -> mavenLocal()
-        "localDirectory", "remotePublic" -> maven {
-          name = pubConfig.name
-          url = uri(pubConfig.url.get())
-          isAllowInsecureProtocol = pubConfig.allowInsecure.get()
-        }
-        "remotePrivate" -> maven {
-          name = pubConfig.name
-          url = uri(pubConfig.url.get())
-          credentials {
-            username = pubConfig.username.get()
-            password = pubConfig.password.get()
+  // Excludes that must reach EVERY configuration the fused-library plugin walks,
+  // including the runtime classpaths of `include(project(...))` targets. Scoping
+  // to just `fusedRuntime` isn't enough — fused-library reads from included
+  // projects' own configs which a scoped exclude can't touch. The aggregator is
+  // intentionally exempt so the transitive-AAR walk below can still see the
+  // resolved artifacts of excluded groups.
+  configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configureEach {
+    // AGP Fused Library rejects any `androidx.databinding:*` dep, including
+    // `viewbinding` pulled transitively by `react { autolinkLibrariesWithApp() }`.
+    exclude(group = "androidx.databinding", module = "viewbinding")
+    exclude(group = "androidx.databinding", module = "databinding-common")
+    exclude(group = "androidx.databinding", module = "databinding-runtime")
+    exclude(group = "androidx.databinding", module = "databinding-adapters")
+    exclude(group = "androidx.databinding", module = "databinding-ktx")
+
+    fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
+    effectiveExcludedGroups().forEach { g -> exclude(group = g) }
+  }
+
+  // Walk the aggregator's resolved artifacts to collect external AAR coords for
+  // `include()`. Auto-discovers ExoPlayer, CameraX, Glide, etc. Lenient via the
+  // modern `artifactView` API — the legacy `lenientConfiguration` throws before
+  // you can read the lenient surface, masking the real failure.
+  val transitiveAarIncludes: Set<String> = run {
+    val collected = mutableSetOf<String>()
+    val artifactView = expoAggregator.incoming.artifactView {
+      isLenient = true
+      attributes {
+        attribute(
+          org.gradle.api.attributes.Attribute.of("artifactType", String::class.java),
+          "aar"
+        )
+      }
+    }
+    artifactView.artifacts.artifacts.forEach { result ->
+      val id = result.id.componentIdentifier
+      if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
+      if (result.file.extension != "aar") return@forEach
+      val group = id.group
+      if (isGroupDenied(group)) return@forEach
+      if (rootProject.findProject(":${id.module}") != null) return@forEach
+      // Drop variant-suffixed Maven coords (e.g. `com.composables:core-android-debug`).
+      // These coords bake the build type into the artifactId, so they have no
+      // cross-variant counterpart and AGP fused-library's internal resolution trips
+      // trying to look them up. The consumer's own resolution picks the matching
+      // variant naturally via Gradle Module Metadata.
+      if (id.module.endsWith("-debug") || id.module.endsWith("-release")) return@forEach
+      collected += "${group}:${id.module}:${id.version}"
+    }
+    logger.lifecycle(
+      "brownfield.fused[${fusedVariant}]: collected ${collected.size} external AAR coords"
+    )
+    collected
+  }
+
+  dependencies {
+    // User's BrownfieldActivity / Fragment / Host code.
+    include(project(":${{libraryName}}"))
+
+    // Every autolinked Android module (Expo + RN community).
+    rootProject.subprojects.forEach { sub ->
+      if (!sub.isFusableAndroidLibrary()) return@forEach
+      include(project(sub.path))
+    }
+
+    // External heavy libs (ExoPlayer, CameraX, Glide, ...). Including them merges
+    // R.txt + resources so `rewriteClasses` can resolve the FQNs modules reference.
+    transitiveAarIncludes.forEach { coord -> include(coord) }
+  }
+
+  publishing {
+    // Mirror the root project's `expoBrownfieldPublishPlugin` repositories. The
+    // publish plugin skips fused modules (no `LibraryExtension`), so without this
+    // loop no `publishBrownfield<V>PublicationTo<X>Repository` tasks are created.
+    repositories {
+      val rootPublishConfig =
+        rootProject.extensions.findByType(expo.modules.plugin.ExpoPublishExtension::class.java)
+      rootPublishConfig?.publications?.forEach { pubConfig ->
+        when (pubConfig.type.get()) {
+          "localMaven" -> mavenLocal()
+          "localDirectory", "remotePublic" -> maven {
+            name = pubConfig.name
+            url = uri(pubConfig.url.get())
+            isAllowInsecureProtocol = pubConfig.allowInsecure.get()
           }
-          isAllowInsecureProtocol = pubConfig.allowInsecure.get()
+          "remotePrivate" -> maven {
+            name = pubConfig.name
+            url = uri(pubConfig.url.get())
+            credentials {
+              username = pubConfig.username.get()
+              password = pubConfig.password.get()
+            }
+            isAllowInsecureProtocol = pubConfig.allowInsecure.get()
+          }
+        }
+      }
+    }
+
+    publications {
+      register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
+        afterEvaluate { from(components["fusedLibraryComponent"]) }
+        // Fused-library emits skip-list modules into the POM using Gradle project names
+        // (`expo-camera`) instead of the real coords (`expo.modules.camera`), so they
+        // can't be resolved by consumers. Strip them.
+        pom.withXml {
+          val deps = (asNode().get("dependencies") as? groovy.util.NodeList)?.firstOrNull() as? groovy.util.Node
+            ?: return@withXml
+          val toRemove = deps.children().filterIsInstance<groovy.util.Node>().filter { dep ->
+            val artifactId = (dep.get("artifactId") as? groovy.util.NodeList)?.firstOrNull()
+              ?.let { (it as? groovy.util.Node)?.text() }
+            artifactId in fusedSkipProjects
+          }
+          toRemove.forEach { deps.remove(it) }
         }
       }
     }
   }
 
-  publications {
-    register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
-      afterEvaluate { from(components["fusedLibraryComponent"]) }
-      // Fused-library emits skip-list modules into the POM using Gradle project names
-      // (`expo-camera`) instead of the real coords (`expo.modules.camera`), so they
-      // can't be resolved by consumers. Strip them.
-      pom.withXml {
-        val deps = (asNode().get("dependencies") as? groovy.util.NodeList)?.firstOrNull() as? groovy.util.Node
-          ?: return@withXml
-        val toRemove = deps.children().filterIsInstance<groovy.util.Node>().filter { dep ->
-          val artifactId = (dep.get("artifactId") as? groovy.util.NodeList)?.firstOrNull()
-            ?.let { (it as? groovy.util.Node)?.text() }
-          artifactId in fusedSkipProjects
+  // Annotate `react-android` / `hermes-android` dependency edges in the published
+  // Gradle Module Metadata with this sibling's `fusedVariant`, so consumers' variant
+  // matching resolves the same RN variant the brownfield's codegen `.so` files were
+  // linked against. Mismatch manifests as either SIGSEGV at component-descriptor
+  // init (release codegen + debug `libreactnative.so`) or unsatisfied-link to debug-
+  // only symbols like `ShadowNode::getDebugName` (debug codegen + release runtime).
+  val metadataTaskName = "generateMetadataFileForBrownfield${fusedVariantCapitalized}Publication"
+  afterEvaluate {
+    tasks.named(metadataTaskName).configure {
+      doLast {
+        val moduleFile = outputs.files.singleFile
+        if (!moduleFile.exists()) return@doLast
+        @Suppress("UNCHECKED_CAST")
+        val root = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as MutableMap<String, Any?>
+        val variants = root["variants"] as? MutableList<MutableMap<String, Any?>> ?: return@doLast
+        var annotatedCount = 0
+        var strippedCount = 0
+        val perVariantAbiCoords = setOf(
+          "com.facebook.react" to "react-android",
+          "com.facebook.hermes" to "hermes-android",
+        )
+        variants.forEach { variant ->
+          val deps = variant["dependencies"] as? MutableList<MutableMap<String, Any?>> ?: return@forEach
+          // Drop natural-emission entries whose group the user excluded — the inject
+          // step below adds the variant-specific coord with the actual resolved
+          // version, avoiding the KMP-parent-vs-`-android`-child duplication that
+          // naturally appears for libs like `io.github.lukmccall:radix-ui-colors`.
+          // Also drop skip-list modules: fused-library emits them under unresolvable
+          // Gradle project names, and Gradle consumers read the .module file over the
+          // POM, so the POM-level strip alone isn't enough.
+          val before = deps.size
+          deps.removeAll { dep ->
+            val g = dep["group"] as? String
+            val m = dep["module"] as? String
+            (g != null && g in effectiveExcludedGroups()) || (m != null && m in fusedSkipProjects)
+          }
+          strippedCount += before - deps.size
+          deps.forEach { dep ->
+            val key = (dep["group"] as? String) to (dep["module"] as? String)
+            if (key in perVariantAbiCoords && dep["attributes"] == null) {
+              dep["attributes"] = mutableMapOf<String, Any?>(
+                "com.android.build.api.attributes.BuildTypeAttr" to fusedVariant
+              )
+              annotatedCount++
+            }
+          }
         }
-        toRemove.forEach { deps.remove(it) }
-      }
-    }
-  }
-}
-
-// AGP `com.android.fused-library` auto-registers a `maven` publication alongside
-// our explicit `brownfield<V>` one at the same coords. `publishToMavenLocal` runs
-// both — the `maven` one overwrites our annotated metadata. Disable it.
-tasks.matching { it.name.startsWith("publishMavenPublicationTo") }.configureEach {
-  enabled = false
-}
-
-// Annotate `react-android` / `hermes-android` dependency edges in the published
-// Gradle Module Metadata with this sibling's `fusedVariant`, so consumers' variant
-// matching resolves the same RN variant the brownfield's codegen `.so` files were
-// linked against. Mismatch manifests as either SIGSEGV at component-descriptor
-// init (release codegen + debug `libreactnative.so`) or unsatisfied-link to debug-
-// only symbols like `ShadowNode::getDebugName` (debug codegen + release runtime).
-val metadataTaskName = "generateMetadataFileForBrownfield${fusedVariantCapitalized}Publication"
-afterEvaluate {
-  tasks.named(metadataTaskName).configure {
-    doLast {
-      val moduleFile = outputs.files.singleFile
-      if (!moduleFile.exists()) return@doLast
-      @Suppress("UNCHECKED_CAST")
-      val root = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as MutableMap<String, Any?>
-      val variants = root["variants"] as? MutableList<MutableMap<String, Any?>> ?: return@doLast
-      var annotatedCount = 0
-      var strippedCount = 0
-      val perVariantAbiCoords = setOf(
-        "com.facebook.react" to "react-android",
-        "com.facebook.hermes" to "hermes-android",
-      )
-      variants.forEach { variant ->
-        val deps = variant["dependencies"] as? MutableList<MutableMap<String, Any?>> ?: return@forEach
-        // Drop natural-emission entries whose group the user excluded — the inject
-        // step below adds the variant-specific coord with the actual resolved
-        // version, avoiding the KMP-parent-vs-`-android`-child duplication that
-        // naturally appears for libs like `io.github.lukmccall:radix-ui-colors`.
-        val before = deps.size
-        deps.removeAll { dep ->
-          val g = dep["group"] as? String ?: return@removeAll false
-          g in effectiveExcludedGroups
-        }
-        strippedCount += before - deps.size
-        deps.forEach { dep ->
-          val key = (dep["group"] as? String) to (dep["module"] as? String)
-          if (key in perVariantAbiCoords && dep["attributes"] == null) {
-            dep["attributes"] = mutableMapOf<String, Any?>(
-              "com.android.build.api.attributes.BuildTypeAttr" to fusedVariant
+        // Inject the excluded transitives so the consumer can resolve them.
+        if (externalDepsForConsumer.isNotEmpty()) {
+          val runtimeVariant = variants.firstOrNull { (it["name"] as? String) == "runtimePublication" }
+          if (runtimeVariant != null) {
+            @Suppress("UNCHECKED_CAST")
+            val deps = (runtimeVariant["dependencies"] as? MutableList<MutableMap<String, Any?>>)
+              ?: mutableListOf<MutableMap<String, Any?>>().also { runtimeVariant["dependencies"] = it }
+            externalDepsForConsumer.forEach { (group, module, version) ->
+              deps.add(mutableMapOf(
+                "group" to group,
+                "module" to module,
+                "version" to mutableMapOf("requires" to version),
+              ))
+            }
+          } else {
+            logger.warn(
+              "brownfield.fused[${fusedVariant}]: 'runtimePublication' variant not found in " +
+                "module metadata — skipped injecting ${externalDepsForConsumer.size} external " +
+                "dependencies. Consumers may fail to resolve excluded-group transitives; this " +
+                "usually means the AGP fused-library plugin changed its published variant names."
             )
-            annotatedCount++
           }
         }
+        moduleFile.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(root)))
+        logger.lifecycle(
+          "brownfield.fused[${fusedVariant}]: annotated $annotatedCount dep edges with " +
+            "BuildTypeAttr=${fusedVariant}, stripped $strippedCount excluded entries, " +
+            "injected ${externalDepsForConsumer.size} external transitives in module metadata"
+        )
       }
-      // Inject the user-excluded transitives so the consumer can resolve them.
-      if (externalDepsForConsumer.isNotEmpty()) {
-        val runtimeVariant = variants.firstOrNull { (it["name"] as? String) == "runtimePublication" }
-        if (runtimeVariant != null) {
-          @Suppress("UNCHECKED_CAST")
-          val deps = (runtimeVariant["dependencies"] as? MutableList<MutableMap<String, Any?>>)
-            ?: mutableListOf<MutableMap<String, Any?>>().also { runtimeVariant["dependencies"] = it }
-          externalDepsForConsumer.forEach { (group, module, version) ->
-            deps.add(mutableMapOf(
-              "group" to group,
-              "module" to module,
-              "version" to mutableMapOf("requires" to version),
-            ))
-          }
-        }
-      }
-      moduleFile.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(root)))
-      logger.lifecycle(
-        "brownfield.fused[${fusedVariant}]: annotated $annotatedCount dep edges with " +
-          "BuildTypeAttr=${fusedVariant}, stripped $strippedCount user-excluded entries, " +
-          "injected ${externalDepsForConsumer.size} user-excluded transitives in module metadata"
-      )
     }
-  }
-  // POM injection at the task-output level (not via `pom.withXml`) because Gradle's
-  // `MavenPublication` runs a consistency check AFTER `withXml` that strips entries
-  // whose coords aren't in the resolved configurations. Our `configureEach` exclude
-  // removes them, so the injection has to happen post-consistency-check.
-  val pomTaskName = "generatePomFileForBrownfield${fusedVariantCapitalized}Publication"
-  tasks.named(pomTaskName).configure {
-    doLast {
-      if (externalDepsForConsumer.isEmpty()) return@doLast
-      val pomFile = outputs.files.singleFile
-      if (!pomFile.exists()) return@doLast
-      val depEntries = externalDepsForConsumer.joinToString("\n") { (group, module, version) ->
-        """    <dependency>
+    // POM injection at the task-output level (not via `pom.withXml`) because Gradle's
+    // `MavenPublication` runs a consistency check AFTER `withXml` that strips entries
+    // whose coords aren't in the resolved configurations. Our `configureEach` exclude
+    // removes them, so the injection has to happen post-consistency-check.
+    val pomTaskName = "generatePomFileForBrownfield${fusedVariantCapitalized}Publication"
+    tasks.named(pomTaskName).configure {
+      doLast {
+        if (externalDepsForConsumer.isEmpty()) return@doLast
+        val pomFile = outputs.files.singleFile
+        if (!pomFile.exists()) return@doLast
+        val depEntries = externalDepsForConsumer.joinToString("\n") { (group, module, version) ->
+          """    <dependency>
       <groupId>${group}</groupId>
       <artifactId>${module}</artifactId>
       <version>${version}</version>
       <scope>runtime</scope>
     </dependency>"""
+        }
+        val xml = pomFile.readText()
+        val updated = if (xml.contains("</dependencies>")) {
+          xml.replace("</dependencies>", "${depEntries}\n  </dependencies>")
+        } else {
+          xml.replace("</project>", "  <dependencies>\n${depEntries}\n  </dependencies>\n</project>")
+        }
+        pomFile.writeText(updated)
       }
-      val xml = pomFile.readText()
-      val updated = if (xml.contains("</dependencies>")) {
-        xml.replace("</dependencies>", "${depEntries}\n  </dependencies>")
-      } else {
-        xml.replace("</project>", "  <dependencies>\n${depEntries}\n  </dependencies>\n</project>")
-      }
-      pomFile.writeText(updated)
     }
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -26,66 +26,90 @@ androidFusedLibrary {
   aarMetadata { minCompileSdk = 36 }
 }
 
-// Originally we skipped dev-only modules (expo-dev-menu, expo-dev-launcher, etc.)
-// to keep dev tooling out of release. But the autolinking-generated
-// `ExpoModulesPackageList.kt` baked into `:${{libraryName}}` references every
-// autolinked module's Package class with a hard static reference — skipping a
-// module from the fused AAR leaves a dangling reference that crashes the host
-// at app startup with `NoClassDefFoundError`. We accept the trade-off: dev
-// modules ship inside the fused AAR (their classes exist, autolinking resolves),
-// but the host still only invokes dev features in debug-side flows. ViewBinding/
-// DataBinding from these modules is stripped by the `configurations.configureEach`
-// block below.
-val devOnlyExpoProjects = emptySet<String>()
-
-// Modules whose classes reference resources from EXTERNAL Maven deps (ExoPlayer for
-// expo-video, CameraX for expo-camera, Google Maps SDK for expo-maps, etc.). AGP
-// Fused Library's `rewriteClasses` step can't rewrite R.id/R.string references to
-// resources it never saw — only the included projects' own R.txt is merged. Including
-// these modules makes the build fail with "unknown symbol of type X and name Y" at
-// `rewriteClasses`. Consumers can still depend on them as regular Maven coords next
-// to the fused AAR.
+// Every autolinked Expo Android module fuses in by default. Earlier iterations
+// skipped "heavy" modules (expo-video, expo-camera, expo-image, expo-maps, etc.)
+// because their classes reference R.* values from EXTERNAL Maven deps (ExoPlayer
+// for expo-video, CameraX for expo-camera, Glide for expo-image, Google Maps SDK
+// for expo-maps, ...) — AGP Fused Library's `rewriteClasses` step couldn't resolve
+// those references because the external libraries came in as POM deps, not as
+// included `include()` targets. The fix below: at Gradle time, walk each Expo
+// module's `releaseRuntimeClasspath`, collect every resolved external AAR, and
+// `include()` it alongside the project. The external library's R.txt + resources
+// end up merged into the fused AAR and `rewriteClasses` resolves cleanly.
 //
-// Extend at invocation time with `-Pbrownfield.fused.skip=foo,bar` (comma-separated
-// project names) if you hit additional `rewriteClasses` failures with other modules.
-val externalResourceExpoProjects = setOf(
-  "expo-video",
-  "expo-camera",
-  "expo-maps",
-  "expo-image",
-  "expo-av",
-  "expo-image-picker",
-  "expo-document-picker",
-)
+// Override at invocation via `-Pbrownfield.fused.skip=foo,bar` if a specific
+// module still trips a build (e.g. a new Expo module introduces an external
+// library that needs a manual coord override).
 val extraSkip: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
   ?.split(',')
   ?.map { it.trim() }
   ?.filter { it.isNotEmpty() }
   ?.toSet()
   ?: emptySet()
-val fusedSkipProjects = devOnlyExpoProjects + externalResourceExpoProjects + extraSkip
+val fusedSkipProjects = extraSkip
 
 // Force every sibling expo module to evaluate its build script before we resolve
-// `include()` targets. Without this, `sub.plugins.hasPlugin(...)` returns false for
-// any project Gradle hasn't reached yet and the fused AAR ships empty.
+// `include()` targets and walk their `releaseRuntimeClasspath`. Without this, the
+// `hasPlugin(...)` check and the classpath resolution both see incomplete state.
 rootProject.subprojects.forEach {
   if (it.path != project.path) {
     evaluationDependsOn(it.path)
   }
 }
 
+// Group prefixes for non-AndroidX coords that MUST stay external in the published POM.
+// The consumer's host app provides these foundational libraries; bundling them inside
+// the fused AAR triggers duplicate-class errors at dex merge time. Extend at
+// invocation via `-Pbrownfield.fused.exclude-transitive=foo,bar`.
+val transitiveIncludeDenylistNonAndroidX = setOf(
+  "org.jetbrains.kotlin",
+  "org.jetbrains.kotlinx",
+  "com.facebook.fbjni",
+  "com.facebook.fresco",
+  "com.facebook.hermes",
+  "com.facebook.react",
+  "com.facebook.soloader",
+  "com.facebook.yoga",
+  "com.google.android.material",
+  "com.google.guava",
+  "com.squareup.okhttp3",
+  "com.squareup.okio",
+)
+// AndroidX subgroups we DO want fused — these provide the heavy library code Expo
+// modules wrap (ExoPlayer for expo-video, CameraX for expo-camera). All other
+// `androidx.*` groups stay external because the consumer's host app already provides
+// them, and Fused Library's validation refuses partially-included transitive-dep
+// chains (one allowed transitive's parent must also be in the fat AAR — easy to
+// trip when AndroidX modules cross-depend).
+val androidxFuseAllowlist = setOf(
+  "androidx.camera",
+  "androidx.media3",
+)
+val extraDenylist: Set<String> =
+  (project.findProperty("brownfield.fused.exclude-transitive") as? String)
+    ?.split(',')
+    ?.map { it.trim() }
+    ?.filter { it.isNotEmpty() }
+    ?.toSet()
+    ?: emptySet()
+val effectiveDenylist = transitiveIncludeDenylistNonAndroidX + extraDenylist
+// Helper that decides if a group should stay external (in POM, not in the fat AAR).
+fun isGroupDenied(group: String): Boolean {
+  if (effectiveDenylist.any { group == it || group.startsWith("$it.") }) return true
+  // AndroidX: deny everything EXCEPT the explicit allowlist.
+  if (group == "androidx" || group.startsWith("androidx.")) {
+    return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
+  }
+  return false
+}
+
 // AGP Fused Library rejects ANY `androidx.databinding:*` dep — including
 // `viewbinding`, which is pulled transitively by `react { autolinkLibrariesWithApp() }`
 // on the brownfield library and by some autolinked modules. We don't use binding
 // in the fused AAR, so strip it from every configuration before validation runs.
-//
-// Plus: skip-list modules (dev-only + external-resource) leak into the fused POM as
-// transitive deps from `:brownfield`'s `react { autolinkLibrariesWithApp() }`, and
-// the Fused Library plugin externalizes them using Gradle project names
-// (`expo-camera`) rather than their real published artifactIds (`expo.modules.camera`).
-// The resulting coords don't resolve at consume time. Strip them from every
-// configuration so they never make it into the published POM — consumers add the
-// modules they actually need as separate deps in their host app.
+// This MUST be registered BEFORE the aggregator below is resolved — `configureEach`
+// fires for every configuration including future ones, and adding excludes after
+// resolution throws "Cannot mutate after resolved".
 configurations.configureEach {
   exclude(group = "androidx.databinding", module = "viewbinding")
   exclude(group = "androidx.databinding", module = "databinding-common")
@@ -94,6 +118,94 @@ configurations.configureEach {
   exclude(group = "androidx.databinding", module = "databinding-ktx")
 
   fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
+}
+
+// Create an aggregator configuration on THIS project that depends on every Expo
+// module. Resolving another project's configuration directly fails under Gradle 8+
+// parallel execution with "attempted without an exclusive lock"; resolving our own
+// configuration is always safe. Attributes pin the consumer side to
+// `java-runtime` + `BuildTypeAttr=release` so Gradle's variant matcher picks each
+// Expo module's release runtime variant rather than emitting "no matching variants"
+// or silently resolving nothing.
+val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+  attributes {
+    attribute(
+      org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE,
+      project.objects.named(org.gradle.api.attributes.Usage::class.java, org.gradle.api.attributes.Usage.JAVA_RUNTIME)
+    )
+    attribute(
+      org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE,
+      project.objects.named(org.gradle.api.attributes.Category::class.java, org.gradle.api.attributes.Category.LIBRARY)
+    )
+    // AGP's `releaseRuntimeElements` exposes multiple sub-variants under one
+    // configuration (`android-aar`, `android-aar-metadata`, `android-classes`,
+    // `android-jni`, ...). Without LibraryElements=aar Gradle can't pick which
+    // sub-variant to give us and emits "cannot choose between the following variants".
+    attribute(
+      org.gradle.api.attributes.LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+      project.objects.named(org.gradle.api.attributes.LibraryElements::class.java, "aar")
+    )
+    attribute(
+      com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
+      project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, "release")
+    )
+  }
+  // Two Expo modules pin different `-android`-suffixed Guava versions which Gradle's
+  // version comparator can't reconcile (the suffix throws off SemVer ordering). The
+  // conflict cascades and lenient resolution returns ZERO artifacts. Neither
+  // `force(...)` nor `eachDependency` resolves it cleanly. Excluding Guava from the
+  // aggregator entirely is the pragmatic fix — Guava is foundational and stays
+  // external in the POM via the denylist above, so the consumer's host app provides
+  // it. Add more `exclude(...)` lines here if another dep introduces a similar
+  // suffix-conflict that the aggregator can't reconcile.
+  exclude(group = "com.google.guava", module = "guava")
+}
+dependencies {
+  rootProject.subprojects.forEach { sub ->
+    if (sub.path == project.path) return@forEach
+    if (sub.name in fusedSkipProjects) return@forEach
+    if (!sub.plugins.hasPlugin("expo-module-gradle-plugin")) return@forEach
+    add("brownfieldFusedExpoAggregator", sub)
+  }
+}
+
+// Walk the aggregator's resolved artifacts to collect external AAR coordinates the
+// fused AAR should `include()`. Auto-discovers ExoPlayer for expo-video, CameraX
+// for expo-camera, Glide for expo-image, etc. without hardcoding per-module coord
+// lists. Foundational coords from the denylist stay out; sibling Expo projects are
+// already include()'d as projects below.
+//
+// Uses the modern `incoming.artifactView { lenient(true) }` API rather than
+// `resolvedConfiguration.lenientConfiguration` — the latter throws on any failure
+// before you can access the lenient surface, masking the underlying error.
+val transitiveAarIncludes: Set<String> = run {
+  val collected = mutableSetOf<String>()
+  // Request `artifactType=aar` on the view. For external Maven AARs that's the
+  // file-extension type. For AGP project deps, Gradle's built-in artifact transforms
+  // converts the `android-aar` sub-variant to a plain `aar` file. Both targets match,
+  // sidestepping the "cannot choose between sub-variants" ambiguity.
+  val artifactView = expoAggregator.incoming.artifactView {
+    isLenient = true
+    attributes {
+      attribute(
+        org.gradle.api.attributes.Attribute.of("artifactType", String::class.java),
+        "aar"
+      )
+    }
+  }
+  artifactView.artifacts.artifacts.forEach { result ->
+    val id = result.id.componentIdentifier
+    if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
+    if (result.file.extension != "aar") return@forEach
+    val group = id.group
+    if (isGroupDenied(group)) return@forEach
+    if (rootProject.findProject(":${id.module}") != null) return@forEach
+    collected += "${group}:${id.module}:${id.version}"
+  }
+  logger.lifecycle("brownfield.fused: collected ${collected.size} external AAR coords")
+  collected
 }
 
 dependencies {
@@ -110,6 +222,14 @@ dependencies {
     if (!sub.plugins.hasPlugin("expo-module-gradle-plugin")) return@forEach
     include(project(sub.path))
   }
+
+  // External Maven AARs reachable from each fused Expo module's release runtime
+  // classpath (ExoPlayer for expo-video, CameraX for expo-camera, Glide for
+  // expo-image, etc.). Bringing them in as `include()` targets merges their R.txt
+  // + resources into the fused AAR so `rewriteClasses` can resolve the FQNs Expo
+  // modules reference. The denylist above keeps foundational coords (kotlin-stdlib,
+  // androidx.core, RN runtime) external in the POM.
+  transitiveAarIncludes.forEach { coord -> include(coord) }
 }
 
 publishing {

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -182,19 +182,45 @@ val expoAggregator = configurations.create("brownfieldFusedExpoAggregator") {
 // This catches BOTH Expo modules (via `expo-module-gradle-plugin`) AND React Native
 // community modules (which only apply `com.android.library`), fixing the previous
 // expo-only filter that silently excluded `react-native-screens` etc.
+// `project` inside a `Project` extension function resolves to the RECEIVER (since
+// `Project.getProject()` returns `this`), not the script's project. Capture the
+// script project's path in an outer `val` so the self-check actually compares the
+// iterated subproject against THIS fused module.
+val thisProjectPath: String = project.path
+
+// `plugins.hasPlugin("com.android.library")` returns false on Expo modules because
+// `expo-module-gradle-plugin` applies AGP via `pluginManager.apply(LibraryPlugin::class.java)`
+// (programmatic class apply), which doesn't register the plugin ID in the ID lookup
+// table. We match by class FQN instead, catching both apply-by-class and apply-by-id.
+fun Project.hasAndroidLibraryPlugin(): Boolean {
+  if (plugins.hasPlugin("com.android.library")) return true
+  if (plugins.toList().any { p ->
+        val n = p.javaClass.name
+        (n.startsWith("com.android.build.gradle.") || n.startsWith("com.android.build.api.")) &&
+          n.endsWith("LibraryPlugin")
+      }) return true
+  val android = extensions.findByName("android") ?: return false
+  return android.javaClass.name.contains("Library", ignoreCase = true)
+}
+
 fun Project.isFusableAndroidLibrary(): Boolean {
-  if (path == project.path) return false
+  if (path == thisProjectPath) return false
   if (name == "${{libraryName}}") return false
   if (name == "${{libraryName}}-fused-release") return false
   if (name == "${{libraryName}}-fused-debug") return false
   if (name in fusedSkipProjects) return false
-  if (!plugins.hasPlugin("com.android.library")) return false
+  if (!hasAndroidLibraryPlugin()) return false
   return true
 }
 
+val fusableSubprojects: List<Project> = rootProject.subprojects.filter { it.isFusableAndroidLibrary() }
+logger.lifecycle(
+  "brownfield.fused[${fusedVariant}]: fusing ${fusableSubprojects.size} subprojects: " +
+    fusableSubprojects.joinToString(", ") { it.name }
+)
+
 dependencies {
-  rootProject.subprojects.forEach { sub ->
-    if (!sub.isFusableAndroidLibrary()) return@forEach
+  fusableSubprojects.forEach { sub ->
     add("brownfieldFusedExpoAggregator", sub)
   }
 }
@@ -258,6 +284,37 @@ dependencies {
 }
 
 publishing {
+  // Mirror the repositories declared on the root project's `expoBrownfieldPublishPlugin`
+  // extension onto THIS fused sibling. The publish plugin's `setupRepositories` runs
+  // via `setupPublishing`, which is gated by `shouldBeSkipped()` — that returns true
+  // for fused modules (no `LibraryExtension`), so the wiring would otherwise stop at
+  // the publication and never create the `publishBrownfield<V>PublicationTo<X>Repository`
+  // tasks. Re-implement the repo loop here against the SAME `ExpoPublishExtension`
+  // config so `--repo <Name>` on the CLI resolves identically for fused and non-fused.
+  repositories {
+    val rootPublishConfig =
+      rootProject.extensions.findByType(expo.modules.plugin.ExpoPublishExtension::class.java)
+    rootPublishConfig?.publications?.forEach { pubConfig ->
+      when (pubConfig.type.get()) {
+        "localMaven" -> mavenLocal()
+        "localDirectory", "remotePublic" -> maven {
+          name = pubConfig.name
+          url = uri(pubConfig.url.get())
+          isAllowInsecureProtocol = pubConfig.allowInsecure.get()
+        }
+        "remotePrivate" -> maven {
+          name = pubConfig.name
+          url = uri(pubConfig.url.get())
+          credentials {
+            username = pubConfig.username.get()
+            password = pubConfig.password.get()
+          }
+          isAllowInsecureProtocol = pubConfig.allowInsecure.get()
+        }
+      }
+    }
+  }
+
   publications {
     register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
       afterEvaluate { from(components["fusedLibraryComponent"]) }

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -15,7 +15,6 @@ group = "${{groupId}}"
 version = "${{version}}"
 
 val fusedVariant = "${{fusedVariant}}"
-val isReleaseVariant = fusedVariant == "release"
 val fusedVariantCapitalized = fusedVariant.replaceFirstChar { it.uppercase() }
 
 androidFusedLibrary {
@@ -24,22 +23,25 @@ androidFusedLibrary {
   aarMetadata { minCompileSdk = 36 }
 }
 
-// Dev tooling is `debugImplementation`-only on the brownfield library, so the
-// release fat AAR must skip it. `setupFusedModeStripping` strips matching entries
-// from the generated `ExpoModulesPackageList.kt` to avoid `NoClassDefFoundError`
-// at host startup. Extend ad-hoc via `-Pbrownfield.fused.skip=foo,bar`.
-val devOnlySkipProjects: Set<String> = if (isReleaseVariant) {
-  setOf("expo-dev-client", "expo-dev-launcher", "expo-dev-menu", "expo-dev-menu-interface")
-} else {
-  emptySet()
-}
+// No hardcoded skip list. Dev tooling (`expo-dev-menu` / `-launcher` / `-client` /
+// `-menu-interface`) is included in BOTH variants:
+//   - For `-fused-release`, AGP fused-library compiles each module's release source
+//     set. `expo-dev-menu` / `expo-dev-launcher` swap their `src/debug` for a tiny
+//     `src/disableInRelease` source set in release builds — it provides STUB
+//     `DevMenuPackage` / `DevLauncherPackageDelegate` classes so `ExpoModulesPackageList`
+//     references resolve at runtime, but with no functional dev tooling. Footprint
+//     stays small and no manual entry-stripping is needed.
+//   - For `-fused-debug`, our `fusedRuntime` attribute override picks the debug
+//     source set → real dev tooling, Metro reload, red-box overlay, etc.
+// `expo-dev-client` and `expo-dev-menu-interface` have no Kotlin/Java sources at
+// all; including them adds nothing to the AAR.
 val extraSkip: Set<String> = (project.findProperty("brownfield.fused.skip") as? String)
   ?.split(',')
   ?.map { it.trim() }
   ?.filter { it.isNotEmpty() }
   ?.toSet()
   ?: emptySet()
-val fusedSkipProjects = devOnlySkipProjects + extraSkip
+val fusedSkipProjects = extraSkip
 
 // Force sibling evaluation before resolving include() targets and walking their
 // runtime classpaths — without this, plugin detection and classpath resolution
@@ -75,36 +77,52 @@ val androidxFuseAllowlist = setOf(
   "androidx.camera",
   "androidx.media3",
 )
-val extraDenylist: Set<String> =
+// Groups the user explicitly wants to keep OUT of the fused AAR — extra groups
+// beyond the auto-detected KMP libs (see below). Configure via gradle.properties
+// or `-P` when auto-detection misses something:
+//   brownfield.fused.exclude-transitive=some.kmp.group,another.group
+val userExcludedGroups: Set<String> =
   (project.findProperty("brownfield.fused.exclude-transitive") as? String)
     ?.split(',')
     ?.map { it.trim() }
     ?.filter { it.isNotEmpty() }
     ?.toSet()
     ?: emptySet()
-val effectiveDenylist = transitiveIncludeDenylistNonAndroidX + extraDenylist
+
+// Auto-detected KMP groups that can't safely be fused. Populated by walking the
+// aggregator's resolution result (below) and inspecting each component's variants
+// for the Kotlin Multiplatform `platform.type` attribute. KMP-published libs trip
+// AGP fused-library's "parent dependency not included" validation when the
+// `-android` child gets fused because the umbrella parent has no AAR.
+val autoExcludedGroups = mutableSetOf<String>()
+
+// Combined view used by configureEach excludes + denylist below. Populated by
+// the resolution walk before configureEach gets registered for other configs.
+fun effectiveExcludedGroups(): Set<String> = userExcludedGroups + autoExcludedGroups
+
 // True → coord stays external in the POM. AndroidX uses an allowlist, everything
-// else uses the denylist above.
+// else uses the denylist (foundational libs + KMP/user-excluded groups).
 fun isGroupDenied(group: String): Boolean {
-  if (effectiveDenylist.any { group == it || group.startsWith("$it.") }) return true
+  val denylist = transitiveIncludeDenylistNonAndroidX + effectiveExcludedGroups()
+  if (denylist.any { group == it || group.startsWith("$it.") }) return true
   if (group == "androidx" || group.startsWith("androidx.")) {
     return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
   }
   return false
 }
 
-// AGP Fused Library rejects any `androidx.databinding:*` dep (including
-// `viewbinding`, pulled transitively by `react { autolinkLibrariesWithApp() }`).
-// Strip them from every configuration. MUST be registered BEFORE the aggregator
-// resolves, otherwise `configureEach` throws "Cannot mutate after resolved".
-configurations.configureEach {
-  exclude(group = "androidx.databinding", module = "viewbinding")
-  exclude(group = "androidx.databinding", module = "databinding-common")
-  exclude(group = "androidx.databinding", module = "databinding-runtime")
-  exclude(group = "androidx.databinding", module = "databinding-adapters")
-  exclude(group = "androidx.databinding", module = "databinding-ktx")
-
-  fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
+// Override AGP fused-library's internal `fusedRuntime` BuildTypeAttr=release →
+// match the sibling's `fusedVariant`. Makes `-fused-debug` actually fuse debug-
+// compiled bytecode (correct `BuildConfig.DEBUG=true`, dev-only code paths active).
+configurations.all {
+  if (name.startsWith("fusedRuntime")) {
+    attributes {
+      attribute(
+        com.android.build.api.attributes.BuildTypeAttr.ATTRIBUTE,
+        project.objects.named(com.android.build.api.attributes.BuildTypeAttr::class.java, fusedVariant)
+      )
+    }
+  }
 }
 
 // Aggregator configuration: depends on every autolinked module, resolved locally
@@ -178,12 +196,74 @@ dependencies {
   }
 }
 
+// Recorded by the aggregator walk: coords whose group is in `userExcludedGroups`
+// — the consumer-side resolution needs to declare these as transitive deps even
+// though we don't fuse them into the AAR. Used by the metadata + POM post-
+// processors below.
+val externalDepsForConsumer = mutableListOf<Triple<String, String, String>>()
+
+// First pass: walk the aggregator's resolutionResult to AUTO-DETECT KMP libs
+// whose umbrella module declares `available-at` redirecting to a different child
+// coord (e.g. `com.composables:core` → `core-android-debug`, or
+// `io.github.lukmccall:radix-ui-colors` → `radix-ui-colors-android`). The
+// umbrella has no content, only the redirect — AGP fused-library's "parent
+// dependency not included" validation fires when the child gets fused but the
+// umbrella isn't (and the umbrella can't be fused, it has no AAR).
+//
+// Gradle exposes the redirect via `ResolvedVariantResult.externalVariant`: when
+// present, this variant is a stand-in for the variant in another module. The
+// umbrella component is the one carrying that link, so its group is what we
+// auto-exclude. Other KMP-published libs that publish full content per artifact
+// (Compose, Kotlin stdlib, etc.) don't have `available-at` and are unaffected.
+expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
+  val id = component.id
+  if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
+  if (transitiveIncludeDenylistNonAndroidX.any { id.group == it || id.group.startsWith("$it.") }) return@forEach
+  val hasAvailableAtRedirect = component.variants.any { variant ->
+    variant.externalVariant.isPresent
+  }
+  if (hasAvailableAtRedirect) autoExcludedGroups.add(id.group)
+}
+if (autoExcludedGroups.isNotEmpty()) {
+  logger.lifecycle(
+    "brownfield.fused[${fusedVariant}]: auto-detected ${autoExcludedGroups.size} KMP " +
+      "umbrella groups to keep external: " + autoExcludedGroups.sorted().joinToString(", ")
+  )
+}
+
+// Excludes that must reach EVERY configuration the fused-library plugin walks,
+// including the runtime classpaths of `include(project(...))` targets. Scoping
+// to just `fusedRuntime` isn't enough — fused-library reads from included
+// projects' own configs which a scoped exclude can't touch.
+//
+// The aggregator is intentionally exempt so the transitive-AAR walk below can
+// still record the resolved versions of excluded groups; we inject those into
+// the published POM/.module as transitive deps for consumers to resolve.
+//
+// MUST be registered BEFORE any other config the fused-library plugin will walk
+// resolves — otherwise `exclude` throws "Cannot mutate after resolved." We
+// resolve the aggregator first (above, for KMP detection) but that's safe
+// because the aggregator is exempt from this configureEach.
+configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configureEach {
+  // AGP Fused Library rejects any `androidx.databinding:*` dep, including
+  // `viewbinding` pulled transitively by `react { autolinkLibrariesWithApp() }`.
+  exclude(group = "androidx.databinding", module = "viewbinding")
+  exclude(group = "androidx.databinding", module = "databinding-common")
+  exclude(group = "androidx.databinding", module = "databinding-runtime")
+  exclude(group = "androidx.databinding", module = "databinding-adapters")
+  exclude(group = "androidx.databinding", module = "databinding-ktx")
+
+  fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
+  effectiveExcludedGroups().forEach { g -> exclude(group = g) }
+}
+
 // Walk the aggregator's resolved artifacts to collect external AAR coords for
 // `include()`. Auto-discovers ExoPlayer, CameraX, Glide, etc. Lenient via the
 // modern `artifactView` API — the legacy `lenientConfiguration` throws before
 // you can read the lenient surface, masking the real failure.
 val transitiveAarIncludes: Set<String> = run {
   val collected = mutableSetOf<String>()
+  val excludedGroups = effectiveExcludedGroups()
   val artifactView = expoAggregator.incoming.artifactView {
     isLenient = true
     attributes {
@@ -198,11 +278,18 @@ val transitiveAarIncludes: Set<String> = run {
     if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
     if (result.file.extension != "aar") return@forEach
     val group = id.group
+    // Record coords from excluded groups so we can inject them as transitive
+    // deps in the published POM/.module — must happen before any filter rejects them.
+    if (group in excludedGroups) {
+      externalDepsForConsumer.add(Triple(group, id.module, id.version))
+    }
     if (isGroupDenied(group)) return@forEach
     if (rootProject.findProject(":${id.module}") != null) return@forEach
-    // Drop per-build-type coords (e.g. `com.composables:core-android-debug`):
-    // AGP fused-library's internal release-hardcoded resolution trips on
-    // cross-variant lookups. Leave them external; the host resolves them.
+    // Drop variant-suffixed Maven coords (e.g. `com.composables:core-android-debug`).
+    // These coords bake the build type into the artifactId, so they have no
+    // cross-variant counterpart and AGP fused-library's internal resolution trips
+    // trying to look them up. The consumer's own resolution picks the matching
+    // variant naturally via Gradle Module Metadata.
     if (id.module.endsWith("-debug") || id.module.endsWith("-release")) return@forEach
     collected += "${group}:${id.module}:${id.version}"
   }
@@ -258,10 +345,9 @@ publishing {
   publications {
     register<MavenPublication>("brownfield${fusedVariantCapitalized}") {
       afterEvaluate { from(components["fusedLibraryComponent"]) }
-      // Fused Library emits skip-list modules into the POM using Gradle project
-      // names (`expo-camera`) instead of the real coords (`expo.modules.camera`),
-      // breaking consumer resolution. Configuration-level excludes don't reach
-      // the POM, so strip them post-generation.
+      // Fused-library emits skip-list modules into the POM using Gradle project names
+      // (`expo-camera`) instead of the real coords (`expo.modules.camera`), so they
+      // can't be resolved by consumers. Strip them.
       pom.withXml {
         val deps = (asNode().get("dependencies") as? groovy.util.NodeList)?.firstOrNull() as? groovy.util.Node
           ?: return@withXml
@@ -272,6 +358,109 @@ publishing {
         }
         toRemove.forEach { deps.remove(it) }
       }
+    }
+  }
+}
+
+// AGP `com.android.fused-library` auto-registers a `maven` publication alongside
+// our explicit `brownfield<V>` one at the same coords. `publishToMavenLocal` runs
+// both — the `maven` one overwrites our annotated metadata. Disable it.
+tasks.matching { it.name.startsWith("publishMavenPublicationTo") }.configureEach {
+  enabled = false
+}
+
+// Annotate `react-android` / `hermes-android` dependency edges in the published
+// Gradle Module Metadata with this sibling's `fusedVariant`, so consumers' variant
+// matching resolves the same RN variant the brownfield's codegen `.so` files were
+// linked against. Mismatch manifests as either SIGSEGV at component-descriptor
+// init (release codegen + debug `libreactnative.so`) or unsatisfied-link to debug-
+// only symbols like `ShadowNode::getDebugName` (debug codegen + release runtime).
+val metadataTaskName = "generateMetadataFileForBrownfield${fusedVariantCapitalized}Publication"
+afterEvaluate {
+  tasks.named(metadataTaskName).configure {
+    doLast {
+      val moduleFile = outputs.files.singleFile
+      if (!moduleFile.exists()) return@doLast
+      @Suppress("UNCHECKED_CAST")
+      val root = groovy.json.JsonSlurper().parseText(moduleFile.readText()) as MutableMap<String, Any?>
+      val variants = root["variants"] as? MutableList<MutableMap<String, Any?>> ?: return@doLast
+      var annotatedCount = 0
+      var strippedCount = 0
+      val perVariantAbiCoords = setOf(
+        "com.facebook.react" to "react-android",
+        "com.facebook.hermes" to "hermes-android",
+      )
+      variants.forEach { variant ->
+        val deps = variant["dependencies"] as? MutableList<MutableMap<String, Any?>> ?: return@forEach
+        // Drop natural-emission entries whose group the user excluded — the inject
+        // step below adds the variant-specific coord with the actual resolved
+        // version, avoiding the KMP-parent-vs-`-android`-child duplication that
+        // naturally appears for libs like `io.github.lukmccall:radix-ui-colors`.
+        val before = deps.size
+        deps.removeAll { dep ->
+          val g = dep["group"] as? String ?: return@removeAll false
+          g in userExcludedGroups
+        }
+        strippedCount += before - deps.size
+        deps.forEach { dep ->
+          val key = (dep["group"] as? String) to (dep["module"] as? String)
+          if (key in perVariantAbiCoords && dep["attributes"] == null) {
+            dep["attributes"] = mutableMapOf<String, Any?>(
+              "com.android.build.api.attributes.BuildTypeAttr" to fusedVariant
+            )
+            annotatedCount++
+          }
+        }
+      }
+      // Inject the user-excluded transitives so the consumer can resolve them.
+      if (externalDepsForConsumer.isNotEmpty()) {
+        val runtimeVariant = variants.firstOrNull { (it["name"] as? String) == "runtimePublication" }
+        if (runtimeVariant != null) {
+          @Suppress("UNCHECKED_CAST")
+          val deps = (runtimeVariant["dependencies"] as? MutableList<MutableMap<String, Any?>>)
+            ?: mutableListOf<MutableMap<String, Any?>>().also { runtimeVariant["dependencies"] = it }
+          externalDepsForConsumer.forEach { (group, module, version) ->
+            deps.add(mutableMapOf(
+              "group" to group,
+              "module" to module,
+              "version" to mutableMapOf("requires" to version),
+            ))
+          }
+        }
+      }
+      moduleFile.writeText(groovy.json.JsonOutput.prettyPrint(groovy.json.JsonOutput.toJson(root)))
+      logger.lifecycle(
+        "brownfield.fused[${fusedVariant}]: annotated $annotatedCount dep edges with " +
+          "BuildTypeAttr=${fusedVariant}, stripped $strippedCount user-excluded entries, " +
+          "injected ${externalDepsForConsumer.size} user-excluded transitives in module metadata"
+      )
+    }
+  }
+  // POM injection at the task-output level (not via `pom.withXml`) because Gradle's
+  // `MavenPublication` runs a consistency check AFTER `withXml` that strips entries
+  // whose coords aren't in the resolved configurations. Our `configureEach` exclude
+  // removes them, so the injection has to happen post-consistency-check.
+  val pomTaskName = "generatePomFileForBrownfield${fusedVariantCapitalized}Publication"
+  tasks.named(pomTaskName).configure {
+    doLast {
+      if (externalDepsForConsumer.isEmpty()) return@doLast
+      val pomFile = outputs.files.singleFile
+      if (!pomFile.exists()) return@doLast
+      val depEntries = externalDepsForConsumer.joinToString("\n") { (group, module, version) ->
+        """    <dependency>
+      <groupId>${group}</groupId>
+      <artifactId>${module}</artifactId>
+      <version>${version}</version>
+      <scope>runtime</scope>
+    </dependency>"""
+      }
+      val xml = pomFile.readText()
+      val updated = if (xml.contains("</dependencies>")) {
+        xml.replace("</dependencies>", "${depEntries}\n  </dependencies>")
+      } else {
+        xml.replace("</project>", "  <dependencies>\n${depEntries}\n  </dependencies>\n</project>")
+      }
+      pomFile.writeText(updated)
     }
   }
 }

--- a/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
+++ b/packages/expo-brownfield/plugin/templates/android/fused/build.gradle.kts
@@ -53,35 +53,72 @@ rootProject.subprojects.forEach {
   evaluationDependsOn(it.path)
 }
 
-// Foundational libraries the host app already provides — bundling them in the
-// fused AAR causes duplicate-class errors at dex merge. Stay external in the POM.
-// Extend via `-Pbrownfield.fused.exclude-transitive=foo,bar`.
-val transitiveIncludeDenylistNonAndroidX = setOf(
-  "org.jetbrains.kotlin",
-  "org.jetbrains.kotlinx",
-  "com.facebook.fbjni",
-  "com.facebook.fresco",
-  "com.facebook.hermes",
+// `androidx.*` allowlist — these must be fused because their transitive chains
+// span non-AndroidX groups (e.g. `androidx.camera:camera-mlkit-vision` depends
+// on `com.google.mlkit:vision-interfaces`; the latter gets pulled into the AAR
+// as a side-effect of fusing an Expo module, and AGP fused-library's "parent
+// dependency not included" validation then demands its AndroidX parent be
+// fused too — which requires the whole `androidx.camera` chain to be fused).
+// Auto-detection can't see these because they're regular Maven parent links,
+// not KMP `available-at` redirects.
+//
+// Extend via `-Pbrownfield.fused.androidx-fuse=androidx.foo,androidx.bar` if
+// another autolinked module pulls a new AndroidX chain with the same pattern.
+val androidxFuseAllowlistDefaults = setOf("androidx.camera", "androidx.media3")
+val androidxFuseAllowlistExtra: Set<String> =
+  (project.findProperty("brownfield.fused.androidx-fuse") as? String)
+    ?.split(',')
+    ?.map { it.trim() }
+    ?.filter { it.isNotEmpty() }
+    ?.toSet()
+    ?: emptySet()
+val androidxFuseAllowlist = androidxFuseAllowlistDefaults + androidxFuseAllowlistExtra
+
+// Android brownfield host platform baseline — NOT a list of application
+// libraries. These are the foundational pieces that, by definition of being a
+// React Native Android brownfield host, the integrating app already provides
+// on its classpath:
+//
+//   • RN runtime — `react-android`, `hermes-android`, `fbjni`, `soloader`,
+//     `yoga`. The host links variant-specific `.so` files against these;
+//     fusing them either duplicate-classes with the host's copies or pins
+//     the wrong variant's native libs. AGP fused-library's "parent
+//     dependency not included" validation also enforces this transitively
+//     (e.g. `fbjni`'s parent is `hermes-android`).
+//
+//   • Kotlin stdlib — `org.jetbrains.kotlin`, `org.jetbrains.kotlinx`. Every
+//     modern Android app pulls these via its own build.
+//
+//   • Host-provided commons — `com.google.android.material`, `com.google.guava`,
+//     `com.facebook.fresco`, `com.squareup.okhttp3`, `com.squareup.okio`.
+//     Beyond duplication risk, AGP fused-library's class rewriter can't
+//     resolve `android:*` framework-attr references in styleables (Material's
+//     `AppBarLayout_android_background` etc.), so fusing Material Design fails
+//     `rewriteClasses` outright.
+//
+// This list encodes structural facts about the brownfield host — not
+// application-specific library choices. If you're adding a NEW group here,
+// it should be because every brownfield host inherently has it (e.g. AGP
+// raised the minimum platform baseline), not because a specific app uses it.
+val hostPlatformBaseline = setOf(
   "com.facebook.react",
+  "com.facebook.hermes",
+  "com.facebook.fbjni",
   "com.facebook.soloader",
   "com.facebook.yoga",
+  "com.facebook.fresco",
+  "org.jetbrains.kotlin",
+  "org.jetbrains.kotlinx",
   "com.google.android.material",
   "com.google.guava",
   "com.squareup.okhttp3",
   "com.squareup.okio",
 )
-// AndroidX subgroups we DO want fused (ExoPlayer for expo-video, CameraX for
-// expo-camera). All other `androidx.*` stays external — Fused Library rejects
-// partial transitive chains, easy to trip with cross-depending AndroidX modules.
-val androidxFuseAllowlist = setOf(
-  "androidx.camera",
-  "androidx.media3",
-)
-// Groups the user explicitly wants to keep OUT of the fused AAR — extra groups
-// beyond the auto-detected KMP libs (see below). Configure via gradle.properties
-// or `-P` when auto-detection misses something:
-//   brownfield.fused.exclude-transitive=some.kmp.group,another.group
-val userExcludedGroups: Set<String> =
+
+// Extra groups the user wants kept OUT of the fused AAR — auto-detection below
+// handles the common KMP-umbrella case, this is only for edge cases:
+//   brownfield.fused.exclude-transitive=some.group,another.group
+val excludedGroupsExtra: Set<String> =
   (project.findProperty("brownfield.fused.exclude-transitive") as? String)
     ?.split(',')
     ?.map { it.trim() }
@@ -89,21 +126,18 @@ val userExcludedGroups: Set<String> =
     ?.toSet()
     ?: emptySet()
 
-// Auto-detected KMP groups that can't safely be fused. Populated by walking the
-// aggregator's resolution result (below) and inspecting each component's variants
-// for the Kotlin Multiplatform `platform.type` attribute. KMP-published libs trip
-// AGP fused-library's "parent dependency not included" validation when the
-// `-android` child gets fused because the umbrella parent has no AAR.
+// Populated below by walking the aggregator's resolution and detecting KMP-style
+// pom-only umbrellas that trip AGP fused-library's "parent dependency not
+// included" validation.
 val autoExcludedGroups = mutableSetOf<String>()
+val effectiveExcludedGroups: Set<String> get() =
+  hostPlatformBaseline + excludedGroupsExtra + autoExcludedGroups
 
-// Combined view used by configureEach excludes + denylist below. Populated by
-// the resolution walk before configureEach gets registered for other configs.
-fun effectiveExcludedGroups(): Set<String> = userExcludedGroups + autoExcludedGroups
-
-// True → coord stays external in the POM. AndroidX uses an allowlist, everything
-// else uses the denylist (foundational libs + KMP/user-excluded groups).
+// True → coord stays external in the POM. AndroidX uses an allowlist; the
+// RN runtime baseline + user-excluded + auto-detected KMP umbrellas form the
+// denylist.
 fun isGroupDenied(group: String): Boolean {
-  val denylist = transitiveIncludeDenylistNonAndroidX + effectiveExcludedGroups()
+  val denylist = effectiveExcludedGroups
   if (denylist.any { group == it || group.startsWith("$it.") }) return true
   if (group == "androidx" || group.startsWith("androidx.")) {
     return androidxFuseAllowlist.none { group == it || group.startsWith("$it.") }
@@ -196,54 +230,58 @@ dependencies {
   }
 }
 
-// Recorded by the aggregator walk: coords whose group is in `userExcludedGroups`
+// Recorded by the aggregator walk: coords whose group is in `effectiveExcludedGroups`
 // — the consumer-side resolution needs to declare these as transitive deps even
 // though we don't fuse them into the AAR. Used by the metadata + POM post-
 // processors below.
 val externalDepsForConsumer = mutableListOf<Triple<String, String, String>>()
 
-// First pass: walk the aggregator's resolutionResult to AUTO-DETECT KMP libs
-// whose umbrella module declares `available-at` redirecting to a different child
-// coord (e.g. `com.composables:core` → `core-android-debug`, or
-// `io.github.lukmccall:radix-ui-colors` → `radix-ui-colors-android`). The
-// umbrella has no content, only the redirect — AGP fused-library's "parent
-// dependency not included" validation fires when the child gets fused but the
-// umbrella isn't (and the umbrella can't be fused, it has no AAR).
+// AUTO-DETECT groups that must stay external. Walks the aggregator's resolution
+// graph once and records two cases:
 //
-// Gradle exposes the redirect via `ResolvedVariantResult.externalVariant`: when
-// present, this variant is a stand-in for the variant in another module. The
-// umbrella component is the one carrying that link, so its group is what we
-// auto-exclude. Other KMP-published libs that publish full content per artifact
-// (Compose, Kotlin stdlib, etc.) don't have `available-at` and are unaffected.
+//   1. Pom-only KMP umbrellas — components where EVERY variant is a redirect
+//      (`available-at`) to another module. The umbrella has no content of its
+//      own, only a pointer; fusing the `-android` child while the umbrella
+//      stays external trips AGP's "parent dependency not included" validation.
+//      Catches `com.composables:core`, `io.github.lukmccall:radix-ui-colors`,
+//      etc. without naming them. Facade umbrellas (Compose, AndroidX) have a
+//      mix of redirect and content variants — they don't match and stay
+//      fusable.
+//
+//   2. Non-allowlisted `androidx.*` groups — `androidx.core` and friends bring
+//      in styleables that reference `android:*` framework attrs (e.g.
+//      `ColorStateListItem` → `android:alpha`). AGP fused-library's class
+//      rewriter can't resolve framework attrs in the merged R, so fusing them
+//      makes `rewriteClasses` fail. Excluding at the configuration level here
+//      stops them from being pulled in via project-dep transitive walks.
 expoAggregator.incoming.resolutionResult.allComponents.forEach { component ->
   val id = component.id
   if (id !is org.gradle.api.artifacts.component.ModuleComponentIdentifier) return@forEach
-  if (transitiveIncludeDenylistNonAndroidX.any { id.group == it || id.group.startsWith("$it.") }) return@forEach
-  val hasAvailableAtRedirect = component.variants.any { variant ->
-    variant.externalVariant.isPresent
+  val group = id.group
+  if (group == "androidx" || group.startsWith("androidx.")) {
+    val inAllowlist = androidxFuseAllowlist.any { group == it || group.startsWith("$it.") }
+    if (!inAllowlist) autoExcludedGroups.add(group)
+    return@forEach
   }
-  if (hasAvailableAtRedirect) autoExcludedGroups.add(id.group)
+  val variants = component.variants
+  if (variants.isEmpty()) return@forEach
+  val isPureUmbrella = variants.all { variant -> variant.externalVariant.isPresent }
+  if (isPureUmbrella) autoExcludedGroups.add(group)
 }
 if (autoExcludedGroups.isNotEmpty()) {
   logger.lifecycle(
-    "brownfield.fused[${fusedVariant}]: auto-detected ${autoExcludedGroups.size} KMP " +
-      "umbrella groups to keep external: " + autoExcludedGroups.sorted().joinToString(", ")
+    "brownfield.fused[${fusedVariant}]: auto-detected ${autoExcludedGroups.size} groups to " +
+      "keep external (KMP umbrellas + non-allowlisted androidx.*): " +
+      autoExcludedGroups.sorted().joinToString(", ")
   )
 }
 
 // Excludes that must reach EVERY configuration the fused-library plugin walks,
 // including the runtime classpaths of `include(project(...))` targets. Scoping
 // to just `fusedRuntime` isn't enough — fused-library reads from included
-// projects' own configs which a scoped exclude can't touch.
-//
-// The aggregator is intentionally exempt so the transitive-AAR walk below can
-// still record the resolved versions of excluded groups; we inject those into
-// the published POM/.module as transitive deps for consumers to resolve.
-//
-// MUST be registered BEFORE any other config the fused-library plugin will walk
-// resolves — otherwise `exclude` throws "Cannot mutate after resolved." We
-// resolve the aggregator first (above, for KMP detection) but that's safe
-// because the aggregator is exempt from this configureEach.
+// projects' own configs which a scoped exclude can't touch. The aggregator is
+// intentionally exempt so the transitive-AAR walk below can still record the
+// resolved versions of excluded groups for POM/.module injection.
 configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configureEach {
   // AGP Fused Library rejects any `androidx.databinding:*` dep, including
   // `viewbinding` pulled transitively by `react { autolinkLibrariesWithApp() }`.
@@ -254,7 +292,7 @@ configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configure
   exclude(group = "androidx.databinding", module = "databinding-ktx")
 
   fusedSkipProjects.forEach { skipName -> exclude(module = skipName) }
-  effectiveExcludedGroups().forEach { g -> exclude(group = g) }
+  effectiveExcludedGroups.forEach { g -> exclude(group = g) }
 }
 
 // Walk the aggregator's resolved artifacts to collect external AAR coords for
@@ -263,7 +301,7 @@ configurations.matching { it.name != "brownfieldFusedExpoAggregator" }.configure
 // you can read the lenient surface, masking the real failure.
 val transitiveAarIncludes: Set<String> = run {
   val collected = mutableSetOf<String>()
-  val excludedGroups = effectiveExcludedGroups()
+  val excludedGroups = effectiveExcludedGroups
   val artifactView = expoAggregator.incoming.artifactView {
     isLenient = true
     attributes {
@@ -399,7 +437,7 @@ afterEvaluate {
         val before = deps.size
         deps.removeAll { dep ->
           val g = dep["group"] as? String ?: return@removeAll false
-          g in userExcludedGroups
+          g in effectiveExcludedGroups
         }
         strippedCount += before - deps.size
         deps.forEach { dep ->

--- a/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
@@ -15,9 +15,9 @@ index dda8db9d25..ee263e78e2 100644
 
  object BrownfieldLifecycleDispatcher {
    fun onApplicationCreate(application: Application) {
-@@ -38,4 +40,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
+@@ -43,4 +45,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
    override fun invokeDefaultOnBackPressed() {
-     super.onBackPressed()
+     finish()
    }
 +
 +  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {

--- a/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/BrownfieldActivity.patch
@@ -2,18 +2,22 @@ diff --git a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivit
 index dda8db9d25..ee263e78e2 100644
 --- a/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
 +++ b/packages/expo-brownfield/plugin/templates/android/BrownfieldActivity.kt
-@@ -4,6 +4,8 @@ import android.app.Application
+@@ -3,9 +3,11 @@ package ${{packageId}}
+ import android.app.Activity
+ import android.app.Application
  import android.content.res.Configuration
- import androidx.appcompat.app.AppCompatActivity
- import expo.modules.ApplicationLifecycleDispatcher
 +import android.view.KeyEvent
+ import androidx.appcompat.app.AppCompatActivity
+ import com.facebook.react.ReactPackage
+ import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler
+ import expo.modules.ApplicationLifecycleDispatcher
 +import expo.modules.devmenu.api.DevMenuApi
- 
+
  object BrownfieldLifecycleDispatcher {
    fun onApplicationCreate(application: Application) {
-@@ -20,4 +22,15 @@ open class BrownfieldActivity : AppCompatActivity() {
-     super.onConfigurationChanged(newConfig)
-     BrownfieldLifecycleDispatcher.onConfigurationChanged(this.application, newConfig)
+@@ -38,4 +40,15 @@ open class BrownfieldActivity : AppCompatActivity(), DefaultHardwareBackBtnHandler {
+   override fun invokeDefaultOnBackPressed() {
+     super.onBackPressed()
    }
 +
 +  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {

--- a/packages/expo-brownfield/plugin/templates/patches/ReactNativeHostManager.patch
+++ b/packages/expo-brownfield/plugin/templates/patches/ReactNativeHostManager.patch
@@ -2,7 +2,7 @@ diff --git a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostMa
 index a9fbbe7d70..f7561327e7 100644
 --- a/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
 +++ b/packages/expo-brownfield/plugin/templates/android/ReactNativeHostManager.kt
-@@ -12,6 +12,16 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
+@@ -13,6 +13,16 @@
  import com.facebook.react.modules.core.DeviceEventManagerModule
  import expo.modules.ExpoReactHostFactory
  import expo.modules.brownfield.BrownfieldNavigationState
@@ -19,9 +19,9 @@ index a9fbbe7d70..f7561327e7 100644
  
  class ReactNativeHostManager {
    companion object {
-@@ -61,13 +71,44 @@ class ReactNativeHostManager {
-       context = application.applicationContext,
-       packageList = PackageList(application).packages + additionalPackages
+@@ -68,13 +78,44 @@
+       packageList = PackageList(application).packages + additionalPackages,
+       useDevSupport = BuildConfig.DEBUG
      )
 +
 +    if (BuildConfig.DEBUG) {
@@ -66,13 +66,13 @@ index a9fbbe7d70..f7561327e7 100644
    setUpNativeBackHandling()
  }
  
-@@ -97,3 +138,30 @@ fun Activity.setUpNativeBackHandling() {
+@@ -104,3 +145,30 @@
  
    componentActivity.onBackPressedDispatcher?.addCallback(componentActivity, backCallback)
  }
 +
 +internal fun maybeGetAppInfoFromManifest(
-+  application: Application, 
++  application: Application,
 +  reactHost: ReactHost?,
 +  activity: Activity
 +) {


### PR DESCRIPTION
# Why

In its current state `npx expo-brownfield build:android` publishes ~30 separate Maven coordinates per release (one per autolinked Expo Android module). This PR adds an opt-in single-fat-AAR mode so consumers only need to publish (and depend on) one AAR per variant.

# How

Add new `--fused` flag to `expo-brownfield build:android`. When set, the CLI targets the new sibling Gradle subprojects emitted by the config plugin,`<library>-fused-release` and `<library>-fused-debug`, producing a single AAR containing every autolinked module + each module's transitive Maven dependencies (ExoPlayer for expo-video, CameraX for expo-camera, etc.).
Key pieces:

- **Inert by default.** Prebuild always emits the two fused siblings, but their build scripts only activate when the CLI passes `-Pbrownfield.fused=true`. Normal builds and IDE sync pay no configuration cost, and non-fused publishes can't accidentally trigger a fat-AAR build via Gradle's cross-project task-name matching.
- **One sibling per variant.** `-fused-release` and `-fused-debug` publish distinct coordinates so hosts wire them as `releaseImplementation` / `debugImplementation`. A `BuildTypeAttr` override makes the debug sibling actually fuse debug bytecode (AGP's fused-library resolves everything as release by default).
- **Fused-only side effects.** The same property skips the publish plugin's per-module re-publish loop and force-bumps AGP to 8.13 just for fused builds (8.12's `rewriteClasses` can't read Kotlin sealed-class bytecode).
- **Fused contents are discovered, not hardcoded.** The sibling resolves the autolinked dependency graph and includes every module plus their external AARs (ExoPlayer, CameraX, Glide, ...). Three groups stay external: the brownfield host baseline (RN runtime, Kotlin stdlib, Material/Guava/OkHttp/Okio), `androidx.*` (AGP's class rewriter can't resolve framework attrs in their styleables; `androidx.camera`/`media3` are allowlisted), and auto-detected pom-only KMP umbrella modules. Everything external is re-declared in the published POM/`.module` so consumers resolve it themselves.
- **Variant-safe RN resolution.** Published metadata annotates the `react-android`/`hermes-android` edges with the sibling's build type, so consumers link the same RN variant the fused codegen `.so` files were built against (a mismatch crashes at startup).
- **Escape hatches.** `-Pbrownfield.fused.skip`, `strip-packages`, `androidx-fuse`, and `exclude-transitive` cover dependency graphs the auto-detection can't; documented in the new Fused mode docs section.
- **Runtime fixes along the way.** `BrownfieldActivity` implements `DefaultHardwareBackBtnHandler` and finishes on default back (avoids an infinite native/JS back-press loop), consumer ProGuard rules ship in the AAR so host R8 keeps reflection-loaded Expo classes, and the dev-menu patch passes `useDevSupport` explicitly so dev tooling follows the AAR variant.


# Test Plan

Automated:

- CLI e2e: fused task construction routed to the sibling subprojects, `--all` expanding to one Gradle invocation per variant, `-Pbrownfield.fused=true` forwarding (including for tasks passed via `-t`), plus existing snapshot/dry-run coverage.
- Plugin e2e: both fused siblings emitted with correct group/version/namespace/variant substitutions and the inert-by-default guard, settings.gradle includes, gradle.properties Fused Library opt-ins, and the conditional AGP force block. (Also fixed the suite's `expectFile` helper, which was async-but-unawaited, so its content assertions actually fail tests now.)

Manual, in `apps/brownfield-tester/expo-app`:

```sh
# Default — publishes both siblings
npx expo-brownfield build:android --fused --repo MavenLocal --verbose

# Or per variant
npx expo-brownfield build:android --fused --release --repo MavenLocal --verbose
npx expo-brownfield build:android --fused --debug   --repo MavenLocal --verbose
``