### PR TITLE
[expo-go] Fix permission view heirarchy posistion

### DIFF
--- a/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
+++ b/apps/expo-go/ios/Client/SwiftUI/HomeRootView.swift
@@ -114,16 +114,16 @@ struct HomeRootView: View {
         )
         .transition(.opacity)
       }
-    }
 
-    if !hasCompletedPermissionFlow {
-      LocalNetworkPermissionView(serverService: viewModel.serverService) {
-        viewModel.serverService.startDiscovery()
-        withAnimation(.easeInOut(duration: 0.3)) {
-          hasCompletedPermissionFlow = true
+      if !hasCompletedPermissionFlow {
+        LocalNetworkPermissionView(serverService: viewModel.serverService) {
+          viewModel.serverService.startDiscovery()
+          withAnimation(.easeInOut(duration: 0.3)) {
+            hasCompletedPermissionFlow = true
+          }
         }
+        .transition(.opacity)
       }
-      .transition(.opacity)
     }
   }
 }

--- a/apps/expo-go/ios/Podfile.lock
+++ b/apps/expo-go/ios/Podfile.lock
@@ -85,6 +85,10 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - ExpoAgeRange (56.0.4):
+    - ExpoModulesCore
+  - ExpoAppleAuthentication (56.0.3):
+    - ExpoModulesCore
   - ExpoAsset (56.0.10):
     - ExpoModulesCore
   - ExpoAudio (56.0.7):
@@ -169,6 +173,8 @@ PODS:
     - ExpoModulesCore
   - ExpoLinking (56.0.8):
     - ExpoModulesCore
+  - ExpoLivePhoto (56.0.3):
+    - ExpoModulesCore
   - ExpoLocalAuthentication (56.0.3):
     - ExpoModulesCore
   - ExpoLocalization (56.0.4):
@@ -186,6 +192,8 @@ PODS:
     - ExpoModulesCore
     - ExpoModulesTestCore
     - React-Core
+  - ExpoMeshGradient (56.0.3):
+    - ExpoModulesCore
   - ExpoModulesCore (56.0.9):
     - boost
     - DoubleConversion
@@ -4062,6 +4070,8 @@ DEPENDENCIES:
   - EXManifests/Tests (from `../../../packages/expo-manifests/ios`)
   - Expo (from `../../../packages/expo`)
   - Expo/Tests (from `../../../packages/expo`)
+  - ExpoAgeRange (from `../../../packages/expo-age-range/ios`)
+  - ExpoAppleAuthentication (from `../../../packages/expo-apple-authentication/ios`)
   - ExpoAsset (from `../../../packages/expo-asset/ios`)
   - ExpoAudio (from `../../../packages/expo-audio/ios`)
   - ExpoBackgroundFetch (from `../../../packages/expo-background-fetch/ios`)
@@ -4094,6 +4104,7 @@ DEPENDENCIES:
   - ExpoKeepAwake (from `../../../packages/expo-keep-awake/ios`)
   - ExpoLinearGradient (from `../../../packages/expo-linear-gradient/ios`)
   - ExpoLinking (from `../../../packages/expo-linking/ios`)
+  - ExpoLivePhoto (from `../../../packages/expo-live-photo/ios`)
   - ExpoLocalAuthentication (from `../../../packages/expo-local-authentication/ios`)
   - ExpoLocalization (from `../../../packages/expo-localization/ios`)
   - ExpoLocation (from `../../../packages/expo-location/ios`)
@@ -4101,6 +4112,7 @@ DEPENDENCIES:
   - ExpoMailComposer (from `../../../packages/expo-mail-composer/ios`)
   - ExpoMediaLibrary (from `../../../packages/expo-media-library/ios`)
   - ExpoMediaLibrary/Tests (from `../../../packages/expo-media-library/ios`)
+  - ExpoMeshGradient (from `../../../packages/expo-mesh-gradient/ios`)
   - ExpoModulesCore (from `../../../packages/expo-modules-core`)
   - ExpoModulesCore/Tests (from `../../../packages/expo-modules-core`)
   - ExpoModulesJSI (from `../../../packages/expo-modules-jsi/apple`)
@@ -4308,6 +4320,10 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-manifests/ios"
   Expo:
     :path: "../../../packages/expo"
+  ExpoAgeRange:
+    :path: "../../../packages/expo-age-range/ios"
+  ExpoAppleAuthentication:
+    :path: "../../../packages/expo-apple-authentication/ios"
   ExpoAsset:
     :path: "../../../packages/expo-asset/ios"
   ExpoAudio:
