### PR TITLE
[chore] Update VS Code workspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,15 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib",
+  "js/ts.tsdk.path": "node_modules/typescript/lib",
   "eslint.workingDirectories": [{ "pattern": "*" }],
   "search.exclude": {
     "packages/**/build": true,
     "docs/public/static/data": true
   },
-  "search.followSymlinks": false
+  "search.followSymlinks": false,
+  "tailwindCSS.lint.suggestCanonicalClasses": "ignore",
+  "tailwindCSS.lint.recommendedVariantOrder": "ignore",
+  "tailwindCSS.classFunctions": ["mergeClasses", "classNames", "clsx"],
+  "tailwindCSS.experimental.classRegex": [
+    ["\\b\\w*[Cc]lass(?:Name)?(?:es|s)?\\s*[:=]\\s*['\"`]([^'\"`]*)['\"`]"]
+  ]
 }


### PR DESCRIPTION
## Summary

- Switch the deprecated `typescript.tsdk` key to its replacement `js/ts.tsdk.path`.
- Add Tailwind CSS settings to silence the canonical-class and recommended-variant-order lints, register our class helper functions (`mergeClasses`, `classNames`, `clsx`), and extend the experimental `classRegex` so Tailwind IntelliSense picks up `className`/`class`-style props.

## Test plan

- [ ] Reload VS Code and confirm the TypeScript SDK still resolves from `node_modules/typescript/lib`.
- [ ] Verify Tailwind IntelliSense triggers inside `className`, `class`, and helper-function string literals.