### PR TITLE
Fix environment variable name for iOS prebuilt modules

### DIFF
--- a/docs/pages/guides/prebuilt-expo-modules.mdx
+++ b/docs/pages/guides/prebuilt-expo-modules.mdx
@@ -11,16 +11,16 @@ Native build times can slow down your development workflow. Expo provides prebui
 **Most projects don't need to do anything** — prebuilt Expo Modules are enabled automatically in new and existing projects with a supported SDK version.
 
 - **Android**: enabled by default since SDK 53.
-- **iOS**: enabled by default in SDK 56+. In SDK 55, enabled by default only on EAS Build — set `EXPO_USE_PRECOMPILED_MODULES=1` in your shell to opt in for local builds.
+- **iOS**: enabled by default in SDK 56+. In SDK 55, enabled by default only on EAS Build — set `EAS_USE_PRECOMPILED_MODULES=1` in your shell to opt in for local builds.
 
 <Collapsible summary="Disabling on iOS">
 
-Set `EXPO_USE_PRECOMPILED_MODULES` to `0`. For local builds, export the env var in your shell.
+Set `EAS_USE_PRECOMPILED_MODULES` to `0`. For local builds, export the env var in your shell.
 
 For EAS Build, create an [EAS environment variable](/eas/environment-variables/manage/):
 
 <Terminal
-  cmd={['$ eas env:create --name EXPO_USE_PRECOMPILED_MODULES --value 0 --visibility plaintext']}
+  cmd={['$ eas env:create --name EAS_USE_PRECOMPILED_MODULES --value 0 --visibility plaintext']}
 />
 
 The CLI will prompt you to select which environment(s) (`development`, `preview`, `production`) the variable applies to.


### PR DESCRIPTION
Align the env variable name with what is set in the EAS environment

# Why

In our project, we had to disable precompiled modules due to a build-time issue related to `react-native-webview` and `@datadog/mobile-react-native-webview`:

<img width="1256" height="60" alt="image" src="https://github.com/user-attachments/assets/f0af0cc2-4139-4064-98f7-941c3c866fb0" />

We noticed that the only difference between the successful and failed builds is the following environment variable:

```bash
EAS_USE_PRECOMPILED_MODULES=1
```

# How

Change the environment variable name in the documentation and examples.

# Test Plan

Set the EAS environment variable and run the build on EAS machines.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
