### PR TITLE
[audio] Support lockscreen controls with playlists.

### DIFF
--- a/apps/native-component-list/src/screens/Audio/AudioControlsScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioControlsScreen.tsx
@@ -35,6 +35,8 @@ enum LockScreenButton {
 }
 
 export default function AudioControlsScreen(props: any) {
+  const [activeLockScreenPlayer, setActiveLockScreenPlayer] = useState<string | null>(null);
+
   React.useLayoutEffect(() => {
     AudioModule.setAudioModeAsync({
       shouldPlayInBackground: true,
@@ -53,24 +55,72 @@ export default function AudioControlsScreen(props: any) {
     <ScrollView contentContainerStyle={styles.contentContainer}>
       <HeadingText>Lock Screen controls</HeadingText>
 
-      <HeadingText>Local Source</HeadingText>
-      <AudioPlayer source={localSource} />
+      <AudioPlayer
+        title="Local Source"
+        source={localSource}
+        activeLockScreenPlayer={activeLockScreenPlayer}
+        setActiveLockScreenPlayer={setActiveLockScreenPlayer}
+      />
 
-      <HeadingText>Remote Source</HeadingText>
-      <AudioPlayer source={remoteSource} />
+      <AudioPlayer
+        title="Remote Source"
+        source={remoteSource}
+        activeLockScreenPlayer={activeLockScreenPlayer}
+        setActiveLockScreenPlayer={setActiveLockScreenPlayer}
+      />
 
-      <HeadingText>Live Stream (HLS)</HeadingText>
-      <AudioPlayer source={liveStreamSource} />
+      <AudioPlayer
+        title="Live Stream (HLS)"
+        source={liveStreamSource}
+        activeLockScreenPlayer={activeLockScreenPlayer}
+        setActiveLockScreenPlayer={setActiveLockScreenPlayer}
+      />
     </ScrollView>
   );
 }
 
-function AudioPlayer({ source }: { source: AudioSource | string | number }) {
+function AudioPlayer({
+  title,
+  source,
+  activeLockScreenPlayer,
+  setActiveLockScreenPlayer,
+}: {
+  title: string;
+  source: AudioSource | string | number;
+  activeLockScreenPlayer: string | null;
+  setActiveLockScreenPlayer: (player: string | null) => void;
+}) {
   const player = useAudioPlayer(source);
   const status = useAudioPlayerStatus(player);
-  const [enabled, setEnabled] = useState(false);
   const [metadata, setMetadata] = useState<1 | 2>(1);
   const [options, setOptions] = useState<AudioLockScreenOptions>();
+  const isActiveForLockScreen = activeLockScreenPlayer === title;
+
+  const getMetadata = (preset: 1 | 2) => {
+    return preset === 1
+      ? {
+          title: 'Test',
+          artist: 'Test artist',
+          artworkUrl: artworkUrl1,
+        }
+      : {
+          title: 'Test 2',
+          artist: 'Test artist 2',
+          artworkUrl: artworkUrl2,
+        };
+  };
+
+  const setLockScreenOptions = (
+    updater: (options?: AudioLockScreenOptions) => AudioLockScreenOptions
+  ) => {
+    setOptions((currentOptions) => {
+      const nextOptions = updater(currentOptions);
+      if (isActiveForLockScreen) {
+        player.setActiveForLockScreen(true, getMetadata(metadata), nextOptions);
+      }
+      return nextOptions;
+    });
+  };
 
   const setIsMuted = (isMuted: boolean) => {
     player.muted = isMuted;
@@ -92,16 +142,17 @@ function AudioPlayer({ source }: { source: AudioSource | string | number }) {
   const toggleButton = (button: LockScreenButton) => {
     switch (button) {
       case LockScreenButton.SEEK_FORWARD:
-        setOptions((o) => ({ ...o, showSeekForward: !o?.showSeekForward }));
+        setLockScreenOptions((o) => ({ ...o, showSeekForward: !o?.showSeekForward }));
         break;
       case LockScreenButton.SEEK_BACKWARD:
-        setOptions((o) => ({ ...o, showSeekBackward: !o?.showSeekBackward }));
+        setLockScreenOptions((o) => ({ ...o, showSeekBackward: !o?.showSeekBackward }));
         break;
     }
   };
 
   return (
     <View>
+      <HeadingText>{title}</HeadingText>
       <Player
         {...status}
         isLive={status.isLive}
@@ -123,20 +174,16 @@ function AudioPlayer({ source }: { source: AudioSource | string | number }) {
       />
       <View style={styles.btnContainer}>
         <Button
-          title={`${enabled ? 'Disable' : 'Enable'} Lock Screen controls`}
+          title={`${isActiveForLockScreen ? 'Disable' : 'Enable'} Lock Screen controls`}
           onPress={() => {
-            player.setActiveForLockScreen(
-              !enabled,
-              {
-                title: 'Test',
-                artist: 'Test artist',
-                artworkUrl: artworkUrl1,
-              },
-              options
-            );
-            setEnabled((e) => !e);
+            const nextActive = !isActiveForLockScreen;
+            player.setActiveForLockScreen(nextActive, getMetadata(metadata), options);
+            setActiveLockScreenPlayer(nextActive ? title : null);
           }}
         />
+        <Text style={styles.statusText}>
+          lock screen: {isActiveForLockScreen ? 'active' : 'inactive'}
+        </Text>
         <BodyText>Lock screen buttons:</BodyText>
         <View style={styles.optionRow}>
           <Checkbox
@@ -155,7 +202,9 @@ function AudioPlayer({ source }: { source: AudioSource | string | number }) {
         <View style={styles.optionRow}>
           <Checkbox
             value={options?.isLiveStream ?? false}
-            onValueChange={() => setOptions((o) => ({ ...o, isLiveStream: !o?.isLiveStream }))}
+            onValueChange={() =>
+              setLockScreenOptions((o) => ({ ...o, isLiveStream: !o?.isLiveStream }))
+            }
           />
           <BodyText style={styles.optionsText}>Force live stream</BodyText>
         </View>
@@ -170,23 +219,12 @@ function AudioPlayer({ source }: { source: AudioSource | string | number }) {
           <Text style={styles.statusText}>error: {status.error ?? 'null'}</Text>
         </View>
         <Button
-          title="Update Metadata"
+          title={`Update Metadata (${metadata === 1 ? 'Test 2' : 'Test'})`}
+          disabled={!isActiveForLockScreen}
           onPress={() => {
-            if (metadata === 1) {
-              player.updateLockScreenMetadata({
-                title: 'Test 2',
-                artist: 'Test artist 2',
-                artworkUrl: artworkUrl2,
-              });
-              setMetadata(2);
-            } else {
-              player.updateLockScreenMetadata({
-                title: 'Test',
-                artist: 'Test artist',
-                artworkUrl: artworkUrl1,
-              });
-              setMetadata(1);
-            }
+            const nextMetadata = metadata === 1 ? 2 : 1;
+            player.updateLockScreenMetadata(getMetadata(nextMetadata));
+            setMetadata(nextMetadata);
           }}
         />
       </View>

--- a/apps/native-component-list/src/screens/Audio/AudioPlaylistScreen.tsx
+++ b/apps/native-component-list/src/screens/Audio/AudioPlaylistScreen.tsx
@@ -1,5 +1,11 @@
-import { AudioSource, useAudioPlaylist, useAudioPlaylistStatus } from 'expo-audio';
-import React, { useState } from 'react';
+import {
+  AudioLockScreenOptions,
+  AudioSource,
+  setAudioModeAsync,
+  useAudioPlaylist,
+  useAudioPlaylistStatus,
+} from 'expo-audio';
+import React, { useCallback, useEffect, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, Pressable } from 'react-native';
 
 import { BodyText } from '../../components/BodyText';
@@ -21,6 +27,11 @@ const INITIAL_SOURCES: AudioSource[] = [
 const ADDITIONAL_SOURCES: AudioSource[] = [
   { uri: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3', name: 'Song 4' },
   { uri: 'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-5.mp3', name: 'Song 5' },
+];
+
+const ARTWORK_URLS = [
+  'https://images.unsplash.com/photo-1549138144-42ff3cdd2bf8?q=80&w=3504&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+  'https://images.unsplash.com/photo-1549228167-511375f69159?q=80&w=3676&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
 ];
 
 function getTrackName(uri: string): string {
@@ -56,6 +67,13 @@ function Button({
 
 export default function AudioPlaylistScreen() {
   const [addTrackIndex, setAddTrackIndex] = useState(0);
+  const [lockScreenEnabled, setLockScreenEnabled] = useState(false);
+  const [lockScreenOptions, setLockScreenOptions] = useState<AudioLockScreenOptions>({
+    showNextTrack: true,
+    showPreviousTrack: true,
+    showSeekBackward: false,
+    showSeekForward: false,
+  });
 
   const playlist = useAudioPlaylist({
     sources: INITIAL_SOURCES,
@@ -70,6 +88,33 @@ export default function AudioPlaylistScreen() {
     ? (currentSource.name ?? getTrackName(currentSource.uri ?? ''))
     : 'No track';
 
+  useEffect(() => {
+    setAudioModeAsync({
+      shouldPlayInBackground: true,
+      interruptionMode: 'doNotMix',
+      playsInSilentMode: true,
+      allowsRecording: false,
+    }).catch((error: unknown) =>
+      console.warn(`Error calling setAudioModeAsync: ${JSON.stringify(error)}`)
+    );
+  }, []);
+
+  const getLockScreenMetadata = useCallback(
+    () => ({
+      title: currentTrackName,
+      artist: 'Expo Audio Playlist',
+      albumTitle: `Track ${status.currentIndex + 1} of ${status.trackCount}`,
+      artworkUrl: ARTWORK_URLS[status.currentIndex % ARTWORK_URLS.length],
+    }),
+    [currentTrackName, status.currentIndex, status.trackCount]
+  );
+
+  useEffect(() => {
+    if (lockScreenEnabled) {
+      playlist.updateLockScreenMetadata(getLockScreenMetadata());
+    }
+  }, [getLockScreenMetadata, lockScreenEnabled, playlist]);
+
   const handleAddTrack = () => {
     const sourceToAdd = ADDITIONAL_SOURCES[addTrackIndex % ADDITIONAL_SOURCES.length];
     playlist.add(sourceToAdd);
@@ -77,7 +122,35 @@ export default function AudioPlaylistScreen() {
   };
 
   const handleClear = () => {
+    if (lockScreenEnabled) {
+      playlist.clearLockScreenControls();
+      setLockScreenEnabled(false);
+    }
     playlist.clear();
+  };
+
+  const toggleLockScreenControls = () => {
+    if (lockScreenEnabled) {
+      playlist.clearLockScreenControls();
+      setLockScreenEnabled(false);
+    } else {
+      playlist.setActiveForLockScreen(true, getLockScreenMetadata(), lockScreenOptions);
+      setLockScreenEnabled(true);
+    }
+  };
+
+  const updateLockScreenOptions = (nextOptions: AudioLockScreenOptions) => {
+    setLockScreenOptions(nextOptions);
+    if (lockScreenEnabled) {
+      playlist.setActiveForLockScreen(true, getLockScreenMetadata(), nextOptions);
+    }
+  };
+
+  const toggleLockScreenOption = (key: keyof AudioLockScreenOptions) => {
+    updateLockScreenOptions({
+      ...lockScreenOptions,
+      [key]: !lockScreenOptions[key],
+    });
   };
 
   return (
@@ -201,6 +274,45 @@ export default function AudioPlaylistScreen() {
       <View style={styles.controls}>
         <Button title="Add Track" onPress={handleAddTrack} />
         <Button title="Clear" onPress={handleClear} />
+      </View>
+
+      <HeadingText>Lock Screen Controls</HeadingText>
+      <View style={styles.lockScreenContainer}>
+        <Button
+          title={`${lockScreenEnabled ? 'Disable' : 'Enable'} Controls`}
+          onPress={toggleLockScreenControls}
+          disabled={sources.length === 0}
+        />
+        <Button
+          title="Update Metadata"
+          onPress={() => playlist.updateLockScreenMetadata(getLockScreenMetadata())}
+          disabled={!lockScreenEnabled}
+        />
+        <View style={styles.lockScreenOptions}>
+          <Button
+            title={`Back ${lockScreenOptions.showSeekBackward ? 'On' : 'Off'}`}
+            onPress={() => toggleLockScreenOption('showSeekBackward')}
+          />
+          <Button
+            title={`Forward ${lockScreenOptions.showSeekForward ? 'On' : 'Off'}`}
+            onPress={() => toggleLockScreenOption('showSeekForward')}
+          />
+          <Button
+            title={`Prev Track ${lockScreenOptions.showPreviousTrack ? 'On' : 'Off'}`}
+            onPress={() => toggleLockScreenOption('showPreviousTrack')}
+          />
+          <Button
+            title={`Next Track ${lockScreenOptions.showNextTrack ? 'On' : 'Off'}`}
+            onPress={() => toggleLockScreenOption('showNextTrack')}
+          />
+          <Button
+            title={`Live ${lockScreenOptions.isLiveStream ? 'On' : 'Off'}`}
+            onPress={() => toggleLockScreenOption('isLiveStream')}
+          />
+        </View>
+        <BodyText color="secondary" style={styles.lockScreenStatus}>
+          {lockScreenEnabled ? 'Playlist is active for lock screen controls' : 'Controls disabled'}
+        </BodyText>
       </View>
     </ScrollView>
   );
@@ -327,5 +439,19 @@ const styles = StyleSheet.create({
   statusValue: {
     fontSize: 14,
     fontWeight: '600',
+  },
+  lockScreenContainer: {
+    gap: 10,
+    marginBottom: 20,
+  },
+  lockScreenOptions: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 12,
+  },
+  lockScreenStatus: {
+    textAlign: 'center',
+    fontSize: 12,
   },
 });

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### 🎉 New features
 
 - Added support for storing recordings in the app document directory on Android and iOS. ([#46189](https://github.com/expo/expo/pull/46189) by [@shubh73](https://github.com/shubh73))
+- Support lockscreen controls with playlists. ([#46020](https://github.com/expo/expo/pull/46020) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioModule.kt
@@ -65,6 +65,12 @@ class AudioModule : Module() {
   private val allPlayables: Sequence<Playable>
     get() = players.values.asSequence() + playlists.values.asSequence()
 
+  private val allLockScreenPlayables: Sequence<LockScreenPlayable>
+    get() = sequence {
+      yieldAll(players.values)
+      yieldAll(playlists.values)
+    }
+
   private val ringerModeReceiver = RingerModeReceiver {
     if (playsInSilentMode) return@RingerModeReceiver
     appContext.mainQueue.launch {
@@ -235,9 +241,9 @@ class AudioModule : Module() {
         recorder.useForegroundService = allowsBackgroundRecording
       }
 
-      players.values.forEach { player ->
-        player.serviceConnection.playsInSilentMode = playsInSilentMode
-        player.serviceConnection.playbackServiceBinder?.service?.playsInSilentMode = playsInSilentMode
+      allLockScreenPlayables.forEach { playable ->
+        playable.serviceConnection.playsInSilentMode = playsInSilentMode
+        playable.serviceConnection.playbackServiceBinder?.service?.playsInSilentMode = playsInSilentMode
       }
 
       if (!shouldPlayInSilentMode()) {
@@ -868,7 +874,28 @@ class AudioModule : Module() {
         }
       }
 
+      Function("setActiveForLockScreen") { ref: AudioPlaylist, active: Boolean, metadata: Metadata?, options: AudioLockScreenOptions? ->
+        runOnMain {
+          ref.setActiveForLockScreen(active, metadata, options)
+        }
+      }
+
+      Function("updateLockScreenMetadata") { ref: AudioPlaylist, metadata: Metadata ->
+        runOnMain {
+          ref.updateLockScreenMetadata(metadata)
+        }
+      }
+
+      Function("clearLockScreenControls") { ref: AudioPlaylist ->
+        runOnMain {
+          ref.clearLockScreenControls()
+        }
+      }
+
       Function("destroy") { playlist: AudioPlaylist ->
+        runOnMain {
+          playlist.clearLockScreenControls()
+        }
         playlists.remove(playlist.id)
       }
     }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlayer.kt
@@ -17,7 +17,6 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.session.MediaSession
 import expo.modules.audio.service.AudioPlaybackServiceConnection
-import expo.modules.audio.service.ServiceBindingState
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.exception.Exceptions
 import java.lang.ref.WeakReference
@@ -57,17 +56,18 @@ class AudioPlayer(
   appContext = appContext,
   updateInterval = updateInterval,
   statusEventName = PLAYBACK_STATUS_UPDATE
-) {
+),
+  LockScreenPlayable {
   var preservesPitch = true
 
   // Lock screen controls
-  var isActiveForLockScreen = false
-  internal var metadata: Metadata? = null
-  internal var lockScreenOptions: AudioLockScreenOptions? = null
-  internal var mediaSession: MediaSession = buildBasicMediaSession(context, ref)
-  val serviceConnection = AudioPlaybackServiceConnection(WeakReference(this), appContext)
+  override var isActiveForLockScreen = false
+  override var metadata: Metadata? = null
+  override var lockScreenOptions: AudioLockScreenOptions? = null
+  override var mediaSession: MediaSession = buildBasicMediaSession(context, ref)
+  override val serviceConnection = AudioPlaybackServiceConnection(WeakReference(this), appContext)
 
-  val isLive: Boolean
+  override val isLive: Boolean
     get() = ref.isCurrentMediaItemLive
 
   val currentOffsetFromLive: Double?
@@ -95,53 +95,6 @@ class AudioPlayer(
     ref.setMediaSource(source)
     ref.prepare()
     startUpdating()
-  }
-
-  fun setActiveForLockScreen(active: Boolean, metadata: Metadata? = null, options: AudioLockScreenOptions? = null) {
-    if (active) {
-      this.metadata = metadata
-      this.lockScreenOptions = options
-      this.isActiveForLockScreen = true
-
-      if (serviceConnection.bindingState == ServiceBindingState.UNBOUND) {
-        serviceConnection.bindWithService()
-      }
-
-      val serviceBinder = serviceConnection.playbackServiceBinder
-      if (serviceBinder != null && serviceConnection.bindingState == ServiceBindingState.BOUND) {
-        serviceBinder.service.setPlayerOptions(this, metadata, options)
-      } else if (serviceConnection.bindingState == ServiceBindingState.BINDING) {
-        // The settings will be applied when the service connects
-      } else {
-        appContext?.jsLogger?.error(
-          getPlaybackServiceErrorMessage("Failed to activate lock screen controls - service binding failed")
-        )
-      }
-    } else if (isActiveForLockScreen) {
-      this.isActiveForLockScreen = false
-      serviceConnection.playbackServiceBinder?.service?.unregisterPlayer()
-    }
-  }
-
-  fun updateLockScreenMetadata(metadata: Metadata) {
-    if (isActiveForLockScreen) {
-      this.metadata = metadata
-
-      val serviceBinder = serviceConnection.playbackServiceBinder
-      if (serviceBinder != null && serviceConnection.bindingState == ServiceBindingState.BOUND) {
-        serviceBinder.service.setPlayerMetadata(this, metadata)
-      } else {
-        appContext?.jsLogger?.warn(
-          getPlaybackServiceErrorMessage("Cannot update lock screen metadata - service not connected")
-        )
-      }
-    }
-  }
-
-  fun clearLockScreenControls() {
-    if (isActiveForLockScreen) {
-      serviceConnection.playbackServiceBinder?.service?.unregisterPlayer()
-    }
   }
 
   override fun onPlaybackStateUpdated(playbackState: Int, justFinished: Boolean) {
@@ -219,7 +172,7 @@ class AudioPlayer(
     )
   }
 
-  internal fun assignBasicMediaSession() {
+  override fun assignBasicMediaSession() {
     mediaSession.release()
     mediaSession = buildBasicMediaSession(context, ref)
   }
@@ -279,7 +232,7 @@ class AudioPlayer(
   override fun releasePlayer() {
     mediaSession.release()
     if (isActiveForLockScreen) {
-      serviceConnection.playbackServiceBinder?.service?.unregisterPlayer()
+      serviceConnection.playbackServiceBinder?.service?.unregisterPlayable()
     }
     serviceConnection.unbind()
     visualizer?.release()

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlaylist.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioPlaylist.kt
@@ -9,7 +9,10 @@ import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.datasource.DataSource
+import androidx.media3.session.MediaSession
+import expo.modules.audio.service.AudioPlaybackServiceConnection
 import expo.modules.kotlin.AppContext
+import java.lang.ref.WeakReference
 
 private const val PLAYLIST_STATUS_UPDATE = "playlistStatusUpdate"
 private const val TRACK_CHANGED = "trackChanged"
@@ -30,10 +33,19 @@ class AudioPlaylist(
   appContext = appContext,
   updateInterval = updateInterval,
   statusEventName = PLAYLIST_STATUS_UPDATE
-) {
+),
+  LockScreenPlayable {
   private var sources: MutableList<AudioSource> = initialSources.toMutableList()
   private var currentRate = 1f
   private var previousMediaItemIndex = 0
+
+  override var isActiveForLockScreen = false
+  override var metadata: Metadata? = null
+  override var lockScreenOptions: AudioLockScreenOptions? = null
+  override var mediaSession: MediaSession = buildBasicMediaSession(context, ref)
+  override val serviceConnection = AudioPlaybackServiceConnection(WeakReference(this), appContext)
+  override val supportsNextTrack = true
+  override val supportsPreviousTrack = true
 
   val currentTrackIndex get() = ref.currentMediaItemIndex
   val trackCount get() = ref.mediaItemCount
@@ -120,6 +132,14 @@ class AudioPlaylist(
     }
   }
 
+  override fun nextTrack() {
+    next()
+  }
+
+  override fun previousTrack() {
+    previous()
+  }
+
   fun skipTo(index: Int) {
     if (index !in 0..<trackCount) return
     ref.seekToDefaultPosition(index)
@@ -169,6 +189,11 @@ class AudioPlaylist(
     ref.setPlaybackSpeed(boundedRate)
   }
 
+  override fun assignBasicMediaSession() {
+    mediaSession.release()
+    mediaSession = buildBasicMediaSession(appContext?.reactContext ?: return, ref)
+  }
+
   override fun currentStatus(): Map<String, Any?> {
     val isMuted = ref.volume == 0f
     val isLoaded = ref.playbackState == Player.STATE_READY
@@ -201,5 +226,15 @@ class AudioPlaylist(
       )
     )
     sendStatusUpdate()
+  }
+
+  override fun releasePlayer() {
+    serviceConnection.release()
+    mediaSession.release()
+    if (isActiveForLockScreen) {
+      serviceConnection.playbackServiceBinder?.service?.unregisterPlayable()
+    }
+    serviceConnection.unbind()
+    super.releasePlayer()
   }
 }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioRecords.kt
@@ -110,6 +110,8 @@ enum class AndroidAudioEncoder(val value: String) : Enumerable {
 class AudioLockScreenOptions(
   @Field val showSeekForward: Boolean,
   @Field val showSeekBackward: Boolean,
+  @Field val showNextTrack: Boolean = false,
+  @Field val showPreviousTrack: Boolean = false,
   @Field val isLiveStream: Boolean? = null
 ) : Record
 

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioUtils.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/AudioUtils.kt
@@ -3,7 +3,7 @@ package expo.modules.audio
 import android.content.Context
 import android.media.AudioDeviceInfo
 import android.os.Bundle
-import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.common.Player
 import androidx.media3.session.MediaSession
 import java.io.File
 import java.io.IOException
@@ -31,7 +31,7 @@ fun getMapFromDeviceInfo(deviceInfo: AudioDeviceInfo): Bundle {
   return map
 }
 
-fun buildBasicMediaSession(context: Context, player: ExoPlayer): MediaSession {
+fun buildBasicMediaSession(context: Context, player: Player): MediaSession {
   return MediaSession.Builder(context, player)
     .setId("ExpoAudioBasicMediaSession_${player.hashCode()}")
     .build()

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/LockScreenPlayable.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/LockScreenPlayable.kt
@@ -1,0 +1,78 @@
+package expo.modules.audio
+
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.MediaSession
+import expo.modules.audio.service.AudioPlaybackServiceConnection
+import expo.modules.audio.service.ServiceBindingState
+
+@OptIn(UnstableApi::class)
+interface LockScreenPlayable : Playable {
+  var isActiveForLockScreen: Boolean
+  var metadata: Metadata?
+  var lockScreenOptions: AudioLockScreenOptions?
+  var mediaSession: MediaSession
+  val serviceConnection: AudioPlaybackServiceConnection
+  val isLive: Boolean
+    get() = player.isCurrentMediaItemLive
+  val supportsNextTrack: Boolean
+    get() = false
+  val supportsPreviousTrack: Boolean
+    get() = false
+
+  fun assignBasicMediaSession()
+
+  fun nextTrack() = Unit
+
+  fun previousTrack() = Unit
+
+  fun setActiveForLockScreen(
+    active: Boolean,
+    metadata: Metadata? = null,
+    options: AudioLockScreenOptions? = null
+  ) {
+    if (active) {
+      this.metadata = metadata
+      this.lockScreenOptions = options
+      this.isActiveForLockScreen = true
+
+      if (serviceConnection.bindingState == ServiceBindingState.UNBOUND) {
+        serviceConnection.bindWithService()
+      }
+
+      val serviceBinder = serviceConnection.playbackServiceBinder
+      if (serviceBinder != null && serviceConnection.bindingState == ServiceBindingState.BOUND) {
+        serviceBinder.service.setPlayableOptions(this, metadata, options)
+      } else if (serviceConnection.bindingState != ServiceBindingState.BINDING) {
+        appContext?.jsLogger?.error(
+          getPlaybackServiceErrorMessage("Failed to activate lock screen controls - service binding failed")
+        )
+      }
+    } else if (isActiveForLockScreen) {
+      this.isActiveForLockScreen = false
+      serviceConnection.playbackServiceBinder?.service?.unregisterPlayable()
+    }
+  }
+
+  fun updateLockScreenMetadata(metadata: Metadata) {
+    if (isActiveForLockScreen) {
+      this.metadata = metadata
+
+      val serviceBinder = serviceConnection.playbackServiceBinder
+      if (serviceBinder != null && serviceConnection.bindingState == ServiceBindingState.BOUND) {
+        serviceBinder.service.setPlayableMetadata(this, metadata)
+      } else {
+        appContext?.jsLogger?.warn(
+          getPlaybackServiceErrorMessage("Cannot update lock screen metadata - service not connected")
+        )
+      }
+    }
+  }
+
+  fun clearLockScreenControls() {
+    if (isActiveForLockScreen) {
+      isActiveForLockScreen = false
+      serviceConnection.playbackServiceBinder?.service?.unregisterPlayable()
+    }
+  }
+}

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -24,7 +24,7 @@ import androidx.media3.session.MediaSessionService
 import androidx.media3.session.MediaStyleNotificationHelper
 import androidx.media3.session.SessionCommand
 import expo.modules.audio.AudioLockScreenOptions
-import expo.modules.audio.AudioPlayer
+import expo.modules.audio.LockScreenPlayable
 import expo.modules.audio.Metadata
 import expo.modules.audio.getPlaybackServiceErrorMessage
 import expo.modules.kotlin.AppContext
@@ -44,14 +44,14 @@ class AudioControlsService : MediaSessionService() {
   private var mediaSession: MediaSession? = null
   private var sessionMetadataPlayer: MetadataInjectingPlayer? = null
   private var currentMetadata: Metadata? = null
-  private var currentPlayer: AudioPlayer? = null
+  private var currentPlayable: LockScreenPlayable? = null
   private var currentOptions: AudioLockScreenOptions? = null
   private val scope = CoroutineScope(Dispatchers.IO)
   private var currentArtworkUrl: URL? = null
   private var currentArtwork: Bitmap? = null
   private var artworkLoadJob: Job? = null
   private val notificationId: Int
-    get() = currentPlayer?.hashCode() ?: CHANNEL_ID.hashCode()
+    get() = currentPlayable?.hashCode() ?: CHANNEL_ID.hashCode()
 
   private var weakContext: WeakReference<AppContext>? = null
   var appContext: AppContext?
@@ -66,9 +66,9 @@ class AudioControlsService : MediaSessionService() {
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
     ensureForegroundNotification()
 
-    val currentPlayerRef = currentPlayer?.ref
+    val currentPlayer = currentPlayable?.player
     val context = appContext
-    if (currentPlayerRef == null || context == null) {
+    if (currentPlayer == null || context == null) {
       stopForeground(STOP_FOREGROUND_REMOVE)
       return super.onStartCommand(intent, flags, startId)
     }
@@ -77,19 +77,21 @@ class AudioControlsService : MediaSessionService() {
       when (intent?.action) {
         ACTION_PLAY -> {
           if (shouldPlayInSilentMode()) {
-            currentPlayerRef.play()
+            currentPlayer.play()
           }
         }
-        ACTION_PAUSE -> currentPlayerRef.pause()
+        ACTION_PAUSE -> currentPlayer.pause()
         ACTION_TOGGLE ->
-          if (currentPlayerRef.isPlaying) {
-            currentPlayerRef.pause()
+          if (currentPlayer.isPlaying) {
+            currentPlayer.pause()
           } else if (shouldPlayInSilentMode()) {
-            currentPlayerRef.play()
+            currentPlayer.play()
           }
 
-        ACTION_SEEK_FORWARD -> currentPlayerRef.seekTo(currentPlayerRef.currentPosition + SEEK_INTERVAL_MS)
-        ACTION_SEEK_BACKWARD -> currentPlayerRef.seekTo(currentPlayerRef.currentPosition - SEEK_INTERVAL_MS)
+        ACTION_SEEK_FORWARD -> seekForward()
+        ACTION_SEEK_BACKWARD -> seekBackward()
+        ACTION_NEXT_TRACK -> nextTrack()
+        ACTION_PREVIOUS_TRACK -> previousTrack()
       }
     }
 
@@ -192,7 +194,17 @@ class AudioControlsService : MediaSessionService() {
       val compactViewIndices = mutableListOf<Int>()
       var currentIndex = 0
 
-      if (currentOptions?.showSeekBackward == true) {
+      if (currentOptions?.showPreviousTrack == true && currentPlayable?.supportsPreviousTrack == true) {
+        builder.addAction(
+          NotificationCompat.Action(
+            androidx.media3.session.R.drawable.media3_icon_previous,
+            "Previous Track",
+            buildActionPendingIntent(ACTION_PREVIOUS_TRACK)
+          )
+        )
+        compactViewIndices.add(currentIndex)
+        currentIndex++
+      } else if (currentOptions?.showSeekBackward == true) {
         builder.addAction(
           NotificationCompat.Action(
             androidx.media3.session.R.drawable.media3_icon_skip_back,
@@ -218,7 +230,16 @@ class AudioControlsService : MediaSessionService() {
       compactViewIndices.add(currentIndex)
       currentIndex++
 
-      if (currentOptions?.showSeekForward == true) {
+      if (currentOptions?.showNextTrack == true && currentPlayable?.supportsNextTrack == true) {
+        builder.addAction(
+          NotificationCompat.Action(
+            androidx.media3.session.R.drawable.media3_icon_next,
+            "Next Track",
+            buildActionPendingIntent(ACTION_NEXT_TRACK)
+          )
+        )
+        compactViewIndices.add(currentIndex)
+      } else if (currentOptions?.showSeekForward == true) {
         builder.addAction(
           NotificationCompat.Action(
             androidx.media3.session.R.drawable.media3_icon_skip_forward,
@@ -240,8 +261,18 @@ class AudioControlsService : MediaSessionService() {
     val session = mediaSession ?: return
     val mediaButtons = mutableListOf<CommandButton>()
 
-    // Add seek backward button if enabled
-    if (currentOptions?.showSeekBackward == true) {
+    val playable = currentPlayable
+
+    if (currentOptions?.showPreviousTrack == true && playable?.supportsPreviousTrack == true) {
+      mediaButtons.add(
+        CommandButton.Builder(CommandButton.ICON_PREVIOUS)
+          .setDisplayName("Previous Track")
+          .setEnabled(true)
+          .setSessionCommand(SessionCommand(ACTION_PREVIOUS_TRACK, Bundle.EMPTY))
+          .setSlots(CommandButton.SLOT_BACK)
+          .build()
+      )
+    } else if (currentOptions?.showSeekBackward == true) {
       mediaButtons.add(
         CommandButton.Builder(CommandButton.ICON_SKIP_BACK_10)
           .setDisplayName("Seek Backward")
@@ -252,7 +283,6 @@ class AudioControlsService : MediaSessionService() {
       )
     }
 
-    // Add play/pause button (always present)
     mediaButtons.add(
       CommandButton.Builder(if (isPlaying) CommandButton.ICON_PAUSE else CommandButton.ICON_PLAY)
         .setDisplayName(if (isPlaying) "Pause" else "Play")
@@ -262,8 +292,16 @@ class AudioControlsService : MediaSessionService() {
         .build()
     )
 
-    // Add seek forward button if enabled
-    if (currentOptions?.showSeekForward == true) {
+    if (currentOptions?.showNextTrack == true && playable?.supportsNextTrack == true) {
+      mediaButtons.add(
+        CommandButton.Builder(CommandButton.ICON_NEXT)
+          .setDisplayName("Next Track")
+          .setEnabled(true)
+          .setSessionCommand(SessionCommand(ACTION_NEXT_TRACK, Bundle.EMPTY))
+          .setSlots(CommandButton.SLOT_FORWARD)
+          .build()
+      )
+    } else if (currentOptions?.showSeekForward == true) {
       mediaButtons.add(
         CommandButton.Builder(CommandButton.ICON_SKIP_FORWARD_10)
           .setDisplayName("Seek Forward")
@@ -320,13 +358,13 @@ class AudioControlsService : MediaSessionService() {
     postOrStartForegroundNotification(startInForegroundRequired)
   }
 
-  private fun resolveSessionPlayer(player: AudioPlayer, options: AudioLockScreenOptions?): Player {
-    val isLive = options?.isLiveStream ?: player.isLive
+  private fun resolveSessionPlayer(playable: LockScreenPlayable, options: AudioLockScreenOptions?): Player {
+    val isLive = options?.isLiveStream ?: playable.isLive
     if (!isLive) {
-      return player.ref
+      return playable.player
     }
 
-    return object : ForwardingPlayer(player.ref) {
+    return object : ForwardingPlayer(playable.player) {
       override fun getAvailableCommands(): Player.Commands {
         return super.getAvailableCommands().buildUpon()
           .remove(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
@@ -335,52 +373,52 @@ class AudioControlsService : MediaSessionService() {
     }
   }
 
-  private fun setActivePlayerInternal(
-    player: AudioPlayer?,
+  private fun setActivePlayableInternal(
+    playable: LockScreenPlayable?,
     metadata: Metadata? = null,
     options: AudioLockScreenOptions? = null
   ) {
     removePlayerListener()
-    currentPlayer?.isActiveForLockScreen = false
+    currentPlayable?.isActiveForLockScreen = false
     hideNotification()
 
-    currentPlayer = player
+    currentPlayable = playable
     currentMetadata = metadata
     currentOptions = options
 
     updateArtwork(metadata, postUpdate = false)
-    player?.isActiveForLockScreen = true
+    playable?.isActiveForLockScreen = true
 
-    if (player != null) {
+    if (playable != null) {
       mediaSession?.release()
       sessionMetadataPlayer = null
 
       appContext?.mainQueue?.launch {
         val context = appContext?.reactContext ?: return@launch
-        val sessionPlayer = MetadataInjectingPlayer(resolveSessionPlayer(player, options)).apply {
+        val sessionPlayer = MetadataInjectingPlayer(resolveSessionPlayer(playable, options)).apply {
           updateMetadata(metadata)
         }
         // Distinguish this lock-screen session from the basic session built in
         // `buildBasicMediaSession` (and from sessions for other players); two
         // MediaSession instances with the empty default ID throw on construction.
         val session = MediaSession.Builder(context, sessionPlayer)
-          .setId("ExpoAudioLockScreenSession_${player.hashCode()}")
-          .setCallback(AudioMediaSessionCallback())
+          .setId("ExpoAudioLockScreenSession_${playable.player.hashCode()}")
+          .setCallback(AudioMediaSessionCallback(this@AudioControlsService))
           .build()
 
         // Replace the basic media session with a session connected to our playback service.
-        player.mediaSession.release()
-        player.mediaSession = session
+        playable.mediaSession.release()
+        playable.mediaSession = session
 
         addSession(session)
         mediaSession = session
         sessionMetadataPlayer = sessionPlayer
 
-        updateSessionCustomLayout(player.ref.isPlaying)
+        updateSessionCustomLayout(playable.player.isPlaying)
 
         postOrStartForegroundNotification(startInForeground = true)
 
-        addPlayerListener(player)
+        addPlayerListener(playable)
 
         // Initial update now that session exists
         postOrStartForegroundNotification(startInForeground = false)
@@ -390,8 +428,8 @@ class AudioControlsService : MediaSessionService() {
     }
   }
 
-  private fun updateMetadataInternal(player: AudioPlayer, metadata: Metadata?) {
-    if (player != currentPlayer || metadata == currentMetadata) {
+  private fun updateMetadataInternal(playable: LockScreenPlayable, metadata: Metadata?) {
+    if (playable != currentPlayable || metadata == currentMetadata) {
       return
     }
     currentMetadata = metadata
@@ -400,16 +438,16 @@ class AudioControlsService : MediaSessionService() {
   }
 
   private fun clearSessionInternal() {
-    val player = currentPlayer
-    player?.isActiveForLockScreen = false
+    val playable = currentPlayable
+    playable?.isActiveForLockScreen = false
     removePlayerListener()
-    currentPlayer = null
     currentMetadata = null
     mediaSession?.release()
     mediaSession = null
     sessionMetadataPlayer = null
     clearArtwork()
-    player?.assignBasicMediaSession()
+    playable?.assignBasicMediaSession()
+    currentPlayable = null
     stopForeground(STOP_FOREGROUND_REMOVE)
   }
 
@@ -422,16 +460,16 @@ class AudioControlsService : MediaSessionService() {
     return binder
   }
 
-  fun setPlayerMetadata(player: AudioPlayer, metadata: Metadata?) {
-    updateMetadataInternal(player, metadata)
+  fun setPlayableMetadata(playable: LockScreenPlayable, metadata: Metadata?) {
+    updateMetadataInternal(playable, metadata)
   }
 
-  fun setPlayerOptions(
-    player: AudioPlayer,
+  fun setPlayableOptions(
+    playable: LockScreenPlayable,
     metadata: Metadata?,
     options: AudioLockScreenOptions?
   ) {
-    if (player == currentPlayer) {
+    if (playable == currentPlayable) {
       currentMetadata = metadata
       currentOptions = options
       updateArtwork(metadata, postUpdate = false)
@@ -440,31 +478,59 @@ class AudioControlsService : MediaSessionService() {
       sessionMetadataPlayer = null
       appContext?.mainQueue?.launch {
         val context = appContext?.reactContext ?: return@launch
-        val sessionPlayer = MetadataInjectingPlayer(resolveSessionPlayer(player, options)).apply {
+        val sessionPlayer = MetadataInjectingPlayer(resolveSessionPlayer(playable, options)).apply {
           updateMetadata(metadata)
         }
         val session = MediaSession.Builder(context, sessionPlayer)
-          .setId("ExpoAudioLockScreenSession_${player.hashCode()}")
-          .setCallback(AudioMediaSessionCallback())
+          .setId("ExpoAudioLockScreenSession_${playable.player.hashCode()}")
+          .setCallback(AudioMediaSessionCallback(this@AudioControlsService))
           .build()
 
-        player.mediaSession.release()
-        player.mediaSession = session
+        playable.mediaSession.release()
+        playable.mediaSession = session
 
         addSession(session)
         mediaSession = session
         sessionMetadataPlayer = sessionPlayer
 
-        updateSessionCustomLayout(player.ref.isPlaying)
+        updateSessionCustomLayout(playable.player.isPlaying)
         postOrStartForegroundNotification(startInForeground = false)
       }
     } else {
-      setActivePlayerInternal(player, metadata, options)
+      setActivePlayableInternal(playable, metadata, options)
     }
   }
 
-  fun unregisterPlayer() {
+  fun unregisterPlayable() {
     clearSessionInternal()
+  }
+
+  fun seekForward() {
+    currentPlayable?.player?.let { player ->
+      player.seekTo(player.currentPosition + SEEK_INTERVAL_MS)
+    }
+  }
+
+  fun seekBackward() {
+    currentPlayable?.player?.let { player ->
+      player.seekTo(player.currentPosition - SEEK_INTERVAL_MS)
+    }
+  }
+
+  fun nextTrack() {
+    currentPlayable?.takeIf { it.supportsNextTrack }?.nextTrack()
+  }
+
+  fun previousTrack() {
+    currentPlayable?.takeIf { it.supportsPreviousTrack }?.previousTrack()
+  }
+
+  fun supportsNextTrack(): Boolean {
+    return currentPlayable?.supportsNextTrack == true
+  }
+
+  fun supportsPreviousTrack(): Boolean {
+    return currentPlayable?.supportsPreviousTrack == true
   }
 
   private fun loadArtworkFromUrl(url: URL, callback: (Bitmap?) -> Unit) {
@@ -528,12 +594,12 @@ class AudioControlsService : MediaSessionService() {
     mediaSession?.release()
     mediaSession = null
     sessionMetadataPlayer = null
-    currentPlayer = null
+    currentPlayable = null
     currentMetadata = null
     currentOptions = null
   }
 
-  private fun addPlayerListener(player: AudioPlayer) {
+  private fun addPlayerListener(playable: LockScreenPlayable) {
     val listener = object : Player.Listener {
       override fun onIsPlayingChanged(isPlaying: Boolean) {
         updateSessionCustomLayout(isPlaying)
@@ -545,17 +611,17 @@ class AudioControlsService : MediaSessionService() {
       }
     }
     playbackListener = listener
-    player.ref.addListener(listener)
+    playable.player.addListener(listener)
   }
 
   private fun removePlayerListener() {
-    // Capture the player and listener in case they change while the coroutine is launching
-    val player = currentPlayer
+    // Capture the playable and listener in case they change while the coroutine is launching
+    val playable = currentPlayable
     val listener = playbackListener ?: return
     playbackListener = null
 
     appContext?.mainQueue?.launch {
-      player?.ref?.removeListener(listener)
+      playable?.player?.removeListener(listener)
     }
   }
 
@@ -567,6 +633,8 @@ class AudioControlsService : MediaSessionService() {
 
     const val ACTION_SEEK_FORWARD = "expo.modules.audio.action.SEEK_FORWARD"
     const val ACTION_SEEK_BACKWARD = "expo.modules.audio.action.SEEK_BACKWARD"
+    const val ACTION_NEXT_TRACK = "expo.modules.audio.action.NEXT_TRACK"
+    const val ACTION_PREVIOUS_TRACK = "expo.modules.audio.action.PREVIOUS_TRACK"
 
     const val SEEK_INTERVAL_MS = 10000L
   }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioMediaSessionCallback.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioMediaSessionCallback.kt
@@ -1,42 +1,56 @@
 package expo.modules.audio.service
 
 import android.os.Bundle
+import androidx.annotation.OptIn
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaSession
 import androidx.media3.session.SessionCommand
 import androidx.media3.session.SessionResult
-import androidx.annotation.OptIn
-import androidx.media3.common.util.UnstableApi
+import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 
 @OptIn(UnstableApi::class)
-class AudioMediaSessionCallback : MediaSession.Callback {
+class AudioMediaSessionCallback(
+  private val service: AudioControlsService
+) : MediaSession.Callback {
   override fun onConnect(
     session: MediaSession,
     controller: MediaSession.ControllerInfo
   ): MediaSession.ConnectionResult {
     try {
-      // Configure commands - custom layout buttons will be rendered from session
+      val availablePlayerCommands = MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS.buildUpon()
+        .add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
+        .add(Player.COMMAND_SEEK_FORWARD)
+        .add(Player.COMMAND_SEEK_BACK)
+        .apply {
+          if (service.supportsPreviousTrack()) {
+            add(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+            add(Player.COMMAND_SEEK_TO_PREVIOUS)
+          }
+          if (service.supportsNextTrack()) {
+            add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+            add(Player.COMMAND_SEEK_TO_NEXT)
+          }
+        }
+        .build()
+
+      val availableSessionCommands = MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
+        .add(SessionCommand(AudioControlsService.ACTION_SEEK_BACKWARD, Bundle.EMPTY))
+        .add(SessionCommand(AudioControlsService.ACTION_SEEK_FORWARD, Bundle.EMPTY))
+        .apply {
+          if (service.supportsPreviousTrack()) {
+            add(SessionCommand(AudioControlsService.ACTION_PREVIOUS_TRACK, Bundle.EMPTY))
+          }
+          if (service.supportsNextTrack()) {
+            add(SessionCommand(AudioControlsService.ACTION_NEXT_TRACK, Bundle.EMPTY))
+          }
+        }
+        .build()
+
       return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
-        .setAvailablePlayerCommands(
-          MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS.buildUpon()
-            // Keep seek commands for the seek slider
-            .add(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM)
-            .add(Player.COMMAND_SEEK_FORWARD)
-            .add(Player.COMMAND_SEEK_BACK)
-            // Remove track navigation commands
-            .remove(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
-            .remove(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
-            .remove(Player.COMMAND_SEEK_TO_PREVIOUS)
-            .remove(Player.COMMAND_SEEK_TO_NEXT)
-            .build()
-        )
-        .setAvailableSessionCommands(
-          MediaSession.ConnectionResult.DEFAULT_SESSION_COMMANDS.buildUpon()
-            .add(SessionCommand(AudioControlsService.ACTION_SEEK_BACKWARD, Bundle.EMPTY))
-            .add(SessionCommand(AudioControlsService.ACTION_SEEK_FORWARD, Bundle.EMPTY))
-            .build()
-        )
+        .setAvailablePlayerCommands(availablePlayerCommands)
+        .setAvailableSessionCommands(availableSessionCommands)
         .build()
     } catch (e: Exception) {
       return MediaSession.ConnectionResult.reject()
@@ -49,14 +63,24 @@ class AudioMediaSessionCallback : MediaSession.Callback {
     command: SessionCommand,
     args: Bundle
   ): ListenableFuture<SessionResult> {
-    when (command.customAction) {
+    return when (command.customAction) {
       AudioControlsService.ACTION_SEEK_FORWARD -> {
-        session.player.seekTo(session.player.currentPosition + AudioControlsService.SEEK_INTERVAL_MS)
+        service.seekForward()
+        Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
       }
       AudioControlsService.ACTION_SEEK_BACKWARD -> {
-        session.player.seekTo(session.player.currentPosition - AudioControlsService.SEEK_INTERVAL_MS)
+        service.seekBackward()
+        Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
       }
+      AudioControlsService.ACTION_NEXT_TRACK -> {
+        service.nextTrack()
+        Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+      }
+      AudioControlsService.ACTION_PREVIOUS_TRACK -> {
+        service.previousTrack()
+        Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+      }
+      else -> super.onCustomCommand(session, controller, command, args)
     }
-    return super.onCustomCommand(session, controller, command, args)
   }
 }

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioPlaybackServiceConnection.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioPlaybackServiceConnection.kt
@@ -5,7 +5,7 @@ import android.os.IBinder
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaSessionService.SERVICE_INTERFACE
-import expo.modules.audio.AudioPlayer
+import expo.modules.audio.LockScreenPlayable
 import expo.modules.audio.getPlaybackServiceErrorMessage
 import expo.modules.kotlin.AppContext
 import java.lang.ref.WeakReference
@@ -14,7 +14,7 @@ class AudioPlaybackServiceBinder(val service: AudioControlsService) : android.os
 
 @OptIn(UnstableApi::class)
 class AudioPlaybackServiceConnection(
-  val player: WeakReference<AudioPlayer>,
+  val playable: WeakReference<LockScreenPlayable>,
   appContext: AppContext
 ) : BaseServiceConnection<AudioPlaybackServiceBinder>(appContext) {
   var playbackServiceBinder: AudioPlaybackServiceBinder? = null
@@ -51,8 +51,8 @@ class AudioPlaybackServiceConnection(
   }
 
   override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
-    val player = player.get()
-    if (player == null || isReleased) {
+    val playable = playable.get()
+    if (playable == null || isReleased) {
       transitionToState(ServiceBindingState.FAILED)
       return
     }
@@ -69,17 +69,17 @@ class AudioPlaybackServiceConnection(
     serviceBinder.service.appContext = appContext
     serviceBinder.service.playsInSilentMode = playsInSilentMode
 
-    if (player.isActiveForLockScreen) {
-      serviceBinder.service.setPlayerOptions(player, player.metadata, player.lockScreenOptions)
+    if (playable.isActiveForLockScreen) {
+      serviceBinder.service.setPlayableOptions(playable, playable.metadata, playable.lockScreenOptions)
     }
   }
 
   override fun onServiceDisconnected(componentName: ComponentName) {
     playbackServiceBinder?.service?.let { service ->
       service.playbackListener?.let { listener ->
-        val player = player.get()
-        if (player != null && !isReleased) {
-          player.ref.removeListener(listener)
+        val playable = playable.get()
+        if (playable != null && !isReleased) {
+          playable.player.removeListener(listener)
         }
       }
       service.playbackListener = null

--- a/packages/expo-audio/ios/AudioModule.swift
+++ b/packages/expo-audio/ios/AudioModule.swift
@@ -265,15 +265,16 @@ public class AudioModule: Module {
       Function("updateLockScreenMetadata") { (player: AudioPlayer, metadata: Metadata?) in
         if player.isActiveForLockScreen {
           player.metadata = metadata
-          MediaController.shared.updateNowPlayingInfo(for: player)
+          MediaController.shared.refreshActivePlayable(player, options: player.lockScreenOptions)
         }
       }
 
       Function("clearLockScreenControls") { (player: AudioPlayer) in
         if player.isActiveForLockScreen {
           player.metadata = nil
+          player.lockScreenOptions = nil
           player.isActiveForLockScreen = false
-          MediaController.shared.setActivePlayer(nil)
+          MediaController.shared.setActivePlayable(nil)
         }
       }
 
@@ -401,7 +402,30 @@ public class AudioModule: Module {
         playlist.clear()
       }
 
+      Function("setActiveForLockScreen") { (playlist: AudioPlaylist, active: Bool, metadata: Metadata?, options: LockScreenOptions?) in
+        playlist.setActiveForLockScreen(active, metadata: metadata, options: options)
+      }
+
+      Function("updateLockScreenMetadata") { (playlist: AudioPlaylist, metadata: Metadata?) in
+        if playlist.isActiveForLockScreen {
+          playlist.metadata = metadata
+          MediaController.shared.refreshActivePlayable(playlist, options: playlist.lockScreenOptions)
+        }
+      }
+
+      Function("clearLockScreenControls") { (playlist: AudioPlaylist) in
+        if playlist.isActiveForLockScreen {
+          playlist.metadata = nil
+          playlist.lockScreenOptions = nil
+          playlist.isActiveForLockScreen = false
+          MediaController.shared.setActivePlayable(nil)
+        }
+      }
+
       Function("destroy") { playlist in
+        if playlist.isActiveForLockScreen {
+          playlist.setActiveForLockScreen(false, metadata: nil, options: nil)
+        }
         self.registry.remove(playlist)
       }
     }

--- a/packages/expo-audio/ios/AudioPlayer.swift
+++ b/packages/expo-audio/ios/AudioPlayer.swift
@@ -6,12 +6,13 @@ private enum AudioConstants {
   static let audioSample = "audioSampleUpdate"
 }
 
-public class AudioPlayer: SharedRef<AVPlayer>, Playable {
+public class AudioPlayer: SharedRef<AVPlayer>, Playable, LockScreenPlayable {
   let id = UUID().uuidString
   var shouldCorrectPitch = true
   var pitchCorrectionQuality: AVAudioTimePitchAlgorithm = .timeDomain
   var isActiveForLockScreen = false
   var metadata: Metadata?
+  var lockScreenOptions: LockScreenOptions?
   var currentRate: Float = 1.0 {
     didSet {
       currentRate = max(0, currentRate)
@@ -66,6 +67,10 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable {
 
   var isLive: Bool {
     ref.currentItem?.duration.isIndefinite ?? false
+  }
+
+  var lockScreenPlayer: AVPlayer {
+    ref
   }
 
   var currentOffsetFromLive: Double? {
@@ -157,10 +162,11 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable {
   func setActiveForLockScreen(_ active: Bool = true, metadata: Metadata? = nil, options: LockScreenOptions?) {
     self.metadata = metadata
     self.isActiveForLockScreen = active
+    self.lockScreenOptions = active ? options : nil
     if active {
-      MediaController.shared.setActivePlayer(self, options: options)
+      MediaController.shared.setActivePlayable(self, options: options)
     } else {
-      MediaController.shared.setActivePlayer(nil)
+      MediaController.shared.setActivePlayable(nil)
     }
   }
 
@@ -508,7 +514,7 @@ public class AudioPlayer: SharedRef<AVPlayer>, Playable {
     owningRegistry?.remove(self)
 
     if isActiveForLockScreen {
-      MediaController.shared.setActivePlayer(nil)
+      MediaController.shared.setActivePlayable(nil)
     }
 
     teardownPlayer()

--- a/packages/expo-audio/ios/AudioPlaylist.swift
+++ b/packages/expo-audio/ios/AudioPlaylist.swift
@@ -7,10 +7,13 @@ private enum PlaylistConstants {
   static let trackChanged = "trackChanged"
 }
 
-public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
+public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable, LockScreenPlayable {
   let id = UUID().uuidString
   private let interval: Double
   private(set) var currentRate: Float = 1.0
+  var isActiveForLockScreen = false
+  var metadata: Metadata?
+  var lockScreenOptions: LockScreenOptions?
 
   var loopMode: LoopMode = .none
   var wasPlaying = false
@@ -46,6 +49,22 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
     ref.timeControlStatus == .playing
   }
 
+  var isLive: Bool {
+    ref.currentItem?.duration.isIndefinite ?? false
+  }
+
+  var lockScreenPlayer: AVPlayer {
+    ref
+  }
+
+  var supportsNextTrack: Bool {
+    true
+  }
+
+  var supportsPreviousTrack: Bool {
+    true
+  }
+
   var isBuffering: Bool {
     ref.isBuffering(isPlaying: isPlaying)
   }
@@ -68,10 +87,18 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
   func play(at rate: Float) {
     registerTimeObserver()
     ref.playImmediately(atRate: rate)
+
+    if isActiveForLockScreen {
+      MediaController.shared.updateNowPlayingInfo(for: self)
+    }
   }
 
   func pause() {
     ref.pause()
+
+    if isActiveForLockScreen {
+      MediaController.shared.updateNowPlayingInfo(for: self)
+    }
   }
 
   func next() {
@@ -101,6 +128,14 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
     } else if loopMode == .all && !sources.isEmpty {
       skipTo(index: sources.count - 1)
     }
+  }
+
+  func nextTrack() {
+    next()
+  }
+
+  func previousTrack() {
+    previous()
   }
 
   func skipTo(index: Int) {
@@ -217,6 +252,17 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
     }
   }
 
+  func setActiveForLockScreen(_ active: Bool = true, metadata: Metadata? = nil, options: LockScreenOptions?) {
+    self.metadata = metadata
+    self.isActiveForLockScreen = active
+    self.lockScreenOptions = active ? options : nil
+    if active {
+      MediaController.shared.setActivePlayable(self, options: options)
+    } else {
+      MediaController.shared.setActivePlayable(nil)
+    }
+  }
+
   func currentStatus() -> [String: Any] {
     return [
       "id": id,
@@ -239,6 +285,10 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
     var arguments = currentStatus()
     arguments.merge(dict) { _, new in new }
     self.emit(event: PlaylistConstants.playlistStatusUpdate, payload: arguments)
+
+    if isActiveForLockScreen {
+      MediaController.shared.updateNowPlayingInfo(for: self)
+    }
   }
 
   private func validIndex(_ index: Int) -> Bool {
@@ -367,6 +417,10 @@ public class AudioPlaylist: SharedRef<AVQueuePlayer>, Playable {
 
     if let endObserver {
       NotificationCenter.default.removeObserver(endObserver)
+    }
+
+    if isActiveForLockScreen {
+      MediaController.shared.setActivePlayable(nil)
     }
 
     ref.pause()

--- a/packages/expo-audio/ios/AudioRecords.swift
+++ b/packages/expo-audio/ios/AudioRecords.swift
@@ -69,6 +69,8 @@ struct Metadata: Record {
 struct LockScreenOptions: Record {
   @Field var showSeekForward: Bool = false
   @Field var showSeekBackward: Bool = false
+  @Field var showNextTrack: Bool = false
+  @Field var showPreviousTrack: Bool = false
   @Field var isLiveStream: Bool? = false
 }
 

--- a/packages/expo-audio/ios/MediaController.swift
+++ b/packages/expo-audio/ios/MediaController.swift
@@ -2,12 +2,46 @@ import MediaPlayer
 import AVFoundation
 import ExpoModulesCore
 
+protocol LockScreenPlayable: AnyObject {
+  var id: String { get }
+  var isActiveForLockScreen: Bool { get set }
+  var metadata: Metadata? { get set }
+  var lockScreenPlayer: AVPlayer { get }
+  var duration: Double { get }
+  var currentTime: Double { get }
+  var isPlaying: Bool { get }
+  var currentRate: Float { get }
+  var isLive: Bool { get }
+  var supportsNextTrack: Bool { get }
+  var supportsPreviousTrack: Bool { get }
+
+  func play(at rate: Float)
+  func pause()
+  func nextTrack()
+  func previousTrack()
+}
+
+extension LockScreenPlayable {
+  var supportsNextTrack: Bool {
+    false
+  }
+
+  var supportsPreviousTrack: Bool {
+    false
+  }
+
+  func nextTrack() {}
+
+  func previousTrack() {}
+}
+
 class MediaController {
   static let shared = MediaController()
 
-  private var activePlayer: AudioPlayer?
+  private var activePlayable: (any LockScreenPlayable)?
   private var remoteCommandCenter = MPRemoteCommandCenter.shared()
   private var nowPlayingInfoCenter = MPNowPlayingInfoCenter.default()
+  private var remoteCommandTargets: [(command: MPRemoteCommand, target: Any)] = []
 
   private var currentArtworkUrl: URL?
   private var cachedArtwork: MPMediaItemArtwork?
@@ -15,44 +49,56 @@ class MediaController {
   private var currentArtworkItemIdentifier: ObjectIdentifier?
   private var isLiveStream = false
 
-  func setActivePlayer(_ player: AudioPlayer?, options: LockScreenOptions? = nil) {
+  func setActivePlayable(_ playable: (any LockScreenPlayable)?, options: LockScreenOptions? = nil) {
     performOnMain {
-      self.setActivePlayerOnMain(player, options: options)
+      self.setActivePlayableOnMain(playable, options: options)
     }
   }
 
-  func updateNowPlayingInfo(for player: AudioPlayer) {
+  func updateNowPlayingInfo(for playable: any LockScreenPlayable) {
     performOnMain {
-      self.updateNowPlayingInfoOnMain(for: player)
+      self.updateNowPlayingInfoOnMain(for: playable)
     }
   }
 
-  private func setActivePlayerOnMain(_ player: AudioPlayer?, options: LockScreenOptions? = nil) {
-    if let previous = activePlayer, previous.id != player?.id {
+  func refreshActivePlayable(_ playable: any LockScreenPlayable, options: LockScreenOptions?) {
+    performOnMain {
+      guard playable.id == self.activePlayable?.id else {
+        return
+      }
+
+      self.disableRemoteCommands()
+      self.clearNowPlayingInfoOnMain()
+      self.setActivePlayableOnMain(playable, options: options)
+    }
+  }
+
+  private func setActivePlayableOnMain(_ playable: (any LockScreenPlayable)?, options: LockScreenOptions? = nil) {
+    if let previous = activePlayable, previous.id != playable?.id {
       previous.isActiveForLockScreen = false
       resetArtworkState()
       currentArtworkItemIdentifier = nil
     }
 
-    activePlayer = player
-    player?.isActiveForLockScreen = true
-    isLiveStream = options?.isLiveStream ?? player?.isLive ?? false
+    activePlayable = playable
+    playable?.isActiveForLockScreen = true
+    isLiveStream = options?.isLiveStream ?? playable?.isLive ?? false
 
-    if let player {
+    if let playable {
       enableRemoteCommands(options: options)
-      updateNowPlayingInfoOnMain(for: player)
+      updateNowPlayingInfoOnMain(for: playable)
     } else {
       disableRemoteCommands()
       clearNowPlayingInfoOnMain()
     }
   }
 
-  private func updateNowPlayingInfoOnMain(for player: AudioPlayer) {
-    guard player.id == activePlayer?.id else {
+  private func updateNowPlayingInfoOnMain(for playable: any LockScreenPlayable) {
+    guard playable.id == activePlayable?.id else {
       return
     }
 
-    let nextArtworkItemIdentifier = player.ref.currentItem.map { ObjectIdentifier($0) }
+    let nextArtworkItemIdentifier = playable.lockScreenPlayer.currentItem.map { ObjectIdentifier($0) }
     if currentArtworkItemIdentifier != nextArtworkItemIdentifier {
       resetArtworkState()
       currentArtworkItemIdentifier = nextArtworkItemIdentifier
@@ -60,47 +106,49 @@ class MediaController {
 
     var nowPlayingInfo = nowPlayingInfoCenter.nowPlayingInfo ?? [String: Any]()
 
-    applyPlaybackInfo(&nowPlayingInfo, for: player)
+    applyPlaybackInfo(&nowPlayingInfo, for: playable)
 
-    if let userMetadata = player.metadata {
+    if let userMetadata = playable.metadata {
       applyUserMetadata(&nowPlayingInfo, from: userMetadata)
-      applyArtwork(&nowPlayingInfo, from: userMetadata, for: player, currentItemIdentifier: nextArtworkItemIdentifier)
+      applyArtwork(&nowPlayingInfo, from: userMetadata, for: playable, currentItemIdentifier: nextArtworkItemIdentifier)
     } else {
       resetArtworkState()
       nowPlayingInfo.removeValue(forKey: MPMediaItemPropertyArtwork)
-      applyAssetMetadata(&nowPlayingInfo, for: player)
+      applyAssetMetadata(&nowPlayingInfo, for: playable)
     }
 
     nowPlayingInfoCenter.nowPlayingInfo = nowPlayingInfo
   }
 
-  private func applyPlaybackInfo(_ info: inout [String: Any], for player: AudioPlayer) {
+  private func applyPlaybackInfo(_ info: inout [String: Any], for playable: any LockScreenPlayable) {
     if isLiveStream {
       info[MPNowPlayingInfoPropertyIsLiveStream] = true
       info.removeValue(forKey: MPMediaItemPropertyPlaybackDuration)
       info.removeValue(forKey: MPNowPlayingInfoPropertyElapsedPlaybackTime)
     } else {
-      info[MPMediaItemPropertyPlaybackDuration] = player.duration
-      info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = player.currentTime
+      info[MPMediaItemPropertyPlaybackDuration] = playable.duration
+      info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = playable.currentTime
     }
-    info[MPNowPlayingInfoPropertyPlaybackRate] = player.isPlaying ? player.ref.rate : 0.0
+    info[MPNowPlayingInfoPropertyPlaybackRate] = playable.isPlaying ? playable.lockScreenPlayer.rate : 0.0
     info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
   }
 
   private func applyUserMetadata(_ info: inout [String: Any], from metadata: Metadata) {
-    if let title = metadata.title {
-      info[MPMediaItemPropertyTitle] = title
-    }
-    if let artist = metadata.artist {
-      info[MPMediaItemPropertyArtist] = artist
-    }
-    if let album = metadata.albumTitle {
-      info[MPMediaItemPropertyAlbumTitle] = album
+    updateInfo(&info, key: MPMediaItemPropertyTitle, value: metadata.title)
+    updateInfo(&info, key: MPMediaItemPropertyArtist, value: metadata.artist)
+    updateInfo(&info, key: MPMediaItemPropertyAlbumTitle, value: metadata.albumTitle)
+  }
+
+  private func updateInfo(_ info: inout [String: Any], key: String, value: Any?) {
+    if let value {
+      info[key] = value
+    } else {
+      info.removeValue(forKey: key)
     }
   }
 
-  private func applyAssetMetadata(_ info: inout [String: Any], for player: AudioPlayer) {
-    guard let currentItem = player.ref.currentItem,
+  private func applyAssetMetadata(_ info: inout [String: Any], for playable: any LockScreenPlayable) {
+    guard let currentItem = playable.lockScreenPlayer.currentItem,
       let asset = currentItem.asset as? AVURLAsset else {
       return
     }
@@ -133,7 +181,7 @@ class MediaController {
   private func applyArtwork(
     _ info: inout [String: Any],
     from metadata: Metadata,
-    for player: AudioPlayer,
+    for playable: any LockScreenPlayable,
     currentItemIdentifier: ObjectIdentifier?
   ) {
     guard let artworkUrl = metadata.artworkUrl else {
@@ -167,7 +215,7 @@ class MediaController {
 
       self.artworkLoadToken = nil
 
-      guard self.activePlayer?.id == player.id,
+      guard self.activePlayable?.id == playable.id,
             self.currentArtworkUrl == artworkUrl,
             self.currentArtworkItemIdentifier == currentItemIdentifier else {
         return
@@ -187,7 +235,7 @@ class MediaController {
 
   private func clearNowPlayingInfoOnMain() {
     nowPlayingInfoCenter.nowPlayingInfo = nil
-    activePlayer = nil
+    activePlayable = nil
     isLiveStream = false
     resetArtworkState()
     currentArtworkItemIdentifier = nil
@@ -232,83 +280,127 @@ class MediaController {
   }
 
   private func enableRemoteCommands(options: LockScreenOptions?) {
-    remoteCommandCenter.playCommand.addTarget { [weak self] _ in
-      guard let player = self?.activePlayer else {
+    removeRemoteCommandTargets()
+
+    let playTarget = remoteCommandCenter.playCommand.addTarget { [weak self] _ in
+      guard let playable = self?.activePlayable else {
         return .commandFailed
       }
 
-      player.play(at: Float(player.currentRate > 0 ? player.currentRate : 1.0))
+      playable.play(at: Float(playable.currentRate > 0 ? playable.currentRate : 1.0))
       return .success
     }
+    remoteCommandTargets.append((remoteCommandCenter.playCommand, playTarget))
 
-    remoteCommandCenter.pauseCommand.addTarget { [weak self] _ in
-      guard let player = self?.activePlayer else {
+    let pauseTarget = remoteCommandCenter.pauseCommand.addTarget { [weak self] _ in
+      guard let playable = self?.activePlayable else {
         return .commandFailed
       }
 
-      player.ref.pause()
+      playable.pause()
       return .success
     }
+    remoteCommandTargets.append((remoteCommandCenter.pauseCommand, pauseTarget))
 
-    remoteCommandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
-      guard let player = self?.activePlayer else {
+    let togglePlayPauseTarget = remoteCommandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
+      guard let playable = self?.activePlayable else {
         return .commandFailed
       }
 
-      if player.isPlaying {
-        player.ref.pause()
+      if playable.isPlaying {
+        playable.pause()
       } else {
-        player.play(at: Float(player.currentRate > 0 ? player.currentRate : 1.0))
+        playable.play(at: Float(playable.currentRate > 0 ? playable.currentRate : 1.0))
       }
       return .success
     }
+    remoteCommandTargets.append((remoteCommandCenter.togglePlayPauseCommand, togglePlayPauseTarget))
 
-    remoteCommandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
-      guard let player = self?.activePlayer,
+    let changePlaybackPositionTarget = remoteCommandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
+      guard let playable = self?.activePlayable,
       let event = event as? MPChangePlaybackPositionCommandEvent else {
         return .commandFailed
       }
 
       let seekTime = CMTime(seconds: event.positionTime, preferredTimescale: 1)
-      player.ref.seek(to: seekTime)
+      playable.lockScreenPlayer.seek(to: seekTime)
 
       return .success
     }
+    remoteCommandTargets.append((remoteCommandCenter.changePlaybackPositionCommand, changePlaybackPositionTarget))
 
     remoteCommandCenter.skipForwardCommand.preferredIntervals = [10.0]
-    remoteCommandCenter.skipForwardCommand.addTarget { [weak self] event in
-      guard let player = self?.activePlayer,
+    let skipForwardTarget = remoteCommandCenter.skipForwardCommand.addTarget { [weak self] event in
+      guard let playable = self?.activePlayable,
       let event = event as? MPSkipIntervalCommandEvent else {
         return .commandFailed
       }
 
-      let currentTime = player.ref.currentTime()
+      let currentTime = playable.lockScreenPlayer.currentTime()
       let seekTime = currentTime + CMTime(seconds: event.interval, preferredTimescale: 1)
-      player.ref.seek(to: seekTime, toleranceBefore: .zero, toleranceAfter: .zero)
+      playable.lockScreenPlayer.seek(to: seekTime, toleranceBefore: .zero, toleranceAfter: .zero)
 
       return .success
     }
+    remoteCommandTargets.append((remoteCommandCenter.skipForwardCommand, skipForwardTarget))
 
     remoteCommandCenter.skipBackwardCommand.preferredIntervals = [10.0]
-    remoteCommandCenter.skipBackwardCommand.addTarget { [weak self] event in
-      guard let player = self?.activePlayer,
+    let skipBackwardTarget = remoteCommandCenter.skipBackwardCommand.addTarget { [weak self] event in
+      guard let playable = self?.activePlayable,
       let event = event as? MPSkipIntervalCommandEvent else {
         return .commandFailed
       }
 
-      let currentTime = player.ref.currentTime()
+      let currentTime = playable.lockScreenPlayer.currentTime()
       let seekTime = currentTime - CMTime(seconds: event.interval, preferredTimescale: 1)
-      player.ref.seek(to: seekTime, toleranceBefore: .zero, toleranceAfter: .zero)
+      playable.lockScreenPlayer.seek(to: seekTime, toleranceBefore: .zero, toleranceAfter: .zero)
 
       return .success
     }
+    remoteCommandTargets.append((remoteCommandCenter.skipBackwardCommand, skipBackwardTarget))
+
+    let nextTrackTarget = remoteCommandCenter.nextTrackCommand.addTarget { [weak self] _ in
+      guard let playable = self?.activePlayable,
+            playable.supportsNextTrack else {
+        return .commandFailed
+      }
+
+      playable.nextTrack()
+      return .success
+    }
+    remoteCommandTargets.append((remoteCommandCenter.nextTrackCommand, nextTrackTarget))
+
+    let previousTrackTarget = remoteCommandCenter.previousTrackCommand.addTarget { [weak self] _ in
+      guard let playable = self?.activePlayable,
+            playable.supportsPreviousTrack else {
+        return .commandFailed
+      }
+
+      playable.previousTrack()
+      return .success
+    }
+    remoteCommandTargets.append((remoteCommandCenter.previousTrackCommand, previousTrackTarget))
 
     remoteCommandCenter.playCommand.isEnabled = true
     remoteCommandCenter.pauseCommand.isEnabled = true
     remoteCommandCenter.togglePlayPauseCommand.isEnabled = true
     remoteCommandCenter.changePlaybackPositionCommand.isEnabled = !isLiveStream
-    remoteCommandCenter.skipForwardCommand.isEnabled = options?.showSeekForward ?? false
-    remoteCommandCenter.skipBackwardCommand.isEnabled = options?.showSeekBackward ?? false
+    let supportsNextTrack = activePlayable?.supportsNextTrack ?? false
+    let supportsPreviousTrack = activePlayable?.supportsPreviousTrack ?? false
+    let showNextTrack = (options?.showNextTrack ?? false) && supportsNextTrack
+    let showPreviousTrack = (options?.showPreviousTrack ?? false) && supportsPreviousTrack
+
+    remoteCommandCenter.skipForwardCommand.isEnabled = (options?.showSeekForward ?? false) && !showNextTrack
+    remoteCommandCenter.skipBackwardCommand.isEnabled = (options?.showSeekBackward ?? false) && !showPreviousTrack
+    remoteCommandCenter.nextTrackCommand.isEnabled = showNextTrack
+    remoteCommandCenter.previousTrackCommand.isEnabled = showPreviousTrack
+  }
+
+  private func removeRemoteCommandTargets() {
+    remoteCommandTargets.forEach { command, target in
+      command.removeTarget(target)
+    }
+    remoteCommandTargets.removeAll()
   }
 
   private func disableRemoteCommands() {
@@ -318,13 +410,9 @@ class MediaController {
     remoteCommandCenter.changePlaybackPositionCommand.isEnabled = false
     remoteCommandCenter.skipForwardCommand.isEnabled = false
     remoteCommandCenter.skipBackwardCommand.isEnabled = false
+    remoteCommandCenter.nextTrackCommand.isEnabled = false
+    remoteCommandCenter.previousTrackCommand.isEnabled = false
 
-    // Remove event targets
-    remoteCommandCenter.playCommand.removeTarget(self)
-    remoteCommandCenter.pauseCommand.removeTarget(self)
-    remoteCommandCenter.togglePlayPauseCommand.removeTarget(self)
-    remoteCommandCenter.changePlaybackPositionCommand.removeTarget(self)
-    remoteCommandCenter.skipForwardCommand.removeTarget(self)
-    remoteCommandCenter.skipBackwardCommand.removeTarget(self)
+    removeRemoteCommandTargets()
   }
 }

--- a/packages/expo-audio/src/AudioConstants.ts
+++ b/packages/expo-audio/src/AudioConstants.ts
@@ -12,6 +12,14 @@ export type AudioLockScreenOptions = {
    */
   showSeekBackward?: boolean;
   /**
+   * Whether the next track button should be displayed on the lock screen.
+   */
+  showNextTrack?: boolean;
+  /**
+   * Whether the previous track button should be displayed on the lock screen.
+   */
+  showPreviousTrack?: boolean;
+  /**
    * Whether the audio is a live stream. When `true`, the lock screen will hide the duration
    * and scrub bar, and disable seek controls.
    */

--- a/packages/expo-audio/src/AudioModule.types.ts
+++ b/packages/expo-audio/src/AudioModule.types.ts
@@ -532,6 +532,36 @@ export declare class AudioPlaylist extends SharedObject<AudioPlaylistEvents> {
   clear(): void;
 
   /**
+   * Sets or removes this audio playlist as the active playlist for lock screen controls.
+   * Only one audio player or playlist can control the lock screen at a time.
+   *
+   * > **Note:** For lock screen controls to work correctly, [`interruptionMode`](#interruptionmode) must be set to `doNotMix` using [`setAudioModeAsync`](#audiosetaudiomodeasyncmode).
+   * > Without this, the OS might not associate lock screen controls with your playlist.
+   *
+   * @param active Whether this playlist should be active for lock screen controls.
+   * @param metadata Optional metadata to display on the lock screen (title, artist, album, artwork).
+   * @param options Optional configuration to configure the lock screen controls.
+   */
+  setActiveForLockScreen(
+    active: boolean,
+    metadata?: AudioMetadata,
+    options?: AudioLockScreenOptions
+  ): void;
+
+  /**
+   * Updates the metadata displayed on the lock screen for this playlist.
+   * This method only has an effect if this playlist is currently active for lock screen controls.
+   * @param metadata The metadata to display (title, artist, album, artwork).
+   */
+  updateLockScreenMetadata(metadata: AudioMetadata): void;
+
+  /**
+   * Removes this playlist from lock screen controls if it's currently active.
+   * This will clear the lock screen's now playing info.
+   */
+  clearLockScreenControls(): void;
+
+  /**
    * Destroy the playlist and free up resources.
    */
   destroy(): void;

--- a/packages/expo-audio/src/AudioPlaylist.web.ts
+++ b/packages/expo-audio/src/AudioPlaylist.web.ts
@@ -1,12 +1,15 @@
 import type {
+  AudioMetadata,
   AudioPlaylistLoopMode,
   AudioPlaylistStatus,
   AudioSource,
   AudioSourceInfo,
 } from './Audio.types';
+import type { AudioLockScreenOptions } from './AudioConstants';
 import { PLAYLIST_STATUS_UPDATE, TRACK_CHANGED } from './AudioEventKeys';
 import type { AudioPlaylist, AudioPlaylistEvents } from './AudioModule.types';
 import { getSourceUri, nextId } from './AudioUtils.web';
+import { mediaSessionController } from './MediaSessionController.web';
 import { resolveSource } from './utils/resolveSource';
 
 function getSourceInfo(source: AudioSource): AudioSourceInfo {
@@ -304,7 +307,28 @@ export class AudioPlaylistWeb
   }
 
   destroy(): void {
+    mediaSessionController.clear(this);
     this.clear();
+  }
+
+  setActiveForLockScreen(
+    active: boolean,
+    metadata?: AudioMetadata,
+    options?: AudioLockScreenOptions
+  ): void {
+    if (active) {
+      mediaSessionController.setActivePlayer(this, metadata, options);
+    } else {
+      mediaSessionController.clear(this);
+    }
+  }
+
+  updateLockScreenMetadata(metadata: AudioMetadata): void {
+    mediaSessionController.updateMetadata(this, metadata);
+  }
+
+  clearLockScreenControls(): void {
+    mediaSessionController.clear(this);
   }
 
   private _transitionToTrack(newIndex: number, previousIndex: number): void {
@@ -509,6 +533,7 @@ export class AudioPlaylistWeb
         this._transitionToTrack(0, this._currentIndex);
       } else {
         this._isPlaying = false;
+        this._updateMediaSession();
         this.emit(PLAYLIST_STATUS_UPDATE, {
           ...this._getStatus(),
           didJustFinish: true,
@@ -539,5 +564,11 @@ export class AudioPlaylistWeb
 
   private _emitStatus(): void {
     this.emit(PLAYLIST_STATUS_UPDATE, this._getStatus());
+    this._updateMediaSession();
+  }
+
+  private _updateMediaSession(): void {
+    mediaSessionController.updatePlaybackState(this);
+    mediaSessionController.updatePositionState(this);
   }
 }

--- a/packages/expo-audio/src/MediaSessionController.web.ts
+++ b/packages/expo-audio/src/MediaSessionController.web.ts
@@ -5,6 +5,8 @@ interface MediaSessionPlayer {
   play(): void;
   pause(): void;
   seekTo(seconds: number): Promise<void>;
+  next?(): void;
+  previous?(): void;
   readonly playing: boolean;
   readonly currentTime: number;
   readonly duration: number;
@@ -172,17 +174,31 @@ class MediaSessionController {
 
     if (this.options?.showSeekForward === true) {
       this._setHandler('seekforward', seekForward);
-      this._setHandler('nexttrack', seekForward);
     } else {
       this._setHandler('seekforward', null);
-      this._setHandler('nexttrack', null);
     }
 
     if (this.options?.showSeekBackward === true) {
       this._setHandler('seekbackward', seekBackward);
-      this._setHandler('previoustrack', seekBackward);
     } else {
       this._setHandler('seekbackward', null);
+    }
+
+    if (this.options?.showNextTrack === true && player.next) {
+      this._setHandler('nexttrack', () => {
+        player.next?.();
+        this.updatePositionState(player);
+      });
+    } else {
+      this._setHandler('nexttrack', null);
+    }
+
+    if (this.options?.showPreviousTrack === true && player.previous) {
+      this._setHandler('previoustrack', () => {
+        player.previous?.();
+        this.updatePositionState(player);
+      });
+    } else {
       this._setHandler('previoustrack', null);
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18106,9 +18106,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 


### PR DESCRIPTION
# Why
Adds support for lock screen controls when using audio playlists

# How
- Reused shared lock screen control by adding common playable instead of duplicating what we do in `AudioPlayer`.
- Added playlist APIs:
  - `setActiveForLockScreen`
  - `updateLockScreenMetadata`
  - `clearLockScreenControls`
- Added next / previous track lock screen options:
  - `showNextTrack`
  - `showPreviousTrack`
- Wired next / previous lock screen actions to playlist navigation.
- Updated ncl examples to test:
  - playlist lock screen controls
  - playlist metadata updates
  - next / previous track controls
  - single-player active lock screen ownership

# Test Plan
Bare expo
