### PR TITLE
fix(cli,create-expo,create-expo-module): Fix containment check for parallel folders sharing prefix [EXP-58]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Restrict `/message` client commands ([#45858](https://github.com/expo/expo/pull/45858) by [@kitten](https://github.com/kitten)
 - Enforce `routerRoot` to be within `projectRoot` to prevent unexpected errors ([#45892](https://github.com/expo/expo/pull/45892) by [@kitten](https://github.com/kitten))
+- Fix containment check in tar extraction to cover parallel folders with same prefix ([#45882](https://github.com/expo/expo/pull/45882) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/utils/tar.ts
+++ b/packages/@expo/cli/src/utils/tar.ts
@@ -34,10 +34,10 @@ export interface ExtractOptions {
 
 export async function extractStream(
   input: ReadableStream,
-  output: string,
+  targetOutput: string,
   options: ExtractOptions = {}
 ): Promise<string> {
-  output = path.resolve(output);
+  const output = path.resolve(targetOutput) + path.sep;
   await fs.promises.mkdir(output, { recursive: true });
 
   const { checksumAlgorithm, strip = 0, rename, filter } = options;

--- a/packages/create-expo-module/src/utils/tar.ts
+++ b/packages/create-expo-module/src/utils/tar.ts
@@ -38,10 +38,10 @@ export interface ExtractOptions {
 
 export async function extractStream(
   input: ReadableStream,
-  output: string,
+  targetOutput: string,
   options: ExtractOptions = {}
 ): Promise<string> {
-  output = path.resolve(output);
+  const output = path.resolve(targetOutput) + path.sep;
   await fs.promises.mkdir(output, { recursive: true });
 
   const { checksumAlgorithm, strip = 0, rename, filter } = options;

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix containment check in tar extraction to cover parallel folders with same prefix ([#45882](https://github.com/expo/expo/pull/45882) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 3.8.0 — 2026-05-13

--- a/packages/create-expo/src/utils/tar.ts
+++ b/packages/create-expo/src/utils/tar.ts
@@ -38,10 +38,10 @@ export interface ExtractOptions {
 
 export async function extractStream(
   input: ReadableStream,
-  output: string,
+  targetOutput: string,
   options: ExtractOptions = {}
 ): Promise<string> {
-  output = path.resolve(output);
+  const output = path.resolve(targetOutput) + path.sep;
   await fs.promises.mkdir(output, { recursive: true });
 
   const { checksumAlgorithm, strip = 0, rename, filter } = options;


### PR DESCRIPTION
## Summary

The `tar.ts` extracting checks with `startsWith` had a typo that was lacking a `+ path.sep` append to check that we're not writing to parallel folders/files with the same prefix.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
