### PR TITLE
[expo-go][Android] Fix scoped path permissions [EXP-47]

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.kt
+++ b/apps/expo-go/android/expoview/src/main/java/versioned/host/exp/exponent/modules/universal/ScopedFilePermissionModule.kt
@@ -1,5 +1,6 @@
 package versioned.host.exp.exponent.modules.universal
 
+import android.content.Context
 import expo.modules.kotlin.services.FilePermissionService
 import host.exp.exponent.utils.ScopedContext
 import java.io.File
@@ -8,6 +9,31 @@ import java.util.EnumSet
 
 class ScopedFilePermissionService(private val scopedContext: ScopedContext) :
   FilePermissionService() {
+  override fun getPathPermissions(context: Context, path: String): EnumSet<Permission> {
+    return try {
+      val canonicalPath = File(path).canonicalPath
+      val scopedDirectories = listOf(
+        scopedContext.filesDir,
+        scopedContext.cacheDir,
+        scopedContext.noBackupFilesDir
+      ).map { it.canonicalPath }
+
+      if (scopedDirectories.any { canonicalPath.isInDirectory(it) }) {
+        return EnumSet.of(Permission.READ, Permission.WRITE)
+      }
+
+      val dataDirCanonicalPath = File(scopedContext.context.applicationInfo.dataDir).canonicalPath
+      if (canonicalPath.isInDirectory(dataDirCanonicalPath)) {
+        return EnumSet.noneOf(Permission::class.java)
+      }
+
+      getExternalPathPermissions(path)
+    } catch (e: IOException) {
+      // Something's not right, let's be cautious.
+      EnumSet.noneOf(Permission::class.java)
+    }
+  }
+
   override fun getExternalPathPermissions(path: String): EnumSet<Permission> {
     try {
       // In scoped context we do not allow access to Expo Go's directory,
@@ -27,4 +53,7 @@ class ScopedFilePermissionService(private val scopedContext: ScopedContext) :
     }
     return super.getExternalPathPermissions(path)
   }
+
+  private fun String.isInDirectory(directory: String): Boolean =
+    startsWith("$directory/") || this == directory
 }


### PR DESCRIPTION
# Why

Follow-up #45967, #45977 

Expo Go's `ScopedFilePermissionService` on Android only overrode `getExternalPathPermissions` but not `getPathPermissions`, so the new permission checks added to `expo-file-system` (delete, openHandle) were not scoped correctly — they would fall through to the base implementation instead of enforcing per-experience sandboxing.

# How

- Override `getPathPermissions` in `ScopedFilePermissionService` to grant read/write access to the current experience's scoped directories (filesDir, cacheDir, noBackupFilesDir) and deny access to other experiences' files within the Expo Go data directory.
- External paths delegate to the existing `getExternalPathPermissions`.
- Add unit tests verifying scoped grants, cross-experience denial, and external path passthrough.

# Test Plan

Repeated tests from #45967 in Expo Go:

- Confirmed that `File.delete()` and `File.openHandle()` work for files within the current experience's sandbox.
- Confirmed that accessing another experience's files is denied.

Repro apps: https://gist.github.com/barthap/afca509d9a1abea012f50a1cc28d1c6b

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)