### PR TITLE
[docs][router] Remove incorrect duplicate description for useGlobalSearchParams matcher

### DIFF
--- a/docs/pages/router/reference/testing.mdx
+++ b/docs/pages/router/reference/testing.mdx
@@ -155,8 +155,6 @@ expect(screen).useLocalSearchParams({ first: 'abc' });
 </PaddedAPIBox>
 <PaddedAPIBox header="useGlobalSearchParams()">
 
-Assert the current screen's pathname that matches a value. Compares using the value of [`useGlobalSearchParams`](/versions/latest/sdk/router/#useglobalsearchparams) hook.
-
 Assert the current global URL parameters against an object. The matcher uses the value of the [`useGlobalSearchParams`](/versions/latest/sdk/router/#useglobalsearchparams) hook on the current `screen`.
 
 ```tsx app.test.tsx


### PR DESCRIPTION
# Why

The `useGlobalSearchParams()` matcher entry in `docs/pages/router/reference/testing.mdx` has two paragraphs where one is needed. The first paragraph appears to be a copy-paste from `toHavePathname()` above — it describes the matcher as asserting "the current screen's pathname," but the matcher actually asserts global search params (which the second paragraph correctly describes).

For consistency, compare with the `useLocalSearchParams()` entry just above it (line ~148), which has a single, correct paragraph.

# How

Removed the first incorrect paragraph, leaving the correct description.

### Diff

```diff
  <PaddedAPIBox header="useGlobalSearchParams()">

- Assert the current screen's pathname that matches a value. Compares using the value of [`useGlobalSearchParams`](/versions/latest/sdk/router/#useglobalsearchparams) hook.
-
  Assert the current global URL parameters against an object. The matcher uses the value of the [`useGlobalSearchParams`](/versions/latest/sdk/router/#useglobalsearchparams) hook on the current `screen`.
```

After the change, the `useGlobalSearchParams()` block matches the structure of its sibling `useLocalSearchParams()` block.

# Test Plan

- Ran `pnpm lint` in `docs/` — all four checks pass (`oxfmt`, `oxlint`, `tsc`, `eslint`).
- Single-block prose deletion; no rendering or link changes.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources — N/A (docs-only change)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build — N/A (docs-only change)
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
