### PR TITLE
fix(expo-updates/cli): Write private key with owner-only permissions [EXP-56]

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [cli] Write private key into owner-only permissions file ([#45880](https://github.com/expo/expo/pull/45880) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.0.12 — 2026-05-15

--- a/packages/expo-updates/cli/build/generateCodeSigningAsync.js
+++ b/packages/expo-updates/cli/build/generateCodeSigningAsync.js
@@ -35,7 +35,9 @@ async function generateCodeSigningAsync(projectRoot, { certificateValidityDurati
     const certificatePEM = (0, code_signing_certificates_1.convertCertificateToCertificatePEM)(certificate);
     await Promise.all([
         fs_1.promises.writeFile(path_1.default.join(keyOutputDir, 'public-key.pem'), keyPairPEM.publicKeyPEM),
-        fs_1.promises.writeFile(path_1.default.join(keyOutputDir, 'private-key.pem'), keyPairPEM.privateKeyPEM),
+        fs_1.promises.writeFile(path_1.default.join(keyOutputDir, 'private-key.pem'), keyPairPEM.privateKeyPEM, {
+            mode: 0o600,
+        }),
         fs_1.promises.writeFile(path_1.default.join(certificateOutputDir, 'certificate.pem'), certificatePEM),
     ]);
     (0, log_1.log)(`Generated public and private keys output in ${keyOutputDir}. Remember to add them to .gitignore or to encrypt them. (e.g. with git-crypt)`);

--- a/packages/expo-updates/cli/src/__tests__/generate-test.ts
+++ b/packages/expo-updates/cli/src/__tests__/generate-test.ts
@@ -48,6 +48,7 @@ describe('codesigning:generate', () => {
     expect(certificatePEM).toBeTruthy();
     expect(privateKeyPEM).toBeTruthy();
     expect(publicKeyPEM).toBeTruthy();
+    expect((await fs.stat(`${keysDir}/private-key.pem`)).mode & 0o777).toBe(0o600);
 
     const certificate = convertCertificatePEMToCertificate(certificatePEM);
     const keyPair = convertKeyPairPEMToKeyPair({ privateKeyPEM, publicKeyPEM });

--- a/packages/expo-updates/cli/src/generateCodeSigningAsync.ts
+++ b/packages/expo-updates/cli/src/generateCodeSigningAsync.ts
@@ -51,7 +51,9 @@ export async function generateCodeSigningAsync(
 
   await Promise.all([
     fs.writeFile(path.join(keyOutputDir, 'public-key.pem'), keyPairPEM.publicKeyPEM),
-    fs.writeFile(path.join(keyOutputDir, 'private-key.pem'), keyPairPEM.privateKeyPEM),
+    fs.writeFile(path.join(keyOutputDir, 'private-key.pem'), keyPairPEM.privateKeyPEM, {
+      mode: 0o600,
+    }),
     fs.writeFile(path.join(certificateOutputDir, 'certificate.pem'), certificatePEM),
   ]);
 


### PR DESCRIPTION
## Summary

Small & easy fix to how the private key is written once generated, since it doesn't need default read permissions, and can be owner-only.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
