### PR TITLE
[docs] Metro docs updates for SDK 56

### DIFF
--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -109,6 +109,19 @@ You will see the changes the next time you restart the dev server. Resolutions a
   Icon={BookOpen02Icon}
 />
 
+## File watching and crawling
+
+From **SDK 56**, Expo's file map supports on-demand filesystem access. In practice, this means your `watchFolders` no longer need to include every module your app bundles, and projects that symlink to dependencies outside of the project root will now resolve correctly.
+
+The on-demand filesystem is controlled by the `experiments.onDemandFilesystem` flag in your [app config](/workflow/configuration/) and is enabled by default.
+
+<BoxLink
+  title="On-demand filesystem"
+  description="Learn how Expo's file map discovers, watches, and lazily resolves source files."
+  href="/versions/latest/config/metro/#on-demand-filesystem"
+  Icon={BookOpen02Icon}
+/>
+
 ## Bundle splitting
 
 Expo CLI automatically splits bundles based on async imports (web-only).

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -113,12 +113,12 @@ You will see the changes the next time you restart the dev server. Resolutions a
 
 From **SDK 56**, Expo's file map supports on-demand filesystem access. In practice, this means your `watchFolders` no longer need to include every module your app bundles, and projects that symlink to dependencies outside of the project root will now resolve correctly.
 
