### PR TITLE
chore: Bump to `@expo/spawn-async@^1.8.0`

### DIFF
--- a/apps/bare-expo/package.json
+++ b/apps/bare-expo/package.json
@@ -99,7 +99,7 @@
   "devDependencies": {
     "@babel/core": "^7.20.0",
     "@expo/cli": "workspace:*",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@types/react": "~19.2.0",
     "babel-preset-expo": "workspace:*",
     "expo-module-scripts": "workspace:*",

--- a/docs/package.json
+++ b/docs/package.json
@@ -85,7 +85,7 @@
   },
   "devDependencies": {
     "@apidevtools/json-schema-ref-parser": "^11.9.3",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@oxlint/plugins": "^1.62.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@tailwindcss/typography": "^0.5.19",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -156,8 +156,8 @@ importers:
         specifier: ^11.9.3
         version: 11.9.3
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@oxlint/plugins':
         specifier: ^1.62.0
         version: 1.64.0
@@ -753,8 +753,8 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@expo/spawn-async@1.7.2':
-    resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
+  '@expo/spawn-async@1.8.0':
+    resolution: {integrity: sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==}
     engines: {node: '>=12'}
 
   '@expo/styleguide-base@3.1.2':
@@ -7519,7 +7519,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@expo/spawn-async@1.7.2':
+  '@expo/spawn-async@1.8.0':
     dependencies:
       cross-spawn: 7.0.6
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Use `osascript.escapeString` utility in `open.ts` ([#45890](https://github.com/expo/expo/pull/45890) by [@kitten](https://github.com/kitten))
 - [Internal] Isolate `expo-session` requests to Expo API and update `resolveTemplate ([#45875](https://github.com/expo/expo/pull/45875) by [@kitten](https://github.com/kitten))
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
 
 ## 56.1.6 — 2026-05-19
 

--- a/packages/@expo/cli/package.json
+++ b/packages/@expo/cli/package.json
@@ -68,7 +68,7 @@
     "@expo/require-utils": "workspace:^56.1.1",
     "@expo/router-server": "workspace:^56.0.9",
     "@expo/schema-utils": "workspace:^56.0.0",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@expo/ws-tunnel": "^1.0.1",
     "@expo/xcpretty": "^4.4.4",
     "@react-native/dev-middleware": "0.85.3",

--- a/packages/@expo/fingerprint/CHANGELOG.md
+++ b/packages/@expo/fingerprint/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 0.18.3 — 2026-05-19
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/fingerprint/package.json
+++ b/packages/@expo/fingerprint/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/expo/expo/tree/main/packages/@expo/fingerprint#readme",
   "dependencies": {
     "@expo/env": "workspace:^2.2.0",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "arg": "^5.0.2",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",

--- a/packages/@expo/image-utils/CHANGELOG.md
+++ b/packages/@expo/image-utils/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 0.9.3 — 2026-05-15
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/image-utils/package.json
+++ b/packages/@expo/image-utils/package.json
@@ -31,7 +31,7 @@
     "build"
   ],
   "dependencies": {
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@expo/require-utils": "workspace:^56.1.1",
     "chalk": "^4.0.0",
     "getenv": "^2.0.0",

--- a/packages/@expo/log-box/package.json
+++ b/packages/@expo/log-box/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@expo/cli": "workspace:*",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@types/react": "~19.2.0",
     "@types/react-dom": "^19.1.7",
     "expo": "workspace:*",

--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 56.0.10 — 2026-05-19
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -69,7 +69,7 @@
     "@expo/env": "workspace:~2.2.0",
     "@expo/json-file": "workspace:~10.1.0",
     "@expo/metro": "~56.0.0",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@jridgewell/gen-mapping": "^0.3.13",
     "@jridgewell/remapping": "^2.3.5",
     "@jridgewell/sourcemap-codec": "^1.5.5",

--- a/packages/@expo/osascript/CHANGELOG.md
+++ b/packages/@expo/osascript/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 2.5.1 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/osascript/package.json
+++ b/packages/@expo/osascript/package.json
@@ -36,7 +36,7 @@
     "node": ">=12"
   },
   "dependencies": {
-    "@expo/spawn-async": "^1.7.2"
+    "@expo/spawn-async": "^1.8.0"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/packages/@expo/package-manager/CHANGELOG.md
+++ b/packages/@expo/package-manager/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 1.11.1 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/package-manager/package.json
+++ b/packages/@expo/package-manager/package.json
@@ -37,7 +37,7 @@
   ],
   "dependencies": {
     "@expo/json-file": "workspace:^10.1.0",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "chalk": "^4.0.0",
     "npm-package-arg": "^11.0.0",
     "ora": "^3.4.0",

--- a/packages/create-expo-module/package.json
+++ b/packages/create-expo-module/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@expo/json-file": "workspace:*",
     "@expo/rudder-sdk-node": "^1.1.1",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@octokit/types": "^15.0.0",
     "@types/cross-spawn": "^6.0.6",
     "@types/ejs": "^3.1.5",

--- a/packages/create-expo/CHANGELOG.md
+++ b/packages/create-expo/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 4.0.1 — 2026-05-19
 
 ### 🐛 Bug fixes

--- a/packages/create-expo/package.json
+++ b/packages/create-expo/package.json
@@ -40,7 +40,7 @@
     "@expo/config": "workspace:*",
     "@expo/json-file": "workspace:*",
     "@expo/package-manager": "workspace:*",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@octokit/types": "^13.5.0",
     "@types/debug": "^4.1.7",
     "@types/getenv": "^1.0.0",

--- a/packages/eslint-config-universe/package.json
+++ b/packages/eslint-config-universe/package.json
@@ -60,7 +60,7 @@
     }
   },
   "devDependencies": {
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "eslint": "^9.24.0",
     "eslint8": "npm:eslint@^8.57.1",
     "jest": "^29.7.0",

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 56.0.11 — 2026-05-19
 
 ### 🐛 Bug fixes

--- a/packages/expo-brownfield/package.json
+++ b/packages/expo-brownfield/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@expo/env": "workspace:~2.2.0",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "chalk": "^4.1.2",
     "commander": "^14.0.3",
     "diff": "^5.2.0",

--- a/packages/expo-doctor/CHANGELOG.md
+++ b/packages/expo-doctor/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 1.19.6 — 2026-05-11
 
 ### 🎉 New features

--- a/packages/expo-doctor/package.json
+++ b/packages/expo-doctor/package.json
@@ -41,7 +41,7 @@
     "@expo/json-file": "workspace:*",
     "@expo/metro": "~56.0.0",
     "@expo/schemer": "workspace:*",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@types/debug": "^4.1.8",
     "@types/getenv": "^1.0.0",
     "@types/semver": "^7.5.8",

--- a/packages/expo-module-scripts/package.json
+++ b/packages/expo-module-scripts/package.json
@@ -73,7 +73,7 @@
     "@babel/plugin-transform-export-namespace-from": "^7.23.4",
     "@babel/preset-env": "^7.23.8",
     "@babel/preset-typescript": "^7.23.3",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@react-native/jest-preset": "0.85.3",
     "@testing-library/react-native": "^13.3.0",
     "@types/jest": "^29.2.1",

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 56.0.8 — 2026-05-19
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-modules-autolinking/package.json
+++ b/packages/expo-modules-autolinking/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@expo/require-utils": "workspace:^56.1.1",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "chalk": "^4.1.0",
     "commander": "^7.2.0"
   }

--- a/packages/expo-test-runner/package.json
+++ b/packages/expo-test-runner/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.23.8",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "chalk": "^4.1.2",
     "commander": "^7.2.0",
     "dot": "^2.0.0-beta.1",

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 56.0.13 — 2026-05-19
 
 ### 🐛 Bug fixes

--- a/packages/expo-updates/package.json
+++ b/packages/expo-updates/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@expo/code-signing-certificates": "^0.0.6",
     "@expo/plist": "workspace:^0.6.0",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "arg": "^4.1.0",
     "chalk": "^4.1.2",
     "debug": "^4.3.4",

--- a/packages/expo-widgets/package.json
+++ b/packages/expo-widgets/package.json
@@ -35,7 +35,7 @@
     "@expo/ui": "workspace:~56.0.9"
   },
   "devDependencies": {
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@types/node": "^22.14.0",
     "@types/react": "~19.2.0",
     "expo": "workspace:*",

--- a/packages/install-expo-modules/CHANGELOG.md
+++ b/packages/install-expo-modules/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 0.14.21 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/install-expo-modules/package.json
+++ b/packages/install-expo-modules/package.json
@@ -39,7 +39,7 @@
     "@expo/config": "workspace:*",
     "@expo/config-plugins": "workspace:*",
     "@expo/package-manager": "workspace:*",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@types/prompts": "^2.0.6",
     "@types/semver": "^7.0.0",
     "chalk": "^4.1.2",

--- a/packages/patch-project/CHANGELOG.md
+++ b/packages/patch-project/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 56.0.12 — 2026-05-19
 
 _This version does not introduce any user-facing changes._

--- a/packages/patch-project/package.json
+++ b/packages/patch-project/package.json
@@ -53,7 +53,7 @@
     "@expo/config": "workspace:~56.0.7",
     "@expo/config-plugins": "workspace:~56.0.6",
     "@expo/env": "workspace:~2.2.0",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "arg": "5.0.2",
     "chalk": "^4.0.0",
     "debug": "^4.3.1",

--- a/packages/uri-scheme/CHANGELOG.md
+++ b/packages/uri-scheme/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))
+
 ## 2.0.22 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/uri-scheme/package.json
+++ b/packages/uri-scheme/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@expo/config-plugins": "workspace:*",
     "@expo/plist": "workspace:*",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@types/prompts": "^2.0.6",
     "chalk": "^4.0.0",
     "commander": "^12.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,8 +258,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/@expo/cli
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@types/react':
         specifier: ~19.2.0
         version: 19.2.14
@@ -277,7 +277,7 @@ importers:
     dependencies:
       '@expo/spawn-async':
         specifier: ^1.7.2
-        version: 1.7.2
+        version: 1.8.0
       jimp-compact:
         specifier: ^0.16.1-2
         version: 0.16.1
@@ -1843,8 +1843,8 @@ importers:
         specifier: workspace:^56.0.0
         version: link:../schema-utils
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@expo/ws-tunnel':
         specifier: ^1.0.1
         version: 1.0.6
@@ -2305,8 +2305,8 @@ importers:
         specifier: workspace:^2.2.0
         version: link:../env
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       arg:
         specifier: ^5.0.2
         version: 5.0.2
@@ -2369,8 +2369,8 @@ importers:
         specifier: workspace:^56.1.1
         version: link:../require-utils
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       chalk:
         specifier: ^4.0.0
         version: 4.1.2
@@ -2479,8 +2479,8 @@ importers:
         specifier: workspace:*
         version: link:../cli
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@types/react':
         specifier: ~19.2.0
         version: 19.2.14
@@ -2542,8 +2542,8 @@ importers:
         specifier: ~56.0.0
         version: 56.0.0
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@jridgewell/gen-mapping':
         specifier: ^0.3.13
         version: 0.3.13
@@ -2713,8 +2713,8 @@ importers:
   packages/@expo/osascript:
     dependencies:
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -2729,8 +2729,8 @@ importers:
         specifier: workspace:^10.1.0
         version: link:../json-file
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       chalk:
         specifier: ^4.0.0
         version: 4.1.2
@@ -3160,8 +3160,8 @@ importers:
         specifier: workspace:*
         version: link:../@expo/package-manager
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@octokit/types':
         specifier: ^13.5.0
         version: 13.10.0
@@ -3229,8 +3229,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(encoding@0.1.13)
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@octokit/types':
         specifier: ^15.0.0
         version: 15.0.2
@@ -3388,8 +3388,8 @@ importers:
         version: 16.5.0
     devDependencies:
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       eslint:
         specifier: ^9.24.0
         version: 9.39.4(jiti@1.21.7)
@@ -3837,8 +3837,8 @@ importers:
         specifier: workspace:~2.2.0
         version: link:../@expo/env
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -4225,8 +4225,8 @@ importers:
         specifier: workspace:*
         version: link:../@expo/schemer
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@types/debug':
         specifier: ^4.1.8
         version: 4.1.12
@@ -4799,8 +4799,8 @@ importers:
         specifier: ^7.23.3
         version: 7.28.5(@babel/core@7.29.0)
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@react-native/jest-preset':
         specifier: 0.85.3
         version: 0.85.3(@babel/core@7.29.0)(react@19.2.3)
@@ -4857,8 +4857,8 @@ importers:
         specifier: workspace:^56.1.1
         version: link:../@expo/require-utils
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       chalk:
         specifier: ^4.1.0
         version: 4.1.2
@@ -5596,8 +5596,8 @@ importers:
         specifier: ^7.23.8
         version: 7.29.2
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -5741,8 +5741,8 @@ importers:
         specifier: workspace:^0.6.0
         version: link:../@expo/plist
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       arg:
         specifier: ^4.1.0
         version: 4.1.3
@@ -5910,8 +5910,8 @@ importers:
         version: 19.2.3
     devDependencies:
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@types/node':
         specifier: ^22.14.0
         version: 22.19.15
@@ -5974,8 +5974,8 @@ importers:
         specifier: workspace:*
         version: link:../@expo/package-manager
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@types/prompts':
         specifier: ^2.0.6
         version: 2.4.9
@@ -6080,8 +6080,8 @@ importers:
         specifier: workspace:~2.2.0
         version: link:../@expo/env
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       arg:
         specifier: 5.0.2
         version: 5.0.2
@@ -6156,8 +6156,8 @@ importers:
         specifier: workspace:*
         version: link:../@expo/plist
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@types/prompts':
         specifier: ^2.0.6
         version: 2.4.9
@@ -6198,8 +6198,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/@expo/plist
       '@expo/spawn-async':
-        specifier: ^1.7.2
-        version: 1.7.2
+        specifier: ^1.8.0
+        version: 1.8.0
       '@expo/swiftlint':
         specifier: ^0.57.1
         version: 0.57.1
@@ -7625,8 +7625,8 @@ packages:
   '@expo/server@0.5.3':
     resolution: {integrity: sha512-WXsWzeBs5v/h0PUfHyNLLz07rwwO5myQ1A5DGYewyyGLmsyl61yVCe8AgAlp1wkiMsqhj2hZqI2u3K10QnCMrQ==}
 
-  '@expo/spawn-async@1.7.2':
-    resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
+  '@expo/spawn-async@1.8.0':
+    resolution: {integrity: sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==}
     engines: {node: '>=12'}
 
   '@expo/styleguide-base@1.0.1':
@@ -17500,7 +17500,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/spawn-async@1.7.2':
+  '@expo/spawn-async@1.8.0':
     dependencies:
       cross-spawn: 7.0.6
 
@@ -17513,7 +17513,7 @@ snapshots:
 
   '@expo/swiftlint@0.57.1':
     dependencies:
-      '@expo/spawn-async': 1.7.2
+      '@expo/spawn-async': 1.8.0
 
   '@expo/vector-icons@15.1.1(expo-font@packages+expo-font)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)':
     dependencies:

--- a/tools/package.json
+++ b/tools/package.json
@@ -36,7 +36,7 @@
     "@expo/osascript": "workspace:*",
     "@expo/plist": "workspace:*",
     "@expo/xcpretty": "^4.4.4",
-    "@expo/spawn-async": "^1.7.2",
+    "@expo/spawn-async": "^1.8.0",
     "@expo/swiftlint": "^0.57.1",
     "@linear/sdk": "^2.6.0",
     "@octokit/rest": "^19.0.7",


### PR DESCRIPTION
## Summary

See: https://github.com/expo/spawn-async/pull/55

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
