### PR TITLE
[video] When caching take into account Authorization / auth-related request headers

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))
+
 ## 56.1.2 — 2026-05-21
 
 ### 🐛 Bug fixes

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,9 +8,9 @@
 
 ### 🐛 Bug fixes
 
-### 💡 Others
-
 - When caching take into account Authorization / auth-related request headers. ([#45995](https://github.com/expo/expo/pull/45995) by [@behenate](https://github.com/behenate))
+
+### 💡 Others
 
 ## 56.1.2 — 2026-05-21
 

--- a/packages/expo-video/android/build.gradle
+++ b/packages/expo-video/android/build.gradle
@@ -29,4 +29,6 @@ dependencies {
   def fragment_version = "1.8.9"
   implementation "androidx.fragment:fragment:$fragment_version"
   implementation "androidx.fragment:fragment-ktx:$fragment_version"
+
+  testImplementation 'junit:junit:4.13.2'
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/VideoCache.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/VideoCache.kt
@@ -9,6 +9,7 @@ import androidx.media3.database.StandaloneDatabaseProvider
 import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
 import androidx.media3.datasource.cache.SimpleCache
 import expo.modules.kotlin.exception.Exceptions
+import expo.modules.video.cache.CacheVariantIndex
 import expo.modules.video.managers.VideoManager
 import java.io.File
 import java.lang.ref.WeakReference
@@ -87,6 +88,9 @@ class VideoCache(context: Context) {
     instance = SimpleCache(getCacheDir(), cacheEvictor, databaseProvider)
     oldCache.release()
     oldCacheDirectory.deleteRecursively()
+    // Variants live in a sibling directory outside SimpleCache, so they must
+    // be wiped explicitly — otherwise an explicit clear leaves orphan records.
+    CacheVariantIndex.clearAll(context)
   }
 
   private fun getFileSize(file: File): Long {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/CachePolicy.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/CachePolicy.kt
@@ -1,0 +1,94 @@
+package expo.modules.video.cache
+
+/**
+ * Result of evaluating an HTTP response against RFC 9111 caching semantics.
+ * Mirrors `CachePolicy.swift` on iOS so both platforms reach the same decision
+ * for a given response.
+ */
+data class CachePolicy(
+  val varyHeaders: List<String>,
+  val isCacheable: Boolean,
+  val allowsAuthorizedReuse: Boolean
+) {
+  companion object {
+    fun evaluate(responseHeaders: Map<String, String>, statusCode: Int): CachePolicy {
+      // Only the success codes a video player can play back are worth caching.
+      // Caching a 401/500 would lock the user into a stale error.
+      if (statusCode != 200 && statusCode != 206) {
+        return CachePolicy(emptyList(), isCacheable = false, allowsAuthorizedReuse = false)
+      }
+
+      val vary = splitRespectingQuotes(headerValue(responseHeaders, "vary"))
+      val cacheControl = directiveNames(splitRespectingQuotes(headerValue(responseHeaders, "cache-control")))
+
+      // `private` excludes shared caches (RFC 9111 §5.2.2.7). Our cache straddles
+      // multiple identities on one device, so we treat ourselves as shared.
+      if (vary.contains("*") || "no-store" in cacheControl || "private" in cacheControl) {
+        return CachePolicy(emptyList(), isCacheable = false, allowsAuthorizedReuse = false)
+      }
+
+      // Cache-Control is consulted only for the §3.5 reuse decision below.
+      // Freshness directives (`max-age`, `Expires`, `Age`) and conditional
+      // revalidation (`If-None-Match`/`Last-Modified`) are not implemented;
+      // cached responses live until LRU eviction.
+      val allowsAuth = "public" in cacheControl ||
+        "must-revalidate" in cacheControl ||
+        "s-maxage" in cacheControl
+
+      val normalizedVary = vary
+        .map { it.lowercase() }
+        .filter { it != "*" }
+        .distinct()
+        .sorted()
+
+      return CachePolicy(normalizedVary, isCacheable = true, allowsAuthorizedReuse = allowsAuth)
+    }
+
+    private fun headerValue(headers: Map<String, String>, name: String): String {
+      val lower = name.lowercase()
+      return headers.entries.firstOrNull { it.key.lowercase() == lower }?.value.orEmpty()
+    }
+
+    /**
+     * Splits a header value on `,` while treating commas inside double-quoted
+     * strings as literal. Required for directives like `private="X-Foo, X-Bar"`
+     * where a naive split would shred the quoted field-name list.
+     */
+    private fun splitRespectingQuotes(value: String): List<String> {
+      val tokens = mutableListOf<String>()
+      val current = StringBuilder()
+      var inQuotes = false
+      for (c in value) {
+        when {
+          c == '"' -> {
+            inQuotes = !inQuotes
+            current.append(c)
+          }
+          c == ',' && !inQuotes -> {
+            val trimmed = current.toString().trim()
+            if (trimmed.isNotEmpty()) tokens.add(trimmed)
+            current.setLength(0)
+          }
+          else -> current.append(c)
+        }
+      }
+      val trimmed = current.toString().trim()
+      if (trimmed.isNotEmpty()) tokens.add(trimmed)
+      return tokens
+    }
+
+    /**
+     * Extracts the directive name (the part before `=`) from each token. Values
+     * are intentionally dropped — the policy decisions above only need presence.
+     */
+    private fun directiveNames(tokens: List<String>): Set<String> {
+      val names = mutableSetOf<String>()
+      for (token in tokens) {
+        val eq = token.indexOf('=')
+        val name = (if (eq >= 0) token.substring(0, eq) else token).trim().lowercase()
+        if (name.isNotEmpty()) names.add(name)
+      }
+      return names
+    }
+  }
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/CachePolicy.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/CachePolicy.kt
@@ -1,10 +1,5 @@
 package expo.modules.video.cache
 
-/**
- * Result of evaluating an HTTP response against RFC 9111 caching semantics.
- * Mirrors `CachePolicy.swift` on iOS so both platforms reach the same decision
- * for a given response.
- */
 data class CachePolicy(
   val varyHeaders: List<String>,
   val isCacheable: Boolean,
@@ -12,8 +7,6 @@ data class CachePolicy(
 ) {
   companion object {
     fun evaluate(responseHeaders: Map<String, String>, statusCode: Int): CachePolicy {
-      // Only the success codes a video player can play back are worth caching.
-      // Caching a 401/500 would lock the user into a stale error.
       if (statusCode != 200 && statusCode != 206) {
         return CachePolicy(emptyList(), isCacheable = false, allowsAuthorizedReuse = false)
       }
@@ -21,16 +14,10 @@ data class CachePolicy(
       val vary = splitRespectingQuotes(headerValue(responseHeaders, "vary"))
       val cacheControl = directiveNames(splitRespectingQuotes(headerValue(responseHeaders, "cache-control")))
 
-      // `private` excludes shared caches (RFC 9111 §5.2.2.7). Our cache straddles
-      // multiple identities on one device, so we treat ourselves as shared.
-      if (vary.contains("*") || "no-store" in cacheControl || "private" in cacheControl) {
+      if (vary.any { it.trim() == "*" }) {
         return CachePolicy(emptyList(), isCacheable = false, allowsAuthorizedReuse = false)
       }
 
-      // Cache-Control is consulted only for the §3.5 reuse decision below.
-      // Freshness directives (`max-age`, `Expires`, `Age`) and conditional
-      // revalidation (`If-None-Match`/`Last-Modified`) are not implemented;
-      // cached responses live until LRU eviction.
       val allowsAuth = "public" in cacheControl ||
         "must-revalidate" in cacheControl ||
         "s-maxage" in cacheControl

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
@@ -18,6 +18,7 @@ internal data class CacheVariant(
   val storageKey: String,
   val varyHeaders: List<String>,
   val varyValues: Map<String, String>,
+  val identityValues: Map<String, String>,
   val allowsAuthorizedReuse: Boolean
 )
 
@@ -37,8 +38,17 @@ internal object CacheVariantIndex {
   fun storageKey(context: Context, url: String, requestHeaders: Map<String, String>): String {
     val normalized = normalize(requestHeaders)
     val variants = pruneEvicted(context, url, load(context, url))
+
+    if (variants.isEmpty() && hasLegacyCacheEntry(url) && identityValues(normalized).isEmpty()) {
+      // Use legacy storage - the source does not specify auth headers.
+      return ""
+    }
     return matchingVariant(variants, normalized)?.storageKey
-      ?: provisionalStorageKey(normalized)
+      ?: provisionalStorageKey(
+        normalizedHeaders = normalized,
+        knownVaryHeaders = variants.flatMap { it.varyHeaders },
+        hasExistingVariants = variants.isNotEmpty()
+      )
   }
 
   /**
@@ -59,10 +69,12 @@ internal object CacheVariantIndex {
     if (!policy.isCacheable) return
     val normalized = normalize(requestHeaders)
     val varyValues = policy.varyHeaders.associateWith { (normalized[it] ?: "") }
+    val identityValues = identityValues(normalized)
     val variant = CacheVariant(
       storageKey = storageKey,
       varyHeaders = policy.varyHeaders,
       varyValues = varyValues,
+      identityValues = identityValues,
       allowsAuthorizedReuse = policy.allowsAuthorizedReuse
     )
     val existing = load(context, url).filterNot { it.storageKey == storageKey } + variant
@@ -75,13 +87,34 @@ internal object CacheVariantIndex {
       val allMatch = variant.varyHeaders.all { name ->
         (normalizedHeaders[name] ?: "") == (variant.varyValues[name] ?: "")
       }
-      if (!allMatch) continue
-      // §3.5 only matters when Authorization isn't already separating variants.
-      val authHandledByVary = AUTHORIZATION in variant.varyHeaders
-      if (hasAuthorization && !authHandledByVary && !variant.allowsAuthorizedReuse) continue
+      if (!allMatch) {
+        continue
+      }
+
+      val identityMatch = variant.identityValues.all { (name, value) ->
+        (normalizedHeaders[name] ?: "") == value
+      }
+
+      if (!identityMatch) {
+        continue
+      }
+      val identityHandledByVariant = variant.identityValues.containsKey(AUTHORIZATION)
+
+      if (hasAuthorization && !identityHandledByVariant && !variant.allowsAuthorizedReuse) {
+        continue
+      }
       return variant
     }
     return null
+  }
+
+  @OptIn(UnstableApi::class)
+  private fun hasLegacyCacheEntry(url: String): Boolean {
+    return try {
+      url in VideoManager.cache.instance.keys
+    } catch (e: Throwable) {
+      false
+    }
   }
 
   /**
@@ -113,11 +146,32 @@ internal object CacheVariantIndex {
     return live
   }
 
-  private fun provisionalStorageKey(normalizedHeaders: Map<String, String>): String {
-    val composite = provisionalIdentityHeaders
+  private fun provisionalStorageKey(
+    normalizedHeaders: Map<String, String>,
+    knownVaryHeaders: List<String>,
+    hasExistingVariants: Boolean
+  ): String {
+    val headers = (provisionalIdentityHeaders + knownVaryHeaders)
+      .map { it.lowercase() }
+      .distinct()
       .sorted()
+    val hasVariantInput = hasExistingVariants ||
+      knownVaryHeaders.isNotEmpty() ||
+      provisionalIdentityHeaders.any { it in normalizedHeaders }
+    if (!hasVariantInput) {
+      // Preserve the pre-variant URL-only cache key for anonymous videos so
+      // existing offline downloads remain playable after upgrading.
+      return ""
+    }
+    val composite = headers
       .joinToString(separator = ";") { name -> "$name:${normalizedHeaders[name] ?: ""}" }
     return sha256(composite)
+  }
+
+  private fun identityValues(normalizedHeaders: Map<String, String>): Map<String, String> {
+    return provisionalIdentityHeaders
+      .filter { it in normalizedHeaders }
+      .associateWith { normalizedHeaders[it].orEmpty() }
   }
 
   private fun normalize(headers: Map<String, String>): Map<String, String> {
@@ -126,7 +180,10 @@ internal object CacheVariantIndex {
 
   private fun load(context: Context, url: String): List<CacheVariant> {
     val file = indexFile(context, url)
-    if (!file.exists()) return emptyList()
+    if (!file.exists()) {
+      return emptyList()
+    }
+
     return try {
       val arr = JSONArray(file.readText())
       List(arr.length()) { i -> decode(arr.getJSONObject(i)) }
@@ -146,12 +203,18 @@ internal object CacheVariantIndex {
   private fun encode(v: CacheVariant): JSONObject {
     val values = JSONObject()
     v.varyValues.forEach { (k, value) -> values.put(k, value) }
+
+    val identityValues = JSONObject()
+    v.identityValues.forEach { (k, value) -> identityValues.put(k, value) }
+
     val headers = JSONArray()
     v.varyHeaders.forEach { headers.put(it) }
+
     return JSONObject()
       .put("storageKey", v.storageKey)
       .put("varyHeaders", headers)
       .put("varyValues", values)
+      .put("identityValues", identityValues)
       .put("allowsAuthorizedReuse", v.allowsAuthorizedReuse)
   }
 
@@ -165,10 +228,18 @@ internal object CacheVariantIndex {
       val key = keysIt.next()
       values[key] = valuesObj.optString(key, "")
     }
+    val identityValuesObj = json.optJSONObject("identityValues") ?: JSONObject()
+    val identityValues = mutableMapOf<String, String>()
+    val identityKeysIt = identityValuesObj.keys()
+    while (identityKeysIt.hasNext()) {
+      val key = identityKeysIt.next()
+      identityValues[key] = identityValuesObj.optString(key, "")
+    }
     return CacheVariant(
       storageKey = json.getString("storageKey"),
       varyHeaders = headers,
       varyValues = values,
+      identityValues = identityValues,
       allowsAuthorizedReuse = json.optBoolean("allowsAuthorizedReuse", false)
     )
   }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
@@ -54,9 +54,15 @@ internal object CacheVariantIndex {
     val variants = pruneEvicted(context, url, load(context, url))
 
     if (variants.isEmpty() && hasLegacyCacheEntry(url) && identityValues(normalized).isEmpty()) {
+      // A pre-upgrade, URL-only cache entry exists for an anonymous request.
+      // It is safe (and required for offline playback) to keep reading it: the
+      // request carries no identity headers, so it can't cross-pollinate. The
+      // recorder promotes it to a proper variant on the next network fetch.
+      // `canReadFromCache` must stay `true` here, otherwise the caller would
+      // evict this entry and break offline downloads made before upgrading.
       return CacheStorageKey(
         storageKey = "",
-        canReadFromCache = false
+        canReadFromCache = true
       )
     }
     matchingVariant(variants, normalized)?.let {
@@ -138,6 +144,10 @@ internal object CacheVariantIndex {
     return try {
       url in VideoManager.cache.instance.keys
     } catch (e: IllegalStateException) {
+      // SimpleCache released.
+      false
+    } catch (e: UninitializedPropertyAccessException) {
+      // `VideoManager.cache` not assigned yet (runs before `onModuleCreated`).
       false
     }
   }
@@ -154,7 +164,10 @@ internal object CacheVariantIndex {
     val keys = try {
       VideoManager.cache.instance.keys
     } catch (e: IllegalStateException) {
-      // Cache not initialized yet; nothing to prune against.
+      // SimpleCache released; nothing to prune against.
+      return variants
+    } catch (e: UninitializedPropertyAccessException) {
+      // `VideoManager.cache` not assigned yet; nothing to prune against.
       return variants
     }
     val live = variants.filter { variant ->

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
@@ -22,12 +22,20 @@ internal data class CacheVariant(
   val allowsAuthorizedReuse: Boolean
 )
 
+internal data class CacheStorageKey(
+  val storageKey: String,
+  val canReadFromCache: Boolean
+)
+
 internal object CacheVariantIndex {
   private const val INDEX_DIR = "ExpoVideoCacheVariants"
   private const val INDEX_SUFFIX = ".variants"
   private const val AUTHORIZATION = "authorization"
 
-  /** Headers used to derive the storage key before any response is seen. */
+  /**
+   * Headers used to derive the storage key before any response is seen.
+   * On Android, cookies are considered only when callers pass them in `VideoSource.headers`.
+   */
   private val provisionalIdentityHeaders = listOf("authorization", "cookie", "proxy-authorization")
 
   /**
@@ -35,20 +43,36 @@ internal object CacheVariantIndex {
    * provisional key when no variant matches yet. The storage key is appended
    * to the URL to form the Media3 cache key.
    */
+  @Synchronized
   fun storageKey(context: Context, url: String, requestHeaders: Map<String, String>): String {
+    return storageKeyResult(context, url, requestHeaders).storageKey
+  }
+
+  @Synchronized
+  fun storageKeyResult(context: Context, url: String, requestHeaders: Map<String, String>): CacheStorageKey {
     val normalized = normalize(requestHeaders)
     val variants = pruneEvicted(context, url, load(context, url))
 
     if (variants.isEmpty() && hasLegacyCacheEntry(url) && identityValues(normalized).isEmpty()) {
-      // Use legacy storage - the source does not specify auth headers.
-      return ""
+      return CacheStorageKey(
+        storageKey = "",
+        canReadFromCache = false
+      )
     }
-    return matchingVariant(variants, normalized)?.storageKey
-      ?: provisionalStorageKey(
+    matchingVariant(variants, normalized)?.let {
+      return CacheStorageKey(
+        storageKey = it.storageKey,
+        canReadFromCache = true
+      )
+    }
+    return CacheStorageKey(
+      storageKey = provisionalStorageKey(
         normalizedHeaders = normalized,
         knownVaryHeaders = variants.flatMap { it.varyHeaders },
         hasExistingVariants = variants.isNotEmpty()
-      )
+      ),
+      canReadFromCache = false
+    )
   }
 
   /**
@@ -59,6 +83,7 @@ internal object CacheVariantIndex {
     File(context.cacheDir, INDEX_DIR).deleteRecursively()
   }
 
+  @Synchronized
   fun recordVariant(
     context: Context,
     url: String,
@@ -112,7 +137,7 @@ internal object CacheVariantIndex {
   private fun hasLegacyCacheEntry(url: String): Boolean {
     return try {
       url in VideoManager.cache.instance.keys
-    } catch (e: Throwable) {
+    } catch (e: IllegalStateException) {
       false
     }
   }
@@ -128,7 +153,7 @@ internal object CacheVariantIndex {
     if (variants.isEmpty()) return variants
     val keys = try {
       VideoManager.cache.instance.keys
-    } catch (e: Throwable) {
+    } catch (e: IllegalStateException) {
       // Cache not initialized yet; nothing to prune against.
       return variants
     }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
@@ -19,12 +19,15 @@ internal data class CacheVariant(
   val varyHeaders: List<String>,
   val varyValues: Map<String, String>,
   val identityValues: Map<String, String>,
-  val allowsAuthorizedReuse: Boolean
+  val allowsAuthorizedReuse: Boolean,
+  val cacheable: Boolean = true
 )
 
 internal data class CacheStorageKey(
   val storageKey: String,
-  val canReadFromCache: Boolean
+  // Whether the caller may serve bytes already in the Media3 cache for this request.
+  val canReadFromCache: Boolean,
+  val cacheable: Boolean = true
 )
 
 internal object CacheVariantIndex {
@@ -68,7 +71,8 @@ internal object CacheVariantIndex {
     matchingVariant(variants, normalized)?.let {
       return CacheStorageKey(
         storageKey = it.storageKey,
-        canReadFromCache = true
+        canReadFromCache = it.cacheable,
+        cacheable = it.cacheable
       )
     }
     return CacheStorageKey(
@@ -89,6 +93,8 @@ internal object CacheVariantIndex {
     File(context.cacheDir, INDEX_DIR).deleteRecursively()
   }
 
+  // A non-cacheable response (e.g. `Vary: *`) is stored as a `cacheable = false`
+  // marker so later reads bypass the cache instead of serving leftover bytes.
   @Synchronized
   fun recordVariant(
     context: Context,
@@ -97,7 +103,6 @@ internal object CacheVariantIndex {
     requestHeaders: Map<String, String>,
     policy: CachePolicy
   ) {
-    if (!policy.isCacheable) return
     val normalized = normalize(requestHeaders)
     val varyValues = policy.varyHeaders.associateWith { (normalized[it] ?: "") }
     val identityValues = identityValues(normalized)
@@ -106,7 +111,8 @@ internal object CacheVariantIndex {
       varyHeaders = policy.varyHeaders,
       varyValues = varyValues,
       identityValues = identityValues,
-      allowsAuthorizedReuse = policy.allowsAuthorizedReuse
+      allowsAuthorizedReuse = policy.allowsAuthorizedReuse,
+      cacheable = policy.isCacheable
     )
     val existing = load(context, url).filterNot { it.storageKey == storageKey } + variant
     save(context, url, existing)
@@ -254,6 +260,7 @@ internal object CacheVariantIndex {
       .put("varyValues", values)
       .put("identityValues", identityValues)
       .put("allowsAuthorizedReuse", v.allowsAuthorizedReuse)
+      .put("cacheable", v.cacheable)
   }
 
   private fun decode(json: JSONObject): CacheVariant {
@@ -278,7 +285,8 @@ internal object CacheVariantIndex {
       varyHeaders = headers,
       varyValues = values,
       identityValues = identityValues,
-      allowsAuthorizedReuse = json.optBoolean("allowsAuthorizedReuse", false)
+      allowsAuthorizedReuse = json.optBoolean("allowsAuthorizedReuse", false),
+      cacheable = json.optBoolean("cacheable", true)
     )
   }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/CacheVariantIndex.kt
@@ -1,0 +1,185 @@
+package expo.modules.video.cache
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import expo.modules.video.managers.VideoManager
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.security.MessageDigest
+
+/**
+ * Per-URL on-disk index of cached response variants. Mirrors the Swift
+ * implementation: each URL may have multiple variants when the server's
+ * `Vary` header indicates the response differs by request headers.
+ */
+internal data class CacheVariant(
+  val storageKey: String,
+  val varyHeaders: List<String>,
+  val varyValues: Map<String, String>,
+  val allowsAuthorizedReuse: Boolean
+)
+
+internal object CacheVariantIndex {
+  private const val INDEX_DIR = "ExpoVideoCacheVariants"
+  private const val INDEX_SUFFIX = ".variants"
+  private const val AUTHORIZATION = "authorization"
+
+  /** Headers used to derive the storage key before any response is seen. */
+  private val provisionalIdentityHeaders = listOf("authorization", "cookie", "proxy-authorization")
+
+  /**
+   * Returns the storage key for the variant matching this request, or a
+   * provisional key when no variant matches yet. The storage key is appended
+   * to the URL to form the Media3 cache key.
+   */
+  fun storageKey(context: Context, url: String, requestHeaders: Map<String, String>): String {
+    val normalized = normalize(requestHeaders)
+    val variants = pruneEvicted(context, url, load(context, url))
+    return matchingVariant(variants, normalized)?.storageKey
+      ?: provisionalStorageKey(normalized)
+  }
+
+  /**
+   * Wipes the on-disk variants directory. Called by `VideoCache.clear()` so
+   * an explicit cache clear doesn't leave behind orphaned variant records.
+   */
+  fun clearAll(context: Context) {
+    File(context.cacheDir, INDEX_DIR).deleteRecursively()
+  }
+
+  fun recordVariant(
+    context: Context,
+    url: String,
+    storageKey: String,
+    requestHeaders: Map<String, String>,
+    policy: CachePolicy
+  ) {
+    if (!policy.isCacheable) return
+    val normalized = normalize(requestHeaders)
+    val varyValues = policy.varyHeaders.associateWith { (normalized[it] ?: "") }
+    val variant = CacheVariant(
+      storageKey = storageKey,
+      varyHeaders = policy.varyHeaders,
+      varyValues = varyValues,
+      allowsAuthorizedReuse = policy.allowsAuthorizedReuse
+    )
+    val existing = load(context, url).filterNot { it.storageKey == storageKey } + variant
+    save(context, url, existing)
+  }
+
+  private fun matchingVariant(variants: List<CacheVariant>, normalizedHeaders: Map<String, String>): CacheVariant? {
+    val hasAuthorization = normalizedHeaders.containsKey(AUTHORIZATION)
+    for (variant in variants) {
+      val allMatch = variant.varyHeaders.all { name ->
+        (normalizedHeaders[name] ?: "") == (variant.varyValues[name] ?: "")
+      }
+      if (!allMatch) continue
+      // §3.5 only matters when Authorization isn't already separating variants.
+      val authHandledByVary = AUTHORIZATION in variant.varyHeaders
+      if (hasAuthorization && !authHandledByVary && !variant.allowsAuthorizedReuse) continue
+      return variant
+    }
+    return null
+  }
+
+  /**
+   * Drops variants whose corresponding data file has been LRU-evicted from
+   * Media3's `SimpleCache`. Without this the index would grow over time with
+   * entries pointing at keys whose payload was reclaimed. The check piggybacks
+   * on `Cache.getKeys()`, which for `SimpleCache` is an in-memory lookup.
+   */
+  @OptIn(UnstableApi::class)
+  private fun pruneEvicted(context: Context, url: String, variants: List<CacheVariant>): List<CacheVariant> {
+    if (variants.isEmpty()) return variants
+    val keys = try {
+      VideoManager.cache.instance.keys
+    } catch (e: Throwable) {
+      // Cache not initialized yet; nothing to prune against.
+      return variants
+    }
+    val live = variants.filter { variant ->
+      val key = if (variant.storageKey.isEmpty()) url else "$url#${variant.storageKey}"
+      key in keys
+    }
+    if (live.size != variants.size) {
+      if (live.isEmpty()) {
+        indexFile(context, url).delete()
+      } else {
+        save(context, url, live)
+      }
+    }
+    return live
+  }
+
+  private fun provisionalStorageKey(normalizedHeaders: Map<String, String>): String {
+    val composite = provisionalIdentityHeaders
+      .sorted()
+      .joinToString(separator = ";") { name -> "$name:${normalizedHeaders[name] ?: ""}" }
+    return sha256(composite)
+  }
+
+  private fun normalize(headers: Map<String, String>): Map<String, String> {
+    return headers.mapKeys { it.key.lowercase() }
+  }
+
+  private fun load(context: Context, url: String): List<CacheVariant> {
+    val file = indexFile(context, url)
+    if (!file.exists()) return emptyList()
+    return try {
+      val arr = JSONArray(file.readText())
+      List(arr.length()) { i -> decode(arr.getJSONObject(i)) }
+    } catch (e: Exception) {
+      emptyList()
+    }
+  }
+
+  private fun save(context: Context, url: String, variants: List<CacheVariant>) {
+    val arr = JSONArray()
+    variants.forEach { arr.put(encode(it)) }
+    val file = indexFile(context, url)
+    file.parentFile?.mkdirs()
+    file.writeText(arr.toString())
+  }
+
+  private fun encode(v: CacheVariant): JSONObject {
+    val values = JSONObject()
+    v.varyValues.forEach { (k, value) -> values.put(k, value) }
+    val headers = JSONArray()
+    v.varyHeaders.forEach { headers.put(it) }
+    return JSONObject()
+      .put("storageKey", v.storageKey)
+      .put("varyHeaders", headers)
+      .put("varyValues", values)
+      .put("allowsAuthorizedReuse", v.allowsAuthorizedReuse)
+  }
+
+  private fun decode(json: JSONObject): CacheVariant {
+    val headersArr = json.optJSONArray("varyHeaders") ?: JSONArray()
+    val headers = List(headersArr.length()) { i -> headersArr.getString(i) }
+    val valuesObj = json.optJSONObject("varyValues") ?: JSONObject()
+    val values = mutableMapOf<String, String>()
+    val keysIt = valuesObj.keys()
+    while (keysIt.hasNext()) {
+      val key = keysIt.next()
+      values[key] = valuesObj.optString(key, "")
+    }
+    return CacheVariant(
+      storageKey = json.getString("storageKey"),
+      varyHeaders = headers,
+      varyValues = values,
+      allowsAuthorizedReuse = json.optBoolean("allowsAuthorizedReuse", false)
+    )
+  }
+
+  private fun indexFile(context: Context, url: String): File {
+    val dir = File(context.cacheDir, INDEX_DIR)
+    return File(dir, sha256(url) + INDEX_SUFFIX)
+  }
+
+  private fun sha256(input: String): String {
+    val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray(Charsets.UTF_8))
+    return bytes.joinToString("") { "%02x".format(it) }
+  }
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/ExpoVideoCacheKeyFactory.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/ExpoVideoCacheKeyFactory.kt
@@ -16,11 +16,17 @@ import androidx.media3.datasource.cache.CacheKeyFactory
 @OptIn(UnstableApi::class)
 internal class ExpoVideoCacheKeyFactory(
   private val context: Context,
-  private val requestHeaders: Map<String, String>
+  private val requestHeaders: Map<String, String>,
+  private val sourceUrl: String?,
+  private val sourceStorageKey: String?
 ) : CacheKeyFactory {
   override fun buildCacheKey(dataSpec: DataSpec): String {
     val url = dataSpec.uri.toString()
-    val variantKey = CacheVariantIndex.storageKey(context, url, requestHeaders)
+    val variantKey = if (url == sourceUrl && sourceStorageKey != null) {
+      sourceStorageKey
+    } else {
+      CacheVariantIndex.storageKey(context, url, requestHeaders)
+    }
     return if (variantKey.isEmpty()) url else "$url#$variantKey"
   }
 }

--- a/packages/expo-video/android/src/main/java/expo/modules/video/cache/ExpoVideoCacheKeyFactory.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/cache/ExpoVideoCacheKeyFactory.kt
@@ -1,0 +1,26 @@
+package expo.modules.video.cache
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.cache.CacheKeyFactory
+
+/**
+ * Cache key factory that folds request headers into the Media3 cache key per
+ * RFC 9111 `Vary` semantics. The base `CacheDataSource` keys cached chunks
+ * solely by URL, which would cross-pollinate authenticated responses across
+ * identities. The variant key disambiguates by the request-header values the
+ * server (or our conservative default) marks as identity-bearing.
+ */
+@OptIn(UnstableApi::class)
+internal class ExpoVideoCacheKeyFactory(
+  private val context: Context,
+  private val requestHeaders: Map<String, String>
+) : CacheKeyFactory {
+  override fun buildCacheKey(dataSpec: DataSpec): String {
+    val url = dataSpec.uri.toString()
+    val variantKey = CacheVariantIndex.storageKey(context, url, requestHeaders)
+    return if (variantKey.isEmpty()) url else "$url#$variantKey"
+  }
+}

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
@@ -11,9 +11,17 @@ import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
+import expo.modules.video.cache.CachePolicy
+import expo.modules.video.cache.CacheVariantIndex
+import expo.modules.video.cache.ExpoVideoCacheKeyFactory
 import expo.modules.video.records.VideoSource
 import expo.modules.video.managers.VideoManager
+import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.asResponseBody
+import okio.ForwardingSource
+import okio.buffer
 
 @OptIn(UnstableApi::class)
 fun buildBaseDataSourceFactory(context: Context, videoSource: VideoSource): DataSource.Factory {
@@ -26,7 +34,11 @@ fun buildBaseDataSourceFactory(context: Context, videoSource: VideoSource): Data
 
 @OptIn(UnstableApi::class)
 fun buildOkHttpDataSourceFactory(context: Context, videoSource: VideoSource): OkHttpDataSource.Factory {
-  val client = OkHttpClient.Builder().build()
+  val clientBuilder = OkHttpClient.Builder()
+  if (videoSource.useCaching) {
+    clientBuilder.addNetworkInterceptor(buildCacheVariantRecorder(context, videoSource))
+  }
+  val client = clientBuilder.build()
 
   // If the application name has ANY non-ASCII characters, we need to strip them out. This is because using non-ASCII characters
   // in the User-Agent header can cause issues with getting the media to play.
@@ -46,10 +58,74 @@ fun buildOkHttpDataSourceFactory(context: Context, videoSource: VideoSource): Ok
 
 @OptIn(UnstableApi::class)
 fun buildCacheDataSourceFactory(context: Context, videoSource: VideoSource): DataSource.Factory {
+  val requestHeaders = videoSource.headers ?: emptyMap()
   return CacheDataSource.Factory().apply {
     setCache(VideoManager.cache.instance)
     setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+    setCacheKeyFactory(ExpoVideoCacheKeyFactory(context, requestHeaders))
     setUpstreamDataSourceFactory(buildBaseDataSourceFactory(context, videoSource))
+  }
+}
+
+@OptIn(UnstableApi::class)
+private fun buildCacheVariantRecorder(context: Context, videoSource: VideoSource): Interceptor {
+  // Captured once: the original `videoSource.uri` is what later cache reads
+  // key against, even if the network response was reached through redirects.
+  val sourceUrl = videoSource.uri?.toString()
+  val requestHeaders = videoSource.headers ?: emptyMap()
+  val normalizedRequest = requestHeaders.mapKeys { it.key.lowercase() }
+  val hasAuthorization = normalizedRequest.containsKey("authorization")
+  return Interceptor { chain ->
+    val response = chain.proceed(chain.request())
+    if (sourceUrl != null) {
+      val responseHeaders = response.headers
+        .toMultimap()
+        .mapValues { it.value.joinToString(separator = ",") }
+      val policy = CachePolicy.evaluate(responseHeaders, response.code)
+      val authorizationCoveredByVary = "authorization" in policy.varyHeaders
+      val authorizationBlocked = hasAuthorization && !authorizationCoveredByVary && !policy.allowsAuthorizedReuse
+      val storageKey = CacheVariantIndex.storageKey(context, sourceUrl, requestHeaders)
+
+      if (!policy.isCacheable || authorizationBlocked) {
+        // Drop this variant's bytes only; other variants for the same URL may
+        // still be valid. Eviction is deferred until Media3 has finished
+        // writing through the body so partial chunks don't linger.
+        return@Interceptor response.evictAfterClose { evictCacheEntry(sourceUrl, storageKey) }
+      }
+      CacheVariantIndex.recordVariant(context, sourceUrl, storageKey, requestHeaders, policy)
+    }
+    response
+  }
+}
+
+@OptIn(UnstableApi::class)
+private fun Response.evictAfterClose(onClose: () -> Unit): Response {
+  val originalBody = body ?: return this
+  val wrappedSource = object : ForwardingSource(originalBody.source()) {
+    private var fired = false
+    override fun close() {
+      try {
+        super.close()
+      } finally {
+        if (!fired) {
+          fired = true
+          onClose()
+        }
+      }
+    }
+  }
+  return newBuilder()
+    .body(wrappedSource.buffer().asResponseBody(originalBody.contentType(), originalBody.contentLength()))
+    .build()
+}
+
+@OptIn(UnstableApi::class)
+private fun evictCacheEntry(url: String, storageKey: String) {
+  val cacheKey = if (storageKey.isEmpty()) url else "$url#$storageKey"
+  try {
+    VideoManager.cache.instance.removeResource(cacheKey)
+  } catch (e: Exception) {
+    // Cache may be released or the key may not exist yet; either way nothing to evict.
   }
 }
 

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
@@ -74,6 +74,14 @@ fun buildCacheDataSourceFactory(
   val sourceUrl = videoSource.uri?.toString()
   val storageKeyResult = sourceUrl?.let { CacheVariantIndex.storageKeyResult(context, it, requestHeaders) }
   val storageKey = storageKeyResult?.storageKey
+  if (storageKeyResult?.cacheable == false) {
+    // Non-cacheable URL (e.g. `Vary: *`): bypass the cache so leftover byte spans
+    // an active player locked from eviction are never read, including offline.
+    if (sourceUrl != null && storageKey != null) {
+      evictCacheEntry(sourceUrl, storageKey)
+    }
+    return buildBaseDataSourceFactory(context, videoSource, storageKey)
+  }
   if (storageKeyResult?.canReadFromCache != true) {
     if (sourceUrl != null && storageKey != null) {
       evictCacheEntry(sourceUrl, storageKey)
@@ -113,19 +121,16 @@ private fun buildCacheVariantRecorder(
       val policy = CachePolicy.evaluate(responseHeaders, response.code)
       val storageKey = cacheStorageKey ?: CacheVariantIndex.storageKey(context, sourceUrl, requestHeaders)
 
+      if (recordedKeys.add(storageKey)) {
+        CacheVariantIndex.recordVariant(context, sourceUrl, storageKey, requestHeaders, policy)
+      }
       if (!policy.isCacheable) {
-        // A previously cached entry under this key (e.g. one that used to be
-        // cacheable) must go now that the server says otherwise. We also evict
-        // again on close because `FLAG_IGNORE_CACHE_ON_ERROR` may let Media3
-        // write partial bytes for this response before the body stream ends.
-        recordedKeys.remove(storageKey)
+        // Best-effort reclaim of any partial bytes Media3 wrote under this key;
+        // the recorded marker is the durable guard if locked spans can't be freed.
         evictCacheEntry(sourceUrl, storageKey)
         return@Interceptor response.evictAfterClose {
           evictCacheEntry(sourceUrl, storageKey)
         }
-      }
-      if (recordedKeys.add(storageKey)) {
-        CacheVariantIndex.recordVariant(context, sourceUrl, storageKey, requestHeaders, policy)
       }
     }
     response

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
@@ -73,8 +73,6 @@ private fun buildCacheVariantRecorder(context: Context, videoSource: VideoSource
   // key against, even if the network response was reached through redirects.
   val sourceUrl = videoSource.uri?.toString()
   val requestHeaders = videoSource.headers ?: emptyMap()
-  val normalizedRequest = requestHeaders.mapKeys { it.key.lowercase() }
-  val hasAuthorization = normalizedRequest.containsKey("authorization")
   return Interceptor { chain ->
     val response = chain.proceed(chain.request())
     if (sourceUrl != null) {
@@ -82,15 +80,12 @@ private fun buildCacheVariantRecorder(context: Context, videoSource: VideoSource
         .toMultimap()
         .mapValues { it.value.joinToString(separator = ",") }
       val policy = CachePolicy.evaluate(responseHeaders, response.code)
-      val authorizationCoveredByVary = "authorization" in policy.varyHeaders
-      val authorizationBlocked = hasAuthorization && !authorizationCoveredByVary && !policy.allowsAuthorizedReuse
       val storageKey = CacheVariantIndex.storageKey(context, sourceUrl, requestHeaders)
 
-      if (!policy.isCacheable || authorizationBlocked) {
-        // Drop this variant's bytes only; other variants for the same URL may
-        // still be valid. Eviction is deferred until Media3 has finished
-        // writing through the body so partial chunks don't linger.
-        return@Interceptor response.evictAfterClose { evictCacheEntry(sourceUrl, storageKey) }
+      if (!policy.isCacheable) {
+        return@Interceptor response.evictAfterClose {
+          evictCacheEntry(sourceUrl, storageKey)
+        }
       }
       CacheVariantIndex.recordVariant(context, sourceUrl, storageKey, requestHeaders, policy)
     }
@@ -100,7 +95,8 @@ private fun buildCacheVariantRecorder(context: Context, videoSource: VideoSource
 
 @OptIn(UnstableApi::class)
 private fun Response.evictAfterClose(onClose: () -> Unit): Response {
-  val originalBody = body ?: return this
+  val originalBody = body
+    ?: return this
   val wrappedSource = object : ForwardingSource(originalBody.source()) {
     private var fired = false
     override fun close() {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
@@ -24,19 +24,27 @@ import okio.ForwardingSource
 import okio.buffer
 
 @OptIn(UnstableApi::class)
-fun buildBaseDataSourceFactory(context: Context, videoSource: VideoSource): DataSource.Factory {
+fun buildBaseDataSourceFactory(
+  context: Context,
+  videoSource: VideoSource,
+  cacheStorageKey: String? = null
+): DataSource.Factory {
   return if (videoSource.uri?.scheme?.startsWith("http") == true) {
-    buildOkHttpDataSourceFactory(context, videoSource)
+    buildOkHttpDataSourceFactory(context, videoSource, cacheStorageKey)
   } else {
     DefaultDataSource.Factory(context)
   }
 }
 
 @OptIn(UnstableApi::class)
-fun buildOkHttpDataSourceFactory(context: Context, videoSource: VideoSource): OkHttpDataSource.Factory {
+fun buildOkHttpDataSourceFactory(
+  context: Context,
+  videoSource: VideoSource,
+  cacheStorageKey: String? = null
+): OkHttpDataSource.Factory {
   val clientBuilder = OkHttpClient.Builder()
   if (videoSource.useCaching) {
-    clientBuilder.addNetworkInterceptor(buildCacheVariantRecorder(context, videoSource))
+    clientBuilder.addNetworkInterceptor(buildCacheVariantRecorder(context, videoSource, cacheStorageKey))
   }
   val client = clientBuilder.build()
 
@@ -57,20 +65,36 @@ fun buildOkHttpDataSourceFactory(context: Context, videoSource: VideoSource): Ok
 }
 
 @OptIn(UnstableApi::class)
-fun buildCacheDataSourceFactory(context: Context, videoSource: VideoSource): DataSource.Factory {
+fun buildCacheDataSourceFactory(
+  context: Context,
+  videoSource: VideoSource
+): DataSource.Factory {
   val requestHeaders = videoSource.headers ?: emptyMap()
+  val sourceUrl = videoSource.uri?.toString()
+  val storageKeyResult = sourceUrl?.let { CacheVariantIndex.storageKeyResult(context, it, requestHeaders) }
+  val storageKey = storageKeyResult?.storageKey
+  if (storageKeyResult?.canReadFromCache != true) {
+    if (sourceUrl != null && storageKey != null) {
+      evictCacheEntry(sourceUrl, storageKey)
+    }
+  }
   return CacheDataSource.Factory().apply {
     setCache(VideoManager.cache.instance)
     setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
-    setCacheKeyFactory(ExpoVideoCacheKeyFactory(context, requestHeaders))
-    setUpstreamDataSourceFactory(buildBaseDataSourceFactory(context, videoSource))
+    setCacheKeyFactory(ExpoVideoCacheKeyFactory(context, requestHeaders, sourceUrl, storageKey))
+    setUpstreamDataSourceFactory(buildBaseDataSourceFactory(context, videoSource, storageKey))
   }
 }
 
 @OptIn(UnstableApi::class)
-private fun buildCacheVariantRecorder(context: Context, videoSource: VideoSource): Interceptor {
+private fun buildCacheVariantRecorder(
+  context: Context,
+  videoSource: VideoSource,
+  cacheStorageKey: String?
+): Interceptor {
   // Captured once: the original `videoSource.uri` is what later cache reads
   // key against, even if the network response was reached through redirects.
+  // `Vary` is intentionally read from the terminal response seen by Media3.
   val sourceUrl = videoSource.uri?.toString()
   val requestHeaders = videoSource.headers ?: emptyMap()
   return Interceptor { chain ->
@@ -80,9 +104,10 @@ private fun buildCacheVariantRecorder(context: Context, videoSource: VideoSource
         .toMultimap()
         .mapValues { it.value.joinToString(separator = ",") }
       val policy = CachePolicy.evaluate(responseHeaders, response.code)
-      val storageKey = CacheVariantIndex.storageKey(context, sourceUrl, requestHeaders)
+      val storageKey = cacheStorageKey ?: CacheVariantIndex.storageKey(context, sourceUrl, requestHeaders)
 
       if (!policy.isCacheable) {
+        evictCacheEntry(sourceUrl, storageKey)
         return@Interceptor response.evictAfterClose {
           evictCacheEntry(sourceUrl, storageKey)
         }
@@ -130,7 +155,10 @@ fun buildMediaSourceFactory(context: Context, dataSourceFactory: DataSource.Fact
 }
 
 @OptIn(UnstableApi::class)
-fun buildExpoVideoMediaSource(context: Context, videoSource: VideoSource): MediaSource {
+fun buildExpoVideoMediaSource(
+  context: Context,
+  videoSource: VideoSource
+): MediaSource {
   val dataSourceFactory = if (videoSource.useCaching) {
     buildCacheDataSourceFactory(context, videoSource)
   } else {

--- a/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
+++ b/packages/expo-video/android/src/main/java/expo/modules/video/utils/DataSourceUtils.kt
@@ -22,6 +22,7 @@ import okhttp3.Response
 import okhttp3.ResponseBody.Companion.asResponseBody
 import okio.ForwardingSource
 import okio.buffer
+import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(UnstableApi::class)
 fun buildBaseDataSourceFactory(
@@ -97,6 +98,12 @@ private fun buildCacheVariantRecorder(
   // `Vary` is intentionally read from the terminal response seen by Media3.
   val sourceUrl = videoSource.uri?.toString()
   val requestHeaders = videoSource.headers ?: emptyMap()
+  // Media3's `CacheDataSource` issues many partial/range requests for a single
+  // video, all sharing the same URL and response headers. The variant only
+  // needs to be recorded once per storage key; tracking the keys we've already
+  // recorded avoids a full load+rewrite of the variants file (under lock) on
+  // every chunk during playback.
+  val recordedKeys = ConcurrentHashMap.newKeySet<String>()
   return Interceptor { chain ->
     val response = chain.proceed(chain.request())
     if (sourceUrl != null) {
@@ -107,12 +114,19 @@ private fun buildCacheVariantRecorder(
       val storageKey = cacheStorageKey ?: CacheVariantIndex.storageKey(context, sourceUrl, requestHeaders)
 
       if (!policy.isCacheable) {
+        // A previously cached entry under this key (e.g. one that used to be
+        // cacheable) must go now that the server says otherwise. We also evict
+        // again on close because `FLAG_IGNORE_CACHE_ON_ERROR` may let Media3
+        // write partial bytes for this response before the body stream ends.
+        recordedKeys.remove(storageKey)
         evictCacheEntry(sourceUrl, storageKey)
         return@Interceptor response.evictAfterClose {
           evictCacheEntry(sourceUrl, storageKey)
         }
       }
-      CacheVariantIndex.recordVariant(context, sourceUrl, storageKey, requestHeaders, policy)
+      if (recordedKeys.add(storageKey)) {
+        CacheVariantIndex.recordVariant(context, sourceUrl, storageKey, requestHeaders, policy)
+      }
     }
     response
   }

--- a/packages/expo-video/android/src/test/java/expo/modules/video/cache/CachePolicyTest.kt
+++ b/packages/expo-video/android/src/test/java/expo/modules/video/cache/CachePolicyTest.kt
@@ -22,10 +22,15 @@ class CachePolicyTest {
   }
 
   @Test
-  fun `quoted commas do not split header tokens`() {
-    val policy = CachePolicy.evaluate(mapOf("Vary" to "Accept-Language, \"X-Foo, X-Bar\""), 200)
+  fun `quoted commas in cache-control do not split into spurious directives`() {
+    // `public` here is a quoted field-name inside the `private` directive's
+    // value, not a real cache directive. A naive comma split would surface it as
+    // a standalone directive and wrongly enable Authorization reuse. (Quoted
+    // lists only ever appear in Cache-Control, never in Vary.)
+    val policy = CachePolicy.evaluate(mapOf("Cache-Control" to "private=\"X-Foo, public, X-Bar\""), 200)
 
-    assertEquals(listOf("\"x-foo, x-bar\"", "accept-language"), policy.varyHeaders)
+    assertTrue(policy.isCacheable)
+    assertFalse(policy.allowsAuthorizedReuse)
   }
 
   @Test

--- a/packages/expo-video/android/src/test/java/expo/modules/video/cache/CachePolicyTest.kt
+++ b/packages/expo-video/android/src/test/java/expo/modules/video/cache/CachePolicyTest.kt
@@ -1,0 +1,46 @@
+package expo.modules.video.cache
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CachePolicyTest {
+  @Test
+  fun `non playable status is not cacheable`() {
+    val policy = CachePolicy.evaluate(emptyMap(), 401)
+
+    assertFalse(policy.isCacheable)
+    assertEquals(emptyList<String>(), policy.varyHeaders)
+  }
+
+  @Test
+  fun `vary star is not cacheable`() {
+    val policy = CachePolicy.evaluate(mapOf("Vary" to "*"), 200)
+
+    assertFalse(policy.isCacheable)
+  }
+
+  @Test
+  fun `quoted commas do not split header tokens`() {
+    val policy = CachePolicy.evaluate(mapOf("Vary" to "Accept-Language, \"X-Foo, X-Bar\""), 200)
+
+    assertEquals(listOf("\"x-foo, x-bar\"", "accept-language"), policy.varyHeaders)
+  }
+
+  @Test
+  fun `public cache control allows authorization reuse`() {
+    val policy = CachePolicy.evaluate(mapOf("Cache-Control" to "public"), 206)
+
+    assertTrue(policy.isCacheable)
+    assertTrue(policy.allowsAuthorizedReuse)
+  }
+
+  @Test
+  fun `missing reuse directives block authorization reuse`() {
+    val policy = CachePolicy.evaluate(mapOf("Cache-Control" to "max-age=3600"), 200)
+
+    assertTrue(policy.isCacheable)
+    assertFalse(policy.allowsAuthorizedReuse)
+  }
+}

--- a/packages/expo-video/ios/Cache/CachePolicy.swift
+++ b/packages/expo-video/ios/Cache/CachePolicy.swift
@@ -1,0 +1,96 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/// Result of evaluating a response against RFC 9111 caching semantics, used to
+/// decide how a video response may be reused across requests.
+struct CachePolicy {
+  /// Header names listed by the response's `Vary` header, lowercased and sorted.
+  /// Excludes `*`; presence of `*` instead sets `isCacheable` to `false`.
+  let varyHeaders: [String]
+
+  /// `false` when the response opts out of storage entirely:
+  /// non-2xx status, `Vary: *`, or `Cache-Control: no-store` / `private`.
+  let isCacheable: Bool
+
+  /// RFC 9111 §3.5: when a request bears `Authorization`, a stored response may
+  /// only be reused if the response carries `public`, `s-maxage`, or
+  /// `must-revalidate`. This precomputes that decision for the response.
+  let allowsAuthorizedReuse: Bool
+
+  static func evaluate(responseHeaders: [String: String], statusCode: Int) -> CachePolicy {
+    // Only the success codes a video player can play back are worth caching.
+    // Caching a 401/500 would lock the user into a stale error.
+    guard statusCode == 200 || statusCode == 206 else {
+      return CachePolicy(varyHeaders: [], isCacheable: false, allowsAuthorizedReuse: false)
+    }
+
+    let vary = splitRespectingQuotes(headerValue(responseHeaders, name: "vary"))
+    let cacheControl = directiveNames(in: splitRespectingQuotes(headerValue(responseHeaders, name: "cache-control")))
+
+    // `private` excludes shared caches (RFC 9111 §5.2.2.7). Our cache straddles
+    // multiple identities on one device, so we treat ourselves as shared.
+    if vary.contains("*") || cacheControl.contains("no-store") || cacheControl.contains("private") {
+      return CachePolicy(varyHeaders: [], isCacheable: false, allowsAuthorizedReuse: false)
+    }
+
+    // Cache-Control is consulted only for the §3.5 reuse decision below.
+    // Freshness directives (`max-age`, `Expires`, `Age`) and conditional
+    // revalidation (`If-None-Match`/`Last-Modified`) are not implemented; cached
+    // responses live until LRU eviction.
+    let allowsAuth = cacheControl.contains("public")
+      || cacheControl.contains("must-revalidate")
+      || cacheControl.contains("s-maxage")
+
+    let normalizedVary = vary.map { $0.lowercased() }.filter { $0 != "*" }.sorted()
+    return CachePolicy(
+      varyHeaders: Array(Set(normalizedVary)).sorted(),
+      isCacheable: true,
+      allowsAuthorizedReuse: allowsAuth
+    )
+  }
+
+  private static func headerValue(_ headers: [String: String], name: String) -> String {
+    let lower = name.lowercased()
+    for (key, value) in headers where key.lowercased() == lower {
+      return value
+    }
+    return ""
+  }
+
+  /// Splits a header value on `,` while treating commas inside double-quoted
+  /// strings as literal. Required for directives like `private="X-Foo, X-Bar"`
+  /// where a naive split would shred the quoted field-name list.
+  private static func splitRespectingQuotes(_ value: String) -> [String] {
+    var tokens: [String] = []
+    var current = ""
+    var inQuotes = false
+    for char in value {
+      if char == "\"" {
+        inQuotes.toggle()
+        current.append(char)
+      } else if char == "," && !inQuotes {
+        let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { tokens.append(trimmed) }
+        current.removeAll(keepingCapacity: true)
+      } else {
+        current.append(char)
+      }
+    }
+    let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+    if !trimmed.isEmpty { tokens.append(trimmed) }
+    return tokens
+  }
+
+  /// Extracts the directive name (the part before `=`) from each token. Values
+  /// are intentionally dropped — the policy decisions above only need presence.
+  private static func directiveNames(in tokens: [String]) -> Set<String> {
+    var names: Set<String> = []
+    for token in tokens {
+      let nameEnd = token.firstIndex(of: "=") ?? token.endIndex
+      let name = token[..<nameEnd].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+      if !name.isEmpty { names.insert(name) }
+    }
+    return names
+  }
+}

--- a/packages/expo-video/ios/Cache/CachePolicy.swift
+++ b/packages/expo-video/ios/Cache/CachePolicy.swift
@@ -2,25 +2,12 @@
 
 import Foundation
 
-/// Result of evaluating a response against RFC 9111 caching semantics, used to
-/// decide how a video response may be reused across requests.
 struct CachePolicy {
-  /// Header names listed by the response's `Vary` header, lowercased and sorted.
-  /// Excludes `*`; presence of `*` instead sets `isCacheable` to `false`.
   let varyHeaders: [String]
-
-  /// `false` when the response opts out of storage entirely:
-  /// non-2xx status, `Vary: *`, or `Cache-Control: no-store` / `private`.
   let isCacheable: Bool
-
-  /// RFC 9111 §3.5: when a request bears `Authorization`, a stored response may
-  /// only be reused if the response carries `public`, `s-maxage`, or
-  /// `must-revalidate`. This precomputes that decision for the response.
   let allowsAuthorizedReuse: Bool
 
   static func evaluate(responseHeaders: [String: String], statusCode: Int) -> CachePolicy {
-    // Only the success codes a video player can play back are worth caching.
-    // Caching a 401/500 would lock the user into a stale error.
     guard statusCode == 200 || statusCode == 206 else {
       return CachePolicy(varyHeaders: [], isCacheable: false, allowsAuthorizedReuse: false)
     }
@@ -28,16 +15,10 @@ struct CachePolicy {
     let vary = splitRespectingQuotes(headerValue(responseHeaders, name: "vary"))
     let cacheControl = directiveNames(in: splitRespectingQuotes(headerValue(responseHeaders, name: "cache-control")))
 
-    // `private` excludes shared caches (RFC 9111 §5.2.2.7). Our cache straddles
-    // multiple identities on one device, so we treat ourselves as shared.
-    if vary.contains("*") || cacheControl.contains("no-store") || cacheControl.contains("private") {
+    if vary.contains(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines) == "*" }) {
       return CachePolicy(varyHeaders: [], isCacheable: false, allowsAuthorizedReuse: false)
     }
 
-    // Cache-Control is consulted only for the §3.5 reuse decision below.
-    // Freshness directives (`max-age`, `Expires`, `Age`) and conditional
-    // revalidation (`If-None-Match`/`Last-Modified`) are not implemented; cached
-    // responses live until LRU eviction.
     let allowsAuth = cacheControl.contains("public")
       || cacheControl.contains("must-revalidate")
       || cacheControl.contains("s-maxage")

--- a/packages/expo-video/ios/Cache/CacheVariantIndex.swift
+++ b/packages/expo-video/ios/Cache/CacheVariantIndex.swift
@@ -18,12 +18,14 @@ struct CacheVariant: Codable {
   /// Caller/application identity headers that must not be reused across values,
   /// even when the server did not list them in `Vary`.
   let identityValues: [String: String]
+  /// File extension used by this variant's data file.
+  let fileExtension: String?
   /// Per RFC 9111 §3.5: whether this response may be reused for an
   /// `Authorization`-bearing request not already disambiguated by `Vary`.
   let allowsAuthorizedReuse: Bool
 
   enum CodingKeys: String, CodingKey {
-    case storageKey, varyHeaders, varyValues, identityValues, allowsAuthorizedReuse
+    case storageKey, varyHeaders, varyValues, identityValues, fileExtension, allowsAuthorizedReuse
   }
 
   init(
@@ -31,12 +33,14 @@ struct CacheVariant: Codable {
     varyHeaders: [String],
     varyValues: [String: String],
     identityValues: [String: String],
+    fileExtension: String? = nil,
     allowsAuthorizedReuse: Bool
   ) {
     self.storageKey = storageKey
     self.varyHeaders = varyHeaders
     self.varyValues = varyValues
     self.identityValues = identityValues
+    self.fileExtension = fileExtension
     self.allowsAuthorizedReuse = allowsAuthorizedReuse
   }
 
@@ -46,6 +50,7 @@ struct CacheVariant: Codable {
     varyHeaders = try container.decode([String].self, forKey: .varyHeaders)
     varyValues = try container.decode([String: String].self, forKey: .varyValues)
     identityValues = try container.decodeIfPresent([String: String].self, forKey: .identityValues) ?? [:]
+    fileExtension = try container.decodeIfPresent(String.self, forKey: .fileExtension)
     allowsAuthorizedReuse = try container.decodeIfPresent(Bool.self, forKey: .allowsAuthorizedReuse) ?? false
   }
 }
@@ -55,6 +60,7 @@ struct CacheVariant: Codable {
 /// HTTP `Vary` rules and the §3.5 `Authorization` reuse restriction.
 enum CacheVariantIndex {
   static let fileSuffix = ".variants"
+  private static let queue = DispatchQueue(label: "expo.video.cache.variants")
   private static let authorizationHeader = "authorization"
   /// Headers that must never be reused across differing identities.
   private static let provisionalIdentityHeaders = ["authorization", "cookie", "proxy-authorization"]
@@ -74,6 +80,12 @@ enum CacheVariantIndex {
   }
 
   static func load(forUrl url: URL) -> [CacheVariant] {
+    return queue.sync {
+      pruneMissingVariantsUnlocked(forUrl: url, fileExtension: nil, variants: loadUnlocked(forUrl: url))
+    }
+  }
+
+  private static func loadUnlocked(forUrl url: URL) -> [CacheVariant] {
     guard let path = indexPath(forUrl: url),
       FileManager.default.fileExists(atPath: path),
       let data = FileManager.default.contents(atPath: path) else {
@@ -84,24 +96,35 @@ enum CacheVariantIndex {
 
   /// Returns the storage key for the variant that matches this request, or
   /// derives a provisional one when no variant matches yet.
-  static func storageKey(forUrl url: URL, requestHeaders: [String: String]?) -> String {
+  static func storageKey(
+    forUrl url: URL,
+    requestHeaders: [String: String]?,
+    fileExtension: String? = nil
+  ) -> String {
     let normalized = normalizedRequestHeaders(forUrl: url, requestHeaders: requestHeaders)
-    if let variant = matchingVariant(forUrl: url, normalizedHeaders: normalized) {
-      return variant.storageKey
+    return queue.sync {
+      let variants = pruneMissingVariantsUnlocked(
+        forUrl: url,
+        fileExtension: fileExtension,
+        variants: loadUnlocked(forUrl: url)
+      )
+      if let variant = matchingVariant(variants: variants, normalizedHeaders: normalized) {
+        return variant.storageKey
+      }
+      let knownVaryHeaders = variants.flatMap { $0.varyHeaders }
+      return provisionalStorageKey(
+        normalizedHeaders: normalized,
+        knownVaryHeaders: knownVaryHeaders,
+        hasExistingVariants: !variants.isEmpty
+      )
     }
-    let variants = load(forUrl: url)
-    let knownVaryHeaders = variants.flatMap { $0.varyHeaders }
-    return provisionalStorageKey(
-      normalizedHeaders: normalized,
-      knownVaryHeaders: knownVaryHeaders,
-      hasExistingVariants: !variants.isEmpty
-    )
   }
 
   static func recordVariant(
     forUrl url: URL,
     storageKey: String,
     requestHeaders: [String: String]?,
+    fileExtension: String? = nil,
     policy: CachePolicy
   ) {
     guard policy.isCacheable else {
@@ -116,21 +139,24 @@ enum CacheVariantIndex {
       varyHeaders: policy.varyHeaders,
       varyValues: varyValues,
       identityValues: identityValues(normalizedHeaders: normalized),
+      fileExtension: fileExtension,
       allowsAuthorizedReuse: policy.allowsAuthorizedReuse
     )
-    var existing = load(forUrl: url)
-    existing.removeAll { $0.storageKey == storageKey }
-    existing.append(variant)
-    save(variants: existing, forUrl: url)
+    queue.sync {
+      var existing = loadUnlocked(forUrl: url)
+      existing.removeAll { $0.storageKey == storageKey }
+      existing.append(variant)
+      saveUnlocked(variants: existing, forUrl: url)
+    }
   }
 
   static func hasIdentityHeaders(_ normalizedHeaders: [String: String]) -> Bool {
     return Self.provisionalIdentityHeaders.contains { normalizedHeaders[$0] != nil }
   }
 
-  private static func matchingVariant(forUrl url: URL, normalizedHeaders: [String: String]) -> CacheVariant? {
+  private static func matchingVariant(variants: [CacheVariant], normalizedHeaders: [String: String]) -> CacheVariant? {
     let hasAuthorization = normalizedHeaders[authorizationHeader] != nil
-    for variant in load(forUrl: url) {
+    for variant in variants {
       let allMatch = variant.varyHeaders.allSatisfy { name in
         (normalizedHeaders[name] ?? "") == (variant.varyValues[name] ?? "")
       }
@@ -157,7 +183,9 @@ enum CacheVariantIndex {
     knownVaryHeaders: [String],
     hasExistingVariants: Bool
   ) -> String {
-    let headers = Array(Set(Self.provisionalIdentityHeaders + knownVaryHeaders.map { $0.lowercased() })).sorted()
+    let headers = Array(
+      Set(Self.provisionalIdentityHeaders + knownVaryHeaders.map { $0.lowercased() })
+    ).sorted()
     let hasVariantInput = hasExistingVariants ||
       !knownVaryHeaders.isEmpty ||
       Self.provisionalIdentityHeaders.contains { normalizedHeaders[$0] != nil }
@@ -167,7 +195,6 @@ enum CacheVariantIndex {
       return ""
     }
     let composite = headers
-      .sorted()
       .map { "\($0):\(normalizedHeaders[$0] ?? "")" }
       .joined(separator: ";")
     return sha256(composite)
@@ -200,9 +227,36 @@ enum CacheVariantIndex {
     )
   }
 
-  private static func save(variants: [CacheVariant], forUrl url: URL) {
-    guard let path = indexPath(forUrl: url),
-      let data = try? JSONEncoder().encode(variants) else {
+  private static func pruneMissingVariantsUnlocked(
+    forUrl url: URL,
+    fileExtension: String?,
+    variants: [CacheVariant]
+  ) -> [CacheVariant] {
+    let live = variants.filter { variant in
+      guard let ext = variant.fileExtension ?? fileExtension else {
+        return true
+      }
+      guard let path = VideoAsset.pathForUrl(url: url, fileExtension: ext, variantKey: variant.storageKey) else {
+        return true
+      }
+      return FileManager.default.fileExists(atPath: path) ||
+        FileManager.default.fileExists(atPath: path + VideoCacheManager.mediaInfoSuffix)
+    }
+    if live.count != variants.count {
+      saveUnlocked(variants: live, forUrl: url)
+    }
+    return live
+  }
+
+  private static func saveUnlocked(variants: [CacheVariant], forUrl url: URL) {
+    guard let path = indexPath(forUrl: url) else {
+      return
+    }
+    if variants.isEmpty {
+      try? FileManager.default.removeItem(atPath: path)
+      return
+    }
+    guard let data = try? JSONEncoder().encode(variants) else {
       return
     }
     let parentDir = URL(fileURLWithPath: path).deletingLastPathComponent()

--- a/packages/expo-video/ios/Cache/CacheVariantIndex.swift
+++ b/packages/expo-video/ios/Cache/CacheVariantIndex.swift
@@ -200,6 +200,19 @@ enum CacheVariantIndex {
     return sha256(composite)
   }
 
+  /// Normalizes request headers (lowercased keys) used for variant matching.
+  ///
+  /// On iOS we additionally fold in cookies from `HTTPCookieStorage.shared` when
+  /// the caller didn't pass an explicit `Cookie` header, so cookie-authenticated
+  /// videos get isolated variants. Android does not do this — it only considers
+  /// cookies passed explicitly in `VideoSource.headers` (OkHttp's default has no
+  /// cookie jar). The asymmetry is intentional.
+  ///
+  /// Note the offline trade-off: because cookies are part of the variant
+  /// identity, a rotated/expired session cookie changes the key, so an
+  /// offline-downloaded cookie-authenticated video may no longer match after the
+  /// cookie changes. This is the correct behavior for cross-identity isolation,
+  /// but callers relying on offline playback should prefer stable auth headers.
   static func normalizedRequestHeaders(forUrl url: URL, requestHeaders: [String: String]?) -> [String: String] {
     var out: [String: String] = [:]
     for (key, value) in requestHeaders ?? [:] {

--- a/packages/expo-video/ios/Cache/CacheVariantIndex.swift
+++ b/packages/expo-video/ios/Cache/CacheVariantIndex.swift
@@ -1,0 +1,141 @@
+// Copyright 2024-present 650 Industries. All rights reserved.
+
+import Foundation
+import CryptoKit
+import ExpoModulesCore
+
+/// One cached representation of a URL. A single URL may produce multiple
+/// variants when the server's `Vary` header indicates the response differs by
+/// request headers (e.g. `Vary: Authorization`).
+struct CacheVariant: Codable {
+  /// Suffix appended to the URL hash to derive the on-disk filename.
+  let storageKey: String
+  /// Header names the server's `Vary` listed for this response (lowercase, sorted).
+  let varyHeaders: [String]
+  /// The request-header values that produced this stored response, used to match
+  /// subsequent requests against this variant.
+  let varyValues: [String: String]
+  /// Per RFC 9111 §3.5: whether this response may be reused for an
+  /// `Authorization`-bearing request not already disambiguated by `Vary`.
+  let allowsAuthorizedReuse: Bool
+}
+
+/// Per-URL on-disk index of cached variants. Each variant points to a stored
+/// response file via its `storageKey`. Variant selection encodes both the
+/// HTTP `Vary` rules and the §3.5 `Authorization` reuse restriction.
+enum CacheVariantIndex {
+  static let fileSuffix = ".variants"
+  private static let authorizationHeader = "authorization"
+  /// Headers that imply a distinct identity. Used to derive the storage key
+  /// for the first request to a URL, before the server has revealed a `Vary`.
+  private static let provisionalIdentityHeaders = ["authorization", "cookie", "proxy-authorization"]
+
+  static func indexPath(forUrl url: URL) -> String? {
+    guard var directory = try? FileManager.default.url(
+      for: .cachesDirectory,
+      in: .userDomainMask,
+      appropriateFor: nil,
+      create: true
+    ) else {
+      return nil
+    }
+    directory.appendPathComponent(VideoCacheManager.expoVideoCacheScheme, isDirectory: true)
+    directory.appendPathComponent(urlHash(url) + Self.fileSuffix)
+    return directory.path
+  }
+
+  static func load(forUrl url: URL) -> [CacheVariant] {
+    guard let path = indexPath(forUrl: url),
+      FileManager.default.fileExists(atPath: path),
+      let data = FileManager.default.contents(atPath: path) else {
+      return []
+    }
+    return (try? JSONDecoder().decode([CacheVariant].self, from: data)) ?? []
+  }
+
+  /// Returns the storage key for the variant that matches this request, or
+  /// derives a provisional one when no variant matches yet.
+  static func storageKey(forUrl url: URL, requestHeaders: [String: String]?) -> String {
+    let normalized = normalize(headers: requestHeaders)
+    if let variant = matchingVariant(forUrl: url, normalizedHeaders: normalized) {
+      return variant.storageKey
+    }
+    return provisionalStorageKey(normalizedHeaders: normalized)
+  }
+
+  static func recordVariant(
+    forUrl url: URL,
+    storageKey: String,
+    requestHeaders: [String: String]?,
+    policy: CachePolicy
+  ) {
+    guard policy.isCacheable else { return }
+    let normalized = normalize(headers: requestHeaders)
+    let varyValues = Dictionary(uniqueKeysWithValues:
+      policy.varyHeaders.map { ($0, normalized[$0] ?? "") }
+    )
+    let variant = CacheVariant(
+      storageKey: storageKey,
+      varyHeaders: policy.varyHeaders,
+      varyValues: varyValues,
+      allowsAuthorizedReuse: policy.allowsAuthorizedReuse
+    )
+    var existing = load(forUrl: url)
+    existing.removeAll { $0.storageKey == storageKey }
+    existing.append(variant)
+    save(variants: existing, forUrl: url)
+  }
+
+  private static func matchingVariant(forUrl url: URL, normalizedHeaders: [String: String]) -> CacheVariant? {
+    let hasAuthorization = normalizedHeaders[authorizationHeader] != nil
+    for variant in load(forUrl: url) {
+      let allMatch = variant.varyHeaders.allSatisfy { name in
+        (normalizedHeaders[name] ?? "") == (variant.varyValues[name] ?? "")
+      }
+      guard allMatch else { continue }
+      // §3.5 only matters when Authorization isn't already separating variants.
+      let authHandledByVary = variant.varyHeaders.contains(authorizationHeader)
+      if hasAuthorization && !authHandledByVary && !variant.allowsAuthorizedReuse {
+        continue
+      }
+      return variant
+    }
+    return nil
+  }
+
+  private static func provisionalStorageKey(normalizedHeaders: [String: String]) -> String {
+    let composite = Self.provisionalIdentityHeaders
+      .sorted()
+      .map { "\($0):\(normalizedHeaders[$0] ?? "")" }
+      .joined(separator: ";")
+    return sha256(composite)
+  }
+
+  private static func normalize(headers: [String: String]?) -> [String: String] {
+    var out: [String: String] = [:]
+    for (key, value) in headers ?? [:] {
+      out[key.lowercased()] = value
+    }
+    return out
+  }
+
+  private static func save(variants: [CacheVariant], forUrl url: URL) {
+    guard let path = indexPath(forUrl: url),
+      let data = try? JSONEncoder().encode(variants) else {
+      return
+    }
+    let parentDir = URL(fileURLWithPath: path).deletingLastPathComponent()
+    try? FileManager.default.createDirectory(at: parentDir, withIntermediateDirectories: true)
+    try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+  }
+
+  private static func urlHash(_ url: URL) -> String {
+    return sha256(url.absoluteString)
+  }
+
+  private static func sha256(_ input: String) -> String {
+    return SHA256.hash(data: Data(input.utf8))
+      .compactMap { String(format: "%02x", $0) }
+      .joined()
+  }
+}

--- a/packages/expo-video/ios/Cache/CacheVariantIndex.swift
+++ b/packages/expo-video/ios/Cache/CacheVariantIndex.swift
@@ -15,9 +15,39 @@ struct CacheVariant: Codable {
   /// The request-header values that produced this stored response, used to match
   /// subsequent requests against this variant.
   let varyValues: [String: String]
+  /// Caller/application identity headers that must not be reused across values,
+  /// even when the server did not list them in `Vary`.
+  let identityValues: [String: String]
   /// Per RFC 9111 §3.5: whether this response may be reused for an
   /// `Authorization`-bearing request not already disambiguated by `Vary`.
   let allowsAuthorizedReuse: Bool
+
+  enum CodingKeys: String, CodingKey {
+    case storageKey, varyHeaders, varyValues, identityValues, allowsAuthorizedReuse
+  }
+
+  init(
+    storageKey: String,
+    varyHeaders: [String],
+    varyValues: [String: String],
+    identityValues: [String: String],
+    allowsAuthorizedReuse: Bool
+  ) {
+    self.storageKey = storageKey
+    self.varyHeaders = varyHeaders
+    self.varyValues = varyValues
+    self.identityValues = identityValues
+    self.allowsAuthorizedReuse = allowsAuthorizedReuse
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    storageKey = try container.decode(String.self, forKey: .storageKey)
+    varyHeaders = try container.decode([String].self, forKey: .varyHeaders)
+    varyValues = try container.decode([String: String].self, forKey: .varyValues)
+    identityValues = try container.decodeIfPresent([String: String].self, forKey: .identityValues) ?? [:]
+    allowsAuthorizedReuse = try container.decodeIfPresent(Bool.self, forKey: .allowsAuthorizedReuse) ?? false
+  }
 }
 
 /// Per-URL on-disk index of cached variants. Each variant points to a stored
@@ -26,8 +56,7 @@ struct CacheVariant: Codable {
 enum CacheVariantIndex {
   static let fileSuffix = ".variants"
   private static let authorizationHeader = "authorization"
-  /// Headers that imply a distinct identity. Used to derive the storage key
-  /// for the first request to a URL, before the server has revealed a `Vary`.
+  /// Headers that must never be reused across differing identities.
   private static let provisionalIdentityHeaders = ["authorization", "cookie", "proxy-authorization"]
 
   static func indexPath(forUrl url: URL) -> String? {
@@ -56,11 +85,17 @@ enum CacheVariantIndex {
   /// Returns the storage key for the variant that matches this request, or
   /// derives a provisional one when no variant matches yet.
   static func storageKey(forUrl url: URL, requestHeaders: [String: String]?) -> String {
-    let normalized = normalize(headers: requestHeaders)
+    let normalized = normalizedRequestHeaders(forUrl: url, requestHeaders: requestHeaders)
     if let variant = matchingVariant(forUrl: url, normalizedHeaders: normalized) {
       return variant.storageKey
     }
-    return provisionalStorageKey(normalizedHeaders: normalized)
+    let variants = load(forUrl: url)
+    let knownVaryHeaders = variants.flatMap { $0.varyHeaders }
+    return provisionalStorageKey(
+      normalizedHeaders: normalized,
+      knownVaryHeaders: knownVaryHeaders,
+      hasExistingVariants: !variants.isEmpty
+    )
   }
 
   static func recordVariant(
@@ -69,8 +104,10 @@ enum CacheVariantIndex {
     requestHeaders: [String: String]?,
     policy: CachePolicy
   ) {
-    guard policy.isCacheable else { return }
-    let normalized = normalize(headers: requestHeaders)
+    guard policy.isCacheable else {
+      return
+    }
+    let normalized = normalizedRequestHeaders(forUrl: url, requestHeaders: requestHeaders)
     let varyValues = Dictionary(uniqueKeysWithValues:
       policy.varyHeaders.map { ($0, normalized[$0] ?? "") }
     )
@@ -78,6 +115,7 @@ enum CacheVariantIndex {
       storageKey: storageKey,
       varyHeaders: policy.varyHeaders,
       varyValues: varyValues,
+      identityValues: identityValues(normalizedHeaders: normalized),
       allowsAuthorizedReuse: policy.allowsAuthorizedReuse
     )
     var existing = load(forUrl: url)
@@ -86,16 +124,27 @@ enum CacheVariantIndex {
     save(variants: existing, forUrl: url)
   }
 
+  static func hasIdentityHeaders(_ normalizedHeaders: [String: String]) -> Bool {
+    return Self.provisionalIdentityHeaders.contains { normalizedHeaders[$0] != nil }
+  }
+
   private static func matchingVariant(forUrl url: URL, normalizedHeaders: [String: String]) -> CacheVariant? {
     let hasAuthorization = normalizedHeaders[authorizationHeader] != nil
     for variant in load(forUrl: url) {
       let allMatch = variant.varyHeaders.allSatisfy { name in
         (normalizedHeaders[name] ?? "") == (variant.varyValues[name] ?? "")
       }
-      guard allMatch else { continue }
-      // §3.5 only matters when Authorization isn't already separating variants.
-      let authHandledByVary = variant.varyHeaders.contains(authorizationHeader)
-      if hasAuthorization && !authHandledByVary && !variant.allowsAuthorizedReuse {
+      guard allMatch else {
+        continue
+      }
+      let identityMatch = variant.identityValues.allSatisfy { name, value in
+        (normalizedHeaders[name] ?? "") == value
+      }
+      guard identityMatch else {
+        continue
+      }
+      let identityHandledByVariant = variant.identityValues[authorizationHeader] != nil
+      if hasAuthorization && !identityHandledByVariant && !variant.allowsAuthorizedReuse {
         continue
       }
       return variant
@@ -103,20 +152,52 @@ enum CacheVariantIndex {
     return nil
   }
 
-  private static func provisionalStorageKey(normalizedHeaders: [String: String]) -> String {
-    let composite = Self.provisionalIdentityHeaders
+  private static func provisionalStorageKey(
+    normalizedHeaders: [String: String],
+    knownVaryHeaders: [String],
+    hasExistingVariants: Bool
+  ) -> String {
+    let headers = Array(Set(Self.provisionalIdentityHeaders + knownVaryHeaders.map { $0.lowercased() })).sorted()
+    let hasVariantInput = hasExistingVariants ||
+      !knownVaryHeaders.isEmpty ||
+      Self.provisionalIdentityHeaders.contains { normalizedHeaders[$0] != nil }
+    if !hasVariantInput {
+      // Preserve the pre-variant URL-only cache filename for anonymous videos
+      // so existing offline downloads remain playable after upgrading.
+      return ""
+    }
+    let composite = headers
       .sorted()
       .map { "\($0):\(normalizedHeaders[$0] ?? "")" }
       .joined(separator: ";")
     return sha256(composite)
   }
 
-  private static func normalize(headers: [String: String]?) -> [String: String] {
+  static func normalizedRequestHeaders(forUrl url: URL, requestHeaders: [String: String]?) -> [String: String] {
     var out: [String: String] = [:]
-    for (key, value) in headers ?? [:] {
+    for (key, value) in requestHeaders ?? [:] {
       out[key.lowercased()] = value
     }
+    if out["cookie"] == nil,
+      let cookies = HTTPCookieStorage.shared.cookies(for: url),
+      !cookies.isEmpty {
+      let cookieHeaders = HTTPCookie.requestHeaderFields(with: cookies)
+      if let cookie = cookieHeaders["Cookie"], !cookie.isEmpty {
+        out["cookie"] = cookie
+      }
+    }
     return out
+  }
+
+  private static func identityValues(normalizedHeaders: [String: String]) -> [String: String] {
+    return Dictionary(uniqueKeysWithValues:
+      Self.provisionalIdentityHeaders.compactMap { name in
+        guard let value = normalizedHeaders[name] else {
+          return nil
+        }
+        return (name, value)
+      }
+    )
   }
 
   private static func save(variants: [CacheVariant], forUrl url: URL) {

--- a/packages/expo-video/ios/Cache/CacheVideoAssetTransportProvider.swift
+++ b/packages/expo-video/ios/Cache/CacheVideoAssetTransportProvider.swift
@@ -9,16 +9,17 @@ internal final class CacheVideoAssetTransportProvider: VideoAssetTransportProvid
       return nil
     }
 
-    let cachedMimeType = MediaInfo(forResourceUrl: source.url)?.mimeType
-    let cachedExtension = mimeTypeToExtension(mimeType: cachedMimeType) ?? ""
-    let fileExtension = source.url.pathExtension.isEmpty ? cachedExtension : source.url.pathExtension
-    guard let saveFilePath = VideoAsset.pathForUrl(url: source.url, fileExtension: fileExtension) else {
-      log.warn("[expo-video] Failed to create a cache file path for the provided source with uri: \(source.url.absoluteString)")
+    guard canCache(source: source) else {
+      log.warn("[expo-video] Provided source with uri: \(source.url.absoluteString) cannot be cached. Caching will be disabled")
       return nil
     }
 
-    guard canCache(source: source) else {
-      log.warn("[expo-video] Provided source with uri: \(source.url.absoluteString) cannot be cached. Caching will be disabled")
+    let variantKey = CacheVariantIndex.storageKey(forUrl: source.url, requestHeaders: source.headers)
+    let cachedMimeType = MediaInfo(forResourceUrl: source.url, variantKey: variantKey)?.mimeType
+    let cachedExtension = mimeTypeToExtension(mimeType: cachedMimeType) ?? ""
+    let fileExtension = source.url.pathExtension.isEmpty ? cachedExtension : source.url.pathExtension
+    guard let saveFilePath = VideoAsset.pathForUrl(url: source.url, fileExtension: fileExtension, variantKey: variantKey) else {
+      log.warn("[expo-video] Failed to create a cache file path for the provided source with uri: \(source.url.absoluteString)")
       return nil
     }
 
@@ -34,7 +35,8 @@ internal final class CacheVideoAssetTransportProvider: VideoAssetTransportProvid
       url: source.url,
       saveFilePath: saveFilePath,
       fileExtension: fileExtension,
-      urlRequestHeaders: source.headers
+      urlRequestHeaders: source.headers,
+      variantKey: variantKey
     )
 
     return VideoAssetLoadPlan(

--- a/packages/expo-video/ios/Cache/CacheVideoAssetTransportProvider.swift
+++ b/packages/expo-video/ios/Cache/CacheVideoAssetTransportProvider.swift
@@ -15,7 +15,12 @@ internal final class CacheVideoAssetTransportProvider: VideoAssetTransportProvid
     }
 
     let cacheRequestHeaders = CacheVariantIndex.normalizedRequestHeaders(forUrl: source.url, requestHeaders: source.headers)
-    let variantKey = CacheVariantIndex.storageKey(forUrl: source.url, requestHeaders: cacheRequestHeaders)
+    let sourceExtension = source.url.pathExtension.isEmpty ? nil : source.url.pathExtension
+    let variantKey = CacheVariantIndex.storageKey(
+      forUrl: source.url,
+      requestHeaders: cacheRequestHeaders,
+      fileExtension: sourceExtension
+    )
     let cachedMimeType = MediaInfo(forResourceUrl: source.url, variantKey: variantKey)?.mimeType ??
       MediaInfo(forResourceUrl: source.url)?.mimeType
     let cachedExtension = mimeTypeToExtension(mimeType: cachedMimeType) ?? ""
@@ -25,10 +30,12 @@ internal final class CacheVideoAssetTransportProvider: VideoAssetTransportProvid
       log.warn("[expo-video] Failed to create a cache file path for the provided source with uri: \(source.url.absoluteString)")
       return nil
     }
-    let shouldUseLegacyCache = !variantKey.isEmpty &&
-      CacheVariantIndex.load(forUrl: source.url).isEmpty &&
-      !CacheVariantIndex.hasIdentityHeaders(cacheRequestHeaders) &&
-      cacheFilesExist(at: legacyFilePath)
+    let shouldUseLegacyCache = hasUsableLegacyCache(
+      forUrl: source.url,
+      variantKey: variantKey,
+      cacheRequestHeaders: cacheRequestHeaders,
+      legacyFilePath: legacyFilePath
+    )
     let effectiveVariantKey = shouldUseLegacyCache ? "" : variantKey
     let saveFilePath = shouldUseLegacyCache ? legacyFilePath : variantFilePath
 
@@ -77,5 +84,17 @@ internal final class CacheVideoAssetTransportProvider: VideoAssetTransportProvid
   private func cacheFilesExist(at path: String) -> Bool {
     return FileManager.default.fileExists(atPath: path) ||
       FileManager.default.fileExists(atPath: path + VideoCacheManager.mediaInfoSuffix)
+  }
+
+  private func hasUsableLegacyCache(
+    forUrl url: URL,
+    variantKey: String,
+    cacheRequestHeaders: [String: String],
+    legacyFilePath: String
+  ) -> Bool {
+    return !variantKey.isEmpty &&
+      CacheVariantIndex.load(forUrl: url).isEmpty &&
+      !CacheVariantIndex.hasIdentityHeaders(cacheRequestHeaders) &&
+      cacheFilesExist(at: legacyFilePath)
   }
 }

--- a/packages/expo-video/ios/Cache/CacheVideoAssetTransportProvider.swift
+++ b/packages/expo-video/ios/Cache/CacheVideoAssetTransportProvider.swift
@@ -14,14 +14,23 @@ internal final class CacheVideoAssetTransportProvider: VideoAssetTransportProvid
       return nil
     }
 
-    let variantKey = CacheVariantIndex.storageKey(forUrl: source.url, requestHeaders: source.headers)
-    let cachedMimeType = MediaInfo(forResourceUrl: source.url, variantKey: variantKey)?.mimeType
+    let cacheRequestHeaders = CacheVariantIndex.normalizedRequestHeaders(forUrl: source.url, requestHeaders: source.headers)
+    let variantKey = CacheVariantIndex.storageKey(forUrl: source.url, requestHeaders: cacheRequestHeaders)
+    let cachedMimeType = MediaInfo(forResourceUrl: source.url, variantKey: variantKey)?.mimeType ??
+      MediaInfo(forResourceUrl: source.url)?.mimeType
     let cachedExtension = mimeTypeToExtension(mimeType: cachedMimeType) ?? ""
     let fileExtension = source.url.pathExtension.isEmpty ? cachedExtension : source.url.pathExtension
-    guard let saveFilePath = VideoAsset.pathForUrl(url: source.url, fileExtension: fileExtension, variantKey: variantKey) else {
+    guard let variantFilePath = VideoAsset.pathForUrl(url: source.url, fileExtension: fileExtension, variantKey: variantKey),
+      let legacyFilePath = VideoAsset.pathForUrl(url: source.url, fileExtension: fileExtension) else {
       log.warn("[expo-video] Failed to create a cache file path for the provided source with uri: \(source.url.absoluteString)")
       return nil
     }
+    let shouldUseLegacyCache = !variantKey.isEmpty &&
+      CacheVariantIndex.load(forUrl: source.url).isEmpty &&
+      !CacheVariantIndex.hasIdentityHeaders(cacheRequestHeaders) &&
+      cacheFilesExist(at: legacyFilePath)
+    let effectiveVariantKey = shouldUseLegacyCache ? "" : variantKey
+    let saveFilePath = shouldUseLegacyCache ? legacyFilePath : variantFilePath
 
     guard let urlWithCustomScheme = source.url.withScheme(VideoCacheManager.expoVideoCacheScheme) else {
       log.warn("[expo-video] CachingPlayerItem error: Urls without a scheme are not supported, the resource won't be cached")
@@ -36,7 +45,8 @@ internal final class CacheVideoAssetTransportProvider: VideoAssetTransportProvid
       saveFilePath: saveFilePath,
       fileExtension: fileExtension,
       urlRequestHeaders: source.headers,
-      variantKey: variantKey
+      cacheRequestHeaders: cacheRequestHeaders,
+      variantKey: effectiveVariantKey
     )
 
     return VideoAssetLoadPlan(
@@ -62,5 +72,10 @@ internal final class CacheVideoAssetTransportProvider: VideoAssetTransportProvid
     }
 
     return !source.hasDRM
+  }
+
+  private func cacheFilesExist(at path: String) -> Bool {
+    return FileManager.default.fileExists(atPath: path) ||
+      FileManager.default.fileExists(atPath: path + VideoCacheManager.mediaInfoSuffix)
   }
 }

--- a/packages/expo-video/ios/Cache/CachedResource.swift
+++ b/packages/expo-video/ios/Cache/CachedResource.swift
@@ -39,7 +39,7 @@ class CachedResource {
     self.dataPath = dataPath
     self.url = resourceUrl
     self.fileHandle = MediaFileHandle(filePath: dataFileUrl)
-    self.mediaInfo = MediaInfo(forResourceUrl: resourceUrl)
+    self.mediaInfo = MediaInfo(at: dataPath + VideoCacheManager.mediaInfoSuffix)
   }
 
   func onResponseReceived(response: HTTPURLResponse) {

--- a/packages/expo-video/ios/Cache/MediaInfo.swift
+++ b/packages/expo-video/ios/Cache/MediaInfo.swift
@@ -71,8 +71,8 @@ class MediaInfo: Codable {
     self.init(data: mediaInfoData, dataPath: path)
   }
 
-  convenience init?(forResourceUrl url: URL) {
-    guard let filePath = VideoAsset.pathForUrl(url: url, fileExtension: url.pathExtension) else {
+  convenience init?(forResourceUrl url: URL, variantKey: String = "") {
+    guard let filePath = VideoAsset.pathForUrl(url: url, fileExtension: url.pathExtension, variantKey: variantKey) else {
       return nil
     }
     let mediaInfoPath = filePath + VideoCacheManager.mediaInfoSuffix

--- a/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
+++ b/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
@@ -60,7 +60,9 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     self.variantKey = variantKey
     cachedResource = CachedResource(dataFileUrl: saveFilePath, resourceUrl: url, dataPath: saveFilePath)
     super.init()
-    self.session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    let delegateQueue = OperationQueue()
+    delegateQueue.maxConcurrentOperationCount = 1
+    self.session = URLSession(configuration: .default, delegate: self, delegateQueue: delegateQueue)
   }
 
   deinit {
@@ -184,6 +186,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
       forUrl: url,
       storageKey: variantKey,
       requestHeaders: cacheRequestHeaders,
+      fileExtension: fileExtension,
       policy: policy
     )
   }

--- a/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
+++ b/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
@@ -16,15 +16,13 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
   private let saveFilePath: String
   private let fileExtension: String
   private let cachedResource: CachedResource
-  /// Caller-declared request headers. Variant matching only considers these;
-  /// `URLSession` may additionally attach cookies from `HTTPCookieStorage.shared`
-  /// at request time, and those don't reach the variant index — so two
-  /// identities differing only in auto-attached cookies will not be separated.
+  /// Caller-declared headers sent on the network request.
   private let urlRequestHeaders: [String: String]?
+  /// Normalized request identity used for cache variant matching. This includes
+  /// the cookie snapshot that `URLSession` is expected to attach.
+  private let cacheRequestHeaders: [String: String]
   private let variantKey: String
-  /// Set to `false` when the response forbids storage (e.g. `Vary: *`,
-  /// `Cache-Control: no-store`). Any data already written for this request is
-  /// evicted when the session ends.
+  /// Set to `false` when the response status is not useful for offline playback.
   private var responseAllowsStorage: Bool = true
   private var policyEvaluated: Bool = false
   internal var onError: ((Error) -> Void)?
@@ -46,11 +44,19 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     return self.saveFilePath
   }
 
-  init(url: URL, saveFilePath: String, fileExtension: String, urlRequestHeaders: [String: String]?, variantKey: String) {
+  init(
+    url: URL,
+    saveFilePath: String,
+    fileExtension: String,
+    urlRequestHeaders: [String: String]?,
+    cacheRequestHeaders: [String: String],
+    variantKey: String
+  ) {
     self.url = url
     self.saveFilePath = saveFilePath
     self.fileExtension = fileExtension
     self.urlRequestHeaders = urlRequestHeaders
+    self.cacheRequestHeaders = cacheRequestHeaders
     self.variantKey = variantKey
     cachedResource = CachedResource(dataFileUrl: saveFilePath, resourceUrl: url, dataPath: saveFilePath)
     super.init()
@@ -169,17 +175,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
       }
     }
     let policy = CachePolicy.evaluate(responseHeaders: headers, statusCode: httpResponse.statusCode)
-    let normalizedRequest = (urlRequestHeaders ?? [:]).reduce(into: [String: String]()) { acc, pair in
-      acc[pair.key.lowercased()] = pair.value
-    }
-    let hasAuthorization = normalizedRequest["authorization"] != nil
-    let authorizationCoveredByVary = policy.varyHeaders.contains("authorization")
-    let authorizationBlocked = hasAuthorization && !authorizationCoveredByVary && !policy.allowsAuthorizedReuse
-
-    responseAllowsStorage = policy.isCacheable && !authorizationBlocked
-
-    // For both !isCacheable and §3.5 cases we drop just this variant's bytes;
-    // other variants for the same URL may still be valid representations.
+    responseAllowsStorage = policy.isCacheable
     if !responseAllowsStorage {
       evictStoredFiles()
       return
@@ -187,7 +183,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     CacheVariantIndex.recordVariant(
       forUrl: url,
       storageKey: variantKey,
-      requestHeaders: urlRequestHeaders,
+      requestHeaders: cacheRequestHeaders,
       policy: policy
     )
   }

--- a/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
+++ b/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
@@ -22,7 +22,22 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
   /// the cookie snapshot that `URLSession` is expected to attach.
   private let cacheRequestHeaders: [String: String]
   private let variantKey: String
-  /// Set to `false` when the response status is not useful for offline playback.
+  /// Whether the response may be stored for offline playback. Defaults to `true`
+  /// ("store unless proven otherwise") and is flipped to `false` if the response
+  /// is evaluated as non-cacheable.
+  ///
+  /// Policy is evaluated only on the *first* HTTP response (see the `policyEvaluated`
+  /// guard in `evaluateCachePolicy`) — that's the authoritative content-information
+  /// response carrying the resource's `Cache-Control`/`Vary`. Later range responses
+  /// for the same resource are assumed to share that policy and are not re-evaluated.
+  /// This is deliberate: re-evaluating every range response would let a transient or
+  /// edge non-2xx (e.g. a `416` on an out-of-range request, or a one-off `503`) flip
+  /// storage to denied and evict an otherwise-good download — hurting offline playback.
+  ///
+  /// The default of `true` is safe because this delegate is only reachable on the
+  /// http(s) loader path (`createUrlRequest` always builds an http(s) request from
+  /// `self.url`), so the first response is always an `HTTPURLResponse` and is
+  /// evaluated before any data is saved in `didCompleteWithError`.
   private var responseAllowsStorage: Bool = true
   private var policyEvaluated: Bool = false
   internal var onError: ((Error) -> Void)?
@@ -60,6 +75,12 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     self.variantKey = variantKey
     cachedResource = CachedResource(dataFileUrl: saveFilePath, resourceUrl: url, dataPath: saveFilePath)
     super.init()
+    // Serial delegate queue (maxConcurrentOperationCount = 1): the cache-policy
+    // state below (`policyEvaluated` / `responseAllowsStorage`) is mutated from
+    // `didReceive response:` and read from `didCompleteWithError:`. A serial
+    // queue makes those callbacks non-overlapping so the state is safe without
+    // an extra lock. Do not revert to `delegateQueue: nil` (concurrent) without
+    // adding synchronization, or it reintroduces a data race on that state.
     let delegateQueue = OperationQueue()
     delegateQueue.maxConcurrentOperationCount = 1
     self.session = URLSession(configuration: .default, delegate: self, delegateQueue: delegateQueue)

--- a/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
+++ b/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
@@ -16,7 +16,17 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
   private let saveFilePath: String
   private let fileExtension: String
   private let cachedResource: CachedResource
+  /// Caller-declared request headers. Variant matching only considers these;
+  /// `URLSession` may additionally attach cookies from `HTTPCookieStorage.shared`
+  /// at request time, and those don't reach the variant index — so two
+  /// identities differing only in auto-attached cookies will not be separated.
   private let urlRequestHeaders: [String: String]?
+  private let variantKey: String
+  /// Set to `false` when the response forbids storage (e.g. `Vary: *`,
+  /// `Cache-Control: no-store`). Any data already written for this request is
+  /// evicted when the session ends.
+  private var responseAllowsStorage: Bool = true
+  private var policyEvaluated: Bool = false
   internal var onError: ((Error) -> Void)?
 
   private var cachableRequests: SynchronizedHashTable<CachableRequest> = SynchronizedHashTable()
@@ -36,11 +46,12 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     return self.saveFilePath
   }
 
-  init(url: URL, saveFilePath: String, fileExtension: String, urlRequestHeaders: [String: String]?) {
+  init(url: URL, saveFilePath: String, fileExtension: String, urlRequestHeaders: [String: String]?, variantKey: String) {
     self.url = url
     self.saveFilePath = saveFilePath
     self.fileExtension = fileExtension
     self.urlRequestHeaders = urlRequestHeaders
+    self.variantKey = variantKey
     cachedResource = CachedResource(dataFileUrl: saveFilePath, resourceUrl: url, dataPath: saveFilePath)
     super.init()
     self.session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
@@ -132,6 +143,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     didReceive response: URLResponse,
     completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
   ) {
+    evaluateCachePolicy(forResponse: response)
     if let cachedDataRequest = cachableRequest(by: dataTask) {
       cachedDataRequest.response = response
       if cachedDataRequest.loadingRequest.contentInformationRequest != nil {
@@ -145,6 +157,46 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     completionHandler(.allow)
   }
 
+  private func evaluateCachePolicy(forResponse response: URLResponse) {
+    guard !policyEvaluated, let httpResponse = response as? HTTPURLResponse else {
+      return
+    }
+    policyEvaluated = true
+    var headers: [String: String] = [:]
+    for (key, value) in httpResponse.allHeaderFields {
+      if let keyString = key as? String, let valueString = value as? String {
+        headers[keyString] = valueString
+      }
+    }
+    let policy = CachePolicy.evaluate(responseHeaders: headers, statusCode: httpResponse.statusCode)
+    let normalizedRequest = (urlRequestHeaders ?? [:]).reduce(into: [String: String]()) { acc, pair in
+      acc[pair.key.lowercased()] = pair.value
+    }
+    let hasAuthorization = normalizedRequest["authorization"] != nil
+    let authorizationCoveredByVary = policy.varyHeaders.contains("authorization")
+    let authorizationBlocked = hasAuthorization && !authorizationCoveredByVary && !policy.allowsAuthorizedReuse
+
+    responseAllowsStorage = policy.isCacheable && !authorizationBlocked
+
+    // For both !isCacheable and §3.5 cases we drop just this variant's bytes;
+    // other variants for the same URL may still be valid representations.
+    if !responseAllowsStorage {
+      evictStoredFiles()
+      return
+    }
+    CacheVariantIndex.recordVariant(
+      forUrl: url,
+      storageKey: variantKey,
+      requestHeaders: urlRequestHeaders,
+      policy: policy
+    )
+  }
+
+  private func evictStoredFiles() {
+    try? FileManager.default.removeItem(atPath: saveFilePath)
+    try? FileManager.default.removeItem(atPath: saveFilePath + VideoCacheManager.mediaInfoSuffix)
+  }
+
   func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
     guard let cachedDataRequest = cachableRequest(by: task) else {
       return
@@ -152,10 +204,14 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
 
     // The data shouldn't be corrupted and can be cached
     if let error = error as? URLError, error.code == URLError.cancelled || error.code == URLError.networkConnectionLost {
-      cachedDataRequest.saveData(to: cachedResource)
+      if responseAllowsStorage {
+        cachedDataRequest.saveData(to: cachedResource)
+      }
       cachedDataRequest.loadingRequest.finishLoading(with: error)
     } else if error == nil {
-      cachedDataRequest.saveData(to: cachedResource)
+      if responseAllowsStorage {
+        cachedDataRequest.saveData(to: cachedResource)
+      }
       cachedDataRequest.loadingRequest.finishLoading()
     } else {
       cachedDataRequest.loadingRequest.finishLoading(with: error)

--- a/packages/expo-video/ios/Cache/VideoCacheManager.swift
+++ b/packages/expo-video/ios/Cache/VideoCacheManager.swift
@@ -155,6 +155,11 @@ class VideoCacheManager {
     }
   }
 
+  private func isAuxiliaryCacheFile(_ url: URL) -> Bool {
+    let s = url.absoluteString
+    return s.hasSuffix(Self.mediaInfoSuffix) || s.hasSuffix(CacheVariantIndex.fileSuffix)
+  }
+
   private func getCacheDirectory() -> URL? {
     let cacheDirs = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
     if let cacheDir = cacheDirs.first {
@@ -173,7 +178,7 @@ class VideoCacheManager {
       includingPropertiesForKeys: [.contentAccessDateKey, .contentModificationDateKey],
       options: .skipsHiddenFiles)
     ) ?? []
-    return fileUrls.filter { !$0.absoluteString.hasSuffix(Self.mediaInfoSuffix) }
+    return fileUrls.filter { !isAuxiliaryCacheFile($0) }
   }
 
   private func fileIsOpen(url: URL) -> Bool {

--- a/packages/expo-video/ios/ExpoVideo.podspec
+++ b/packages/expo-video/ios/ExpoVideo.podspec
@@ -21,7 +21,12 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
 
   s.source_files = "**/*.{h,m,swift}"
+  s.exclude_files = 'Tests'
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES'
   }
+
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests'
+  end
 end

--- a/packages/expo-video/ios/Tests/CachePolicyTests.swift
+++ b/packages/expo-video/ios/Tests/CachePolicyTests.swift
@@ -20,13 +20,18 @@ struct CachePolicyTests {
   }
 
   @Test
-  func `quoted commas do not split header tokens`() {
+  func `quoted commas in cache-control do not split into spurious directives`() {
+    // `public` here is a quoted field-name inside the `private` directive's
+    // value, not a real cache directive. A naive comma split would surface it as
+    // a standalone directive and wrongly enable Authorization reuse. (Quoted
+    // lists only ever appear in Cache-Control, never in Vary.)
     let policy = CachePolicy.evaluate(
-      responseHeaders: ["Vary": "Accept-Language, \"X-Foo, X-Bar\""],
+      responseHeaders: ["Cache-Control": "private=\"X-Foo, public, X-Bar\""],
       statusCode: 200
     )
 
-    #expect(policy.varyHeaders == ["\"x-foo, x-bar\"", "accept-language"])
+    #expect(policy.isCacheable)
+    #expect(policy.allowsAuthorizedReuse == false)
   }
 
   @Test

--- a/packages/expo-video/ios/Tests/CachePolicyTests.swift
+++ b/packages/expo-video/ios/Tests/CachePolicyTests.swift
@@ -1,0 +1,47 @@
+import Testing
+
+@testable import ExpoVideo
+
+@Suite("CachePolicy")
+struct CachePolicyTests {
+  @Test
+  func `non playable status is not cacheable`() {
+    let policy = CachePolicy.evaluate(responseHeaders: [:], statusCode: 401)
+
+    #expect(policy.isCacheable == false)
+    #expect(policy.varyHeaders.isEmpty)
+  }
+
+  @Test
+  func `vary star is not cacheable`() {
+    let policy = CachePolicy.evaluate(responseHeaders: ["Vary": "*"], statusCode: 200)
+
+    #expect(policy.isCacheable == false)
+  }
+
+  @Test
+  func `quoted commas do not split header tokens`() {
+    let policy = CachePolicy.evaluate(
+      responseHeaders: ["Vary": "Accept-Language, \"X-Foo, X-Bar\""],
+      statusCode: 200
+    )
+
+    #expect(policy.varyHeaders == ["\"x-foo, x-bar\"", "accept-language"])
+  }
+
+  @Test
+  func `public cache control allows authorization reuse`() {
+    let policy = CachePolicy.evaluate(responseHeaders: ["Cache-Control": "public"], statusCode: 206)
+
+    #expect(policy.isCacheable)
+    #expect(policy.allowsAuthorizedReuse)
+  }
+
+  @Test
+  func `missing reuse directives block authorization reuse`() {
+    let policy = CachePolicy.evaluate(responseHeaders: ["Cache-Control": "max-age=3600"], statusCode: 200)
+
+    #expect(policy.isCacheable)
+    #expect(policy.allowsAuthorizedReuse == false)
+  }
+}

--- a/packages/expo-video/ios/VideoAsset.swift
+++ b/packages/expo-video/ios/VideoAsset.swift
@@ -53,8 +53,12 @@ internal class VideoAsset: AVURLAsset, @unchecked Sendable {
     try await preAssetLoadCallback?(self)
   }
 
-  static func pathForUrl(url: URL, fileExtension: String) -> String? {
-    let hashedData = SHA256.hash(data: Data(url.absoluteString.utf8))
+  static func pathForUrl(url: URL, fileExtension: String, variantKey: String = "") -> String? {
+    // Variant key folds caller-supplied request headers (per RFC 9111 Vary
+    // semantics) into the cache filename so two identities cannot collide on
+    // the same stored response.
+    let composite = variantKey.isEmpty ? url.absoluteString : url.absoluteString + "#" + variantKey
+    let hashedData = SHA256.hash(data: Data(composite.utf8))
     let hashString = hashedData.compactMap { String(format: "%02x", $0) }.joined()
     let parsedExtension = fileExtension.starts(with: ".") || fileExtension.isEmpty ? fileExtension : ("." + fileExtension)
     let hashFilename = hashString + parsedExtension

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -13,6 +13,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   lazy var audioTracks: VideoPlayerAudioTracks = VideoPlayerAudioTracks(owner: self)
   lazy var seeker: VideoPlayerSeeker = VideoPlayerSeeker(player: self)
   private var tracksLoadingTask: Task<(), Never>?
+  private var blockEvents = false
 
   var loop = false
   var audioMixingMode: AudioMixingMode = .doNotMix {
@@ -181,6 +182,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   deinit {
+    blockEvents = true
     observer?.cleanup()
     NowPlayingManager.shared.unregisterPlayer(self)
     VideoManager.shared.unregister(videoPlayer: self)
@@ -412,7 +414,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func safeEmit(event: String, payload: Record? = nil) {
-    if self.appContext != nil {
+    if self.appContext != nil && !blockEvents {
       self.emit(event: event, payload: payload?.toDictionary(appContext: appContext))
     }
   }

--- a/packages/expo-video/ios/VideoPlayer.swift
+++ b/packages/expo-video/ios/VideoPlayer.swift
@@ -13,7 +13,6 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   lazy var audioTracks: VideoPlayerAudioTracks = VideoPlayerAudioTracks(owner: self)
   lazy var seeker: VideoPlayerSeeker = VideoPlayerSeeker(player: self)
   private var tracksLoadingTask: Task<(), Never>?
-  private var blockEvents = false
 
   var loop = false
   var audioMixingMode: AudioMixingMode = .doNotMix {
@@ -182,7 +181,6 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   deinit {
-    blockEvents = true
     observer?.cleanup()
     NowPlayingManager.shared.unregisterPlayer(self)
     VideoManager.shared.unregister(videoPlayer: self)
@@ -414,7 +412,7 @@ internal final class VideoPlayer: SharedRef<AVPlayer>, Hashable, VideoPlayerObse
   }
 
   func safeEmit(event: String, payload: Record? = nil) {
-    if self.appContext != nil && !blockEvents {
+    if self.appContext != nil {
       self.emit(event: event, payload: payload?.toDictionary(appContext: appContext))
     }
   }


### PR DESCRIPTION
# Why

EXP-51 flagged that `expo-video` caches video responses without taking `Authorization` / auth-related request headers into account.

Users can pass authenticated video URLs and headers, but the native cache was still keyed only by URL, so different authenticated responses could end up sharing the same cached resource.

# How

This is originally by @kitten and then polished up a littbe bit by me.

Add variant-aware cache keys for `expo-video` on Android and iOS.

The cache now stores per-URL variant metadata based on response `Vary` headers and identity-bearing request headers like `Authorization`, `Cookie`, and `Proxy-Authorization`.

Keep the old URL-only cache path for anonymous cached videos, so existing offline cache entries don't stop working after upgrading.


# Test Plan

Tested in bare-expo on iOS and Android with an unauthenticated source.
