### PR TITLE
[docs] Fix guide titles and broken link in calendar docs

### DIFF
--- a/docs/pages/guides/sdk-libraries-migration/contacts.mdx
+++ b/docs/pages/guides/sdk-libraries-migration/contacts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Migrate to the new expo-contacts API
-sidebar_title: New expo-contacts API
+sidebar_title: expo-contacts/legacy
 description: Migrate from the legacy expo-contacts API to the new class-based expo-contacts API with Contact.
 ---
 

--- a/docs/pages/versions/unversioned/sdk/calendar.mdx
+++ b/docs/pages/versions/unversioned/sdk/calendar.mdx
@@ -19,7 +19,7 @@ import {
 
 `expo-calendar` provides an API for interacting with the device's system calendars, events, reminders, and associated records.
 
-Additionally, it provides methods to launch the [system-provided calendar UI](#launching-system-provided-calendar-dialogs) to allow the user to view or edit events. On iOS, they present either [`EKEventViewController`](https://developer.apple.com/documentation/eventkitui/ekeventviewcontroller) or [`EKEventEditViewController`](https://developer.apple.com/documentation/eventkitui/ekeventeditviewcontroller) as a modal.
+Additionally, it provides methods to launch the system-provided calendar UI to allow the user to view or edit events. On iOS, they present either [`EKEventViewController`](https://developer.apple.com/documentation/eventkitui/ekeventviewcontroller) or [`EKEventEditViewController`](https://developer.apple.com/documentation/eventkitui/ekeventeditviewcontroller) as a modal.
 
 ## Installation
 

--- a/docs/pages/versions/v56.0.0/sdk/calendar.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/calendar.mdx
@@ -19,7 +19,7 @@ import {
 
 `expo-calendar` provides an API for interacting with the device's system calendars, events, reminders, and associated records.
 
-Additionally, it provides methods to launch the [system-provided calendar UI](#launching-system-provided-calendar-dialogs) to allow the user to view or edit events. On iOS, they present either [`EKEventViewController`](https://developer.apple.com/documentation/eventkitui/ekeventviewcontroller) or [`EKEventEditViewController`](https://developer.apple.com/documentation/eventkitui/ekeventeditviewcontroller) as a modal.
+Additionally, it provides methods to launch the system-provided calendar UI to allow the user to view or edit events. On iOS, they present either [`EKEventViewController`](https://developer.apple.com/documentation/eventkitui/ekeventviewcontroller) or [`EKEventEditViewController`](https://developer.apple.com/documentation/eventkitui/ekeventeditviewcontroller) as a modal.
 
 ## Installation
 


### PR DESCRIPTION
# Why

Fixes a broken link in the calendar docs and renames the migration guides' titles.

# Test Plan
Docs Preview