### PR TITLE
[ui] document drop-in replacement components in expo-ui

### DIFF
--- a/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/date-time-picker.mdx
@@ -13,6 +13,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/datetimepicker) for `@react-native-community/datetimepicker`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 A component that provides access to the system UI for date and time selection.
 
 <ContentSpotlight file="sdk/datetimepicker.mp4" loop={false} />

--- a/docs/pages/versions/unversioned/sdk/masked-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/masked-view.mdx
@@ -12,6 +12,8 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/maskedview) for `@react-native-masked-view/masked-view`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 `@react-native-masked-view/masked-view` provides a masked view that only displays the pixels that overlap with the view rendered in its mask element.
 
 > **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and later requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.

--- a/docs/pages/versions/unversioned/sdk/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/picker.mdx
@@ -12,6 +12,8 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/picker) for `@react-native-picker/picker`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 A component that provides access to the system UI for picking between several options.
 
 ## Installation

--- a/docs/pages/versions/unversioned/sdk/segmented-control.mdx
+++ b/docs/pages/versions/unversioned/sdk/segmented-control.mdx
@@ -12,6 +12,8 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/segmentedcontrol) for `@react-native-segmented-control/segmented-control`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 It's like a fancy radio button, or in Apple's words: "A horizontal control that consists of multiple segments, each segment functioning as a discrete button" ([source](https://developer.apple.com/documentation/uikit/uisegmentedcontrol)). This component renders to a [`UISegmentedControl`](https://developer.apple.com/documentation/uikit/uisegmentedcontrol) on iOS, and to faithful recreations of that control on Android and web (because no equivalent exists on those platforms' standard libraries).
 
 ## Installation

--- a/docs/pages/versions/unversioned/sdk/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/slider.mdx
@@ -14,6 +14,8 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 {/* todo: add video */}
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/slider) for `@react-native-community/slider`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 A component library that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
 ## Installation

--- a/docs/pages/versions/v55.0.0/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/date-time-picker.mdx
@@ -13,6 +13,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/datetimepicker) for `@react-native-community/datetimepicker`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 A component that provides access to the system UI for date and time selection.
 
 <ContentSpotlight file="sdk/datetimepicker.mp4" loop={false} />

--- a/docs/pages/versions/v55.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/picker.mdx
@@ -12,6 +12,8 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/picker) for `@react-native-picker/picker`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 A component that provides access to the system UI for picking between several options.
 
 ## Installation

--- a/docs/pages/versions/v55.0.0/sdk/segmented-control.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/segmented-control.mdx
@@ -12,6 +12,8 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/segmentedcontrol) for `@react-native-segmented-control/segmented-control`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 It's like a fancy radio button, or in Apple's words: "A horizontal control that consists of multiple segments, each segment functioning as a discrete button" ([source](https://developer.apple.com/documentation/uikit/uisegmentedcontrol)). This component renders to a [`UISegmentedControl`](https://developer.apple.com/documentation/uikit/uisegmentedcontrol) on iOS, and to faithful recreations of that control on Android and web (because no equivalent exists on those platforms' standard libraries).
 
 ## Installation

--- a/docs/pages/versions/v56.0.0/sdk/date-time-picker.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/date-time-picker.mdx
@@ -13,6 +13,8 @@ import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/datetimepicker) for `@react-native-community/datetimepicker`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 A component that provides access to the system UI for date and time selection.
 
 <ContentSpotlight file="sdk/datetimepicker.mp4" loop={false} />

--- a/docs/pages/versions/v56.0.0/sdk/masked-view.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/masked-view.mdx
@@ -12,6 +12,8 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/maskedview) for `@react-native-masked-view/masked-view`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 `@react-native-masked-view/masked-view` provides a masked view that only displays the pixels that overlap with the view rendered in its mask element.
 
 > **warning** You can only have one of either `@react-native-community/masked-view` (deprecated) or `@react-native-masked-view/masked-view` installed in your project at any given time. React Navigation v6 and later requires `@react-native-masked-view/masked-view`, so you should use that package instead if you are using the latest version of React Navigation.

--- a/docs/pages/versions/v56.0.0/sdk/picker.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/picker.mdx
@@ -12,6 +12,8 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/picker) for `@react-native-picker/picker`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 A component that provides access to the system UI for picking between several options.
 
 ## Installation

--- a/docs/pages/versions/v56.0.0/sdk/segmented-control.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/segmented-control.mdx
@@ -12,6 +12,8 @@ import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { BoxLink } from '~/ui/components/BoxLink';
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/segmentedcontrol) for `@react-native-segmented-control/segmented-control`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 It's like a fancy radio button, or in Apple's words: "A horizontal control that consists of multiple segments, each segment functioning as a discrete button" ([source](https://developer.apple.com/documentation/uikit/uisegmentedcontrol)). This component renders to a [`UISegmentedControl`](https://developer.apple.com/documentation/uikit/uisegmentedcontrol) on iOS, and to faithful recreations of that control on Android and web (because no equivalent exists on those platforms' standard libraries).
 
 ## Installation

--- a/docs/pages/versions/v56.0.0/sdk/slider.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/slider.mdx
@@ -14,6 +14,8 @@ import { BoxLink } from '~/ui/components/BoxLink';
 
 {/* todo: add video */}
 
+> **important** [`@expo/ui` provides a drop-in replacement](./ui/drop-in-replacements/slider) for `@react-native-community/slider`, powered by Jetpack Compose on Android and SwiftUI on iOS.
+
 A component library that provides access to the system UI for a slider control, that allows users to pick among a range of values by dragging an anchor.
 
 ## Installation


### PR DESCRIPTION
# Why

Readers landing on the community-package SDK pages (`@react-native-community/datetimepicker`, `@react-native-picker/picker`, etc.) had no signal that `@expo/ui` ships native drop-in replacements for them.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How



Added a `> **Tip:** …` callout right under the description on each community-package
page, linking to the matching `ui/drop-in-replacements/<name>` doc.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan



preview deployment

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)