-The on-demand filesystem is controlled by the `experiments.onDemandFilesystem` flag in your [app config](/workflow/configuration/) and is enabled by default.
+The on-demand filesystem is controlled by the [`experiments.onDemandFilesystem`](/versions/v56.0.0/config/app/#ondemandfilesystem) flag in your [app config](/workflow/configuration/) and is enabled by default.
 
 <BoxLink
   title="On-demand filesystem"
   description="Learn how Expo's file map discovers, watches, and lazily resolves source files."
-  href="/versions/latest/config/metro/#on-demand-filesystem"
+  href="/versions/v56.0.0/config/metro/#on-demand-filesystem"
   Icon={BookOpen02Icon}
 />
 

--- a/docs/pages/guides/why-metro.mdx
+++ b/docs/pages/guides/why-metro.mdx
@@ -27,7 +27,7 @@ The Expo team collaborates with Meta to develop Metro for Expo Router, adding fe
 
 ## Battle-tested at scale
 
-Nearly every React Native app in the world uses Metro, making it a battle-tested solution optimized for large-scale projects. This makes it suitable for developers of all sizes, from hobbyists to large companies. Metro is designed specifically to handle large-scale Meta apps, which is why it has features such as native file watching with Watchman and [shared remote caches](https://metrobundler.dev/docs/caching).
+Nearly every React Native app in the world uses Metro, making it a battle-tested solution optimized for large-scale projects. This makes it suitable for developers of all sizes, from hobbyists to large companies. Metro is designed specifically to handle large-scale Meta apps, which is why it has features such as delta bundling and [shared remote caches](https://metrobundler.dev/docs/caching).
 
 ## On-demand processing
 
@@ -70,7 +70,7 @@ While bundlers like Vite leverage built-in ESM support in the browser, this appr
 Several bundlers are opting to write their core in Rust for performance reasons, but this comes with some trade-offs, such as more challenging contributions, patches, and development. Metro uses a mix of technologies based on the operation:
 
 - The core bundler and utilities are written in JS/Flow.
-- File watching is written in C++ via Watchman, with a JS fallback. Watchman is then used across projects on your computer.
+- File watching uses a JS crawler by default, and can optionally use Watchman (C++) when installed.
 - AST is parsed with Hermes parser (WebAssembly) to a Babel-compatible format.
 - AST transformation is done with Babel. This maximizes developer customization.
 - Minification uses Hermes on native platforms and Terser (with optional ESBuild support) for web.

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -419,7 +419,7 @@ The VS Code extension for improving the developer experience of working with app
 
 ### Watchman
 
-The file watcher used by [Metro](#metro-bundler) to perform hot reloads during development. Watchman contains native code and may cause issues when installed globally. Watchman is maintained by [Meta](#meta).
+A file watcher daemon which [Metro](#metro-bundler) can optionally use to crawl and query a project's files. Watchman contains native code and may cause issues when installed globally. Watchman is maintained by [Meta](#meta).
 
 ### webpack
 

--- a/docs/pages/versions/unversioned/config/metro.mdx
+++ b/docs/pages/versions/unversioned/config/metro.mdx
@@ -385,6 +385,26 @@ Always try to implement custom logic in the resolver if possible, caching is muc
 
 Always use `babel-preset-expo` as the default Babel preset, this ensures the transformation is always compatible with Expo runtimes. `babel-preset-expo` uses all of the caller inputs internally to optimize for a given platform, engine, and environment.
 
+## On-demand filesystem
+
+Expo uses a fork of `metro-file-map` ([`@expo/metro-file-map`](https://github.com/expo/expo/tree/main/packages/@expo/metro-file-map)) to discover, watch, and lazily resolve source files.
+
+Metro pre-crawls every directory listed in `watchFolders` on startup. In [monorepos](/guides/monorepos), this typically means every workspace will be crawled. With on-demand filesystem access enabled, the file map can lazily read files outside of `watchFolders` as they are requested by the resolver instead. This lets you reduce the number of `watchFolders` entries safely, which trades file watcher coverage for faster startup times, without breaking imports that reach out of the project root.
+
+The on-demand crawling also allows symlinks to be resolved outside of your monorepo root, which adds [Global Virtual Store support](https://pnpm.io/global-virtual-store) in package managers such as Bun and pnpm.
+
+This feature is enabled by default and can be disabled by setting `experiments.onDemandFilesystem` to `false` in your [app config](/versions/latest/config/app/):
+
+```json app.json
+{
+  "expo": {
+    "experiments": {
+      "onDemandFilesystem": false
+    }
+  }
+}
+```
+
 ## Node.js built-ins
 
 When bundling for a server environment, Expo's Metro config automatically supports externalizing Node.js built-in modules (`fs`, `path`, `node:crypto`, and more) based on the current Node.js version. If the CLI is bundling for a browser environment, then built-ins will first check if the module is installed locally, then fallback on an empty shim. For example, if you install `path` for use in the browser, this can be used, otherwise, the module will automatically be skipped.

--- a/docs/pages/versions/v56.0.0/config/metro.mdx
+++ b/docs/pages/versions/v56.0.0/config/metro.mdx
@@ -385,6 +385,26 @@ Always try to implement custom logic in the resolver if possible, caching is muc
 
 Always use `babel-preset-expo` as the default Babel preset, this ensures the transformation is always compatible with Expo runtimes. `babel-preset-expo` uses all of the caller inputs internally to optimize for a given platform, engine, and environment.
 
+## On-demand filesystem
+
+Expo uses a fork of `metro-file-map` ([`@expo/metro-file-map`](https://github.com/expo/expo/tree/main/packages/@expo/metro-file-map)) to discover, watch, and lazily resolve source files.
+
+Metro pre-crawls every directory listed in `watchFolders` on startup. In [monorepos](/guides/monorepos), this typically means every workspace will be crawled. With on-demand filesystem access enabled, the file map can lazily read files outside of `watchFolders` as they are requested by the resolver instead. This lets you reduce the number of `watchFolders` entries safely, which trades file watcher coverage for faster startup times, without breaking imports that reach out of the project root.
+
+The on-demand crawling also allows symlinks to be resolved outside of your monorepo root, which adds [Global Virtual Store support](https://pnpm.io/global-virtual-store) in package managers such as Bun and pnpm.
+
+This feature is enabled by default and can be disabled by setting `experiments.onDemandFilesystem` to `false` in your [app config](/versions/latest/config/app/):
+
+```json app.json
+{
+  "expo": {
+    "experiments": {
+      "onDemandFilesystem": false
+    }
+  }
+}
+```
+
 ## Node.js built-ins
 
 When bundling for a server environment, Expo's Metro config automatically supports externalizing Node.js built-in modules (`fs`, `path`, `node:crypto`, and more) based on the current Node.js version. If the CLI is bundling for a browser environment, then built-ins will first check if the module is installed locally, then fallback on an empty shim. For example, if you install `path` for use in the browser, this can be used, otherwise, the module will automatically be skipped.


### PR DESCRIPTION
## Summary

We've made Node crawling/watching the default over Watchman, added the `onDemandFilesystem` flag and feature, and need to add some notes on `watchFolders` and related changes.

## Set of changes

- Update "Why Metro" to change Watchman mentions
- Glossary: Update Watchman section
- Metro config: Add On-demand Filesystem section (copied to v56.0.0)
- Customizing Metro: Link to the above