### PR TITLE
[observe-tester] Add metrics filter

### DIFF
--- a/apps/observe-tester/app/(tabs)/(sessions)/sessions/[id].tsx
+++ b/apps/observe-tester/app/(tabs)/(sessions)/sessions/[id].tsx
@@ -10,6 +10,7 @@ import { CrashReportPanel } from '@/components/CrashReportPanel';
 import { Divider } from '@/components/Divider';
 import { JSONView } from '@/components/JSONView';
 import { LogsPanel } from '@/components/LogsPanel';
+import { MetricsFilter } from '@/components/MetricsFilter';
 import { MetricsPanel } from '@/components/MetricsPanel';
 import { SessionHeader } from '@/components/SessionHeader';
 import { useTheme } from '@/utils/theme';
@@ -20,6 +21,17 @@ export default function SessionDetail() {
   const [session, setSession] = useState<Session | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [showRawJson, setShowRawJson] = useState(false);
+  const [selectedMetricNames, setSelectedMetricNames] = useState<Set<string>>(() => new Set());
+
+  // Seed the selection to every distinct metric name once per session id. Keyed on `session?.id`
+  // so refocusing the tab (which reloads sessions and creates a new metrics array reference)
+  // doesn't wipe the user's filter.
+  useEffect(() => {
+    if (!session) return;
+    const names = new Set<string>();
+    for (const metric of session.metrics) names.add(metric.name);
+    setSelectedMetricNames(names);
+  }, [session?.id]);
 
   const { markInteractive } = useObserve();
   useEffect(() => {
@@ -63,7 +75,12 @@ export default function SessionDetail() {
             </>
           ) : null}
           <Text style={[styles.sectionTitle, { color: theme.text.default }]}>Metrics</Text>
-          <MetricsPanel metrics={session.metrics} />
+          <MetricsFilter
+            metrics={session.metrics}
+            selected={selectedMetricNames}
+            onChange={setSelectedMetricNames}
+          />
+          <MetricsPanel metrics={session.metrics} filter={selectedMetricNames} />
           <Divider style={styles.divider} />
           <Text style={[styles.sectionTitle, { color: theme.text.default }]}>Log events</Text>
           <LogsPanel logs={session.logs} />

--- a/apps/observe-tester/components/MetricsFilter.tsx
+++ b/apps/observe-tester/components/MetricsFilter.tsx
@@ -1,0 +1,205 @@
+import { Ionicons } from '@expo/vector-icons';
+import {
+  BottomSheetModal,
+  BottomSheetView,
+} from '@expo/ui/community/bottom-sheet';
+import type { Metric } from 'expo-app-metrics';
+import { useMemo, useRef } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+import { Chevron } from '@/components/Chevron';
+import { capitalize, categoryRank } from '@/utils/metricCategories';
+import { useTheme } from '@/utils/theme';
+
+type MetricsFilterProps = {
+  metrics: Metric[];
+  selected: ReadonlySet<string>;
+  onChange: (next: Set<string>) => void;
+};
+
+export function MetricsFilter({ metrics, selected, onChange }: MetricsFilterProps) {
+  const theme = useTheme();
+  const sheetRef = useRef<BottomSheetModal>(null);
+
+  const optionsByCategory = useMemo(() => buildOptionsByCategory(metrics), [metrics]);
+  const allNames = useMemo(() => {
+    const set = new Set<string>();
+    for (const { names } of optionsByCategory) {
+      for (const name of names) set.add(name);
+    }
+    return set;
+  }, [optionsByCategory]);
+
+  const totalCount = allNames.size;
+  const selectedCount = selected.size;
+  const summary =
+    totalCount === 0
+      ? 'No metrics'
+      : selectedCount === totalCount
+        ? `All ${totalCount} metrics types`
+        : `${selectedCount} of ${totalCount} metrics types`;
+
+  function open() {
+    sheetRef.current?.present();
+  }
+
+  function toggle(name: string, value: boolean) {
+    const next = new Set(selected);
+    if (value) next.add(name);
+    else next.delete(name);
+    onChange(next);
+  }
+
+  return (
+    <View>
+      <Pressable
+        onPress={open}
+        disabled={totalCount === 0}
+        style={({ pressed }) => [
+          styles.pill,
+          {
+            backgroundColor: theme.background.element,
+            borderColor: theme.border.default,
+            opacity: pressed ? 0.6 : 1,
+          },
+        ]}>
+        <Text style={[styles.pillLabel, { color: theme.text.default }]}>{summary}</Text>
+        <Chevron expanded={false} size={14} color={theme.text.tertiary} animated={false} />
+      </Pressable>
+
+      <BottomSheetModal
+        ref={sheetRef}
+        enablePanDownToClose
+        backgroundStyle={{ backgroundColor: theme.background.screen }}>
+        <BottomSheetView style={styles.sheetContent}>
+          <Text style={[styles.sheetTitle, { color: theme.text.default }]}>Filter metrics</Text>
+
+          <ScrollView style={styles.sheetScroll} contentContainerStyle={styles.sheetScrollContent}>
+            {optionsByCategory.map(({ category, names }) => (
+              <View key={category} style={styles.categorySection}>
+                <Text style={[styles.categoryHeader, { color: theme.text.tertiary }]}>
+                  {capitalize(category).toUpperCase()}
+                </Text>
+                {names.map((name) => {
+                  const checked = selected.has(name);
+                  return (
+                    <Pressable
+                      key={name}
+                      onPress={() => toggle(name, !checked)}
+                      style={({ pressed }) => [styles.checkRow, pressed && { opacity: 0.6 }]}>
+                      <Ionicons
+                        name={checked ? 'checkbox' : 'square-outline'}
+                        size={22}
+                        color={checked ? theme.button.primary.background : theme.text.tertiary}
+                      />
+                      <Text style={[styles.checkLabel, { color: theme.text.default }]}>{name}</Text>
+                    </Pressable>
+                  );
+                })}
+              </View>
+            ))}
+          </ScrollView>
+
+          <View style={[styles.footer, { borderTopColor: theme.border.default }]}>
+            <Pressable
+              onPress={() => onChange(new Set())}
+              style={({ pressed }) => [styles.footerLink, pressed && { opacity: 0.6 }]}>
+              <Text style={[styles.footerLinkLabel, { color: theme.text.default }]}>Clear</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => onChange(new Set(allNames))}
+              style={({ pressed }) => [styles.footerLink, pressed && { opacity: 0.6 }]}>
+              <Text style={[styles.footerLinkLabel, { color: theme.text.default }]}>Select all</Text>
+            </Pressable>
+          </View>
+        </BottomSheetView>
+      </BottomSheetModal>
+    </View>
+  );
+}
+
+function buildOptionsByCategory(metrics: Metric[]): { category: string; names: string[] }[] {
+  const map = new Map<string, Set<string>>();
+  for (const metric of metrics) {
+    let set = map.get(metric.category);
+    if (!set) {
+      set = new Set<string>();
+      map.set(metric.category, set);
+    }
+    set.add(metric.name);
+  }
+  return Array.from(map.entries())
+    .map(([category, names]) => ({ category, names: Array.from(names) }))
+    .sort(
+      (a, b) =>
+        categoryRank(a.category) - categoryRank(b.category) || a.category.localeCompare(b.category)
+    );
+}
+
+const styles = StyleSheet.create({
+  pill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    borderRadius: 8,
+    borderWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    marginBottom: 12,
+  },
+  pillLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  sheetContent: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingTop: 8,
+    paddingBottom: 20,
+  },
+  sheetTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  sheetScroll: {
+    flex: 1,
+  },
+  sheetScrollContent: {
+    paddingBottom: 16,
+  },
+  categorySection: {
+    marginBottom: 16,
+  },
+  categoryHeader: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.5,
+    marginBottom: 6,
+  },
+  checkRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+    paddingVertical: 8,
+  },
+  checkLabel: {
+    fontSize: 15,
+    flexShrink: 1,
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    borderTopWidth: 1,
+    paddingTop: 12,
+  },
+  footerLink: {
+    paddingVertical: 6,
+    paddingHorizontal: 4,
+  },
+  footerLinkLabel: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});

