### PR TITLE
[docs][router] Remove duplicate Link.Trigger in link-preview custom preview example

### DIFF
--- a/docs/pages/router/reference/link-preview.mdx
+++ b/docs/pages/router/reference/link-preview.mdx
@@ -66,7 +66,6 @@ export default function Page() {
   return (
     <Link href="/about">
       <Link.Trigger>About</Link.Trigger>
-      <Link.Trigger>Content</Link.Trigger>
       <Link.Preview style={{ width, height: previewHeight }}>
         <Image
           onLoad={e => setImageSize(e.nativeEvent.source)}


### PR DESCRIPTION
# Why

The "Custom preview" example in `docs/pages/router/reference/link-preview.mdx` has two consecutive `<Link.Trigger>` elements inside the same `<Link>`, which contradicts both the basic example earlier in the file (which uses a single `<Link.Trigger>`) and the "Known limitations" section below it that documents `<Link.Trigger>` constraints.

The duplicate appears to be a copy-paste artifact — there's no scenario where a `<Link>` should contain more than one trigger.

# How

Removed the duplicate `<Link.Trigger>Content</Link.Trigger>` line, keeping `<Link.Trigger>About</Link.Trigger>` consistent with the basic example and with the `href="/about"` on the parent `<Link>`.

### Diff

```diff
  <Link href="/about">
    <Link.Trigger>About</Link.Trigger>
-   <Link.Trigger>Content</Link.Trigger>
    <Link.Preview style={{ width, height: previewHeight }}>
      <Image
        onLoad={e => setImageSize(e.nativeEvent.source)}
        source={source}
        style={{ width: '100%', height: '100%' }}
      />
    </Link.Preview>
  </Link>
```

# Test Plan

- Ran `pnpm lint` in `docs/` — all four checks pass (`oxfmt`, `oxlint`, `tsc`, `eslint`).
- Single-line code-block deletion; no rendering change beyond the example block.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources — N/A (docs-only change)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — N/A (docs-only change)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
