### PR TITLE
[android] fix(calendar): Add missing escaping for `calendarIds` [EXP-62]

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Add missing escaping of `calendarIds` filter input ([#45951](https://github.com/expo/expo/pull/45951) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-13

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/EventRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/EventRepository.kt
@@ -36,14 +36,14 @@ class EventRepository(context: Context) {
         ContentUris.appendId(builder, eEndDate)
         builder.build()
       }
-      val selection = buildSelectionForEventsQuery(eStartDate, eEndDate, calendars)
+      val (selection, selectionArgs) = buildSelectionForEventsQuery(eStartDate, eEndDate, calendars)
       val sortOrder = "${CalendarContract.Instances.BEGIN} ASC"
 
       val cursor = contentResolver.query(
         uri,
         findEventsQueryParameters,
         selection,
-        null,
+        selectionArgs,
         sortOrder
       )
 
@@ -204,21 +204,30 @@ class EventRepository(context: Context) {
   }
 }
 
-private fun buildSelectionForEventsQuery(startDateMillis: Long, endDateMillis: Long, calendars: List<String>): String {
+private fun buildSelectionForEventsQuery(
+  startDateMillis: Long,
+  endDateMillis: Long,
+  calendars: List<String>
+): Pair<String, Array<String>> {
   val selectionConditions = mutableListOf(
-    "${CalendarContract.Instances.BEGIN} >= $startDateMillis",
-    "${CalendarContract.Instances.END} <= $endDateMillis",
-    "${CalendarContract.Instances.VISIBLE} = 1"
+    "${CalendarContract.Instances.BEGIN} >= ?",
+    "${CalendarContract.Instances.END} <= ?",
+    "${CalendarContract.Instances.VISIBLE} = ?"
+  )
+  val selectionArgs = mutableListOf(
+    startDateMillis.toString(),
+    endDateMillis.toString(),
+    "1"
   )
 
   if (calendars.isNotEmpty()) {
-    val calendarQuery = calendars.joinToString(" OR ") { calendar ->
-      "${CalendarContract.Instances.CALENDAR_ID} = '$calendar'"
-    }
-    selectionConditions += calendarQuery
+    val placeholders = calendars.joinToString(",") { "?" }
+    selectionConditions += "${CalendarContract.Instances.CALENDAR_ID} IN ($placeholders)"
+    selectionArgs += calendars
   }
 
-  return selectionConditions
+  val selection = selectionConditions
     .joinToString(" AND ") { condition -> "($condition)" }
     .let { expr -> "($expr)" }
+  return selection to selectionArgs.toTypedArray()
 }

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/EventRepository.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/domain/event/EventRepository.kt
@@ -221,7 +221,7 @@ private fun buildSelectionForEventsQuery(
   )
 
   if (calendars.isNotEmpty()) {
-    val placeholders = calendars.joinToString(",") { "?" }
+    val placeholders = Array(calendars.size) { "?" }.joinToString(",")
     selectionConditions += "${CalendarContract.Instances.CALENDAR_ID} IN ($placeholders)"
     selectionArgs += calendars
   }


### PR DESCRIPTION
## Summary

The `calendarIds` threaded through to the query builder were being inlined without being escaped properly, which could cause unexpected interpolation issues in the SQL query. It's unrealistic to expect that `calendarIds` would be an unexpected/invalid value, but this should still be resolved, since it's an unexpected interpolation bug missing `'` escaping.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