--- a/apps/observe-tester/components/MetricsPanel.tsx
+++ b/apps/observe-tester/components/MetricsPanel.tsx
@@ -2,15 +2,26 @@ import type { Metric } from 'expo-app-metrics';
 import { StyleSheet, Text, View } from 'react-native';
 
 import { JSONView } from '@/components/JSONView';
+import { capitalize, categoryRank } from '@/utils/metricCategories';
 import { useTheme } from '@/utils/theme';
 
-export function MetricsPanel({ metrics }: { metrics: Metric[] }) {
+type MetricsPanelProps = {
+  metrics: Metric[];
+  /**
+   * When provided, only metrics whose `name` is in the set are rendered. An empty set hides everything
+   * and falls through to the standard "No metrics recorded" empty state.
+   */
+  filter?: ReadonlySet<string>;
+};
+
+export function MetricsPanel({ metrics, filter }: MetricsPanelProps) {
   const theme = useTheme();
-  if (metrics.length === 0) {
+  const visibleMetrics = filter ? metrics.filter((metric) => filter.has(metric.name)) : metrics;
+  if (visibleMetrics.length === 0) {
     return <Text style={[styles.empty, { color: theme.text.secondary }]}>No metrics recorded</Text>;
   }
 
-  const groups = groupByCategory(metrics);
+  const groups = groupByCategory(visibleMetrics);
 
   return (
     <View style={styles.container}>
@@ -81,9 +92,6 @@ export function MetricsPanel({ metrics }: { metrics: Metric[] }) {
   );
 }
 
-// Categories rendered in this order; anything else falls in alphabetically afterward.
-const CATEGORY_ORDER = ['appStartup', 'frameRate', 'memory', 'updates', 'session'];
-
 function groupByCategory(metrics: Metric[]) {
   const map = new Map<string, Metric[]>();
   for (const metric of metrics) {
@@ -102,20 +110,11 @@ function groupByCategory(metrics: Metric[]) {
     );
 }
 
-function categoryRank(category: string) {
-  const index = CATEGORY_ORDER.indexOf(category);
-  return index === -1 ? CATEGORY_ORDER.length : index;
-}
-
 function formatValue(value: number) {
   if (Number.isInteger(value)) {
     return value.toString();
   }
   return value.toFixed(3);
-}
-
-function capitalize(value: string) {
-  return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 const styles = StyleSheet.create({

--- a/apps/observe-tester/package.json
+++ b/apps/observe-tester/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@expo/html-elements": "workspace:*",
     "@expo/styleguide-base": "^1.0.1",
+    "@expo/ui": "workspace:*",
     "@expo/vector-icons": "^15.0.2",
     "@react-navigation/bottom-tabs": "^7.15.5",
     "@react-navigation/native": "^7.1.33",

--- a/apps/observe-tester/utils/metricCategories.ts
+++ b/apps/observe-tester/utils/metricCategories.ts
@@ -1,0 +1,11 @@
+// Categories rendered in this order; anything else falls in alphabetically afterward.
+export const CATEGORY_ORDER = ['appStartup', 'frameRate', 'memory', 'updates', 'session'];
+
+export function categoryRank(category: string) {
+  const index = CATEGORY_ORDER.indexOf(category);
+  return index === -1 ? CATEGORY_ORDER.length : index;
+}
+
+export function capitalize(value: string) {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1334,6 +1334,9 @@ importers:
       '@expo/styleguide-base':
         specifier: ^1.0.1
         version: 1.0.1(react@19.2.3)
+      '@expo/ui':
+        specifier: workspace:*
+        version: link:../../packages/expo-ui
       '@expo/vector-icons':
         specifier: ^15.0.2
         version: 15.1.1(expo-font@packages+expo-font)(react-native@0.85.3(@babel/core@7.29.0)(@react-native/jest-preset@0.85.3(@babel/core@7.29.0)(react@19.2.3))(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)


### PR DESCRIPTION
# Why

Adding metric type filter to see only selected metric types. It's useful for testing specific metrics

# How

Add bottom sheet filter

# Test Plan

<img height="512" alt="Simulator Screenshot - iPhone 16 Pro (iOS 18) - 2026-05-20 at 10 55 13" src="https://github.com/user-attachments/assets/c1d0f029-ab82-42dc-be81-a6f89ed35963" />
<img height="512" alt="Simulator Screenshot - iPhone 16 Pro (iOS 18) - 2026-05-20 at 10 55 09" src="https://github.com/user-attachments/assets/b0700335-883d-470f-bdb2-89d83fc9bda1" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
