### PR TITLE
fix(camera): respect Android video stabilization support

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Use the selected camera to determine video stabilization support. ([#45896](https://github.com/expo/expo/pull/45896) by [@vivekjm](https://github.com/vivekjm))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-13

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -611,8 +611,16 @@ class ExpoCameraView(
       if (mirror) {
         setMirrorMode(MirrorMode.MIRROR_MODE_ON_FRONT_ONLY)
       }
-      setVideoStabilizationEnabled(videoStabilizationMode.isEnabled())
+      setVideoStabilizationEnabled(isVideoStabilizationEnabled())
     }.build()
+  }
+
+  private fun isVideoStabilizationEnabled(): Boolean {
+    val isStabilizationSupported = camera?.cameraInfo?.let { cameraInfo ->
+      Recorder.getVideoCapabilities(cameraInfo).isStabilizationSupported
+    } ?: false
+
+    return isStabilizationSupported && videoStabilizationMode.isEnabled()
   }
 
   private fun startFocusMetering() {

--- a/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
+++ b/packages/expo-camera/android/src/main/java/expo/modules/camera/ExpoCameraView.kt
@@ -494,7 +494,10 @@ class ExpoCameraView(
 
     imageCaptureUseCase = imageCaptureBuilder.build()
 
-    val videoCapture = createVideoCapture()
+    val selectedCameraInfo = cameraSelector
+      .filter(cameraProvider.availableCameraInfos)
+      .firstOrNull()
+    val videoCapture = createVideoCapture(selectedCameraInfo)
     imageAnalysisUseCase = createImageAnalyzer()
 
     val useCases = UseCaseGroup.Builder().apply {
@@ -590,7 +593,7 @@ class ExpoCameraView(
     }
   }
 
-  private fun createVideoCapture(): VideoCapture<Recorder> {
+  private fun createVideoCapture(cameraInfo: CameraInfo?): VideoCapture<Recorder> {
     val preferredQuality = videoQuality.mapToQuality()
     val fallbackStrategy = FallbackStrategy.higherQualityOrLowerThan(preferredQuality)
     val qualitySelector = QualitySelector.from(preferredQuality, fallbackStrategy)
@@ -611,13 +614,13 @@ class ExpoCameraView(
       if (mirror) {
         setMirrorMode(MirrorMode.MIRROR_MODE_ON_FRONT_ONLY)
       }
-      setVideoStabilizationEnabled(isVideoStabilizationEnabled())
+      setVideoStabilizationEnabled(isVideoStabilizationEnabled(cameraInfo))
     }.build()
   }
 
-  private fun isVideoStabilizationEnabled(): Boolean {
-    val isStabilizationSupported = camera?.cameraInfo?.let { cameraInfo ->
-      Recorder.getVideoCapabilities(cameraInfo).isStabilizationSupported
+  private fun isVideoStabilizationEnabled(cameraInfo: CameraInfo?): Boolean {
+    val isStabilizationSupported = cameraInfo?.let {
+      Recorder.getVideoCapabilities(it).isStabilizationSupported
     } ?: false
 
     return isStabilizationSupported && videoStabilizationMode.isEnabled()


### PR DESCRIPTION
### Why

Fixes #32413.

Some Android devices freeze the camera preview or fail video recording when CameraX video stabilization is enabled even though the active camera does not support it. `expo-camera` currently enables stabilization for every non-`off` `videoStabilizationMode`, including the default `auto`, without checking CameraX capabilities.

### How

Before building the `VideoCapture`, this now asks CameraX for the active camera's `Recorder` video capabilities and only enables stabilization when both conditions are true:

- the requested Expo stabilization mode is not `off`
- `Recorder.getVideoCapabilities(cameraInfo).isStabilizationSupported` is true

This keeps stabilization enabled on supported devices and avoids forcing it on unsupported devices.

### Test Plan

- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" pnpm install --filter expo-camera... --frozen-lockfile`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" pnpm --filter expo-camera lint`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" pnpm --filter expo-camera build`
- `PATH="$HOME/.nvm/versions/node/v22.22.0/bin:$PATH" pnpm --filter expo-camera test`