### PR TITLE
[expo-observe] improve observe integration in bare-expo

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -109,6 +109,7 @@
     "expo-navigation-bar": "workspace:*",
     "expo-network": "workspace:*",
     "expo-notifications": "workspace:*",
+    "expo-observe": "workspace:*",
     "expo-print": "workspace:*",
     "expo-processing": "workspace:*",
     "expo-screen-capture": "workspace:*",

--- a/apps/native-component-list/src/screens/ComponentListScreen.tsx
+++ b/apps/native-component-list/src/screens/ComponentListScreen.tsx
@@ -1,5 +1,6 @@
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { Link, NavigationAction, useLinkBuilder, useLinkProps } from '@react-navigation/native';
+import { useObserve } from 'expo-observe';
 import React from 'react';
 import {
   FlatList,
@@ -111,10 +112,12 @@ function LinkButton({
 
 export default function ComponentListScreen(props: Props) {
   const { theme } = useTheme();
+  const { markInteractive } = useObserve();
 
   React.useEffect(() => {
     StatusBar.setHidden(false);
-  }, []);
+    markInteractive();
+  }, [markInteractive]);
 
   const { width } = useWindowDimensions();
   const isMobile = width <= 640;

--- a/apps/native-component-list/src/screens/Screens/index.tsx
+++ b/apps/native-component-list/src/screens/Screens/index.tsx
@@ -2,7 +2,8 @@ import {
   createNativeStackNavigator,
   NativeStackNavigationProp,
 } from '@react-navigation/native-stack';
-import React from 'react';
+import { useObserve } from 'expo-observe';
+import React, { useEffect } from 'react';
 import { FlatList, StyleSheet, Text, TouchableHighlight, View } from 'react-native';
 
 import Container from './container';
@@ -19,28 +20,27 @@ type Links = { Container: undefined; NativeStack: undefined; Navigation: undefin
 
 type Props = { navigation: NativeStackNavigationProp<Links> };
 
-class MainScreen extends React.Component<Props> {
-  static navigationOptions = {
-    title: '📱 React Native Screens Examples',
-  };
-  render() {
-    const data = Object.keys(SCREENS);
-    return (
-      <FlatList
-        style={styles.list}
-        data={data}
-        ItemSeparatorComponent={ItemSeparator}
-        keyExtractor={(item) => item}
-        renderItem={(props) => (
-          <MainScreenItem
-            item={props.item}
-            // @ts-ignore
-            onPressItem={(key) => this.props.navigation.navigate(key)}
-          />
-        )}
-      />
-    );
-  }
+function MainScreen({ navigation }: Props) {
+  const data = Object.keys(SCREENS);
+  const { markInteractive } = useObserve();
+  useEffect(() => {
+    markInteractive();
+  }, [markInteractive]);
+  return (
+    <FlatList
+      style={styles.list}
+      data={data}
+      ItemSeparatorComponent={ItemSeparator}
+      keyExtractor={(item) => item}
+      renderItem={(props) => (
+        <MainScreenItem
+          item={props.item}
+          // @ts-ignore
+          onPressItem={(key) => navigation.navigate(key)}
+        />
+      )}
+    />
+  );
 }
 
 const ItemSeparator = () => <View style={styles.separator} />;

--- a/apps/test-suite/package.json
+++ b/apps/test-suite/package.json
@@ -57,6 +57,7 @@
     "expo-navigation-bar": "workspace:*",
     "expo-network": "workspace:*",
     "expo-notifications": "workspace:*",
+    "expo-observe": "workspace:*",
     "expo-screen-orientation": "workspace:*",
     "expo-secure-store": "workspace:*",
     "expo-sms": "workspace:*",

--- a/apps/test-suite/screens/SelectScreen.tsx
+++ b/apps/test-suite/screens/SelectScreen.tsx
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Checkbox } from 'expo-checkbox';
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
+import { useObserve } from 'expo-observe';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { FlatList, Linking, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -46,6 +47,7 @@ function ListItem({
 
 export default function SelectScreen({ navigation }) {
   const { theme } = useTheme();
+  const { markInteractive } = useObserve();
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [modules, setModules] = useState<Module[]>([]);
   const [footerHeight, setFooterHeight] = useState(0);
@@ -53,6 +55,14 @@ export default function SelectScreen({ navigation }) {
   const onFooterLayout = useCallback((e) => {
     setFooterHeight(e.nativeEvent.layout.height);
   }, []);
+
+  const hasMarkedInteractive = useRef(false);
+  useEffect(() => {
+    if (modules.length > 0 && !hasMarkedInteractive.current) {
+      hasMarkedInteractive.current = true;
+      markInteractive();
+    }
+  }, [modules, markInteractive]);
 
   useEffect(() => {
     AsyncStorage.getItem(SELECTION_STORAGE_KEY).then((value) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -992,6 +992,9 @@ importers:
       expo-notifications:
         specifier: workspace:*
         version: link:../../packages/expo-notifications
+      expo-observe:
+        specifier: workspace:*
+        version: link:../../packages/expo-observe
       expo-print:
         specifier: workspace:*
         version: link:../../packages/expo-print
@@ -1700,6 +1703,9 @@ importers:
       expo-notifications:
         specifier: workspace:*
         version: link:../../packages/expo-notifications
+      expo-observe:
+        specifier: workspace:*
+        version: link:../../packages/expo-observe
       expo-screen-orientation:
         specifier: workspace:*
         version: link:../../packages/expo-screen-orientation


### PR DESCRIPTION
# Why

`bare-expo` (via `native-component-list` and `test-suite`) is one of the apps we exercise with `expo-observe`, but the entry screens never called `markInteractive()`. That means TTI/interactive metrics for those flows were missing or inaccurate, making it harder to dogfood `expo-observe` against a real app.

# How

1. Add `expo-observe` as a workspace dependency to `native-component-list` and `test-suite`.
2. Call `useObserve().markInteractive()` from the screens that act as the interactive landing surface:
   - `ComponentListScreen`
   - `Screens/index` `MainScreen` (converted from a class to a function component so it can use hooks)
   - `test-suite` `SelectScreen`

# Test Plan

1. CI
2. Manual testing in bare-expo — verified `markInteractive` fires and shows up in `expo-observe` metrics.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)