### PR TITLE
[create-expo-module] support SharedObject view props

### DIFF
--- a/packages/create-expo-module/e2e/__tests__/index-test.ts
+++ b/packages/create-expo-module/e2e/__tests__/index-test.ts
@@ -563,6 +563,64 @@ describe('non-interactive defaults warning', () => {
   });
 });
 
+describe('--features option', () => {
+  it('should generate shared object view prop wiring when view and shared object are selected', async () => {
+    const project = createFakeProject('features-shared-view-project');
+    const slug = 'shared-view';
+
+    await executePassing(
+      [
+        slug,
+        '--local',
+        '--name',
+        'SharedThing',
+        '--package',
+        'expo.modules.sharedview',
+        '--platform',
+        'apple',
+        'android',
+        '--features',
+        'View',
+        'SharedObject',
+        '--source',
+        localTemplatePath,
+      ],
+      { cwd: project }
+    );
+
+    const modulePath = path.join(project, 'modules', slug);
+    const viewTsx = fs.readFileSync(path.join(modulePath, 'src', 'SharedThingView.tsx'), 'utf8');
+    const typesTs = fs.readFileSync(path.join(modulePath, 'src', 'SharedThing.types.ts'), 'utf8');
+    const swiftModule = fs.readFileSync(
+      path.join(modulePath, 'ios', 'SharedThingModule.swift'),
+      'utf8'
+    );
+    const kotlinModule = fs.readFileSync(
+      path.join(
+        modulePath,
+        'android',
+        'src',
+        'main',
+        'java',
+        'expo',
+        'modules',
+        'sharedview',
+        'SharedThingModule.kt'
+      ),
+      'utf8'
+    );
+
+    expect(viewTsx).toContain('__expo_shared_object_id__');
+    expect(viewTsx).toContain('NativeSharedThingViewProps');
+    expect(typesTs).toContain('sharedObject?: SharedThingModuleSharedObject | null');
+    expect(typesTs).toContain('sharedObject?: number | null');
+    expect(swiftModule).toContain('Prop("sharedObject")');
+    expect(swiftModule).toContain('sharedObject: SharedThingModuleSharedObject?');
+    expect(kotlinModule).toContain('Prop("sharedObject")');
+    expect(kotlinModule).toContain('sharedObject: SharedThingModuleSharedObject? ->');
+  });
+});
+
 describe('add-platform-support', () => {
   const localTemplatePath = path.resolve(__dirname, '../../../expo-module-template');
 

--- a/packages/create-expo-module/src/__tests__/snippets-test.ts
+++ b/packages/create-expo-module/src/__tests__/snippets-test.ts
@@ -30,6 +30,13 @@ const mockData = {
   type: 'standalone' as const,
 };
 
+function getMockDataWithFeatures(features: string[]) {
+  return {
+    ...mockData,
+    project: { ...mockData.project, features },
+  };
+}
+
 // Path to the actual snippets directory in the template package
 const SNIPPETS_DIR = path.resolve(__dirname, '../../../../packages/expo-module-template/snippets');
 
@@ -80,6 +87,27 @@ describe('buildViewSnippets', () => {
   it('includes ViewEvent block when ViewEvent selected', async () => {
     const result = await buildViewSnippets(SNIPPETS_DIR, ['View', 'ViewEvent'], mockData, 'swift');
     expect(result).toContain('Events("onTap")');
+  });
+
+  it('should include shared object prop when view and shared object are selected', async () => {
+    const result = await buildViewSnippets(
+      SNIPPETS_DIR,
+      ['View', 'SharedObject'],
+      getMockDataWithFeatures(['View', 'SharedObject']),
+      'swift'
+    );
+    expect(result).toContain('Prop("sharedObject")');
+    expect(result).toContain('sharedObject: MyModuleModuleSharedObject?');
+  });
+
+  it('should not include shared object prop when view is not selected', async () => {
+    const result = await buildViewSnippets(
+      SNIPPETS_DIR,
+      ['SharedObject'],
+      getMockDataWithFeatures(['SharedObject']),
+      'swift'
+    );
+    expect(result.trim()).toBe('');
   });
 });
 
@@ -178,6 +206,17 @@ describe('buildAppSnippets', () => {
     const result = await buildAppSnippets(SNIPPETS_DIR, ['SharedObject'], mockData, 'imports');
     expect(result).toContain('useMyModuleModuleSharedObject');
   });
+
+  it('should pass shared object to view jsx when both features are selected', async () => {
+    const dataWithViewAndSharedObject = getMockDataWithFeatures(['View', 'SharedObject']);
+    const result = await buildAppSnippets(
+      SNIPPETS_DIR,
+      ['View', 'SharedObject'],
+      dataWithViewAndSharedObject,
+      'jsx'
+    );
+    expect(result).toContain('sharedObject={sharedObject}');
+  });
 });
 
 describe('copyFileSnippets', () => {
@@ -221,6 +260,28 @@ describe('copyFileSnippets', () => {
       await copyFileSnippets(SNIPPETS_DIR, [], mockData, tmpDir);
       const entries = await fs.promises.readdir(tmpDir);
       expect(entries).toHaveLength(0);
+    } finally {
+      await fs.promises.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should generate view wrapper that forwards shared object id', async () => {
+    const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'snippets-test-'));
+    const dataWithViewAndSharedObject = getMockDataWithFeatures(['View', 'SharedObject']);
+    try {
+      await copyFileSnippets(
+        SNIPPETS_DIR,
+        ['View', 'SharedObject'],
+        dataWithViewAndSharedObject,
+        tmpDir
+      );
+      const viewTsx = path.join(tmpDir, 'src', `${mockData.project.viewName}.tsx`);
+      const content = await fs.promises.readFile(viewTsx, 'utf8');
+      expect(content).toContain('NativeMyModuleViewProps');
+      expect(content).toContain('__expo_shared_object_id__');
+      expect(content).toContain(
+        'sharedObject={sharedObject == null ? null : getSharedObjectId(sharedObject)}'
+      );
     } finally {
       await fs.promises.rm(tmpDir, { recursive: true, force: true });
     }

--- a/packages/create-expo-module/src/snippets.ts
+++ b/packages/create-expo-module/src/snippets.ts
@@ -15,7 +15,7 @@ const MODULE_LEVEL_FEATURES: Feature[] = [
   'SharedObject',
 ];
 
-const VIEW_LEVEL_FEATURES: Feature[] = ['ViewEvent'];
+const VIEW_LEVEL_FEATURES: Feature[] = ['ViewEvent', 'SharedObject'];
 const WEB_MODULE_FEATURES: Feature[] = ['Constant', 'Function', 'AsyncFunction'];
 const APP_SNIPPET_FEATURES: Feature[] = [
   'Constant',
@@ -83,6 +83,9 @@ export async function buildViewSnippets(
   data: object,
   ext: 'swift' | 'kt'
 ): Promise<string> {
+  if (!features.includes('View')) {
+    return '';
+  }
   const selected = VIEW_LEVEL_FEATURES.filter((f) => features.includes(f));
   const parts = await Promise.all(
     selected.map((feature) => renderSnippet(snippetsDir, feature, `view-block.${ext}.ejs`, data))

--- a/packages/expo-module-template/snippets/SharedObject/view-block.kt.ejs
+++ b/packages/expo-module-template/snippets/SharedObject/view-block.kt.ejs
@@ -1,0 +1,3 @@
+      Prop("sharedObject") { view: <%- project.viewName %>, sharedObject: <%- project.sharedObjectName %>? ->
+        view.sharedObject = sharedObject
+      }

--- a/packages/expo-module-template/snippets/SharedObject/view-block.swift.ejs
+++ b/packages/expo-module-template/snippets/SharedObject/view-block.swift.ejs
@@ -1,0 +1,3 @@
+      Prop("sharedObject") { (view: <%- project.viewName %>, sharedObject: <%- project.sharedObjectName %>?) in
+        view.sharedObject = sharedObject
+      }

--- a/packages/expo-module-template/snippets/View/app.jsx.tsx.ejs
+++ b/packages/expo-module-template/snippets/View/app.jsx.tsx.ejs
@@ -1,3 +1,3 @@
         <Group name="Views">
-          <<%- project.viewName %><% if (project.features.includes('ViewEvent')) { %> onTap={() => console.log('Tapped!')}<% } %> style={styles.view} />
+          <<%- project.viewName %><% if (project.features.includes('SharedObject')) { %> sharedObject={sharedObject}<% } %><% if (project.features.includes('ViewEvent')) { %> onTap={() => console.log('Tapped!')}<% } %> style={styles.view} />
         </Group>

--- a/packages/expo-module-template/snippets/View/view.kt.ejs
+++ b/packages/expo-module-template/snippets/View/view.kt.ejs
@@ -10,6 +10,17 @@ import expo.modules.kotlin.AppContext
 <% } %>import expo.modules.kotlin.views.ExpoView
 
 class <%- project.viewName %>(context: Context, appContext: AppContext) : ExpoView(context, appContext) {
+  private val label = TextView(context).apply {
+    gravity = Gravity.CENTER
+  }
+<% if (project.features.includes('SharedObject')) { %>
+  var sharedObject: <%- project.sharedObjectName %>? = null
+    set(value) {
+      field = value
+      updateLabel()
+    }
+
+<% } -%>
 <% if (project.features.includes('ViewEvent')) { %>  private val onTap by EventDispatcher<Unit>()
 
 <% } %>  init {
@@ -19,14 +30,15 @@ class <%- project.viewName %>(context: Context, appContext: AppContext) : ExpoVi
       gravity = Gravity.CENTER
       setBackgroundColor(Color.parseColor("#aabbcc"))
     }
-    val label = TextView(context).apply {
-      text = "<%- project.name %> - native view<% if (project.features.includes('ViewEvent')) { %>\nTap the view to emit a view event<% } %>"
-      gravity = Gravity.CENTER
-    }
+    updateLabel()
     container.addView(label)
     addView(container)
 <% if (project.features.includes('ViewEvent')) { %>    setOnClickListener {
       onTap(Unit)
     }
 <% } %>  }
+
+  private fun updateLabel() {
+    label.text = "<%- project.name %> - native view<% if (project.features.includes('ViewEvent')) { %>\nTap the view to emit a view event<% } %><% if (project.features.includes('SharedObject')) { %>\nShared object count: ${sharedObject?.count ?: 0}<% } %>"
+  }
 }

--- a/packages/expo-module-template/snippets/View/view.swift.ejs
+++ b/packages/expo-module-template/snippets/View/view.swift.ejs
@@ -4,6 +4,13 @@ import ExpoModulesCore
 // to apply the proper styling (e.g. border radius and shadows).
 class <%- project.viewName %>: ExpoView {
   let label = UILabel()
+<% if (project.features.includes('SharedObject')) { -%>
+  var sharedObject: <%- project.sharedObjectName %>? {
+    didSet {
+      updateLabel()
+    }
+  }
+<% } -%>
 <% if (project.features.includes('ViewEvent')) { -%>
   let onTap = EventDispatcher()
 <% } -%>
@@ -12,11 +19,15 @@ class <%- project.viewName %>: ExpoView {
     super.init(appContext: appContext)
     clipsToBounds = true
     backgroundColor = UIColor(red: 0.67, green: 0.73, blue: 0.80, alpha: 1.0)
-    label.text = "<%- project.name %> - native view<% if (project.features.includes('ViewEvent')) { %>\nTap the view to emit a view event<% } %>"
     label.textAlignment = .center
     label.numberOfLines = 0
     label.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+    updateLabel()
     addSubview(label)
+  }
+
+  private func updateLabel() {
+    label.text = "<%- project.name %> - native view<% if (project.features.includes('ViewEvent')) { %>\nTap the view to emit a view event<% } %><% if (project.features.includes('SharedObject')) { %>\nShared object count: \(sharedObject?.count ?? 0)<% } %>"
   }
 <% if (project.features.includes('ViewEvent')) { %>
   override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {

--- a/packages/expo-module-template/snippets/View/view.tsx.ejs
+++ b/packages/expo-module-template/snippets/View/view.tsx.ejs
@@ -1,10 +1,27 @@
 import { requireNativeView } from 'expo';
 import * as React from 'react';
 
-import { <%- project.viewName %>Props } from './<%- project.name %>.types';
+import { <% if (project.features.includes('SharedObject')) { %>Native<%- project.viewName %>Props, <% } %><%- project.viewName %>Props } from './<%- project.name %>.types';
 
-const NativeView: React.ComponentType<<%- project.viewName %>Props> = requireNativeView('<%- project.name %>');
+const NativeView: React.ComponentType<<% if (project.features.includes('SharedObject')) { %>Native<%- project.viewName %>Props<% } else { %><%- project.viewName %>Props<% } %>> = requireNativeView('<%- project.name %>');
 
+<% if (project.features.includes('SharedObject')) { -%>
+function getSharedObjectId(object: unknown): number | null {
+  return (object as { __expo_shared_object_id__?: number } | null)?.__expo_shared_object_id__ ?? null;
+}
+
+<% } -%>
 export default function <%- project.viewName %>(props: <%- project.viewName %>Props) {
+<% if (project.features.includes('SharedObject')) { -%>
+  const { sharedObject, ...nativeProps } = props;
+
+  return (
+    <NativeView
+      {...nativeProps}
+      sharedObject={sharedObject == null ? null : getSharedObjectId(sharedObject)}
+    />
+  );
+<% } else { -%>
   return <NativeView {...props} />;
+<% } -%>
 }

--- a/packages/expo-module-template/src/{%- project.name %}.types.ts
+++ b/packages/expo-module-template/src/{%- project.name %}.types.ts
@@ -1,7 +1,12 @@
 <% const hasEvent = project.features.includes('Event'); -%>
 <% const hasView = project.features.includes('View') || project.features.includes('ViewEvent'); -%>
+<% const hasSharedObjectViewProp = hasView && project.features.includes('SharedObject'); -%>
 <% if (hasView) { -%>
 import type { StyleProp, ViewStyle } from 'react-native';
+
+<% } -%>
+<% if (hasSharedObjectViewProp) { -%>
+import type { <%- project.sharedObjectName %> } from './<%- project.sharedObjectName %>';
 
 <% } -%>
 <% if (!hasEvent && !hasView) { -%>
@@ -26,6 +31,15 @@ export type <%- project.viewName %>Props = {
 <% if (project.features.includes('ViewEvent')) { -%>
   onTap: (event: { nativeEvent: OnTapEventPayload }) => void;
 <% } -%>
+<% if (hasSharedObjectViewProp) { -%>
+  sharedObject?: <%- project.sharedObjectName %> | null;
+<% } -%>
   style?: StyleProp<ViewStyle>;
 };
+<% if (hasSharedObjectViewProp) { -%>
+
+export type Native<%- project.viewName %>Props = Omit<<%- project.viewName %>Props, 'sharedObject'> & {
+  sharedObject?: number | null;
+};
+<% } -%>
 <% } -%>


### PR DESCRIPTION
# Why

Generated Expo modules can combine SharedObject and View, but passing the JS proxy directly as a view prop can resolve to nil/native null. This gives create-expo-module a first-class example for forwarding the shared object id.

# How

Added View + SharedObject native prop snippets, updated the generated React wrapper to pass __expo_shared_object_id__, and covered the combined feature path in unit/e2e tests.

# Test Plan

- git diff --check
- Tried pnpm --filter create-expo-module test -- --runTestsByPath packages/create-expo-module/src/__tests__/snippets-test.ts, but this checkout has no node_modules, so expo-module was not found.

# Checklist

- [ ] I added a changelog.md entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for npx expo prebuild & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)