### PR TITLE
[file-system] Fix FileMode in Jest file-system mock

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Fixed the jest mock's `FileSystemFileHandle` to honor `FileMode` string values (`'r'`, `'w'`, `'wa'`, `'wt'`, `'rw'`) instead of the obsolete name table, expose handle and file metadata, and match the documented default mode for `content://` URIs. The dispatch is now exhaustive over `FileMode`, so future enum additions fail to compile in the mock. (by [@radko93](https://github.com/radko93))
+
 ### 💡 Others
 
 - [Android] Remove unused native dependencies. ([#45939](https://github.com/expo/expo/pull/45939) by [@jakex7](https://github.com/jakex7))

--- a/packages/expo-file-system/mocks/FileSystem.ts
+++ b/packages/expo-file-system/mocks/FileSystem.ts
@@ -261,14 +261,22 @@ export class FileSystemFile {
     const existing = store.get(key);
     const now = nextMockTimestamp();
     const createdAt = existing?.exists ? (existing.createdAt ?? now) : now;
+    const type = existing?.type ?? null;
     if (options.append) {
       const prior = existing?.bytes ?? new Uint8Array(0);
       const merged = new Uint8Array(prior.length + bytes.length);
       merged.set(prior, 0);
       merged.set(bytes, prior.length);
-      store.set(key, { kind: 'file', bytes: merged, exists: true, createdAt, modifiedAt: now });
+      store.set(key, {
+        kind: 'file',
+        bytes: merged,
+        type,
+        exists: true,
+        createdAt,
+        modifiedAt: now,
+      });
     } else {
-      store.set(key, { kind: 'file', bytes, exists: true, createdAt, modifiedAt: now });
+      store.set(key, { kind: 'file', bytes, type, exists: true, createdAt, modifiedAt: now });
     }
   }
 
@@ -452,6 +460,7 @@ export class FileSystemFileHandle {
         store.set(key, {
           kind: 'file',
           bytes: new Uint8Array(0),
+          type: entry?.type ?? null,
           exists: true,
           createdAt: entry?.createdAt ?? nextMockTimestamp(),
           modifiedAt: nextMockTimestamp(),

--- a/packages/expo-file-system/mocks/FileSystem.ts
+++ b/packages/expo-file-system/mocks/FileSystem.ts
@@ -5,11 +5,15 @@
  * `expo-file-system`) with a small in-memory filesystem so tests can exercise
  * create/write/read/move/copy/delete end-to-end. This module is what
  * `jest-expo`'s preset feeds to `requireNativeModule('FileSystem')`.
+ * Timestamps use a logical clock reset by `__resetMockFileSystem()`; do not use
+ * `Date.now()` here.
  *
  * DO NOT regenerate this file with `expo-modules-test-core` — the generator
  * emits a bare stub and will overwrite the behavior here. Same pattern as
  * `packages/expo-crypto/mocks/ExpoCryptoAES.ts`.
  */
+
+import { FileMode } from '../src/File.types';
 
 export type URL = string;
 export type FileSystemPath = any;
@@ -30,6 +34,8 @@ type Entry = {
   bytes?: Uint8Array;
   type?: string | null;
   exists: boolean;
+  createdAt?: number;
+  modifiedAt?: number;
 };
 
 const store = new Map<string, Entry>();
@@ -37,9 +43,21 @@ const store = new Map<string, Entry>();
 const SEED_DIRS = [documentDirectory, cacheDirectory, bundleDirectory];
 
 function seed() {
+  const t = nextMockTimestamp();
   for (const uri of SEED_DIRS) {
-    store.set(normalizeKey(uri), { kind: 'dir', exists: true });
+    store.set(normalizeKey(uri), { kind: 'dir', exists: true, createdAt: t, modifiedAt: t });
   }
+}
+
+/**
+ * Logical clock used for `createdAt` / `modifiedAt` on stored entries.
+ * Resetting the mock filesystem also resets it so each test sees a stable
+ * sequence of timestamps independent of wall-clock time.
+ */
+let mockClock = 0;
+
+function nextMockTimestamp(): number {
+  return ++mockClock;
 }
 
 /**
@@ -51,6 +69,7 @@ export function __resetMockFileSystem() {
   store.clear();
   listeners.clear();
   cancelled.clear();
+  mockClock = 0;
   seed();
 }
 
@@ -156,8 +175,9 @@ function assertParent(uri: string, allowMissing: boolean) {
     if (next === cursor) break;
     cursor = next;
   }
+  const now = nextMockTimestamp();
   for (const dirKey of missing) {
-    store.set(dirKey, { kind: 'dir', exists: true });
+    store.set(dirKey, { kind: 'dir', exists: true, createdAt: now, modifiedAt: now });
   }
 }
 
@@ -175,18 +195,36 @@ export class FileSystemFile {
     return !!(entry && entry.kind === 'file' && entry.exists);
   }
 
-  get size(): number | null {
+  get size(): number {
     const entry = store.get(normalizeKey(this.uri));
-    return entry && entry.kind === 'file' && entry.exists ? (entry.bytes?.length ?? 0) : null;
+    return entry && entry.kind === 'file' && entry.exists ? (entry.bytes?.length ?? 0) : 0;
   }
 
-  get type(): string | null {
+  get type(): string {
     const entry = store.get(normalizeKey(this.uri));
-    return entry?.type ?? null;
+    return entry?.type ?? '';
   }
 
   get md5(): string | null {
-    return this.exists ? fakeMd5(this.uri, this.size ?? 0) : null;
+    return this.exists ? fakeMd5(this.uri, this.size) : null;
+  }
+
+  get modificationTime(): number | null {
+    const entry = store.get(normalizeKey(this.uri));
+    return entry?.exists ? (entry.modifiedAt ?? null) : null;
+  }
+
+  get lastModified(): number | null {
+    return this.modificationTime;
+  }
+
+  get creationTime(): number | null {
+    const entry = store.get(normalizeKey(this.uri));
+    return entry?.exists ? (entry.createdAt ?? null) : null;
+  }
+
+  get contentUri(): string {
+    return '';
   }
 
   create(options: { intermediates?: boolean; overwrite?: boolean } = {}): void {
@@ -198,7 +236,14 @@ export class FileSystemFile {
       }
     }
     assertParent(this.uri, !!options.intermediates);
-    store.set(key, { kind: 'file', bytes: new Uint8Array(0), exists: true });
+    const now = nextMockTimestamp();
+    store.set(key, {
+      kind: 'file',
+      bytes: new Uint8Array(0),
+      exists: true,
+      createdAt: now,
+      modifiedAt: now,
+    });
   }
 
   write(
@@ -213,15 +258,17 @@ export class FileSystemFile {
       bytes = new Uint8Array(content);
     }
     const key = normalizeKey(this.uri);
+    const existing = store.get(key);
+    const now = nextMockTimestamp();
+    const createdAt = existing?.exists ? (existing.createdAt ?? now) : now;
     if (options.append) {
-      const existing = store.get(key);
       const prior = existing?.bytes ?? new Uint8Array(0);
       const merged = new Uint8Array(prior.length + bytes.length);
       merged.set(prior, 0);
       merged.set(bytes, prior.length);
-      store.set(key, { kind: 'file', bytes: merged, exists: true });
+      store.set(key, { kind: 'file', bytes: merged, exists: true, createdAt, modifiedAt: now });
     } else {
-      store.set(key, { kind: 'file', bytes, exists: true });
+      store.set(key, { kind: 'file', bytes, exists: true, createdAt, modifiedAt: now });
     }
   }
 
@@ -267,17 +314,19 @@ export class FileSystemFile {
       exists: true,
       uri: this.uri,
       size,
+      modificationTime: entry.modifiedAt ?? null,
+      creationTime: entry.createdAt ?? null,
       ...(options.md5 ? { md5: fakeMd5(this.uri, size) } : {}),
     };
   }
 
-  open(mode: number | string = 0): FileSystemFileHandle {
+  open(mode?: FileMode): FileSystemFileHandle {
     const key = normalizeKey(this.uri);
     const entry = store.get(key);
     if (!entry || entry.kind !== 'file' || !entry.exists) {
       throw new Error('File does not exist');
     }
-    return new FileSystemFileHandle(key, mode);
+    return new FileSystemFileHandle(key, mode ?? defaultModeForUri(this.uri));
   }
 
   delete(): void {
@@ -311,11 +360,14 @@ export class FileSystemFile {
       throw new Error('Destination already exists');
     }
     assertParent(destKey, false);
+    const now = nextMockTimestamp();
     store.set(destKey, {
       kind: 'file',
       bytes: new Uint8Array(entry.bytes ?? new Uint8Array(0)),
       type: entry.type ?? null,
       exists: true,
+      createdAt: now,
+      modifiedAt: now,
     });
   }
 
@@ -370,24 +422,68 @@ export class FileSystemFileHandle {
   private cursor: number;
   private closed = false;
 
-  constructor(key: string, mode: number | string) {
+  constructor(key: string, mode: FileMode) {
     this.key = key;
-    const modeStr = typeof mode === 'string' ? mode : MODE_NAMES[mode] ?? 'readwrite';
-    this.readOnly = modeStr === 'read';
-    this.writeOnly = modeStr === 'write';
     const entry = store.get(key);
-    if (modeStr === 'truncate') {
-      store.set(key, { kind: 'file', bytes: new Uint8Array(0), exists: true });
-      this.cursor = 0;
-    } else if (modeStr === 'append') {
-      this.cursor = entry?.bytes?.length ?? 0;
-    } else {
-      this.cursor = 0;
+    switch (mode) {
+      case FileMode.ReadWrite:
+        this.readOnly = false;
+        this.writeOnly = false;
+        this.cursor = 0;
+        break;
+      case FileMode.ReadOnly:
+        this.readOnly = true;
+        this.writeOnly = false;
+        this.cursor = 0;
+        break;
+      case FileMode.WriteOnly:
+        this.readOnly = false;
+        this.writeOnly = true;
+        this.cursor = 0;
+        break;
+      case FileMode.Append:
+        this.readOnly = false;
+        this.writeOnly = true;
+        this.cursor = entry?.bytes?.length ?? 0;
+        break;
+      case FileMode.Truncate:
+        this.readOnly = false;
+        this.writeOnly = true;
+        store.set(key, {
+          kind: 'file',
+          bytes: new Uint8Array(0),
+          exists: true,
+          createdAt: entry?.createdAt ?? nextMockTimestamp(),
+          modifiedAt: nextMockTimestamp(),
+        });
+        this.cursor = 0;
+        break;
+      default:
+        assertNever(mode);
     }
   }
 
   private ensureOpen() {
     if (this.closed) throw new Error('File handle is closed');
+  }
+
+  get offset(): number | null {
+    return this.closed ? null : this.cursor;
+  }
+
+  set offset(value: number | null) {
+    if (this.closed || value == null) {
+      return;
+    }
+    this.cursor = value;
+  }
+
+  get size(): number | null {
+    if (this.closed) {
+      return null;
+    }
+    const entry = store.get(this.key);
+    return entry?.bytes?.length ?? 0;
   }
 
   readBytes(count: number): Uint8Array {
@@ -403,14 +499,25 @@ export class FileSystemFileHandle {
   writeBytes(buffer: Uint8Array): void {
     this.ensureOpen();
     if (this.readOnly) throw new Error('File handle is read-only');
-    const entry = store.get(this.key) ?? { kind: 'file' as const, bytes: new Uint8Array(0), exists: true };
+    const entry = store.get(this.key) ?? {
+      kind: 'file' as const,
+      bytes: new Uint8Array(0),
+      exists: true,
+    };
     const prior = entry.bytes ?? new Uint8Array(0);
-    const newLength = Math.max(prior.length, this.cursor + buffer.length);
+    const writeOffset = Math.min(this.cursor, prior.length);
+    const newLength = Math.max(prior.length, writeOffset + buffer.length);
     const merged = new Uint8Array(newLength);
     merged.set(prior, 0);
-    merged.set(buffer, this.cursor);
-    store.set(this.key, { ...entry, kind: 'file', bytes: merged, exists: true });
-    this.cursor += buffer.length;
+    merged.set(buffer, writeOffset);
+    store.set(this.key, {
+      ...entry,
+      kind: 'file',
+      bytes: merged,
+      exists: true,
+      modifiedAt: nextMockTimestamp(),
+    });
+    this.cursor = writeOffset + buffer.length;
   }
 
   close(): void {
@@ -418,15 +525,13 @@ export class FileSystemFileHandle {
   }
 }
 
-// FileMode enum values from src/ExpoFileSystem.types.ts — keep as numbers but
-// map by name so callers using either work.
-const MODE_NAMES: Record<number, string> = {
-  0: 'readwrite',
-  1: 'read',
-  2: 'write',
-  3: 'append',
-  4: 'truncate',
-};
+function assertNever(value: never): never {
+  throw new Error(`Unhandled FileMode in jest-expo mock: ${String(value)}`);
+}
+
+function defaultModeForUri(uri: string): FileMode {
+  return uri.startsWith('content://') ? FileMode.ReadOnly : FileMode.ReadWrite;
+}
 
 export class FileSystemDirectory {
   uri: string;
@@ -442,6 +547,20 @@ export class FileSystemDirectory {
     return !!(entry && entry.kind === 'dir' && entry.exists);
   }
 
+  get size(): number | null {
+    const entry = store.get(normalizeKey(this.uri));
+    if (!entry || entry.kind !== 'dir' || !entry.exists) {
+      return null;
+    }
+    const prefix = `${normalizeKey(this.uri)}/`;
+    let total = 0;
+    for (const [key, e] of store) {
+      if (!e.exists || e.kind !== 'file' || !key.startsWith(prefix)) continue;
+      total += e.bytes?.length ?? 0;
+    }
+    return total;
+  }
+
   info(): any {
     const entry = store.get(normalizeKey(this.uri));
     if (!entry || entry.kind !== 'dir' || !entry.exists) {
@@ -450,7 +569,10 @@ export class FileSystemDirectory {
     return {
       exists: true,
       uri: this.uri,
-      files: directChildren(this.uri).map((child) => child.uri),
+      files: directChildren(this.uri).map((child) => basename(child.uri)),
+      size: this.size,
+      modificationTime: entry.modifiedAt ?? null,
+      creationTime: entry.createdAt ?? null,
     };
   }
 
@@ -467,7 +589,8 @@ export class FileSystemDirectory {
       deleteSubtree(key);
     }
     assertParent(this.uri, !!options.intermediates);
-    store.set(key, { kind: 'dir', exists: true });
+    const now = nextMockTimestamp();
+    store.set(key, { kind: 'dir', exists: true, createdAt: now, modifiedAt: now });
   }
 
   delete(): void {
@@ -500,11 +623,14 @@ export class FileSystemDirectory {
     if (store.get(childKey)?.exists) {
       throw new Error('File already exists');
     }
+    const now = nextMockTimestamp();
     store.set(childKey, {
       kind: 'file',
       bytes: new Uint8Array(0),
       type: mimeType ?? null,
       exists: true,
+      createdAt: now,
+      modifiedAt: now,
     });
     return new FileSystemFile(childKey);
   }
@@ -519,7 +645,8 @@ export class FileSystemDirectory {
     if (store.get(childKey)?.exists) {
       throw new Error('Directory already exists');
     }
-    store.set(childKey, { kind: 'dir', exists: true });
+    const now = nextMockTimestamp();
+    store.set(childKey, { kind: 'dir', exists: true, createdAt: now, modifiedAt: now });
     return new FileSystemDirectory(childKey);
   }
 
@@ -665,21 +792,24 @@ function deleteSubtree(rootKey: string) {
 function copySubtree(srcKey: string, destKey: string) {
   const srcEntry = store.get(srcKey);
   if (!srcEntry) return;
-  store.set(destKey, cloneEntry(srcEntry));
+  const now = nextMockTimestamp();
+  store.set(destKey, cloneEntry(srcEntry, now));
   const prefix = `${srcKey}/`;
   for (const [key, entry] of store) {
     if (!key.startsWith(prefix)) continue;
     const rewritten = destKey + key.slice(srcKey.length);
-    store.set(rewritten, cloneEntry(entry));
+    store.set(rewritten, cloneEntry(entry, now));
   }
 }
 
-function cloneEntry(entry: Entry): Entry {
+function cloneEntry(entry: Entry, timestamp: number): Entry {
   return {
     kind: entry.kind,
     exists: entry.exists,
     type: entry.type ?? null,
     bytes: entry.bytes ? new Uint8Array(entry.bytes) : undefined,
+    createdAt: timestamp,
+    modifiedAt: timestamp,
   };
 }
 
@@ -713,7 +843,8 @@ export async function downloadFileAsync(
     throw err;
   }
 
-  store.set(destKey, { kind: 'file', bytes, exists: true });
+  const now = nextMockTimestamp();
+  store.set(destKey, { kind: 'file', bytes, exists: true, createdAt: now, modifiedAt: now });
   return destKey;
 }
 

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -1,5 +1,6 @@
 import { DownloadTask, File, Directory, Paths, UploadTask } from '../..';
 import { __resetMockFileSystem } from '../../mocks/FileSystem';
+import { FileMode } from '../File.types';
 
 beforeEach(() => {
   __resetMockFileSystem();
@@ -188,6 +189,21 @@ describe('expo-file-system behavioral mock', () => {
     expect(children[0].uri).toBe(file.uri);
   });
 
+  it('Directory.info returns child names, size, and deterministic metadata', () => {
+    const dir = new Directory(Paths.cache, 'info-dir');
+    dir.create();
+    const creationTime = dir.info().creationTime;
+    dir.createFile('a.txt', null).write('abc');
+    dir.createFile('b.txt', null).write('de');
+
+    expect(dir.info()).toMatchObject({
+      exists: true,
+      files: ['a.txt', 'b.txt'],
+      size: 5,
+      creationTime,
+    });
+  });
+
   it('File.write(string) and File.text() roundtrip utf-8', async () => {
     const file = new File(Paths.cache, 'hello.txt');
     file.write('hello world');
@@ -215,6 +231,37 @@ describe('expo-file-system behavioral mock', () => {
     const file = new File(Paths.cache, 'encoded.txt');
     file.write(Buffer.from('hello').toString('base64'), { encoding: 'base64' });
     expect(file.textSync()).toBe('hello');
+  });
+
+  it('File metadata uses deterministic timestamps that reset with the mock filesystem', () => {
+    const file = new File(Paths.cache, 'metadata.txt');
+    expect(file.size).toBe(0);
+    expect(file.type).toBe('');
+    expect(file.modificationTime).toBeNull();
+    expect(file.lastModified).toBeNull();
+    expect(file.creationTime).toBeNull();
+
+    file.create();
+    const creationTime = file.creationTime;
+    expect(creationTime).toEqual(expect.any(Number));
+    expect(creationTime).toBeGreaterThan(0);
+    expect(file.modificationTime).toBe(creationTime);
+
+    file.write('hello');
+    expect(file.size).toBe(5);
+    expect(file.creationTime).toBe(creationTime);
+    expect(file.modificationTime).toBeGreaterThan(creationTime!);
+    expect(file.lastModified).toBe(file.modificationTime);
+    expect(file.info()).toMatchObject({
+      size: 5,
+      creationTime,
+      modificationTime: file.modificationTime,
+    });
+
+    __resetMockFileSystem();
+    const resetFile = new File(Paths.cache, 'metadata.txt');
+    resetFile.create();
+    expect(resetFile.creationTime).toBe(creationTime);
   });
 
   it('File.move updates this.uri and removes the source', async () => {
@@ -304,6 +351,82 @@ describe('expo-file-system behavioral mock', () => {
     expect(result.uri).toContain('downloads/out.bin');
     expect(result.exists).toBe(true);
     expect(result.textSync()).toBe('mock:https://example.com/foo.bin');
+  });
+
+  describe('FileMode handling', () => {
+    function encode(contents: string): Uint8Array {
+      return new TextEncoder().encode(contents);
+    }
+
+    function makeFile(name: string, contents = 'hello'): File {
+      const file = new File(Paths.cache, name);
+      file.create();
+      file.write(contents);
+      return file;
+    }
+
+    it('FileMode.ReadOnly rejects writes', () => {
+      const file = makeFile('readonly.txt');
+      const handle = file.open(FileMode.ReadOnly);
+      expect(() => handle.writeBytes(new Uint8Array([1, 2, 3]))).toThrow();
+      handle.close();
+    });
+
+    it('FileMode.WriteOnly rejects reads', () => {
+      const file = makeFile('writeonly.txt');
+      const handle = file.open(FileMode.WriteOnly);
+      expect(() => handle.readBytes(1)).toThrow();
+      handle.close();
+    });
+
+    it('FileMode.Append positions the cursor at end of file', () => {
+      const file = makeFile('append.txt', 'abc');
+      const handle = file.open(FileMode.Append);
+      handle.writeBytes(encode('def'));
+      handle.close();
+      expect(file.textSync()).toBe('abcdef');
+    });
+
+    it('FileMode.Truncate wipes existing contents on open', () => {
+      const file = makeFile('truncate.txt', 'will-be-wiped');
+      const handle = file.open(FileMode.Truncate);
+      handle.writeBytes(encode('fresh'));
+      handle.close();
+      expect(file.textSync()).toBe('fresh');
+    });
+
+    it('FileMode.ReadWrite is the default and allows both', () => {
+      const file = makeFile('rw.txt', 'seed');
+      const handle = file.open();
+      expect(handle.readBytes(4)).toEqual(encode('seed'));
+      handle.writeBytes(encode('!'));
+      handle.close();
+      expect(file.textSync()).toBe('seed!');
+    });
+
+    it('tracks offset and size while the handle is open', () => {
+      const file = makeFile('handle-metadata.txt', 'abc');
+      const handle = file.open(FileMode.ReadOnly);
+      expect(handle.offset).toBe(0);
+      expect(handle.size).toBe(3);
+      handle.readBytes(2);
+      expect(handle.offset).toBe(2);
+      handle.close();
+      expect(handle.offset).toBeNull();
+      expect(handle.size).toBeNull();
+    });
+
+    it('honors offset writes and appends when offset is past the file size', () => {
+      const file = makeFile('offset-writes.txt', 'abcd');
+      const handle = file.open(FileMode.ReadWrite);
+      handle.offset = 1;
+      handle.writeBytes(encode('Z'));
+      expect(handle.offset).toBe(2);
+      handle.offset = 99;
+      handle.writeBytes(encode('!'));
+      handle.close();
+      expect(file.textSync()).toBe('aZcd!');
+    });
   });
 });
 

--- a/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
+++ b/packages/expo-file-system/src/__tests__/FileSystem-test.native.ts
@@ -395,6 +395,21 @@ describe('expo-file-system behavioral mock', () => {
       expect(file.textSync()).toBe('fresh');
     });
 
+    it('preserves the stored mime type across write() and Truncate opens', () => {
+      const dir = new Directory(Paths.cache, 'typed');
+      dir.create();
+      const file = dir.createFile('x.txt', 'text/plain');
+      expect(file.type).toBe('text/plain');
+
+      file.write('hello');
+      expect(file.type).toBe('text/plain');
+
+      const handle = file.open(FileMode.Truncate);
+      handle.writeBytes(encode('fresh'));
+      handle.close();
+      expect(file.type).toBe('text/plain');
+    });
+
     it('FileMode.ReadWrite is the default and allows both', () => {
       const file = makeFile('rw.txt', 'seed');
       const handle = file.open();


### PR DESCRIPTION
# Why

Follow-up to #45027 addressing the concrete drift @barthap flagged in his [post-merge review](https://github.com/expo/expo/pull/45027#issuecomment-4477820927), in particular:

> The file-handle mock still doesn't fully line up with the current `FileMode` API, so tests using `open()` can exercise behavior that differs from native.

The native `FileMode` (`packages/expo-file-system/src/File.types.ts:54`) is a string enum (`'rw'`, `'r'`, `'w'`, `'wa'`, `'wt'`). The mock was dispatching on an obsolete number→name table (`'read'`, `'write'`, `'truncate'`, …), so every non-default mode silently degraded:

- `file.open(FileMode.ReadOnly)` accepted `writeBytes()`
- `file.open(FileMode.WriteOnly)` accepted `readBytes()`
- `file.open(FileMode.Append)` left the cursor at `0` instead of EOF
- `file.open(FileMode.Truncate)` did not clear the file

While in here, also closed the cheap metadata shape gaps between the mock and the native file/directory declarations, so consumer tests reading file metadata see the same deterministic surface they would get from the real native module.

The broader concerns from the review (`DownloadTask` / `UploadTask` shallowness, watcher no-ops, and whether a behavioral mock belongs in the preset at all) are intentionally out of scope here. Those should be decided strategically rather than expanded one mock method at a time.

# How

**FileMode handling**
- `FileSystemFile.open(mode?: FileMode)` now matches the native signature.
- `FileSystemFileHandle` dispatches on `FileMode` via `switch`, with `assertNever(mode)` in `default`. Adding a new variant upstream will fail to compile in the mock until it's handled here — the maintenance lever that was missing before.
- Default mode now respects the documented native behavior: `content://` URIs default to `FileMode.ReadOnly`, everything else to `FileMode.ReadWrite`.
- `FileSystemFileHandle` exposes `offset` (read/write) and `size` getters, returning `null` after the handle is closed, matching the native type.

**Metadata shape parity**
- `FileSystemFile.size`: `number | null` → `number` (returns `0` when the file is missing).
- `FileSystemFile.type`: `string | null` → `string` (returns `''`).
- Added `FileSystemFile.modificationTime`, `lastModified`, `creationTime`, `contentUri`.
- Added `FileSystemDirectory.size` (sum of contained file byte lengths, `null` when the dir is missing).

**Deterministic timestamps**
- *Opinionated:* created/modified timestamps come from a logical clock reset by `__resetMockFileSystem()`, not wall-clock time. Picked this over `Date.now()` so snapshots stay stable and tests can assert that a write actually bumped `lastModified` without consumers installing `jest.useFakeTimers`. Other reasonable choices: a fixed `0` (loses the "did it change?" property), or leaning on real `Date.now()` (introduces flakiness). Happy to swap if you prefer a different pattern — no consumers depend on the values yet.
- File header documents the convention so future contributors don't reach for `Date.now()` reflexively.

No runtime source changes — this only tightens the mock that ships alongside the package and is loaded by `jest-expo`'s preset.

# Test Plan

Extended `src/__tests__/FileSystem-test.native.ts`:

- `FileMode handling` block: each `FileMode` variant exercises the right access/cursor semantics; default mode is `ReadWrite`.
- Handle metadata: `offset` / `size` while open, both `null` after close; offset-positioned writes append when past EOF.
- Added explicit coverage for deterministic metadata and `Directory.info()` shape.

```
$ yarn test
Test Suites: 10 passed, 10 total
Tests:       14 skipped, 194 passed, 208 total

$ yarn lint
(clean)

$ yarn build
(clean)
```

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)