### PR TITLE
[build-properties][Android] Add support for `EXPO_USE_ANDROID_PRECOMPILED_HEADERS` env

### DIFF
--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -293,7 +293,7 @@ function updateAndroidSettingsGradle({ contents, buildFromSource, }) {
     return newContents;
 }
 const withAndroidPrecompiledHeaders = (config, props) => {
-    if (!props.android?.usePrecompiledHeaders) {
+    if (!props.android?.usePrecompiledHeaders && process.env.EXPO_USE_PRECOMPILED_HEADERS !== '1') {
         return config;
     }
     config = (0, config_plugins_1.withAppBuildGradle)(config, (config) => {

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -293,7 +293,7 @@ function updateAndroidSettingsGradle({ contents, buildFromSource, }) {
     return newContents;
 }
 const withAndroidPrecompiledHeaders = (config, props) => {
-    if (!props.android?.usePrecompiledHeaders && process.env.EXPO_USE_PRECOMPILED_HEADERS !== '1') {
+    if (!props.android?.usePrecompiledHeaders && process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS !== '1') {
         return config;
     }
     config = (0, config_plugins_1.withAppBuildGradle)(config, (config) => {

--- a/packages/expo-build-properties/build/android.js
+++ b/packages/expo-build-properties/build/android.js
@@ -293,7 +293,8 @@ function updateAndroidSettingsGradle({ contents, buildFromSource, }) {
     return newContents;
 }
 const withAndroidPrecompiledHeaders = (config, props) => {
-    if (!props.android?.usePrecompiledHeaders && process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS !== '1') {
+    if (!props.android?.usePrecompiledHeaders &&
+        process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS !== '1') {
         return config;
     }
     config = (0, config_plugins_1.withAppBuildGradle)(config, (config) => {

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -188,6 +188,8 @@ export interface PluginConfigTypeAndroid extends SharedBuildConfigFields {
      * native libraries, significantly speeding up C++ compilation by pre-compiling
      * commonly used React Native headers.
      *
+     * Can also be enabled by setting the `EXPO_USE_PRECOMPILED_HEADERS=1` environment variable.
+     *
      * > **Note:** This feature is experimental and might not work with all native libraries.
      *
      * @default false

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -188,7 +188,7 @@ export interface PluginConfigTypeAndroid extends SharedBuildConfigFields {
      * native libraries, significantly speeding up C++ compilation by pre-compiling
      * commonly used React Native headers.
      *
-     * Can also be enabled by setting the `EXPO_USE_PRECOMPILED_HEADERS=1` environment variable.
+     * Can also be enabled by setting the `EXPO_USE_ANDROID_PRECOMPILED_HEADERS=1` environment variable.
      *
      * > **Note:** This feature is experimental and might not work with all native libraries.
      *

--- a/packages/expo-build-properties/src/__tests__/android-pch-test.ts
+++ b/packages/expo-build-properties/src/__tests__/android-pch-test.ts
@@ -1,4 +1,22 @@
-import { updateBuildGradleForPCH } from '../android';
+import { updateBuildGradleForPCH, withAndroidPrecompiledHeaders } from '../android';
+
+const mockWithAppBuildGradle = jest.fn().mockImplementation((config) => config);
+
+jest.mock('@expo/config-plugins/build/plugins/android-plugins', () => {
+  const plugins = jest.requireActual('@expo/config-plugins/build/plugins/android-plugins');
+  return {
+    ...plugins,
+    withAppBuildGradle: mockWithAppBuildGradle,
+  };
+});
+
+jest.mock('@expo/config-plugins/build/plugins/withDangerousMod', () => {
+  const mod = jest.requireActual('@expo/config-plugins/build/plugins/withDangerousMod');
+  return {
+    ...mod,
+    withDangerousMod: jest.fn().mockImplementation((config) => config),
+  };
+});
 
 const TEMPLATE_BUILD_GRADLE = `\
 apply plugin: "com.android.application"
@@ -37,6 +55,39 @@ dependencies {
     implementation("com.facebook.react:react-android")
 }
 `;
+
+describe(withAndroidPrecompiledHeaders, () => {
+  const mockConfig = { name: 'test', slug: 'test' } as any;
+
+  afterEach(() => {
+    delete process.env.EXPO_USE_PRECOMPILED_HEADERS;
+    mockWithAppBuildGradle.mockClear();
+  });
+
+  it('should skip when neither config nor env var is set', () => {
+    withAndroidPrecompiledHeaders(mockConfig, { android: {} });
+    expect(mockWithAppBuildGradle).not.toHaveBeenCalled();
+  });
+
+  it('should apply when usePrecompiledHeaders is true in config', () => {
+    withAndroidPrecompiledHeaders(mockConfig, {
+      android: { usePrecompiledHeaders: true },
+    });
+    expect(mockWithAppBuildGradle).toHaveBeenCalled();
+  });
+
+  it('should apply when EXPO_USE_PRECOMPILED_HEADERS env var is set to 1', () => {
+    process.env.EXPO_USE_PRECOMPILED_HEADERS = '1';
+    withAndroidPrecompiledHeaders(mockConfig, { android: {} });
+    expect(mockWithAppBuildGradle).toHaveBeenCalled();
+  });
+
+  it('should skip when EXPO_USE_PRECOMPILED_HEADERS env var is not 1', () => {
+    process.env.EXPO_USE_PRECOMPILED_HEADERS = '0';
+    withAndroidPrecompiledHeaders(mockConfig, { android: {} });
+    expect(mockWithAppBuildGradle).not.toHaveBeenCalled();
+  });
+});
 
 describe(updateBuildGradleForPCH, () => {
   it('should add externalNativeBuild block inside android section', () => {

--- a/packages/expo-build-properties/src/__tests__/android-pch-test.ts
+++ b/packages/expo-build-properties/src/__tests__/android-pch-test.ts
@@ -60,7 +60,7 @@ describe(withAndroidPrecompiledHeaders, () => {
   const mockConfig = { name: 'test', slug: 'test' } as any;
 
   afterEach(() => {
-    delete process.env.EXPO_USE_PRECOMPILED_HEADERS;
+    delete process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS;
     mockWithAppBuildGradle.mockClear();
   });
 
@@ -76,14 +76,14 @@ describe(withAndroidPrecompiledHeaders, () => {
     expect(mockWithAppBuildGradle).toHaveBeenCalled();
   });
 
-  it('should apply when EXPO_USE_PRECOMPILED_HEADERS env var is set to 1', () => {
-    process.env.EXPO_USE_PRECOMPILED_HEADERS = '1';
+  it('should apply when EXPO_USE_ANDROID_PRECOMPILED_HEADERS env var is set to 1', () => {
+    process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS = '1';
     withAndroidPrecompiledHeaders(mockConfig, { android: {} });
     expect(mockWithAppBuildGradle).toHaveBeenCalled();
   });
 
-  it('should skip when EXPO_USE_PRECOMPILED_HEADERS env var is not 1', () => {
-    process.env.EXPO_USE_PRECOMPILED_HEADERS = '0';
+  it('should skip when EXPO_USE_ANDROID_PRECOMPILED_HEADERS env var is not 1', () => {
+    process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS = '0';
     withAndroidPrecompiledHeaders(mockConfig, { android: {} });
     expect(mockWithAppBuildGradle).not.toHaveBeenCalled();
   });

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -357,7 +357,10 @@ export function updateAndroidSettingsGradle({
 }
 
 export const withAndroidPrecompiledHeaders: ConfigPlugin<PluginConfigType> = (config, props) => {
-  if (!props.android?.usePrecompiledHeaders && process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS !== '1') {
+  if (
+    !props.android?.usePrecompiledHeaders &&
+    process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS !== '1'
+  ) {
     return config;
   }
 

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -357,7 +357,7 @@ export function updateAndroidSettingsGradle({
 }
 
 export const withAndroidPrecompiledHeaders: ConfigPlugin<PluginConfigType> = (config, props) => {
-  if (!props.android?.usePrecompiledHeaders && process.env.EXPO_USE_PRECOMPILED_HEADERS !== '1') {
+  if (!props.android?.usePrecompiledHeaders && process.env.EXPO_USE_ANDROID_PRECOMPILED_HEADERS !== '1') {
     return config;
   }
 

--- a/packages/expo-build-properties/src/android.ts
+++ b/packages/expo-build-properties/src/android.ts
@@ -357,7 +357,7 @@ export function updateAndroidSettingsGradle({
 }
 
 export const withAndroidPrecompiledHeaders: ConfigPlugin<PluginConfigType> = (config, props) => {
-  if (!props.android?.usePrecompiledHeaders) {
+  if (!props.android?.usePrecompiledHeaders && process.env.EXPO_USE_PRECOMPILED_HEADERS !== '1') {
     return config;
   }
 

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -233,6 +233,8 @@ export interface PluginConfigTypeAndroid extends SharedBuildConfigFields {
    * native libraries, significantly speeding up C++ compilation by pre-compiling
    * commonly used React Native headers.
    *
+   * Can also be enabled by setting the `EXPO_USE_PRECOMPILED_HEADERS=1` environment variable.
+   *
    * > **Note:** This feature is experimental and might not work with all native libraries.
    *
    * @default false

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -233,7 +233,7 @@ export interface PluginConfigTypeAndroid extends SharedBuildConfigFields {
    * native libraries, significantly speeding up C++ compilation by pre-compiling
    * commonly used React Native headers.
    *
-   * Can also be enabled by setting the `EXPO_USE_PRECOMPILED_HEADERS=1` environment variable.
+   * Can also be enabled by setting the `EXPO_USE_ANDROID_PRECOMPILED_HEADERS=1` environment variable.
    *
    * > **Note:** This feature is experimental and might not work with all native libraries.
    *


### PR DESCRIPTION
# Why

A follow up to the https://github.com/expo/expo/pull/45922#pullrequestreview-4311361595.
Adds alternative way to enable PCH, which would be easier to run experiment on EAS. 

# Test Plan

- unit tests ✅ 
- prebuild bare-expo ✅ 