### PR TITLE
fix(cli): Sanitize log-box data and script [EXP-59]

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Add missing HTML sanitization when serializing log-box error data ([#45885](https://github.com/expo/expo/pull/45885) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.1.6 — 2026-05-19

--- a/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
+++ b/packages/@expo/cli/src/start/server/metro/metroErrorInterface.ts
@@ -307,9 +307,9 @@ export async function getErrorOverlayHtmlAsync({
     isDisabled: false,
     logs: [log],
   };
-  const html = `<html><head><style>#root,body,html{height:100%;background-color:black}body{overflow:hidden}#root{display:flex}</style></head><body><div id="root"></div><script id="_expo-static-error" type="application/json">${JSON.stringify(
-    logBoxContext
-  )}</script></body></html>`;
+  // Escape `<` so error contents like `</script>` cannot break out of the embedded JSON block.
+  const serializedLogBox = JSON.stringify(logBoxContext).replace(/</g, '\\u003c');
+  const html = `<html><head><style>#root,body,html{height:100%;background-color:black}body{overflow:hidden}#root{display:flex}</style></head><body><div id="root"></div><script id="_expo-static-error" type="application/json">${serializedLogBox}</script></body></html>`;
 
   // TODO: We could reuse the pre-built DOM Log Box from @expo/log-box
   const errorOverlayEntry = await createMetroEndpointAsync(
@@ -330,7 +330,8 @@ export async function getErrorOverlayHtmlAsync({
     }
   );
 
-  const htmlWithJs = html.replace('</body>', `<script src=${errorOverlayEntry}></script></body>`);
+  const escapedSrc = errorOverlayEntry.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  const htmlWithJs = html.replace('</body>', `<script src="${escapedSrc}"></script></body>`);
   return htmlWithJs;
 }
 


### PR DESCRIPTION
## Summary

Low probability of causing issues or being used to cause issues, but seems like a low-hanging fruit to fix. This could lead to corrupted log-box data output, or XSS in theory (most likely self-inflicted, since error messages aren't externally controlled)

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
