### PR TITLE
[core][Android] Fix `Unrecognized dependency notation`

### DIFF
--- a/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+++ b/packages/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
@@ -6,6 +6,7 @@ import expo.modules.plugin.Version
 import expo.modules.plugin.safeGet
 import org.gradle.api.Action
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Dependency
 import org.gradle.api.publish.maven.MavenPom
 import org.gradle.internal.extensions.core.extra
 import java.io.File
@@ -38,8 +39,9 @@ open class ExpoModuleExtension(val project: Project) {
     return project.rootProject.extra.safeGet<Any>(name) ?: default
   }
 
-  fun getExpoDependency(name: String): Any {
-    return autolinking.getExpoDependency(project, name)
+  fun getExpoDependency(name: String): Dependency {
+    val notation = autolinking.getExpoDependency(project, name)
+    return project.dependencies.create(notation)
   }
 
   var canBePublished: Boolean = true


### PR DESCRIPTION
# Why

Fixes `Unrecognized dependency notation` warning when using `implementation expoModule.getExpoDependency("...")`

# Test Plan

- bare-expo ✅ 