### PR TITLE
fix(precompile) Fix Hermes version resolution polarity in pod install logic

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Hermes version resolution polarity in `precompiled_modules.rb` so external prebuilt artifacts are looked up under the V1 Hermes subfolder by default, matching `hermes-engine.podspec`.
+
 ### 💡 Others
 
 - Bump to `@expo/spawn-async@^1.8.0` ([#45999](https://github.com/expo/expo/pull/45999) by [@kitten](https://github.com/kitten))

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Fix Hermes version resolution polarity in `precompiled_modules.rb` so external prebuilt artifacts are looked up under the V1 Hermes subfolder by default, matching `hermes-engine.podspec`.
+- Fix Hermes version resolution polarity in `precompiled_modules.rb` so external prebuilt artifacts are looked up under the V1 Hermes subfolder by default, matching `hermes-engine.podspec`. ([#46053](https://github.com/expo/expo/pull/46053) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/precompiled_modules.rb
@@ -1754,7 +1754,9 @@ module Expo
         @hermes_version ||= begin
           rn_path = react_native_path
           if rn_path
-            is_v1 = ENV['RCT_HERMES_V1_ENABLED'] == '1'
+            # Matches hermes-engine.podspec polarity: V1 is the default, classic
+            # is selected only when the consuming app explicitly sets the env var to "0".
+            is_v1 = ENV['RCT_HERMES_V1_ENABLED'] != '0'
             props_path = File.join(rn_path, 'sdks', 'hermes-engine', 'version.properties')
             version = File.exist?(props_path) ?
               parse_version_properties(props_path)[is_v1 ? 'HERMES_V1_VERSION_NAME' : 'HERMES_VERSION_NAME'] : nil


### PR DESCRIPTION
## Why

After fixing the hermes version selector when building react-native-worklets in #46051 the lookup for the 3rd party xcfframework would fail due to the same polarity issue in the pod install logic as well

## How

Fixed this by swapping polarity in the test in the ruby code as well.

## Test-plan

✅ Run pod install and verify that 3rd party frameworks are found

## Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
