### PR TITLE
[config-types] Regenerate types

### DIFF
--- a/packages/@expo/config-types/build/ExpoConfig.d.ts
+++ b/packages/@expo/config-types/build/ExpoConfig.d.ts
@@ -169,7 +169,7 @@ export interface ExpoConfig {
          */
         useNativeDebug?: boolean;
         /**
-         * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to false.
+         * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to true.
          */
         enableBsdiffPatchSupport?: boolean;
     };

--- a/packages/@expo/config-types/src/ExpoConfig.ts
+++ b/packages/@expo/config-types/src/ExpoConfig.ts
@@ -177,7 +177,7 @@ export interface ExpoConfig {
      */
     useNativeDebug?: boolean;
     /**
-     * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to false.
+     * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to true.
      */
     enableBsdiffPatchSupport?: boolean;
   };

--- a/packages/@expo/config-types/src/__tests__/fixtures/ExpoConfig.backup.ts
+++ b/packages/@expo/config-types/src/__tests__/fixtures/ExpoConfig.backup.ts
@@ -177,7 +177,7 @@ export interface ExpoConfig {
      */
     useNativeDebug?: boolean;
     /**
-     * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to false.
+     * Whether to enable support for downloading and applying bundle diffs using bsdiff. Defaults to true.
      */
     enableBsdiffPatchSupport?: boolean;
   };

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/__snapshots__/withDefaultPlugins-test.ts.snap
@@ -626,6 +626,12 @@ exports[`built-in plugins introspects mods 1`] = `
                   },
                   {
                     "$": {
+                      "android:name": "expo.modules.updates.ENABLE_BSDIFF_PATCH_SUPPORT",
+                      "android:value": "true",
+                    },
+                  },
+                  {
+                    "$": {
                       "android:name": "expo.modules.updates.EXPO_RUNTIME_VERSION",
                       "android:value": "@string/expo_runtime_version",
                     },
@@ -826,6 +832,7 @@ exports[`built-in plugins introspects mods 1`] = `
         },
         "expoPlist": {
           "EXUpdatesCheckOnLaunch": "NEVER",
+          "EXUpdatesEnableBsdiffPatchSupport": true,
           "EXUpdatesEnabled": true,
           "EXUpdatesLaunchWaitMs": 650,
           "EXUpdatesRuntimeVersion": "1.0",
@@ -1263,6 +1270,12 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
                   },
                   {
                     "$": {
+                      "android:name": "expo.modules.updates.ENABLE_BSDIFF_PATCH_SUPPORT",
+                      "android:value": "true",
+                    },
+                  },
+                  {
+                    "$": {
                       "android:name": "expo.modules.updates.EXPO_RUNTIME_VERSION",
                       "android:value": "@string/expo_runtime_version",
                     },
@@ -1443,6 +1456,7 @@ exports[`built-in plugins introspects mods in a managed project 1`] = `
         },
         "expoPlist": {
           "EXUpdatesCheckOnLaunch": "NEVER",
+          "EXUpdatesEnableBsdiffPatchSupport": true,
           "EXUpdatesEnabled": true,
           "EXUpdatesLaunchWaitMs": 650,
           "EXUpdatesRuntimeVersion": "1.0",


### PR DESCRIPTION
# Why
We've changed the default of `enableBsdiffPatchSupport` in updates to true.

# How
Regenerate the types

# Test Plan
