### PR TITLE
chore: Update ios-prebuild-external-xcframeworks.yml runs-on to `macos-26`

### DIFF
--- a/.github/workflows/ios-prebuild-external-xcframeworks.yml
+++ b/.github/workflows/ios-prebuild-external-xcframeworks.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   prebuild:
-    runs-on: macos-26-arm64
+    runs-on: macos-26
     timeout-minutes: 120
     permissions:
       contents: read


### PR DESCRIPTION
See stuck run: https://github.com/expo/expo/actions/runs/26184922049/job/77037692142

We didn't seem to ever had a valid run for `runs-on: macos-26-arm64` and searches suggest this may be invalid: https://github.com/expo/expo/actions/workflows/ios-prebuild-external-xcframeworks.yml