### PR TITLE
[expo-modules-core] Suppress `-Wunused-result` warning in `FrontendConverter.cpp`

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Suppress `-Wunused-result` compiler warning in `FrontendConverter.cpp`. ([#46073](https://github.com/expo/expo/pull/46073) by [@tomekzaw](https://github.com/tomekzaw))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
+++ b/packages/expo-modules-core/android/src/main/cpp/types/FrontendConverter.cpp
@@ -775,7 +775,7 @@ jobject SynchronizableFrontendConverter::convert(
 bool SynchronizableFrontendConverter::canConvert(jsi::Runtime &rt, const jsi::Value &value) const {
   try {
     // TODO(@lukmccall): find a better way to check this without throwing exception
-    worklets::extractSerializableOrThrow(rt, value);
+    (void)worklets::extractSerializableOrThrow(rt, value);
     return true;
   } catch (...) {
     return false;


### PR DESCRIPTION
# Why

The Android build emits a `-Wunused-result` warning because `worklets::extractSerializableOrThrow` is declared with `[[nodiscard]]` and `SynchronizableFrontendConverter::canConvert` intentionally discards the returned value (the call is used purely for its throwing side effect to probe convertibility).

```
> Task :expo-modules-core:buildCMakeRelWithDebInfo[arm64-v8a]
.../FrontendConverter.cpp:778:5: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
  778 |     worklets::extractSerializableOrThrow(rt, value);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

# How

Cast the call to `void` to acknowledge that the result is intentionally discarded.

# Test Plan

- Build `expo-modules-core` for Android (`buildCMakeRelWithDebInfo[arm64-v8a]`) and confirm the warning is no longer emitted.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)