### PR TITLE
fix(expo-localization): Pre-validate locale string in config-plugin [EXP-59]

### DIFF
--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Prevalidate locale strings in config-plugin ([#45888](https://github.com/expo/expo/pull/45888) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-13

--- a/packages/expo-localization/plugin/build/withExpoLocalization.js
+++ b/packages/expo-localization/plugin/build/withExpoLocalization.js
@@ -7,6 +7,19 @@ exports.convertBcp47ToResourceQualifier = convertBcp47ToResourceQualifier;
 const config_plugins_1 = require("expo/config-plugins");
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
+function isValidBCP47(tag) {
+    try {
+        return !!new Intl.Locale(tag);
+    }
+    catch {
+        return false;
+    }
+}
+function assertLocale(value) {
+    if (typeof value !== 'string' || !isValidBCP47(value)) {
+        throw new Error(`Invalid supportedLocales entry ${JSON.stringify(value)}: must be a BCP-47 locale tag.`);
+    }
+}
 function convertBcp47ToResourceQualifier(locale) {
     return `b+${locale.replaceAll('-', '+')}`;
 }
@@ -54,6 +67,7 @@ function withExpoLocalizationAndroid(config, data) {
         ? mergedConfig.supportedLocales.android
         : mergedConfig.supportedLocales;
     if (supportedLocales) {
+        supportedLocales.forEach(assertLocale);
         config = (0, config_plugins_1.withDangerousMod)(config, [
             'android',
             (config) => {

--- a/packages/expo-localization/plugin/src/withExpoLocalization.ts
+++ b/packages/expo-localization/plugin/src/withExpoLocalization.ts
@@ -23,6 +23,22 @@ export type ConfigPluginProps = {
       };
 };
 
+function isValidBCP47(tag: string) {
+  try {
+    return !!new Intl.Locale(tag);
+  } catch {
+    return false;
+  }
+}
+
+function assertLocale(value: unknown): asserts value is string {
+  if (typeof value !== 'string' || !isValidBCP47(value)) {
+    throw new Error(
+      `Invalid supportedLocales entry ${JSON.stringify(value)}: must be a BCP-47 locale tag.`
+    );
+  }
+}
+
 export function convertBcp47ToResourceQualifier(locale: string): string {
   return `b+${locale.replaceAll('-', '+')}`;
 }
@@ -78,6 +94,7 @@ function withExpoLocalizationAndroid(config: ExpoConfig, data: ConfigPluginProps
       : mergedConfig.supportedLocales;
 
   if (supportedLocales) {
+    supportedLocales.forEach(assertLocale);
     config = withDangerousMod(config, [
       'android',
       (config) => {


### PR DESCRIPTION
## Summary

Pre-validate locale string in config-plugin.

Related to #45887 in spirit.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
