### PR TITLE
fix(cli): respect REACT_NATIVE_PACKAGER_HOSTNAME in dev server location

### DIFF
--- a/packages/@expo/cli/src/start/server/BundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/BundlerDevServer.ts
@@ -211,10 +211,9 @@ export abstract class BundlerDevServer {
       location: {
         // The port is the main thing we want to send back.
         port: options.port,
-        // localhost isn't always correct.
-        host: 'localhost',
+        host: process.env.REACT_NATIVE_PACKAGER_HOSTNAME?.trim() || 'localhost',
         // http is the only supported protocol on native.
-        url: `http://localhost:${options.port}`,
+        url: `http://${process.env.REACT_NATIVE_PACKAGER_HOSTNAME?.trim() || 'localhost'}:${options.port}`,
         protocol: 'http',
       },
       middleware: {},

--- a/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
+++ b/packages/@expo/cli/src/start/server/metro/MetroBundlerDevServer.ts
@@ -1338,7 +1338,8 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       });
 
     // Required for symbolication:
-    const serverBaseUrl = `${address?.protocol ?? 'http'}://localhost:${address?.port ?? options.port}`;
+    const host = process.env.REACT_NATIVE_PACKAGER_HOSTNAME?.trim() || 'localhost';
+    const serverBaseUrl = `${address?.protocol ?? 'http'}://${host}:${address?.port ?? options.port}`;
     process.env.EXPO_DEV_SERVER_ORIGIN = serverBaseUrl;
 
     if (!options.isExporting) {
@@ -1570,8 +1571,7 @@ export class MetroBundlerDevServer extends BundlerDevServer {
       location: {
         // The port is the main thing we want to send back.
         port: address?.port ?? options.port,
-        // localhost isn't always correct.
-        host: 'localhost',
+        host,
         url: serverBaseUrl,
         protocol: address?.protocol ?? 'http',
       },


### PR DESCRIPTION
## Summary

The `location` object returned by `MetroBundlerDevServer.startImplementationAsync()` and the headless fallback in `BundlerDevServer` hardcoded `localhost`, ignoring `REACT_NATIVE_PACKAGER_HOSTNAME`. This caused `getDevServerUrl()` to always return a localhost URL, preventing dev client auto-discovery on remote machines.

- `UrlCreator.getDefaultHostname()` correctly checks `REACT_NATIVE_PACKAGER_HOSTNAME`
- But `getDevServerUrl()` returns `location.url` directly, bypassing `UrlCreator`
- The existing comment (`// localhost isn't always correct.`) acknowledged the problem

This change uses `REACT_NATIVE_PACKAGER_HOSTNAME` when constructing the `location` object, making it consistent with `UrlCreator` behavior.

## Test Plan

1. Set `REACT_NATIVE_PACKAGER_HOSTNAME=10.0.0.5`
2. Run `npx expo start --dev-client`
3. **Before:** Terminal shows `Metro: http://localhost:8081`, dev client cannot auto-discover server
4. **After:** Terminal shows `Metro: http://10.0.0.5:8081`, dev client connects correctly

Affects anyone running Expo dev server on a remote machine (EC2, Codespaces, VPS) with dev client connecting over a non-local network (e.g., Tailscale).

Fixes #45902