### PR TITLE
Add ExpoObserve screen to native-components-list

### DIFF
--- a/apps/native-component-list/package.json
+++ b/apps/native-component-list/package.json
@@ -63,6 +63,7 @@
     "expo": "workspace:*",
     "expo-2d-context": "^0.0.4",
     "expo-age-range": "workspace:*",
+    "expo-app-metrics": "workspace:*",
     "expo-apple-authentication": "workspace:*",
     "expo-application": "workspace:*",
     "expo-asset": "workspace:*",

--- a/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
+++ b/apps/native-component-list/src/navigation/ExpoApisStackNavigator.tsx
@@ -253,6 +253,13 @@ export const ScreensList: ScreenConfig[] = [
   },
   {
     getComponent() {
+      return optionalRequire(() => require('../screens/ExpoObserveScreen'));
+    },
+    name: 'ExpoObserve',
+    options: { title: 'Expo Observe' },
+  },
+  {
+    getComponent() {
       return optionalRequire(() => require('../screens/ImageManipulatorScreen'));
     },
     name: 'ImageManipulator',

--- a/apps/native-component-list/src/screens/ExpoObserveScreen.tsx
+++ b/apps/native-component-list/src/screens/ExpoObserveScreen.tsx
@@ -1,0 +1,84 @@
+import { useFocusEffect } from '@react-navigation/native';
+import { useTheme } from 'ThemeProvider';
+import AppMetrics, { type MainSession, type Metric } from 'expo-app-metrics';
+import * as React from 'react';
+import { RefreshControl, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+export default function ExpoObserveScreen() {
+  const { theme } = useTheme();
+  const [session, setSession] = React.useState<MainSession | null>(null);
+  const [refreshing, setRefreshing] = React.useState(false);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      let cancelled = false;
+      AppMetrics.getMainSession().then((s) => {
+        if (!cancelled) setSession(s);
+      });
+      return () => {
+        cancelled = true;
+      };
+    }, [])
+  );
+
+  const onRefresh = React.useCallback(async () => {
+    setRefreshing(true);
+    try {
+      setSession(await AppMetrics.getMainSession());
+    } finally {
+      setRefreshing(false);
+    }
+  }, []);
+
+  const navMetrics: Metric[] = (session?.metrics ?? []).filter((m) => m.category === 'navigation');
+
+  return (
+    <ScrollView
+      style={{ flex: 1 }}
+      contentContainerStyle={styles.content}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}>
+      <Text style={[styles.header, { color: theme.text.default }]}>Navigation metrics</Text>
+      {navMetrics.length === 0 ? (
+        <Text style={{ color: theme.text.secondary }}>
+          No navigation metrics yet. Navigate around the app, then pull to refresh.
+        </Text>
+      ) : (
+        navMetrics.map((m, i) => (
+          <View key={`${m.timestamp}-${i}`} style={styles.row}>
+            <View style={styles.rowTop}>
+              <Text style={[styles.name, { color: theme.text.default }]}>
+                expo.navigation.{m.name}
+              </Text>
+              <Text style={[styles.value, { color: theme.text.default }]}>
+                {m.value.toFixed(3)}s
+              </Text>
+            </View>
+            {m.routeName ? (
+              <Text style={{ color: theme.text.secondary }}>Route: {m.routeName}</Text>
+            ) : null}
+            {m.params ? (
+              <Text style={{ color: theme.text.secondary }}>
+                Params: {JSON.stringify(m.params)}
+              </Text>
+            ) : null}
+          </View>
+        ))
+      )}
+    </ScrollView>
+  );
+}
+
+ExpoObserveScreen.navigationOptions = { title: 'Expo Observe' };
+
+const styles = StyleSheet.create({
+  content: { padding: 12, gap: 8 },
+  header: { fontSize: 18, fontWeight: '600', marginBottom: 4 },
+  row: {
+    paddingVertical: 8,
+    borderBottomColor: 'rgba(0,0,0,0.1)',
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  rowTop: { flexDirection: 'row', justifyContent: 'space-between' },
+  name: { fontFamily: 'Courier', fontSize: 14 },
+  value: { fontFamily: 'Courier', fontSize: 14 },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -857,6 +857,9 @@ importers:
       expo-age-range:
         specifier: workspace:*
         version: link:../../packages/expo-age-range
+      expo-app-metrics:
+        specifier: workspace:*
+        version: link:../../packages/expo-app-metrics
       expo-apple-authentication:
         specifier: workspace:*
         version: link:../../packages/expo-apple-authentication
@@ -17286,11 +17289,6 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
-    dependencies:
-      eslint: 8.57.1
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
     dependencies:
       eslint: 9.39.4(jiti@1.21.7)
@@ -21721,7 +21719,7 @@ snapshots:
 
   eslint@8.57.1:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.57.1


### PR DESCRIPTION
# Why

To make testing react-navigation integration with expo-observe easier

# How


# Test Plan


https://github.com/user-attachments/assets/14d9a647-9f34-410c-8e0f-82a66870892a



# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
