### PR TITLE
[ci] Fork-safety audit

### DIFF
--- a/.github/workflows/bare-diffs.yml
+++ b/.github/workflows/bare-diffs.yml
@@ -37,7 +37,7 @@ jobs:
           pnpm expotools generate-bare-diffs --check
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && github.event.ref == 'refs/heads/main'
+        if: failure() && github.event.ref == 'refs/heads/main' && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_docs }}
           author_name: Check for Changes in Bare Diffs

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -55,6 +55,7 @@ concurrency:
 
 jobs:
   jest-ubuntu:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -98,6 +99,7 @@ jobs:
         run: pnpm test:e2e --max-workers 1 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
   jest-windows:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: windows-2022
     strategy:
       fail-fast: false
@@ -157,6 +159,7 @@ jobs:
         run: pnpm test:e2e --max-workers 1 --shard ${{ matrix.shard }}/${{ strategy.job-total }}
 
   playwright-ubuntu:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
@@ -216,6 +219,7 @@ jobs:
           retention-days: 30
 
   playwright-windows:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: windows-2022
     strategy:
       fail-fast: false

--- a/.github/workflows/create-expo-app.yml
+++ b/.github/workflows/create-expo-app.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   test:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/create-expo-module.yml
+++ b/.github/workflows/create-expo-module.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   test:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false

--- a/.github/workflows/development-client-latest-e2e.yml
+++ b/.github/workflows/development-client-latest-e2e.yml
@@ -75,7 +75,7 @@ jobs:
           path: packages/expo-dev-client/artifacts
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && github.repository == 'expo/expo'
+        if: failure()
         with:
           webhook: ${{ secrets.slack_webhook_dev_client }}
           channel: '#dev-clients'

--- a/.github/workflows/fingerprint.yml
+++ b/.github/workflows/fingerprint.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   test:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]

--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -87,20 +87,20 @@ jobs:
           include-hidden-files: true
 
       - name: Authenticate to Google Cloud
-        if: ${{ success() && github.event.inputs.publish == 'true' }}
+        if: ${{ success() && github.event.inputs.publish == 'true' && github.repository == 'expo/expo' }}
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           project_id: exponentjs
           workload_identity_provider: projects/321830142373/locations/global/workloadIdentityPools/github/providers/expo
 
       - name: Setup gcloud
-        if: ${{ success() && github.event.inputs.publish == 'true' }}
+        if: ${{ success() && github.event.inputs.publish == 'true' && github.repository == 'expo/expo' }}
         uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
         with:
           project_id: exponentjs
 
       - name: Upload XCFramework directory structure to GCS
-        if: ${{ success() && github.event.inputs.publish == 'true' }}
+        if: ${{ success() && github.event.inputs.publish == 'true' && github.repository == 'expo/expo' }}
         run: |
           SYNC_ROOT="$RUNNER_TEMP/precompiled-modules-upload"
           rm -rf "$SYNC_ROOT"

--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
@@ -53,7 +54,7 @@ jobs:
           xcodebuild -workspace ios/BareExpo.xcworkspace -scheme BareExpo -configuration Release -sdk iphonesimulator -derivedDataPath "ios/build" | xcpretty
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'

--- a/.github/workflows/issue-stale.yml
+++ b/.github/workflows/issue-stale.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   close-issues:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   action:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5

--- a/.github/workflows/native-component-list.yml
+++ b/.github/workflows/native-component-list.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: apps/native-component-list
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event.ref == 'refs/heads/main')
+        if: failure() && (github.event.ref == 'refs/heads/main') && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_api }}
           author_name: Build Native Component List

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   check-packages:
+    if: github.event_name != 'schedule' || github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     steps:
       - name: 👀 Checkout
