### PR TITLE
[ui] add docs for @expo/material-symbols

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
@@ -12,7 +12,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
 
-An icon component for rendering Android XML vector drawables in Jetpack Compose. The recommended source is [`@expo/material-symbols`](https://github.com/expo/material-symbols/tree/main/packages/expo-material-symbols) — it ships Google's [Material Symbols](https://fonts.google.com/icons) as individual asset subpaths, so Metro only bundles the icons you actually import. For other styles (rounded, sharp, filled) or custom axes, the package's [`add-material-symbols`](#custom-styles-via-add-material-symbols) CLI downloads any variant directly into your project.
+An icon component for rendering Material Symbol XML vector drawables in Jetpack Compose. The recommended source is [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) — it ships Google's [Material Symbols](https://fonts.google.com/icons) as individual asset subpaths, so Metro only bundles the icons you actually import. For other styles (rounded, sharp, filled) or custom axes, the package's [CLI](#custom-styles-via-expomaterial-symbols-cli) downloads any variant directly into your project.
 
 <ContentSpotlight
   variant="component"
@@ -26,7 +26,7 @@ An icon component for rendering Android XML vector drawables in Jetpack Compose.
 
 <APIInstallSection />
 
-To use Material Symbols icons, also install the companion package:
+Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons. For a different style or custom axes, see [Custom styles](#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
 ```bash
 $ npx expo install @expo/material-symbols
@@ -36,7 +36,7 @@ $ npx expo install @expo/material-symbols
 
 ### Basic icon
 
-Import any icon directly from its own subpath — each icon resolves to a Metro asset that `Icon` can render natively.
+Import any icon directly from its own subpath of `@expo/material-symbols` — each icon resolves to a Metro asset that `Icon` can render natively. For local XML files you add to your project, use `require()` instead (see [Custom styles](#custom-styles-via-expomaterial-symbols-cli) below).
 
 ```tsx BasicIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
@@ -85,22 +85,22 @@ export default function SizedIcon() {
 }
 ```
 
-### Custom styles via `add-material-symbols`
+### Custom styles via `@expo/material-symbols` CLI
 
-`@expo/material-symbols` ships the **outlined** style with default axes. When you need a different style (`rounded`, `sharp`), a filled variant, or custom weight, grade, or optical size, use the `add-material-symbols` CLI to fetch specific drawables straight from Google Fonts into your project.
+`@expo/material-symbols` ships the **outlined** style with default axes. When you need a different style (`rounded`, `sharp`), a filled variant, or custom weight, grade, or optical size, use its CLI to fetch specific drawables straight from Google Fonts into your project.
 
 ```bash
 # Download icons by name (defaults: outlined, weight 400, 24px)
-$ npx add-material-symbols star home
+$ npx @expo/material-symbols star home
 
 # Rounded style
-$ npx add-material-symbols --style rounded star home
+$ npx @expo/material-symbols --style rounded star home
 
 # Sharp + filled
-$ npx add-material-symbols --style sharp --fill favorite
+$ npx @expo/material-symbols --style sharp --fill favorite
 
 # Paste a URL from fonts.google.com/icons to preserve the axes you picked there
-$ npx add-material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"
+$ npx @expo/material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"
 ```
 
 | Option                | Description                                | Default    |
@@ -112,7 +112,7 @@ $ npx add-material-symbols "https://fonts.google.com/icons?selected=Material+Sym
 | `-g, --grade <grad>`  | Grade: `-25`, `0`, `200`                   | `0`        |
 | `--opsz <size>`       | Optical size: `20`, `24`, `40`, `48`       | `24`       |
 
-The CLI writes ready-to-use XML vector drawables into your project. Load them with `require()` (or a static `import`) and pass them to `Icon`.
+The CLI writes ready-to-use XML vector drawables into your project. Load them with `require()` and pass them to `Icon`.
 
 ```tsx CustomIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
@@ -120,7 +120,7 @@ import { Host, Icon } from '@expo/ui/jetpack-compose';
 export default function CustomIcon() {
   return (
     <Host matchContents>
-      <Icon source={require('./assets/star-rounded.xml')} size={32} />
+      <Icon source={require('./assets/star-rounded.xml')} size={32} contentDescription="Star" />
     </Host>
   );
 }

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
@@ -12,7 +12,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
 
-An icon component for rendering icons in Jetpack Compose. We recommend downloading icons as XML vector drawables from [Material Symbols](https://fonts.google.com/icons), which is the standard approach for Android development.
+An icon component for rendering Android XML vector drawables in Jetpack Compose. The recommended source is [`@expo/material-symbols`](https://github.com/expo/material-symbols/tree/main/packages/expo-material-symbols) — it ships Google's [Material Symbols](https://fonts.google.com/icons) as individual asset subpaths, so Metro only bundles the icons you actually import. For other styles (rounded, sharp, filled) or custom axes, the package's [`add-material-symbols`](#custom-styles-via-add-material-symbols) CLI downloads any variant directly into your project.
 
 <ContentSpotlight
   variant="component"
@@ -26,19 +26,26 @@ An icon component for rendering icons in Jetpack Compose. We recommend downloadi
 
 <APIInstallSection />
 
+To use Material Symbols icons, also install the companion package:
+
+```bash
+$ npx expo install @expo/material-symbols
+```
+
 ## Usage
 
 ### Basic icon
 
-Use `require()` to load an XML vector drawable downloaded from [Material Symbols](https://fonts.google.com/icons).
+Import any icon directly from its own subpath — each icon resolves to a Metro asset that `Icon` can render natively.
 
 ```tsx BasicIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
+import Home from '@expo/material-symbols/home.xml';
 
 export default function BasicIcon() {
   return (
     <Host matchContents>
-      <Icon source={require('./assets/home.xml')} contentDescription="Home" />
+      <Icon source={Home} contentDescription="Home" />
     </Host>
   );
 }
@@ -50,15 +57,12 @@ Use the `tint` prop to apply a color overlay to the icon.
 
 ```tsx TintedIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
+import Favorite from '@expo/material-symbols/favorite.xml';
 
 export default function TintedIcon() {
   return (
     <Host matchContents>
-      <Icon
-        source={require('./assets/favorite.xml')}
-        tint="#6200ee"
-        contentDescription="Favorite"
-      />
+      <Icon source={Favorite} tint="#6200ee" contentDescription="Favorite" />
     </Host>
   );
 }
@@ -70,11 +74,53 @@ Specify a custom size in dp using the `size` prop.
 
 ```tsx SizedIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
+import Settings from '@expo/material-symbols/settings.xml';
 
 export default function SizedIcon() {
   return (
     <Host matchContents>
-      <Icon source={require('./assets/settings.xml')} size={48} contentDescription="Settings" />
+      <Icon source={Settings} size={48} contentDescription="Settings" />
+    </Host>
+  );
+}
+```
+
+### Custom styles via `add-material-symbols`
+
+`@expo/material-symbols` ships the **outlined** style with default axes. When you need a different style (`rounded`, `sharp`), a filled variant, or custom weight, grade, or optical size, use the `add-material-symbols` CLI to fetch specific drawables straight from Google Fonts into your project.
+
+```bash
+# Download icons by name (defaults: outlined, weight 400, 24px)
+$ npx add-material-symbols star home
+
+# Rounded style
+$ npx add-material-symbols --style rounded star home
+
+# Sharp + filled
+$ npx add-material-symbols --style sharp --fill favorite
+
+# Paste a URL from fonts.google.com/icons to preserve the axes you picked there
+$ npx add-material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"
+```
+
+| Option                | Description                                | Default    |
+| --------------------- | ------------------------------------------ | ---------- |
+| `-o, --output <dir>`  | Output directory                           | `./assets` |
+| `-s, --style <style>` | Icon style: `outlined`, `rounded`, `sharp` | `outlined` |
+| `-f, --fill`          | Use the filled variant                     |            |
+| `-w, --weight <wght>` | Weight: `100`–`700`                        | `400`      |
+| `-g, --grade <grad>`  | Grade: `-25`, `0`, `200`                   | `0`        |
+| `--opsz <size>`       | Optical size: `20`, `24`, `40`, `48`       | `24`       |
+
+The CLI writes ready-to-use XML vector drawables into your project. Load them with `require()` (or a static `import`) and pass them to `Icon`.
+
+```tsx CustomIcon.tsx
+import { Host, Icon } from '@expo/ui/jetpack-compose';
+
+export default function CustomIcon() {
+  return (
+    <Host matchContents>
+      <Icon source={require('./assets/star-rounded.xml')} size={32} />
     </Host>
   );
 }

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
@@ -9,6 +9,7 @@ platforms: ['android', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Terminal } from '~/ui/components/Snippet';
 
 > **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
 
@@ -28,9 +29,7 @@ An icon component for rendering Material Symbol XML vector drawables in Jetpack 
 
 Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons. For a different style or custom axes, see [Custom styles](#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
-```bash
-$ npx expo install @expo/material-symbols
-```
+<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
 
 ## Usage
 
@@ -89,19 +88,21 @@ export default function SizedIcon() {
 
 `@expo/material-symbols` ships the **outlined** style with default axes. When you need a different style (`rounded`, `sharp`), a filled variant, or custom weight, grade, or optical size, use its CLI to fetch specific drawables straight from Google Fonts into your project.
 
-```bash
-# Download icons by name (defaults: outlined, weight 400, 24px)
-$ npx @expo/material-symbols star home
-
-# Rounded style
-$ npx @expo/material-symbols --style rounded star home
-
-# Sharp + filled
-$ npx @expo/material-symbols --style sharp --fill favorite
-
-# Paste a URL from fonts.google.com/icons to preserve the axes you picked there
-$ npx @expo/material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"
-```
+<Terminal
+  cmd={[
+    '# Download icons by name (defaults: outlined, weight 400, 24px)',
+    '$ npx @expo/material-symbols star home',
+    '',
+    '# Rounded style',
+    '$ npx @expo/material-symbols --style rounded star home',
+    '',
+    '# Sharp + filled',
+    '$ npx @expo/material-symbols --style sharp --fill favorite',
+    '',
+    '# Paste a URL from fonts.google.com/icons to preserve the axes you picked there',
+    '$ npx @expo/material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"',
+  ]}
+/>
 
 | Option                | Description                                | Default    |
 | --------------------- | ------------------------------------------ | ---------- |

--- a/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { Terminal } from '~/ui/components/Snippet';
 
-A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/).
+A platform-native icon. On Android, it renders a Material Symbol XML vector drawable (recommended source: [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols)). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/).
 
 > **Note:** `Icon` does not render on web.
 
@@ -18,7 +18,7 @@ A platform-native icon. On Android, it renders a Material Symbol XML vector draw
 
 <APIInstallSection />
 
-Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons on Android. For a different style or custom axes, see [Custom styles](/versions/latest/sdk/ui/jetpack-compose/icon/#custom-styles-via-expomaterial-symbols-cli) — no install needed.
+Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons on Android. For a different style or custom axes, see [Custom styles on the Jetpack Compose Icon page](/versions/latest/sdk/ui/jetpack-compose/icon/#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
 <Terminal cmd={['$ npx expo install @expo/material-symbols']} />
 

--- a/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://github.com/expo/material-symbols/tree/main/packages/expo-material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/)
+A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/).
 
 > **Note:** `Icon` does not render on web.
 

--- a/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
@@ -9,13 +9,19 @@ platforms: ['android', 'ios', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://github.com/expo/expo/tree/main/packages/material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/)
+A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://github.com/expo/material-symbols/tree/main/packages/expo-material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/)
 
 > **Note:** `Icon` does not render on web.
 
 ## Installation
 
 <APIInstallSection />
+
+To render Material Symbols on Android, also install the companion package:
+
+```bash
+$ npx expo install @expo/material-symbols
+```
 
 ## Usage
 

--- a/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/icon.mdx
@@ -8,6 +8,7 @@ platforms: ['android', 'ios', 'expo-go']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { Terminal } from '~/ui/components/Snippet';
 
 A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/).
 
@@ -17,11 +18,9 @@ A platform-native icon. On Android, it renders a Material Symbol XML vector draw
 
 <APIInstallSection />
 
-To render Material Symbols on Android, also install the companion package:
+Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons on Android. For a different style or custom axes, see [Custom styles](/versions/latest/sdk/ui/jetpack-compose/icon/#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
-```bash
-$ npx expo install @expo/material-symbols
-```
+<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
 
 ## Usage
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
@@ -12,7 +12,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
 
-An icon component for rendering Android XML vector drawables in Jetpack Compose. The recommended source is [`@expo/material-symbols`](https://github.com/expo/material-symbols/tree/main/packages/expo-material-symbols) — it ships Google's [Material Symbols](https://fonts.google.com/icons) as individual asset subpaths, so Metro only bundles the icons you actually import. For other styles (rounded, sharp, filled) or custom axes, the package's [`add-material-symbols`](#custom-styles-via-add-material-symbols) CLI downloads any variant directly into your project.
+An icon component for rendering Material Symbol XML vector drawables in Jetpack Compose. The recommended source is [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) — it ships Google's [Material Symbols](https://fonts.google.com/icons) as individual asset subpaths, so Metro only bundles the icons you actually import. For other styles (rounded, sharp, filled) or custom axes, the package's [CLI](#custom-styles-via-expomaterial-symbols-cli) downloads any variant directly into your project.
 
 <ContentSpotlight
   variant="component"
@@ -26,7 +26,7 @@ An icon component for rendering Android XML vector drawables in Jetpack Compose.
 
 <APIInstallSection />
 
-To use Material Symbols icons, also install the companion package:
+Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons. For a different style or custom axes, see [Custom styles](#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
 ```bash
 $ npx expo install @expo/material-symbols
@@ -36,7 +36,7 @@ $ npx expo install @expo/material-symbols
 
 ### Basic icon
 
-Import any icon directly from its own subpath — each icon resolves to a Metro asset that `Icon` can render natively.
+Import any icon directly from its own subpath of `@expo/material-symbols` — each icon resolves to a Metro asset that `Icon` can render natively. For local XML files you add to your project, use `require()` instead (see [Custom styles](#custom-styles-via-expomaterial-symbols-cli) below).
 
 ```tsx BasicIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
@@ -85,22 +85,22 @@ export default function SizedIcon() {
 }
 ```
 
-### Custom styles via `add-material-symbols`
+### Custom styles via `@expo/material-symbols` CLI
 
-`@expo/material-symbols` ships the **outlined** style with default axes. When you need a different style (`rounded`, `sharp`), a filled variant, or custom weight, grade, or optical size, use the `add-material-symbols` CLI to fetch specific drawables straight from Google Fonts into your project.
+`@expo/material-symbols` ships the **outlined** style with default axes. When you need a different style (`rounded`, `sharp`), a filled variant, or custom weight, grade, or optical size, use its CLI to fetch specific drawables straight from Google Fonts into your project.
 
 ```bash
 # Download icons by name (defaults: outlined, weight 400, 24px)
-$ npx add-material-symbols star home
+$ npx @expo/material-symbols star home
 
 # Rounded style
-$ npx add-material-symbols --style rounded star home
+$ npx @expo/material-symbols --style rounded star home
 
 # Sharp + filled
-$ npx add-material-symbols --style sharp --fill favorite
+$ npx @expo/material-symbols --style sharp --fill favorite
 
 # Paste a URL from fonts.google.com/icons to preserve the axes you picked there
-$ npx add-material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"
+$ npx @expo/material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"
 ```
 
 | Option                | Description                                | Default    |
@@ -112,7 +112,7 @@ $ npx add-material-symbols "https://fonts.google.com/icons?selected=Material+Sym
 | `-g, --grade <grad>`  | Grade: `-25`, `0`, `200`                   | `0`        |
 | `--opsz <size>`       | Optical size: `20`, `24`, `40`, `48`       | `24`       |
 
-The CLI writes ready-to-use XML vector drawables into your project. Load them with `require()` (or a static `import`) and pass them to `Icon`.
+The CLI writes ready-to-use XML vector drawables into your project. Load them with `require()` and pass them to `Icon`.
 
 ```tsx CustomIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
@@ -120,7 +120,7 @@ import { Host, Icon } from '@expo/ui/jetpack-compose';
 export default function CustomIcon() {
   return (
     <Host matchContents>
-      <Icon source={require('./assets/star-rounded.xml')} size={32} />
+      <Icon source={require('./assets/star-rounded.xml')} size={32} contentDescription="Star" />
     </Host>
   );
 }

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
@@ -12,7 +12,7 @@ import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
 > **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
 
-An icon component for rendering icons in Jetpack Compose. We recommend downloading icons as XML vector drawables from [Material Symbols](https://fonts.google.com/icons), which is the standard approach for Android development.
+An icon component for rendering Android XML vector drawables in Jetpack Compose. The recommended source is [`@expo/material-symbols`](https://github.com/expo/material-symbols/tree/main/packages/expo-material-symbols) — it ships Google's [Material Symbols](https://fonts.google.com/icons) as individual asset subpaths, so Metro only bundles the icons you actually import. For other styles (rounded, sharp, filled) or custom axes, the package's [`add-material-symbols`](#custom-styles-via-add-material-symbols) CLI downloads any variant directly into your project.
 
 <ContentSpotlight
   variant="component"
@@ -26,19 +26,26 @@ An icon component for rendering icons in Jetpack Compose. We recommend downloadi
 
 <APIInstallSection />
 
+To use Material Symbols icons, also install the companion package:
+
+```bash
+$ npx expo install @expo/material-symbols
+```
+
 ## Usage
 
 ### Basic icon
 
-Use `require()` to load an XML vector drawable downloaded from [Material Symbols](https://fonts.google.com/icons).
+Import any icon directly from its own subpath — each icon resolves to a Metro asset that `Icon` can render natively.
 
 ```tsx BasicIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
+import Home from '@expo/material-symbols/home.xml';
 
 export default function BasicIcon() {
   return (
     <Host matchContents>
-      <Icon source={require('./assets/home.xml')} contentDescription="Home" />
+      <Icon source={Home} contentDescription="Home" />
     </Host>
   );
 }
@@ -50,15 +57,12 @@ Use the `tint` prop to apply a color overlay to the icon.
 
 ```tsx TintedIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
+import Favorite from '@expo/material-symbols/favorite.xml';
 
 export default function TintedIcon() {
   return (
     <Host matchContents>
-      <Icon
-        source={require('./assets/favorite.xml')}
-        tint="#6200ee"
-        contentDescription="Favorite"
-      />
+      <Icon source={Favorite} tint="#6200ee" contentDescription="Favorite" />
     </Host>
   );
 }
@@ -70,11 +74,53 @@ Specify a custom size in dp using the `size` prop.
 
 ```tsx SizedIcon.tsx
 import { Host, Icon } from '@expo/ui/jetpack-compose';
+import Settings from '@expo/material-symbols/settings.xml';
 
 export default function SizedIcon() {
   return (
     <Host matchContents>
-      <Icon source={require('./assets/settings.xml')} size={48} contentDescription="Settings" />
+      <Icon source={Settings} size={48} contentDescription="Settings" />
+    </Host>
+  );
+}
+```
+
+### Custom styles via `add-material-symbols`
+
+`@expo/material-symbols` ships the **outlined** style with default axes. When you need a different style (`rounded`, `sharp`), a filled variant, or custom weight, grade, or optical size, use the `add-material-symbols` CLI to fetch specific drawables straight from Google Fonts into your project.
+
+```bash
+# Download icons by name (defaults: outlined, weight 400, 24px)
+$ npx add-material-symbols star home
+
+# Rounded style
+$ npx add-material-symbols --style rounded star home
+
+# Sharp + filled
+$ npx add-material-symbols --style sharp --fill favorite
+
+# Paste a URL from fonts.google.com/icons to preserve the axes you picked there
+$ npx add-material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"
+```
+
+| Option                | Description                                | Default    |
+| --------------------- | ------------------------------------------ | ---------- |
+| `-o, --output <dir>`  | Output directory                           | `./assets` |
+| `-s, --style <style>` | Icon style: `outlined`, `rounded`, `sharp` | `outlined` |
+| `-f, --fill`          | Use the filled variant                     |            |
+| `-w, --weight <wght>` | Weight: `100`–`700`                        | `400`      |
+| `-g, --grade <grad>`  | Grade: `-25`, `0`, `200`                   | `0`        |
+| `--opsz <size>`       | Optical size: `20`, `24`, `40`, `48`       | `24`       |
+
+The CLI writes ready-to-use XML vector drawables into your project. Load them with `require()` (or a static `import`) and pass them to `Icon`.
+
+```tsx CustomIcon.tsx
+import { Host, Icon } from '@expo/ui/jetpack-compose';
+
+export default function CustomIcon() {
+  return (
+    <Host matchContents>
+      <Icon source={require('./assets/star-rounded.xml')} size={32} />
     </Host>
   );
 }

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
@@ -9,6 +9,7 @@ platforms: ['android', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
+import { Terminal } from '~/ui/components/Snippet';
 
 > **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
 
@@ -28,9 +29,7 @@ An icon component for rendering Material Symbol XML vector drawables in Jetpack 
 
 Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons. For a different style or custom axes, see [Custom styles](#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
-```bash
-$ npx expo install @expo/material-symbols
-```
+<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
 
 ## Usage
 
@@ -89,19 +88,21 @@ export default function SizedIcon() {
 
 `@expo/material-symbols` ships the **outlined** style with default axes. When you need a different style (`rounded`, `sharp`), a filled variant, or custom weight, grade, or optical size, use its CLI to fetch specific drawables straight from Google Fonts into your project.
 
-```bash
-# Download icons by name (defaults: outlined, weight 400, 24px)
-$ npx @expo/material-symbols star home
-
-# Rounded style
-$ npx @expo/material-symbols --style rounded star home
-
-# Sharp + filled
-$ npx @expo/material-symbols --style sharp --fill favorite
-
-# Paste a URL from fonts.google.com/icons to preserve the axes you picked there
-$ npx @expo/material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"
-```
+<Terminal
+  cmd={[
+    '# Download icons by name (defaults: outlined, weight 400, 24px)',
+    '$ npx @expo/material-symbols star home',
+    '',
+    '# Rounded style',
+    '$ npx @expo/material-symbols --style rounded star home',
+    '',
+    '# Sharp + filled',
+    '$ npx @expo/material-symbols --style sharp --fill favorite',
+    '',
+    '# Paste a URL from fonts.google.com/icons to preserve the axes you picked there',
+    '$ npx @expo/material-symbols "https://fonts.google.com/icons?selected=Material+Symbols+Outlined:check_box:FILL@1;wght@300;GRAD@0;opsz@24"',
+  ]}
+/>
 
 | Option                | Description                                | Default    |
 | --------------------- | ------------------------------------------ | ---------- |

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
@@ -8,6 +8,7 @@ platforms: ['android', 'ios', 'expo-go']
 
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
+import { Terminal } from '~/ui/components/Snippet';
 
 A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/).
 
@@ -17,11 +18,9 @@ A platform-native icon. On Android, it renders a Material Symbol XML vector draw
 
 <APIInstallSection />
 
-To render Material Symbols on Android, also install the companion package:
+Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons on Android. For a different style or custom axes, see [Custom styles](/versions/v56.0.0/sdk/ui/jetpack-compose/icon/#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
-```bash
-$ npx expo install @expo/material-symbols
-```
+<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
 
 ## Usage
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
@@ -9,7 +9,7 @@ platforms: ['android', 'ios', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://github.com/expo/material-symbols/tree/main/packages/expo-material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/)
+A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/).
 
 > **Note:** `Icon` does not render on web.
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
@@ -9,13 +9,19 @@ platforms: ['android', 'ios', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
-A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://github.com/expo/expo/tree/main/packages/material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/)
+A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://github.com/expo/material-symbols/tree/main/packages/expo-material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/)
 
 > **Note:** `Icon` does not render on web.
 
 ## Installation
 
 <APIInstallSection />
+
+To render Material Symbols on Android, also install the companion package:
+
+```bash
+$ npx expo install @expo/material-symbols
+```
 
 ## Usage
 

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/icon.mdx
@@ -10,7 +10,7 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { Terminal } from '~/ui/components/Snippet';
 
-A platform-native icon. On Android, it renders a Material Symbol XML vector drawable supplied through [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) (other XML vector drawable assets aren't officially supported). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/).
+A platform-native icon. On Android, it renders a Material Symbol XML vector drawable (recommended source: [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols)). On iOS, it renders an [SF Symbol](https://developer.apple.com/sf-symbols/).
 
 > **Note:** `Icon` does not render on web.
 
@@ -18,7 +18,7 @@ A platform-native icon. On Android, it renders a Material Symbol XML vector draw
 
 <APIInstallSection />
 
-Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons on Android. For a different style or custom axes, see [Custom styles](/versions/v56.0.0/sdk/ui/jetpack-compose/icon/#custom-styles-via-expomaterial-symbols-cli) — no install needed.
+Optionally, install [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) to use the bundled icons on Android. For a different style or custom axes, see [Custom styles on the Jetpack Compose Icon page](/versions/v56.0.0/sdk/ui/jetpack-compose/icon/#custom-styles-via-expomaterial-symbols-cli) — no install needed.
 
 <Terminal cmd={['$ npx expo install @expo/material-symbols']} />
 


### PR DESCRIPTION
# Why



The Jetpack Compose `Icon` docs didn't mention the `@expo/material-symbols` package or its `add-material-symbols` CLI. The universal `Icon` page also linked to a non-existent repo.

# How

- Rewrote `jetpack-compose/icon.mdx` to import icons from `@expo/material-symbols/<icon>.xml` subpaths and added a section on the `add-material-symbols` CLI for non-default styles/axes.
- Added the `@expo/material-symbols` install hint on `universal/icon.mdx` and fixed its broken repo link.
- Mirrored to `unversioned` and `v56.0.0`.

# Test Plan

run website locally or preview at https://pr-45929.expo-docs.pages.dev/versions/v56.0.0/sdk/ui/jetpack-compose/icon/

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->


<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)