### PR TITLE
[modules-jsi][ios] Implement converters for `JavaScriptRepresentable` to prevent crashes on iOS 17 and 16

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Implement converters for `JavaScriptRepresentable` to prevent crashes on iOS 17 and 16. ([#45950](https://github.com/expo/expo/pull/45950) by [@behenate](https://github.com/behenate))
+  
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-15

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
@@ -16,7 +16,18 @@ internal protocol JSIRepresentable: JavaScriptRepresentable, Sendable, ~Copyable
   func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value
 }
 
-internal extension JSIRepresentable {
+extension JSIRepresentable {
+  public static func fromJavaScriptValue(_ value: JavaScriptValue) -> Self {
+    guard let jsiRuntime = value.runtime else {
+      FatalError.runtimeLost()
+    }
+    return Self.fromJSIValue(value.pointee, in: jsiRuntime.pointee)
+  }
+
+  public func toJavaScriptValue(in runtime: JavaScriptRuntime) -> JavaScriptValue {
+    return JavaScriptValue(runtime, toJSIValue(in: runtime.pointee))
+  }
+
   static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> Self {
     FatalError.unimplemented()
   }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JavaScriptRepresentable.swift
@@ -16,25 +16,50 @@ public protocol JavaScriptRepresentable: Sendable, ~Copyable {
   func toJavaScriptValue(in runtime: JavaScriptRuntime) -> JavaScriptValue
 }
 
-public extension JavaScriptRepresentable {
-  static func fromJavaScriptValue(_ value: JavaScriptValue) -> Self {
-    guard let jsiRuntime = value.runtime else {
-      FatalError.runtimeLost()
+extension Optional: JavaScriptRepresentable where Wrapped: JavaScriptRepresentable {
+  public static func fromJavaScriptValue(_ value: JavaScriptValue) -> Self {
+    if value.isNull() || value.isUndefined() {
+      return nil
     }
-    if let JSIRepresentableType = Self.self as? JSIRepresentable.Type {
-      return JSIRepresentableType.fromJSIValue(value.pointee, in: jsiRuntime.pointee) as! Self
-    }
-    FatalError.unimplemented()
+    return Wrapped.fromJavaScriptValue(value)
   }
 
-  func toJavaScriptValue(in runtime: JavaScriptRuntime) -> JavaScriptValue {
-    if let self = self as? JSIRepresentable {
-      return JavaScriptValue(runtime, self.toJSIValue(in: runtime.pointee))
+  public func toJavaScriptValue(in runtime: JavaScriptRuntime) -> JavaScriptValue {
+    guard let self else {
+      return .null
     }
-    FatalError.unimplemented()
+    return self.toJavaScriptValue(in: runtime)
   }
 }
 
-extension Optional: JavaScriptRepresentable where Wrapped: JavaScriptRepresentable {}
-extension Array: JavaScriptRepresentable where Element: JavaScriptRepresentable {}
-extension Dictionary: JavaScriptRepresentable where Key == String, Value: JavaScriptRepresentable {}
+extension Array: JavaScriptRepresentable where Element: JavaScriptRepresentable {
+  public static func fromJavaScriptValue(_ value: JavaScriptValue) -> Self {
+    return value.getArray().map { Element.fromJavaScriptValue($0) }
+  }
+
+  public func toJavaScriptValue(in runtime: JavaScriptRuntime) -> JavaScriptValue {
+    let values = map { $0.toJavaScriptValue(in: runtime) }
+    return JavaScriptArray(runtime, items: values).asValue()
+  }
+}
+
+extension Dictionary: JavaScriptRepresentable where Key == String, Value: JavaScriptRepresentable {
+  public static func fromJavaScriptValue(_ value: JavaScriptValue) -> Self {
+    let object = value.getObject()
+    var result: Self = [:]
+
+    for key in object.getPropertyNames() {
+      result[key] = Value.fromJavaScriptValue(object.getProperty(key))
+    }
+    return result
+  }
+
+  public func toJavaScriptValue(in runtime: JavaScriptRuntime) -> JavaScriptValue {
+    let object = JavaScriptObject(runtime)
+
+    for (key, value) in self {
+      object.setProperty(key, value: value.toJavaScriptValue(in: runtime))
+    }
+    return object.asValue()
+  }
+}

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRef.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRef.swift
@@ -89,7 +89,16 @@ public final class JavaScriptRef<T: JavaScriptType & ~Copyable>: JavaScriptType,
   }
 }
 
-extension JavaScriptRef: JavaScriptRepresentable where T: JavaScriptRepresentable & ~Copyable {}
+extension JavaScriptRef: JavaScriptRepresentable where T: JavaScriptRepresentable & ~Copyable {
+  public static func fromJavaScriptValue(_ value: JavaScriptValue) -> JavaScriptRef<T> {
+    return JavaScriptRef(T.fromJavaScriptValue(value))
+  }
+
+  public func toJavaScriptValue(in runtime: JavaScriptRuntime) -> JavaScriptValue {
+    return take()?.toJavaScriptValue(in: runtime) ?? .undefined
+  }
+}
+
 extension JavaScriptRef: JSIRepresentable where T: JSIRepresentable & ~Copyable {
   static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> JavaScriptRef {
     FatalError.unimplemented()


### PR DESCRIPTION
# Why

The cast in [JavaScriptValuesBuffer](https://github.com/expo/expo/blob/6322cda59423fb225424360cfe0a14e9f36e5330/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptValuesBuffer.swift#L131-L135) fails into the `else` block, most likely due to different OS swift runtimes compared to newer versions of iOS. Leading to a crash because the methods are not implemented.

# How

Implement the missing methods

# Test Plan

Tested by building and running BareExpo on an older iOS version.