@@ -75,14 +76,14 @@ jobs:
         run: pnpm expotools check-packages --since $SINCE --core
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_api }}
           author_name: Check packages
 
   check-packages-windows:
     runs-on: windows-latest
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'schedule' && github.repository == 'expo/expo') }}
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -106,7 +107,7 @@ jobs:
         run: pnpm expotools check-packages --all
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event_name == 'schedule' || github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_api }}
           author_name: Check packages

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   ios-build:
+    if: github.repository == 'expo/expo'
     strategy:
       fail-fast: true
       matrix:
@@ -87,6 +88,7 @@ jobs:
           author_name: React Native Nightly (iOS)
 
   android-build:
+    if: github.repository == 'expo/expo'
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -113,7 +113,7 @@ jobs:
           path: apps/bare-expo/macos/build/BareExpo.app
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   ios-build:
+    if: github.repository == 'expo/expo'
     runs-on: macos-15
     steps:
       - name: 👀 Checkout
@@ -87,6 +88,7 @@ jobs:
           author_name: Test Suite Nightly (iOS)
 
   ios-test:
+    if: github.repository == 'expo/expo'
     needs: ios-build
     runs-on: macos-15
     steps:
@@ -153,6 +155,7 @@ jobs:
           author_name: Test Suite Nightly (iOS)
 
   android-build:
+    if: github.repository == 'expo/expo'
     runs-on: ubuntu-24.04
     env:
       ORG_GRADLE_PROJECT_reactNativeArchitectures: x86_64
@@ -216,6 +219,7 @@ jobs:
           author_name: Test Suite Nightly (Android)
 
   android-test:
+    if: github.repository == 'expo/expo'
     needs: android-build
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -230,7 +230,7 @@ jobs:
         run: ccache -s -v
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
@@ -325,7 +325,7 @@ jobs:
           echo "Artifacts URL: ${{ steps.upload-artifacts.outputs.artifact-url }}"
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_ios }}
           channel: '#expo-ios'
@@ -428,7 +428,7 @@ jobs:
         run: ccache -s -v
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_android }}
           channel: '#expo-android'
@@ -507,7 +507,7 @@ jobs:
           echo "Artifacts URL: ${{ steps.upload-artifacts.outputs.artifact-url }}"
       - name: 🔔 Notify on Slack
         uses: ./.github/actions/slack-notify
-        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-'))
+        if: failure() && (github.event.ref == 'refs/heads/main' || startsWith(github.event.ref, 'refs/heads/sdk-')) && github.repository == 'expo/expo'
         with:
           webhook: ${{ secrets.slack_webhook_android }}
           channel: '#expo-android'


### PR DESCRIPTION
Picks up where #45782 and #45859 left off and closes out this sweep. Those two fixed scheduled workflows that auto-fired on forks (#45782) and secret-gated `pull_request_target`, `issues`, and label workflows (#45859). This does the same for nightly jobs that test global org-published artifacts, the hourly issue-maintenance crons, the GCP publish path in `ios-prebuild-external-xcframeworks`, and Slack-notify steps that referenced org-only webhooks. Each one sat red or burned CI on every fork run today. Adding `if: github.repository == 'expo/expo'` at the job or step level turns those into clean skips without changing anything on `expo/expo`.

Covers `test-react-native-nightly`, `test-suite-nightly`, `lock`, `issue-stale`, `cli`, `create-expo-app`, `create-expo-module`, `fingerprint`, `sdk`, `ios-static-frameworks`, `ios-prebuild-external-xcframeworks`, `bare-diffs`, `native-component-list`, `test-suite`, and `test-suite-macos`. One redundant step-level repo check on an already-gated job in `development-client-latest-e2e` removed.

# Test Plan

Inspect. `github.repository` is a built-in runner context. On `expo/expo` every guard evaluates true and the workflow runs as before. On a fork the guard is false and the job (or step) skips cleanly. `actionlint` is clean.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
  - Not applicable: workflow-only change.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
  - Not applicable: workflow-only change.
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
  - Not applicable: no docs touched.
