### PR TITLE
fix(widgets/plugin): Add input validation/sanitization [EXP-58][EXP-59]

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Validate/sanitize config-plugin inputs more comprehensively ([#45884](https://github.com/expo/expo/pull/45884) by [@kitten](https://github.com/kitten))
+
 ## 56.0.9 — 2026-05-15
 
 ### 🎉 New features

--- a/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
+++ b/packages/expo-widgets/plugin/build/withWidgetSourceFiles.js
@@ -40,31 +40,71 @@ const plist_1 = __importDefault(require("@expo/plist"));
 const config_plugins_1 = require("expo/config-plugins");
 const fs = __importStar(require("fs"));
 const path = __importStar(require("path"));
-const withWidgetSourceFiles = (config, { widgets, targetName, onFilesGenerated, groupIdentifier }) => (0, config_plugins_1.withDangerousMod)(config, [
-    'ios',
-    async (config) => {
-        const projectRoot = config.modRequest.platformProjectRoot;
-        const targetDirectory = path.join(projectRoot, targetName);
-        const existingInfoPlistPath = path.join(targetDirectory, 'Info.plist');
-        const existingInfoPlist = fs.existsSync(existingInfoPlistPath)
-            ? fs.readFileSync(existingInfoPlistPath, 'utf8')
-            : null;
-        if (fs.existsSync(targetDirectory)) {
-            fs.rmSync(targetDirectory, { recursive: true, force: true });
+const WidgetFamily_type_1 = require("./types/WidgetFamily.type");
+const VALID_WIDGET_FAMILIES = new Set(Object.values(WidgetFamily_type_1.WidgetFamily));
+function assertSwiftIdentifier(value, label) {
+    if (typeof value !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+        throw new Error(`Invalid ${label} ${JSON.stringify(value)}: must be a Swift identifier.`);
+    }
+}
+function assertWidgetFamily(value) {
+    if (typeof value !== 'string' || !VALID_WIDGET_FAMILIES.has(value)) {
+        throw new Error(`Invalid supportedFamilies entry ${JSON.stringify(value)}: must be one of ${[...VALID_WIDGET_FAMILIES].join(', ')}.`);
+    }
+}
+function validateWidget(widget) {
+    assertSwiftIdentifier(widget.name, 'widget name');
+    for (const family of widget.supportedFamilies) {
+        assertWidgetFamily(family);
+    }
+    if (widget.configuration) {
+        for (const [paramName, param] of Object.entries(widget.configuration.parameters)) {
+            assertSwiftIdentifier(paramName, 'parameter name');
+            if (param.type === 'number' && typeof param.default !== 'number') {
+                throw new Error(`Invalid default for ${JSON.stringify(paramName)}: must be a number.`);
+            }
+            else if (param.type === 'boolean' && typeof param.default !== 'boolean') {
+                throw new Error(`Invalid default for ${JSON.stringify(paramName)}: must be a boolean.`);
+            }
+            else if (param.type === 'enum') {
+                assertSwiftIdentifier(param.default, `default for ${JSON.stringify(paramName)}`);
+                for (const value of param.values) {
+                    assertSwiftIdentifier(value.value, `enum case for ${JSON.stringify(paramName)}`);
+                }
+            }
         }
-        fs.mkdirSync(targetDirectory, { recursive: true });
-        const entitlementsPath = path.join(targetDirectory, `${targetName}.entitlements`);
-        const entitlementsContent = {
-            'com.apple.security.application-groups': [groupIdentifier],
-        };
-        fs.writeFileSync(entitlementsPath, plist_1.default.build(entitlementsContent));
-        const infoPlistPath = createInfoPlist(groupIdentifier, targetDirectory, config.ios?.version ?? config.version ?? '1.0', config.ios?.buildNumber ?? '1', existingInfoPlist);
-        const indexSwiftPath = createIndexSwift(widgets, targetDirectory);
-        const widgetSwiftPaths = widgets.map((widget) => createWidgetSwift(widget, targetDirectory));
-        onFilesGenerated([entitlementsPath, infoPlistPath, indexSwiftPath, ...widgetSwiftPaths]);
-        return config;
-    },
-]);
+    }
+}
+const withWidgetSourceFiles = (config, { widgets, targetName, onFilesGenerated, groupIdentifier }) => {
+    for (const widget of widgets) {
+        validateWidget(widget);
+    }
+    return (0, config_plugins_1.withDangerousMod)(config, [
+        'ios',
+        async (config) => {
+            const projectRoot = config.modRequest.platformProjectRoot;
+            const targetDirectory = path.join(projectRoot, targetName);
+            const existingInfoPlistPath = path.join(targetDirectory, 'Info.plist');
+            const existingInfoPlist = fs.existsSync(existingInfoPlistPath)
+                ? fs.readFileSync(existingInfoPlistPath, 'utf8')
+                : null;
+            if (fs.existsSync(targetDirectory)) {
+                fs.rmSync(targetDirectory, { recursive: true, force: true });
+            }
+            fs.mkdirSync(targetDirectory, { recursive: true });
+            const entitlementsPath = path.join(targetDirectory, `${targetName}.entitlements`);
+            const entitlementsContent = {
+                'com.apple.security.application-groups': [groupIdentifier],
+            };
+            fs.writeFileSync(entitlementsPath, plist_1.default.build(entitlementsContent));
+            const infoPlistPath = createInfoPlist(groupIdentifier, targetDirectory, config.ios?.version ?? config.version ?? '1.0', config.ios?.buildNumber ?? '1', existingInfoPlist);
+            const indexSwiftPath = createIndexSwift(widgets, targetDirectory);
+            const widgetSwiftPaths = widgets.map((widget) => createWidgetSwift(widget, targetDirectory));
+            onFilesGenerated([entitlementsPath, infoPlistPath, indexSwiftPath, ...widgetSwiftPaths]);
+            return config;
+        },
+    ]);
+};
 const createIndexSwift = (widgets, targetPath) => {
     const indexFilePath = path.join(targetPath, `index.swift`);
     const numberOfWidgets = widgets.length;
@@ -138,8 +178,8 @@ struct ${widget.name}: Widget {
     StaticConfiguration(kind: name, provider: WidgetsTimelineProvider(name: name)) { entry in
       WidgetsEntryView(entry: entry)
     }
-    .configurationDisplayName("${widget.displayName}")
-    .description("${widget.description}")
+    .configurationDisplayName(${JSON.stringify(widget.displayName)})
+    .description(${JSON.stringify(widget.description)})
     .supportedFamilies([.${widget.supportedFamilies.join(', .')}])${widget.contentMarginsDisabled ? '\n    .contentMarginsDisabled()' : ''}
   }
 }`;
@@ -150,8 +190,8 @@ internal import ExpoWidgets
 
 // AppIntent
 struct ${widget.name}ConfigurationAppIntent: WidgetConfigurationIntent {
-  static var title: LocalizedStringResource = "${widget.configuration?.title ?? widget.displayName} Configuration"
-${widget.configuration?.description ? `  static var description: LocalizedStringResource = "${widget.configuration?.description}"\n` : ''}
+  static var title: LocalizedStringResource = ${JSON.stringify(`${widget.configuration?.title ?? widget.displayName} Configuration`)}
+${widget.configuration?.description ? `  static var description: LocalizedStringResource = ${JSON.stringify(widget.configuration.description)}\n` : ''}
 ${Object.entries(widget.configuration?.parameters ?? {})
         .map(([name, param]) => {
         let paramType;
@@ -171,7 +211,7 @@ ${Object.entries(widget.configuration?.parameters ?? {})
             default:
                 paramType = 'String';
         }
-        return `  @Parameter(title: "${param.title}", default: ${param.type === 'string' ? `"${param.default}"` : param.type === 'number' ? param.default : param.type === 'boolean' ? param.default : `${widget.name}${name[0]?.toUpperCase() + name.slice(1)}Enum.${param.default}`})\n  var ${name}: ${paramType}`;
+        return `  @Parameter(title: ${JSON.stringify(param.title)}, default: ${param.type === 'string' ? JSON.stringify(param.default) : param.type === 'number' ? param.default : param.type === 'boolean' ? param.default : `${widget.name}${name[0]?.toUpperCase() + name.slice(1)}Enum.${param.default}`})\n  var ${name}: ${paramType}`;
     })
         .join('\n')}
 
@@ -192,12 +232,12 @@ enum ${paramTypeName}: String, CaseIterable, AppEnum {
         })
             .join('\n  ')}
 
-  static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "${param.title}")
+  static var typeDisplayRepresentation = TypeDisplayRepresentation(name: ${JSON.stringify(param.title)})
 
   static var caseDisplayRepresentations: [${paramTypeName}: DisplayRepresentation] = [
     ${param.values
             .map((value) => {
-            return `.${value.value}: DisplayRepresentation(title: "${value.name}")`;
+            return `.${value.value}: DisplayRepresentation(title: ${JSON.stringify(value.name)})`;
         })
             .join(',\n    ')}
   ]
@@ -297,8 +337,8 @@ struct ${widget.name}: Widget {
     return AppIntentConfiguration(kind: name, intent: ${widget.name}ConfigurationAppIntent.self, provider: ${widget.name}TimelineProvider()) { entry in
       ${widget.name}EntryView(entry: entry)
     }
-    .configurationDisplayName("${widget.displayName}")
-    .description("${widget.description}")
+    .configurationDisplayName(${JSON.stringify(widget.displayName)})
+    .description(${JSON.stringify(widget.description)})
     .supportedFamilies([.${widget.supportedFamilies.join(', .')}])${widget.contentMarginsDisabled ? '\n    .contentMarginsDisabled()' : ''}
   }
 }`;

--- a/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { WidgetConfig } from './types/WidgetConfig.type';
+import { WidgetFamily } from './types/WidgetFamily.type';
 
 type WidgetSourceFilesProps = {
   targetName: string;
@@ -12,11 +13,41 @@ type WidgetSourceFilesProps = {
   onFilesGenerated: (files: string[]) => void;
 };
 
-function assertSwiftIdentifier(name: string): void {
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+const VALID_WIDGET_FAMILIES: ReadonlySet<string> = new Set(Object.values(WidgetFamily));
+
+function assertSwiftIdentifier(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(value)) {
+    throw new Error(`Invalid ${label} ${JSON.stringify(value)}: must be a Swift identifier.`);
+  }
+}
+
+function assertWidgetFamily(value: unknown): asserts value is WidgetFamily {
+  if (typeof value !== 'string' || !VALID_WIDGET_FAMILIES.has(value)) {
     throw new Error(
-      `Invalid widget name ${JSON.stringify(name)}: must be a valid Swift identifier (letters, digits, and underscores; not starting with a digit).`
+      `Invalid supportedFamilies entry ${JSON.stringify(value)}: must be one of ${[...VALID_WIDGET_FAMILIES].join(', ')}.`
     );
+  }
+}
+
+function validateWidget(widget: WidgetConfig): void {
+  assertSwiftIdentifier(widget.name, 'widget name');
+  for (const family of widget.supportedFamilies) {
+    assertWidgetFamily(family);
+  }
+  if (widget.configuration) {
+    for (const [paramName, param] of Object.entries(widget.configuration.parameters)) {
+      assertSwiftIdentifier(paramName, 'parameter name');
+      if (param.type === 'number' && typeof param.default !== 'number') {
+        throw new Error(`Invalid default for ${JSON.stringify(paramName)}: must be a number.`);
+      } else if (param.type === 'boolean' && typeof param.default !== 'boolean') {
+        throw new Error(`Invalid default for ${JSON.stringify(paramName)}: must be a boolean.`);
+      } else if (param.type === 'enum') {
+        assertSwiftIdentifier(param.default, `default for ${JSON.stringify(paramName)}`);
+        for (const value of param.values) {
+          assertSwiftIdentifier(value.value, `enum case for ${JSON.stringify(paramName)}`);
+        }
+      }
+    }
   }
 }
 
@@ -25,7 +56,7 @@ const withWidgetSourceFiles: ConfigPlugin<WidgetSourceFilesProps> = (
   { widgets, targetName, onFilesGenerated, groupIdentifier }
 ) => {
   for (const widget of widgets) {
-    assertSwiftIdentifier(widget.name);
+    validateWidget(widget);
   }
   return withDangerousMod(config, [
     'ios',
@@ -155,8 +186,8 @@ struct ${widget.name}: Widget {
     StaticConfiguration(kind: name, provider: WidgetsTimelineProvider(name: name)) { entry in
       WidgetsEntryView(entry: entry)
     }
-    .configurationDisplayName("${widget.displayName}")
-    .description("${widget.description}")
+    .configurationDisplayName(${JSON.stringify(widget.displayName)})
+    .description(${JSON.stringify(widget.description)})
     .supportedFamilies([.${widget.supportedFamilies.join(', .')}])${widget.contentMarginsDisabled ? '\n    .contentMarginsDisabled()' : ''}
   }
 }`;
@@ -167,8 +198,8 @@ internal import ExpoWidgets
 
 // AppIntent
 struct ${widget.name}ConfigurationAppIntent: WidgetConfigurationIntent {
-  static var title: LocalizedStringResource = "${widget.configuration?.title ?? widget.displayName} Configuration"
-${widget.configuration?.description ? `  static var description: LocalizedStringResource = "${widget.configuration?.description}"\n` : ''}
+  static var title: LocalizedStringResource = ${JSON.stringify(`${widget.configuration?.title ?? widget.displayName} Configuration`)}
+${widget.configuration?.description ? `  static var description: LocalizedStringResource = ${JSON.stringify(widget.configuration.description)}\n` : ''}
 ${Object.entries(widget.configuration?.parameters ?? {})
   .map(([name, param]) => {
     let paramType: string;
@@ -188,7 +219,7 @@ ${Object.entries(widget.configuration?.parameters ?? {})
       default:
         paramType = 'String';
     }
-    return `  @Parameter(title: "${param.title}", default: ${param.type === 'string' ? `"${param.default}"` : param.type === 'number' ? param.default : param.type === 'boolean' ? param.default : `${widget.name}${name[0]?.toUpperCase() + name.slice(1)}Enum.${param.default}`})\n  var ${name}: ${paramType}`;
+    return `  @Parameter(title: ${JSON.stringify(param.title)}, default: ${param.type === 'string' ? JSON.stringify(param.default) : param.type === 'number' ? param.default : param.type === 'boolean' ? param.default : `${widget.name}${name[0]?.toUpperCase() + name.slice(1)}Enum.${param.default}`})\n  var ${name}: ${paramType}`;
   })
   .join('\n')}
 
@@ -208,12 +239,12 @@ enum ${paramTypeName}: String, CaseIterable, AppEnum {
     })
     .join('\n  ')}
 
-  static var typeDisplayRepresentation = TypeDisplayRepresentation(name: "${param.title}")
+  static var typeDisplayRepresentation = TypeDisplayRepresentation(name: ${JSON.stringify(param.title)})
 
   static var caseDisplayRepresentations: [${paramTypeName}: DisplayRepresentation] = [
     ${param.values
       .map((value) => {
-        return `.${value.value}: DisplayRepresentation(title: "${value.name}")`;
+        return `.${value.value}: DisplayRepresentation(title: ${JSON.stringify(value.name)})`;
       })
       .join(',\n    ')}
   ]
@@ -313,8 +344,8 @@ struct ${widget.name}: Widget {
     return AppIntentConfiguration(kind: name, intent: ${widget.name}ConfigurationAppIntent.self, provider: ${widget.name}TimelineProvider()) { entry in
       ${widget.name}EntryView(entry: entry)
     }
-    .configurationDisplayName("${widget.displayName}")
-    .description("${widget.description}")
+    .configurationDisplayName(${JSON.stringify(widget.displayName)})
+    .description(${JSON.stringify(widget.description)})
     .supportedFamilies([.${widget.supportedFamilies.join(', .')}])${widget.contentMarginsDisabled ? '\n    .contentMarginsDisabled()' : ''}
   }
 }`;

--- a/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
+++ b/packages/expo-widgets/plugin/src/withWidgetSourceFiles.ts
@@ -12,11 +12,22 @@ type WidgetSourceFilesProps = {
   onFilesGenerated: (files: string[]) => void;
 };
 
+function assertSwiftIdentifier(name: string): void {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    throw new Error(
+      `Invalid widget name ${JSON.stringify(name)}: must be a valid Swift identifier (letters, digits, and underscores; not starting with a digit).`
+    );
+  }
+}
+
 const withWidgetSourceFiles: ConfigPlugin<WidgetSourceFilesProps> = (
   config,
   { widgets, targetName, onFilesGenerated, groupIdentifier }
-) =>
-  withDangerousMod(config, [
+) => {
+  for (const widget of widgets) {
+    assertSwiftIdentifier(widget.name);
+  }
+  return withDangerousMod(config, [
     'ios',
     async (config) => {
       const projectRoot = config.modRequest.platformProjectRoot;
@@ -50,6 +61,7 @@ const withWidgetSourceFiles: ConfigPlugin<WidgetSourceFilesProps> = (
       return config;
     },
   ]);
+};
 
 const createIndexSwift = (widgets: WidgetConfig[], targetPath: string): string => {
   const indexFilePath = path.join(targetPath, `index.swift`);


### PR DESCRIPTION
## Summary

The widget names can lead to unexpected writes, since the name is used when writing a file, e.g. when the name contains `/` or `..`. This doesn't generally cause issues but is confusing to allow, and we can just add a small pre-validation check.

Similarly, other config plugin values weren't validated or sanitized while interpolating them. This is more severe since some of them end up in the generated code, and can lead to late errors.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
