### PR TITLE
expo-video crashes app when loading cached video on device with fille…

### DIFF
--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix crash when loading a cached video when the device is out of disk space. ([#46062](https://github.com/expo/expo/pull/46062) by [@dmilin1](https://github.com/dmilin1))
+
 ### 💡 Others
 
 ## 56.1.1 — 2026-05-15

--- a/packages/expo-video/ios/Cache/MediaFileHandle.swift
+++ b/packages/expo-video/ios/Cache/MediaFileHandle.swift
@@ -116,20 +116,20 @@ internal class MediaFileHandle {
 
     try writeHandle.seek(toOffset: UInt64(offset))
 
-    writeHandle.write(data)
-    writeHandle.synchronizeFile()
+    try writeHandle.write(contentsOf: data)
+    try writeHandle.synchronize()
   }
 
-  func append(data: Data) {
+  func append(data: Data) throws {
     lock.lock()
     defer { lock.unlock() }
     guard let writeHandle = writeHandle else {
-      return
+      throw VideoCacheException("Failed to append data to cache file handle: Write handle not available for file at: \(filePath)")
     }
 
-    writeHandle.seekToEndOfFile()
-    writeHandle.write(data)
-    writeHandle.synchronizeFile()
+    try writeHandle.seekToEnd()
+    try writeHandle.write(contentsOf: data)
+    try writeHandle.synchronize()
   }
 
   func close() {


### PR DESCRIPTION
# Why

expo-video's on-disk cache currently crashes the host app when the device runs out of disk space (or hits any other FileHandle write failure). MediaFileHandle uses the legacy `FileHandle` APIs which raise Objective‑C NSFileHandleOperationExceptions on failure rather than throwing Swift errors. The existing do/catch in CachedResource.writeData only catches Swift throws, so the NSException propagates all the way up and terminates the app.

Here's an example stack trace of a real crash report:
```
NSFileHandleOperationException: *** -[NSConcreteFileHandle writeData:]: No space left on device
  Foundation              _NSFileHandleRaiseOperationExceptionWhileReading
  Foundation              -[NSConcreteFileHandle writeData:]
  expo-video              MediaFileHandle.write
  expo-video              CachedResource.writeData
  expo-video              closure in CachableRequest.saveData
  libswift_Concurrency    future_adapter
```

# How

Switched ios/Cache/MediaFileHandle.swift to the iOS 13.4+ throwing FileHandle APIs so disk errors surface as Swift errors that the existing do/catch in CachedResource.writeData can already handle (logging a warning instead of crashing)

# Test Plan

1. Fill up a device's disk space as much as possible.
2. Play a video large enough that the cache will fill up any leftover space.
3. App crashes without this change. After the changes in this PR, the app no longer crashes.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
