### PR TITLE
fix(cli): Prevalidate `easProjectId` for JSON cache config path [EXP-56]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Add missing HTML sanitization when serializing log-box error data ([#45885](https://github.com/expo/expo/pull/45885) by [@kitten](https://github.com/kitten))
 - Fix missing await on bundle/assets output copies in `export:embed` ([#45883](https://github.com/expo/expo/pull/45883) by [@kitten](https://github.com/kitten))
+- Prevalidate `easProjectId` before using it as cache path ([#45879](https://github.com/expo/expo/pull/45879) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
+++ b/packages/@expo/cli/src/utils/__tests__/codesigning-test.ts
@@ -125,6 +125,16 @@ describe(getCodeSigningInfoAsync, () => {
         expect(result).toBeNull();
       });
 
+      it('rejects easProjectId values that contain path segments', async () => {
+        await expect(
+          getCodeSigningInfoAsync(
+            { extra: { eas: { projectId: '../outside-project' } } } as any,
+            'keyid="expo-root", alg="rsa-v1_5-sha256"',
+            undefined
+          )
+        ).rejects.toThrow('Invalid EAS project ID for development code signing cache');
+      });
+
       it('falls back to cached when there is a network error', async () => {
         const result = await getCodeSigningInfoAsync(
           { extra: { eas: { projectId: 'testprojectid' } } } as any,

--- a/packages/@expo/cli/src/utils/codesigning.ts
+++ b/packages/@expo/cli/src/utils/codesigning.ts
@@ -63,8 +63,15 @@ export function getDevelopmentCodeSigningDirectory(): string {
   return path.join(getExpoHomeDirectory(), 'codesigning');
 }
 
+function assertBasenameValue(input: string): void {
+  if (!input || input === '.' || input === '..' || input !== path.basename(input)) {
+    throw new CommandError('Invalid EAS project ID for development code signing cache');
+  }
+}
+
 function getProjectDevelopmentCodeSigningInfoFile<T extends JSONObject>(defaults: T) {
   function getFile(easProjectId: string): JsonFile<T> {
+    assertBasenameValue(easProjectId);
     const filePath = path.join(
       getDevelopmentCodeSigningDirectory(),
       easProjectId,


### PR DESCRIPTION
## Summary

Invalid `easProjectId` values could cause unexpected reads/writes.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
