### PR TITLE
[e2e] Optimize iOS test-suite loading

### DIFF
--- a/apps/bare-expo/e2e/image-comparison/inspector/scripts/build.sh
+++ b/apps/bare-expo/e2e/image-comparison/inspector/scripts/build.sh
@@ -21,12 +21,15 @@ echo "Building for iOS Simulator..."
 xcrun -sdk iphonesimulator swiftc \
     -target arm64-apple-ios16.0-simulator \
     -emit-library \
+    -O \
     -module-name IOSScreenInspectorFramework \
     -o "$BIN_DIR/IOSScreenInspectorFramework_sim_arm64" \
     "$SRC_DIR/ScreenInspector.swift" \
     "$SRC_DIR/UICapture.swift" \
     "$SRC_DIR/constructor.c" \
-    -Xlinker -install_name -Xlinker @rpath/IOSScreenInspectorFramework.framework/IOSScreenInspectorFramework
+    -Xlinker -install_name -Xlinker @rpath/IOSScreenInspectorFramework.framework/IOSScreenInspectorFramework \
+    -Xlinker -fixup_chains \
+    -Xlinker -dead_strip
 
 # Create universal simulator framework binary
 echo "Creating universal simulator framework..."

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/ScreenInspector.swift
@@ -10,18 +10,17 @@ private func log(_ message: String) {
     logger.log("[\(LOG_TAG)] \(message)")
 }
 
-@objc public class ScreenInspector: NSObject {
+public final class ScreenInspector {
     private var isRunning = false
     private var serverQueue: DispatchQueue
     private let requestPipePath = "/tmp/ios_screen_inspector_request"
     private let responsePipePath = "/tmp/ios_screen_inspector_response"
 
-    public override init() {
+    public init() {
         self.serverQueue = DispatchQueue(label: "screenInspector.server", qos: .userInitiated)
-        super.init()
     }
 
-    @objc public func start() {
+    public func start() {
         guard !isRunning else {
             log("Server already running")
             return

--- a/apps/bare-expo/e2e/image-comparison/inspector/src/constructor.c
+++ b/apps/bare-expo/e2e/image-comparison/inspector/src/constructor.c
@@ -1,14 +1,8 @@
-#include <stdio.h>
-#include <syslog.h>
-
 // Forward declare the Swift function
 extern void screen_inspector_dylib_init(void);
 
 __attribute__((constructor))
 static void customConstructor(int argc, const char **argv)
- {
-     syslog(LOG_ERR, "[ScreenInspector] Dylib injection successful in %s\n", argv[0]);
-
-     // Call Swift initialization directly
-     screen_inspector_dylib_init();
+{
+    screen_inspector_dylib_init();
 }


### PR DESCRIPTION
## Why

A small iOS e2e infrastructure improvement: shave dyld load time for the screen-inspector dylib that gets injected into BareExpo on launch. Independent of the actual `ios-test-e2e` fix in #45881; this just makes the per-flow injection cheaper.

## How

Adjust how `IOSScreenInspectorFramework` is built:

- **`-O`, `-Xlinker -fixup_chains`, `-Xlinker -dead_strip`.** Binary shrinks from 168K → 112K and uses chained fixups, which dyld can apply faster than the classic rebase/bind opcodes.
- **Drop `@objc`/`NSObject` from `ScreenInspector`.** The class is only called from the C `@_cdecl` shim, never from Objective-C, so registering it with the Objective-C runtime during `objc_init` is wasted work.

## Test plan

- [ ] CI: `ios-test-e2e` reaches the test phase and runs Maestro flows.

<!-- disable:changelog-checks -->
