### PR TITLE
[go] allow staging updates host

### DIFF
--- a/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
+++ b/apps/expo-go/android/expoview/src/main/java/host/exp/exponent/ExpoUpdatesAppLoader.kt
@@ -46,6 +46,7 @@ import kotlin.time.toDuration
 private const val UPDATE_AVAILABLE_EVENT = "updateAvailable"
 private const val UPDATE_NO_UPDATE_AVAILABLE_EVENT = "noUpdateAvailable"
 private const val UPDATE_ERROR_EVENT = "error"
+private val EAS_UPDATE_HOSTS = setOf("u.expo.dev", "staging-u.expo.dev")
 
 /**
  * Entry point to expo-updates in Expo Go. Fulfills many of the
@@ -266,7 +267,9 @@ class ExpoUpdatesAppLoader @JvmOverloads constructor(
             // ReactAndroid will load the bundle on its own in development mode
             if (!manifest.isDevelopmentMode()) {
               val launchAssetFile = launcher.launchAssetFile!!
-              val isEasUpdate = runCatching { URI(manifestUrl).host }.getOrNull() == "u.expo.dev"
+              val isEasUpdate = runCatching { URI(manifestUrl).host }
+                .getOrNull()
+                ?.let(EAS_UPDATE_HOSTS::contains) == true
               if (!isEasUpdate && HermesBundleUtils.isHermesBundle(File(launchAssetFile))) {
                 val errorJson = JSONObject().apply {
                   put("errorCode", "EXPERIENCE_HERMES_BUNDLE_NOT_SUPPORTED")

--- a/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
+++ b/apps/expo-go/ios/Exponent/Kernel/AppLoader/EXAppLoaderExpoUpdates.m
@@ -21,6 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString * const kSnackRuntimeProjectId = @"933fd9c0-1666-11e7-afca-d980795c5824";
 
+static BOOL isEASUpdateHost(NSString * _Nullable host)
+{
+  return [host isEqualToString:@"u.expo.dev"] || [host isEqualToString:@"staging-u.expo.dev"];
+}
+
 @interface EXAppLoaderExpoUpdates ()
 
 @property (nonatomic, strong, nullable) NSURL *manifestUrl;
@@ -301,7 +306,7 @@ static NSString * const kSnackRuntimeProjectId = @"933fd9c0-1666-11e7-afca-d9807
     return;
   }
   _bundle = [NSData dataWithContentsOfURL:launcher.launchAssetUrl];
-  BOOL isEasUpdate = [_httpManifestUrl.host isEqualToString:@"u.expo.dev"];
+  BOOL isEasUpdate = isEASUpdateHost(_httpManifestUrl.host);
   if (!isEasUpdate && [EXAppLoaderExpoUpdates isHermesBundle:_bundle]) {
     EXManifestResource *manifestResource = [[EXManifestResource alloc] initWithManifestUrl:_httpManifestUrl originalUrl:_manifestUrl];
     _error = [manifestResource formatError:[NSError errorWithDomain:EXRuntimeErrorDomain code:0 userInfo:@{


### PR DESCRIPTION
# Why

Expo Go already allows Hermes bundles from EAS Updates on `u.expo.dev`. Staging updates use `staging-u.expo.dev`, so those bundles were still rejected by the loaders.

# How

Added the staging update host to the EAS update host checks in the Android and iOS Expo Go loaders.

# Test Plan

- Ran `git diff --check`.
- Searched the touched loaders to confirm `u.expo.dev` and `staging-u.expo.dev` are accepted.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
