### PR TITLE
[file-system][Android] Fix FileHandle permissions and path-traversal bug [EXP-47]

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -19,6 +19,8 @@
 ### 🐛 Bug fixes
 
 - Fixed the jest mock's `FileSystemFileHandle` to honor `FileMode` string values (`'r'`, `'w'`, `'wa'`, `'wt'`, `'rw'`) instead of the obsolete name table, expose handle and file metadata, and match the documented default mode for `content://` URIs. The dispatch is now exhaustive over `FileMode`, so future enum additions fail to compile in the mock. (by [@radko93](https://github.com/radko93))
+- [Android] Added missing permission checks to `delete()` and `openHandle()` in the next-gen File System API. ([#45967](https://github.com/expo/expo/pull/45967) by [@barthap](https://github.com/barthap))
+- [Android] Fixed path traversal vulnerability in `createFile`, `createDirectory`, and `rename` that allowed escaping the parent directory. ([#45967](https://github.com/expo/expo/pull/45967) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemDirectory.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemDirectory.kt
@@ -2,6 +2,7 @@ package expo.modules.filesystem
 
 import android.net.Uri
 import expo.modules.kotlin.services.FilePermissionService
+import java.io.File
 
 class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
   fun validatePath() {
@@ -76,6 +77,7 @@ class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
   fun createFile(mimeType: String?, fileName: String): FileSystemFile {
     validateType()
     validatePermission(FilePermissionService.Permission.WRITE)
+    validateChildTarget(fileName)
     val newFile = file.createFile(mimeType ?: "text/plain", fileName)
       ?: throw UnableToCreateException("file could not be created")
     return FileSystemFile(newFile.uri)
@@ -84,9 +86,22 @@ class FileSystemDirectory(uri: Uri) : FileSystemPath(uri) {
   fun createDirectory(fileName: String): FileSystemDirectory {
     validateType()
     validatePermission(FilePermissionService.Permission.WRITE)
+    validateChildTarget(fileName)
     val newDirectory = file.createDirectory(fileName)
       ?: throw UnableToCreateException("directory could not be created")
     return FileSystemDirectory(newDirectory.uri)
+  }
+
+  private fun validateChildTarget(fileName: String) {
+    validateFileSystemChildName(fileName)
+    if (uri.isContentUri || uri.isAssetUri) {
+      return
+    }
+    val parent = javaFile.canonicalFile
+    val child = File(parent, fileName).canonicalFile
+    if (child.parentFile?.canonicalPath != parent.canonicalPath) {
+      throw UnableToCreateException("child path escapes parent directory")
+    }
   }
 
   // this function is internal and will be removed in the future (when returning arrays of shared objects is supported)

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemFile.kt
@@ -10,6 +10,12 @@ import expo.modules.kotlin.typedarray.TypedArray
 import java.io.FileOutputStream
 import java.security.MessageDigest
 
+internal fun FileMode.requiredPermissions(): List<FilePermissionService.Permission> = when (this) {
+  FileMode.READ -> listOf(FilePermissionService.Permission.READ)
+  FileMode.WRITE, FileMode.APPEND, FileMode.TRUNCATE -> listOf(FilePermissionService.Permission.WRITE)
+  FileMode.READ_WRITE -> listOf(FilePermissionService.Permission.READ, FilePermissionService.Permission.WRITE)
+}
+
 class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
   private val contentResolver
     get() = appContext?.reactContext?.contentResolver ?: throw Exceptions.ReactContextLost()
@@ -56,9 +62,13 @@ class FileSystemFile(uri: Uri) : FileSystemPath(uri) {
 
   fun openHandle(mode: FileMode?): FileSystemFileHandle {
     val fileImpl = file
+    val resolvedMode = mode ?: if (fileImpl is SAFDocumentFile) FileMode.READ else FileMode.READ_WRITE
+    for (permission in resolvedMode.requiredPermissions()) {
+      validatePermission(permission)
+    }
     return when (fileImpl) {
-      is JavaFile -> FileSystemFileHandle.forJavaFile(fileImpl, mode ?: FileMode.READ_WRITE)
-      is SAFDocumentFile -> FileSystemFileHandle.forContentURI(fileImpl.uri, mode ?: FileMode.READ, contentResolver)
+      is JavaFile -> FileSystemFileHandle.forJavaFile(fileImpl, resolvedMode)
+      is SAFDocumentFile -> FileSystemFileHandle.forContentURI(fileImpl.uri, resolvedMode, contentResolver)
       else -> throw Exceptions.IllegalStateException("File handle is not supported for ${file.uri}")
     }
   }

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -21,6 +21,16 @@ import java.util.EnumSet
 import java.util.regex.Pattern
 import kotlin.io.path.moveTo
 
+internal fun validateFileSystemChildName(name: String) {
+  val invalid = name.isEmpty() ||
+    name == "." ||
+    name == ".." ||
+    name.any { it == '/' || it == '\\' }
+  if (invalid) {
+    throw UnableToCreateException("child name must be a single path segment")
+  }
+}
+
 val Uri.isContentUri
   get(): Boolean {
     return scheme == "content"
@@ -75,6 +85,7 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
       }
 
   fun delete() {
+    validatePermission(FilePermissionService.Permission.WRITE)
     if (!file.exists()) {
       throw UnableToDeleteException("uri '${file.uri}' does not exist")
     }
@@ -134,9 +145,12 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
       // TODO: Consider adding a check for asset URIs – this returns asset files of Expo Go (such as root-cert), but these are already freely available on apk mirrors ect.
       return true
     }
+    return checkPermissionForPath(javaFile.path, permission)
+  }
 
+  private fun checkPermissionForPath(path: String, permission: FilePermissionService.Permission): Boolean {
     val permissions = appContext?.filePermission?.getPathPermissions(
-      appContext?.reactContext ?: throw Exceptions.ReactContextLost(), javaFile.path
+      appContext?.reactContext ?: throw Exceptions.ReactContextLost(), path
     ) ?: EnumSet.noneOf(FilePermissionService.Permission::class.java)
     return permissions.contains(permission)
   }
@@ -176,7 +190,13 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
   fun rename(newName: String) {
     validateType()
     validatePermission(FilePermissionService.Permission.WRITE)
-    val newFile = File(javaFile.parent, newName)
+    validateFileSystemChildName(newName)
+    val parent = javaFile.parentFile?.canonicalFile
+      ?: throw UnableToCreateException("parent directory does not exist")
+    val newFile = File(parent, newName).canonicalFile
+    if (newFile.parentFile?.canonicalPath != parent.canonicalPath) {
+      throw UnableToCreateException("child path escapes parent directory")
+    }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       javaFile.toPath().moveTo(newFile.toPath())
       uri = newFile.toUri()

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemPath.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import android.os.Build
 import android.provider.DocumentsContract
-import androidx.core.net.toUri
 import expo.modules.filesystem.unifiedfile.AssetFile
 import expo.modules.filesystem.unifiedfile.ContentProviderFile
 import expo.modules.filesystem.fsops.DestinationSpec
@@ -191,20 +190,30 @@ abstract class FileSystemPath(var uri: Uri) : SharedObject() {
     validateType()
     validatePermission(FilePermissionService.Permission.WRITE)
     validateFileSystemChildName(newName)
-    val parent = javaFile.parentFile?.canonicalFile
+    val parent = javaFile.parentFile
       ?: throw UnableToCreateException("parent directory does not exist")
-    val newFile = File(parent, newName).canonicalFile
-    if (newFile.parentFile?.canonicalPath != parent.canonicalPath) {
+    // Use canonical paths only for containment checks, so symlinks and aliases cannot escape the parent.
+    val parentCanonicalPath = parent.canonicalPath
+    val newFile = File(parent, newName)
+    if (newFile.canonicalFile.parentFile?.canonicalPath != parentCanonicalPath) {
       throw UnableToCreateException("child path escapes parent directory")
     }
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       javaFile.toPath().moveTo(newFile.toPath())
-      uri = newFile.toUri()
     } else {
       javaFile.copyTo(newFile)
       javaFile.delete()
-      uri = newFile.toUri()
     }
+    uri = renamedUri(newName)
+  }
+
+  private fun renamedUri(newName: String): Uri {
+    // Preserve the original URI spelling; canonical paths can rewrite /data/user/0 to /data/data.
+    val currentUri = uri.toString()
+    val currentPath = currentUri.trimEnd('/')
+    val parentUri = currentUri.substring(0, currentPath.lastIndexOf('/') + 1)
+    val renamedUri = Uri.withAppendedPath(Uri.parse(parentUri), newName).toString()
+    return Uri.parse(if (this is FileSystemDirectory) "$renamedUri/" else renamedUri)
   }
 
   val modificationTime: Long?

--- a/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
+++ b/packages/expo-file-system/android/src/test/java/expo/modules/filesystem/FileSystemFileTest.kt
@@ -2,16 +2,34 @@ package expo.modules.filesystem
 
 import android.net.Uri
 import android.os.Build
+import com.facebook.react.bridge.BridgeReactContext
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.ModulesProvider
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.services.FilePermissionService
+import expo.modules.kotlin.services.Service
+import java.io.File
+import java.lang.ref.WeakReference
+import java.nio.file.Files
+import java.util.EnumSet
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.R])
 class FileSystemFileTest {
+  @get:Rule
+  val temporaryFolder = TemporaryFolder()
+
   @Test
   fun createRejectsContentUriBeforeResolvingFileType() {
     val file = FileSystemFile(Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADownload"))
@@ -25,4 +43,171 @@ class FileSystemFileTest {
         exception.message?.contains("Directory.createFile") == true
     )
   }
+
+  @Test
+  fun fileModeRequiredPermissionsMatchHandleAccess() {
+    assertEquals(listOf(FilePermissionService.Permission.READ), FileMode.READ.requiredPermissions())
+    assertEquals(listOf(FilePermissionService.Permission.WRITE), FileMode.WRITE.requiredPermissions())
+    assertEquals(listOf(FilePermissionService.Permission.WRITE), FileMode.APPEND.requiredPermissions())
+    assertEquals(listOf(FilePermissionService.Permission.WRITE), FileMode.TRUNCATE.requiredPermissions())
+    assertEquals(
+      listOf(FilePermissionService.Permission.READ, FilePermissionService.Permission.WRITE),
+      FileMode.READ_WRITE.requiredPermissions()
+    )
+  }
+
+  @Test
+  fun openHandleRequiresPermissionsMatchingFileModeBeforeOpeningFile() {
+    val source = temporaryFolder.newFile("read-write.txt").apply {
+      writeText("content")
+    }
+    val file = FileSystemFile(Uri.fromFile(source))
+      .withAppContext(permissionServiceReturning(EnumSet.of(FilePermissionService.Permission.READ)))
+
+    assertThrows(InvalidPermissionException::class.java) {
+      file.openHandle(FileMode.READ_WRITE)
+    }
+  }
+
+  @Test
+  fun deleteRequiresWritePermissionBeforeDeletingFile() {
+    val source = temporaryFolder.newFile("delete-target.txt")
+    val file = FileSystemFile(Uri.fromFile(source))
+      .withAppContext(permissionServiceReturning(EnumSet.of(FilePermissionService.Permission.READ)))
+
+    assertThrows(InvalidPermissionException::class.java) {
+      file.delete()
+    }
+
+    assertTrue(source.exists())
+  }
+
+  @Test
+  fun createFileRejectsChildNameThatEscapesParentDirectory() {
+    val parent = temporaryFolder.newFolder("parent")
+    val escaped = File(parent.parentFile, "escaped.txt")
+    val directory = FileSystemDirectory(Uri.fromFile(parent))
+      .withAppContext(permissionServiceReturning(EnumSet.of(FilePermissionService.Permission.WRITE)))
+
+    assertThrows(UnableToCreateException::class.java) {
+      directory.createFile("text/plain", "../escaped.txt")
+    }
+
+    assertFalse(escaped.exists())
+  }
+
+  @Test
+  fun createFileRejectsSingleSegmentSymlinkThatEscapesParentDirectory() {
+    val parent = temporaryFolder.newFolder("parent-with-file-link")
+    val escaped = temporaryFolder.newFile("linked-outside.txt")
+    createSymbolicLink(File(parent, "linked-file"), escaped)
+    val directory = FileSystemDirectory(Uri.fromFile(parent))
+      .withAppContext(permissionServiceReturning(EnumSet.of(FilePermissionService.Permission.WRITE)))
+
+    assertThrows(UnableToCreateException::class.java) {
+      directory.createFile("text/plain", "linked-file")
+    }
+  }
+
+  @Test
+  fun createDirectoryRejectsChildNameThatEscapesParentDirectory() {
+    val parent = temporaryFolder.newFolder("parent-dir")
+    val escaped = File(parent.parentFile, "escaped-dir")
+    val directory = FileSystemDirectory(Uri.fromFile(parent))
+      .withAppContext(permissionServiceReturning(EnumSet.of(FilePermissionService.Permission.WRITE)))
+
+    assertThrows(UnableToCreateException::class.java) {
+      directory.createDirectory("../escaped-dir")
+    }
+
+    assertFalse(escaped.exists())
+  }
+
+  @Test
+  fun createDirectoryRejectsSingleSegmentSymlinkThatEscapesParentDirectory() {
+    val parent = temporaryFolder.newFolder("parent-with-dir-link")
+    val escaped = temporaryFolder.newFolder("linked-outside-dir")
+    createSymbolicLink(File(parent, "linked-dir"), escaped)
+    val directory = FileSystemDirectory(Uri.fromFile(parent))
+      .withAppContext(permissionServiceReturning(EnumSet.of(FilePermissionService.Permission.WRITE)))
+
+    assertThrows(UnableToCreateException::class.java) {
+      directory.createDirectory("linked-dir")
+    }
+  }
+
+  @Test
+  fun renameRejectsChildNameThatEscapesParentDirectory() {
+    val parent = temporaryFolder.newFolder("rename-parent")
+    val source = File(parent, "source.txt").apply {
+      writeText("content")
+    }
+    val escaped = File(parent.parentFile, "renamed-outside.txt")
+    val file = FileSystemFile(Uri.fromFile(source))
+      .withAppContext(
+        permissionServiceReturning(
+          EnumSet.of(FilePermissionService.Permission.READ, FilePermissionService.Permission.WRITE)
+        )
+      )
+
+    assertThrows(UnableToCreateException::class.java) {
+      file.rename("../renamed-outside.txt")
+    }
+
+    assertTrue(source.exists())
+    assertFalse(escaped.exists())
+  }
+
+  @Test
+  fun renameRejectsSingleSegmentSymlinkThatEscapesParentDirectory() {
+    val parent = temporaryFolder.newFolder("rename-parent-with-link")
+    val source = File(parent, "source.txt").apply {
+      writeText("content")
+    }
+    val escaped = temporaryFolder.newFile("rename-linked-outside.txt")
+    createSymbolicLink(File(parent, "linked-file"), escaped)
+    val file = FileSystemFile(Uri.fromFile(source))
+      .withAppContext(
+        permissionServiceReturning(
+          EnumSet.of(FilePermissionService.Permission.READ, FilePermissionService.Permission.WRITE)
+        )
+      )
+
+    assertThrows(UnableToCreateException::class.java) {
+      file.rename("linked-file")
+    }
+
+    assertTrue(source.exists())
+  }
+
+  private fun createSymbolicLink(link: File, target: File) {
+    Files.createSymbolicLink(link.toPath(), target.toPath())
+  }
+
+  private fun permissionServiceReturning(permissions: EnumSet<FilePermissionService.Permission>) =
+    object : FilePermissionService() {
+      override fun getPathPermissions(
+        context: android.content.Context,
+        path: String
+      ): EnumSet<Permission> = permissions
+    }
+
+  private fun createAppContext(permissionService: FilePermissionService): AppContext {
+    val reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
+    return AppContext(
+      object : ModulesProvider {
+        override fun getModulesMap(): Map<Class<out Module>, String?> = emptyMap()
+        override fun getServices(): List<Class<out Service>> = emptyList()
+      },
+      expo.modules.core.ModuleRegistry(emptyList(), emptyList()),
+      WeakReference(reactContext)
+    ).also {
+      it.services.register(FilePermissionService::class.java, permissionService)
+    }
+  }
+
+  private fun <T : FileSystemPath> T.withAppContext(permissionService: FilePermissionService): T =
+    apply {
+      runtimeContextHolder = WeakReference(createAppContext(permissionService).runtime)
+    }
 }


### PR DESCRIPTION
# Why

The `expo-file-system` API on Android lacks permission checks on `delete()` and `openHandle()`, and allows path traversal via `../` in `createFile`, `createDirectory`, and `rename`.

# How

- Add write-permission validation to `FileSystemPath.delete()`.
- Add mode-based permission validation to `FileSystemFile.openHandle()` before opening file handles.
- Validate child names in `createFile`, `createDirectory`, and `rename` — reject empty names, `.`/`..`, slashes, and canonical paths that escape the parent directory (including via symlinks).

# Test Plan

- Added unit tests covering permission enforcement, path traversal rejection, and symlink escape rejection.
- Confirmed that `Directory.createFile("text/plain", "../escape.txt")` throws instead of creating a file outside the directory.
- Confirmed that `File.delete()` throws when the app does not have write permission to the path.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)