### PR TITLE
test(config-plugins,prebuild-config): Fix plist test shifts (strict equal error)

### DIFF
--- a/packages/@expo/config-plugins/src/ios/__tests__/Entitlements-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Entitlements-test.ts
@@ -39,7 +39,7 @@ describe(ensureApplicationTargetEntitlementsFileConfigured, () => {
 
     // New file has the contents of the old entitlements file
     const data = plist.parse(await fs.promises.readFile(entitlementsPath!, 'utf8'));
-    expect(data).toStrictEqual({
+    expect(data).toEqual({
       // No entitlements enabled by default
     });
   });
@@ -61,7 +61,7 @@ describe(ensureApplicationTargetEntitlementsFileConfigured, () => {
 
     // New file has the contents of the old entitlements file
     const data = plist.parse(await fs.promises.readFile(entitlementsPath, 'utf8'));
-    expect(data).toStrictEqual({});
+    expect(data).toEqual({});
   });
 
   it('does not create any entitlements files if it already exists', async () => {
@@ -82,7 +82,7 @@ describe(ensureApplicationTargetEntitlementsFileConfigured, () => {
 
     // New file has the contents of the old entitlements file
     const data = plist.parse(await fs.promises.readFile(entitlementsPath, 'utf8'));
-    expect(data).toStrictEqual({ special: true });
+    expect(data).toEqual({ special: true });
 
     // entitlement file in default location does not exist
     expect(fs.existsSync('/app/ios/testproject/testproject.entitlements')).toBe(false);

--- a/packages/@expo/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
+++ b/packages/@expo/prebuild-config/src/plugins/__tests__/withDefaultPlugins-test.ts
@@ -409,12 +409,12 @@ describe('built-in plugins', () => {
     const infoPlist = await plist.parse(
       fsMock.readFileSync(path.join(projectRoot, 'ios/HelloWorld/Info.plist'), 'utf8')
     );
-    expect(infoPlist.bar).toStrictEqual({ val: ['foo'] });
+    expect(infoPlist.bar).toEqual({ val: ['foo'] });
     // Ensure the entitlements object is merged correctly
     const entitlements = await plist.parse(
       fsMock.readFileSync(path.join(projectRoot, 'ios/HelloWorld/mycoolapp.entitlements'), 'utf8')
     );
-    expect(entitlements.foo).toStrictEqual('bar');
+    expect(entitlements.foo).toEqual('bar');
 
     // Ensure files are always written in the correct format
     for (const xmlPath of [


### PR DESCRIPTION
## Summary

Follow-up to #45854

`toStrictEqual` doesn't match if the prototypes don't match (`null` vs `Object`)

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
