### PR TITLE
Fix Contact class type mismatch

### DIFF
--- a/packages/expo-contacts/build/next/ExpoContactsNext.web.d.ts
+++ b/packages/expo-contacts/build/next/ExpoContactsNext.web.d.ts
@@ -1,7 +1,6 @@
 import type { ContactsPermissionResponse } from './types/Permissions';
-import { Contact } from './types/Contact';
 declare const _default: {
-    Contact: typeof Contact;
+    Contact: typeof import("./types/Contact").Contact;
     getPermissionsAsync: () => Promise<ContactsPermissionResponse>;
     requestPermissionsAsync: () => Promise<ContactsPermissionResponse>;
     addListener: () => {

--- a/packages/expo-contacts/build/next/ExpoContactsNext.web.d.ts.map
+++ b/packages/expo-contacts/build/next/ExpoContactsNext.web.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"ExpoContactsNext.web.d.ts","sourceRoot":"","sources":["../../src/next/ExpoContactsNext.web.ts"],"names":[],"mappings":"AAEA,OAAO,KAAK,EAAE,0BAA0B,EAAE,MAAM,qBAAqB,CAAC;AACtE,OAAO,EAAE,OAAO,EAAE,MAAM,iBAAiB,CAAC;;;;;;;;;;;;;AAW1C,wBASwD"}
+{"version":3,"file":"ExpoContactsNext.web.d.ts","sourceRoot":"","sources":["../../src/next/ExpoContactsNext.web.ts"],"names":[],"mappings":"AAEA,OAAO,KAAK,EAAE,0BAA0B,EAAE,MAAM,qBAAqB,CAAC;;;;;;;;;;;;;AAiBtE,wBAS6B"}

--- a/packages/expo-contacts/src/next/ExpoContactsNext.web.ts
+++ b/packages/expo-contacts/src/next/ExpoContactsNext.web.ts
@@ -1,7 +1,8 @@
 import { PermissionStatus } from 'expo';
 
-import { Contact } from './types/Contact';
 import type { ContactsPermissionResponse } from './types/Permissions';
+
+type ExpoContactsNext = typeof import('./ExpoContactsNext').default;
 
 const noPermissionResponse: ContactsPermissionResponse = {
   status: PermissionStatus.UNDETERMINED,
@@ -9,6 +10,10 @@ const noPermissionResponse: ContactsPermissionResponse = {
   granted: false,
   canAskAgain: true,
 };
+
+const Contact = class {
+  constructor(public id: string) {}
+} as ExpoContactsNext['Contact'];
 
 const noop = () => {};
 
@@ -21,4 +26,4 @@ export default {
   removeAllListeners: noop,
   emit: noop,
   listenerCount: () => 0,
-} satisfies typeof import('./ExpoContactsNext').default;
+} satisfies ExpoContactsNext;


### PR DESCRIPTION
# Why

when cleaning the types, I used `Contact` (not a class, but a class type) as value, and TS don't see the issue here.

# How

- keep the minimum polyfill of the class to makes it work on web

# Test Plan

- open bare-expo on web

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
