### PR TITLE
[cli] Respect package manager release age gates in dependency checks

### DIFF
--- a/packages/@expo/cli/src/start/doctor/dependencies/__tests__/packageManagerReleaseAge-test.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/__tests__/packageManagerReleaseAge-test.ts
@@ -1,0 +1,131 @@
+import { vol } from 'memfs';
+
+import { fetch } from '../../../../utils/fetch';
+import { filterDependenciesBlockedByPackageManagerAgeGateAsync } from '../packageManagerReleaseAge';
+
+jest.mock('../../../../utils/fetch', () => ({
+  fetch: jest.fn(),
+}));
+
+const projectRoot = '/test-project';
+
+function mockRegistryTimes(times: Record<string, string>) {
+  jest.mocked(fetch).mockResolvedValue({
+    ok: true,
+    json: jest.fn().mockResolvedValue({ time: times }),
+  } as any);
+}
+
+describe(filterDependenciesBlockedByPackageManagerAgeGateAsync, () => {
+  beforeEach(() => {
+    vol.reset();
+    jest.mocked(fetch).mockReset();
+  });
+
+  it('skips warnings when Yarn npmMinimalAgeGate still blocks the expected version', async () => {
+    vol.fromJSON(
+      {
+        '.yarnrc.yml': 'npmMinimalAgeGate: 1440\n',
+      },
+      projectRoot
+    );
+    mockRegistryTimes({ '1.2.3': '2026-05-24T00:00:00.000Z' });
+
+    await expect(
+      filterDependenciesBlockedByPackageManagerAgeGateAsync(
+        projectRoot,
+        [
+          {
+            packageName: 'expo-splash-screen',
+            packageType: 'dependencies',
+            expectedVersionOrRange: '~1.2.3',
+            actualVersion: '1.2.2',
+          },
+        ],
+        new Date('2026-05-24T12:00:00.000Z')
+      )
+    ).resolves.toEqual([]);
+  });
+
+  it('keeps warnings when the expected version is older than the configured age gate', async () => {
+    vol.fromJSON(
+      {
+        '.npmrc': 'minimumReleaseAge=60\n',
+      },
+      projectRoot
+    );
+    mockRegistryTimes({ '1.2.3': '2026-05-24T00:00:00.000Z' });
+
+    const deps = [
+      {
+        packageName: 'expo-updates',
+        packageType: 'dependencies' as const,
+        expectedVersionOrRange: '~1.2.3',
+        actualVersion: '1.2.2',
+      },
+    ];
+
+    await expect(
+      filterDependenciesBlockedByPackageManagerAgeGateAsync(
+        projectRoot,
+        deps,
+        new Date('2026-05-24T02:00:00.000Z')
+      )
+    ).resolves.toEqual(deps);
+  });
+
+  it('respects package manager exclusion lists', async () => {
+    vol.fromJSON(
+      {
+        'pnpm-workspace.yaml': 'minimumReleaseAge: 1440\nminimumReleaseAgeExclude:\n  - expo-*\n',
+      },
+      projectRoot
+    );
+    mockRegistryTimes({ '1.2.3': '2026-05-24T00:00:00.000Z' });
+
+    const deps = [
+      {
+        packageName: 'expo-splash-screen',
+        packageType: 'dependencies' as const,
+        expectedVersionOrRange: '~1.2.3',
+        actualVersion: '1.2.2',
+      },
+    ];
+
+    await expect(
+      filterDependenciesBlockedByPackageManagerAgeGateAsync(
+        projectRoot,
+        deps,
+        new Date('2026-05-24T12:00:00.000Z')
+      )
+    ).resolves.toEqual(deps);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('supports Bun minimumReleaseAge seconds and fail-opens when registry metadata is unavailable', async () => {
+    vol.fromJSON(
+      {
+        'bunfig.toml': 'minimumReleaseAge = 86400\n',
+      },
+      projectRoot
+    );
+    jest.mocked(fetch).mockResolvedValue({ ok: false } as any);
+
+    const deps = [
+      {
+        packageName: 'expo-updates',
+        packageType: 'dependencies' as const,
+        expectedVersionOrRange: '~1.2.3',
+        actualVersion: '1.2.2',
+      },
+    ];
+
+    await expect(
+      filterDependenciesBlockedByPackageManagerAgeGateAsync(
+        projectRoot,
+        deps,
+        new Date('2026-05-24T12:00:00.000Z')
+      )
+    ).resolves.toEqual(deps);
+  });
+});

--- a/packages/@expo/cli/src/start/doctor/dependencies/packageManagerReleaseAge.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/packageManagerReleaseAge.ts
@@ -1,0 +1,240 @@
+import fs from 'fs';
+import path from 'path';
+import semver from 'semver';
+
+import type { IncorrectDependency } from './validateDependenciesVersions';
+import { fetch } from '../../../utils/fetch';
+
+const debug = require('debug')(
+  'expo:doctor:dependencies:package-manager-age'
+) as typeof console.log;
+
+type PackageManagerAgeGate = {
+  minimumAgeMs: number;
+  excludedPackages: string[];
+};
+
+type NpmRegistryPackument = {
+  time?: Record<string, string>;
+};
+
+/**
+ * Package managers can intentionally avoid freshly published npm versions to
+ * reduce supply-chain risk. If Expo's expected package version is still inside
+ * that configured age window, the package manager will refuse to install the
+ * version that expo-doctor recommends. In that case, suppress the warning and
+ * let the user's package-manager policy catch up naturally.
+ */
+export async function filterDependenciesBlockedByPackageManagerAgeGateAsync(
+  projectRoot: string,
+  incorrectDeps: IncorrectDependency[],
+  now: Date = new Date()
+): Promise<IncorrectDependency[]> {
+  if (!incorrectDeps.length) {
+    return incorrectDeps;
+  }
+
+  const ageGate = await resolvePackageManagerAgeGateAsync(projectRoot);
+  if (!ageGate) {
+    return incorrectDeps;
+  }
+
+  const filtered = await Promise.all(
+    incorrectDeps.map(async (dep) => {
+      if (isPackageExcludedFromAgeGate(dep.packageName, ageGate.excludedPackages)) {
+        return dep;
+      }
+
+      const expectedVersion = semver.minVersion(dep.expectedVersionOrRange)?.version;
+      if (!expectedVersion) {
+        return dep;
+      }
+
+      const publishedAt = await getPackageVersionPublishedAtAsync(dep.packageName, expectedVersion);
+      if (!publishedAt) {
+        return dep;
+      }
+
+      const ageMs = now.getTime() - publishedAt.getTime();
+      if (ageMs >= 0 && ageMs < ageGate.minimumAgeMs) {
+        debug(
+          `Skipping ${dep.packageName}@${dep.expectedVersionOrRange}; package-manager release age gate still blocks ${expectedVersion}`
+        );
+        return null;
+      }
+
+      return dep;
+    })
+  );
+
+  return filtered.filter(Boolean) as IncorrectDependency[];
+}
+
+async function resolvePackageManagerAgeGateAsync(
+  projectRoot: string
+): Promise<PackageManagerAgeGate | null> {
+  const configs = await Promise.all([
+    readYarnAgeGateAsync(projectRoot),
+    readPnpmAgeGateAsync(projectRoot),
+    readBunAgeGateAsync(projectRoot),
+  ]);
+
+  return configs.find(Boolean) ?? null;
+}
+
+async function readYarnAgeGateAsync(projectRoot: string): Promise<PackageManagerAgeGate | null> {
+  const yarnrc = await readTextFileIfExistsAsync(path.join(projectRoot, '.yarnrc.yml'));
+  if (!yarnrc) {
+    return null;
+  }
+
+  const ageMinutes = readNumberProperty(yarnrc, 'npmMinimalAgeGate');
+  if (!ageMinutes || ageMinutes <= 0) {
+    return null;
+  }
+
+  return {
+    minimumAgeMs: ageMinutes * 60 * 1000,
+    excludedPackages: readYamlListProperty(yarnrc, 'npmPreapprovedPackages'),
+  };
+}
+
+async function readPnpmAgeGateAsync(projectRoot: string): Promise<PackageManagerAgeGate | null> {
+  const configText = (
+    await Promise.all([
+      readTextFileIfExistsAsync(path.join(projectRoot, '.npmrc')),
+      readTextFileIfExistsAsync(path.join(projectRoot, '.pnpmrc')),
+      readTextFileIfExistsAsync(path.join(projectRoot, 'pnpm-workspace.yaml')),
+    ])
+  )
+    .filter(Boolean)
+    .join('\n');
+
+  if (!configText) {
+    return null;
+  }
+
+  const ageMinutes = readNumberProperty(configText, 'minimumReleaseAge');
+  if (!ageMinutes || ageMinutes <= 0) {
+    return null;
+  }
+
+  return {
+    minimumAgeMs: ageMinutes * 60 * 1000,
+    excludedPackages: [
+      ...readIniListProperty(configText, 'minimumReleaseAgeExclude'),
+      ...readYamlListProperty(configText, 'minimumReleaseAgeExclude'),
+    ],
+  };
+}
+
+async function readBunAgeGateAsync(projectRoot: string): Promise<PackageManagerAgeGate | null> {
+  const bunfig = await readTextFileIfExistsAsync(path.join(projectRoot, 'bunfig.toml'));
+  if (!bunfig) {
+    return null;
+  }
+
+  const ageSeconds = readNumberProperty(bunfig, 'minimumReleaseAge');
+  if (!ageSeconds || ageSeconds <= 0) {
+    return null;
+  }
+
+  return {
+    minimumAgeMs: ageSeconds * 1000,
+    excludedPackages: readTomlArrayProperty(bunfig, 'minimumReleaseAgeExcludes'),
+  };
+}
+
+async function readTextFileIfExistsAsync(filePath: string): Promise<string | null> {
+  try {
+    return await fs.promises.readFile(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function readNumberProperty(text: string, propertyName: string): number | null {
+  const match = text.match(new RegExp(`^\\s*${propertyName}\\s*[:=]\\s*(\\d+)\\s*$`, 'm'));
+  return match ? Number(match[1]!) : null;
+}
+
+function readIniListProperty(text: string, propertyName: string): string[] {
+  const match = text.match(new RegExp(`^\\s*${propertyName}\\s*=\\s*(.+?)\\s*$`, 'm'));
+  if (!match) {
+    return [];
+  }
+  return splitPackageList(match[1]!);
+}
+
+function readYamlListProperty(text: string, propertyName: string): string[] {
+  const inline = text.match(new RegExp(`^\\s*${propertyName}\\s*:\\s*\\[(.*?)\\]\\s*$`, 'm'));
+  if (inline) {
+    return splitPackageList(inline[1]!);
+  }
+
+  const block = text.match(
+    new RegExp(`^\\s*${propertyName}\\s*:\\s*\\n((?:\\s+-\\s+.+\\n?)+)`, 'm')
+  );
+  if (!block) {
+    return [];
+  }
+
+  return block[1]!
+    .split('\n')
+    .map((line) => line.match(/^\s+-\s+(.+?)\s*$/)?.[1])
+    .filter((value): value is string => !!value)
+    .map((value) => stripQuotes(value));
+}
+
+function readTomlArrayProperty(text: string, propertyName: string): string[] {
+  const match = text.match(new RegExp(`^\\s*${propertyName}\\s*=\\s*\\[(.*?)\\]\\s*$`, 'm'));
+  return match ? splitPackageList(match[1]!) : [];
+}
+
+function splitPackageList(value: string): string[] {
+  return value
+    .split(',')
+    .map((item) => stripQuotes(item.trim()))
+    .filter(Boolean);
+}
+
+function stripQuotes(value: string): string {
+  return value.replace(/^['"]|['"]$/g, '');
+}
+
+function isPackageExcludedFromAgeGate(packageName: string, excludedPackages: string[]): boolean {
+  return excludedPackages.some((pattern) => {
+    if (pattern === packageName) {
+      return true;
+    }
+
+    if (pattern.includes('*')) {
+      const regex = new RegExp(`^${pattern.split('*').map(escapeRegExp).join('.*')}$`);
+      return regex.test(packageName);
+    }
+
+    return false;
+  });
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+async function getPackageVersionPublishedAtAsync(
+  packageName: string,
+  version: string
+): Promise<Date | null> {
+  try {
+    const response = await fetch(`https://registry.npmjs.org/${encodeURIComponent(packageName)}`);
+    if (!response.ok) {
+      return null;
+    }
+
+    const packument = (await response.json()) as NpmRegistryPackument;
+    const publishedAt = packument.time?.[version];
+    return publishedAt ? new Date(publishedAt) : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
+++ b/packages/@expo/cli/src/start/doctor/dependencies/validateDependenciesVersions.ts
@@ -7,6 +7,7 @@ import semverRangeSubset from 'semver/ranges/subset';
 
 import type { BundledNativeModules } from './bundledNativeModules';
 import { getCombinedKnownVersionsAsync } from './getVersionedPackages';
+import { filterDependenciesBlockedByPackageManagerAgeGateAsync } from './packageManagerReleaseAge';
 import {
   correctReactNativeTvVersion,
   isReactNativeTvProjectAsync,
@@ -200,6 +201,11 @@ export async function getVersionedDependenciesAsync(
       (dep) => !incorrectAndExcludedDeps.includes(dep.packageName)
     );
   }
+
+  incorrectDeps = await filterDependenciesBlockedByPackageManagerAgeGateAsync(
+    projectRoot,
+    incorrectDeps
+  );
 
   return incorrectDeps;
 }


### PR DESCRIPTION
## Why

Closes #44479.

Package managers can intentionally block freshly published package versions with release age gates, such as Yarn's `npmMinimalAgeGate`, pnpm's `minimumReleaseAge`, and Bun's `minimumReleaseAge`.

When Expo has just published a compatible package version, dependency validation can warn users to install that fresh version even though their package manager is correctly refusing it until the age gate expires. With pnpm 11 now defaulting `minimumReleaseAge` to 24h, this can create noisy false positives right after Expo package releases.

## How

- Adds a dependency validation filter that reads common release age gate settings from:
  - Yarn `.yarnrc.yml`: `npmMinimalAgeGate`, `npmPreapprovedPackages`
  - pnpm `.npmrc`, `.pnpmrc`, `pnpm-workspace.yaml`: `minimumReleaseAge`, `minimumReleaseAgeExclude`
  - Bun `bunfig.toml`: `minimumReleaseAge`, `minimumReleaseAgeExcludes`
- Resolves the expected package version from Expo's semver range and checks the publish time from the npm registry.
- Suppresses the warning only while the expected version is still inside the configured age gate.
- Preserves warnings for package-manager age-gate exclusions/preapprovals and fails open when config or registry metadata cannot be read.

## Test plan

- `CI=true corepack pnpm install --no-frozen-lockfile --ignore-scripts --config.confirmModulesPurge=false --filter @expo/cli...`
- `CI=true corepack pnpm --filter @expo/cli build`
- `cd packages/@expo/cli && CI=true corepack pnpm lint -- src/start/doctor/dependencies/packageManagerReleaseAge.ts src/start/doctor/dependencies/validateDependenciesVersions.ts src/start/doctor/dependencies/__tests__/packageManagerReleaseAge-test.ts src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts`
- `cd packages/@expo/cli && CI=true corepack pnpm typecheck`
- `cd packages/@expo/cli && CI=true corepack pnpm exec jest --config jest.config.js --runTestsByPath src/start/doctor/dependencies/__tests__/packageManagerReleaseAge-test.ts src/start/doctor/dependencies/__tests__/validateDependenciesVersions-test.ts --runInBand`
