### PR TITLE
[app-metrics] Fix DeviceInfo.current deadlock during app launch

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -102,6 +102,7 @@ jobs:
             "packages/expo-modules-core/**/ios/**",
             "packages/expo-modules-autolinking/**/ios/**",
             "packages/expo/**/ios/**",
+            "packages/expo-app-metrics/**",
             "packages/expo-constants/**/ios/**",
             "packages/expo-crypto/**/ios/**",
             "packages/expo-file-system/**/ios/**",

--- a/packages/expo-app-metrics/ios/Storage/DeviceInfo.swift
+++ b/packages/expo-app-metrics/ios/Storage/DeviceInfo.swift
@@ -1,4 +1,5 @@
 import SystemConfiguration
+import UIKit
 
 /**
  Provides some basic informations about the device.
@@ -9,10 +10,19 @@ public struct DeviceInfo: Codable, Equatable, Sendable {
   public let systemName: String
   public let systemVersion: String
 
-  static let current: DeviceInfo = {
-    return MainActor.runSynchronously {
-      let device = UIDevice.current
+  nonisolated(unsafe) private static var _current: DeviceInfo?
 
+  static var current: DeviceInfo {
+    // Memoized lazily, but NOT via `static let` — a `dispatch_once`-backed cache deadlocks if a
+    // worker actor enters this init from off-main and `dispatch_sync`s to main while main is
+    // simultaneously waiting on a separate `dispatch_once` whose initializer transitively needs
+    // `DeviceInfo.current`. Concurrent first-callers race through `runSynchronously`, which
+    // serializes them on main and produces identical snapshots; last-writer-wins is fine.
+    if let cached = _current {
+      return cached
+    }
+    let snapshot = MainActor.runSynchronously {
+      let device = UIDevice.current
       return DeviceInfo(
         modelName: getDeviceModelName(device: device),
         modelIdentifier: getDeviceModelIdentifier() ?? device.model,
@@ -20,7 +30,9 @@ public struct DeviceInfo: Codable, Equatable, Sendable {
         systemVersion: device.systemVersion
       )
     }
-  }()
+    _current = snapshot
+    return snapshot
+  }
 }
 
 /**


### PR DESCRIPTION
## Why

The `ios-test-e2e` job has been failing on `main` since 2026-05-14 with `IOSDriverTimeoutException` and `Unknown application display identifier dev.mobile.maestro-driver-iosUITests.xctrunner`. After a long chase that initially pointed at Maestro + iOS 26 incompatibility, the actual root cause turned out to be a deadlock during BareExpo's launch — Maestro's XCUITest driver couldn't attach because the app process was stuck in `application:didFinishLaunchingWithOptions:` and never finished scene creation.

## Root cause

`DeviceInfo.current` was implemented as a `static let` whose initializer called `MainActor.runSynchronously { ... }`. The combination of `static let` (which uses `dispatch_once`) and a synchronous main-thread hop is a latent deadlock:

- **Main thread** lazy-inits `AppLaunchState`, which reads `DeviceInfo.current.systemVersion` → enters `DeviceInfo.current`'s `dispatch_once`.
- **`AppMetricsActor` worker** (enqueued from `Session.init`) calls `SessionRow.snapshot(...)` → reads `DeviceInfo.current` → tries to enter the same `dispatch_once`.

Whichever thread enters first wins the token; the loser blocks. If the worker wins, it then `dispatch_sync`s back to main inside the once — but main is already blocked waiting on the worker's `dispatch_once`. Classic deadlock.

The race outcome depends on simulator/scheduler timing, which is why the bug only manifested on freshly-created simulators (slower cold launch widens the window during which the worker actor task can run first). Existing booted sims with warm caches consistently won the race on main, masking the bug.

## How

Drop the `static let`'s `dispatch_once` cache. Memoize in a plain `nonisolated(unsafe) static var _current: DeviceInfo?` instead. Concurrent first-callers serialize through `MainActor.runSynchronously`'s main-thread hop and produce identical snapshots; last writer wins. No `dispatch_once` means no shared lazy-init lock to deadlock on.

Confirmed locally with a fresh iPhone 17 Pro simulator that reliably reproduced the deadlock; with the fix, BareExpo launches cleanly and Maestro's driver attaches.

## Test plan

- [x] CI: `ios-test-e2e` reaches the test phase and runs Maestro flows.

tvOS compile workflow fails, but it seems unrelated.

<!-- disable:changelog-checks -->