### PR TITLE
docs(expo-router): update CLAUDE.md to reflect vendored react-navigation

### DIFF
--- a/packages/expo-router/CLAUDE.md
+++ b/packages/expo-router/CLAUDE.md
@@ -1,6 +1,6 @@
 # Expo Router
 
-File-based routing library for React Native and web applications. Built on top of React Navigation, it provides automatic route generation from file structure, deep linking, typed routes, and cross-platform navigation.
+File-based routing library for React Native and web applications. It provides automatic route generation from file structure, deep linking, typed routes, and cross-platform navigation. React Navigation's core code is vendored/forked into `src/react-navigation/` — there are no external `@react-navigation/*` dependencies.
 
 ## Structure
 
@@ -71,7 +71,18 @@ File-based routing library for React Native and web applications. Built on top o
 │   │   ├── Sitemap.tsx        # Route introspection
 │   │   └── Unmatched.tsx      # 404 screen
 │   │
-│   ├── fork/                  # Forked React Navigation code
+│   ├── react-navigation/      # Vendored React Navigation source (replaces all @react-navigation/* deps)
+│   │   ├── core/              # @react-navigation/core internals
+│   │   ├── native/            # @react-navigation/native (linking, back-button)
+│   │   ├── native-stack/      # @react-navigation/native-stack
+│   │   ├── bottom-tabs/       # @react-navigation/bottom-tabs
+│   │   ├── stack/             # @react-navigation/stack
+│   │   ├── drawer/            # @react-navigation/drawer
+│   │   ├── material-top-tabs/ # @react-navigation/material-top-tabs
+│   │   ├── elements/          # @react-navigation/elements
+│   │   └── routers/           # @react-navigation/routers
+│   │
+│   ├── fork/                  # Expo-specific overrides on top of the vendored react-navigation code
 │   │   ├── NavigationContainer.tsx  # Custom NavigationContainer
 │   │   ├── getStateFromPath.ts      # URL → navigation state
 │   │   ├── getPathFromState.ts      # Navigation state → URL


### PR DESCRIPTION
## Summary

- Removes the outdated "Built on top of React Navigation" description — `@react-navigation/*` packages are no longer external dependencies
- Notes that React Navigation source is vendored into `src/react-navigation/`
- Adds the full `src/react-navigation/` directory tree to the Structure section
- Clarifies that `fork/` contains Expo-specific overrides on top of the vendored code

🤖 Generated with [Claude Code](https://claude.com/claude-code)