### PR TITLE
[docs] Update HTML escaping [EXP-55]

### DIFF
--- a/docs/common/code-utilities.ts
+++ b/docs/common/code-utilities.ts
@@ -102,7 +102,12 @@ export function cleanCopyValue(value: string, version?: string) {
 }
 
 export function escapeHtml(text: string) {
-  return text.replace(/"/g, '&quot;');
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 export function replaceXmlCommentsWithAnnotations(value: string) {

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -70,7 +70,7 @@ export function Code({ className, children, title }: CodeProps) {
 
   useEffect(() => {
     tippyFunc('.code-annotation.with-tooltip', {
-      allowHTML: true,
+      allowHTML: false,
       theme: 'expo',
       placement: 'top',
       arrow: roundArrow,
@@ -80,7 +80,7 @@ export function Code({ className, children, title }: CodeProps) {
     });
 
     tippyFunc('.tutorial-code-annotation.with-tooltip', {
-      allowHTML: true,
+      allowHTML: false,
       theme: 'expo',
       placement: 'top',
       arrow: roundArrow,

--- a/docs/components/base/code.tsx
+++ b/docs/components/base/code.tsx
@@ -27,6 +27,30 @@ import { TextTheme } from '~/ui/components/Text/types';
 const { default: testTippy } = tippy;
 const tippyFunc = testTippy ?? tippy;
 
+// Builds a tooltip DOM tree from the annotation's data-tippy-content attribute.
+// Recognizes `code` -> <code> and **bold** -> <strong>.
+function buildTooltipContent(raw: string): HTMLSpanElement {
+  const wrapper = document.createElement('span');
+  const parts = raw.split(/(`[^`]+`|\*\*[^*]+\*\*)/);
+  for (const part of parts) {
+    if (!part) {
+      continue;
+    }
+    if (part.startsWith('`') && part.endsWith('`')) {
+      const code = document.createElement('code');
+      code.textContent = part.slice(1, -1);
+      wrapper.appendChild(code);
+    } else if (part.startsWith('**') && part.endsWith('**')) {
+      const strong = document.createElement('strong');
+      strong.textContent = part.slice(2, -2);
+      wrapper.appendChild(strong);
+    } else {
+      wrapper.appendChild(document.createTextNode(part));
+    }
+  }
+  return wrapper;
+}
+
 const attributes = {
   'data-text': true,
 };
@@ -71,6 +95,9 @@ export function Code({ className, children, title }: CodeProps) {
   useEffect(() => {
     tippyFunc('.code-annotation.with-tooltip', {
       allowHTML: false,
+      ignoreAttributes: true,
+      content: (reference: Element) =>
+        buildTooltipContent(reference.getAttribute('data-tippy-content') ?? ''),
       theme: 'expo',
       placement: 'top',
       arrow: roundArrow,
@@ -81,6 +108,9 @@ export function Code({ className, children, title }: CodeProps) {
 
     tippyFunc('.tutorial-code-annotation.with-tooltip', {
       allowHTML: false,
+      ignoreAttributes: true,
+      content: (reference: Element) =>
+        buildTooltipContent(reference.getAttribute('data-tippy-content') ?? ''),
       theme: 'expo',
       placement: 'top',
       arrow: roundArrow,

--- a/docs/pages/build-reference/app-versions.mdx
+++ b/docs/pages/build-reference/app-versions.mdx
@@ -52,7 +52,7 @@ EAS servers can store and manage your app's developer-facing build version (`and
 ```json eas.json
 {
   "cli": {
-    /* @info The app version source is set to <CODE>remote</CODE> to store and manage the version of your app. */
+    /* @info The app version source is set to `remote` to store and manage the version of your app. */
     "appVersionSource": "remote"
     /* @end */
   },
@@ -66,7 +66,7 @@ EAS servers can store and manage your app's developer-facing build version (`and
       /* @end */
     },
     "production": {
-      /* @info The <CODE>autoIncrement</CODE> property is set to <CODE>true</CODE> to automatically increment the <CODE>android.versionCode</CODE> and <CODE>ios.buildNumber</CODE> values. */
+      /* @info The `autoIncrement` property is set to `true` to automatically increment the `android.versionCode` and `ios.buildNumber` values. */
       "autoIncrement": true
       /* @end */
     }
@@ -120,7 +120,7 @@ With this setup, EAS reads app version values and builds projects as they are. I
 ```json eas.json
 {
   "cli": {
-    /* @info The app version source is set to <CODE>local</CODE> for you to manage the version of your app manually. */
+    /* @info The app version source is set to `local` for you to manage the version of your app manually. */
     "appVersionSource": "local"
     /* @end */
   },
@@ -134,7 +134,7 @@ With this setup, EAS reads app version values and builds projects as they are. I
       /* @end */
     },
     "production": {
-      /* @info The <CODE>autoIncrement</CODE> property is set to <CODE>true</CODE> to automatically increment the <CODE>android.versionCode</CODE> and <CODE>ios.buildNumber</CODE> values. */
+      /* @info The `autoIncrement` property is set to `true` to automatically increment the `android.versionCode` and `ios.buildNumber` values. */
       "autoIncrement": true
       /* @end */
     }

--- a/docs/pages/config-plugins/development-and-debugging.mdx
+++ b/docs/pages/config-plugins/development-and-debugging.mdx
@@ -131,7 +131,7 @@ Packages should attempt to use the built-in **AndroidManifest.xml** [merging sys
 Here is an example of a package's **AndroidManifest.xml**, which injects a required permission:
 
 ```xml AndroidManifest.xml
-<!-- @info Include <code>xmlns:android="..."</code> to use <code>android:*</code> properties like <code>android:name</code> in your manifest. -->
+<!-- @info Include `xmlns:android="..."` to use `android:*` properties like `android:name` in your manifest. -->
 <manifest package="expo.modules.filesystem" xmlns:android="http://schemas.android.com/apk/res/android">
   <!-- @end -->
   <uses-permission android:name="android.permission.INTERNET"/>
@@ -441,7 +441,7 @@ Instead of modifying them directly with the `withProjectBuildGradle`, `withAppBu
 The `gradle.properties` is a static key/value pair that groovy files can read from. For example, say you wanted to control some toggle in Groovy:
 
 ```properties gradle.properties
-# @info Safely modified using the <code>withGradleProperties()</code> mod. #
+# @info Safely modified using the `withGradleProperties()` mod. #
 expo.react.jsEngine=hermes
 # @end #
 ```
@@ -449,7 +449,7 @@ expo.react.jsEngine=hermes
 Then later in a Gradle file:
 
 ```groovy app/build.gradle
-project.ext.react = [/* @info This code would be added to the template ahead of time, but it could be regexed in using <code>withAppBuildGradle()</code> */ enableHermes: findProperty('expo.react.jsEngine') ?: 'jsc' /* @end */]
+project.ext.react = [/* @info This code would be added to the template ahead of time, but it could be regexed in using `withAppBuildGradle()` */ enableHermes: findProperty('expo.react.jsEngine') ?: 'jsc' /* @end */]
 ```
 
 - For keys in the `gradle.properties`, use camel case separated by `.`s, and usually starting with the `expo` prefix to denote that the property is managed by prebuild.

--- a/docs/pages/config-plugins/mods.mdx
+++ b/docs/pages/config-plugins/mods.mdx
@@ -132,7 +132,7 @@ const withCustomProductName: ConfigPlugin<string> = (config, customName) => {
   return withXcodeProject(
     config,
     async (
-      /* @info <CODE>{ modResults, modRequest }</CODE> */ config
+      /* @info `{ modResults, modRequest }` */ config
       /* @end */
     ) => {
       config.modResults = IOSConfig.Name.setProductName({ name: customName }, config.modResults);

--- a/docs/pages/config-plugins/plugins.mdx
+++ b/docs/pages/config-plugins/plugins.mdx
@@ -224,7 +224,7 @@ type AndroidProps = {
 
 const withAndroidPlugin: ConfigPlugin<AndroidProps> = (
   config,
-  /* @info Pass an <code>options</code> object to the plugin. */ options = {}/* @end */
+  /* @info Pass an `options` object to the plugin. */ options = {}/* @end */
 ) => {
   /* @info Use the provided message or fall back to a default */
   const message = options.message || 'Hello world, from Expo plugin!';
@@ -249,7 +249,7 @@ type IosProps = {
   message?: string;
 };
 
-const withIosPlugin: ConfigPlugin<IosProps> = (config, /* @info Pass an <code>options</code> object to the plugin. */ options = {}/* @end */) => {
+const withIosPlugin: ConfigPlugin<IosProps> = (config, /* @info Pass an `options` object to the plugin. */ options = {}/* @end */) => {
    /* @info Use the provided message or fall back to a default */
   const message = options.message || 'Hello world, from Expo plugin!';
   /* @end */

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -173,7 +173,7 @@ import { StyleSheet, Text, View } from 'react-native';
 export const CustomText = ({ children }: PropsWithChildren) => <Text>{children}</Text>;
 /* @end */
 
-/* @info This component currently renders a welcome message on the app screen using the <CODE>CustomText</CODE> component. */
+/* @info This component currently renders a welcome message on the app screen using the `CustomText` component. */
 export default function HomeScreen() {
   return (
     <View style={styles.container}>

--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -60,7 +60,7 @@ Ensure that the `uiMode` flag is present on your `MainActivity` (and any other a
 Implement the `onConfigurationChanged` method in **MainActivity.java**:
 
 ```java
-/* @info Import the <CODE>Intent</CODE> and <CODE>Configuration</CODE> classes. */
+/* @info Import the `Intent` and `Configuration` classes. */
 import android.content.Intent;
 import android.content.res.Configuration;
 /* @end */
@@ -124,7 +124,7 @@ In some cases, you will find it helpful to get the current color scheme imperati
 
 {/* prettier-ignore */}
 ```tsx
-import { Text, StyleSheet, View, /* @info Import <CODE>useColorScheme</CODE> from react-native */ useColorScheme /* @end */ } from 'react-native';
+import { Text, StyleSheet, View, /* @info Import `useColorScheme` from react-native */ useColorScheme /* @end */ } from 'react-native';
 /* @info Automatically switches bar style based on theme. */
 import { StatusBar } from 'expo-status-bar';
 /* @end */

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -190,16 +190,16 @@ The [`expo-splash-screen`](/versions/latest/sdk/splash-screen/) library provides
 Map the font file using the `useFonts` hook in a top-level component such as the root layout (**src/app/\_layout.tsx**) file in your project:
 
 ```tsx src/app/_layout.tsx
-/* @info Import <CODE>useFonts</CODE> hook from <CODE>expo-font</CODE>. */ import { useFonts } from 'expo-font'; /* @end */
-/* @info Import <CODE>SplashScreen</CODE> so that when the fonts are not loaded, we can continue to show <CODE>SplashScreen</CODE>. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
+/* @info Import `useFonts` hook from `expo-font`. */ import { useFonts } from 'expo-font'; /* @end */
+/* @info Import `SplashScreen` so that when the fonts are not loaded, we can continue to show `SplashScreen`. */ import * as SplashScreen from 'expo-splash-screen'; /* @end */
 import {useEffect} from 'react';
 
-/* @info This prevents <CODE>SplashScreen</CODE> from auto hiding while the fonts are in loading state. */
+/* @info This prevents `SplashScreen` from auto hiding while the fonts are in loading state. */
 SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function RootLayout() {
-  /* @info Map the font file using <CODE>useFonts</CODE> hook. */
+  /* @info Map the font file using `useFonts` hook. */
   const [loaded, error] = useFonts({
     'Inter-Black': require('./assets/fonts/Inter-Black.otf'),
   });
@@ -325,20 +325,20 @@ After installing the font package, map the font using the `useFonts` hook in a t
 
 ```tsx src/app/_layout.tsx
 // Rest of the import statements
-/* @info Import <CODE>Inter_900Black</CODE> and <CODE>useFonts</CODE> hook from <CODE>@expo-google-fonts/inter</CODE>*/
+/* @info Import `Inter_900Black` and `useFonts` hook from `@expo-google-fonts/inter`*/
 import { Inter_900Black, useFonts } from '@expo-google-fonts/inter';
 /* @end */
-/* @info Import <CODE>SplashScreen</CODE> so that when the fonts are not loaded, we can continue to show <CODE>SplashScreen</CODE>. */
+/* @info Import `SplashScreen` so that when the fonts are not loaded, we can continue to show `SplashScreen`. */
 import * as SplashScreen from 'expo-splash-screen';
 /* @end */
 import {useEffect} from 'react';
 
-/* @info This prevents <CODE>SplashScreen</CODE> from auto hiding while the fonts are in loading state. */
+/* @info This prevents `SplashScreen` from auto hiding while the fonts are in loading state. */
 SplashScreen.preventAutoHideAsync();
 /* @end */
 
 export default function RootLayout() {
-  /* @info Map the font file using <CODE>useFonts</CODE> hook. */
+  /* @info Map the font file using `useFonts` hook. */
   const [loaded, error] = useFonts({
     Inter_900Black,
   });

--- a/docs/pages/eas/environment-variables/manage.mdx
+++ b/docs/pages/eas/environment-variables/manage.mdx
@@ -124,18 +124,18 @@ const getAppName = () => {
 };
 
 export default {
-  /* @info Using <CODE>getAppName()</CODE> for "name" property */
+  /* @info Using `getAppName()` for "name" property */
   name: getAppName(),
   /* @end */
   /* @hide ... */ /* @end */
   ios: {
-    /* @info Using <CODE>getUniqueIdentifier()</CODE> for "bundleIdentifier" property */
+    /* @info Using `getUniqueIdentifier()` for "bundleIdentifier" property */
     bundleIdentifier: getUniqueIdentifier(),
     /* @end */
     /* @hide ... */ /* @end */
   },
   android: {
-    /* @info Using <CODE>getUniqueIdentifier()</CODE> for "package" property */
+    /* @info Using `getUniqueIdentifier()` for "package" property */
     package: getUniqueIdentifier(),
     /* @end */
     /* @hide ... */ /* @end */

--- a/docs/pages/eas/environment-variables/usage.mdx
+++ b/docs/pages/eas/environment-variables/usage.mdx
@@ -17,25 +17,25 @@ To have full control over the environments used for your builds, you can specify
 {
   "build": {
     "development": {
-      /* @info Using <CODE>development</CODE> environment */
+      /* @info Using `development` environment */
       "environment": "development"
       /* @end */
       /* @hide ... */ /* @end */
     },
     "preview": {
-      /* @info Using <CODE>preview</CODE> environment */
+      /* @info Using `preview` environment */
       "environment": "preview"
       /* @end */
       /* @hide ... */ /* @end */
     },
     "production": {
-      /* @info Using <CODE>production</CODE> environment */
+      /* @info Using `production` environment */
       "environment": "production"
       /* @end */
       /* @hide ... */ /* @end */
     },
     "my-profile": {
-      /* @info Using <CODE>production</CODE> environment */
+      /* @info Using `production` environment */
       "environment": "production"
       /* @end */
       /* @hide ... */ /* @end */

--- a/docs/pages/guides/authentication.mdx
+++ b/docs/pages/guides/authentication.mdx
@@ -51,7 +51,7 @@ import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
 
-/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+/* @info **Web only:** This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
@@ -68,7 +68,7 @@ export default function App() {
       clientId: 'CLIENT_ID',
       scopes: ['identity'],
       redirectUri: makeRedirectUri({
-        /* @info The URI <code>[scheme]://</code> to be used. If undefined, the <code>scheme</code> property of your app.json or app.config.js will be used instead. */
+        /* @info The URI `[scheme]://` to be used. If undefined, the `scheme` property of your app.json or app.config.js will be used instead. */
         scheme: 'your.app'
         /* @end */
       }),
@@ -121,7 +121,7 @@ import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, useAutoDiscovery } from 'expo-auth-session';
 import { Button, Platform } from 'react-native';
 
-/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+/* @info **Web only:** This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
@@ -211,12 +211,12 @@ import * as WebBrowser from 'expo-web-browser';
 
 function App() {
   useEffect(() => {
-    /* @info <strong>Android only:</strong> Start loading the default browser app in the background to improve transition time. */
+    /* @info **Android only:** Start loading the default browser app in the background to improve transition time. */
     WebBrowser.warmUpAsync();
     /* @end */
 
     return () => {
-      /* @info <strong>Android only:</strong> Cool down the browser when the component unmounts to help improve memory on low-end Android devices. */
+      /* @info **Android only:** Cool down the browser when the component unmounts to help improve memory on low-end Android devices. */
       WebBrowser.coolDownAsync();
       /* @end */
     };
@@ -238,7 +238,7 @@ import { useEffect } from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, useAuthRequest, ResponseType } from 'expo-auth-session';
 
-/* @info <strong>Web only:</strong> This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
+/* @info **Web only:** This method should be invoked on the page that the auth popup gets redirected to on web, it'll ensure that authentication is completed properly. On native this does nothing. */
 WebBrowser.maybeCompleteAuthSession();
 /* @end */
 
@@ -250,13 +250,13 @@ const discovery = {
 function App() {
   const [request, response, promptAsync] = useAuthRequest(
     {
-      /* @info Request that the server returns an <code>access_token</code>, not all providers support this. */
+      /* @info Request that the server returns an `access_token`, not all providers support this. */
       responseType: ResponseType.Token,
       /* @end */
       clientId: 'CLIENT_ID',
       scopes: ['user-read-email', 'playlist-modify-public'],
       redirectUri: makeRedirectUri({
-        /* @info The URI <code>[scheme]://</code> to be used. If undefined, the <code>scheme</code> property of your app.json or app.config.js will be used instead. */
+        /* @info The URI `[scheme]://` to be used. If undefined, the `scheme` property of your app.json or app.config.js will be used instead. */
         scheme: 'your.app'
         /* @end */
       }),

--- a/docs/pages/guides/icons.mdx
+++ b/docs/pages/guides/icons.mdx
@@ -103,11 +103,10 @@ export default function App() {
   });
   /* @end */
 
-  /* @info See <a href="/develop/user-interface/fonts/#wait-for-fonts-to-load"> Waiting for fonts to Load section</a> for more information on how to display a splash screen when fonts are loaded. */
+  // See the "Waiting for fonts to load" section at /develop/user-interface/fonts/#wait-for-fonts-to-load for more information on how to display a splash screen when fonts are loaded.
   if (!fontsLoaded) {
     return null;
   }
-  /* @end */
 
   return (
     <View style={styles.container}>

--- a/docs/pages/guides/using-bun.mdx
+++ b/docs/pages/guides/using-bun.mdx
@@ -47,7 +47,7 @@ To use an [exact version of Bun](/eas/json/#bun) with EAS, add the version numbe
 {
   "build": {
     "development": {
-      /* @info Use <CODE>bun</CODE> property in eas.json to specify the exact version.*/
+      /* @info Use `bun` property in eas.json to specify the exact version.*/
       "bun": "1.0.0"
       /* @end */
       /* @hide ... */ /* @end */

--- a/docs/pages/guides/using-eslint.mdx
+++ b/docs/pages/guides/using-eslint.mdx
@@ -207,7 +207,7 @@ If you're using VS Code, install the [ESLint extension](https://marketplace.visu
 ESLint can be slow to run on large projects. The easiest way to speed up the process is to lint fewer files. Add a **.eslintignore** file to your project root to ignore certain files and directories such as:
 
 ```sh .eslintignore
-# @info Ignore the root <b>.expo</b> directory. #
+# @info Ignore the root **.expo** directory. #
 /.expo
 # @end #
 node_modules

--- a/docs/pages/linking/android-app-links.mdx
+++ b/docs/pages/linking/android-app-links.mdx
@@ -34,7 +34,7 @@ The following example shows a basic configuration that enables your app to appea
       "intentFilters": [
         {
           "action": "VIEW",
-          /* @info Add the <CODE>autoVerify</CODE> property to the intent filter in app config to enable app links.*/
+          /* @info Add the `autoVerify` property to the intent filter in app config to enable app links.*/
           "autoVerify": true,
           /* @end */
           "data": [
@@ -104,12 +104,12 @@ Add `package_name` and `sha256_cert_fingerprints` to the **assetlinks.json** fil
     "relation": ["delegate_permission/common.handle_all_urls"],
     "target": {
       "namespace": "android_app",
-      /* @info Replace <CODE>com.example</CODE> with your app's package name. */
+      /* @info Replace `com.example` with your app's package name. */
       "package_name": "com.example",
       /* @end */
       "sha256_cert_fingerprints": [
         // Supports multiple fingerprints for different apps and keys
-        /* @info Replace <CODE>14:6D:E9:83...</CODE> with your app's SHA256 certificate fingerprint. */
+        /* @info Replace `14:6D:E9:83...` with your app's SHA256 certificate fingerprint. */
         "14:6D:E9:83:51:7F:66:01:84:93:4F:2F:5E:E0:8F:3A:D6:F4:CA:41:1A:CF:45:BF:8D:10:76:76:CD"
         /* @end */
       ]

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -18,7 +18,7 @@ To provide a link to your app, add a custom string to the [`scheme`](/versions/l
 ```json app.json
 {
   "expo": {
-    /* @info <CODE>scheme</CODE> property allows you to add a custom scheme to your app. */
+    /* @info `scheme` property allows you to add a custom scheme to your app. */
     "scheme": "myapp"
     /* @end */
   }

--- a/docs/pages/linking/ios-universal-links.mdx
+++ b/docs/pages/linking/ios-universal-links.mdx
@@ -41,11 +41,11 @@ If you're using Expo Router to build your website (or any other modern React fra
     "details": [
       {
         // Syntax: "<APPLE_TEAM_ID>.<BUNDLE_ID>"
-        /* @info Replace <CODE>QQ57RJ5UTD.com.example.myapp</CODE> with your own Apple Team ID and bundle identifier. */
+        /* @info Replace `QQ57RJ5UTD.com.example.myapp` with your own Apple Team ID and bundle identifier. */
         "appID": "QQ57RJ5UTD.com.example.myapp",
         /* @end */
         // All paths that should support redirecting.
-        /* @info Replace <CODE>/records/*</CODE> with your own path. */
+        /* @info Replace `/records/*` with your own path. */
         "paths": ["/records/*"]
         /* @end */
       }

--- a/docs/pages/router/advanced/custom-tabs.mdx
+++ b/docs/pages/router/advanced/custom-tabs.mdx
@@ -114,7 +114,7 @@ The `TabSlot` component renders the current route. `TabSlot` can be nested insid
     </TabTrigger>
   </TabList>
   {/* Customize how `<TabSlot />` is rendered. */}
-  /* @info <CODE>TabSlot</CODE> can be nested inside custom components. */
+  /* @info `TabSlot` can be nested inside custom components. */
   <View>
     <View>
       <TabSlot />
@@ -153,7 +153,7 @@ If you need to change the structure of a component, you can override its underly
 ```tsx Custom TabList
 <Tabs>
   <TabSlot />
-  /* @info Change the appearance of the <CODE>TabList</CODE>. */
+  /* @info Change the appearance of the `TabList`. */
   <TabList asChild>
     {/* Render a custom TabList */}
     <CustomTabList>
@@ -170,7 +170,7 @@ If you need to change the structure of a component, you can override its underly
 <Tabs>
   <TabSlot />
   <TabList asChild>
-    /* @info Change the appearance of the <CODE>TabTrigger</CODE>. */
+    /* @info Change the appearance of the `TabTrigger`. */
     <TabTrigger name="home" href="/" asChild>
       {/* Render a custom button */}
       <CustomButton>
@@ -192,7 +192,7 @@ The `TabList` is both the configuration and default appearance of the `Tabs`, bu
   <TabSlot />
   {/* A custom tab bar */}
   <View>
-    /* @info A custom tab bar. <CODE>TabTrigger</CODE>'s outside of TabList do not need the <CODE>href</CODE> prop. */
+    /* @info A custom tab bar. `TabTrigger`'s outside of TabList do not need the `href` prop. */
     <View>
       <TabTrigger name="home">
         <Text>Home</Text>
@@ -203,7 +203,7 @@ The `TabList` is both the configuration and default appearance of the `Tabs`, bu
     </View>
     /* @end */
   </View>
-  /* @info <CODE>TabList</CODE> needs to be rendered, but not necessary displayed. */
+  /* @info `TabList` needs to be rendered, but not necessary displayed. */
   <TabList style={{ display: 'none' }}>
     /* @end */
     <TabTrigger name="home" href="/">

--- a/docs/pages/router/advanced/modals.mdx
+++ b/docs/pages/router/advanced/modals.mdx
@@ -61,7 +61,7 @@ export default function Layout() {
       <Stack.Screen
         name="modal"
         options={{
-          /* @info Set the <CODE>presentation</CODE> mode to <CODE>modal</CODE> for the modal route. */
+          /* @info Set the `presentation` mode to `modal` for the modal route. */
           presentation: 'modal',
           /* @end */
         }}
@@ -82,7 +82,7 @@ export default function Home() {
   return (
     <View style={styles.container}>
       <Text>Home screen</Text>
-      /* @info Use the <CODE>Link</CODE> component to navigate to the modal screen. The <CODE>href</CODE> prop is the route name of the modal screen. */
+      /* @info Use the `Link` component to navigate to the modal screen. The `href` prop is the route name of the modal screen. */
       <Link href="/modal" style={styles.link}>
         Open modal
       </Link>
@@ -136,18 +136,18 @@ A modal loses its previous context when it is the current screen in the navigato
 
 {/* prettier-ignore */}
 ```tsx src/app/modal.tsx
-import { Link, /* @info Import the <CODE>router</CODE> object which is used to navigate imperatively. */ router /* @end */} from 'expo-router';
+import { Link, /* @info Import the `router` object which is used to navigate imperatively. */ router /* @end */} from 'expo-router';
 import { StyleSheet, Text, View } from 'react-native';
 
 export default function Modal() {
-  /* @info Use <CODE>router.canGoBack()</CODE> to check if the modal is presented as a standalone screen. If the screen was reloaded or navigated to directly, then the modal should be presented as a full screen. You may need to change the UI to account for this. */
+  /* @info Use `router.canGoBack()` to check if the modal is presented as a standalone screen. If the screen was reloaded or navigated to directly, then the modal should be presented as a full screen. You may need to change the UI to account for this. */
   const isPresented = router.canGoBack();
   /* @end */
 
   return (
     <View style={styles.container}>
       <Text>Modal screen</Text>
-      /* @info On web, use <CODE>../</CODE> as a simple way to navigate to the root. This is not analogous to <CODE>goBack</CODE>.*/
+      /* @info On web, use `../` as a simple way to navigate to the root. This is not analogous to `goBack`.*/
       {isPresented && <Link href="../">Dismiss modal</Link>}
       /* @end */
     </View>
@@ -176,7 +176,7 @@ export default function Modal() {
   return (
     <View style={styles.container}>
       <Text>Modal screen</Text>
-      /* @info Use <CODE>Platform.OS</CODE> to check if the current platform is iOS and then use <CODE>StatusBar</CODE> component to change the appearance. */
+      /* @info Use `Platform.OS` to check if the current platform is iOS and then use `StatusBar` component to change the appearance. */
       <StatusBar style={Platform.OS === 'ios' ? 'light' : 'auto'} />
       /* @end */
     </View>
@@ -226,7 +226,7 @@ export default function Layout() {
       <Stack.Screen
         name="modal"
         options={{
-          /* @info Set the <CODE>presentation</CODE> mode to <CODE>formSheet</CODE>. */
+          /* @info Set the `presentation` mode to `formSheet`. */
           presentation: 'formSheet',
           /* @end */
         }}
@@ -352,7 +352,7 @@ import { StyleSheet, Text, View } from 'react-native';
 
 export default function Modal() {
   return (
-    /* @info Using <CODE>flex: 1</CODE> fills the available space within the sheet. */
+    /* @info Using `flex: 1` fills the available space within the sheet. */
     <View style={styles.container}>
       /* @end */
       <Text>Modal content</Text>

--- a/docs/pages/router/advanced/stack.mdx
+++ b/docs/pages/router/advanced/stack.mdx
@@ -58,7 +58,7 @@ import { Stack } from 'expo-router';
 export default function Layout() {
   return (
     <Stack
-      /* @info <A href="https://reactnavigation.org/docs/headers/#sharing-common-options-across-screens">Click for more information on available <CODE>screenOptions</CODE> from React Navigation documentation</A>.*/
+      // See React Navigation documentation for more information on available screenOptions: https://reactnavigation.org/docs/headers/#sharing-common-options-across-screens
       screenOptions={{
         headerStyle: {
           backgroundColor: '#f4511e',
@@ -68,7 +68,6 @@ export default function Layout() {
           fontWeight: 'bold',
         },
       }}>
-      /* @end */
       {/* Optionally configure static options outside the route.*/}
       <Stack.Screen name="home" options={{}} />
     </Stack>
@@ -343,17 +342,17 @@ Dismiss is different from `back` as it targets the closest stack and not the cur
 {/* prettier-ignore */}
 ```tsx src/app/settings.tsx
 import { Button, View } from 'react-native';
-/* @info Import <CODE>useRouter</CODE> from Expo Router. */
+/* @info Import `useRouter` from Expo Router. */
 import { useRouter } from 'expo-router';
 /* @end */
 
 export default function Settings() {
-  /* @info Access the router from the <CODE>useRouter</CODE> hook. */
+  /* @info Access the router from the `useRouter` hook. */
   const router = useRouter();
   /* @end */
 
   const handleDismiss = (count: number) => {
-    /* @info In the handler method, call <CODE>router.dismiss</CODE> to go back. */
+    /* @info In the handler method, call `router.dismiss` to go back. */
     router.dismiss(count)
     /* @end */
   };
@@ -379,17 +378,17 @@ For example, consider the history of `/one`, `/two`, `/three` routes, where `/th
 {/* prettier-ignore */}
 ```tsx src/app/settings.tsx
 import { Button, View, Text } from 'react-native';
-/* @info Import <CODE>useRouter</CODE> from Expo Router. */
+/* @info Import `useRouter` from Expo Router. */
 import { useRouter } from 'expo-router';
 /* @end */
 
 export default function Settings() {
-  /* @info Access the router from the <CODE>useRouter</CODE> hook. */
+  /* @info Access the router from the `useRouter` hook. */
   const router = useRouter();
   /* @end */
 
   const handleDismissAll = () => {
-    /* @info In the handler method, call <CODE>router.dismissTo</CODE> to go back to a specific route. */
+    /* @info In the handler method, call `router.dismissTo` to go back to a specific route. */
     router.dismissTo('/')
     /* @end */
   };
@@ -413,17 +412,17 @@ For example, the `home` route is the first screen, and the `settings` is the las
 {/* prettier-ignore */}
 ```tsx src/app/settings.tsx
 import { Button, View, Text } from 'react-native';
-/* @info Import <CODE>useRouter</CODE> from Expo Router. */
+/* @info Import `useRouter` from Expo Router. */
 import { useRouter } from 'expo-router';
 /* @end */
 
 export default function Settings() {
-  /* @info Access the router from the <CODE>useRouter</CODE> hook. */
+  /* @info Access the router from the `useRouter` hook. */
   const router = useRouter();
   /* @end */
 
   const handleDismissAll = () => {
-    /* @info In the handler method, call <CODE>router.dismissAll</CODE> to go back to the first screen in a stack. */
+    /* @info In the handler method, call `router.dismissAll` to go back to the first screen in a stack. */
     router.dismissAll()
     /* @end */
   };
@@ -445,19 +444,19 @@ To check if it is possible to dismiss the current screen. Returns `true` if the 
 {/* prettier-ignore */}
 ```tsx src/app/settings.tsx|collapseHeight=410
 import { Button, View } from 'react-native';
-/* @info Import <CODE>useRouter</CODE> from Expo Router. */
+/* @info Import `useRouter` from Expo Router. */
 import { useRouter } from 'expo-router';
 /* @end */
 
 export default function Settings() {
-  /* @info Access the router from <CODE>useRouter</CODE> hook. */
+  /* @info Access the router from `useRouter` hook. */
   const router = useRouter();
   /* @end */
 
   const handleDismiss = (count: number) => {
     /* @info Check if we can dismiss. */
     if (router.canDismiss()) {
-      /* @info In the handler method, call <CODE>router.dismiss</CODE> to go back to. */
+      /* @info In the handler method, call `router.dismiss` to go back to. */
       router.dismiss(count)
       /* @end */
     }

--- a/docs/pages/router/advanced/tabs.mdx
+++ b/docs/pages/router/advanced/tabs.mdx
@@ -183,7 +183,7 @@ export default function TabLayout() {
       <Tabs.Screen
         name="index"
         options={{
-          /* @info Adding <CODE>href: null</CODE> in this tab's <CODE>options</CODE> will not show this tab in the tab bar.*/
+          /* @info Adding `href: null` in this tab's `options` will not show this tab in the tab bar.*/
           href: null,
           /* @end */
         }}

--- a/docs/pages/router/advanced/web-modals.mdx
+++ b/docs/pages/router/advanced/web-modals.mdx
@@ -459,7 +459,7 @@ Modify your project's root layout (**src/app/\_layout.tsx**) to add an `options`
 ```tsx src/app/_layout.tsx
 import { Stack } from 'expo-router';
 
-/* @info <CODE>unstable_settings</CODE> can be set in any stack's <CODE>_layout.tsx</CODE> file. It is used to define the initial route name for the stack, which ensures that users have a consistent starting point, especially when deep linking. */
+/* @info `unstable_settings` can be set in any stack's `_layout.tsx` file. It is used to define the initial route name for the stack, which ensures that users have a consistent starting point, especially when deep linking. */
 export const unstable_settings = {
   initialRouteName: 'index',
 };
@@ -472,10 +472,10 @@ export default function Layout() {
       <Stack.Screen
         name="modal"
         options={{
-          /* @info Set the <CODE>presentation</CODE> mode to <CODE>transparentModal</CODE> for the modal route.*/
+          /* @info Set the `presentation` mode to `transparentModal` for the modal route.*/
           presentation: 'transparentModal',
           /* @end */
-          /* @info (Optional) Set the <CODE>animation</CODE> to <CODE>fade</CODE>.*/
+          /* @info (Optional) Set the `animation` to `fade`.*/
           animation: 'fade',
           /* @end */
           /* @info Prevents showing the header. Useful for the behavior of web modals.*/

--- a/docs/pages/router/basics/common-navigation-patterns.mdx
+++ b/docs/pages/router/basics/common-navigation-patterns.mdx
@@ -54,7 +54,7 @@ In the **src/app/(tabs)/feed/\_layout.tsx** file, return a `Stack` component:
 ```tsx src/app/(tabs)/feed/_layout.tsx
 import { Stack } from 'expo-router';
 
-/* @info Setting <CODE>initialRouteName</CODE> ensures that direct links deep into the stack still push the index route onto the stack first. */
+/* @info Setting `initialRouteName` ensures that direct links deep into the stack still push the index route onto the stack first. */
 export const unstable_settings = {
   initialRouteName: 'index',
 };

--- a/docs/pages/router/basics/navigation.mdx
+++ b/docs/pages/router/basics/navigation.mdx
@@ -55,14 +55,14 @@ The typical way to link to a page in Expo Router is to use links like web apps. 
 {/* prettier-ignore */}
 ```tsx src/app/index.tsx
 import { View } from 'react-native';
-/* @info Import the <CODE>Link</CODE> React component from <CODE>expo-router</CODE>. */
+/* @info Import the `Link` React component from `expo-router`. */
 import { Link } from 'expo-router';
 /* @end */
 
 export default function Page() {
   return (
     <View>
-      /* @info Tapping this will link to the <strong>about</strong> page. */
+      /* @info Tapping this will link to the **about** page. */
       <Link href="/about">About</Link>
       /* @end */
     </View>
@@ -79,7 +79,7 @@ import { Link } from 'expo-router';
 
 export default function Page() {
   return (
-    /* @info The <CODE>onPress</CODE> event that navigates to <CODE>/other</CODE> will be passed to <CODE>Pressable</CODE>. */
+    /* @info The `onPress` event that navigates to `/other` will be passed to `Pressable`. */
     <Link href="/other" asChild>
     /* @end */
       <Pressable>
@@ -138,7 +138,7 @@ Each of these links will navigate to the same page:
 
 {/* prettier-ignore */}
 ```tsx src/app/index.tsx
-/* @info Import the <CODE>Link</CODE> React component and <CODE>router</CODE> to navigate imperatively from <CODE>expo-router</CODE>. */
+/* @info Import the `Link` React component and `router` to navigate imperatively from `expo-router`. */
 import { Link, router } from 'expo-router';
 /* @end */
 import { View, Pressable, Text } from 'react-native';

--- a/docs/pages/router/migrate/from-react-navigation.mdx
+++ b/docs/pages/router/migrate/from-react-navigation.mdx
@@ -419,7 +419,7 @@ function Header() {;
       <Link href="/">Home</Link>
       <Link
         href="/profile"
-        style={/* @info Use <code>pathname</code> to determine if the link is active. */[pathname === '/profile' && { color: 'blue' }]/* @end */}>
+        style={/* @info Use `pathname` to determine if the link is active. */[pathname === '/profile' && { color: 'blue' }]/* @end */}>
         Profile
       </Link>
       <Link href="/settings">Settings</Link>

--- a/docs/pages/router/reference/url-parameters.mdx
+++ b/docs/pages/router/reference/url-parameters.mdx
@@ -163,7 +163,7 @@ import { useLocalSearchParams } from 'expo-router';
 
 export default function Route() {
   const { everything } = useLocalSearchParams<{
-    /* @info <b>everything</b> will be an array of path segments, even if there's only one */
+    /* @info **everything** will be an array of path segments, even if there's only one */
     everything: string[];
     /* @end */
   }>();
@@ -185,11 +185,11 @@ import { useLocalSearchParams } from 'expo-router';
 
 export default function Route() {
   const { everything } = useLocalSearchParams<{
-    /* @info <b>everything</b> will be an array of path segments, even if there's only one */
+    /* @info **everything** will be an array of path segments, even if there's only one */
     everything: string[];
-    /* @info <b>query</b> is an optional search parameter */
+    /* @info **query** is an optional search parameter */
     query?: string;
-    /* @info <b>query2</b> is an optional search parameter */
+    /* @info **query2** is an optional search parameter */
     query2?: string;
     /* @end */
   }>();
@@ -222,7 +222,7 @@ export default function Page() {
       value={search}
       onChangeText={search => {
         setSearch(search);
-        /* @info Set the search parameter <b>query</b> to the text input <b>search</b> */
+        /* @info Set the search parameter **query** to the text input **search** */
         router.setParams({ query: search });
         /* @end */
       }}

--- a/docs/pages/router/web/api-routes.mdx
+++ b/docs/pages/router/web/api-routes.mdx
@@ -674,7 +674,7 @@ import path from 'node:path';
 import { createRequestHandler } from 'expo-server/adapter/netlify';
 
 export default createRequestHandler({
-  /* @info Points to the root <CODE>dist/</CODE> (output) directory */
+  /* @info Points to the root `dist/` (output) directory */
   build: path.join(__dirname, '../../dist/server'),
   /* @end */
 });
@@ -753,7 +753,7 @@ Create a server entry file. All requests will be delegated through this middlewa
 const { createRequestHandler } = require('expo-server/adapter/vercel');
 
 module.exports = createRequestHandler({
-  /* @info Points to the root <CODE>dist/</CODE> (output) directory */
+  /* @info Points to the root `dist/` (output) directory */
   build: require('path').join(__dirname, '../dist/server'),
   /* @end */
 });

--- a/docs/pages/router/web/static-rendering.mdx
+++ b/docs/pages/router/web/static-rendering.mdx
@@ -99,7 +99,7 @@ export async function generateStaticParams(): Promise<Record<string, string>[]> 
 
 ```tsx src/app/[id]/_layout.tsx
 export async function generateStaticParams(): Promise<Record<string, string>[]> {
-  /* @info Any dynamic children that export <CODE>generateStaticParams</CODE> will be invoked once for every entry in the array. */
+  /* @info Any dynamic children that export `generateStaticParams` will be invoked once for every entry in the array. */
   return [{ id: 'one' }, { id: 'two' }];
   /* @end */
 }

--- a/docs/pages/tutorial/add-navigation.mdx
+++ b/docs/pages/tutorial/add-navigation.mdx
@@ -73,7 +73,7 @@ import { Stack } from 'expo-router';
 
 export default function RootLayout() {
   return (
-    /* @tutinfo Wrap screens inside <CODE>Stack</CODE> navigator. Add <CODE>options</CODE> prop to <CODE>/index</CODE> route. Add another <CODE>Stack.Screen</CODE> component to add <CODE>/about</CODE> route. */
+    /* @tutinfo Wrap screens inside `Stack` navigator. Add `options` prop to `/index` route. Add another `Stack.Screen` component to add `/about` route. */
     <Stack>
       <Stack.Screen name="index" options={{ title: 'Home' }} />
       <Stack.Screen name="about" options={{ title: 'About' }} />
@@ -104,13 +104,13 @@ We'll use Expo Router's `Link` component to navigate from the `/index` route to 
 {/* prettier-ignore */}
 ```tsx app/index.tsx|collapseHeight=300
 import { Text, View, StyleSheet } from 'react-native';
-/* @tutinfo Import <CODE>Link</CODE> component from <CODE>expo-router</CODE>. */ import { Link } from 'expo-router'; /* @end */
+/* @tutinfo Import `Link` component from `expo-router`. */ import { Link } from 'expo-router'; /* @end */
 
 export default function Index() {
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Home screen</Text>
-      /* @tutinfo Add <CODE>Link</CODE> component after <CODE>Text</CODE> component and pass the <CODE>href</CODE> prop with <CODE>/about</CODE> route. */
+      /* @tutinfo Add `Link` component after `Text` component and pass the `href` prop with `/about` route. */
       <Link href="/about" style={styles.button}>
         Go to About screen
       </Link>
@@ -129,7 +129,7 @@ const styles = StyleSheet.create({
   text: {
     color: '#fff',
   },
-  /* @tutinfo Add the style of <CODE>fontSize</CODE>, <CODE>textDecorationLine</CODE>, and <CODE>color</CODE> to <CODE>Link</CODE> component. */
+  /* @tutinfo Add the style of `fontSize`, `textDecorationLine`, and `color` to `Link` component. */
   button: {
     fontSize: 20,
     textDecorationLine: 'underline',
@@ -163,7 +163,7 @@ import { Link, Stack } from 'expo-router';
 export default function NotFoundScreen() {
   return (
     <>
-      /* @tutinfo Add <CODE>Stack.Screen</CODE> component with <CODE>options</CODE> prop to update the title of <CODE>+not-found</CODE> route. */
+      /* @tutinfo Add `Stack.Screen` component with `options` prop to update the title of `+not-found` route. */
       <Stack.Screen options={{ title: 'Oops! Not Found' }} />
       /* @end */
       <View style={styles.container}>
@@ -239,7 +239,7 @@ import { Stack } from 'expo-router';
 export default function RootLayout() {
   return (
     <Stack>
-      /* @tutinfo This is how a tab navigator is nested inside a stack navigator, especially when the Root layout is composed of a parent stack navigator. We're also setting the <CODE>headerShown</CODE> option to <CODE>false</CODE> to hide the header for the tab navigator. Otherwise, there will be two headers displayed on each screen. */
+      /* @tutinfo This is how a tab navigator is nested inside a stack navigator, especially when the Root layout is composed of a parent stack navigator. We're also setting the `headerShown` option to `false` to hide the header for the tab navigator. Otherwise, there will be two headers displayed on each screen. */
       <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
       /* @end */
     </Stack>
@@ -256,7 +256,7 @@ import { Tabs } from 'expo-router';
 export default function TabLayout() {
   return (
     <Tabs>
-      /* @tutinfo <CODE>Tabs.Screen</CODE> component works in a similar way and accepts same props as <CODE>Stack.Screen</CODE> component. The only difference is the navigation pattern on the device. */
+      /* @tutinfo `Tabs.Screen` component works in a similar way and accepts same props as `Stack.Screen` component. The only difference is the navigation pattern on the device. */
       <Tabs.Screen name="index" options={{ title: 'Home' }} />
       <Tabs.Screen name="about" options={{ title: 'About' }} />
       /* @end */
@@ -290,14 +290,14 @@ Modify the **(tabs)/\_layout.tsx** file to add tab bar icons:
 {/* prettier-ignore */}
 ```tsx app/(tabs)/_layout.tsx
 import { Tabs } from 'expo-router';
-/* @tutinfo Import <CODE>Ionicons</CODE> icon set.*/
+/* @tutinfo Import `Ionicons` icon set.*/
 import Ionicons from '@expo/vector-icons/Ionicons';
 /* @end */
 
 export default function TabLayout() {
   return (
     <Tabs
-      /* @tutinfo There are many <CODE>screenOptions</CODE> we can use to customize the tab bar. We're changing the active tab color here to custom value which we will also use later in our app. */
+      /* @tutinfo There are many `screenOptions` we can use to customize the tab bar. We're changing the active tab color here to custom value which we will also use later in our app. */
       screenOptions={{
         tabBarActiveTintColor: '#ffd33d',
       }}
@@ -308,7 +308,7 @@ export default function TabLayout() {
         options={{
           title: 'Home',
           tabBarIcon: ({ color, focused }) => (
-            /* @tutinfo The <CODE>focused</CODE> param allows us to change a tab's icon and label behavior when it is active and inactive.*/
+            /* @tutinfo The `focused` param allows us to change a tab's icon and label behavior when it is active and inactive.*/
             <Ionicons name={focused ? 'home-sharp' : 'home-outline'} color={color} size={24} />
             /* @end */
           ),

--- a/docs/pages/tutorial/build-a-screen.mdx
+++ b/docs/pages/tutorial/build-a-screen.mdx
@@ -82,16 +82,16 @@ To use the Image component in **app/(tabs)/index.tsx** file:
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=380
 import { View, StyleSheet } from 'react-native';
-/* @tutinfo Import the <CODE>Image</CODE> component. */ import { Image } from 'expo-image'; /* @end */
+/* @tutinfo Import the `Image` component. */ import { Image } from 'expo-image'; /* @end */
 
-/* @tutinfo Import the image from the "assets/images/" directory. Since this picture is a static resource, you have to reference it using <CODE>require</CODE>. */
+/* @tutinfo Import the image from the "assets/images/" directory. Since this picture is a static resource, you have to reference it using `require`. */
 const PlaceholderImage = require('@/assets/images/background-image.png');
 /* @end */
 
 export default function Index() {
   return (
     <View style={styles.container}>
-      /* @tutinfo Wrap the <CODE>Image</CODE> component inside a container. Also, add the image component to display the placeholder image. */
+      /* @tutinfo Wrap the `Image` component inside a container. Also, add the image component to display the placeholder image. */
       <View style={styles.imageContainer}>
         <Image source={PlaceholderImage} style={styles.image} />
       </View>
@@ -104,7 +104,7 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: '#25292e',
-    /* @tutinfo Modify container styles to remove <CODE>justifyContent</CODE> property. */
+    /* @tutinfo Modify container styles to remove `justifyContent` property. */
     alignItems: 'center',
     /* @end */
   },
@@ -170,7 +170,7 @@ export default function Index() {
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>
-        /* @tutinfo Replace <CODE>Image</CODE> component with <CODE>ImageViewer</CODE>. */
+        /* @tutinfo Replace `Image` component with `ImageViewer`. */
         <ImageViewer imgSource={PlaceholderImage} />
         /* @end */
       </View>
@@ -265,7 +265,7 @@ export default function Index() {
       <View style={styles.imageContainer}>
         <ImageViewer imgSource={PlaceholderImage} />
       </View>
-      /* @tutinfo Use the reusable <CODE>Button</CODE> component to create two buttons and encapsulate them inside a <CODE>View</CODE> component. */
+      /* @tutinfo Use the reusable `Button` component to create two buttons and encapsulate them inside a `View` component. */
       <View style={styles.footerContainer}>
         <Button label="Choose a photo" />
         <Button label="Use this photo" />
@@ -324,7 +324,7 @@ type Props = {
   /* @tutinfo Add theme prop. */theme?: 'primary';/* @end */
 };
 
-export default function Button({ label, /* @tutinfo The prop <CODEtheme</CODE> to detect the button variant. */theme/* @end */ }: Props) {
+export default function Button({ label, /* @tutinfo The prop `theme` to detect the button variant. */theme/* @end */ }: Props) {
   /* @tutinfo Conditionally render the primary themed button. */
   if (theme === 'primary') {
   /* @end */
@@ -410,7 +410,7 @@ export default function Index() {
         <ImageViewer imgSource={PlaceholderImage} />
       </View>
       <View style={styles.footerContainer}>
-        /* @tutinfo Add <CODE>"primary"</CODE> theme on the first button. */
+        /* @tutinfo Add `"primary"` theme on the first button. */
         <Button theme="primary" label="Choose a photo" />
         /* @end */
         <Button label="Use this photo" />

--- a/docs/pages/tutorial/create-a-modal.mdx
+++ b/docs/pages/tutorial/create-a-modal.mdx
@@ -46,7 +46,7 @@ const PlaceholderImage = require('@/assets/images/background-image.png');
 
 export default function Index() {
   const [selectedImage, setSelectedImage] = useState<string | undefined>(undefined);
-  /* @tutinfo Create a state variable inside the <CODE>Index</CODE> component. */
+  /* @tutinfo Create a state variable inside the `Index` component. */
   const [showAppOptions, setShowAppOptions] = useState<boolean>(false);
   /* @end */
 
@@ -72,14 +72,14 @@ export default function Index() {
       <View style={styles.imageContainer}>
         <ImageViewer imgSource={PlaceholderImage} selectedImage={selectedImage} />
       </View>
-      /* @tutinfo Based on the value of <CODE>showAppOptions</CODE>, the buttons will be displayed. Also, move the existing buttons in the conditional operator block. */
+      /* @tutinfo Based on the value of `showAppOptions`, the buttons will be displayed. Also, move the existing buttons in the conditional operator block. */
       {showAppOptions ? (
         <View />
       /* @end */
       ) : (
         <View style={styles.footerContainer}>
           <Button theme="primary" label="Choose a photo" onPress={pickImageAsync} />
-          /* @tutinfo Replace the <CODE>alert()</CODE> with the <CODE>onPress</CODE>.*/
+          /* @tutinfo Replace the `alert()` with the `onPress`.*/
           <Button label="Use this photo" onPress={() => setShowAppOptions(true)} />
           /* @end */
         </View>
@@ -110,7 +110,7 @@ Now, we can remove the `alert` on the `Button` component and update the `onPress
 
 {/* prettier-ignore */}
 ```tsx components/Button.tsx
-<Pressable style={styles.button} /* @tutinfo Replace the <CODE>alert()</CODE> with the <CODE>onPress</CODE>.*/ onPress={onPress}/* @end */>
+<Pressable style={styles.button} /* @tutinfo Replace the `alert()` with the `onPress`.*/ onPress={onPress}/* @end */>
 ```
 
 </Step>
@@ -221,7 +221,7 @@ import { useState } from 'react';
 
 import Button from '@/components/Button';
 import ImageViewer from '@/components/ImageViewer';
-/* @tutinfo Import <CODE>IconButton</CODE> and <CODE>CircleButton</CODE> components.*/
+/* @tutinfo Import `IconButton` and `CircleButton` components.*/
 import IconButton from '@/components/IconButton';
 import CircleButton from '@/components/CircleButton';
 /* @end */
@@ -267,7 +267,7 @@ export default function Index() {
         <ImageViewer imgSource={PlaceholderImage} selectedImage={selectedImage} />
       </View>
       {showAppOptions ? (
-        /* @tutinfo Replace empty <CODE>View</CODE> component with this snippet to display App option buttons. */
+        /* @tutinfo Replace empty `View` component with this snippet to display App option buttons. */
         <View style={styles.optionsContainer}>
           <View style={styles.optionsRow}>
             <IconButton icon="refresh" label="Reset" onPress={onReset} />
@@ -299,7 +299,7 @@ const styles = StyleSheet.create({
     flex: 1 / 3,
     alignItems: 'center',
   },
-  /* @tutinfo Add styles for the new <CODE>View</CODE> components. */
+  /* @tutinfo Add styles for the new `View` components. */
   optionsContainer: {
     position: 'absolute',
     bottom: 80,
@@ -414,7 +414,7 @@ import Button from '@/components/Button';
 import ImageViewer from '@/components/ImageViewer';
 import IconButton from '@/components/IconButton';
 import CircleButton from '@/components/CircleButton';
-/* @tutinfo import the <CODE>EmojiPicker</CODE> component. */
+/* @tutinfo import the `EmojiPicker` component. */
 import EmojiPicker from '@/components/EmojiPicker';
 /* @end */
 
@@ -479,7 +479,7 @@ export default function Index() {
           <Button label="Use this photo" onPress={() => setShowAppOptions(true)} />
         </View>
       )}
-      /* @tutinfo Render the <CODE>EmojiPicker</CODE> component at the bottom of the <CODE>Index</CODE> component. */
+      /* @tutinfo Render the `EmojiPicker` component at the bottom of the `Index` component. */
       <EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
         {/* Emoji list component will go here */}
       </EmojiPicker>
@@ -606,7 +606,7 @@ import ImageViewer from '@/components/ImageViewer';
 import IconButton from '@/components/IconButton';
 import CircleButton from '@/components/CircleButton';
 import EmojiPicker from '@/components/EmojiPicker';
-/* @tutinfo Import the <CODE>EmojiList</CODE> component. */
+/* @tutinfo Import the `EmojiList` component. */
 import EmojiList from '@/components/EmojiList';
 /* @end */
 
@@ -671,7 +671,7 @@ export default function Index() {
         </View>
       )}
       <EmojiPicker isVisible={isModalVisible} onClose={onModalClose}>
-        /* @tutinfo Render the <CODE>EmojiList</CODE> component inside the <CODE>EmojiPicker</CODE> component. */
+        /* @tutinfo Render the `EmojiList` component inside the `EmojiPicker` component. */
         <EmojiList onSelect={setPickedEmoji} onCloseModal={onModalClose} />
         /* @end */
       </EmojiPicker>
@@ -758,7 +758,7 @@ import IconButton from '@/components/IconButton';
 import CircleButton from '@/components/CircleButton';
 import EmojiPicker from '@/components/EmojiPicker';
 import EmojiList from '@/components/EmojiList';
-/* @tutinfo Import the <CODE>EmojiSticker</CODE> component. */import EmojiSticker from '@/components/EmojiSticker';/* @end */
+/* @tutinfo Import the `EmojiSticker` component. */import EmojiSticker from '@/components/EmojiSticker';/* @end */
 
 const PlaceholderImage = require('@/assets/images/background-image.png');
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -153,7 +153,7 @@ Let's modify **app/index.tsx** screen:
 
 {/* prettier-ignore */}
 ```tsx app/index.tsx|collapseHeight=340
-import { Text, View, /* @tutinfo Import <CODE>StyleSheet</CODE> to define styles. */ StyleSheet/* @end */ } from 'react-native';
+import { Text, View, /* @tutinfo Import `StyleSheet` to define styles. */ StyleSheet/* @end */ } from 'react-native';
 
 export default function Index() {
   return (
@@ -168,7 +168,7 @@ export default function Index() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    /* @tutinfo Add the value of <CODE>backgroundColor</CODE> property with <CODE>'#25292e'</CODE>.*/
+    /* @tutinfo Add the value of `backgroundColor` property with `'#25292e'`.*/
     backgroundColor: '#25292e',
     /* @end */
     alignItems: 'center',

--- a/docs/pages/tutorial/eas/android-production-build.mdx
+++ b/docs/pages/tutorial/eas/android-production-build.mdx
@@ -250,7 +250,7 @@ Let's set the track to `internal` in **eas.json**.
   /* @hide ... */ /* @end */
   "submit": {
     "production": {
-      /* @info Set <CODE>track</CODE> to <CODE>internal</CODE>. */
+      /* @info Set `track` to `internal`. */
       "android": {
         "track": "internal"
       }
@@ -290,7 +290,7 @@ To release the app for production:
   "submit": {
     "production": {
       "android": {
-        /* @info Change the track to <CODE>production</CODE>. */
+        /* @info Change the track to `production`. */
         "track": "production"
         /* @end */
       }

--- a/docs/pages/tutorial/eas/internal-distribution-builds.mdx
+++ b/docs/pages/tutorial/eas/internal-distribution-builds.mdx
@@ -55,7 +55,7 @@ From our initial setup in **eas.json**, we already have a default configuration 
 {
   "build": {
     "preview": {
-      /* @info The <CODE>distribution</CODE> in <CODE>preview</CODE> profile has its value set to <CODE>internal</CODE>. */
+      /* @info The `distribution` in `preview` profile has its value set to `internal`. */
       "distribution": "internal"
       /* @end */
     }

--- a/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
@@ -35,7 +35,7 @@ In **eas.json**, add a new build profile called `ios-simulator` with the propert
     "development": {
       /* @hide ... */ /* @end */
     },
-    /* @info The <CODE>simulator</CODE> property is required for iOS Simulator builds. */
+    /* @info The `simulator` property is required for iOS Simulator builds. */
     "ios-simulator": {
       "ios": {
         "simulator": true
@@ -51,7 +51,7 @@ For a development build, it's necessary to have the `developmentClient` and `dis
 ```json eas.json
 {
   "ios-simulator": {
-    /* @info The <CODE>extends</CODE> keyword inherits properties from the <CODE>development</CODE> profile. */
+    /* @info The `extends` keyword inherits properties from the `development` profile. */
     "extends": "development",
     /* @end */
     "ios": {

--- a/docs/pages/tutorial/eas/manage-app-versions.mdx
+++ b/docs/pages/tutorial/eas/manage-app-versions.mdx
@@ -62,13 +62,13 @@ You can view them in your project's **eas.json**:
 {
   "cli": {
     /* @hide ... */ /* @end */
-    /* @info The <CODE>appVersionSource</CODE> is set to <CODE>remote</CODE>. */
+    /* @info The `appVersionSource` is set to `remote`. */
     "appVersionSource": "remote"
     /* @end */
   },
   "build": {
     "production": {
-      /* @info The <CODE>autoIncrement</CODE> is set <CODE>true</CODE> to automatically increment the <CODE>versionCode</CODE> or <CODE>buildNumber</CODE>. */
+      /* @info The `autoIncrement` is set `true` to automatically increment the `versionCode` or `buildNumber`. */
       "autoIncrement": true
       /* @end */
     }

--- a/docs/pages/tutorial/eas/multiple-app-variants.mdx
+++ b/docs/pages/tutorial/eas/multiple-app-variants.mdx
@@ -51,7 +51,7 @@ Each variant requires a unique Android Application ID and iOS Bundle Identifier 
 
 ```js app.config.js
 export default ({ config }) => ({
-  /* @info The <CODE>config</CODE> object copies all existing configuration from app.json file.*/
+  /* @info The `config` object copies all existing configuration from app.json file.*/
   ...config,
   /* @end */
 });
@@ -104,21 +104,21 @@ We'll use `getAppName()` to assign dynamic `name` values for the app and `getUni
 ```js app.config.js
 export default ({ config }) => ({
   ...config,
-  /* @info Using <CODE>getAppName()</CODE> for "name" property */
+  /* @info Using `getAppName()` for "name" property */
   name: getAppName(),
   /* @end */
   ios: {
-    /* @info Include existing <CODE>ios</CODE> configuration from app.json */
+    /* @info Include existing `ios` configuration from app.json */
     ...config.ios,
     /* @end */
-    /* @info Using <CODE>getUniqueIdentifier()</CODE> for "bundleIdentifier" property */
+    /* @info Using `getUniqueIdentifier()` for "bundleIdentifier" property */
     bundleIdentifier: getUniqueIdentifier(),
   },
   android: {
-    /* @info Include existing <CODE>android</CODE> configuration from app.json */
+    /* @info Include existing `android` configuration from app.json */
     ...config.android,
     /* @end */
-    /* @info Using <CODE>getUniqueIdentifier()</CODE> for "package" property */
+    /* @info Using `getUniqueIdentifier()` for "package" property */
     package: getUniqueIdentifier(),
   },
 });
@@ -139,7 +139,7 @@ In **eas.json**, add the `APP_VARIANT` environment variable:
     "development": {
       "developmentClient": true,
       "distribution": "internal",
-      /* @info Add <CODE>env.APP_VARIANT</CODE> to access the environment variable for the build profile*/
+      /* @info Add `env.APP_VARIANT` to access the environment variable for the build profile*/
       "env": {
         "APP_VARIANT": "development"
       }
@@ -147,7 +147,7 @@ In **eas.json**, add the `APP_VARIANT` environment variable:
     },
     "preview": {
       "distribution": "internal",
-      /* @info Add <CODE>env.APP_VARIANT</CODE> to access the environment variable for the build profile*/
+      /* @info Add `env.APP_VARIANT` to access the environment variable for the build profile*/
       "env": {
         "APP_VARIANT": "preview"
       }

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -33,11 +33,11 @@ To get gesture interactions to work in the app, we'll render `<GestureHandlerRoo
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx
 // ... rest of the import statements remain same
-/* @tutinfo Import <CODE>GestureHandlerRootView</CODE> from <CODE>react-native-gesture-handler-library</CODE>. */import { GestureHandlerRootView } from 'react-native-gesture-handler';/* @end */
+/* @tutinfo Import `GestureHandlerRootView` from `react-native-gesture-handler-library`. */import { GestureHandlerRootView } from 'react-native-gesture-handler';/* @end */
 
 export default function Index() {
   return (
-    /* @tutinfo Replace the root level <CODE>View</CODE> component with <CODE>GestureHandlerRootView</CODE>. */
+    /* @tutinfo Replace the root level `View` component with `GestureHandlerRootView`. */
     <GestureHandlerRootView style={styles.container}>
     /* @end */
       {/* ...rest of the code remains */}
@@ -62,7 +62,7 @@ An `Animated` component looks at the `style` prop of the component and determine
 {/* prettier-ignore */}
 ```tsx components/EmojiSticker.tsx
 import { ImageSourcePropType, View } from 'react-native';
-/* @tutinfo Import <CODE>Animated</CODE> from <CODE>react-native-reanimated</CODE>. */import Animated from 'react-native-reanimated';/* @end */
+/* @tutinfo Import `Animated` from `react-native-reanimated`. */import Animated from 'react-native-reanimated';/* @end */
 
 type Props = {
   imageSize: number;
@@ -72,7 +72,7 @@ type Props = {
 export default function EmojiSticker({ imageSize, stickerSource }: Props) {
   return (
     <View style={{ top: -350 }}>
-      /* @tutinfo Replace the <CODE>Image</CODE> component with <CODE>Animated.Image</CODE>. */
+      /* @tutinfo Replace the `Image` component with `Animated.Image`. */
       <Animated.Image
         source={stickerSource}
         resizeMode="contain"
@@ -180,11 +180,11 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
 
   return (
     <View style={{ top: -350 }}>
-      /* @tutinfo Wrap the <CODE>Animated.Image</CODE> component with <CODE>GestureDetector</CODE>.*/ <GestureDetector gesture={doubleTap}>/* @end */
+      /* @tutinfo Wrap the `Animated.Image` component with `GestureDetector`.*/ <GestureDetector gesture={doubleTap}>/* @end */
         <Animated.Image
           source={stickerSource}
           resizeMode="contain"
-          style={/* @tutinfo Modify the <CODE>style</CODE> prop on the <CODE>Animated.Image</CODE> to pass the <CODE>imageStyle</CODE>. */[imageStyle, { width: imageSize, height: imageSize }]/* @end */}
+          style={/* @tutinfo Modify the `style` prop on the `Animated.Image` to pass the `imageStyle`. */[imageStyle, { width: imageSize, height: imageSize }]/* @end */}
         />
       /* @tutinfo */
       </GestureDetector>
@@ -217,14 +217,14 @@ To recognize a dragging gesture on the sticker and to track its movement, we'll 
 ```tsx components/EmojiSticker.tsx
 export default function EmojiSticker({ imageSize, stickerSource }: Props) {
   const scaleImage = useSharedValue(imageSize);
-  /* @tutinfo Add <CODE>translateX</CODE> and <CODE>translateY</CODE> shared values.*/
+  /* @tutinfo Add `translateX` and `translateY` shared values.*/
   const translateX = useSharedValue(0);
   const translateY = useSharedValue(0);
   /* @end */
   // ...rest of the code remains same
 
   return (
-    /* @tutinfo Replace the <CODE>View</CODE> component with <CODE>Animated.View</CODE>. */<Animated.View style={{ top: -350 }}>/* @end */
+    /* @tutinfo Replace the `View` component with `Animated.View`. */<Animated.View style={{ top: -350 }}>/* @end */
       <GestureDetector gesture={doubleTap}>
         {/* ...rest of the code remains same */}
       </GestureDetector>
@@ -320,8 +320,8 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
   });
 
   return (
-    /* @tutinfo Wrap all components inside <CODE>GestureDetector</CODE>. */<GestureDetector gesture={drag}>/* @end */
-      <Animated.View style={/* @tutinfo Add <CODE>containerStyle</CODE> to the <CODE>Animated.View</CODE> style prop. */[containerStyle, { top: -350 }]/* @end */}>
+    /* @tutinfo Wrap all components inside `GestureDetector`. */<GestureDetector gesture={drag}>/* @end */
+      <Animated.View style={/* @tutinfo Add `containerStyle` to the `Animated.View` style prop. */[containerStyle, { top: -350 }]/* @end */}>
         <GestureDetector gesture={doubleTap}>
           <Animated.Image
             source={stickerSource}

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -50,10 +50,10 @@ In **app/(tabs)/index.tsx**, import `expo-image-picker` library and create a `pi
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
 // ...rest of the import statements remain unchanged
-/* @tutinfo Import <CODE>ImagePicker</CODE>. */ import * as ImagePicker from 'expo-image-picker';/* @end */
+/* @tutinfo Import `ImagePicker`. */ import * as ImagePicker from 'expo-image-picker';/* @end */
 
 export default function Index() {
-  /* @tutinfo Pass image picker options to <CODE>launchImageLibraryAsync()</CODE> */
+  /* @tutinfo Pass image picker options to `launchImageLibraryAsync()` */
   const pickImageAsync = async () => {
     let result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images'],
@@ -98,7 +98,7 @@ import FontAwesome from '@expo/vector-icons/FontAwesome';
 type Props = {
   label: string;
   theme?: 'primary';
-  /* @tutinfo Define the type for <CODE>onPress</CODE> prop. */
+  /* @tutinfo Define the type for `onPress` prop. */
   onPress?: () => void;
   /* @end */
 };
@@ -306,7 +306,7 @@ Modify the **app/(tabs)/index.tsx** file:
 ```tsx app/(tabs)/index.tsx
 import { View, StyleSheet } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
-/* @tutinfo Import <CODE>useState</CODE> hook from <CODE>react<CODE>.*/
+/* @tutinfo Import `useState` hook from `react`.*/
 import { useState } from 'react';
 /* @end */
 
@@ -328,7 +328,7 @@ export default function Index() {
     });
 
     if (!result.canceled) {
-      /* @tutinfo Pick the first uri from the <CODE>assets</CODE> array. Also, there is only one image selected at a time so you don't have to change this. */
+      /* @tutinfo Pick the first uri from the `assets` array. Also, there is only one image selected at a time so you don't have to change this. */
       setSelectedImage(result.assets[0].uri);
       /* @end */
     } else {
@@ -339,7 +339,7 @@ export default function Index() {
   return (
     <View style={styles.container}>
       <View style={styles.imageContainer}>
-        /* @tutinfo Pass the selected image URI to the <CODE>ImageViewer</CODE> component. */
+        /* @tutinfo Pass the selected image URI to the `ImageViewer` component. */
         <ImageViewer imgSource={PlaceholderImage} selectedImage={selectedImage} />
         /* @end */
       </View>
@@ -385,12 +385,12 @@ type Props = {
   /* @end */
 };
 
-export default function ImageViewer({ imgSource, /* @tutinfo Pass the <CODE>selectedImage</CODE> prop.*/selectedImage/* @end */ }: Props) {
+export default function ImageViewer({ imgSource, /* @tutinfo Pass the `selectedImage` prop.*/selectedImage/* @end */ }: Props) {
   /* @tutinfo If the selected image is not null, show the image from the device, otherwise, show the placeholder image. */
   const imageSource = selectedImage ? { uri: selectedImage } : imgSource;
   /* @end */
 
-  /* @tutinfo <CODE>imgSource</CODE> replaced by <CODE>imageSource</CODE>. */
+  /* @tutinfo `imgSource` replaced by `imageSource`. */
   return <Image source={imageSource} style={styles.image} />;
   /* @end */
 }

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -58,7 +58,7 @@ import { useEffect, useRef, useState } from 'react';
 import { ImageSourcePropType, View, StyleSheet, /* @tutinfo */Platform/* @end */ } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { captureRef } from 'react-native-view-shot';
-/* @tutinfo Import <CODE>domtoimage</CODE> library. */import domtoimage from 'dom-to-image';/* @end */
+/* @tutinfo Import `domtoimage` library. */import domtoimage from 'dom-to-image';/* @end */
 
 import Button from '@/components/Button';
 import ImageViewer from '@/components/ImageViewer';

--- a/docs/pages/tutorial/screenshot.mdx
+++ b/docs/pages/tutorial/screenshot.mdx
@@ -51,7 +51,7 @@ import * as ImagePicker from 'expo-image-picker';
 // ...rest of the code remains same
 
 export default function Index() {
-  /* @tutinfo Add this statement to import the permissions response and <CODE>requestPermission()</CODE> method from the hook. */const [permissionResponse, requestPermission] = ImagePicker.useMediaLibraryPermissions();/* @end */
+  /* @tutinfo Add this statement to import the permissions response and `requestPermission()` method from the hook. */const [permissionResponse, requestPermission] = ImagePicker.useMediaLibraryPermissions();/* @end */
   // ...rest of the code remains same
 
   /* @tutinfo Add an if statement to check the permission status. The requestPermission() method will trigger a dialog box for the user to grant or deny the permission. */
@@ -80,8 +80,8 @@ We'll use `react-native-view-shot` to allow the user to take a screenshot within
 
 {/* prettier-ignore */}
 ```tsx app/(tabs)/index.tsx|collapseHeight=440
-import { useState, /* @tutinfo Import <CODE>useRef</CODE> hook from <CODE>react</CODE>. */useRef/* @end */ } from 'react';
-/* @tutinfo Import <CODE>captureRef</CODE> from <CODE>react-native-view-shot</CODE>. */import { captureRef } from 'react-native-view-shot';/* @end */
+import { useState, /* @tutinfo Import `useRef` hook from `react`. */useRef/* @end */ } from 'react';
+/* @tutinfo Import `captureRef` from `react-native-view-shot`. */import { captureRef } from 'react-native-view-shot';/* @end */
 
 export default function Index() {
   /* @tutinfo Create an imageRef variable. */ const imageRef = useRef<View>(null);/* @end */

--- a/docs/pages/versions/unversioned/sdk/keep-awake.mdx
+++ b/docs/pages/versions/unversioned/sdk/keep-awake.mdx
@@ -62,7 +62,7 @@ export default class KeepAwakeExample extends React.Component {
   }
 
   _activate = () => {
-    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */ activateKeepAwake(); /* @end */
+    /* @info Screen will remain on after called until **deactivateKeepAwake()** is called. */ activateKeepAwake(); /* @end */
     alert('Activated!');
   };
 

--- a/docs/pages/versions/unversioned/sdk/notifications.mdx
+++ b/docs/pages/versions/unversioned/sdk/notifications.mdx
@@ -271,7 +271,7 @@ function useNotificationObserver() {
 }
 
 export default function Layout() {
-  /* @info Observe at the root. Ensure this layout never returns <b>null</b> or the navigation will go unhandled. */
+  /* @info Observe at the root. Ensure this layout never returns **null** or the navigation will go unhandled. */
   useNotificationObserver();
   /* @end */
 

--- a/docs/pages/versions/v53.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/keep-awake.mdx
@@ -62,7 +62,7 @@ export default class KeepAwakeExample extends React.Component {
   }
 
   _activate = () => {
-    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */ activateKeepAwake(); /* @end */
+    /* @info Screen will remain on after called until **deactivateKeepAwake()** is called. */ activateKeepAwake(); /* @end */
     alert('Activated!');
   };
 

--- a/docs/pages/versions/v53.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/notifications.mdx
@@ -272,7 +272,7 @@ function useNotificationObserver() {
 }
 
 export default function Layout() {
-  /* @info Observe at the root. Ensure this layout never returns <b>null</b> or the navigation will go unhandled. */
+  /* @info Observe at the root. Ensure this layout never returns **null** or the navigation will go unhandled. */
   useNotificationObserver();
   /* @end */
 

--- a/docs/pages/versions/v54.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/keep-awake.mdx
@@ -62,7 +62,7 @@ export default class KeepAwakeExample extends React.Component {
   }
 
   _activate = () => {
-    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */ activateKeepAwake(); /* @end */
+    /* @info Screen will remain on after called until **deactivateKeepAwake()** is called. */ activateKeepAwake(); /* @end */
     alert('Activated!');
   };
 

--- a/docs/pages/versions/v54.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/notifications.mdx
@@ -271,7 +271,7 @@ function useNotificationObserver() {
 }
 
 export default function Layout() {
-  /* @info Observe at the root. Ensure this layout never returns <b>null</b> or the navigation will go unhandled. */
+  /* @info Observe at the root. Ensure this layout never returns **null** or the navigation will go unhandled. */
   useNotificationObserver();
   /* @end */
 

--- a/docs/pages/versions/v55.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/keep-awake.mdx
@@ -62,7 +62,7 @@ export default class KeepAwakeExample extends React.Component {
   }
 
   _activate = () => {
-    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */ activateKeepAwake(); /* @end */
+    /* @info Screen will remain on after called until **deactivateKeepAwake()** is called. */ activateKeepAwake(); /* @end */
     alert('Activated!');
   };
 

--- a/docs/pages/versions/v55.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/notifications.mdx
@@ -271,7 +271,7 @@ function useNotificationObserver() {
 }
 
 export default function Layout() {
-  /* @info Observe at the root. Ensure this layout never returns <b>null</b> or the navigation will go unhandled. */
+  /* @info Observe at the root. Ensure this layout never returns **null** or the navigation will go unhandled. */
   useNotificationObserver();
   /* @end */
 

--- a/docs/pages/versions/v56.0.0/sdk/keep-awake.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/keep-awake.mdx
@@ -62,7 +62,7 @@ export default class KeepAwakeExample extends React.Component {
   }
 
   _activate = () => {
-    /* @info Screen will remain on after called until <strong>deactivateKeepAwake()</strong> is called. */ activateKeepAwake(); /* @end */
+    /* @info Screen will remain on after called until **deactivateKeepAwake()** is called. */ activateKeepAwake(); /* @end */
     alert('Activated!');
   };
 

--- a/docs/pages/versions/v56.0.0/sdk/notifications.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/notifications.mdx
@@ -271,7 +271,7 @@ function useNotificationObserver() {
 }
 
 export default function Layout() {
-  /* @info Observe at the root. Ensure this layout never returns <b>null</b> or the navigation will go unhandled. */
+  /* @info Observe at the root. Ensure this layout never returns **null** or the navigation will go unhandled. */
   useNotificationObserver();
   /* @end */
 


### PR DESCRIPTION
## Summary

There's two places where HTML inserts aren't desirable and we'd like to avoid them, to prevent missed reviews from escalating into broken pages or unwanted HTML code being inserted.

## Set of changes

- Replace HTML escaping in `escapeHtml` code utility
- Disable HTML in tippy

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
