### PR TITLE
[expo-updates] Don't fail e2e setup when template ships no pnpm-workspace.yaml

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -762,8 +762,9 @@ export async function initAsync(
     }
   );
 
-  // Remove default `pnpm-workspace.yaml`
-  await fs.rm(path.join(projectRoot, 'pnpm-workspace.yaml'));
+  // Remove default `pnpm-workspace.yaml` if the template still ships one. Newer template versions
+  // omit it; `force: true` keeps both cases working.
+  await fs.rm(path.join(projectRoot, 'pnpm-workspace.yaml'), { force: true });
 
   // We are done with template tarball
   await fs.rm(localTSTemplatePathName);


### PR DESCRIPTION
## Why

The [Updates EAS e2e workflow](https://expo.dev/accounts/expo-ci/projects/expo-workflow-testing/workflows/019e3227-da19-76c6-a769-53512877292b#job-019e3227-dc64-7ce0-b46f-ca0f1354592e) has been failing in the setup step with:

```
[Error: ENOENT: no such file or directory, lstat '/Users/expo/workingdir/updates-e2e/pnpm-workspace.yaml']
```

`packages/expo-updates/e2e/setup/project.ts` unconditionally removes `pnpm-workspace.yaml` from the freshly-created test project right after `pnpm create expo-app …` returns. That cleanup was written for `create-expo-nightly`, which *generates* a `pnpm-workspace.yaml` during project creation. The stable `create-expo` path (which the EAS workflow actually uses) doesn't generate that file, so `fs.rm` throws `ENOENT` and the setup step exits 1.

Verified:
- The local `templates/expo-template-blank-typescript/` source tree contains no `pnpm-workspace.yaml`.
- The published `expo-template-blank-typescript-56.0.12.tgz` tarball doesn't include one either.
- The only place that *creates* a `pnpm-workspace.yaml` during project init is `packages/create-expo-nightly/src/Project.ts` (added in 0c537ee4f7c).

## How

Pass `force: true` to `fs.rm` so the call no-ops if the file isn't there. Keeps both code paths working — if a future template variant ships one, it still gets removed.

## Test plan

- [ ] Trigger the EAS Updates e2e workflow on this branch and confirm the setup step completes.

<!-- disable:changelog-checks -->
