### PR TITLE
[dev-launcher][dev-menu] Apply iOS dev menu setting toggles immediately

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Apply dev launcher gesture and auto-launch settings immediately instead of requiring an app restart. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 💡 Others
 
 ## 56.0.12 — 2026-05-19

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Apply dev launcher gesture and auto-launch settings immediately instead of requiring an app restart. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Apply dev launcher gesture and auto-launch settings immediately instead of requiring an app restart. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@gabrieldonadel](https://github.com/gabrieldonadel)) ([#46000](https://github.com/expo/expo/pull/46000) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevLauncherViewModel.swift
@@ -4,6 +4,7 @@ import ExpoModulesCore
 import Foundation
 import AuthenticationServices
 import Network
+import EXDevMenu
 
 private let selectedAccountKey = "expo-selected-account-id"
 private let sessionKey = "expo-session-secret"
@@ -34,17 +35,19 @@ class DevLauncherViewModel: ObservableObject {
   @Published var hasStoredCrash = false
   @Published var shakeDevice = true {
     didSet {
-      saveMenuPreference(key: "EXDevMenuMotionGestureEnabled", value: shakeDevice)
+      DevMenuManager.shared.setMotionGestureEnabled(shakeDevice)
     }
   }
   @Published var threeFingerLongPress = false {
     didSet {
-      saveMenuPreference(key: "EXDevMenuTouchGestureEnabled", value: threeFingerLongPress)
+      // Route through DevMenuManager so the recognizer is installed/uninstalled immediately
+      DevMenuManager.shared.setTouchGestureEnabled(threeFingerLongPress)
     }
   }
   @Published var showOnLaunch = false {
     didSet {
-      saveMenuPreference(key: "EXDevMenuShowsAtLaunch", value: showOnLaunch)
+      // Route through DevMenuManager so the auto-launch observer is refreshed immediately
+      DevMenuManager.shared.setShowsAtLaunch(showOnLaunch)
     }
   }
   @Published var isAuthenticated = false
@@ -202,7 +205,7 @@ class DevLauncherViewModel: ObservableObject {
     stopServerDiscovery()
     startDevServerBrowser()
   }
-  
+
   func markNetworkPermissionGranted() {
     UserDefaults.standard.set(true, forKey: networkPermissionGrantedKey)
     permissionStatus = .granted
@@ -408,10 +411,6 @@ class DevLauncherViewModel: ObservableObject {
     shakeDevice = defaults.object(forKey: "EXDevMenuMotionGestureEnabled") as? Bool ?? true
     threeFingerLongPress = defaults.object(forKey: "EXDevMenuTouchGestureEnabled") as? Bool ?? true
     showOnLaunch = defaults.object(forKey: "EXDevMenuShowsAtLaunch") as? Bool ?? false
-  }
-
-  private func saveMenuPreference(key: String, value: Bool) {
-    UserDefaults.standard.set(value, forKey: key)
   }
 
   private func checkAuthenticationStatus() {

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS] Add `setShowsAtLaunch`/`getShowsAtLaunch` to `DevMenuManager` so preferences can be toggled at runtime and applied immediately. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Add `setShowsAtLaunch`/`getShowsAtLaunch` to `DevMenuManager` so preferences can be toggled at runtime and applied immediately. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@gabrieldonadel](https://github.com/gabrieldonadel)) ([#46000](https://github.com/expo/expo/pull/46000) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Add `setShowsAtLaunch`/`getShowsAtLaunch` to `DevMenuManager` so preferences can be toggled at runtime and applied immediately. ([#XXXXX](https://github.com/expo/expo/pull/XXXXX) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 - Fix FAB resizing on label disappearance ([#45869](https://github.com/expo/expo/pull/45869) by [@Wenszel](https://github.com/Wenszel))

--- a/packages/expo-dev-menu/ios/DevMenuManager.swift
+++ b/packages/expo-dev-menu/ios/DevMenuManager.swift
@@ -196,6 +196,16 @@ open class DevMenuManager: NSObject {
   }
 
   @objc
+  public func setShowsAtLaunch(_ enabled: Bool) {
+    DevMenuPreferences.showsAtLaunch = enabled
+  }
+
+  @objc
+  public func getShowsAtLaunch() -> Bool {
+    return DevMenuPreferences.showsAtLaunch
+  }
+
+  @objc
   public func setShowFloatingActionButton(_ enabled: Bool) {
     DevMenuPreferences.showFloatingActionButton = enabled
   }


### PR DESCRIPTION
# Why

First noticed this while testing in a physical device, the three-finger long-press dev menu gesture on iOS only stopped responding after the next app launch when a user disabled it from the dev launcher settings. I would expect it to take effect immediately.

Taking a look at the code, I noticed this also affected the "show on launch" toggle, which could still auto-open the menu after being disabled.

Root cause: the SwiftUI dev launcher in `expo-dev-launcher` wrote preference values straight to `UserDefaults`, bypassing the `DevMenuPreferences` setters in `expo-dev-menu`. Those setters are where the side effects live — installing/uninstalling `DevMenuTouchInterceptor` for the gesture recognizer, and calling `DevMenuManager.updateAutoLaunchObserver()` for auto-launch. The values were persisted but the live state wasn't updated until `DevMenuPreferences.setup()` re-read UserDefaults on next launch.

# How

Routed the SwiftUI toggles through `DevMenuManager.shared` so the setters run immediately:

- `threeFingerLongPress` → `setTouchGestureEnabled`  
- `shakeDevice` → `setMotionGestureEnabled`  
- `showOnLaunch` → new `setShowsAtLaunch` added on `DevMenuManager` mirroring the other accessors

Removed the now-unused `saveMenuPreference` helper from `DevLauncherViewModel`.

# Test Plan

1. Build BareExpo and run on real iOS device.
2. Open the dev launcher → Settings.
3. Toggle Three-finger long-press off. Without restarting the app, perform a three-finger long press on the loaded app; the developer menu should not open. Toggle it back on and confirm the gesture works again.
4. Toggle Shake to open off and shake the device; the menu should not open. Toggle back on and confirm shake works.
6. Kill and relaunch the app; verify the persisted values are still correct.
