### PR TITLE
fix(cli): Fix inverted check in Metro middleware

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Escape content inserted into interstitial page ([#45839](https://github.com/expo/expo/pull/45839) by [@kitten](https://github.com/kitten))
 - Read raw MCP URL env var only from original system env vars ([#45842](https://github.com/expo/expo/pull/45842) by [@kitten](https://github.com/kitten))
 - Read selected env vars only from original system env vars, not from `@expo/env` env files ([#45833](https://github.com/expo/expo/pull/45833) by [@kitten](https://github.com/kitten))
+- Fix inverted path check in Metro middleware
 
 ### 💡 Others
 

--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Escape content inserted into interstitial page ([#45839](https://github.com/expo/expo/pull/45839) by [@kitten](https://github.com/kitten))
 - Read raw MCP URL env var only from original system env vars ([#45842](https://github.com/expo/expo/pull/45842) by [@kitten](https://github.com/kitten))
 - Read selected env vars only from original system env vars, not from `@expo/env` env files ([#45833](https://github.com/expo/expo/pull/45833) by [@kitten](https://github.com/kitten))
-- Fix inverted path check in Metro middleware
+- Fix inverted path check in Metro middleware ([#46006](https://github.com/expo/expo/pull/46006) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
+++ b/packages/@expo/cli/src/start/server/metro/dev-server/createMetroMiddleware.ts
@@ -124,7 +124,7 @@ const ensureFileInRootDirectory = async (root: string, file: string): Promise<st
     file = await fs.promises.realpath(file);
     // Cannot be accessed using Metro's server API, we need to move the file
     // into the project root and try again.
-    if (!isPathInside(file, root)) {
+    if (isPathInside(file, root)) {
       return file;
     } else {
       return null;


### PR DESCRIPTION
## Summary

Accidentally inverted check from recent change. Tests caught this

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
