### PR TITLE
 [docs] Fix settings menu not opening on Native Project Upgrade Helper diff blocks

### DIFF
--- a/docs/ui/components/Snippet/DiffBlock.test.tsx
+++ b/docs/ui/components/Snippet/DiffBlock.test.tsx
@@ -1,10 +1,15 @@
 import { jest } from '@jest/globals';
 import { render, Screen, screen } from '@testing-library/react';
 import fs from 'fs-extra';
+import GithubSlugger from 'github-slugger';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { createHeadingManager } from '~/common/headingManager';
+import { HeadingsContext } from '~/common/withHeadingManager';
+
 import { DiffBlock } from '.';
+import { PermalinkedSnippetHeader } from './PermalinkedSnippetHeader';
 
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -73,5 +78,35 @@ index fa45c70206..0000000000
     render(<DiffBlock raw={diffWithDelete} collapseDeletedFiles />);
 
     expect(screen.queryByText(`import 'react-native';`)).not.toBeInTheDocument();
+  });
+
+  it('keeps permalinked diff header actions outside of the permalink link', () => {
+    const headingManager = createHeadingManager(new GithubSlugger(), { headings: [] });
+    const singleFileDiff = `diff --git a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+index 43aaf83..3d5a6c7 100644
+--- a/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
++++ b/templates/expo-template-bare-minimum/android/app/src/main/AndroidManifest.xml
+@@ -1 +1 @@
+-<manifest />
++<manifest xmlns:tools="http://schemas.android.com/tools" />`;
+
+    render(
+      <HeadingsContext.Provider value={headingManager}>
+        <DiffBlock
+          raw={singleFileDiff}
+          filenameModifier={str => str.replace('templates/expo-template-bare-minimum/', '')}
+          filenameToLinkUrl={filename => `https://github.com/expo/expo/tree/sdk-55/${filename}`}
+          SnippetHeaderComponent={PermalinkedSnippetHeader}
+        />
+      </HeadingsContext.Provider>
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'android/app/src/main/AndroidManifest.xml' })
+    ).toHaveAttribute('href', '#androidappsrcmainandroidmanifestxml');
+    expect(screen.queryByRole('link', { name: /Raw/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Show settings/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Raw' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show settings' })).toBeInTheDocument();
   });
 });

--- a/docs/ui/components/Snippet/PermalinkedSnippetHeader.tsx
+++ b/docs/ui/components/Snippet/PermalinkedSnippetHeader.tsx
@@ -8,7 +8,7 @@ import { SnippetHeader, SnippetHeaderProps } from './SnippetHeader';
 
 export const PermalinkedSnippetHeader = withHeadingManager(
   (props: SnippetHeaderProps & HeadingManagerProps) => {
-    const { title } = props;
+    const { headingManager, title, ...snippetHeaderProps } = props;
     let sidebarTitle;
     if (typeof title === 'string') {
       const pathSegments = title.split('/');
@@ -17,19 +17,22 @@ export const PermalinkedSnippetHeader = withHeadingManager(
       sidebarTitle =
         pathSegments.length > 2 ? pathSegments[0] + '/../' + pathSegments.at(-1) : title;
     }
-    const heading = props.headingManager.addHeading(title, 3, {
+    const heading = headingManager.addHeading(title, 3, {
       sidebarTitle,
       sidebarType: HeadingType.CODE_FILE_PATH,
     });
 
     return (
-      <LinkBase
-        id={heading.slug}
-        href={'#' + heading.slug}
-        ref={heading.ref}
-        className="scroll-m-4">
-        <SnippetHeader {...props} />
-      </LinkBase>
+      <div id={heading.slug} ref={heading.ref} className="scroll-m-4">
+        <SnippetHeader
+          {...snippetHeaderProps}
+          title={
+            <LinkBase href={'#' + heading.slug} className="text-inherit hocus:underline">
+              {title}
+            </LinkBase>
+          }
+        />
+      </div>
     );
   }
 );


### PR DESCRIPTION
# Why

On the [Native Project Upgrade Helper](https://docs.expo.dev/bare/upgrade) page, the three-dot settings menu next to each filename does not open. 

Clicking the three-dot settings menu button instead scrolls the page and selects the filename text. 


https://github.com/user-attachments/assets/69c21e1c-f892-429d-9581-088b28fb4959



# How

- Restructure `PermalinkedSnippetHeader` so the anchor wraps only the filename text instead of the whole header.
- Add a regression test to ensure permalinked diff headers keep `Raw` and settings actions outside the file permalink.

# Test Plan


https://github.com/user-attachments/assets/fc6faad9-cb75-4f2d-a28f-5cef2bb31489



# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
