### PR TITLE
fix(config-types): Fix URL used for generate script [EXP-59]

### DIFF
--- a/packages/@expo/config-types/scripts/generate.js
+++ b/packages/@expo/config-types/scripts/generate.js
@@ -30,8 +30,7 @@ const program = new Command(packageJSON.name)
   * @returns {Promise<Record<string, any>>}
   */
 async function fetchSchemaAsync(version) {
-  const url = `http://exp.host/--/api/v2/project/configuration/schema/${version}`;
-
+  const url = `https://exp.host/--/api/v2/project/configuration/schema/${version}`;
   const response = await fetch(url);
   const data = await response.json();
 


### PR DESCRIPTION
## Summary

Small issue caught in unrelated fixes. We don't have to use `http` for this API URL.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
