### PR TITLE
[bare-expo][Android] Add stub PCH generation for Android Studio sync

### DIFF
--- a/apps/bare-expo/android/app/build.gradle
+++ b/apps/bare-expo/android/app/build.gradle
@@ -207,3 +207,64 @@ class ExecuteSetupAndroidProject implements Plugin<Project> {
 }
 
 apply plugin: ExecuteSetupAndroidProject
+
+// Generates minimal stub PCH files from an empty header so the IDE's C++ engine
+// doesn't fail during sync. The actual build regenerates proper PCH files via ninja.
+def cxxDir = project.file(".cxx")
+def generateStubPCHTask = tasks.register("generateStubPCH") {
+  dependsOn("configureCMakeDebug")
+
+  doLast {
+    if (!cxxDir.exists()) {
+      return
+    }
+
+    cxxDir.eachFileRecurse { file ->
+      if (file.name != "compile_commands.json") {
+        return
+      }
+
+      new groovy.json.JsonSlurper().parseText(file.text).each { entry ->
+        if (!entry.file.endsWith("cmake_pch.hxx.cxx")) {
+          return
+        }
+
+        def pchFile = new File(entry.file.substring(0, entry.file.length() - ".cxx".length()) + ".pch")
+
+        if (!pchFile.exists() || pchFile.length() == 0) {
+          pchFile.parentFile.mkdirs()
+
+          def compiler = entry.command.split(" ")[0]
+          def target = (entry.command =~ /--target=\S+/)[0]
+          def sysroot = (entry.command =~ /--sysroot=\S+/)[0]
+
+          def stubHeader = new File(pchFile.parentFile, "stub_pch.hxx")
+          stubHeader.text = ""
+
+          def process = new ProcessBuilder(
+            compiler,
+            target,
+            sysroot,
+            "-x", "c++-header",
+            "-o", pchFile.absolutePath,
+            stubHeader.absolutePath
+          )
+            .directory(new File(entry.directory))
+            .redirectErrorStream(true)
+            .start()
+          process.outputStream.close()
+          if (process.waitFor() != 0) {
+            throw new GradleException("Stub PCH generation failed: ${process.inputStream.text}")
+          }
+        }
+
+        // Ensure PCH is older than source so ninja rebuilds the real one during build
+        pchFile.setLastModified(new File(entry.file).lastModified() - 1)
+      }
+    }
+  }
+}
+
+tasks.register("prepareKotlinBuildScriptModel") {
+  dependsOn(generateStubPCHTask)
+}


### PR DESCRIPTION
# Why

Adds a generateStubPCH Gradle task to bare-expo, similar to the one in expo-modules-core, so Android Studio's C++ engine doesn't fail during project sync when PCH files don't exist yet.

# How

After `configureCMakeDebug`, the task scans `compile_commands.json` for PCH entries and compiles empty stub `.pch` files using just the compiler, target, and sysroot - avoiding the complex -D defines that break naive command parsing. Stubs are backdated, so ninja regenerates the real PCH files during the actual build.

# Test Plan

- Open bare-expo in Android Studio, verify C++ sync completes without errors
- Run `./gradlew :app:generateStubPCH` - should succeed and generate `.pch` files under `.cxx/`
- Run a full debug build after sync - ninja should regenerate proper PCH files