### PR TITLE
[docs] link to universal components from platform-specific expo-ui docs

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/bottomsheet.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`BottomSheet`](../universal/bottomsheet) — it renders the appropriate native component per platform.
+
 Expo UI ModalBottomSheet matches the official Jetpack Compose [Bottom Sheet API](https://developer.android.com/develop/ui/compose/components/bottom-sheets) and displays content in a modal sheet that slides up from the bottom.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/button.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/button.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Button`](../universal/button) — it renders the appropriate native component per platform.
+
 Expo UI provides five button components that match the official Jetpack Compose [Button API](https://developer.android.com/develop/ui/compose/components/button): `Button` (filled), `FilledTonalButton`, `OutlinedButton`, `ElevatedButton`, and `TextButton`. All variants share the same props and accept composable children for content.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/checkbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/checkbox.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Checkbox`](../universal/checkbox) — it renders the appropriate native component per platform.
+
 Expo UI Checkbox matches the official Jetpack Compose [Checkbox](https://developer.android.com/develop/ui/compose/components/checkbox) API.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/column.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/column.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Column`](../universal/column) — it renders the appropriate native component per platform.
+
 Expo UI Column matches the official Jetpack Compose [Column](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#Column) API and places children vertically with configurable arrangement and alignment.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For a cross-platform picker, see [`Picker`](../universal/picker) — built on top of `ExposedDropdownMenuBox` on Android.
+
 Expo UI `ExposedDropdownMenuBox` matches the official Jetpack Compose [`ExposedDropdownMenuBox`](https://kotlinlang.org/api/compose-multiplatform/material3/androidx.compose.material3/-exposed-dropdown-menu-box.html). Use the `menuAnchor()` modifier on the anchor content (typically a read-only `TextField`) and `ExposedDropdownMenu` to wrap `DropdownMenuItem` children.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/host.mdx
@@ -9,6 +9,8 @@ platforms: ['android', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
+> **info** For cross-platform usage, see the universal [`Host`](../universal/host) — it renders the appropriate native component per platform.
+
 The `Host` component is the bridge between React Native and Jetpack Compose. Every Jetpack Compose component from `@expo/ui/jetpack-compose` must be wrapped in a `Host` to render correctly.
 
 ## Installation

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/icon.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
+
 An icon component for rendering icons in Jetpack Compose. We recommend downloading icons as XML vector drawables from [Material Symbols](https://fonts.google.com/icons), which is the standard approach for Android development.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/pulltorefreshbox.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/pulltorefreshbox.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For a cross-platform list with pull-to-refresh, see [`List`](../universal/list) — built on top of `PullToRefreshBox` on Android.
+
 Expo UI PullToRefreshBox matches the official Jetpack Compose [PullToRefreshBox](<https://developer.android.com/reference/kotlin/androidx/compose/material3/pulltorefresh/package-summary#PullToRefreshBox(kotlin.Boolean,kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.material3.pulltorefresh.PullToRefreshState,androidx.compose.ui.Alignment,kotlin.Function1,kotlin.Function1)>) API. It wraps scrollable content and shows a refresh indicator when pulled.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/row.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/row.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Row`](../universal/row) — it renders the appropriate native component per platform.
+
 Expo UI Row matches the official Jetpack Compose [Row](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#Row) API and places children horizontally with configurable arrangement and alignment.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/slider.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Slider`](../universal/slider) — it renders the appropriate native component per platform.
+
 Expo UI Slider matches the official Jetpack Compose [Slider API](https://developer.android.com/develop/ui/compose/components/slider) and allows selecting values from a bounded range.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/spacer.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/spacer.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Spacer`](../universal/spacer) — it renders the appropriate native component per platform.
+
 Expo UI Spacer matches the official Jetpack Compose [Spacer](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#Spacer) API and is used to add flexible or fixed-size space between elements in a layout.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/switch.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/switch.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Switch`](../universal/switch) — it renders the appropriate native component per platform.
+
 Expo UI Switch matches the official Jetpack Compose [Switch](https://developer.android.com/develop/ui/compose/components/switch) API.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/text.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/text.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Text`](../universal/text) — it renders the appropriate native component per platform.
+
 Expo UI Text matches the official Jetpack Compose [Text styling](https://developer.android.com/develop/ui/compose/text/style-text) API and displays text with Material 3 typography styles, custom fonts, and text formatting options.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`TextInput`](../universal/textinput) — it renders the appropriate native component per platform.
+
 Expo UI provides two text field components that match the official Jetpack Compose [TextField API](https://developer.android.com/develop/ui/compose/text/user-input): `TextField` (filled) and `OutlinedTextField` (outlined border). Both variants share the same props and support composable slot children for label, placeholder, icons, prefix, suffix, and supporting text.
 
 | Type     | Appearance                                     | Purpose                                                                                                       |

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/bottomsheet.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`BottomSheet`](../universal/bottomsheet) — it renders the appropriate native component per platform.
+
 Expo UI BottomSheet matches the official SwiftUI [sheet API](<https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)>) and presents content from the bottom of the screen.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/button.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/button.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Button`](../universal/button) — it renders the appropriate native component per platform.
+
 Expo UI Button matches the official SwiftUI [Button API](https://developer.apple.com/documentation/swiftui/button) and supports styling via the [`buttonStyle`](modifiers/#buttonstylestyle), [`controlSize`](modifiers/#controlsizesize), and other modifiers.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/host.mdx
@@ -9,6 +9,8 @@ platforms: ['ios', 'tvos', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
+> **info** For cross-platform usage, see the universal [`Host`](../universal/host) — it renders the appropriate native component per platform.
+
 A component that allows you to put the other `@expo/ui/swift-ui` components in React Native. It acts like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) for DOM, [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) for [`react-native-skia`](https://shopify.github.io/react-native-skia/), which underlying uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) to render the SwiftUI views in UIKit.
 
 Since the `Host` component is a React Native [`View`](https://reactnative.dev/docs/view), you can pass the [`style`](https://reactnative.dev/docs/style) prop to it or `matchContents` prop to make the `Host` component match the contents' size.

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/hstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/hstack.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Row`](../universal/row) — it renders the appropriate native component per platform.
+
 Expo UI HStack matches the official SwiftUI [HStack API](https://developer.apple.com/documentation/swiftui/hstack) and arranges its children horizontally.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/image.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/image.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
+
 Expo UI Image displays SF Symbols using the SwiftUI [Image API](https://developer.apple.com/documentation/swiftui/image). SF Symbols are a library of configurable symbols provided by Apple.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/list.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/list.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`List`](../universal/list) — it renders the appropriate native component per platform.
+
 Expo UI List matches the official SwiftUI [List API](https://developer.apple.com/documentation/swiftui/list) and supports styling via the [`listStyle`](modifiers/#liststylestyle) modifier, various row/section modifiers, as well as selection, reordering, and editing capabilities.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/picker.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/picker.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Picker`](../universal/picker) — it renders the appropriate native component per platform.
+
 Expo UI Picker matches the official SwiftUI [Picker API](https://developer.apple.com/documentation/swiftui/picker) and supports all picker styles via the [`pickerStyle`](modifiers/#pickerstylestyle) modifier.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/scrollview.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/scrollview.mdx
@@ -9,6 +9,8 @@ platforms: ['ios', 'tvos', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
+> **info** For cross-platform usage, see the universal [`ScrollView`](../universal/scrollview) — it renders the appropriate native component per platform.
+
 Expo UI ScrollView matches the official SwiftUI [ScrollView API](https://developer.apple.com/documentation/swiftui/scrollview) and provides a scrollable container for its children.
 
 ## Installation

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/slider.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/slider.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Slider`](../universal/slider) — it renders the appropriate native component per platform.
+
 Expo UI Slider matches the official SwiftUI [Slider API](https://developer.apple.com/documentation/swiftui/slider) and allows selecting values from a bounded range.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/spacer.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/spacer.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Spacer`](../universal/spacer) — it renders the appropriate native component per platform.
+
 Expo UI Spacer matches the official SwiftUI [Spacer API](https://developer.apple.com/documentation/swiftui/spacer) and expands to fill available space in a stack.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/text.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/text.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Text`](../universal/text) — it renders the appropriate native component per platform.
+
 Expo UI Text matches the official SwiftUI [Text API](https://developer.apple.com/documentation/swiftui/text).
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`TextInput`](../universal/textinput) — it renders the appropriate native component per platform.
+
 Expo UI TextField matches the official SwiftUI [TextField API](https://developer.apple.com/documentation/swiftui/textfield) and supports single-line and multiline input, keyboard configuration, submit handling, and an imperative `ref` for programmatic control.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/toggle.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/toggle.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Switch`](../universal/switch) — it renders the appropriate native component per platform.
+
 Expo UI Toggle matches the official SwiftUI [Toggle API](https://developer.apple.com/documentation/swiftui/toggle) and supports styling via the [`toggleStyle`](modifiers/#togglestylestyle) modifier.
 
 <ComponentDiagram

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/vstack.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/vstack.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Column`](../universal/column) — it renders the appropriate native component per platform.
+
 Expo UI VStack matches the official SwiftUI [VStack API](https://developer.apple.com/documentation/swiftui/vstack) and arranges its children vertically.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/bottomsheet.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`BottomSheet`](../universal/bottomsheet) — it renders the appropriate native component per platform.
+
 Expo UI ModalBottomSheet matches the official Jetpack Compose [Bottom Sheet API](https://developer.android.com/develop/ui/compose/components/bottom-sheets) and displays content in a modal sheet that slides up from the bottom.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/button.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/button.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Button`](../universal/button) — it renders the appropriate native component per platform.
+
 Expo UI provides five button components that match the official Jetpack Compose [Button API](https://developer.android.com/develop/ui/compose/components/button): `Button` (filled), `FilledTonalButton`, `OutlinedButton`, `ElevatedButton`, and `TextButton`. All variants share the same props and accept composable children for content.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/checkbox.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/checkbox.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Checkbox`](../universal/checkbox) — it renders the appropriate native component per platform.
+
 Expo UI Checkbox matches the official Jetpack Compose [Checkbox](https://developer.android.com/develop/ui/compose/components/checkbox) API.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/column.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/column.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Column`](../universal/column) — it renders the appropriate native component per platform.
+
 Expo UI Column matches the official Jetpack Compose [Column](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#Column) API and places children vertically with configurable arrangement and alignment.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/exposeddropdownmenubox.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For a cross-platform picker, see [`Picker`](../universal/picker) — built on top of `ExposedDropdownMenuBox` on Android.
+
 Expo UI `ExposedDropdownMenuBox` matches the official Jetpack Compose [`ExposedDropdownMenuBox`](https://kotlinlang.org/api/compose-multiplatform/material3/androidx.compose.material3/-exposed-dropdown-menu-box.html). Use the `menuAnchor()` modifier on the anchor content (typically a read-only `TextField`) and `ExposedDropdownMenu` to wrap `DropdownMenuItem` children.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/host.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/host.mdx
@@ -9,6 +9,8 @@ platforms: ['android', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
+> **info** For cross-platform usage, see the universal [`Host`](../universal/host) — it renders the appropriate native component per platform.
+
 The `Host` component is the bridge between React Native and Jetpack Compose. Every Jetpack Compose component from `@expo/ui/jetpack-compose` must be wrapped in a `Host` to render correctly.
 
 ## Installation

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/icon.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
+
 An icon component for rendering icons in Jetpack Compose. We recommend downloading icons as XML vector drawables from [Material Symbols](https://fonts.google.com/icons), which is the standard approach for Android development.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/pulltorefreshbox.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/pulltorefreshbox.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For a cross-platform list with pull-to-refresh, see [`List`](../universal/list) — built on top of `PullToRefreshBox` on Android.
+
 Expo UI PullToRefreshBox matches the official Jetpack Compose [PullToRefreshBox](<https://developer.android.com/reference/kotlin/androidx/compose/material3/pulltorefresh/package-summary#PullToRefreshBox(kotlin.Boolean,kotlin.Function0,androidx.compose.ui.Modifier,androidx.compose.material3.pulltorefresh.PullToRefreshState,androidx.compose.ui.Alignment,kotlin.Function1,kotlin.Function1)>) API. It wraps scrollable content and shows a refresh indicator when pulled.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/row.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/row.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Row`](../universal/row) — it renders the appropriate native component per platform.
+
 Expo UI Row matches the official Jetpack Compose [Row](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#Row) API and places children horizontally with configurable arrangement and alignment.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/slider.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/slider.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Slider`](../universal/slider) — it renders the appropriate native component per platform.
+
 Expo UI Slider matches the official Jetpack Compose [Slider API](https://developer.android.com/develop/ui/compose/components/slider) and allows selecting values from a bounded range.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/spacer.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/spacer.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Spacer`](../universal/spacer) — it renders the appropriate native component per platform.
+
 Expo UI Spacer matches the official Jetpack Compose [Spacer](https://developer.android.com/reference/kotlin/androidx/compose/foundation/layout/package-summary#Spacer) API and is used to add flexible or fixed-size space between elements in a layout.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/switch.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/switch.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Switch`](../universal/switch) — it renders the appropriate native component per platform.
+
 Expo UI Switch matches the official Jetpack Compose [Switch](https://developer.android.com/develop/ui/compose/components/switch) API.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/text.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/text.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Text`](../universal/text) — it renders the appropriate native component per platform.
+
 Expo UI Text matches the official Jetpack Compose [Text styling](https://developer.android.com/develop/ui/compose/text/style-text) API and displays text with Material 3 typography styles, custom fonts, and text formatting options.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`TextInput`](../universal/textinput) — it renders the appropriate native component per platform.
+
 Expo UI provides two text field components that match the official Jetpack Compose [TextField API](https://developer.android.com/develop/ui/compose/text/user-input): `TextField` (filled) and `OutlinedTextField` (outlined border). Both variants share the same props and support composable slot children for label, placeholder, icons, prefix, suffix, and supporting text.
 
 | Type     | Appearance                                     | Purpose                                                                                                       |

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/bottomsheet.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/bottomsheet.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`BottomSheet`](../universal/bottomsheet) — it renders the appropriate native component per platform.
+
 Expo UI BottomSheet matches the official SwiftUI [sheet API](<https://developer.apple.com/documentation/swiftui/view/sheet(ispresented:ondismiss:content:)>) and presents content from the bottom of the screen.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/button.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/button.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Button`](../universal/button) — it renders the appropriate native component per platform.
+
 Expo UI Button matches the official SwiftUI [Button API](https://developer.apple.com/documentation/swiftui/button) and supports styling via the [`buttonStyle`](modifiers/#buttonstylestyle), [`controlSize`](modifiers/#controlsizesize), and other modifiers.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/host.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/host.mdx
@@ -9,6 +9,8 @@ platforms: ['ios', 'tvos', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
+> **info** For cross-platform usage, see the universal [`Host`](../universal/host) — it renders the appropriate native component per platform.
+
 A component that allows you to put the other `@expo/ui/swift-ui` components in React Native. It acts like [`<svg>`](https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Element/svg) for DOM, [`<Canvas>`](https://shopify.github.io/react-native-skia/docs/canvas/overview/) for [`react-native-skia`](https://shopify.github.io/react-native-skia/), which underlying uses [`UIHostingController`](https://developer.apple.com/documentation/swiftui/uihostingcontroller) to render the SwiftUI views in UIKit.
 
 Since the `Host` component is a React Native [`View`](https://reactnative.dev/docs/view), you can pass the [`style`](https://reactnative.dev/docs/style) prop to it or `matchContents` prop to make the `Host` component match the contents' size.

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/hstack.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/hstack.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Row`](../universal/row) — it renders the appropriate native component per platform.
+
 Expo UI HStack matches the official SwiftUI [HStack API](https://developer.apple.com/documentation/swiftui/hstack) and arranges its children horizontally.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/image.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/image.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Icon`](../universal/icon) — it renders the appropriate native component per platform.
+
 Expo UI Image displays SF Symbols using the SwiftUI [Image API](https://developer.apple.com/documentation/swiftui/image). SF Symbols are a library of configurable symbols provided by Apple.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/list.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/list.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`List`](../universal/list) — it renders the appropriate native component per platform.
+
 Expo UI List matches the official SwiftUI [List API](https://developer.apple.com/documentation/swiftui/list) and supports styling via the [`listStyle`](modifiers/#liststylestyle) modifier, various row/section modifiers, as well as selection, reordering, and editing capabilities.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/picker.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/picker.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Picker`](../universal/picker) — it renders the appropriate native component per platform.
+
 Expo UI Picker matches the official SwiftUI [Picker API](https://developer.apple.com/documentation/swiftui/picker) and supports all picker styles via the [`pickerStyle`](modifiers/#pickerstylestyle) modifier.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/scrollview.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/scrollview.mdx
@@ -9,6 +9,8 @@ platforms: ['ios', 'tvos', 'expo-go']
 import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 
+> **info** For cross-platform usage, see the universal [`ScrollView`](../universal/scrollview) — it renders the appropriate native component per platform.
+
 Expo UI ScrollView matches the official SwiftUI [ScrollView API](https://developer.apple.com/documentation/swiftui/scrollview) and provides a scrollable container for its children.
 
 ## Installation

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/slider.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/slider.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Slider`](../universal/slider) — it renders the appropriate native component per platform.
+
 Expo UI Slider matches the official SwiftUI [Slider API](https://developer.apple.com/documentation/swiftui/slider) and allows selecting values from a bounded range.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/spacer.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/spacer.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Spacer`](../universal/spacer) — it renders the appropriate native component per platform.
+
 Expo UI Spacer matches the official SwiftUI [Spacer API](https://developer.apple.com/documentation/swiftui/spacer) and expands to fill available space in a stack.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/text.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/text.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Text`](../universal/text) — it renders the appropriate native component per platform.
+
 Expo UI Text matches the official SwiftUI [Text API](https://developer.apple.com/documentation/swiftui/text).
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`TextInput`](../universal/textinput) — it renders the appropriate native component per platform.
+
 Expo UI TextField matches the official SwiftUI [TextField API](https://developer.apple.com/documentation/swiftui/textfield) and supports single-line and multiline input, keyboard configuration, submit handling, and an imperative `ref` for programmatic control.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/toggle.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/toggle.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Switch`](../universal/switch) — it renders the appropriate native component per platform.
+
 Expo UI Toggle matches the official SwiftUI [Toggle API](https://developer.apple.com/documentation/swiftui/toggle) and supports styling via the [`toggleStyle`](modifiers/#togglestylestyle) modifier.
 
 <ComponentDiagram

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/vstack.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/vstack.mdx
@@ -10,6 +10,8 @@ import APISection from '~/components/plugins/APISection';
 import { APIInstallSection } from '~/components/plugins/InstallSection';
 import { ComponentDiagram } from '~/ui/components/Diagram';
 
+> **info** For cross-platform usage, see the universal [`Column`](../universal/column) — it renders the appropriate native component per platform.
+
 Expo UI VStack matches the official SwiftUI [VStack API](https://developer.apple.com/documentation/swiftui/vstack) and arranges its children vertically.
 
 <ComponentDiagram


### PR DESCRIPTION
# Why

Readers landing on a platform-specific `@expo/ui` page (Jetpack Compose or SwiftUI) have no signal that a universal cross-platform counterpart exists in `@expo/ui/universal`.

# How

Added a `> **info** …` callout as the first body line on each platform-specific page that has a clear universal counterpart. Custom phrasing for two cases where the universal API is built on a more general primitive:

- `jetpack-compose/exposeddropdownmenubox` → links to `universal/Picker`
- `jetpack-compose/pulltorefreshbox` → links to `universal/List`

Applied to `unversioned` and `v56.0.0`

# Test Plan

See the docs preview, e.g https://pr-45945.expo-docs.pages.dev/versions/v56.0.0/sdk/ui/swift-ui/button/

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)