### PR TITLE
[android] fix(local-authentication): Handle concurrent `authenticateAsync` calls predictably [EXP-67]

### DIFF
--- a/apps/native-component-list/src/screens/LocalAuthenticationScreen.tsx
+++ b/apps/native-component-list/src/screens/LocalAuthenticationScreen.tsx
@@ -73,6 +73,29 @@ const LocalAuthenticationScreen = () => {
     }
   };
 
+  const doubleAuthenticate = async () => {
+    const fire = (label: string) =>
+      LocalAuthentication.authenticateAsync({
+        promptMessage: `Authenticate (${label})`,
+        cancelLabel: 'Cancel',
+        promptSubtitle: `Call ${label}`,
+        disableDeviceFallback: true,
+        biometricsSecurityLevel: securityLevels[securityLevelIndex],
+      }).then((result) => {
+        alert(
+          result.success
+            ? `Call ${label}: success`
+            : // @ts-ignore
+              `Call ${label}: error=${result.error}`
+        );
+      });
+
+    const first = fire('A');
+    await new Promise((r) => setTimeout(r, 2000));
+    const second = fire('B');
+    await Promise.all([first, second]);
+  };
+
   return (
     <View style={styles.container}>
       <View style={styles.capabilitiesContainer}>
@@ -116,6 +139,11 @@ const LocalAuthenticationScreen = () => {
               style={styles.button}
               onPress={() => authenticate(false)}
               title="Authenticate without device fallback"
+            />
+            <Button
+              style={styles.button}
+              onPress={doubleAuthenticate}
+              title="Double authenticate (2s delay)"
             />
           </View>
         )}

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Ensure concurrent `authenticateAsync` calls don't resolve the active prompt's promise ([#45954](https://github.com/expo/expo/pull/45954) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
+++ b/packages/expo-local-authentication/android/src/main/java/expo/modules/localauthentication/LocalAuthenticationModule.kt
@@ -90,8 +90,6 @@ class LocalAuthenticationModule : Module() {
         return@AsyncFunction
       }
 
-      this@LocalAuthenticationModule.authOptions = options
-
       // BiometricPrompt callbacks are invoked on the main thread so also run this there to avoid
       // having to do locking.
       appContext.mainQueue.launch {
@@ -100,16 +98,22 @@ class LocalAuthenticationModule : Module() {
     }
 
     AsyncFunction<Unit>("cancelAuthenticate") {
-      biometricPrompt?.cancelAuthentication()
+      val current = activePromise
+      val currentPrompt = biometricPrompt
+      activePromise = null
+      biometricPrompt = null
       isAuthenticating = false
+      isRetryingWithDeviceCredentials = false
+      currentPrompt?.cancelAuthentication()
+      current?.resolve(createResponse(error = "user_cancel"))
     }.runOnQueue(Queues.MAIN)
 
     OnActivityResult { activity, (requestCode, resultCode, data) ->
       if (requestCode == DEVICE_CREDENTIAL_FALLBACK_CODE) {
         if (resultCode == Activity.RESULT_OK) {
-          promise?.resolve(createResponse())
+          activePromise?.resolve(createResponse())
         } else {
-          promise?.resolve(
+          activePromise?.resolve(
             createResponse(
               error = "user_cancel",
               warning = "Device Credentials canceled"
@@ -120,8 +124,7 @@ class LocalAuthenticationModule : Module() {
         isAuthenticating = false
         isRetryingWithDeviceCredentials = false
         biometricPrompt = null
-        promise = null
-        authOptions = null
+        activePromise = null
       } else if (activity is FragmentActivity) {
         // If the user uses PIN as an authentication method, the result will be passed to the `onActivityResult`.
         // Unfortunately, react-native doesn't pass this value to the underlying fragment - we won't resolve the promise.
@@ -141,67 +144,65 @@ class LocalAuthenticationModule : Module() {
   private val biometricManager by lazy { BiometricManager.from(context) }
   private val packageManager by lazy { context.packageManager }
   private var biometricPrompt: BiometricPrompt? = null
-  private var promise: Promise? = null
-  private var authOptions: AuthOptions? = null
+  private var activePromise: Promise? = null
   private var isRetryingWithDeviceCredentials = false
   private var isAuthenticating = false
 
-  private val authenticationCallback: BiometricPrompt.AuthenticationCallback = object : BiometricPrompt.AuthenticationCallback() {
+  private fun buildAuthenticationCallback(
+    callPromise: Promise,
+    callOptions: AuthOptions
+  ): BiometricPrompt.AuthenticationCallback = object : BiometricPrompt.AuthenticationCallback() {
     override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
-      isAuthenticating = false
-      isRetryingWithDeviceCredentials = false
-      biometricPrompt = null
-      promise?.resolve(
-        Bundle().apply {
-          putBoolean("success", true)
-        }
-      )
-      promise = null
-      authOptions = null
+      finishCall(callPromise) {
+        callPromise.resolve(
+          Bundle().apply {
+            putBoolean("success", true)
+          }
+        )
+      }
     }
 
     override fun onAuthenticationError(errMsgId: Int, errString: CharSequence) {
-      // Make sure to fallback to the Device Credentials if the Biometrics hardware is unavailable.
-      if (isBiometricUnavailable(errMsgId) && isDeviceSecure && !isRetryingWithDeviceCredentials) {
-        val options = authOptions
-
-        if (options != null) {
-          val disableDeviceFallback = options.disableDeviceFallback
-
-          // Don't run the device credentials fallback if it's disabled.
-          if (!disableDeviceFallback) {
-            promise?.let {
-              isRetryingWithDeviceCredentials = true
-              promptDeviceCredentialsFallback(options, it)
-              return
-            }
-          }
-        }
+      if (
+        isBiometricUnavailable(errMsgId) &&
+        isDeviceSecure &&
+        !isRetryingWithDeviceCredentials &&
+        !callOptions.disableDeviceFallback &&
+        activePromise === callPromise
+      ) {
+        isRetryingWithDeviceCredentials = true
+        promptDeviceCredentialsFallback(callOptions, callPromise)
+        return
       }
-
-      isAuthenticating = false
-      isRetryingWithDeviceCredentials = false
-      biometricPrompt = null
-      promise?.resolve(
-        createResponse(
-          error = convertErrorCode(errMsgId),
-          warning = errString.toString()
+      finishCall(callPromise) {
+        callPromise.resolve(
+          createResponse(
+            error = convertErrorCode(errMsgId),
+            warning = errString.toString()
+          )
         )
-      )
-      promise = null
-      authOptions = null
+      }
     }
+  }
+
+  // Drop late callbacks for a call whose promise was already settled by another path (e.g. cancelAuthenticate).
+  private inline fun finishCall(callPromise: Promise, resolve: () -> Unit) {
+    if (activePromise !== callPromise) {
+      return
+    }
+    activePromise = null
+    biometricPrompt = null
+    isAuthenticating = false
+    isRetryingWithDeviceCredentials = false
+    resolve()
   }
 
   @UiThread
   private fun authenticate(fragmentActivity: FragmentActivity, options: AuthOptions, promise: Promise) {
     if (isAuthenticating) {
-      this.promise?.resolve(
-        createResponse(
-          error = "app_cancel"
-        )
-      )
-      this.promise = promise
+      // Reject the new call rather than supersede. AndroidX `BiometricPrompt` won't show a
+      // replacement prompt while the previous fragment is still detaching
+      promise.resolve(createResponse(error = "app_cancel"))
       return
     }
 
@@ -212,9 +213,9 @@ class LocalAuthenticationModule : Module() {
     }
 
     isAuthenticating = true
-    this.promise = promise
+    activePromise = promise
     val executor: Executor = Executors.newSingleThreadExecutor()
-    val localBiometricPrompt = BiometricPrompt(fragmentActivity, executor, authenticationCallback)
+    val localBiometricPrompt = BiometricPrompt(fragmentActivity, executor, buildAuthenticationCallback(promise, options))
     biometricPrompt = localBiometricPrompt
     val promptInfoBuilder = PromptInfo.Builder().apply {
       setTitle(options.promptMessage)
@@ -231,19 +232,23 @@ class LocalAuthenticationModule : Module() {
     try {
       localBiometricPrompt.authenticate(promptInfo)
     } catch (e: NullPointerException) {
-      promise.reject(UnexpectedException("Canceled authentication due to an internal error", e))
+      finishCall(promise) {
+        promise.reject(UnexpectedException("Canceled authentication due to an internal error", e))
+      }
     }
   }
 
   private fun promptDeviceCredentialsFallback(options: AuthOptions, promise: Promise) {
     val fragmentActivity = appContext.throwingActivity as FragmentActivity?
     if (fragmentActivity == null) {
-      promise.resolve(
-        createResponse(
-          error = "not_available",
-          warning = "getCurrentActivity() returned null"
+      finishCall(promise) {
+        promise.resolve(
+          createResponse(
+            error = "not_available",
+            warning = "getCurrentActivity() returned null"
+          )
         )
-      )
+      }
       return
     }
 
@@ -261,7 +266,7 @@ class LocalAuthenticationModule : Module() {
       }
 
       val executor: Executor = Executors.newSingleThreadExecutor()
-      val localBiometricPrompt = BiometricPrompt(fragmentActivity, executor, authenticationCallback)
+      val localBiometricPrompt = BiometricPrompt(fragmentActivity, executor, buildAuthenticationCallback(promise, options))
 
       biometricPrompt = localBiometricPrompt
 
@@ -277,7 +282,9 @@ class LocalAuthenticationModule : Module() {
       try {
         localBiometricPrompt.authenticate(promptInfo)
       } catch (e: NullPointerException) {
-        promise.reject(UnexpectedException("Canceled authentication due to an internal error", e))
+        finishCall(promise) {
+          promise.reject(UnexpectedException("Canceled authentication due to an internal error", e))
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

Concurrent calls to `authenticateAsync` could act unintuitively on Android. A second call could resolve the promise of the first call, while leaving the second call cancelled, rather than the opposite. If we let two concurrent calls happen without cleaning up state properly, we may resolve the first promise with the second prompt's options, instead of blocking the second call.

This could in theory be unexpected, since it allows a mismatch between the promise resolution and the options passed to `authenticateAsync` that the developer meant to be applied to the resolution.

## Set of changes

- Add clean up procedures to the Android implementation and actively cancel concurrent calls
- Add NCL reproduction

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