@@ -4366,6 +4382,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-linear-gradient/ios"
   ExpoLinking:
     :path: "../../../packages/expo-linking/ios"
+  ExpoLivePhoto:
+    :path: "../../../packages/expo-live-photo/ios"
   ExpoLocalAuthentication:
     :path: "../../../packages/expo-local-authentication/ios"
   ExpoLocalization:
@@ -4378,6 +4396,8 @@ EXTERNAL SOURCES:
     :path: "../../../packages/expo-mail-composer/ios"
   ExpoMediaLibrary:
     :path: "../../../packages/expo-media-library/ios"
+  ExpoMeshGradient:
+    :path: "../../../packages/expo-mesh-gradient/ios"
   ExpoModulesCore:
     :path: "../../../packages/expo-modules-core"
   ExpoModulesJSI:
@@ -4644,6 +4664,8 @@ SPEC CHECKSUMS:
   EXJSONUtils: dba2755f4e24009eaf87a876b2d615ea06c16e42
   EXManifests: 67869a6d8efa7cb53a7b8b53f451d378c124073f
   Expo: 9308fb3a105302b61fc1eedb912de60157a5a706
+  ExpoAgeRange: c652074c8c24bf52bd3201ecd017040c867ba58b
+  ExpoAppleAuthentication: 47f6f6c6722a7facef29d15397635b785086bc5e
   ExpoAsset: 6a8796be15348a3a4023116c3d76983161b12bad
   ExpoAudio: 3a08e84dfc9f516a8c083bcc154df82d2a3c9709
   ExpoBackgroundFetch: c789e560168e62eed1b74fbf05ec21128af34f93
@@ -4673,12 +4695,14 @@ SPEC CHECKSUMS:
   ExpoKeepAwake: 359c47a1d9ccc3a3c519bca6e39562cce230c5bb
   ExpoLinearGradient: 16c2b9c6105444883d34958d573725de1293b8d0
   ExpoLinking: 16e9c6e222d8c47fc8e4922f9c35635b770c63fa
+  ExpoLivePhoto: 3c2bd665a63afa8a465b16b564e4c9ab83ea60eb
   ExpoLocalAuthentication: 64e8c5756df07c8a89f078293ec17899c1325a43
   ExpoLocalization: 18a218aa883b7bf46ee3d18d912631ed3348b560
   ExpoLocation: f2ca41c8d91d4758ca53a2715c52f778696744df
   ExpoLogBox: 6e1ab3a1048a8a9305e7120465aa9214df57ef14
   ExpoMailComposer: e202b670f62063851ed74c964034037312d523a8
   ExpoMediaLibrary: 2ee3defd62fa8da9cb80fdcca71968cdeec7b24f
+  ExpoMeshGradient: baf62012104fd9c1719de67f88c69958abcd2ed1
   ExpoModulesCore: 88d9ff5d0717c97f746ba71e0240798e02f15357
   ExpoModulesJSI: cbbc6e69c19e02dc61ef5b27ee980c889b1d53ee
   ExpoModulesTestCore: b9f612ac94633aaf03ab5b41400317bfd963b5e7
@@ -4723,7 +4747,7 @@ SPEC CHECKSUMS:
   GoogleAppMeasurement: 8a82b93a6400c8e6551c0bcd66a9177f2e067aed
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
-  hermes-engine: 020d7dbf64ea2ac7f2dc43408d80cc6035c4b3e8
+  hermes-engine: 971c315ad976a4dcbf09795cb72e85ea3f7200d9
   libavif: 5f8e715bea24debec477006f21ef9e95432e254d
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8


### PR DESCRIPTION
# Why
Fixes https://exponent-internal.slack.com/archives/C02T514E4RK/p1779034585154779

# How
In `HomeRootView`, the `LocalNetworkPermissionView()` block was a sibling of the ZStack instead of a child. 

# Test Plan
Reproed the problem on a physical device. Making the block a child maintains the correct z order.
<img width="450" height="978" alt="RocketSim_Screenshot_iPhone_17_Pro_6 3_2026-05-18_11 13 59" src="https://github.com/user-attachments/assets/22c780a0-844c-437a-9988-eed6f308c6b5" />
<img width="450" height="978" alt="RocketSim_Screenshot_iPhone_17_Pro_6 3_2026-05-18_11 14 13" src="https://github.com/user-attachments/assets/5a4bc25e-1e59-4bdf-ac17-3cfbf9c9f124" />
<img width="450" height="978" alt="RocketSim_Screenshot_iPhone_17_Pro_6 3_2026-05-18_11 20 31" src="https://github.com/user-attachments/assets/14cca194-79d4-4695-bbf6-848c6c0f9516" />
