### PR TITLE
fix(tools): Sanitize raw stdout printing [EXP-60]

### DIFF
--- a/tools/src/Utils.ts
+++ b/tools/src/Utils.ts
@@ -2,6 +2,7 @@ import basicSpawnAsync, { SpawnResult, SpawnOptions, SpawnPromise } from '@expo/
 import chalk from 'chalk';
 import { glob, GlobOptions } from 'glob';
 import ora from 'ora';
+import { stripVTControlCharacters } from 'util';
 
 import { EXPO_DIR } from './Constants';
 
@@ -139,6 +140,10 @@ export function arrayize<T>(value: T | T[]): T[] {
     return value;
   }
   return value != null ? [value] : [];
+}
+
+export function sanitizeTerminalOutput(input: string): string {
+  return stripVTControlCharacters(input).replace(/[\x00-\x08\x0B-\x1F\x7F-\x9F]/g, '');
 }
 
 /**

--- a/tools/src/commands/CIInspectCommand.ts
+++ b/tools/src/commands/CIInspectCommand.ts
@@ -13,6 +13,7 @@ import {
   getWorkflowRunsForRepoAsync,
 } from '../GitHubActions';
 import logger from '../Logger';
+import { sanitizeTerminalOutput } from '../Utils';
 
 // --- TUI helpers ---
 
@@ -447,7 +448,7 @@ function printLogSnippets(snippets: string[]): void {
   for (let si = 0; si < snippets.length; si++) {
     const indented = snippets[si]
       .split('\n')
-      .map((line) => `    \u2502 ${line}`)
+      .map((line) => `    \u2502 ${sanitizeTerminalOutput(line)}`)
       .join('\n');
     logger.log(indented);
     if (si < snippets.length - 1) {

--- a/tools/src/commands/CherryPickCommand.ts
+++ b/tools/src/commands/CherryPickCommand.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import Git, { GitLog } from '../Git';
 import logger from '../Logger';
+import { sanitizeTerminalOutput } from '../Utils';
 
 type ActionOptions = {
   from?: string;
@@ -133,8 +134,8 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
         .map(
           (commit) =>
             ` ❌ ${chalk.red(commit.hash.slice(0, 10))} ${commit.authorDate} ${chalk.magenta(
-              commit.authorName
-            )} ${commit.title}`
+              sanitizeTerminalOutput(commit.authorName)
+            )} ${sanitizeTerminalOutput(commit.title)}`
         )
         .join('\n')
     );
@@ -157,8 +158,8 @@ async function main(packageNames: string[], options: ActionOptions): Promise<voi
         value: commit.hash,
         short: commit.hash,
         name: `${chalk.yellow(commit.hash.slice(0, 10))} ${commit.authorDate} ${chalk.magenta(
-          commit.authorName
-        )} ${commit.title}`,
+          sanitizeTerminalOutput(commit.authorName)
+        )} ${sanitizeTerminalOutput(commit.title)}`,
       })),
       default: candidateCommits.map((commit) => commit.hash),
       pageSize: Math.min(candidateCommits.length, (process.stdout.rows || 100) - 4),


### PR DESCRIPTION
## Summary

We're allowing any VT control sequences in a few sensitive places in our `tools` console output.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
