### PR TITLE
[core][iOS] Resolve SharedObject's JS value on the JS thread when emitting

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix occasional `SharedObject.emit` crashes caused by an off-thread JSI lookup. ([#45986](https://github.com/expo/expo/pull/45986) by [@tsapeta](https://github.com/tsapeta))
+
 ### 💡 Others
 
 ## 56.0.10 — 2026-05-19

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObject.swift
@@ -77,11 +77,14 @@ open class SharedObject: AnySharedObject {
       log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
       return
     }
-    guard let jsValue = getJavaScriptValue() else {
-      log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
-      return
-    }
-    runtime.schedule {
+    runtime.schedule { [weak appContext, sharedObjectId] in
+      guard let appContext else {
+        return
+      }
+      guard let jsValue = appContext.sharedObjectRegistry.toJavaScriptValue(sharedObjectId: sharedObjectId) else {
+        log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
+        return
+      }
       dispatch(event: event, payload: payload, to: jsValue, in: runtime)
     }
   }
@@ -101,12 +104,12 @@ open class SharedObject: AnySharedObject {
       log.warn("Trying to send event '\(event)' to \(type(of: self)), but the JS runtime has been lost")
       return
     }
-    guard let jsValue = getJavaScriptValue() else {
-      log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
-      return
-    }
-    runtime.schedule { [weak appContext] in
+    runtime.schedule { [weak appContext, sharedObjectId] in
       guard let appContext else {
+        return
+      }
+      guard let jsValue = appContext.sharedObjectRegistry.toJavaScriptValue(sharedObjectId: sharedObjectId) else {
+        log.warn("Trying to send event '\(event)' to JS, but the JS object is no longer associated with the native instance")
         return
       }
       do {

--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
@@ -182,6 +182,17 @@ public final class SharedObjectRegistry: Sendable {
   }
 
   /**
+   Variant of `toJavaScriptValue(_:)` that looks up by id rather than by native object.
+   */
+  @JavaScriptActor
+  internal func toJavaScriptValue(sharedObjectId id: SharedObjectId) -> JavaScriptValue? {
+    let pair = state.withLock { state in
+      return state.pairs[id]
+    }
+    return pair?.javaScript.lock()?.asValue()
+  }
+
+  /**
    Gets the JS shared object that is paired with a given native object.
    */
   internal func toJavaScriptObject(_ nativeObject: SharedObject) -> JavaScriptObject? {


### PR DESCRIPTION
# Why

`SharedObject.emit` was racing against Hermes GC and producing crashes deep inside JSI. A representative iOS crash:

```
Thread 2 Crashed:: com.facebook.react.runtime.JavaScript
0   hermesvm        facebook::hermes::HermesRuntimeImpl::hasNativeState(jsi::Object const&) + 212
1   <app>           jsi::Object::hasNativeState<expo::EventEmitter::NativeState>(jsi::Runtime&) + 12
2   <app>           expo::EventEmitter::NativeState::get(...) + 52
3   <app>           expo::EventEmitter::emitEvent(...) + 56
4   <app>           +[EXJSUtils emitEvent:runtimePointer:objectPointer:argumentsPointer:argumentCount:] + 120
5   <app>           closure #1 in dispatch(event:payload:to:in:) (SharedObject.swift:142)
…
```

The faulting `jsi::Object*` was non-sensical (`0x614d49556369727a`), which on Hermes means the object had been collected / its slot reused by the time `hasNativeState` ran.

# Root cause

Both `emit` overloads resolved the paired `JavaScriptValue` **on the calling thread** before scheduling the dispatch closure:

```swift
guard let jsValue = getJavaScriptValue() else { … }   // calling thread
runtime.schedule {
  dispatch(event: event, payload: payload, to: jsValue, in: runtime)
}
```

`getJavaScriptValue()` goes through `SharedObjectRegistry.toJavaScriptValue(_:)` → `JavaScriptWeakObject.lock()` → `JavaScriptObject.asValue()`. The last two call into JSI:

- `pointee.lock(runtime.pointee)` mutates the weak-ref table.
- `facebook.jsi.Value(runtime.pointee, pointee)` clones the underlying `jsi::Object` via `Runtime::cloneObject`.

Both are JS-thread-only on Hermes. Doing them on a background thread can race with `HadesGC` and produce a `JavaScriptValue` whose underlying handle points into recycled GC memory. When the scheduled closure later derefs that handle on the JS thread, `hasNativeState` walks garbage.

# Fix

Move the weak-to-strong promotion into the scheduled closure so it runs on the JS thread:

- Capture `sharedObjectId` (an `Int`, `Sendable`) and `[weak appContext]` in the `runtime.schedule { … }` capture list.
- Resolve `JavaScriptValue` on the JS-thread side via a new `SharedObjectRegistry.toJavaScriptValue(sharedObjectId:)` overload that is `@JavaScriptActor`-isolated.
- The existing `toJavaScriptValue(_:)` / `toJavaScriptObject(_:)` overloads and the public `SharedObject.getJavaScript{Value,Object}()` helpers are left unchanged — their implicit JS-thread requirement is no worse than before. Tightening those with `@JavaScriptActor` is a separate follow-up because it cascades through `AnyDynamicType.castToJS` and public API.

# Test plan

- [x] Run apps that previously hit the crash (apps emitting frequent shared-object events under memory pressure / aggressive GC) and confirm no regressions.
- [x] `pnpm test` in `expo-modules-core` (iOS) — no behavior change expected; existing tests should pass unchanged.
- [x] Sanity-check that events still reach JS listeners (e.g. an app that listens to a `SharedObject.emit` event continues to receive it).
