### PR TITLE
[file-system][Android] Use scoped cache/docs dirs in Expo Go [EXP-47]

### DIFF
--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fixed the jest mock's `FileSystemFileHandle` to honor `FileMode` string values (`'r'`, `'w'`, `'wa'`, `'wt'`, `'rw'`) instead of the obsolete name table, expose handle and file metadata, and match the documented default mode for `content://` URIs. The dispatch is now exhaustive over `FileMode`, so future enum additions fail to compile in the mock. (by [@radko93](https://github.com/radko93))
 - [Android] Added missing permission checks to `delete()` and `openHandle()` in the next-gen File System API. ([#45967](https://github.com/expo/expo/pull/45967) by [@barthap](https://github.com/barthap))
 - [Android] Fixed path traversal vulnerability in `createFile`, `createDirectory`, and `rename` that allowed escaping the parent directory. ([#45967](https://github.com/expo/expo/pull/45967) by [@barthap](https://github.com/barthap))
+- [Android] Fixed `Paths.cache` and `Paths.document` pointing to wrong directory in Expo Go.
 
 ### 💡 Others
 

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### 🛠 Breaking changes
 
+- [Android] In Expo Go, `Paths.cache` and `Paths.document` are now pointing to experience-isolated directories. ([#45977](https://github.com/expo/expo/pull/45977) by [@barthap](https://github.com/barthap))
+
 ### 🎉 New features
 
 ### 🐛 Bug fixes
@@ -21,7 +23,7 @@
 - Fixed the jest mock's `FileSystemFileHandle` to honor `FileMode` string values (`'r'`, `'w'`, `'wa'`, `'wt'`, `'rw'`) instead of the obsolete name table, expose handle and file metadata, and match the documented default mode for `content://` URIs. The dispatch is now exhaustive over `FileMode`, so future enum additions fail to compile in the mock. (by [@radko93](https://github.com/radko93))
 - [Android] Added missing permission checks to `delete()` and `openHandle()` in the next-gen File System API. ([#45967](https://github.com/expo/expo/pull/45967) by [@barthap](https://github.com/barthap))
 - [Android] Fixed path traversal vulnerability in `createFile`, `createDirectory`, and `rename` that allowed escaping the parent directory. ([#45967](https://github.com/expo/expo/pull/45967) by [@barthap](https://github.com/barthap))
-- [Android] Fixed `Paths.cache` and `Paths.document` pointing to wrong directory in Expo Go.
+- [Android] Fixed `Paths.cache` and `Paths.document` pointing to wrong directory in Expo Go. ([#45977](https://github.com/expo/expo/pull/45977) by [@barthap](https://github.com/barthap))
 
 ### 💡 Others
 

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/FileSystemModule.kt
@@ -21,6 +21,12 @@ class FileSystemModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.AppContextLost()
 
+  private val filesDirectory: File
+    get() = appContext.persistentFilesDirectory
+
+  private val cacheDirectory: File
+    get() = appContext.cacheDirectory
+
   private val downloadStore = DownloadTaskStore()
 
   @RequiresApi(Build.VERSION_CODES.O)
@@ -30,11 +36,11 @@ class FileSystemModule : Module() {
     Events("downloadProgress")
 
     Constant("documentDirectory") {
-      Uri.fromFile(context.filesDir).toString() + "/"
+      Uri.fromFile(filesDirectory).toString() + "/"
     }
 
     Constant("cacheDirectory") {
-      Uri.fromFile(context.cacheDir).toString() + "/"
+      Uri.fromFile(cacheDirectory).toString() + "/"
     }
 
     Constant("bundleDirectory") {
@@ -42,11 +48,11 @@ class FileSystemModule : Module() {
     }
 
     Property("totalDiskSpace") {
-      File(context.filesDir.path).totalSpace
+      filesDirectory.totalSpace
     }
 
     Property("availableDiskSpace") {
-      File(context.filesDir.path).freeSpace
+      filesDirectory.freeSpace
     }
 
     AsyncFunction("downloadFileAsync") Coroutine { url: URI, to: FileSystemPath, options: DownloadOptions?, downloadUUID: String? ->

--- a/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/legacy/FileSystemLegacyModule.kt
+++ b/packages/expo-file-system/android/src/main/java/expo/modules/filesystem/legacy/FileSystemLegacyModule.kt
@@ -80,6 +80,10 @@ fun slashifyFilePath(path: String?): String? {
 open class FileSystemLegacyModule : Module() {
   private val context: Context
     get() = appContext.reactContext ?: throw Exceptions.AppContextLost()
+  private val filesDirectory: File
+    get() = appContext.persistentFilesDirectory
+  private val cacheDirectory: File
+    get() = appContext.cacheDirectory
   private var client: OkHttpClient? = null
   private var dirPermissionsRequest: Promise? = null
   private val taskHandlers: MutableMap<String, TaskHandler> = HashMap()
@@ -90,11 +94,11 @@ open class FileSystemLegacyModule : Module() {
     Name("ExponentFileSystem")
 
     Constant("documentDirectory") {
-      Uri.fromFile(context.filesDir).toString() + "/"
+      Uri.fromFile(filesDirectory).toString() + "/"
     }
 
     Constant("cacheDirectory") {
-      Uri.fromFile(context.cacheDir).toString() + "/"
+      Uri.fromFile(cacheDirectory).toString() + "/"
     }
 
     Constant("bundleDirectory") {
@@ -108,8 +112,8 @@ open class FileSystemLegacyModule : Module() {
 
     OnCreate {
       try {
-        ensureDirExists(context.filesDir)
-        ensureDirExists(context.cacheDir)
+        ensureDirExists(filesDirectory)
+        ensureDirExists(cacheDirectory)
       } catch (e: Exception) {
         e.printStackTrace()
       }


### PR DESCRIPTION
# Why

Follow-up #45967 

In Expo Go, `Paths.cache` and `Paths.document` (and the legacy `FileSystem.documentDirectory` / `cacheDirectory` constants) pointed to the base app context's directories instead of the scoped per-experience directories. This meant all experiences shared the same file storage, breaking sandboxing.

# How

- Replace direct `context.filesDir` / `context.cacheDir` calls with `appContext.persistentFilesDirectory` / `appContext.cacheDirectory` in both `FileSystemModule` and `FileSystemLegacyModule`. These properties resolve to scoped directories when running inside Expo Go.

# Test Plan

Opened a project in Expo Go on Android. Confirmed `FileSystem.documentDirectory` and `FileSystem.cacheDirectory` print scoped paths (containing the experience key) rather than the base app paths.

Bare-expo stays unchanged.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)