### PR TITLE
[notifications] Add consumerProguardFiles so bundled R8 rule applies

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] Apply bundled `proguard-rules.pro` via `consumerProguardFiles` so the `-keep class expo.modules.notifications.**` rule is added to consumer apps' R8 pass; without it, classes that are serialized to `SharedPreferences` (e.g. `NotificationRequest`, trigger subclasses) get obfuscated and `getAllScheduledNotificationsAsync()` silently returns `[]` while scheduled notifications never fire in release builds. ([#45974](https://github.com/expo/expo/pull/45974) by [@jiunshinn](https://github.com/jiunshinn))
+- [android] Apply bundled `proguard-rules.pro` via `consumerProguardFiles` so the `-keep class expo.modules.notifications.**` rule is added to consumer apps' R8 pass. ([#45974](https://github.com/expo/expo/pull/45974) by [@jiunshinn](https://github.com/jiunshinn))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [android] Apply bundled `proguard-rules.pro` via `consumerProguardFiles` so the `-keep class expo.modules.notifications.**` rule is added to consumer apps' R8 pass; without it, classes that are serialized to `SharedPreferences` (e.g. `NotificationRequest`, trigger subclasses) get obfuscated and `getAllScheduledNotificationsAsync()` silently returns `[]` while scheduled notifications never fire in release builds. ([#45292](https://github.com/expo/expo/issues/45292) by [@jiunshinn](https://github.com/jiunshinn))
+- [android] Apply bundled `proguard-rules.pro` via `consumerProguardFiles` so the `-keep class expo.modules.notifications.**` rule is added to consumer apps' R8 pass; without it, classes that are serialized to `SharedPreferences` (e.g. `NotificationRequest`, trigger subclasses) get obfuscated and `getAllScheduledNotificationsAsync()` silently returns `[]` while scheduled notifications never fire in release builds. ([#45974](https://github.com/expo/expo/pull/45974) by [@jiunshinn](https://github.com/jiunshinn))
 
 ### 💡 Others
 

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] Apply bundled `proguard-rules.pro` via `consumerProguardFiles` so the `-keep class expo.modules.notifications.**` rule is added to consumer apps' R8 pass; without it, classes that are serialized to `SharedPreferences` (e.g. `NotificationRequest`, trigger subclasses) get obfuscated and `getAllScheduledNotificationsAsync()` silently returns `[]` while scheduled notifications never fire in release builds. ([#45292](https://github.com/expo/expo/issues/45292) by [@jiunshinn](https://github.com/jiunshinn))
+
 ### 💡 Others
 
 ## 56.0.9 — 2026-05-15

--- a/packages/expo-notifications/android/build.gradle
+++ b/packages/expo-notifications/android/build.gradle
@@ -13,6 +13,7 @@ android {
     versionCode 21
     versionName '56.0.9'
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    consumerProguardFiles 'proguard-rules.pro'
   }
 
   buildFeatures {


### PR DESCRIPTION
## Why

Fixes #45292.

`packages/expo-notifications/android/build.gradle` ships a `proguard-rules.pro` containing `-keep class expo.modules.notifications.** {*;}`, but never declares `consumerProguardFiles 'proguard-rules.pro'`, so the rule is **never** applied to consumer apps' R8 pass.

In a signed release build with R8 enabled (the typical Expo setup via `expo-build-properties.enableProguardInReleaseBuilds: true`):

- `NotificationRequest`, `NotificationContent`, and `NotificationTrigger` subclasses get obfuscated (e.g. `expo.modules.notifications.notifications.model.NotificationRequest` → `V6.g`).
- `SharedPreferencesNotificationsStore` serializes these classes to `SharedPreferences` via `ObjectOutputStream`, then reads them back via `ObjectInputStream.readObject()`.
- `readObject()` throws `ClassNotFoundException`, which the store silently swallows and returns `null` per entry.
- `Notifications.getAllScheduledNotificationsAsync()` therefore returns `[]` regardless of how many notifications were scheduled.
- The `AlarmManager` broadcast also fails to deserialize on its scheduled trigger time → **no scheduled notifications ever fire**.
- All of this is silent — no log, no error surfaced to JS.

## How

One-line addition inside the existing `defaultConfig` block, mirroring the pattern already used by sibling packages — e.g. [`expo-modules-core/android/build.gradle`](https://github.com/expo/expo/blob/main/packages/expo-modules-core/android/build.gradle):

```diff
 defaultConfig {
   versionCode 21
   versionName '56.0.9'
   testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+  consumerProguardFiles 'proguard-rules.pro'
 }
```

The `proguard-rules.pro` file already exists in the package; only the directive that wires it up was missing.

## Test plan

- [ ] Build a release AAB of an Expo app with `expo-notifications` and `expo-build-properties.enableProguardInReleaseBuilds: true` against this branch.
- [ ] Schedule a notification with `Notifications.scheduleNotificationAsync({ trigger: { type: 'date', date: Date.now() + 60_000 }, content: { title: 'X', body: 'Y' } })`.
- [ ] `Notifications.getAllScheduledNotificationsAsync()` returns the scheduled entry (not `[]`).
- [ ] Notification fires at the scheduled time.
- [ ] Reproduce the failure mode by building the same app against `main` without this patch — `getAllScheduledNotificationsAsync()` returns `[]` and nothing fires.

---

cc @vonovak — you asked for a PR with a fix on the issue.
cc @a-resh — original reporter; happy to defer if you already have a PR in progress, just let me know.