### PR TITLE
[docs] link to expo-maps from react-native-maps docs page

### DIFF
--- a/docs/pages/versions/unversioned/sdk/map-view.mdx
+++ b/docs/pages/versions/unversioned/sdk/map-view.mdx
@@ -12,6 +12,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
+> **important** [`expo-maps`](./maps) is an Expo-built alternative to `react-native-maps`, powered by Google Maps on Android and Apple Maps on iOS.
+
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).

--- a/docs/pages/versions/v55.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/map-view.mdx
@@ -12,6 +12,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
+> **important** [`expo-maps`](./maps) is an Expo-built alternative to `react-native-maps`, powered by Google Maps on Android and Apple Maps on iOS.
+
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).

--- a/docs/pages/versions/v56.0.0/sdk/map-view.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/map-view.mdx
@@ -12,6 +12,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
+> **important** [`expo-maps`](./maps) is an Expo-built alternative to `react-native-maps`, powered by Google Maps on Android and Apple Maps on iOS.
+
 `react-native-maps` provides a Map component that uses Google Maps on Android and Apple Maps or Google Maps on iOS.
 
 No additional setup is required when testing your project using Expo Go. However, **to deploy the app binary on app stores** additional steps are required for Google Maps. For more information, see the [instructions below](#deploy-app-with-google-maps).


### PR DESCRIPTION
# Why

readers of the `react-native-maps` page may not be aware we built `expo-maps`.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add a callout to the docs.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

checked the docs localy

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)