### PR TITLE
[expo] Use expo re-exports for expo-modules-core imports

### DIFF
--- a/apps/native-component-list/src/screens/AppleAuthenticationScreen.tsx
+++ b/apps/native-component-list/src/screens/AppleAuthenticationScreen.tsx
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Slider from '@react-native-community/slider';
+import { type EventSubscription } from 'expo';
 import * as AppleAuthentication from 'expo-apple-authentication';
-import { type EventSubscription } from 'expo-modules-core';
 import React from 'react';
 import { Alert, Button, ScrollView, StyleSheet, Text, View } from 'react-native';
 

--- a/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
+++ b/apps/native-component-list/src/screens/Contacts/ContactsScreen.tsx
@@ -1,8 +1,8 @@
 import { useFocusEffect } from '@react-navigation/native';
 import { StackNavigationProp } from '@react-navigation/stack';
+import { Platform } from 'expo';
 import * as Contacts from 'expo-contacts/legacy';
 import { Directory, File, Paths } from 'expo-file-system';
-import { Platform } from 'expo-modules-core';
 import React from 'react';
 import { RefreshControl, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 

--- a/apps/native-component-list/src/screens/GL/PIXISpriteScreen.tsx
+++ b/apps/native-component-list/src/screens/GL/PIXISpriteScreen.tsx
@@ -1,6 +1,6 @@
 import './BeforePIXI';
+import { Platform } from 'expo';
 import { Asset } from 'expo-asset';
-import { Platform } from 'expo-modules-core';
 import * as PIXI from 'pixi.js';
 import { Dimensions } from 'react-native';
 

--- a/apps/native-component-list/src/screens/Image/ImageScreen.tsx
+++ b/apps/native-component-list/src/screens/Image/ImageScreen.tsx
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import { optionalRequire } from '../../navigation/routeBuilder';
 import ComponentListScreen, { componentScreensToListElements } from '../ComponentListScreen';

--- a/apps/native-component-list/src/screens/LocalAuthenticationScreen.tsx
+++ b/apps/native-component-list/src/screens/LocalAuthenticationScreen.tsx
@@ -1,7 +1,7 @@
 import SegmentedControl from '@react-native-segmented-control/segmented-control';
+import { Platform } from 'expo';
 import * as LocalAuthentication from 'expo-local-authentication';
 import { BiometricsSecurityLevel } from 'expo-local-authentication';
-import { Platform } from 'expo-modules-core';
 import React, { useState, useEffect } from 'react';
 import { View, StyleSheet } from 'react-native';
 

--- a/apps/native-component-list/src/screens/MeshGradientScreen.tsx
+++ b/apps/native-component-list/src/screens/MeshGradientScreen.tsx
@@ -1,5 +1,5 @@
+import { Platform } from 'expo';
 import { MeshGradientView } from 'expo-mesh-gradient';
-import { Platform } from 'expo-modules-core';
 import { useCallback, useState } from 'react';
 import { Dimensions, StyleSheet, Text, View } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';

--- a/apps/native-component-list/src/screens/NotificationScreen.tsx
+++ b/apps/native-component-list/src/screens/NotificationScreen.tsx
@@ -1,5 +1,5 @@
+import { EventSubscription } from 'expo';
 import * as Device from 'expo-device';
-import { EventSubscription } from 'expo-modules-core';
 import * as Notifications from 'expo-notifications';
 import { getAllScheduledNotificationsAsync } from 'expo-notifications';
 import React from 'react';

--- a/apps/native-component-list/src/screens/PickerScreen.tsx
+++ b/apps/native-component-list/src/screens/PickerScreen.tsx
@@ -1,5 +1,5 @@
 import { Picker, PickerProps, PickerIOS } from '@react-native-picker/picker';
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 import * as React from 'react';
 import { Button } from 'react-native';
 

--- a/apps/native-component-list/src/screens/ScreenOrientationScreen.tsx
+++ b/apps/native-component-list/src/screens/ScreenOrientationScreen.tsx
@@ -1,4 +1,4 @@
-import { Platform, type EventSubscription } from 'expo-modules-core';
+import { Platform, type EventSubscription } from 'expo';
 import * as ScreenOrientation from 'expo-screen-orientation';
 import React from 'react';
 import { ScrollView, SafeAreaView } from 'react-native';

--- a/apps/native-component-list/src/screens/SensorScreen.tsx
+++ b/apps/native-component-list/src/screens/SensorScreen.tsx
@@ -1,4 +1,4 @@
-import { type EventSubscription } from 'expo-modules-core';
+import { type EventSubscription } from 'expo';
 import * as Sensors from 'expo-sensors';
 import React, { useEffect, useState } from 'react';
 import { Platform, ScrollView, StyleSheet, Text, TouchableOpacity, View } from 'react-native';

--- a/apps/native-component-list/src/screens/SwitchScreen.tsx
+++ b/apps/native-component-list/src/screens/SwitchScreen.tsx
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 import * as React from 'react';
 import { Switch } from 'react-native';
 

--- a/apps/native-component-list/src/screens/Video/VideoAudioTracksScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoAudioTracksScreen.tsx
@@ -1,6 +1,5 @@
 import { Picker } from '@react-native-picker/picker';
-import { useEvent } from 'expo';
-import { Platform } from 'expo-modules-core';
+import { Platform, useEvent } from 'expo';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import React, { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';

--- a/apps/native-component-list/src/screens/Video/VideoCacheScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoCacheScreen.tsx
@@ -1,5 +1,5 @@
 import { Picker } from '@react-native-picker/picker';
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 import {
   useVideoPlayer,
   VideoView,

--- a/apps/native-component-list/src/screens/Video/VideoDRMScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoDRMScreen.tsx
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import { View, Text } from 'react-native';
 

--- a/apps/native-component-list/src/screens/Video/VideoSourcesScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoSourcesScreen.tsx
@@ -1,5 +1,5 @@
 import { Picker } from '@react-native-picker/picker';
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 import { useVideoPlayer, VideoView, VideoSource } from 'expo-video';
 import React, { useRef, useState } from 'react';
 import { ScrollView, Text, View, Button } from 'react-native';

--- a/apps/native-component-list/src/screens/Video/VideoSubtitlesScreen.tsx
+++ b/apps/native-component-list/src/screens/Video/VideoSubtitlesScreen.tsx
@@ -1,6 +1,5 @@
 import { Picker } from '@react-native-picker/picker';
-import { useEvent } from 'expo';
-import { Platform } from 'expo-modules-core';
+import { Platform, useEvent } from 'expo';
 import { useVideoPlayer, VideoView } from 'expo-video';
 import React, { useEffect, useState } from 'react';
 import { View, Text } from 'react-native';

--- a/apps/native-component-list/src/screens/ViewShotScreen.tsx
+++ b/apps/native-component-list/src/screens/ViewShotScreen.tsx
@@ -1,7 +1,7 @@
+import { Platform } from 'expo';
 import { Image, ImageErrorEventData } from 'expo-image';
 import { LinearGradient } from 'expo-linear-gradient';
 import * as MediaLibrary from 'expo-media-library/legacy';
-import { Platform } from 'expo-modules-core';
 import { useRef, useState } from 'react';
 import { Dimensions, ScrollView, StyleSheet, Text, View, Alert } from 'react-native';
 import { captureRef as takeSnapshotAsync, captureScreen } from 'react-native-view-shot';

--- a/packages/expo-age-range/src/ExpoAgeRange.ts
+++ b/packages/expo-age-range/src/ExpoAgeRange.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { ExpoAgeRangeModule } from './ExpoAgeRange.types';
 

--- a/packages/expo-app-integrity/src/ExpoAppIntegrity.ts
+++ b/packages/expo-app-integrity/src/ExpoAppIntegrity.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { ExpoAppIntegrityModule } from './ExpoAppIntegrity.types';
 

--- a/packages/expo-apple-authentication/src/AppleAuthentication.ts
+++ b/packages/expo-apple-authentication/src/AppleAuthentication.ts
@@ -1,4 +1,4 @@
-import { CodedError, type EventSubscription, UnavailabilityError } from 'expo-modules-core';
+import { CodedError, type EventSubscription, UnavailabilityError } from 'expo';
 
 import type {
   AppleAuthenticationCredential,
@@ -163,5 +163,4 @@ export function addRevokeListener(listener: () => void): EventSubscription {
   return ExpoAppleAuthentication.addListener('Expo.appleIdCredentialRevoked', listener);
 }
 
-// TODO(@kitten): Remove re-export from EMC
-export type { EventSubscription as Subscription } from 'expo-modules-core';
+export type { EventSubscription as Subscription } from 'expo';

--- a/packages/expo-apple-authentication/src/ExpoAppleAuthentication.ts
+++ b/packages/expo-apple-authentication/src/ExpoAppleAuthentication.ts
@@ -1,4 +1,4 @@
-import { requireOptionalNativeModule } from 'expo-modules-core';
+import { requireOptionalNativeModule } from 'expo';
 
 // If the real native module doesn't exist, make a pretend one, instead of
 // `null`, so we can offer an `isAvailableAsync` (that will always give

--- a/packages/expo-apple-authentication/src/ExpoAppleAuthenticationButton.ts
+++ b/packages/expo-apple-authentication/src/ExpoAppleAuthenticationButton.ts
@@ -1,10 +1,10 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import { Platform } from 'react-native';
 
 let ExpoAppleAuthenticationButton: any;
 
 if (Platform.OS === 'ios') {
-  ExpoAppleAuthenticationButton = requireNativeViewManager('ExpoAppleAuthentication');
+  ExpoAppleAuthenticationButton = requireNativeView('ExpoAppleAuthentication');
 }
 
 export default ExpoAppleAuthenticationButton;

--- a/packages/expo-application/src/Application.ts
+++ b/packages/expo-application/src/Application.ts
@@ -1,4 +1,4 @@
-import { Platform, UnavailabilityError } from 'expo-modules-core';
+import { Platform, UnavailabilityError } from 'expo';
 
 import type {
   ApplicationReleaseType,

--- a/packages/expo-application/src/ExpoApplication.ts
+++ b/packages/expo-application/src/ExpoApplication.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoApplication');

--- a/packages/expo-audio/src/AudioModule.ts
+++ b/packages/expo-audio/src/AudioModule.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NativeAudioModule } from './AudioModule.types';
 

--- a/packages/expo-audio/src/AudioModule.types.ts
+++ b/packages/expo-audio/src/AudioModule.types.ts
@@ -1,5 +1,5 @@
 import type { PermissionResponse } from 'expo';
-import { NativeModule, SharedObject } from 'expo-modules-core';
+import { NativeModule, SharedObject } from 'expo';
 
 import type {
   AudioMetadata,

--- a/packages/expo-audio/src/AudioStream.ts
+++ b/packages/expo-audio/src/AudioStream.ts
@@ -1,4 +1,4 @@
-import { useReleasingSharedObject } from 'expo-modules-core';
+import { useReleasingSharedObject } from 'expo';
 import { useEffect, useRef, useState } from 'react';
 
 import { AUDIO_STREAM_BUFFER, AUDIO_STREAM_STATUS } from './AudioEventKeys';

--- a/packages/expo-audio/src/AudioStream.types.ts
+++ b/packages/expo-audio/src/AudioStream.types.ts
@@ -1,4 +1,4 @@
-import type { SharedObject } from 'expo-modules-core';
+import type { SharedObject } from 'expo';
 
 export type AudioStreamEncoding = 'float32' | 'int16';
 

--- a/packages/expo-audio/src/ExpoAudio.ts
+++ b/packages/expo-audio/src/ExpoAudio.ts
@@ -1,5 +1,4 @@
-import { useEvent, type PermissionResponse } from 'expo';
-import { useReleasingSharedObject } from 'expo-modules-core';
+import { useEvent, useReleasingSharedObject, type PermissionResponse } from 'expo';
 import { useEffect, useMemo } from 'react';
 import { Platform } from 'react-native';
 

--- a/packages/expo-audio/src/ExpoAudio.web.ts
+++ b/packages/expo-audio/src/ExpoAudio.web.ts
@@ -1,5 +1,4 @@
-import { useEvent, type PermissionResponse } from 'expo';
-import { useReleasingSharedObject } from 'expo-modules-core';
+import { useEvent, useReleasingSharedObject, type PermissionResponse } from 'expo';
 import { useEffect, useMemo } from 'react';
 
 import type {

--- a/packages/expo-audio/src/index.ts
+++ b/packages/expo-audio/src/index.ts
@@ -1,4 +1,3 @@
-// TODO(@kitten): Remove re-exports from EMC
 export { type PermissionResponse, type PermissionExpiration, PermissionStatus } from 'expo';
 
 export * from './ExpoAudio';

--- a/packages/expo-audio/src/utils/options.ts
+++ b/packages/expo-audio/src/utils/options.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import type {
   RecordingOptions,

--- a/packages/expo-background-fetch/src/BackgroundFetch.ts
+++ b/packages/expo-background-fetch/src/BackgroundFetch.ts
@@ -1,5 +1,4 @@
-import { isRunningInExpoGo } from 'expo';
-import { Platform, UnavailabilityError } from 'expo-modules-core';
+import { isRunningInExpoGo, Platform, UnavailabilityError } from 'expo';
 import * as TaskManager from 'expo-task-manager';
 
 import { type BackgroundFetchOptions, BackgroundFetchStatus } from './BackgroundFetch.types';

--- a/packages/expo-background-fetch/src/ExpoBackgroundFetch.ts
+++ b/packages/expo-background-fetch/src/ExpoBackgroundFetch.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoBackgroundFetch');

--- a/packages/expo-background-task/src/BackgroundTask.ts
+++ b/packages/expo-background-task/src/BackgroundTask.ts
@@ -1,5 +1,4 @@
-import { isRunningInExpoGo } from 'expo';
-import { Platform, UnavailabilityError } from 'expo-modules-core';
+import { isRunningInExpoGo, Platform, UnavailabilityError } from 'expo';
 import * as TaskManager from 'expo-task-manager';
 
 import type { BackgroundTaskOptions } from './BackgroundTask.types';

--- a/packages/expo-battery/src/Battery.ts
+++ b/packages/expo-battery/src/Battery.ts
@@ -1,4 +1,4 @@
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 import { useEffect, useState } from 'react';
 
 import {
@@ -293,5 +293,4 @@ export {
   type PowerState,
 } from './Battery.types';
 
-// TODO(@kitten): Remove re-exports from EMC
-export type { EventSubscription as Subscription } from 'expo-modules-core';
+export type { EventSubscription as Subscription } from 'expo';

--- a/packages/expo-battery/src/ExpoBattery.ts
+++ b/packages/expo-battery/src/ExpoBattery.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoBattery');

--- a/packages/expo-battery/src/ExpoBattery.web.ts
+++ b/packages/expo-battery/src/ExpoBattery.web.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Platform } from 'expo-modules-core';
+import { EventEmitter, Platform } from 'expo';
 
 import { type BatteryEvents, BatteryState } from './Battery.types';
 

--- a/packages/expo-blur/src/NativeBlurModule.android.tsx
+++ b/packages/expo-blur/src/NativeBlurModule.android.tsx
@@ -1,5 +1,5 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 
-export const NativeBlurView = requireNativeViewManager('ExpoBlur', 'ExpoBlurView');
+export const NativeBlurView = requireNativeView('ExpoBlur', 'ExpoBlurView');
 
-export const NativeBlurTargetView = requireNativeViewManager('ExpoBlur', 'ExpoBlurTargetView');
+export const NativeBlurTargetView = requireNativeView('ExpoBlur', 'ExpoBlurTargetView');

--- a/packages/expo-blur/src/NativeBlurModule.tsx
+++ b/packages/expo-blur/src/NativeBlurModule.tsx
@@ -1,6 +1,6 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import { View } from 'react-native';
 
-export const NativeBlurView = requireNativeViewManager('ExpoBlur', 'ExpoBlurView');
+export const NativeBlurView = requireNativeView('ExpoBlur', 'ExpoBlurView');
 
 export const NativeBlurTargetView = View;

--- a/packages/expo-brightness/src/Brightness.ts
+++ b/packages/expo-brightness/src/Brightness.ts
@@ -1,5 +1,9 @@
-import { type PermissionResponse, createPermissionHook } from 'expo';
-import { type EventSubscription, UnavailabilityError } from 'expo-modules-core';
+import {
+  type PermissionResponse,
+  createPermissionHook,
+  type EventSubscription,
+  UnavailabilityError,
+} from 'expo';
 import { Platform } from 'react-native';
 
 import ExpoBrightness from './ExpoBrightness';
@@ -29,7 +33,6 @@ export type BrightnessEvent = {
   brightness: number;
 };
 
-// TODO(@kitten): Remove re-exports from EMC
 export {
   type PermissionExpiration,
   type PermissionHookOptions,

--- a/packages/expo-brightness/src/ExpoBrightness.ts
+++ b/packages/expo-brightness/src/ExpoBrightness.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoBrightness');

--- a/packages/expo-brownfield/src/ExpoBrownfieldModule.ts
+++ b/packages/expo-brownfield/src/ExpoBrownfieldModule.ts
@@ -1,5 +1,5 @@
 import { requireNativeModule } from 'expo';
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 
 import type {
   ExpoBrownfieldModuleSpec,
@@ -9,8 +9,7 @@ import type {
 
 const ExpoBrownfieldModule = requireNativeModule<ExpoBrownfieldModuleSpec>('ExpoBrownfieldModule');
 
-// TODO(@kitten): Remove re-export from EMC
-export type { EventSubscription } from 'expo-modules-core';
+export type { EventSubscription } from 'expo';
 export type { MessageEvent };
 
 // SECTION: Navigation API

--- a/packages/expo-brownfield/src/ExpoBrownfieldStateModule.ts
+++ b/packages/expo-brownfield/src/ExpoBrownfieldStateModule.ts
@@ -1,5 +1,5 @@
 import { requireNativeModule } from 'expo';
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 import { useCallback, useEffect, useState } from 'react';
 
 import type {

--- a/packages/expo-calendar/src/Calendar.ts
+++ b/packages/expo-calendar/src/Calendar.ts
@@ -1,5 +1,9 @@
-import { createPermissionHook, PermissionStatus, type PermissionHookOptions } from 'expo';
-import { UnavailabilityError } from 'expo-modules-core';
+import {
+  createPermissionHook,
+  PermissionStatus,
+  UnavailabilityError,
+  type PermissionHookOptions,
+} from 'expo';
 import { Platform, processColor } from 'react-native';
 
 import InternalExpoCalendar from './ExpoCalendar';

--- a/packages/expo-calendar/src/ExpoCalendar.ts
+++ b/packages/expo-calendar/src/ExpoCalendar.ts
@@ -1,5 +1,9 @@
-import { isRunningInExpoGo, type PermissionResponse } from 'expo';
-import { NativeModule, requireNativeModule } from 'expo-modules-core';
+import {
+  NativeModule,
+  isRunningInExpoGo,
+  requireNativeModule,
+  type PermissionResponse,
+} from 'expo';
 import type { ProcessedColorValue } from 'react-native';
 
 import type {

--- a/packages/expo-calendar/src/legacy/Calendar.ts
+++ b/packages/expo-calendar/src/legacy/Calendar.ts
@@ -1,5 +1,4 @@
-import { type PermissionResponse, createPermissionHook } from 'expo';
-import { UnavailabilityError } from 'expo-modules-core';
+import { type PermissionResponse, createPermissionHook, UnavailabilityError } from 'expo';
 import { Platform, processColor } from 'react-native';
 
 import { stringifyDateValues, stringifyIfDate } from '../utils';

--- a/packages/expo-calendar/src/legacy/ExpoCalendar.ts
+++ b/packages/expo-calendar/src/legacy/ExpoCalendar.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoCalendar');

--- a/packages/expo-camera/src/Camera.types.ts
+++ b/packages/expo-camera/src/Camera.types.ts
@@ -1,5 +1,5 @@
 import { type PermissionResponse } from 'expo';
-import { NativeModule } from 'expo-modules-core';
+import { NativeModule } from 'expo';
 import type { Ref } from 'react';
 import type { ViewProps } from 'react-native';
 
@@ -585,14 +585,13 @@ export type BarcodeType =
   | 'code128'
   | 'upc_a';
 
-// TODO(@kitten): Remove re-exports from EMC
 export {
+  type EventSubscription as Subscription,
   type PermissionResponse,
   PermissionStatus,
   type PermissionExpiration,
   type PermissionHookOptions,
 } from 'expo';
-export { type EventSubscription as Subscription } from 'expo-modules-core';
 
 export type PhotoResult = {
   /**

--- a/packages/expo-camera/src/CameraView.tsx
+++ b/packages/expo-camera/src/CameraView.tsx
@@ -1,4 +1,4 @@
-import { Platform, UnavailabilityError, type EventSubscription } from 'expo-modules-core';
+import { Platform, UnavailabilityError, type EventSubscription } from 'expo';
 import { Component, createRef } from 'react';
 
 import type {

--- a/packages/expo-camera/src/ExpoCamera.ts
+++ b/packages/expo-camera/src/ExpoCamera.ts
@@ -1,8 +1,8 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import type { ComponentType } from 'react';
 
 import type { CameraNativeProps } from './Camera.types';
 
-const ExpoCamera: ComponentType<CameraNativeProps> = requireNativeViewManager('ExpoCamera');
+const ExpoCamera: ComponentType<CameraNativeProps> = requireNativeView('ExpoCamera');
 
 export default ExpoCamera;

--- a/packages/expo-camera/src/ExpoCamera.web.tsx
+++ b/packages/expo-camera/src/ExpoCamera.web.tsx
@@ -1,4 +1,4 @@
-import { CodedError } from 'expo-modules-core';
+import { CodedError } from 'expo';
 import {
   type PropsWithChildren,
   useRef,

--- a/packages/expo-camera/src/ExpoCameraManager.ts
+++ b/packages/expo-camera/src/ExpoCameraManager.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { CameraNativeModule } from './Camera.types';
 

--- a/packages/expo-camera/src/ExpoCameraManager.web.ts
+++ b/packages/expo-camera/src/ExpoCameraManager.web.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import type {
   BarcodeType,

--- a/packages/expo-camera/src/utils/props.ts
+++ b/packages/expo-camera/src/utils/props.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import type { CameraNativeProps, CameraType, FlashMode, CameraViewProps } from '../Camera.types';
 import CameraManager from '../ExpoCameraManager';

--- a/packages/expo-camera/src/web/WebUserMediaManager.ts
+++ b/packages/expo-camera/src/web/WebUserMediaManager.ts
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 async function sourceSelectedAsync(
   isMuted: boolean,

--- a/packages/expo-cellular/src/Cellular.ts
+++ b/packages/expo-cellular/src/Cellular.ts
@@ -1,5 +1,4 @@
-import { createPermissionHook, PermissionStatus } from 'expo';
-import { Platform, UnavailabilityError } from 'expo-modules-core';
+import { createPermissionHook, PermissionStatus, Platform, UnavailabilityError } from 'expo';
 
 import type { PermissionResponse, CellularGeneration } from './Cellular.types';
 import ExpoCellular from './ExpoCellular';

--- a/packages/expo-cellular/src/ExpoCellular.ts
+++ b/packages/expo-cellular/src/ExpoCellular.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoCellular');

--- a/packages/expo-clipboard/src/Clipboard.ts
+++ b/packages/expo-clipboard/src/Clipboard.ts
@@ -1,4 +1,4 @@
-import { type EventSubscription, UnavailabilityError, Platform } from 'expo-modules-core';
+import { type EventSubscription, UnavailabilityError, Platform } from 'expo';
 
 import type {
   ClipboardImage,
@@ -9,8 +9,7 @@ import type {
 } from './Clipboard.types';
 import ExpoClipboard, { clipboardEventName } from './ExpoClipboard';
 
-// TODO(@kitten): Remove re-export from EMC
-export type { EventSubscription as Subscription } from 'expo-modules-core';
+export type { EventSubscription as Subscription } from 'expo';
 
 /**
  * Gets the content of the user's clipboard. Calling this method on web will prompt

--- a/packages/expo-clipboard/src/ExpoClipboard.ts
+++ b/packages/expo-clipboard/src/ExpoClipboard.ts
@@ -1,4 +1,4 @@
-import { NativeModule, requireNativeModule } from 'expo-modules-core';
+import { NativeModule, requireNativeModule } from 'expo';
 
 import type {
   ClipboardImage,

--- a/packages/expo-clipboard/src/ExpoClipboardPasteButton.ts
+++ b/packages/expo-clipboard/src/ExpoClipboardPasteButton.ts
@@ -1,10 +1,10 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import { Platform } from 'react-native';
 
 let ExpoClipboard: any;
 
 if (Platform.OS === 'ios') {
-  ExpoClipboard = requireNativeViewManager('ExpoClipboard');
+  ExpoClipboard = requireNativeView('ExpoClipboard');
 }
 
 export default ExpoClipboard;

--- a/packages/expo-clipboard/src/web/Exceptions.ts
+++ b/packages/expo-clipboard/src/web/Exceptions.ts
@@ -1,4 +1,4 @@
-import { CodedError } from 'expo-modules-core';
+import { CodedError } from 'expo';
 
 export class ClipboardUnavailableException extends CodedError {
   constructor() {

--- a/packages/expo-contacts/src/ContactAccessButton.tsx
+++ b/packages/expo-contacts/src/ContactAccessButton.tsx
@@ -1,5 +1,4 @@
-import { requireNativeView } from 'expo';
-import { Platform, requireOptionalNativeModule } from 'expo-modules-core';
+import { requireNativeView, Platform, requireOptionalNativeModule } from 'expo';
 import React from 'react';
 import type { ColorValue, ViewProps } from 'react-native';
 

--- a/packages/expo-contacts/src/ContactsModule.ts
+++ b/packages/expo-contacts/src/ContactsModule.ts
@@ -1,5 +1,5 @@
-import { UnavailabilityError } from 'expo-modules-core';
-import type { EventSubscription } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
+import type { EventSubscription } from 'expo';
 
 import expoContactsModule from './ExpoContactsNext';
 import { FallbackContainer } from './types/Container';

--- a/packages/expo-contacts/src/ExpoContactsNext.ts
+++ b/packages/expo-contacts/src/ExpoContactsNext.ts
@@ -1,4 +1,4 @@
-import { NativeModule, Platform, requireNativeModule } from 'expo-modules-core';
+import { NativeModule, Platform, requireNativeModule } from 'expo';
 
 import type { Contact } from './types/Contact';
 import type { Container } from './types/Container';

--- a/packages/expo-contacts/src/legacy/ContactAccessButton.tsx
+++ b/packages/expo-contacts/src/legacy/ContactAccessButton.tsx
@@ -1,5 +1,4 @@
-import { requireNativeView } from 'expo';
-import { Platform, requireOptionalNativeModule } from 'expo-modules-core';
+import { requireNativeView, Platform, requireOptionalNativeModule } from 'expo';
 import React from 'react';
 import type { ColorValue, ViewProps } from 'react-native';
 

--- a/packages/expo-contacts/src/legacy/Contacts.ts
+++ b/packages/expo-contacts/src/legacy/Contacts.ts
@@ -1,5 +1,4 @@
-import { type PermissionResponse } from 'expo';
-import { type EventSubscription, UnavailabilityError, uuid } from 'expo-modules-core';
+import { type PermissionResponse, type EventSubscription, UnavailabilityError, uuid } from 'expo';
 import { Platform, Share, type ShareOptions } from 'react-native';
 
 import ExpoContacts from './ExpoContacts';
@@ -557,7 +556,6 @@ export type Container = {
   type: ContainerType;
 };
 
-// TODO(@kitten): Remove re-exports from EMC
 export { PermissionStatus, type PermissionResponse, type PermissionExpiration } from 'expo';
 
 /**

--- a/packages/expo-contacts/src/legacy/ExpoContacts.ts
+++ b/packages/expo-contacts/src/legacy/ExpoContacts.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoContacts');

--- a/packages/expo-crypto/src/Crypto.ts
+++ b/packages/expo-crypto/src/Crypto.ts
@@ -1,5 +1,4 @@
-import type { UintBasedTypedArray, IntBasedTypedArray } from 'expo-modules-core';
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError, type UintBasedTypedArray, type IntBasedTypedArray } from 'expo';
 
 import type { CryptoDigestOptions, Digest } from './Crypto.types';
 import { CryptoDigestAlgorithm, CryptoEncoding } from './Crypto.types';

--- a/packages/expo-crypto/src/ExpoCrypto.ts
+++ b/packages/expo-crypto/src/ExpoCrypto.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoCrypto');

--- a/packages/expo-crypto/src/ExpoCrypto.web.ts
+++ b/packages/expo-crypto/src/ExpoCrypto.web.ts
@@ -1,5 +1,4 @@
-import type { TypedArray } from 'expo-modules-core';
-import { CodedError } from 'expo-modules-core';
+import { type TypedArray, CodedError } from 'expo';
 
 import type { CryptoDigestAlgorithm, CryptoDigestOptions } from './Crypto.types';
 import { CryptoEncoding } from './Crypto.types';

--- a/packages/expo-dev-menu/src/ExpoDevMenu.ts
+++ b/packages/expo-dev-menu/src/ExpoDevMenu.ts
@@ -1,3 +1,3 @@
-import { requireOptionalNativeModule } from 'expo-modules-core';
+import { requireOptionalNativeModule } from 'expo';
 
 export default requireOptionalNativeModule('ExpoDevMenu');

--- a/packages/expo-device/src/Device.ts
+++ b/packages/expo-device/src/Device.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import { DeviceType } from './Device.types';
 import ExpoDevice from './ExpoDevice';

--- a/packages/expo-device/src/ExpoDevice.ts
+++ b/packages/expo-device/src/ExpoDevice.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoDevice');

--- a/packages/expo-device/src/ExpoDevice.web.ts
+++ b/packages/expo-device/src/ExpoDevice.web.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 import UAParser from 'ua-parser-js';
 
 import { DeviceType } from './Device.types';

--- a/packages/expo-device/src/__tests__/ExpoDevice-test.web.ts
+++ b/packages/expo-device/src/__tests__/ExpoDevice-test.web.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import ExpoDevice from '../ExpoDevice.web';
 

--- a/packages/expo-document-picker/src/ExpoDocumentPicker.ts
+++ b/packages/expo-document-picker/src/ExpoDocumentPicker.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoDocumentPicker');

--- a/packages/expo-document-picker/src/ExpoDocumentPicker.web.ts
+++ b/packages/expo-document-picker/src/ExpoDocumentPicker.web.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import type { DocumentPickerAsset, DocumentPickerOptions, DocumentPickerResult } from './types';
 

--- a/packages/expo-glass-effect/src/GlassContainer.ios.tsx
+++ b/packages/expo-glass-effect/src/GlassContainer.ios.tsx
@@ -2,11 +2,11 @@
 
 'use client';
 
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 
 import type { GlassContainerProps } from './GlassContainer.types';
 
-const NativeGlassContainer = requireNativeViewManager<GlassContainerProps>(
+const NativeGlassContainer = requireNativeView<GlassContainerProps>(
   'ExpoGlassEffect',
   'GlassContainer'
 );

--- a/packages/expo-glass-effect/src/GlassView.ios.tsx
+++ b/packages/expo-glass-effect/src/GlassView.ios.tsx
@@ -2,11 +2,11 @@
 
 'use client';
 
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 
 import type { GlassViewProps } from './GlassView.types';
 
-const NativeGlassView = requireNativeViewManager<GlassViewProps>('ExpoGlassEffect', 'GlassView');
+const NativeGlassView = requireNativeView<GlassViewProps>('ExpoGlassEffect', 'GlassView');
 
 const GlassView = (props: GlassViewProps) => {
   return <NativeGlassView {...props} />;

--- a/packages/expo-glass-effect/src/isGlassEffectAPIAvailable.ios.ts
+++ b/packages/expo-glass-effect/src/isGlassEffectAPIAvailable.ios.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 let IS_GLASS_EFFECT_API_AVAILABLE: boolean | undefined;
 

--- a/packages/expo-glass-effect/src/isLiquidGlassAvailable.ios.ts
+++ b/packages/expo-glass-effect/src/isLiquidGlassAvailable.ios.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 let IS_LIQUID_GLASS_AVAILABLE: boolean | undefined;
 

--- a/packages/expo-haptics/src/Haptics.ts
+++ b/packages/expo-haptics/src/Haptics.ts
@@ -1,4 +1,4 @@
-import { Platform, UnavailabilityError } from 'expo-modules-core';
+import { Platform, UnavailabilityError } from 'expo';
 
 import ExpoHaptics from './ExpoHaptics';
 import { NotificationFeedbackType, ImpactFeedbackStyle, AndroidHaptics } from './Haptics.types';

--- a/packages/expo-image-manipulator/src/ImageManipulator.ts
+++ b/packages/expo-image-manipulator/src/ImageManipulator.ts
@@ -1,4 +1,4 @@
-import { useReleasingSharedObject } from 'expo-modules-core';
+import { useReleasingSharedObject } from 'expo';
 import type { SharedRef } from 'expo-modules-core/types';
 
 import type { Action, ImageResult, SaveOptions } from './ImageManipulator.types';

--- a/packages/expo-image-manipulator/src/NativeImageManipulatorModule.web.ts
+++ b/packages/expo-image-manipulator/src/NativeImageManipulatorModule.web.ts
@@ -1,5 +1,4 @@
-import { NativeModule } from 'expo';
-import { registerWebModule } from 'expo-modules-core';
+import { NativeModule, registerWebModule } from 'expo';
 import type { SharedRef } from 'expo-modules-core/types';
 
 import ImageManipulatorContext from './web/ImageManipulatorContext.web';

--- a/packages/expo-image-manipulator/src/web/actions/CropAction.web.ts
+++ b/packages/expo-image-manipulator/src/web/actions/CropAction.web.ts
@@ -1,4 +1,4 @@
-import { CodedError } from 'expo-modules-core';
+import { CodedError } from 'expo';
 
 import type { ActionCrop } from '../../ImageManipulator.types';
 import { getContext } from '../utils.web';

--- a/packages/expo-image-manipulator/src/web/actions/ExtentAction.web.ts
+++ b/packages/expo-image-manipulator/src/web/actions/ExtentAction.web.ts
@@ -1,4 +1,4 @@
-import { CodedError } from 'expo-modules-core';
+import { CodedError } from 'expo';
 
 import type { ActionExtent } from '../../ImageManipulator.types';
 import { getContext } from '../utils.web';

--- a/packages/expo-image-manipulator/src/web/utils.web.ts
+++ b/packages/expo-image-manipulator/src/web/utils.web.ts
@@ -1,4 +1,4 @@
-import { CodedError } from 'expo-modules-core';
+import { CodedError } from 'expo';
 
 export function getContext(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
   const ctx = canvas.getContext('2d');

--- a/packages/expo-image-picker/src/ExponentImagePicker.ts
+++ b/packages/expo-image-picker/src/ExponentImagePicker.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExponentImagePicker');

--- a/packages/expo-image-picker/src/ImagePicker.ts
+++ b/packages/expo-image-picker/src/ImagePicker.ts
@@ -1,11 +1,12 @@
 import {
+  CodedError,
   PermissionStatus,
+  UnavailabilityError,
   createPermissionHook,
   type PermissionExpiration,
   type PermissionHookOptions,
   type PermissionResponse,
 } from 'expo';
-import { CodedError, UnavailabilityError } from 'expo-modules-core';
 
 import ExponentImagePicker from './ExponentImagePicker';
 import type {

--- a/packages/expo-image-picker/src/__tests__/ExponentImagePicker-test.web.ts
+++ b/packages/expo-image-picker/src/__tests__/ExponentImagePicker-test.web.ts
@@ -3,7 +3,7 @@
  */
 import { screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import ExponentImagePicker from '../ExponentImagePicker';
 

--- a/packages/expo-image/src/ExpoImage.tsx
+++ b/packages/expo-image/src/ExpoImage.tsx
@@ -1,4 +1,4 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import React from 'react';
 import type { NativeSyntheticEvent } from 'react-native';
 import { StyleSheet, Platform, processColor } from 'react-native';
@@ -10,7 +10,7 @@ import type {
   ImageProgressEventData,
 } from './Image.types';
 
-const NativeExpoImage = requireNativeViewManager('ExpoImage');
+const NativeExpoImage = requireNativeView('ExpoImage');
 
 function withDeprecatedNativeEvent<NativeEvent>(
   event: NativeSyntheticEvent<NativeEvent>

--- a/packages/expo-image/src/Image.tsx
+++ b/packages/expo-image/src/Image.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Platform, createSnapshotFriendlyRef } from 'expo-modules-core';
+import { Platform, createSnapshotFriendlyRef } from 'expo';
 import React from 'react';
 import { StyleSheet, processColor, type ImageStyle, type TextStyle, type View } from 'react-native';
 

--- a/packages/expo-image/src/ImageModule.web.ts
+++ b/packages/expo-image/src/ImageModule.web.ts
@@ -1,4 +1,4 @@
-import { NativeModule, registerWebModule } from 'expo-modules-core';
+import { NativeModule, registerWebModule } from 'expo';
 
 import type { ImageCacheConfig, ImageRef, ImageSource, ImageNativeModule } from './Image.types';
 import ImageRefWeb from './web/ImageRef';

--- a/packages/expo-image/src/utils/AssetSourceResolver.web.ts
+++ b/packages/expo-image/src/utils/AssetSourceResolver.web.ts
@@ -1,5 +1,5 @@
 import type { PackagerAsset } from '@react-native/assets-registry/registry';
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 import { PixelRatio } from 'react-native';
 
 export type ResolvedAssetSource = {

--- a/packages/expo-image/src/utils/resolveSources.tsx
+++ b/packages/expo-image/src/utils/resolveSources.tsx
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import type { ImageNativeProps, ImageProps, ImageSource } from '../Image.types';
 import { isImageRef } from '../utils';

--- a/packages/expo-intent-launcher/src/ExpoIntentLauncher.android.ts
+++ b/packages/expo-intent-launcher/src/ExpoIntentLauncher.android.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoIntentLauncher');

--- a/packages/expo-intent-launcher/src/IntentLauncher.ts
+++ b/packages/expo-intent-launcher/src/IntentLauncher.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import ExpoIntentLauncher from './ExpoIntentLauncher';
 

--- a/packages/expo-linear-gradient/src/NativeLinearGradient.android.tsx
+++ b/packages/expo-linear-gradient/src/NativeLinearGradient.android.tsx
@@ -1,4 +1,4 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import * as React from 'react';
 import { StyleSheet, View } from 'react-native';
 
@@ -48,4 +48,4 @@ export default function NativeLinearGradient({
   );
 }
 
-const BaseNativeLinearGradient = requireNativeViewManager('ExpoLinearGradient');
+const BaseNativeLinearGradient = requireNativeView('ExpoLinearGradient');

--- a/packages/expo-linear-gradient/src/NativeLinearGradient.ios.tsx
+++ b/packages/expo-linear-gradient/src/NativeLinearGradient.ios.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import type * as React from 'react';
 
 import type { NativeLinearGradientProps } from './NativeLinearGradient.types';
 
-const NativeLinearGradient = requireNativeViewManager(
+const NativeLinearGradient = requireNativeView(
   'ExpoLinearGradient'
 ) as React.FC<NativeLinearGradientProps>;
 

--- a/packages/expo-live-photo/src/LivePhotoModule.ts
+++ b/packages/expo-live-photo/src/LivePhotoModule.ts
@@ -1,3 +1,3 @@
-import { requireOptionalNativeModule } from 'expo-modules-core';
+import { requireOptionalNativeModule } from 'expo';
 
 export default requireOptionalNativeModule('ExpoLivePhoto');

--- a/packages/expo-live-photo/src/LivePhotoView.tsx
+++ b/packages/expo-live-photo/src/LivePhotoView.tsx
@@ -1,4 +1,4 @@
-import { requireNativeViewManager, UnavailabilityError } from 'expo-modules-core';
+import { requireNativeView, UnavailabilityError } from 'expo';
 import { useRef, useImperativeHandle } from 'react';
 import type { NativeSyntheticEvent } from 'react-native';
 
@@ -16,7 +16,7 @@ type NativeLivePhotoViewProps = LivePhotoViewProps & {
 };
 
 const NativeView: React.ComponentType<NativeLivePhotoViewProps> | null = isAvailable()
-  ? requireNativeViewManager('ExpoLivePhoto')
+  ? requireNativeView('ExpoLivePhoto')
   : null;
 
 function isAvailable() {

--- a/packages/expo-local-authentication/src/ExpoLocalAuthentication.ts
+++ b/packages/expo-local-authentication/src/ExpoLocalAuthentication.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoLocalAuthentication');

--- a/packages/expo-local-authentication/src/LocalAuthentication.ts
+++ b/packages/expo-local-authentication/src/LocalAuthentication.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 import invariant from 'invariant';
 
 import ExpoLocalAuthentication from './ExpoLocalAuthentication';

--- a/packages/expo-local-authentication/src/LocalAuthentication.types.ts
+++ b/packages/expo-local-authentication/src/LocalAuthentication.types.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 export type LocalAuthenticationResult =
   | { success: true }

--- a/packages/expo-localization/src/ExpoLocalization.native.ts
+++ b/packages/expo-localization/src/ExpoLocalization.native.ts
@@ -1,4 +1,4 @@
-import { type EventSubscription, requireNativeModule } from 'expo-modules-core';
+import { type EventSubscription, requireNativeModule } from 'expo';
 
 const ExpoLocalizationModule = requireNativeModule('ExpoLocalization');
 

--- a/packages/expo-localization/src/ExpoLocalization.ts
+++ b/packages/expo-localization/src/ExpoLocalization.ts
@@ -1,5 +1,5 @@
 /* eslint-env browser */
-import { type EventSubscription, Platform } from 'expo-modules-core';
+import { type EventSubscription, Platform } from 'expo';
 
 import type { Calendar, CalendarIdentifier, Locale } from './Localization.types';
 

--- a/packages/expo-location/src/ExpoLocation.ts
+++ b/packages/expo-location/src/ExpoLocation.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoLocation');

--- a/packages/expo-location/src/ExpoLocation.web.ts
+++ b/packages/expo-location/src/ExpoLocation.web.ts
@@ -1,5 +1,4 @@
-import { type PermissionResponse, PermissionStatus } from 'expo';
-import { UnavailabilityError } from 'expo-modules-core';
+import { PermissionStatus, UnavailabilityError, type PermissionResponse } from 'expo';
 
 import type { LocationLastKnownOptions, LocationObject, LocationOptions } from './Location.types';
 import { LocationAccuracy } from './Location.types';

--- a/packages/expo-location/src/GeolocationPolyfill.ts
+++ b/packages/expo-location/src/GeolocationPolyfill.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import ExpoLocation from './ExpoLocation';
 import type { LocationObject, LocationOptions } from './Location.types';

--- a/packages/expo-location/src/Location.ts
+++ b/packages/expo-location/src/Location.ts
@@ -1,5 +1,4 @@
-import { createPermissionHook, isRunningInExpoGo, type PermissionResponse } from 'expo';
-import { Platform } from 'expo-modules-core';
+import { createPermissionHook, isRunningInExpoGo, Platform, type PermissionResponse } from 'expo';
 
 import ExpoLocation from './ExpoLocation';
 import type {

--- a/packages/expo-location/src/LocationEventEmitter.web.ts
+++ b/packages/expo-location/src/LocationEventEmitter.web.ts
@@ -1,3 +1,3 @@
-import { EventEmitter } from 'expo-modules-core';
+import { EventEmitter } from 'expo';
 
 export const LocationEventEmitter = new EventEmitter();

--- a/packages/expo-location/src/LocationSubscribers.ts
+++ b/packages/expo-location/src/LocationSubscribers.ts
@@ -1,4 +1,4 @@
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 
 import ExpoLocation from './ExpoLocation';
 import type {

--- a/packages/expo-location/src/__tests__/Location-test.native.ts
+++ b/packages/expo-location/src/__tests__/Location-test.native.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 import { mockProperty, unmockAllProperties } from 'jest-expo';
 
 import ExpoLocation from '../ExpoLocation';

--- a/packages/expo-mail-composer/src/ExpoMailComposer.ts
+++ b/packages/expo-mail-composer/src/ExpoMailComposer.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 // TODO: Rename the package to 'ExpoMail'
 export default requireNativeModule('ExpoMailComposer');

--- a/packages/expo-media-library/src/legacy/ExpoMediaLibrary.ts
+++ b/packages/expo-media-library/src/legacy/ExpoMediaLibrary.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoMediaLibrary');

--- a/packages/expo-media-library/src/legacy/MediaLibrary.ts
+++ b/packages/expo-media-library/src/legacy/MediaLibrary.ts
@@ -1,5 +1,9 @@
-import { type PermissionResponse as EXPermissionResponse, createPermissionHook } from 'expo';
-import { UnavailabilityError, type EventSubscription } from 'expo-modules-core';
+import {
+  type PermissionResponse as EXPermissionResponse,
+  createPermissionHook,
+  UnavailabilityError,
+  type EventSubscription,
+} from 'expo';
 import { Platform } from 'react-native';
 
 import MediaLibrary from './ExpoMediaLibrary';
@@ -366,7 +370,7 @@ export {
   type PermissionResponse as EXPermissionResponse,
   type PermissionHookOptions,
 } from 'expo';
-export { type EventSubscription as Subscription } from 'expo-modules-core';
+export { type EventSubscription as Subscription } from 'expo';
 
 function arrayize<T>(item: T | T[]): T[] {
   if (Array.isArray(item)) {

--- a/packages/expo-media-library/src/legacyWarnings.ts
+++ b/packages/expo-media-library/src/legacyWarnings.ts
@@ -1,4 +1,4 @@
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 
 import type {
   Album,

--- a/packages/expo-media-library/src/next/js/AssetAlbum.ts
+++ b/packages/expo-media-library/src/next/js/AssetAlbum.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 import { Platform } from 'react-native';
 
 import { NativeAsset, NativeAlbum } from '../native';

--- a/packages/expo-media-library/src/next/js/Permissions.ts
+++ b/packages/expo-media-library/src/next/js/Permissions.ts
@@ -1,9 +1,8 @@
-import { createPermissionHook } from 'expo';
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError, createPermissionHook, type PermissionResponse } from 'expo';
 import { Platform } from 'react-native';
 
 import { NativeMediaLibraryModule } from '../native';
-import type { GranularPermission, MediaTypeFilter, PermissionResponse } from '../types';
+import type { GranularPermission, MediaTypeFilter } from '../types';
 
 /**
  * Asks the user to grant permissions for accessing media in user's media library.

--- a/packages/expo-media-library/src/next/js/Subscriptions.ts
+++ b/packages/expo-media-library/src/next/js/Subscriptions.ts
@@ -1,4 +1,4 @@
-import { type EventSubscription } from 'expo-modules-core';
+import { type EventSubscription } from 'expo';
 
 import { NativeMediaLibraryModule } from '../native';
 import type { MediaLibraryAssetsChangeEvent } from '../types';

--- a/packages/expo-media-library/src/next/native/NativeMediaLibraryModule.web.ts
+++ b/packages/expo-media-library/src/next/native/NativeMediaLibraryModule.web.ts
@@ -1,5 +1,9 @@
-import { PermissionStatus, type PermissionResponse } from 'expo';
-import { type EventSubscription, UnavailabilityError } from 'expo-modules-core';
+import {
+  PermissionStatus,
+  type PermissionResponse,
+  type EventSubscription,
+  UnavailabilityError,
+} from 'expo';
 
 import type {
   AssetField,

--- a/packages/expo-media-library/src/next/types/Subscriptions.types.ts
+++ b/packages/expo-media-library/src/next/types/Subscriptions.types.ts
@@ -1,4 +1,4 @@
-export { type EventSubscription, type EventSubscription as Subscription } from 'expo-modules-core';
+export { type EventSubscription, type EventSubscription as Subscription } from 'expo';
 
 /**
  * An event emitted when assets in the media library change.

--- a/packages/expo-network/src/ExpoNetwork.ts
+++ b/packages/expo-network/src/ExpoNetwork.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoNetwork');

--- a/packages/expo-network/src/ExpoNetwork.web.ts
+++ b/packages/expo-network/src/ExpoNetwork.web.ts
@@ -1,4 +1,4 @@
-import { NativeModule, registerWebModule } from 'expo-modules-core';
+import { NativeModule, registerWebModule } from 'expo';
 
 import type { NetworkEvents, NetworkState } from './Network.types';
 import { NetworkStateType } from './Network.types';

--- a/packages/expo-network/src/Network.ts
+++ b/packages/expo-network/src/Network.ts
@@ -1,4 +1,4 @@
-import { type EventSubscription, UnavailabilityError } from 'expo-modules-core';
+import { type EventSubscription, UnavailabilityError } from 'expo';
 import { useEffect, useState } from 'react';
 
 import ExpoNetwork from './ExpoNetwork';

--- a/packages/expo-notifications/src/BackgroundNotificationTasksModule.native.ts
+++ b/packages/expo-notifications/src/BackgroundNotificationTasksModule.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { BackgroundNotificationTasksModule } from './BackgroundNotificationTasksModule.types';
 

--- a/packages/expo-notifications/src/BadgeModule.native.ts
+++ b/packages/expo-notifications/src/BadgeModule.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { BadgeModule } from './BadgeModule.types';
 

--- a/packages/expo-notifications/src/DevicePushTokenAutoRegistration.fx.ts
+++ b/packages/expo-notifications/src/DevicePushTokenAutoRegistration.fx.ts
@@ -1,5 +1,5 @@
 import 'abort-controller/polyfill';
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import ServerRegistrationModule from './ServerRegistrationModule';
 import { addPushTokenListener } from './TokenEmitter';

--- a/packages/expo-notifications/src/NotificationCategoriesModule.native.ts
+++ b/packages/expo-notifications/src/NotificationCategoriesModule.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NotificationCategoriesModule } from './NotificationCategoriesModule.types';
 

--- a/packages/expo-notifications/src/NotificationCategoriesModule.ts
+++ b/packages/expo-notifications/src/NotificationCategoriesModule.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import type { NotificationCategoriesModule } from './NotificationCategoriesModule.types';
 

--- a/packages/expo-notifications/src/NotificationChannelGroupManager.native.ts
+++ b/packages/expo-notifications/src/NotificationChannelGroupManager.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NotificationChannelGroupManager } from './NotificationChannelGroupManager.types';
 

--- a/packages/expo-notifications/src/NotificationChannelManager.native.ts
+++ b/packages/expo-notifications/src/NotificationChannelManager.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NotificationChannelManager } from './NotificationChannelManager.types';
 

--- a/packages/expo-notifications/src/NotificationPermissions.ts
+++ b/packages/expo-notifications/src/NotificationPermissions.ts
@@ -1,4 +1,4 @@
-import { Platform, UnavailabilityError } from 'expo-modules-core';
+import { Platform, UnavailabilityError } from 'expo';
 
 import type { NotificationPermissionsRequest } from './NotificationPermissions.types';
 import NotificationPermissionsModule from './NotificationPermissionsModule';

--- a/packages/expo-notifications/src/NotificationPermissionsModule.native.ts
+++ b/packages/expo-notifications/src/NotificationPermissionsModule.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NotificationPermissionsModule } from './NotificationPermissionsModule.types';
 

--- a/packages/expo-notifications/src/NotificationPermissionsModule.ts
+++ b/packages/expo-notifications/src/NotificationPermissionsModule.ts
@@ -1,5 +1,4 @@
-import { PermissionStatus } from 'expo';
-import { Platform } from 'expo-modules-core';
+import { PermissionStatus, Platform } from 'expo';
 
 import type {
   NativeNotificationPermissionsRequest,

--- a/packages/expo-notifications/src/NotificationPresenterModule.native.ts
+++ b/packages/expo-notifications/src/NotificationPresenterModule.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NotificationPresenterModule } from './NotificationPresenterModule.types';
 

--- a/packages/expo-notifications/src/NotificationScheduler.native.ts
+++ b/packages/expo-notifications/src/NotificationScheduler.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NotificationSchedulerModule } from './NotificationScheduler.types';
 

--- a/packages/expo-notifications/src/Notifications.types.ts
+++ b/packages/expo-notifications/src/Notifications.types.ts
@@ -4,7 +4,7 @@
  * On Android under `remoteMessage` field a JS version of the Firebase `RemoteMessage` may be accessed.
  * On iOS under `payload` you may find full contents of [`UNNotificationContent`'s](https://developer.apple.com/documentation/usernotifications/unnotificationcontent?language=objc) [`userInfo`](https://developer.apple.com/documentation/usernotifications/unnotificationcontent/1649869-userinfo?language=objc), for example [remote notification payload](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CreatingtheNotificationPayload.html).
  */
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 
 export type PushNotificationTrigger = {
   type: 'push';
@@ -806,9 +806,12 @@ export type MaybeNotificationResponse = NotificationResponse | null | undefined;
  * */
 export type Subscription = EventSubscription;
 
-// TODO(@kitten): Remove re-exports from EMC
-export { type PermissionExpiration, type PermissionResponse, PermissionStatus } from 'expo';
-export { type EventSubscription } from 'expo-modules-core';
+export {
+  type PermissionExpiration,
+  type PermissionResponse,
+  PermissionStatus,
+  type EventSubscription,
+} from 'expo';
 
 /**
  * Payload for the background notification handler task.

--- a/packages/expo-notifications/src/NotificationsEmitter.ts
+++ b/packages/expo-notifications/src/NotificationsEmitter.ts
@@ -1,4 +1,5 @@
-import { LegacyEventEmitter, type EventSubscription, UnavailabilityError } from 'expo-modules-core';
+import { type EventSubscription, UnavailabilityError } from 'expo';
+import { LegacyEventEmitter } from 'expo-modules-core';
 
 import type { Notification, NotificationResponse } from './Notifications.types';
 import NotificationsEmitterModule from './NotificationsEmitterModule';

--- a/packages/expo-notifications/src/NotificationsEmitterModule.native.ts
+++ b/packages/expo-notifications/src/NotificationsEmitterModule.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NotificationsEmitterModule } from './NotificationsEmitterModule.types';
 

--- a/packages/expo-notifications/src/NotificationsEmitterModule.ts
+++ b/packages/expo-notifications/src/NotificationsEmitterModule.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import type { NotificationsEmitterModule } from './NotificationsEmitterModule.types';
 

--- a/packages/expo-notifications/src/NotificationsHandler.ts
+++ b/packages/expo-notifications/src/NotificationsHandler.ts
@@ -1,9 +1,5 @@
-import {
-  LegacyEventEmitter,
-  type EventSubscription,
-  CodedError,
-  UnavailabilityError,
-} from 'expo-modules-core';
+import { type EventSubscription, CodedError, UnavailabilityError } from 'expo';
+import { LegacyEventEmitter } from 'expo-modules-core';
 
 import type { Notification, NotificationBehavior } from './Notifications.types';
 import NotificationsHandlerModule from './NotificationsHandlerModule';

--- a/packages/expo-notifications/src/NotificationsHandlerModule.native.ts
+++ b/packages/expo-notifications/src/NotificationsHandlerModule.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { NotificationsHandlerModule } from './NotificationsHandlerModule.types';
 

--- a/packages/expo-notifications/src/NotificationsHandlerModule.ts
+++ b/packages/expo-notifications/src/NotificationsHandlerModule.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import type { NotificationsHandlerModule } from './NotificationsHandlerModule.types';
 

--- a/packages/expo-notifications/src/PushTokenManager.native.ts
+++ b/packages/expo-notifications/src/PushTokenManager.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { PushTokenManagerModule } from './PushTokenManager.types';
 

--- a/packages/expo-notifications/src/PushTokenManager.ts
+++ b/packages/expo-notifications/src/PushTokenManager.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import type { PushTokenManagerModule } from './PushTokenManager.types';
 

--- a/packages/expo-notifications/src/PushTokenManager.types.ts
+++ b/packages/expo-notifications/src/PushTokenManager.types.ts
@@ -1,4 +1,4 @@
-import { NativeModule } from 'expo-modules-core';
+import { NativeModule } from 'expo';
 
 export type PushTokenManagerModuleEvents = {
   onDevicePushToken: (params: { devicePushToken: string }) => void;

--- a/packages/expo-notifications/src/ServerRegistrationModule.native.ts
+++ b/packages/expo-notifications/src/ServerRegistrationModule.native.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { ServerRegistrationModule } from './ServerRegistrationModule.types';
 

--- a/packages/expo-notifications/src/ServerRegistrationModule.web.ts
+++ b/packages/expo-notifications/src/ServerRegistrationModule.web.ts
@@ -1,4 +1,4 @@
-import { CodedError, uuid } from 'expo-modules-core';
+import { CodedError, uuid } from 'expo';
 
 import type { ServerRegistrationModule } from './ServerRegistrationModule.types';
 

--- a/packages/expo-notifications/src/TokenEmitter.ts
+++ b/packages/expo-notifications/src/TokenEmitter.ts
@@ -1,4 +1,4 @@
-import { type EventSubscription, Platform } from 'expo-modules-core';
+import { type EventSubscription, Platform } from 'expo';
 
 import PushTokenManager from './PushTokenManager';
 import type { DevicePushToken } from './Tokens.types';

--- a/packages/expo-notifications/src/Tokens.types.ts
+++ b/packages/expo-notifications/src/Tokens.types.ts
@@ -1,4 +1,4 @@
-import type { Platform } from 'expo-modules-core';
+import type { Platform } from 'expo';
 
 // @docsMissing
 export interface NativeDevicePushToken {

--- a/packages/expo-notifications/src/TopicSubscriptionModule.android.ts
+++ b/packages/expo-notifications/src/TopicSubscriptionModule.android.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { TopicSubscriptionModule } from './TopicSubscriptionModule.types';
 

--- a/packages/expo-notifications/src/cancelAllScheduledNotificationsAsync.ts
+++ b/packages/expo-notifications/src/cancelAllScheduledNotificationsAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationScheduler from './NotificationScheduler';
 

--- a/packages/expo-notifications/src/cancelScheduledNotificationAsync.ts
+++ b/packages/expo-notifications/src/cancelScheduledNotificationAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationScheduler from './NotificationScheduler';
 

--- a/packages/expo-notifications/src/deleteNotificationCategoryAsync.ts
+++ b/packages/expo-notifications/src/deleteNotificationCategoryAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationCategoriesModule from './NotificationCategoriesModule';
 

--- a/packages/expo-notifications/src/deleteNotificationChannelAsync.android.ts
+++ b/packages/expo-notifications/src/deleteNotificationChannelAsync.android.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationChannelManager from './NotificationChannelManager';
 

--- a/packages/expo-notifications/src/deleteNotificationChannelGroupAsync.android.ts
+++ b/packages/expo-notifications/src/deleteNotificationChannelGroupAsync.android.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationChannelGroupManager from './NotificationChannelGroupManager';
 

--- a/packages/expo-notifications/src/dismissAllNotificationsAsync.ts
+++ b/packages/expo-notifications/src/dismissAllNotificationsAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationPresenter from './NotificationPresenterModule';
 

--- a/packages/expo-notifications/src/dismissNotificationAsync.ts
+++ b/packages/expo-notifications/src/dismissNotificationAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationPresenter from './NotificationPresenterModule';
 

--- a/packages/expo-notifications/src/getAllScheduledNotificationsAsync.ts
+++ b/packages/expo-notifications/src/getAllScheduledNotificationsAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationScheduler from './NotificationScheduler';
 import type { NotificationRequest } from './Notifications.types';

--- a/packages/expo-notifications/src/getBadgeCountAsync.ts
+++ b/packages/expo-notifications/src/getBadgeCountAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import BadgeModule from './BadgeModule';
 

--- a/packages/expo-notifications/src/getDevicePushTokenAsync.ts
+++ b/packages/expo-notifications/src/getDevicePushTokenAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError, Platform } from 'expo-modules-core';
+import { UnavailabilityError, Platform } from 'expo';
 
 import PushTokenManager from './PushTokenManager';
 import type { DevicePushToken } from './Tokens.types';

--- a/packages/expo-notifications/src/getDevicePushTokenAsync.web.ts
+++ b/packages/expo-notifications/src/getDevicePushTokenAsync.web.ts
@@ -1,5 +1,5 @@
+import { CodedError, Platform } from 'expo';
 import Constants from 'expo-constants';
-import { CodedError, Platform } from 'expo-modules-core';
 import { DeviceEventEmitter } from 'react-native';
 
 import type { DevicePushToken } from './Tokens.types';

--- a/packages/expo-notifications/src/getExpoPushTokenAsync.ts
+++ b/packages/expo-notifications/src/getExpoPushTokenAsync.ts
@@ -1,6 +1,6 @@
+import { Platform, CodedError, UnavailabilityError } from 'expo';
 import * as Application from 'expo-application';
 import Constants from 'expo-constants';
-import { Platform, CodedError, UnavailabilityError } from 'expo-modules-core';
 
 import { setAutoServerRegistrationEnabledAsync } from './DevicePushTokenAutoRegistration.fx';
 import ServerRegistrationModule from './ServerRegistrationModule';

--- a/packages/expo-notifications/src/getNextTriggerDateAsync.ts
+++ b/packages/expo-notifications/src/getNextTriggerDateAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationScheduler from './NotificationScheduler';
 import type { SchedulableNotificationTriggerInput } from './Notifications.types';

--- a/packages/expo-notifications/src/getNotificationCategoriesAsync.ts
+++ b/packages/expo-notifications/src/getNotificationCategoriesAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationCategoriesModule from './NotificationCategoriesModule';
 import type { NotificationCategory } from './Notifications.types';

--- a/packages/expo-notifications/src/getNotificationChannelAsync.android.ts
+++ b/packages/expo-notifications/src/getNotificationChannelAsync.android.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationChannelManager from './NotificationChannelManager';
 import type { NotificationChannel } from './NotificationChannelManager.types';

--- a/packages/expo-notifications/src/getNotificationChannelGroupAsync.android.ts
+++ b/packages/expo-notifications/src/getNotificationChannelGroupAsync.android.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationChannelGroupManager from './NotificationChannelGroupManager';
 import type { NotificationChannelGroup } from './NotificationChannelGroupManager.types';

--- a/packages/expo-notifications/src/getNotificationChannelGroupsAsync.android.ts
+++ b/packages/expo-notifications/src/getNotificationChannelGroupsAsync.android.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationChannelGroupManager from './NotificationChannelGroupManager';
 import type { NotificationChannelGroup } from './NotificationChannelGroupManager.types';

--- a/packages/expo-notifications/src/getNotificationChannelsAsync.android.ts
+++ b/packages/expo-notifications/src/getNotificationChannelsAsync.android.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationChannelManager from './NotificationChannelManager';
 import type { NotificationChannel } from './NotificationChannelManager.types';

--- a/packages/expo-notifications/src/getPresentedNotificationsAsync.ts
+++ b/packages/expo-notifications/src/getPresentedNotificationsAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationPresenter from './NotificationPresenterModule';
 import type { Notification } from './Notifications.types';

--- a/packages/expo-notifications/src/registerTaskAsync.ts
+++ b/packages/expo-notifications/src/registerTaskAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import BackgroundNotificationTasksModule from './BackgroundNotificationTasksModule';
 

--- a/packages/expo-notifications/src/scheduleNotificationAsync.ts
+++ b/packages/expo-notifications/src/scheduleNotificationAsync.ts
@@ -1,4 +1,4 @@
-import { Platform, UnavailabilityError, uuid } from 'expo-modules-core';
+import { Platform, UnavailabilityError, uuid } from 'expo';
 
 import NotificationScheduler from './NotificationScheduler';
 import type {

--- a/packages/expo-notifications/src/setBadgeCountAsync.ts
+++ b/packages/expo-notifications/src/setBadgeCountAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError, Platform } from 'expo-modules-core';
+import { UnavailabilityError, Platform } from 'expo';
 
 import BadgeModule from './BadgeModule';
 import type { WebSetBadgeCountOptions } from './BadgeModule.types';

--- a/packages/expo-notifications/src/setNotificationCategoryAsync.ts
+++ b/packages/expo-notifications/src/setNotificationCategoryAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationCategoriesModule from './NotificationCategoriesModule';
 import type {

--- a/packages/expo-notifications/src/setNotificationChannelAsync.android.ts
+++ b/packages/expo-notifications/src/setNotificationChannelAsync.android.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationChannelManager from './NotificationChannelManager';
 import type {

--- a/packages/expo-notifications/src/setNotificationChannelGroupAsync.android.ts
+++ b/packages/expo-notifications/src/setNotificationChannelGroupAsync.android.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import NotificationChannelGroupManager from './NotificationChannelGroupManager';
 import type {

--- a/packages/expo-notifications/src/topicSubscription.ts
+++ b/packages/expo-notifications/src/topicSubscription.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import TopicSubscriptionModule from './TopicSubscriptionModule';
 import { warnOfExpoGoPushUsage } from './warnOfExpoGoPushUsage';

--- a/packages/expo-notifications/src/unregisterForNotificationsAsync.ts
+++ b/packages/expo-notifications/src/unregisterForNotificationsAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import PushTokenManager from './PushTokenManager';
 

--- a/packages/expo-notifications/src/unregisterTaskAsync.ts
+++ b/packages/expo-notifications/src/unregisterTaskAsync.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import BackgroundNotificationTasksModule from './BackgroundNotificationTasksModule';
 

--- a/packages/expo-notifications/src/utils/updateDevicePushTokenAsync.ts
+++ b/packages/expo-notifications/src/utils/updateDevicePushTokenAsync.ts
@@ -1,5 +1,5 @@
+import { CodedError, Platform, UnavailabilityError } from 'expo';
 import * as Application from 'expo-application';
-import { CodedError, Platform, UnavailabilityError } from 'expo-modules-core';
 
 import ServerRegistrationModule from '../ServerRegistrationModule';
 import type { DevicePushToken } from '../Tokens.types';

--- a/packages/expo-notifications/src/warnOfExpoGoPushUsage.ts
+++ b/packages/expo-notifications/src/warnOfExpoGoPushUsage.ts
@@ -1,5 +1,4 @@
-import { isRunningInExpoGo } from 'expo';
-import { Platform } from 'expo-modules-core';
+import { isRunningInExpoGo, Platform } from 'expo';
 
 let didWarn = false;
 

--- a/packages/expo-print/src/ExponentPrint.ts
+++ b/packages/expo-print/src/ExponentPrint.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoPrint');

--- a/packages/expo-print/src/Print.ts
+++ b/packages/expo-print/src/Print.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 import { Platform } from 'react-native';
 
 import ExponentPrint from './ExponentPrint';

--- a/packages/expo-router/src/color/materialColor.android.ts
+++ b/packages/expo-router/src/color/materialColor.android.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 import { Appearance } from 'react-native';
 
 export type AndroidMaterialColorName =

--- a/packages/expo-router/src/getLinkingConfig.ts
+++ b/packages/expo-router/src/getLinkingConfig.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import type { RouteNode } from './Route';
 import { INTERNAL_SLOT_NAME, NOT_FOUND_ROUTE_NAME, SITEMAP_ROUTE_NAME } from './constants';

--- a/packages/expo-screen-capture/src/ExpoScreenCapture.ts
+++ b/packages/expo-screen-capture/src/ExpoScreenCapture.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoScreenCapture');

--- a/packages/expo-screen-capture/src/ScreenCapture.ts
+++ b/packages/expo-screen-capture/src/ScreenCapture.ts
@@ -1,5 +1,10 @@
-import { createPermissionHook, type PermissionResponse, PermissionStatus } from 'expo';
-import { UnavailabilityError, type EventSubscription } from 'expo-modules-core';
+import {
+  createPermissionHook,
+  type PermissionResponse,
+  PermissionStatus,
+  UnavailabilityError,
+  type EventSubscription,
+} from 'expo';
 import { useEffect } from 'react';
 
 import ExpoScreenCapture from './ExpoScreenCapture';
@@ -218,6 +223,5 @@ const defaultPermissionsResponse: PermissionResponse = {
   status: PermissionStatus.GRANTED,
 };
 
-// TODO(@kitten): Remove re-exports from EMC
 export { type PermissionResponse, PermissionStatus, type PermissionHookOptions } from 'expo';
-export { type EventSubscription as Subscription } from 'expo-modules-core';
+export { type EventSubscription as Subscription } from 'expo';

--- a/packages/expo-screen-orientation/src/ExpoScreenOrientation.ts
+++ b/packages/expo-screen-orientation/src/ExpoScreenOrientation.ts
@@ -1,3 +1,3 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 export default requireNativeModule('ExpoScreenOrientation');

--- a/packages/expo-screen-orientation/src/ExpoScreenOrientation.web.ts
+++ b/packages/expo-screen-orientation/src/ExpoScreenOrientation.web.ts
@@ -1,4 +1,4 @@
-import { NativeModule, Platform, registerWebModule } from 'expo-modules-core';
+import { NativeModule, Platform, registerWebModule } from 'expo';
 
 import { getOrientationLockAsync, getOrientationAsync } from './ScreenOrientation';
 import type { ExpoOrientationEvents } from './ScreenOrientation.types';

--- a/packages/expo-screen-orientation/src/ScreenOrientation.ts
+++ b/packages/expo-screen-orientation/src/ScreenOrientation.ts
@@ -1,4 +1,4 @@
-import { Platform, type EventSubscription, UnavailabilityError } from 'expo-modules-core';
+import { Platform, type EventSubscription, UnavailabilityError } from 'expo';
 import { Dimensions } from 'react-native';
 
 import ExpoScreenOrientation from './ExpoScreenOrientation';
@@ -23,8 +23,7 @@ export {
   type ScreenOrientationInfo,
 } from './ScreenOrientation.types';
 
-// TODO(@kitten): Remove re-export from EMC
-export type { EventSubscription as Subscription } from 'expo-modules-core';
+export type { EventSubscription as Subscription } from 'expo';
 
 let _orientationChangeSubscribers: EventSubscription[] = [];
 

--- a/packages/expo-secure-store/src/ExpoSecureStore.ts
+++ b/packages/expo-secure-store/src/ExpoSecureStore.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoSecureStore');

--- a/packages/expo-sensors/src/DeviceSensor.ts
+++ b/packages/expo-sensors/src/DeviceSensor.ts
@@ -1,5 +1,10 @@
-import { type PermissionResponse, type PermissionExpiration, PermissionStatus } from 'expo';
-import { type EventSubscription, Platform } from 'expo-modules-core';
+import {
+  type PermissionResponse,
+  type PermissionExpiration,
+  PermissionStatus,
+  type EventSubscription,
+  Platform,
+} from 'expo';
 
 /**
  * @hidden

--- a/packages/expo-sensors/src/ExpoBarometer.ts
+++ b/packages/expo-sensors/src/ExpoBarometer.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoBarometer');

--- a/packages/expo-sensors/src/ExpoLightSensor.ts
+++ b/packages/expo-sensors/src/ExpoLightSensor.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoLightSensor');

--- a/packages/expo-sensors/src/ExponentAccelerometer.ts
+++ b/packages/expo-sensors/src/ExponentAccelerometer.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExponentAccelerometer');

--- a/packages/expo-sensors/src/ExponentDeviceMotion.ts
+++ b/packages/expo-sensors/src/ExponentDeviceMotion.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExponentDeviceMotion');

--- a/packages/expo-sensors/src/ExponentGyroscope.ts
+++ b/packages/expo-sensors/src/ExponentGyroscope.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExponentGyroscope');

--- a/packages/expo-sensors/src/ExponentMagnetometer.ts
+++ b/packages/expo-sensors/src/ExponentMagnetometer.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExponentMagnetometer');

--- a/packages/expo-sensors/src/ExponentMagnetometerUncalibrated.ts
+++ b/packages/expo-sensors/src/ExponentMagnetometerUncalibrated.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExponentMagnetometerUncalibrated');

--- a/packages/expo-sensors/src/ExponentPedometer.ts
+++ b/packages/expo-sensors/src/ExponentPedometer.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExponentPedometer');

--- a/packages/expo-sensors/src/Pedometer.ts
+++ b/packages/expo-sensors/src/Pedometer.ts
@@ -1,5 +1,9 @@
-import { type PermissionResponse, PermissionStatus } from 'expo';
-import { type EventSubscription, UnavailabilityError } from 'expo-modules-core';
+import {
+  type PermissionResponse,
+  PermissionStatus,
+  type EventSubscription,
+  UnavailabilityError,
+} from 'expo';
 import invariant from 'invariant';
 
 import ExponentPedometer from './ExponentPedometer';
@@ -90,6 +94,9 @@ const defaultPermissionsResponse: PermissionResponse = {
   status: PermissionStatus.GRANTED,
 };
 
-// TODO(@kitten): Remove re-exports from EMC
-export { type PermissionResponse, PermissionStatus, type PermissionExpiration } from 'expo';
-export { type EventSubscription as Subscription } from 'expo-modules-core';
+export {
+  type PermissionResponse,
+  PermissionStatus,
+  type PermissionExpiration,
+  type EventSubscription as Subscription,
+} from 'expo';

--- a/packages/expo-sensors/src/__tests__/Magnetometer-test.native.ts
+++ b/packages/expo-sensors/src/__tests__/Magnetometer-test.native.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import Magnetometer from '../Magnetometer';
 import MagnetometerUncalibrated from '../MagnetometerUncalibrated';

--- a/packages/expo-sensors/src/__tests__/mocks/MockNativeSensorModule.ts
+++ b/packages/expo-sensors/src/__tests__/mocks/MockNativeSensorModule.ts
@@ -1,4 +1,4 @@
-import { NativeModule } from 'expo-modules-core';
+import { NativeModule } from 'expo';
 
 export default class MockNativeSensorModule extends NativeModule {
   startObserving = jest.fn(async () => {});

--- a/packages/expo-sensors/src/utils/isSensorEnabledAsync.web.ts
+++ b/packages/expo-sensors/src/utils/isSensorEnabledAsync.web.ts
@@ -1,5 +1,4 @@
-import { type PermissionResponse, PermissionStatus } from 'expo';
-import { Platform } from 'expo-modules-core';
+import { type PermissionResponse, PermissionStatus, Platform } from 'expo';
 
 type SensorEventName = 'deviceorientation' | 'devicemotion';
 

--- a/packages/expo-sharing/src/Sharing.ts
+++ b/packages/expo-sharing/src/Sharing.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import type { ResolvedSharePayload, SharePayload, SharingOptions } from './Sharing.types';
 import SharingNativeModule from './SharingNativeModule';

--- a/packages/expo-sharing/src/SharingNativeModule.ts
+++ b/packages/expo-sharing/src/SharingNativeModule.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { SharingOptions, ResolvedSharePayload, SharePayload } from './Sharing.types';
 

--- a/packages/expo-sharing/src/SharingNativeModule.web.ts
+++ b/packages/expo-sharing/src/SharingNativeModule.web.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 type ShareOptions = { title?: string; text?: string; url?: string };
 

--- a/packages/expo-sms/src/ExpoSMS.native.ts
+++ b/packages/expo-sms/src/ExpoSMS.native.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoSMS');

--- a/packages/expo-sms/src/SMS.ts
+++ b/packages/expo-sms/src/SMS.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError, Platform } from 'expo-modules-core';
+import { UnavailabilityError, Platform } from 'expo';
 
 import ExpoSMS from './ExpoSMS';
 import type { SMSAttachment, SMSResponse, SMSOptions } from './SMS.types';

--- a/packages/expo-sms/src/__tests__/SMS-test.ts
+++ b/packages/expo-sms/src/__tests__/SMS-test.ts
@@ -1,4 +1,4 @@
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 import ExpoSMS from '../ExpoSMS';
 import * as SMS from '../SMS';

--- a/packages/expo-speech/src/ExponentSpeech.ts
+++ b/packages/expo-speech/src/ExponentSpeech.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoSpeech');

--- a/packages/expo-speech/src/ExponentSpeech.web.ts
+++ b/packages/expo-speech/src/ExponentSpeech.web.ts
@@ -1,4 +1,4 @@
-import { CodedError, NativeModule, registerWebModule } from 'expo-modules-core';
+import { CodedError, NativeModule, registerWebModule } from 'expo';
 
 import type { SpeechOptions, WebVoice } from './Speech.types';
 import { VoiceQuality } from './Speech.types';

--- a/packages/expo-speech/src/Speech.ts
+++ b/packages/expo-speech/src/Speech.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 
 import ExponentSpeech from './ExponentSpeech';
 import type { SpeechOptions, Voice } from './Speech.types';

--- a/packages/expo-splash-screen/src/SplashScreen.native.ts
+++ b/packages/expo-splash-screen/src/SplashScreen.native.ts
@@ -1,5 +1,4 @@
-import { isRunningInExpoGo } from 'expo';
-import { requireOptionalNativeModule } from 'expo-modules-core';
+import { isRunningInExpoGo, requireOptionalNativeModule } from 'expo';
 
 import type { SplashScreenNativeModule, SplashScreenOptions } from './SplashScreen.types';
 

--- a/packages/expo-sqlite/src/SQLiteDatabase.ts
+++ b/packages/expo-sqlite/src/SQLiteDatabase.ts
@@ -1,4 +1,4 @@
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 import { Platform } from 'react-native';
 
 import ExpoSQLite from './ExpoSQLite';

--- a/packages/expo-store-review/src/ExpoStoreReview.native.ts
+++ b/packages/expo-store-review/src/ExpoStoreReview.native.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoStoreReview');

--- a/packages/expo-store-review/src/StoreReview.ts
+++ b/packages/expo-store-review/src/StoreReview.ts
@@ -1,5 +1,5 @@
+import { Platform } from 'expo';
 import Constants from 'expo-constants';
-import { Platform } from 'expo-modules-core';
 import { Linking } from 'react-native';
 
 import StoreReview from './ExpoStoreReview';

--- a/packages/expo-symbols/src/SymbolModule.ts
+++ b/packages/expo-symbols/src/SymbolModule.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('SymbolModule');

--- a/packages/expo-symbols/src/SymbolView.ios.tsx
+++ b/packages/expo-symbols/src/SymbolView.ios.tsx
@@ -1,11 +1,10 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import type { JSX } from 'react';
 import { processColor } from 'react-native';
 
 import type { NativeSymbolViewProps, SymbolViewProps } from './SymbolModule.types';
 
-const NativeView: React.ComponentType<NativeSymbolViewProps> =
-  requireNativeViewManager('SymbolModule');
+const NativeView: React.ComponentType<NativeSymbolViewProps> = requireNativeView('SymbolModule');
 
 export function SymbolView(props: SymbolViewProps): JSX.Element {
   if (!NativeView) {

--- a/packages/expo-system-ui/src/ExpoSystemUI.ts
+++ b/packages/expo-system-ui/src/ExpoSystemUI.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoSystemUI');

--- a/packages/expo-task-manager/src/ExpoTaskManager.ts
+++ b/packages/expo-task-manager/src/ExpoTaskManager.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoTaskManager');

--- a/packages/expo-task-manager/src/TaskManager.ts
+++ b/packages/expo-task-manager/src/TaskManager.ts
@@ -1,4 +1,5 @@
-import { LegacyEventEmitter, Platform, UnavailabilityError } from 'expo-modules-core';
+import { Platform, UnavailabilityError } from 'expo';
+import { LegacyEventEmitter } from 'expo-modules-core';
 import { AppRegistry } from 'react-native';
 
 import ExpoTaskManager from './ExpoTaskManager';

--- a/packages/expo-tracking-transparency/src/ExpoTrackingTransparency.ts
+++ b/packages/expo-tracking-transparency/src/ExpoTrackingTransparency.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 // TODO: Rename the package to 'ExpoTracking'
 export default requireNativeModule('ExpoTrackingTransparency');

--- a/packages/expo-tracking-transparency/src/TrackingTransparency.ts
+++ b/packages/expo-tracking-transparency/src/TrackingTransparency.ts
@@ -4,8 +4,8 @@ import {
   PermissionStatus,
   type PermissionExpiration,
   type PermissionHookOptions,
+  UnavailabilityError,
 } from 'expo';
-import { UnavailabilityError } from 'expo-modules-core';
 import { Platform } from 'react-native';
 
 import ExpoTrackingTransparency from './ExpoTrackingTransparency';
@@ -151,7 +151,6 @@ export function isAvailable(): boolean {
   return Boolean(ExpoTrackingTransparency);
 }
 
-// TODO(@kitten): Remove re-exports from EMC
 export {
   type PermissionResponse,
   PermissionStatus,

--- a/packages/expo-ui/src/State/useNativeState.ts
+++ b/packages/expo-ui/src/State/useNativeState.ts
@@ -1,5 +1,4 @@
-import { requireNativeModule } from 'expo';
-import { type SharedObject, useReleasingSharedObject } from 'expo-modules-core';
+import { requireNativeModule, type SharedObject, useReleasingSharedObject } from 'expo';
 import { useRef } from 'react';
 
 import { worklets } from './optionalWorklets';

--- a/packages/expo-ui/src/State/useWorkletProp.ts
+++ b/packages/expo-ui/src/State/useWorkletProp.ts
@@ -1,5 +1,4 @@
-import { requireNativeModule } from 'expo';
-import { type SharedObject, useReleasingSharedObject } from 'expo-modules-core';
+import { requireNativeModule, type SharedObject, useReleasingSharedObject } from 'expo';
 
 import { worklets } from './optionalWorklets';
 

--- a/packages/expo-updates/e2e/fixtures/App.tsx
+++ b/packages/expo-updates/e2e/fixtures/App.tsx
@@ -1,7 +1,7 @@
 import { Inter_900Black } from '@expo-google-fonts/inter';
 import Constants from 'expo-constants';
 import { ExpoUpdatesManifest } from 'expo-manifests';
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 import { StatusBar } from 'expo-status-bar';
 import * as Updates from 'expo-updates';
 import { UpdatesLogEntry } from 'expo-updates';

--- a/packages/expo-video-thumbnails/src/ExpoVideoThumbnails.ts
+++ b/packages/expo-video-thumbnails/src/ExpoVideoThumbnails.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoVideoThumbnails');

--- a/packages/expo-video/src/NativeVideoModule.ts
+++ b/packages/expo-video/src/NativeVideoModule.ts
@@ -1,4 +1,4 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 
 import type { VideoPlayer } from './VideoPlayer.types';
 import type { VideoThumbnail } from './VideoThumbnail';

--- a/packages/expo-video/src/NativeVideoView.ts
+++ b/packages/expo-video/src/NativeVideoView.ts
@@ -1,8 +1,8 @@
-import { requireNativeViewManager } from 'expo-modules-core';
+import { requireNativeView } from 'expo';
 import { Platform } from 'react-native';
 
 const defaultViewName = Platform.OS === 'android' ? 'SurfaceVideoView' : 'VideoView';
 
-export default requireNativeViewManager('ExpoVideo', defaultViewName);
+export default requireNativeView('ExpoVideo', defaultViewName);
 export const NativeTextureVideoView =
-  Platform.OS === 'android' ? requireNativeViewManager('ExpoVideo', 'TextureVideoView') : null;
+  Platform.OS === 'android' ? requireNativeView('ExpoVideo', 'TextureVideoView') : null;

--- a/packages/expo-video/src/VideoPlayer.tsx
+++ b/packages/expo-video/src/VideoPlayer.tsx
@@ -1,4 +1,4 @@
-import { useReleasingSharedObject } from 'expo-modules-core';
+import { useReleasingSharedObject } from 'expo';
 
 import NativeVideoModule from './NativeVideoModule';
 import type { VideoSource, VideoPlayer, PlayerBuilderOptions } from './VideoPlayer.types';

--- a/packages/expo-web-browser/src/ExpoWebBrowser.ts
+++ b/packages/expo-web-browser/src/ExpoWebBrowser.ts
@@ -1,2 +1,2 @@
-import { requireNativeModule } from 'expo-modules-core';
+import { requireNativeModule } from 'expo';
 export default requireNativeModule('ExpoWebBrowser');

--- a/packages/expo-web-browser/src/ExpoWebBrowser.web.ts
+++ b/packages/expo-web-browser/src/ExpoWebBrowser.web.ts
@@ -1,4 +1,4 @@
-import { CodedError } from 'expo-modules-core';
+import { CodedError } from 'expo';
 import { AppState } from 'react-native';
 import type { AppStateStatus, NativeEventSubscription } from 'react-native';
 

--- a/packages/expo-web-browser/src/WebBrowser.ts
+++ b/packages/expo-web-browser/src/WebBrowser.ts
@@ -1,4 +1,4 @@
-import { UnavailabilityError } from 'expo-modules-core';
+import { UnavailabilityError } from 'expo';
 import type { AppStateStatus, EmitterSubscription } from 'react-native';
 import { AppState, Linking, Platform, processColor } from 'react-native';
 

--- a/packages/expo-widgets/src/ExpoWidgets.ts
+++ b/packages/expo-widgets/src/ExpoWidgets.ts
@@ -1,4 +1,4 @@
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 
 import type {
   ExpoTimelineEntry,

--- a/packages/expo-widgets/src/Widgets.ts
+++ b/packages/expo-widgets/src/Widgets.ts
@@ -1,4 +1,4 @@
-import type { EventSubscription } from 'expo-modules-core';
+import type { EventSubscription } from 'expo';
 import { Platform } from 'react-native';
 
 import ExpoWidgetsModule from './ExpoWidgets';

--- a/packages/expo/src/__tests__/__fbBatchedBridgeConfig-test.ts
+++ b/packages/expo/src/__tests__/__fbBatchedBridgeConfig-test.ts
@@ -1,6 +1,6 @@
 import 'react-native';
 import '../Expo.fx';
-import { Platform } from 'expo-modules-core';
+import { Platform } from 'expo';
 
 jest.mock('../async-require/getDevServer');
 


### PR DESCRIPTION
# Why
Follow-up to https://github.com/expo/expo/pull/45565
This PR replaces imports of expo-modules-core with expo in packages that expo doesn’t depend on (e.g. expo-constants)

# How
Replaces imports from `expo-modules-core` with `expo`

# Test plan
BareExpo