### PR TITLE
[expo-observe][ios] fix expo.navigation.tti mapping

### DIFF
--- a/packages/expo-observe/ios/OpenTelemetry.swift
+++ b/packages/expo-observe/ios/OpenTelemetry.swift
@@ -199,7 +199,8 @@ let metricNameMap = [
 
   // Navigation
   "navigation/cold_ttr": "expo.navigation.cold_ttr",
-  "navigation/warm_ttr": "expo.navigation.warm_ttr"
+  "navigation/warm_ttr": "expo.navigation.warm_ttr",
+  "navigation/tti": "expo.navigation.tti",
 ]
 
 nonisolated(unsafe) let formatter = ISO8601DateFormatter()


### PR DESCRIPTION
# Why

@kadikraman noticed that no navigation TTI metrics are sent on iOS

`expo.navigation.tti` was missing from the open telemetry mappings on iOS

# How

Add the mapping

# Test Plan

Observe tester on iOS

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
