### PR TITLE
[docs] Guard redirects to prevent unwanted patterns [EXP-55]

### DIFF
--- a/docs/common/client-redirects.test.ts
+++ b/docs/common/client-redirects.test.ts
@@ -52,6 +52,18 @@ test('adds forward slash to end of path', () => {
   expect(newPath).toEqual('/more/expo-cli/');
 });
 
+test('collapses protocol-relative leading slashes so the path stays same-origin', () => {
+  expect(getRedirectPath('//attacker.example/docs')).toEqual('/attacker.example/docs/');
+});
+
+test('does not let repeated index.html segments produce a protocol-relative path', () => {
+  expect(getRedirectPath('/index.html/attacker.example/index.html')).not.toMatch(/^\/\//);
+});
+
+test('does not let repeated .html segments produce a protocol-relative path', () => {
+  expect(getRedirectPath('/.html/attacker.example/.html')).not.toMatch(/^\/\//);
+});
+
 test('redirects old versions to latest', () => {
   const redirectPath = '/versions/v50.0.0/sdk/camera/';
   const newPath = getRedirectPath(redirectPath);

--- a/docs/common/client-redirects.ts
+++ b/docs/common/client-redirects.ts
@@ -1,14 +1,20 @@
 import versions from '~/public/static/constants/versions.json';
 
 export function getRedirectPath(redirectPath: string): string {
-  // index.html is no longer a thing in our docs
+  // Collapse leading slashes so the path can't become a protocol-relative
+  // URL when assigned to window.location.href downstream.
+  redirectPath = redirectPath.replace(/^\/+/, '/');
+
+  // index.html is no longer a thing in our docs. Anchor to end of string so
+  // a repeated segment (e.g. /index.html/x/index.html) can't strip the first
+  // occurrence and leave a protocol-relative `//x/...` path behind.
   if (pathIncludesIndexHtml(redirectPath)) {
-    redirectPath = redirectPath.replace('index.html', '');
+    redirectPath = redirectPath.replace(/index\.html$/, '');
   }
 
   // Remove the .html extension if it is included in the path
   if (pathIncludesHtmlExtension(redirectPath)) {
-    redirectPath = redirectPath.replace('.html', '');
+    redirectPath = redirectPath.replace(/\.html$/, '');
   }
 
   // Unsure why this is happening, but sometimes URLs end up with /null in


### PR DESCRIPTION
## Summary

This guards our redirect normalisation for unwanted patterns. These could be missed during a review and only cause behaviour we don't need / aren't desirable.

- Replace double-slashes in redirect paths
- Fix `index.html` replacement to be only replaced at end of path

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
