### PR TITLE
[docs] Add Expo Observe to glossary and monitoring services page

### DIFF
--- a/docs/pages/monitoring/services.mdx
+++ b/docs/pages/monitoring/services.mdx
@@ -12,7 +12,7 @@ import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-Once your app is released, you can track anonymized usage and performance data to give you insights on how users experience your app. This data includes which updates are in use, when users encounter bugs, how the app performs in production, and more.
+Once your app is released, you can track anonymized usage data to give you insights on how users use your app. This data includes which updates are in use, when users experience bugs, how the app performs in production, and more.
 
 ## EAS Insights
 

--- a/docs/pages/monitoring/services.mdx
+++ b/docs/pages/monitoring/services.mdx
@@ -5,13 +5,14 @@ description: Learn how to monitor the usage of your Expo and React Native app af
 
 import { LogrocketIcon } from '@expo/styleguide-icons/custom/LogrocketIcon';
 import { SentryIcon } from '@expo/styleguide-icons/custom/SentryIcon';
+import { ActivityIcon } from '@expo/styleguide-icons/outline/ActivityIcon';
 import { BookOpen02Icon } from '@expo/styleguide-icons/outline/BookOpen02Icon';
 import { DataIcon } from '@expo/styleguide-icons/outline/DataIcon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-Once your app is released, you can track anonymized usage data to give you insights on how users use your app. This data includes which updates are in use, when users experience bugs, and more.
+Once your app is released, you can track anonymized usage and performance data to give you insights on how users experience your app. This data includes which updates are in use, when users encounter bugs, how the app performs in production, and more.
 
 ## EAS Insights
 
@@ -29,6 +30,24 @@ Get started with the following guide:
   description="Learn how to use EAS Insights to monitor your app."
   href="/eas-insights/introduction/"
   Icon={DataIcon}
+/>
+
+## Expo Observe
+
+[Expo Observe](/eas/observe/introduction/) is a performance monitoring service from Expo that tracks how your app performs in production. It gives you visibility in startup metrics (such as cold launch time, time to first render, and time to interactive) from real app user sessions, rendering performance, and app user experience across different devices, networks, and conditions.
+
+<ContentSpotlight
+  alt="Performance metrics on the Expo Observe dashboard."
+  src="/static/images/expo-observe/dashboard.png"
+/>
+
+Get started with the following guide:
+
+<BoxLink
+  title="Expo Observe"
+  description="Learn how to use Expo Observe to monitor your app's performance."
+  href="/eas/observe/introduction/"
+  Icon={ActivityIcon}
 />
 
 ## LogRocket

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -126,7 +126,7 @@ The development server is typically hosted on `http://localhost:8081`. It hosts 
 
 ### Expo Application Services (EAS)
 
-[Expo Application Services (EAS)](/eas) are deeply integrated cloud services for Expo and React Native apps, such as [EAS Build](/build/introduction/), [EAS Submit](/submit/introduction/), [EAS Update](/eas-update/introduction/), [EAS Metadata](/eas/metadata/), [EAS Insights](/eas-insights/introduction/), [EAS Hosting](/eas/hosting/introduction/), and [EAS Workflows](/eas/workflows/introduction/).
+[Expo Application Services (EAS)](/eas) are deeply integrated cloud services for Expo and React Native apps, such as [EAS Build](/build/introduction/), [EAS Submit](/submit/introduction/), [EAS Update](/eas-update/introduction/), [EAS Metadata](/eas/metadata/), [EAS Insights](/eas-insights/introduction/), [EAS Hosting](/eas/hosting/introduction/), [EAS Workflows](/eas/workflows/introduction/), and [Expo Observe](/eas/observe/introduction/).
 
 ### EAS Build
 
@@ -222,6 +222,10 @@ A file named **expo-module.config.json** that lives in the root directory of a [
 ### Expo Modules API
 
 [Expo Modules API](/modules/module-api/) is a cross-platform API for writing native modules in Kotlin and Swift to add new capabilities to your apps. This API is provided by the library `expo-modules-core` which is included in the `expo` package.
+
+### Expo Observe
+
+[Expo Observe](/eas/observe/introduction/) is a performance monitoring service that tracks how an app performs in production, including cold and warm launch times, time to first render, and time to interactive. It uses the `expo-observe` library to collect metrics from production builds, which can then be viewed in the Observe dashboard.
 
 ### Expo Orbit
 


### PR DESCRIPTION
# Why

[Expo Observe](https://docs.expo.dev/eas/observe/introduction/) is missing from the two main discovery surfaces where readers go to find Expo's monitoring tools. It is also absent from the inline list of EAS sub-services in the glossary's `Expo Application Services (EAS)` entry, which is the canonical EAS inventory.

# How

- In `pages/more/glossary-of-terms.mdx`, add a new `Expo Observe` entry alphabetically.
- In `pages/monitoring/services.mdx`, add a new section about `Expo Observe`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2298" height="324" alt="CleanShot 2026-05-21 at 01 22 35@2x" src="https://github.com/user-attachments/assets/37f2e4df-deb6-4464-91ca-3f60f82d553b" />

<img width="4108" height="2100" alt="CleanShot 2026-05-21 at 01 22 06@2x" src="https://github.com/user-attachments/assets/3d36bad6-506a-4758-83ec-b6e7980308e1" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
