### PR TITLE
[JSI] Fix `no such module 'jsi'` when package path contains `=`

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed `no such module 'jsi'` build error when the package path contains `=` (pnpm virtual store with patched dependencies). ([#45948](https://github.com/expo/expo/issues/45948) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Fixed `no such module 'jsi'` build error when the package path contains `=` (pnpm virtual store with patched dependencies). ([#45956](https://github.com/expo/expo/pull/45956) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fixed `no such module 'jsi'` build error when the package path contains `=` (pnpm virtual store with patched dependencies). ([#45948](https://github.com/expo/expo/issues/45948) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-15

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -278,8 +278,14 @@ if [[ -f "${PODS_ROOT}/Local Podspecs/React-Core.podspec.json" ]]; then
   SOURCE_FILES+=("${PODS_ROOT}/Local Podspecs/React-Core.podspec.json")
 fi
 
-# Generate the module map for the `jsi` Clang module.
-env PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
+# Generate the module map for the `jsi` Clang module. Set the env vars inline
+# instead of via `env`: pnpm's virtual-store paths contain `=` characters
+# (e.g. `patch_hash=…`), and BSD `env` parses positional args containing `=`
+# as additional NAME=VALUE assignments — so `env FOO=bar /pnpm/path=with/equals`
+# never finds a command, silently dumps the environment, and exits 0. The
+# parent `set -eo pipefail` doesn't catch that, the modulemap never gets
+# written, and xcodebuild later fails with `no such module 'jsi'`.
+PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
 GENERATED_MODULE_MAP="${PACKAGE_DIR}/.generated/module.modulemap"
 SOURCE_FILES+=("$GENERATED_MODULE_MAP")
 

--- a/packages/expo-modules-jsi/apple/scripts/test.sh
+++ b/packages/expo-modules-jsi/apple/scripts/test.sh
@@ -64,7 +64,7 @@ link_xcframework "ReactNativeDependencies" \
 
 # --- Generate the jsi module map ---
 
-env PODS_ROOT="$PODS_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
+PODS_ROOT="$PODS_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
 
 # --- Pick a simulator destination ---
 


### PR DESCRIPTION
## Why

Fixes #45948.

When `expo-modules-jsi` lands in a directory whose path contains `=` characters — most commonly under pnpm's virtual store (`.pnpm/expo-modules-jsi@…_react-native@…_patch_hash=…/…`) — building the host app fails with:

```
error: module map file '…/apple/.generated/module.modulemap' not found
error: no such module 'jsi'
```

### Root cause

`apple/scripts/build-xcframework.sh` invokes the modulemap generator like:

```bash
env PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
```

By design, `env` keeps parsing positional args as `NAME=VALUE` assignments and only treats [the first operand without `=`](https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html) as the program to invoke. The script path passed here has `=` in *every* component:

```
/…/.pnpm/expo-modules-jsi@56.0.5_react-native@0.85.3_patch_hash=…/…/scripts/generate-modulemap.sh
```

So `env` consumes the whole path as extra assignments, never finds a command, just **dumps the environment and exits 0**. The parent's `set -eo pipefail` doesn't catch that, the modulemap never gets written, and xcodebuild later fails as above.

Minimal reproducer (no pnpm needed):
```bash
mkdir -p '/tmp/has=equals' && echo '#!/bin/bash
echo TEST RAN' > '/tmp/has=equals/s.sh' && chmod +x '/tmp/has=equals/s.sh'
env FOO=bar '/tmp/has=equals/s.sh'   # silently dumps env, never runs the script
```

This is silent in most setups because npm/yarn don't put `=` in install paths, and even most pnpm setups don't until something forces a hashed virtual-store dir (a patched dependency, like the `react-native.patch` in the linked repro).

## How

Drop the `env` wrapper and set the env vars inline on the same command — the shell handles per-command env vars without trying to parse subsequent args:

```diff
- env PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
+ PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
```

Same fix applied in `test.sh` for the equivalent call site. Added a comment at the build script call site explaining why `env` is not safe here.

The `env -i` invocation around `xcodebuild` (line 160) is unaffected — `xcodebuild` is a PATH name with no `=`, so `env` parses it correctly as the command.

## Test Plan

- Cloned the repro from #45948 (`davidjbng/expo-modules-jsi-error-repro`), reproduced the failure on this machine, copied the patched scripts in, then ran `xcodebuild` against the workspace → `** BUILD SUCCEEDED **`, all four xcframework slices built cleanly in ~25s.
- Verified the underlying `env`-with-`=`-in-path behavior with the minimal reproducer above.
