### PR TITLE
[docs] Update Convex guide for EAS integration CLI

### DIFF
--- a/docs/pages/guides/using-convex.mdx
+++ b/docs/pages/guides/using-convex.mdx
@@ -4,99 +4,74 @@ description: Add a database to your app with Convex.
 ---
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-[Convex](https://www.convex.dev/) is a TypeScript-based database that requires no cluster management, SQL, or ORMs. Convex provides real-time updates over a WebSocket, making it perfect for reactive apps.
+[Convex](https://www.convex.dev/) is a backend platform for building reactive apps with a realtime database, server functions, file storage, search, scheduling, and type-safe client libraries without the need for cluster management, SQL, or ORMs.
+
+The EAS CLI integration can create and connect the Convex project for you. It replaces the manual setup steps where you install the package, create a Convex team and project, copy deployment URLs, and configure EAS environment variables.
+
+<Prerequisites>
+  <Requirement title="Expo account">
+    Sign up for an [Expo account](https://expo.dev/signup).
+  </Requirement>
+  <Requirement title="EAS CLI">Install EAS CLI globally with `npm install -g eas-cli`.</Requirement>
+  <Requirement title="Expo project linked to EAS">
+    Create an Expo project and link it to EAS with `eas init`.
+  </Requirement>
+</Prerequisites>
+
+## Connect Convex with EAS
 
 <Step label="1">
 
-## Install Convex
+### Run the EAS CLI integration command
 
-After you have created your [Expo project](/get-started/create-a-project/), install `convex` using the following command:
+From your Expo project directory, run:
 
-<Terminal cmd={['$ npx expo install convex']} />
+<Terminal cmd={['$ eas integrations:convex:connect']} />
+
+The command will prompt for a Convex deployment region, project name, and team name when needed. It only asks for a team name when it needs to create a new Convex team connection.
+
+You can also pass values explicitly:
+
+<Terminal
+  cmd={[
+    '$ eas integrations:convex:connect --region aws-us-east-1 --team-name "Your-team-name" --project-name "your-app"',
+  ]}
+/>
+
+The integration command:
+
+- Installs the `convex` package with `npx expo install convex`
+- Creates a Convex team connection for your EAS account, or reuses an existing one
+- Creates a Convex project and deployment for the current Expo app
+- Writes `CONVEX_DEPLOY_KEY` and `EXPO_PUBLIC_CONVEX_URL` to **.env.local**
+- Creates or updates the `EXPO_PUBLIC_CONVEX_URL` EAS project environment variable for the production, preview, and development environments
+- Sends an invitation to your verified email so you can claim the Convex team and open the Convex dashboard
 
 </Step>
 
 <Step label="2">
 
-## Set up a Convex dev deployment
+### Start Convex locally
 
-Run the following command to set up your Convex project:
+After the integration command finishes, start the Convex dev server:
 
 <Terminal cmd={['$ npx convex dev']} />
 
-This command:
-
-- Creates a Convex account or allows you to log in.
-- Creates a project on Convex.
-- Saves your production and deployment URLs.
-
-It also creates a **convex/** folder where you can write backend API functions that Convex will host.
-
-Leave this command running in one terminal window so that it can sync your functions with your dev deployment in Convex's cloud.
+This creates the local **convex** directory if your project does not have one yet, generates the typed API files, and syncs your Convex functions with your deployment while it runs.
 
 </Step>
 
 <Step label="3">
 
-## Save the Convex URL as an EAS environment variable
+### Add a Convex provider
 
-Running `npx convex dev` saves your deployment URL to a **.env.local** file as `EXPO_PUBLIC_CONVEX_URL`. To make it available in your app builds, add it as an [EAS environment variable](/eas/environment-variables/) in a new terminal session:
+Create a Convex client with the deployment URL that the EAS integration wrote to **.env.local**, then wrap your app in `ConvexProvider`.
 
-<Terminal
-  cmd={[
-    '$ eas env:create --name EXPO_PUBLIC_CONVEX_URL --value https://YOUR_DEPLOYMENT_URL.convex.cloud --visibility plaintext --environment production --environment preview --environment development',
-  ]}
-/>
-
-Replace `https://YOUR_DEPLOYMENT_URL.convex.cloud` with the `EXPO_PUBLIC_CONVEX_URL` value from your **.env.local** file. To learn more, see [Environment variables](/guides/environment-variables/).
-
-</Step>
-
-<Step label="4">
-
-## Seed your database
-
-Next, create a **sampleData.jsonl** file with the following sample data:
-
-```json sampleData.jsonl
-{"text": "Buy groceries", "isCompleted": true}
-{"text": "Go for a swim", "isCompleted": true}
-{"text": "Integrate Convex", "isCompleted": false}
-```
-
-To send this data to Convex, run:
-
-<Terminal cmd={['$ npx convex import --table tasks sampleData.jsonl']} />
-
-</Step>
-
-<Step label="5">
-
-## Query the database
-
-All queries in Convex are TypeScript code. Create a **convex/tasks.ts** file with the following contents:
-
-```ts convex/tasks.ts
-import { query } from './_generated/server';
-
-export const get = query({
-  args: {},
-  handler: async ctx => {
-    return await ctx.db.query('tasks').collect();
-  },
-});
-```
-
-</Step>
-
-<Step label="6">
-
-## Connect your app
-
-In the top-level **src/app/\_layout.tsx** file in your app, create a `ConvexReactClient` and pass it to a `ConvexProvider` wrapping your component tree:
+For an Expo Router project, update **src/app/\_layout.tsx**:
 
 ```tsx src/app/_layout.tsx
 import { ConvexProvider, ConvexReactClient } from 'convex/react';
@@ -109,9 +84,7 @@ const convex = new ConvexReactClient(process.env.EXPO_PUBLIC_CONVEX_URL!, {
 export default function RootLayout() {
   return (
     <ConvexProvider client={convex}>
-      <Stack>
-        <Stack.Screen name="index" />
-      </Stack>
+      <Stack />
     </ConvexProvider>
   );
 }
@@ -119,11 +92,24 @@ export default function RootLayout() {
 
 </Step>
 
-<Step label="7">
+<Step label="4">
 
-## Display the data in your app
+### Query Convex from your app
 
-In your app, use the `useQuery` hook to fetch data from your `api.tasks.get` API:
+Add a query function in the **convex** directory:
+
+```ts convex/tasks.ts
+import { query } from './_generated/server';
+
+export const get = query({
+  args: {},
+  handler: async ctx => {
+    return await ctx.db.query('tasks').collect();
+  },
+});
+```
+
+Then call it from your app with `useQuery`:
 
 ```tsx src/app/index.tsx
 import { api } from '@/convex/_generated/api';
@@ -134,14 +120,9 @@ export default function Index() {
   const tasks = useQuery(api.tasks.get);
 
   return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}>
-      {tasks?.map(({ _id, text }) => (
-        <Text key={_id}>{text}</Text>
+    <View>
+      {tasks?.map(task => (
+        <Text key={task._id}>{task.text}</Text>
       ))}
     </View>
   );
@@ -150,10 +131,25 @@ export default function Index() {
 
 </Step>
 
-## Next steps
+To learn more about how Convex works, including database documents, functions, and client subscriptions, see the Convex overview:
 
 <BoxLink
-  title="Learn how to use Convex"
-  description="Learn how Convex works while building a chat app."
-  href="https://docs.convex.dev/tutorial/"
+  title="Convex overview"
+  description="Learn the core Convex concepts behind database documents, functions, and realtime client updates."
+  href="https://docs.convex.dev/understanding/"
 />
+
+## Manage the integration
+
+Use these commands to inspect or manage the Convex integration later:
+
+<Terminal
+  cmd={[
+    '$ eas integrations:convex:project',
+    '$ eas integrations:convex:dashboard',
+    '$ eas integrations:convex:team',
+    '$ eas integrations:convex:team:invite',
+  ]}
+/>
+
+If you remove the link with `eas integrations:convex:project:delete` or `eas integrations:convex:team:delete`, EAS removes its integration metadata. These commands do not destroy resources on Convex.


### PR DESCRIPTION
# Why

The Convex guide still described the older manual setup flow. EAS CLI now has `eas integrations:convex:connect`, which automates the Expo-specific setup work for connecting Convex to an EAS project.

# How

Updated the Convex guide to center setup around `eas integrations:convex:connect`, including the steps the command now handles:

- installing `convex`
- creating or reusing the Convex team connection
- creating the Convex project and deployment
- writing `CONVEX_DEPLOY_KEY` and `EXPO_PUBLIC_CONVEX_URL` to `.env.local`
- creating or updating the `EXPO_PUBLIC_CONVEX_URL` EAS environment variable
- sending the Convex team invite when possible

Kept the remaining developer steps focused on running `npx convex dev`, adding the Convex provider, querying data, and linking to Convex's conceptual overview instead of their React Native quickstart.

# Test Plan

Read the diff.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)