### PR TITLE
[docs] Update bun init command in monorepos guide

### DIFF
--- a/docs/pages/guides/monorepos.mdx
+++ b/docs/pages/guides/monorepos.mdx
@@ -121,7 +121,7 @@ Let's go back to the root and create the **packages** directory. This directory 
     npm: ['$ mkdir -p packages/cool-package && cd packages/cool-package && npm init'],
     yarn: ['$ mkdir -p packages/cool-package && cd packages/cool-package && yarn init'],
     pnpm: ['$ mkdir -p packages/cool-package && cd packages/cool-package && pnpm init'],
-    bun: ['$ mkdir -p packages/cool-package && cd packages/cool-package && bun init --minimal'],
+    bun: ['$ mkdir -p packages/cool-package && cd packages/cool-package && bun init -y'],
   }}
 />
 


### PR DESCRIPTION
# Why

Fix ENG-21352

# How

Swap `bun init --minimal` for `bun init -y` in the Terminal block on `pages/guides/monorepos.mdx`. The `-y` flag accepts defaults non-interactively and produces a `package.json` that includes `name`, matching the behavior of the `npm`, `yarn`, and `pnpm` commands shown alongside it.

# Test Plan

Proofread.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
