### PR TITLE
fix(precompile) use bundledNativeVersions.json to resolve versions

### DIFF
--- a/tools/src/prebuilds/pipeline/RunSteps.test.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.test.ts
@@ -181,11 +181,10 @@ describe('resolveFlavorTemplatedPath', () => {
 describe('rebindExternalPackagesToBundledVersions', () => {
   it('rewrites path and packageVersion for packages listed in bundledNativeModules', () => {
     const pkg = makePkg('rn-safe-area', [], { path: '/before', packageVersion: '5.6.2' });
-    rebindExternalPackagesToBundledVersions(
-      [pkg],
-      { 'rn-safe-area': '~5.7.0' },
-      () => ({ path: '/after', version: '5.7.0' })
-    );
+    rebindExternalPackagesToBundledVersions([pkg], { 'rn-safe-area': '~5.7.0' }, () => ({
+      path: '/after',
+      version: '5.7.0',
+    }));
     assert.equal(pkg.packageVersion, '5.7.0');
     assert.equal(pkg.path, '/after');
   });
@@ -194,11 +193,7 @@ describe('rebindExternalPackagesToBundledVersions', () => {
     const pkg = makePkg('rn-safe-area', [], { path: '/before', packageVersion: '5.6.2' });
     assert.throws(
       () =>
-        rebindExternalPackagesToBundledVersions(
-          [pkg],
-          { 'rn-safe-area': '~5.7.0' },
-          () => null
-        ),
+        rebindExternalPackagesToBundledVersions([pkg], { 'rn-safe-area': '~5.7.0' }, () => null),
       (err: Error) =>
         err.message.includes('rn-safe-area') &&
         err.message.includes('~5.7.0') &&
@@ -210,14 +205,10 @@ describe('rebindExternalPackagesToBundledVersions', () => {
   it('leaves packages absent from the bundled map untouched', () => {
     const pkg = makePkg('private-pkg', [], { path: '/before', packageVersion: '0.0.1' });
     let resolverCalled = false;
-    rebindExternalPackagesToBundledVersions(
-      [pkg],
-      { 'something-else': '1.0.0' },
-      () => {
-        resolverCalled = true;
-        return null;
-      }
-    );
+    rebindExternalPackagesToBundledVersions([pkg], { 'something-else': '1.0.0' }, () => {
+      resolverCalled = true;
+      return null;
+    });
     assert.equal(resolverCalled, false);
     assert.equal(pkg.packageVersion, '0.0.1');
     assert.equal(pkg.path, '/before');

--- a/tools/src/prebuilds/pipeline/RunSteps.test.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.test.ts
@@ -17,6 +17,7 @@ import {
   collectSharedSPMDependencies,
   CACHE_DEPS,
   expandWithUnbuiltDependencies,
+  rebindExternalPackagesToBundledVersions,
 } from './RunSteps';
 import type { SPMPackageSource } from '../ExternalPackage';
 import type { SPMProduct, SPMPackageDependencyConfig } from '../SPMConfig.types';
@@ -170,6 +171,56 @@ describe('resolveFlavorTemplatedPath', () => {
       resolveFlavorTemplatedPath('{flavor}/path/{flavor}.tar.gz', 'Release'),
       'Release/path/Release.tar.gz'
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rebindExternalPackagesToBundledVersions
+// ---------------------------------------------------------------------------
+
+describe('rebindExternalPackagesToBundledVersions', () => {
+  it('rewrites path and packageVersion for packages listed in bundledNativeModules', () => {
+    const pkg = makePkg('rn-safe-area', [], { path: '/before', packageVersion: '5.6.2' });
+    rebindExternalPackagesToBundledVersions(
+      [pkg],
+      { 'rn-safe-area': '~5.7.0' },
+      () => ({ path: '/after', version: '5.7.0' })
+    );
+    assert.equal(pkg.packageVersion, '5.7.0');
+    assert.equal(pkg.path, '/after');
+  });
+
+  it('throws with an actionable error when no installed version satisfies the bundled range', () => {
+    const pkg = makePkg('rn-safe-area', [], { path: '/before', packageVersion: '5.6.2' });
+    assert.throws(
+      () =>
+        rebindExternalPackagesToBundledVersions(
+          [pkg],
+          { 'rn-safe-area': '~5.7.0' },
+          () => null
+        ),
+      (err: Error) =>
+        err.message.includes('rn-safe-area') &&
+        err.message.includes('~5.7.0') &&
+        err.message.includes('bundledNativeModules.json') &&
+        err.message.includes('pnpm install')
+    );
+  });
+
+  it('leaves packages absent from the bundled map untouched', () => {
+    const pkg = makePkg('private-pkg', [], { path: '/before', packageVersion: '0.0.1' });
+    let resolverCalled = false;
+    rebindExternalPackagesToBundledVersions(
+      [pkg],
+      { 'something-else': '1.0.0' },
+      () => {
+        resolverCalled = true;
+        return null;
+      }
+    );
+    assert.equal(resolverCalled, false);
+    assert.equal(pkg.packageVersion, '0.0.1');
+    assert.equal(pkg.path, '/before');
   });
 });
 

--- a/tools/src/prebuilds/pipeline/RunSteps.test.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.test.ts
@@ -17,7 +17,7 @@ import {
   collectSharedSPMDependencies,
   CACHE_DEPS,
   expandWithUnbuiltDependencies,
-  rebindExternalPackagesToBundledVersions,
+  rebindExternalPackagesToBundledVersionsAsync,
 } from './RunSteps';
 import type { SPMPackageSource } from '../ExternalPackage';
 import type { SPMProduct, SPMPackageDependencyConfig } from '../SPMConfig.types';
@@ -175,25 +175,30 @@ describe('resolveFlavorTemplatedPath', () => {
 });
 
 // ---------------------------------------------------------------------------
-// rebindExternalPackagesToBundledVersions
+// rebindExternalPackagesToBundledVersionsAsync
 // ---------------------------------------------------------------------------
 
-describe('rebindExternalPackagesToBundledVersions', () => {
-  it('rewrites path and packageVersion for packages listed in bundledNativeModules', () => {
+describe('rebindExternalPackagesToBundledVersionsAsync', () => {
+  it('rewrites path and packageVersion for packages listed in bundledNativeModules', async () => {
     const pkg = makePkg('rn-safe-area', [], { path: '/before', packageVersion: '5.6.2' });
-    rebindExternalPackagesToBundledVersions([pkg], { 'rn-safe-area': '~5.7.0' }, () => ({
-      path: '/after',
-      version: '5.7.0',
-    }));
+    await rebindExternalPackagesToBundledVersionsAsync(
+      [pkg],
+      { 'rn-safe-area': '~5.7.0' },
+      async () => ({ path: '/after', version: '5.7.0' })
+    );
     assert.equal(pkg.packageVersion, '5.7.0');
     assert.equal(pkg.path, '/after');
   });
 
-  it('throws with an actionable error when no installed version satisfies the bundled range', () => {
+  it('throws with an actionable error when no installed version satisfies the bundled range', async () => {
     const pkg = makePkg('rn-safe-area', [], { path: '/before', packageVersion: '5.6.2' });
-    assert.throws(
+    await assert.rejects(
       () =>
-        rebindExternalPackagesToBundledVersions([pkg], { 'rn-safe-area': '~5.7.0' }, () => null),
+        rebindExternalPackagesToBundledVersionsAsync(
+          [pkg],
+          { 'rn-safe-area': '~5.7.0' },
+          async () => null
+        ),
       (err: Error) =>
         err.message.includes('rn-safe-area') &&
         err.message.includes('~5.7.0') &&
@@ -202,13 +207,17 @@ describe('rebindExternalPackagesToBundledVersions', () => {
     );
   });
 
-  it('leaves packages absent from the bundled map untouched', () => {
+  it('leaves packages absent from the bundled map untouched', async () => {
     const pkg = makePkg('private-pkg', [], { path: '/before', packageVersion: '0.0.1' });
     let resolverCalled = false;
-    rebindExternalPackagesToBundledVersions([pkg], { 'something-else': '1.0.0' }, () => {
-      resolverCalled = true;
-      return null;
-    });
+    await rebindExternalPackagesToBundledVersionsAsync(
+      [pkg],
+      { 'something-else': '1.0.0' },
+      async () => {
+        resolverCalled = true;
+        return null;
+      }
+    );
     assert.equal(resolverCalled, false);
     assert.equal(pkg.packageVersion, '0.0.1');
     assert.equal(pkg.path, '/before');

--- a/tools/src/prebuilds/pipeline/RunSteps.test.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.test.ts
@@ -17,7 +17,7 @@ import {
   collectSharedSPMDependencies,
   CACHE_DEPS,
   expandWithUnbuiltDependencies,
-  rebindExternalPackagesToBundledVersionsAsync,
+  rebindExternalPackagesToBundledVersions,
 } from './RunSteps';
 import type { SPMPackageSource } from '../ExternalPackage';
 import type { SPMProduct, SPMPackageDependencyConfig } from '../SPMConfig.types';
@@ -175,30 +175,25 @@ describe('resolveFlavorTemplatedPath', () => {
 });
 
 // ---------------------------------------------------------------------------
-// rebindExternalPackagesToBundledVersionsAsync
+// rebindExternalPackagesToBundledVersions
 // ---------------------------------------------------------------------------
 
-describe('rebindExternalPackagesToBundledVersionsAsync', () => {
-  it('rewrites path and packageVersion for packages listed in bundledNativeModules', async () => {
+describe('rebindExternalPackagesToBundledVersions', () => {
+  it('rewrites path and packageVersion for packages listed in bundledNativeModules', () => {
     const pkg = makePkg('rn-safe-area', [], { path: '/before', packageVersion: '5.6.2' });
-    await rebindExternalPackagesToBundledVersionsAsync(
-      [pkg],
-      { 'rn-safe-area': '~5.7.0' },
-      async () => ({ path: '/after', version: '5.7.0' })
-    );
+    rebindExternalPackagesToBundledVersions([pkg], { 'rn-safe-area': '~5.7.0' }, () => ({
+      path: '/after',
+      version: '5.7.0',
+    }));
     assert.equal(pkg.packageVersion, '5.7.0');
     assert.equal(pkg.path, '/after');
   });
 
-  it('throws with an actionable error when no installed version satisfies the bundled range', async () => {
+  it('throws with an actionable error when no installed version satisfies the bundled range', () => {
     const pkg = makePkg('rn-safe-area', [], { path: '/before', packageVersion: '5.6.2' });
-    await assert.rejects(
+    assert.throws(
       () =>
-        rebindExternalPackagesToBundledVersionsAsync(
-          [pkg],
-          { 'rn-safe-area': '~5.7.0' },
-          async () => null
-        ),
+        rebindExternalPackagesToBundledVersions([pkg], { 'rn-safe-area': '~5.7.0' }, () => null),
       (err: Error) =>
         err.message.includes('rn-safe-area') &&
         err.message.includes('~5.7.0') &&
@@ -207,17 +202,13 @@ describe('rebindExternalPackagesToBundledVersionsAsync', () => {
     );
   });
 
-  it('leaves packages absent from the bundled map untouched', async () => {
+  it('leaves packages absent from the bundled map untouched', () => {
     const pkg = makePkg('private-pkg', [], { path: '/before', packageVersion: '0.0.1' });
     let resolverCalled = false;
-    await rebindExternalPackagesToBundledVersionsAsync(
-      [pkg],
-      { 'something-else': '1.0.0' },
-      async () => {
-        resolverCalled = true;
-        return null;
-      }
-    );
+    rebindExternalPackagesToBundledVersions([pkg], { 'something-else': '1.0.0' }, () => {
+      resolverCalled = true;
+      return null;
+    });
     assert.equal(resolverCalled, false);
     assert.equal(pkg.packageVersion, '0.0.1');
     assert.equal(pkg.path, '/before');

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -16,6 +16,7 @@ import path from 'path';
 import { PACKAGES_DIR } from '../../Constants';
 import logger from '../../Logger';
 import { getPackageByName } from '../../Packages';
+import { getBundledVersionsAsync } from '../../ProjectVersions';
 import { Artifacts } from '../Artifacts';
 import { Dependencies } from '../Dependencies';
 import type { SPMPackageSource } from '../ExternalPackage';
@@ -31,6 +32,7 @@ import {
   verifyAllPackagesAsync,
   verifyLocalTarballPathsIfSetAsync,
 } from '../Utils';
+import { resolvePackageFromPnpmStore } from '../resolvePackage';
 import type { PrebuildContext } from './Context';
 import type { Step } from './Types';
 
@@ -42,6 +44,41 @@ import type { Step } from './Types';
  * Standard external dependencies that come from the cache (not from other packages).
  */
 export const CACHE_DEPS = new Set(['ReactNativeDependencies', 'React', 'Hermes']);
+
+// ---------------------------------------------------------------------------
+// Helper: rebindExternalPackagesToBundledVersions
+// ---------------------------------------------------------------------------
+
+/**
+ * Rebinds each external package's `path` / `packageVersion` to the pnpm-store
+ * install whose version satisfies `packages/expo/bundledNativeModules.json` —
+ * the canonical SDK manifest end users resolve against via `expo install`.
+ * Packages absent from the bundled map are left untouched. Throws when a
+ * bundled-listed package has no satisfying install anywhere in the workspace.
+ */
+export function rebindExternalPackagesToBundledVersions(
+  externalPackages: SPMPackageSource[],
+  bundledNativeModules: Record<string, string>,
+  resolve: (name: string, range: string) => { path: string; version: string } | null
+): void {
+  for (const pkg of externalPackages) {
+    const range = bundledNativeModules[pkg.packageName];
+    if (!range) continue;
+    const resolved = resolve(pkg.packageName, range);
+    if (!resolved) {
+      throw new Error(
+        `No installed version of "${pkg.packageName}" in the monorepo satisfies ${range} ` +
+          `(from packages/expo/bundledNativeModules.json — the canonical SDK manifest for ` +
+          `"expo install" and create-expo templates). Without a satisfying install, the ` +
+          `prebuilt XCFramework would be invisible to precompiled_modules.rb at end-user ` +
+          `pod install. Fix: add "${pkg.packageName}" to some workspace at a version ` +
+          `satisfying ${range} and run "pnpm install".`
+      );
+    }
+    pkg.path = resolved.path;
+    pkg.packageVersion = resolved.version;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helper: resolveFlavorTemplatedPath
@@ -486,11 +523,25 @@ export const prepareInputsStep: Step<PrebuildContext> = {
     ctx.packages = sorted;
     ctx.dependsOn = dependsOn;
 
-    // Log external packages if any
     const externalPackages = ctx.packages.filter((p) => isExternalPackage(p));
+
+    // 4b. Rebind each external package's source path to the install in the pnpm
+    // store whose version satisfies bundledNativeModules.json. This decouples the
+    // precompile from apps/bare-expo's pin, which drifts. Packages absent from
+    // the bundled map keep their bare-expo-resolved path.
+    rebindExternalPackagesToBundledVersions(
+      externalPackages,
+      await getBundledVersionsAsync(),
+      resolvePackageFromPnpmStore
+    );
+
+    // Log external packages with their resolved versions, so the post-rebind
+    // values are visible in the build output.
     if (externalPackages.length > 0) {
       logger.info(
-        `📦 External packages to build:\n${chalk.blue(externalPackages.map((p) => p.packageName).join(', '))}`
+        `📦 External packages to build:\n${chalk.blue(
+          externalPackages.map((p) => `${p.packageName}@${p.packageVersion}`).join(', ')
+        )}`
       );
     }
 

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -32,7 +32,7 @@ import {
   verifyAllPackagesAsync,
   verifyLocalTarballPathsIfSetAsync,
 } from '../Utils';
-import { resolvePackageFromPnpmStore } from '../resolvePackage';
+import { resolveInstalledPackage } from '../resolvePackage';
 import type { PrebuildContext } from './Context';
 import type { Step } from './Types';
 
@@ -46,25 +46,25 @@ import type { Step } from './Types';
 export const CACHE_DEPS = new Set(['ReactNativeDependencies', 'React', 'Hermes']);
 
 // ---------------------------------------------------------------------------
-// Helper: rebindExternalPackagesToBundledVersions
+// Helper: rebindExternalPackagesToBundledVersionsAsync
 // ---------------------------------------------------------------------------
 
 /**
- * Rebinds each external package's `path` / `packageVersion` to the pnpm-store
- * install whose version satisfies `packages/expo/bundledNativeModules.json` —
- * the canonical SDK manifest end users resolve against via `expo install`.
+ * Rebinds each external package's `path` / `packageVersion` to the install in
+ * any monorepo workspace whose version satisfies `packages/expo/bundledNativeModules.json`
+ * — the canonical SDK manifest end users resolve against via `expo install`.
  * Packages absent from the bundled map are left untouched. Throws when a
  * bundled-listed package has no satisfying install anywhere in the workspace.
  */
-export function rebindExternalPackagesToBundledVersions(
+export async function rebindExternalPackagesToBundledVersionsAsync(
   externalPackages: SPMPackageSource[],
   bundledNativeModules: Record<string, string>,
-  resolve: (name: string, range: string) => { path: string; version: string } | null
-): void {
+  resolve: (name: string, range: string) => Promise<{ path: string; version: string } | null>
+): Promise<void> {
   for (const pkg of externalPackages) {
     const range = bundledNativeModules[pkg.packageName];
     if (!range) continue;
-    const resolved = resolve(pkg.packageName, range);
+    const resolved = await resolve(pkg.packageName, range);
     if (!resolved) {
       throw new Error(
         `No installed version of "${pkg.packageName}" in the monorepo satisfies ${range} ` +
@@ -525,14 +525,14 @@ export const prepareInputsStep: Step<PrebuildContext> = {
 
     const externalPackages = ctx.packages.filter((p) => isExternalPackage(p));
 
-    // 4b. Rebind each external package's source path to the install in the pnpm
-    // store whose version satisfies bundledNativeModules.json. This decouples the
-    // precompile from apps/bare-expo's pin, which drifts. Packages absent from
-    // the bundled map keep their bare-expo-resolved path.
-    rebindExternalPackagesToBundledVersions(
+    // 4b. Rebind each external package's source path to the install in any
+    // workspace whose version satisfies bundledNativeModules.json. This decouples
+    // the precompile from apps/bare-expo's pin, which drifts. Packages absent
+    // from the bundled map keep their bare-expo-resolved path.
+    await rebindExternalPackagesToBundledVersionsAsync(
       externalPackages,
       await getBundledVersionsAsync(),
-      resolvePackageFromPnpmStore
+      resolveInstalledPackage
     );
 
     // Log external packages with their resolved versions, so the post-rebind

--- a/tools/src/prebuilds/pipeline/RunSteps.ts
+++ b/tools/src/prebuilds/pipeline/RunSteps.ts
@@ -46,7 +46,7 @@ import type { Step } from './Types';
 export const CACHE_DEPS = new Set(['ReactNativeDependencies', 'React', 'Hermes']);
 
 // ---------------------------------------------------------------------------
-// Helper: rebindExternalPackagesToBundledVersionsAsync
+// Helper: rebindExternalPackagesToBundledVersions
 // ---------------------------------------------------------------------------
 
 /**
@@ -56,15 +56,15 @@ export const CACHE_DEPS = new Set(['ReactNativeDependencies', 'React', 'Hermes']
  * Packages absent from the bundled map are left untouched. Throws when a
  * bundled-listed package has no satisfying install anywhere in the workspace.
  */
-export async function rebindExternalPackagesToBundledVersionsAsync(
+export function rebindExternalPackagesToBundledVersions(
   externalPackages: SPMPackageSource[],
   bundledNativeModules: Record<string, string>,
-  resolve: (name: string, range: string) => Promise<{ path: string; version: string } | null>
-): Promise<void> {
+  resolve: (name: string, range: string) => { path: string; version: string } | null
+): void {
   for (const pkg of externalPackages) {
     const range = bundledNativeModules[pkg.packageName];
     if (!range) continue;
-    const resolved = await resolve(pkg.packageName, range);
+    const resolved = resolve(pkg.packageName, range);
     if (!resolved) {
       throw new Error(
         `No installed version of "${pkg.packageName}" in the monorepo satisfies ${range} ` +
@@ -529,7 +529,7 @@ export const prepareInputsStep: Step<PrebuildContext> = {
     // workspace whose version satisfies bundledNativeModules.json. This decouples
     // the precompile from apps/bare-expo's pin, which drifts. Packages absent
     // from the bundled map keep their bare-expo-resolved path.
-    await rebindExternalPackagesToBundledVersionsAsync(
+    rebindExternalPackagesToBundledVersions(
       externalPackages,
       await getBundledVersionsAsync(),
       resolveInstalledPackage

--- a/tools/src/prebuilds/resolvePackage.test.ts
+++ b/tools/src/prebuilds/resolvePackage.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for resolvePackageFromPnpmStore — uses a tmpdir-mocked pnpm store layout
+ * so the suite is hermetic and does not depend on what the live workspace happens
+ * to have installed.
+ */
+import fs from 'fs';
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import os from 'os';
+import path from 'path';
+
+import { resolvePackageFromPnpmStore } from './resolvePackage';
+
+function withTempStore<T>(fn: (storeRoot: string) => T): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-store-'));
+  try {
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function writeStoreEntry(storeRoot: string, entryDir: string, packageName: string) {
+  const inner = path.join(storeRoot, entryDir, 'node_modules', packageName);
+  fs.mkdirSync(inner, { recursive: true });
+  fs.writeFileSync(path.join(inner, 'package.json'), '{}');
+}
+
+describe('resolvePackageFromPnpmStore', () => {
+  it('returns the install when exactly one version satisfies', () => {
+    withTempStore((storeRoot) => {
+      const entry = 'react-native-safe-area-context@5.7.0_react-native@0.85.3';
+      writeStoreEntry(storeRoot, entry, 'react-native-safe-area-context');
+      const result = resolvePackageFromPnpmStore('react-native-safe-area-context', '~5.7.0', {
+        storeRoot,
+      });
+      assert.deepEqual(result, {
+        version: '5.7.0',
+        path: path.join(storeRoot, entry, 'node_modules', 'react-native-safe-area-context'),
+      });
+    });
+  });
+
+  it('returns the highest version when multiple satisfy', () => {
+    withTempStore((storeRoot) => {
+      writeStoreEntry(storeRoot, 'rn@5.6.2_x', 'rn');
+      writeStoreEntry(storeRoot, 'rn@5.7.0_x', 'rn');
+      const result = resolvePackageFromPnpmStore('rn', '^5.6.0', { storeRoot });
+      assert.equal(result?.version, '5.7.0');
+    });
+  });
+
+  it('resolves scoped packages via the slash-to-plus encoding', () => {
+    withTempStore((storeRoot) => {
+      const entry = '@shopify+react-native-skia@2.6.2_x';
+      writeStoreEntry(storeRoot, entry, '@shopify/react-native-skia');
+      const result = resolvePackageFromPnpmStore('@shopify/react-native-skia', '2.6.2', {
+        storeRoot,
+      });
+      assert.equal(result?.version, '2.6.2');
+      assert.ok(result?.path.endsWith(path.join(entry, 'node_modules', '@shopify', 'react-native-skia')));
+    });
+  });
+
+  it('parses the version correctly for patched entries (patch_hash suffix)', () => {
+    withTempStore((storeRoot) => {
+      writeStoreEntry(storeRoot, 'rn-reanimated@4.3.1_patch_hash=abc_x', 'rn-reanimated');
+      const result = resolvePackageFromPnpmStore('rn-reanimated', '~4.3.0', { storeRoot });
+      assert.equal(result?.version, '4.3.1');
+    });
+  });
+
+  it('returns null when no installed version satisfies the range', () => {
+    withTempStore((storeRoot) => {
+      writeStoreEntry(storeRoot, 'rn@5.6.2_x', 'rn');
+      assert.equal(resolvePackageFromPnpmStore('rn', '~5.7.0', { storeRoot }), null);
+    });
+  });
+
+  it('skips entries whose inner node_modules/<pkg> is missing (half-installed)', () => {
+    withTempStore((storeRoot) => {
+      // Higher version is half-installed (no package.json).
+      fs.mkdirSync(path.join(storeRoot, 'rn@5.7.0_x', 'node_modules', 'rn'), { recursive: true });
+      writeStoreEntry(storeRoot, 'rn@5.6.5_x', 'rn');
+      const result = resolvePackageFromPnpmStore('rn', '^5.6.0', { storeRoot });
+      assert.equal(result?.version, '5.6.5');
+    });
+  });
+
+  it('skips entries whose version segment is not valid semver', () => {
+    withTempStore((storeRoot) => {
+      fs.mkdirSync(path.join(storeRoot, 'rn-svg@not-a-version_foo'), { recursive: true });
+      writeStoreEntry(storeRoot, 'rn-svg@15.15.4_x', 'rn-svg');
+      const result = resolvePackageFromPnpmStore('rn-svg', '15.15.4', { storeRoot });
+      assert.equal(result?.version, '15.15.4');
+    });
+  });
+
+  it('returns null without throwing when the store root does not exist', () => {
+    const missing = path.join(os.tmpdir(), `pnpm-missing-${Date.now()}`);
+    assert.equal(resolvePackageFromPnpmStore('x', '1.0.0', { storeRoot: missing }), null);
+  });
+});

--- a/tools/src/prebuilds/resolvePackage.test.ts
+++ b/tools/src/prebuilds/resolvePackage.test.ts
@@ -1,10 +1,8 @@
 /**
- * Tests for resolveInstalledPackage — uses a tmpdir-mocked monorepo layout
- * (workspace dirs with their own node_modules/<pkg>/package.json) so the suite
- * is hermetic and doesn't depend on what the live workspace happens to have
- * installed. Resolution goes through Node's `require.resolve`, so the test
- * just has to put a real `node_modules/<pkg>/package.json` in each fake
- * workspace and let Node's algorithm find it.
+ * Hermetic tests for resolveInstalledPackage. Each test builds a fake monorepo
+ * under a tmpdir with workspace dirs that each have their own
+ * `node_modules/<pkg>/package.json`, then calls the resolver with the tmpdir as
+ * repoRoot. Node's `require.resolve` does the rest.
  */
 import fs from 'fs';
 import assert from 'node:assert/strict';
@@ -14,55 +12,38 @@ import path from 'path';
 
 import { resolveInstalledPackage } from './resolvePackage';
 
-function withTempRepo<T>(fn: (repoRoot: string) => Promise<T> | T): Promise<T> | T {
+function withTempRepo<T>(fn: (repoRoot: string) => T): T {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mono-'));
-  const cleanup = () => fs.rmSync(dir, { recursive: true, force: true });
   try {
-    const result = fn(dir);
-    if (result instanceof Promise) {
-      return result.finally(cleanup);
-    }
-    cleanup();
-    return result;
-  } catch (err) {
-    cleanup();
-    throw err;
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 }
 
-function writeWorkspaceWithDep(
+function installInWorkspace(
   repoRoot: string,
   workspaceRelDir: string,
   packageName: string,
   version: string
 ) {
-  const workspaceDir = path.join(repoRoot, workspaceRelDir);
-  fs.mkdirSync(workspaceDir, { recursive: true });
-  fs.writeFileSync(
-    path.join(workspaceDir, 'package.json'),
-    JSON.stringify({ name: path.basename(workspaceDir), dependencies: { [packageName]: version } })
-  );
-  const installDir = path.join(workspaceDir, 'node_modules', packageName);
+  const installDir = path.join(repoRoot, workspaceRelDir, 'node_modules', packageName);
   fs.mkdirSync(installDir, { recursive: true });
   fs.writeFileSync(
     path.join(installDir, 'package.json'),
     JSON.stringify({ name: packageName, version })
   );
-  // Node's `require.resolve` returns the realpath (no `/private` prefix on macOS,
-  // `/var` is a symlink to `/private/var`), so normalize here for comparisons.
+  // require.resolve returns the realpath (macOS `/var` → `/private/var`).
   return fs.realpathSync(installDir);
 }
 
 describe('resolveInstalledPackage', () => {
-  it('returns the install when exactly one workspace has a satisfying version', async () => {
-    await withTempRepo(async (repoRoot) => {
-      const installDir = writeWorkspaceWithDep(
-        repoRoot,
-        'apps/expo-go',
-        'react-native-safe-area-context',
-        '5.7.0'
-      );
-      const result = await resolveInstalledPackage('react-native-safe-area-context', '~5.7.0', {
+  it('returns the install when exactly one workspace has a satisfying version', () => {
+    withTempRepo((repoRoot) => {
+      const installDir = installInWorkspace(repoRoot, 'apps/expo-go', 'rn-sample', '5.7.0');
+      // A second workspace without the dep is skipped.
+      fs.mkdirSync(path.join(repoRoot, 'apps/empty'), { recursive: true });
+      const result = resolveInstalledPackage('rn-sample', '~5.7.0', {
         repoRoot,
         workspacePatterns: ['apps/*'],
       });
@@ -70,11 +51,11 @@ describe('resolveInstalledPackage', () => {
     });
   });
 
-  it('returns the highest version when multiple workspaces have different versions', async () => {
-    await withTempRepo(async (repoRoot) => {
-      writeWorkspaceWithDep(repoRoot, 'apps/bare-expo', 'rn-sample', '5.6.2');
-      writeWorkspaceWithDep(repoRoot, 'apps/expo-go', 'rn-sample', '5.7.0');
-      const result = await resolveInstalledPackage('rn-sample', '^5.6.0', {
+  it('returns the highest version when multiple workspaces have different versions', () => {
+    withTempRepo((repoRoot) => {
+      installInWorkspace(repoRoot, 'apps/bare-expo', 'rn-sample', '5.6.2');
+      installInWorkspace(repoRoot, 'apps/expo-go', 'rn-sample', '5.7.0');
+      const result = resolveInstalledPackage('rn-sample', '^5.6.0', {
         repoRoot,
         workspacePatterns: ['apps/*'],
       });
@@ -82,15 +63,15 @@ describe('resolveInstalledPackage', () => {
     });
   });
 
-  it('resolves scoped packages', async () => {
-    await withTempRepo(async (repoRoot) => {
-      const installDir = writeWorkspaceWithDep(
+  it('resolves scoped packages', () => {
+    withTempRepo((repoRoot) => {
+      const installDir = installInWorkspace(
         repoRoot,
         'apps/expo-go',
         '@shopify/react-native-skia',
         '2.6.2'
       );
-      const result = await resolveInstalledPackage('@shopify/react-native-skia', '2.6.2', {
+      const result = resolveInstalledPackage('@shopify/react-native-skia', '2.6.2', {
         repoRoot,
         workspacePatterns: ['apps/*'],
       });
@@ -98,10 +79,10 @@ describe('resolveInstalledPackage', () => {
     });
   });
 
-  it('returns null when no workspace has a satisfying version', async () => {
-    await withTempRepo(async (repoRoot) => {
-      writeWorkspaceWithDep(repoRoot, 'apps/bare-expo', 'rn-sample', '5.6.2');
-      const result = await resolveInstalledPackage('rn-sample', '~5.7.0', {
+  it('returns null when no workspace has a satisfying version', () => {
+    withTempRepo((repoRoot) => {
+      installInWorkspace(repoRoot, 'apps/bare-expo', 'rn-sample', '5.6.2');
+      const result = resolveInstalledPackage('rn-sample', '~5.7.0', {
         repoRoot,
         workspacePatterns: ['apps/*'],
       });
@@ -109,38 +90,11 @@ describe('resolveInstalledPackage', () => {
     });
   });
 
-  it('deduplicates when multiple workspaces resolve to the same install path', async () => {
-    await withTempRepo(async (repoRoot) => {
-      // Two workspaces, but both happen to resolve to the same node_modules path
-      // (simulating a hoisted/shared install). The de-dup should prevent double-counting.
-      const sharedInstall = writeWorkspaceWithDep(
-        repoRoot,
-        'apps/shared-install',
-        'rn-sample',
-        '5.7.0'
-      );
-      // Workspace with no node_modules of its own — require.resolve walks up
-      // and finds nothing, so it's just skipped.
-      fs.mkdirSync(path.join(repoRoot, 'apps/empty'), { recursive: true });
-      fs.writeFileSync(path.join(repoRoot, 'apps/empty/package.json'), '{}');
-      const result = await resolveInstalledPackage('rn-sample', '~5.7.0', {
-        repoRoot,
-        workspacePatterns: ['apps/*'],
-      });
-      assert.deepEqual(result, { version: '5.7.0', path: sharedInstall });
-    });
-  });
-
-  it('skips workspaces that do not have the package installed', async () => {
-    await withTempRepo(async (repoRoot) => {
-      // expo-go has it, native-component-list does not.
-      const installDir = writeWorkspaceWithDep(repoRoot, 'apps/expo-go', 'rn-sample', '5.7.0');
-      fs.mkdirSync(path.join(repoRoot, 'apps/native-component-list'), { recursive: true });
-      fs.writeFileSync(
-        path.join(repoRoot, 'apps/native-component-list/package.json'),
-        JSON.stringify({ name: 'native-component-list' })
-      );
-      const result = await resolveInstalledPackage('rn-sample', '~5.7.0', {
+  it('ignores a workspace install with a non-semver version', () => {
+    withTempRepo((repoRoot) => {
+      installInWorkspace(repoRoot, 'apps/garbage', 'rn-sample', 'not-a-version');
+      const installDir = installInWorkspace(repoRoot, 'apps/ok', 'rn-sample', '5.7.0');
+      const result = resolveInstalledPackage('rn-sample', '^5.0.0', {
         repoRoot,
         workspacePatterns: ['apps/*'],
       });
@@ -148,31 +102,12 @@ describe('resolveInstalledPackage', () => {
     });
   });
 
-  it('returns null without throwing when the repo root does not exist', async () => {
+  it('returns null without throwing when the repo root does not exist', () => {
     const missing = path.join(os.tmpdir(), `mono-missing-${Date.now()}`);
-    const result = await resolveInstalledPackage('rn-sample', '1.0.0', {
+    const result = resolveInstalledPackage('rn-sample', '1.0.0', {
       repoRoot: missing,
       workspacePatterns: ['apps/*'],
     });
     assert.equal(result, null);
-  });
-
-  it('ignores a workspace install with a non-semver version', async () => {
-    await withTempRepo(async (repoRoot) => {
-      const garbage = path.join(repoRoot, 'apps/garbage/node_modules/rn-sample');
-      fs.mkdirSync(garbage, { recursive: true });
-      fs.writeFileSync(
-        path.join(garbage, 'package.json'),
-        JSON.stringify({ name: 'rn-sample', version: 'not-a-version' })
-      );
-      fs.writeFileSync(path.join(repoRoot, 'apps/garbage/package.json'), '{}');
-
-      const installDir = writeWorkspaceWithDep(repoRoot, 'apps/ok', 'rn-sample', '5.7.0');
-      const result = await resolveInstalledPackage('rn-sample', '^5.0.0', {
-        repoRoot,
-        workspacePatterns: ['apps/*'],
-      });
-      assert.deepEqual(result, { version: '5.7.0', path: installDir });
-    });
   });
 });

--- a/tools/src/prebuilds/resolvePackage.test.ts
+++ b/tools/src/prebuilds/resolvePackage.test.ts
@@ -1,7 +1,10 @@
 /**
- * Tests for resolvePackageFromPnpmStore — uses a tmpdir-mocked pnpm store layout
- * so the suite is hermetic and does not depend on what the live workspace happens
- * to have installed.
+ * Tests for resolveInstalledPackage — uses a tmpdir-mocked monorepo layout
+ * (workspace dirs with their own node_modules/<pkg>/package.json) so the suite
+ * is hermetic and doesn't depend on what the live workspace happens to have
+ * installed. Resolution goes through Node's `require.resolve`, so the test
+ * just has to put a real `node_modules/<pkg>/package.json` in each fake
+ * workspace and let Node's algorithm find it.
  */
 import fs from 'fs';
 import assert from 'node:assert/strict';
@@ -9,97 +12,167 @@ import { describe, it } from 'node:test';
 import os from 'os';
 import path from 'path';
 
-import { resolvePackageFromPnpmStore } from './resolvePackage';
+import { resolveInstalledPackage } from './resolvePackage';
 
-function withTempStore<T>(fn: (storeRoot: string) => T): T {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-store-'));
+function withTempRepo<T>(fn: (repoRoot: string) => Promise<T> | T): Promise<T> | T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mono-'));
+  const cleanup = () => fs.rmSync(dir, { recursive: true, force: true });
   try {
-    return fn(dir);
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    const result = fn(dir);
+    if (result instanceof Promise) {
+      return result.finally(cleanup);
+    }
+    cleanup();
+    return result;
+  } catch (err) {
+    cleanup();
+    throw err;
   }
 }
 
-function writeStoreEntry(storeRoot: string, entryDir: string, packageName: string) {
-  const inner = path.join(storeRoot, entryDir, 'node_modules', packageName);
-  fs.mkdirSync(inner, { recursive: true });
-  fs.writeFileSync(path.join(inner, 'package.json'), '{}');
+function writeWorkspaceWithDep(
+  repoRoot: string,
+  workspaceRelDir: string,
+  packageName: string,
+  version: string
+) {
+  const workspaceDir = path.join(repoRoot, workspaceRelDir);
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(workspaceDir, 'package.json'),
+    JSON.stringify({ name: path.basename(workspaceDir), dependencies: { [packageName]: version } })
+  );
+  const installDir = path.join(workspaceDir, 'node_modules', packageName);
+  fs.mkdirSync(installDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(installDir, 'package.json'),
+    JSON.stringify({ name: packageName, version })
+  );
+  // Node's `require.resolve` returns the realpath (no `/private` prefix on macOS,
+  // `/var` is a symlink to `/private/var`), so normalize here for comparisons.
+  return fs.realpathSync(installDir);
 }
 
-describe('resolvePackageFromPnpmStore', () => {
-  it('returns the install when exactly one version satisfies', () => {
-    withTempStore((storeRoot) => {
-      const entry = 'react-native-safe-area-context@5.7.0_react-native@0.85.3';
-      writeStoreEntry(storeRoot, entry, 'react-native-safe-area-context');
-      const result = resolvePackageFromPnpmStore('react-native-safe-area-context', '~5.7.0', {
-        storeRoot,
+describe('resolveInstalledPackage', () => {
+  it('returns the install when exactly one workspace has a satisfying version', async () => {
+    await withTempRepo(async (repoRoot) => {
+      const installDir = writeWorkspaceWithDep(
+        repoRoot,
+        'apps/expo-go',
+        'react-native-safe-area-context',
+        '5.7.0'
+      );
+      const result = await resolveInstalledPackage('react-native-safe-area-context', '~5.7.0', {
+        repoRoot,
+        workspacePatterns: ['apps/*'],
       });
-      assert.deepEqual(result, {
-        version: '5.7.0',
-        path: path.join(storeRoot, entry, 'node_modules', 'react-native-safe-area-context'),
-      });
+      assert.deepEqual(result, { version: '5.7.0', path: installDir });
     });
   });
 
-  it('returns the highest version when multiple satisfy', () => {
-    withTempStore((storeRoot) => {
-      writeStoreEntry(storeRoot, 'rn@5.6.2_x', 'rn');
-      writeStoreEntry(storeRoot, 'rn@5.7.0_x', 'rn');
-      const result = resolvePackageFromPnpmStore('rn', '^5.6.0', { storeRoot });
+  it('returns the highest version when multiple workspaces have different versions', async () => {
+    await withTempRepo(async (repoRoot) => {
+      writeWorkspaceWithDep(repoRoot, 'apps/bare-expo', 'rn-sample', '5.6.2');
+      writeWorkspaceWithDep(repoRoot, 'apps/expo-go', 'rn-sample', '5.7.0');
+      const result = await resolveInstalledPackage('rn-sample', '^5.6.0', {
+        repoRoot,
+        workspacePatterns: ['apps/*'],
+      });
       assert.equal(result?.version, '5.7.0');
     });
   });
 
-  it('resolves scoped packages via the slash-to-plus encoding', () => {
-    withTempStore((storeRoot) => {
-      const entry = '@shopify+react-native-skia@2.6.2_x';
-      writeStoreEntry(storeRoot, entry, '@shopify/react-native-skia');
-      const result = resolvePackageFromPnpmStore('@shopify/react-native-skia', '2.6.2', {
-        storeRoot,
-      });
-      assert.equal(result?.version, '2.6.2');
-      assert.ok(
-        result?.path.endsWith(path.join(entry, 'node_modules', '@shopify', 'react-native-skia'))
+  it('resolves scoped packages', async () => {
+    await withTempRepo(async (repoRoot) => {
+      const installDir = writeWorkspaceWithDep(
+        repoRoot,
+        'apps/expo-go',
+        '@shopify/react-native-skia',
+        '2.6.2'
       );
+      const result = await resolveInstalledPackage('@shopify/react-native-skia', '2.6.2', {
+        repoRoot,
+        workspacePatterns: ['apps/*'],
+      });
+      assert.deepEqual(result, { version: '2.6.2', path: installDir });
     });
   });
 
-  it('parses the version correctly for patched entries (patch_hash suffix)', () => {
-    withTempStore((storeRoot) => {
-      writeStoreEntry(storeRoot, 'rn-reanimated@4.3.1_patch_hash=abc_x', 'rn-reanimated');
-      const result = resolvePackageFromPnpmStore('rn-reanimated', '~4.3.0', { storeRoot });
-      assert.equal(result?.version, '4.3.1');
+  it('returns null when no workspace has a satisfying version', async () => {
+    await withTempRepo(async (repoRoot) => {
+      writeWorkspaceWithDep(repoRoot, 'apps/bare-expo', 'rn-sample', '5.6.2');
+      const result = await resolveInstalledPackage('rn-sample', '~5.7.0', {
+        repoRoot,
+        workspacePatterns: ['apps/*'],
+      });
+      assert.equal(result, null);
     });
   });
 
-  it('returns null when no installed version satisfies the range', () => {
-    withTempStore((storeRoot) => {
-      writeStoreEntry(storeRoot, 'rn@5.6.2_x', 'rn');
-      assert.equal(resolvePackageFromPnpmStore('rn', '~5.7.0', { storeRoot }), null);
+  it('deduplicates when multiple workspaces resolve to the same install path', async () => {
+    await withTempRepo(async (repoRoot) => {
+      // Two workspaces, but both happen to resolve to the same node_modules path
+      // (simulating a hoisted/shared install). The de-dup should prevent double-counting.
+      const sharedInstall = writeWorkspaceWithDep(
+        repoRoot,
+        'apps/shared-install',
+        'rn-sample',
+        '5.7.0'
+      );
+      // Workspace with no node_modules of its own — require.resolve walks up
+      // and finds nothing, so it's just skipped.
+      fs.mkdirSync(path.join(repoRoot, 'apps/empty'), { recursive: true });
+      fs.writeFileSync(path.join(repoRoot, 'apps/empty/package.json'), '{}');
+      const result = await resolveInstalledPackage('rn-sample', '~5.7.0', {
+        repoRoot,
+        workspacePatterns: ['apps/*'],
+      });
+      assert.deepEqual(result, { version: '5.7.0', path: sharedInstall });
     });
   });
 
-  it('skips entries whose inner node_modules/<pkg> is missing (half-installed)', () => {
-    withTempStore((storeRoot) => {
-      // Higher version is half-installed (no package.json).
-      fs.mkdirSync(path.join(storeRoot, 'rn@5.7.0_x', 'node_modules', 'rn'), { recursive: true });
-      writeStoreEntry(storeRoot, 'rn@5.6.5_x', 'rn');
-      const result = resolvePackageFromPnpmStore('rn', '^5.6.0', { storeRoot });
-      assert.equal(result?.version, '5.6.5');
+  it('skips workspaces that do not have the package installed', async () => {
+    await withTempRepo(async (repoRoot) => {
+      // expo-go has it, native-component-list does not.
+      const installDir = writeWorkspaceWithDep(repoRoot, 'apps/expo-go', 'rn-sample', '5.7.0');
+      fs.mkdirSync(path.join(repoRoot, 'apps/native-component-list'), { recursive: true });
+      fs.writeFileSync(
+        path.join(repoRoot, 'apps/native-component-list/package.json'),
+        JSON.stringify({ name: 'native-component-list' })
+      );
+      const result = await resolveInstalledPackage('rn-sample', '~5.7.0', {
+        repoRoot,
+        workspacePatterns: ['apps/*'],
+      });
+      assert.deepEqual(result, { version: '5.7.0', path: installDir });
     });
   });
 
-  it('skips entries whose version segment is not valid semver', () => {
-    withTempStore((storeRoot) => {
-      fs.mkdirSync(path.join(storeRoot, 'rn-svg@not-a-version_foo'), { recursive: true });
-      writeStoreEntry(storeRoot, 'rn-svg@15.15.4_x', 'rn-svg');
-      const result = resolvePackageFromPnpmStore('rn-svg', '15.15.4', { storeRoot });
-      assert.equal(result?.version, '15.15.4');
+  it('returns null without throwing when the repo root does not exist', async () => {
+    const missing = path.join(os.tmpdir(), `mono-missing-${Date.now()}`);
+    const result = await resolveInstalledPackage('rn-sample', '1.0.0', {
+      repoRoot: missing,
+      workspacePatterns: ['apps/*'],
     });
+    assert.equal(result, null);
   });
 
-  it('returns null without throwing when the store root does not exist', () => {
-    const missing = path.join(os.tmpdir(), `pnpm-missing-${Date.now()}`);
-    assert.equal(resolvePackageFromPnpmStore('x', '1.0.0', { storeRoot: missing }), null);
+  it('ignores a workspace install with a non-semver version', async () => {
+    await withTempRepo(async (repoRoot) => {
+      const garbage = path.join(repoRoot, 'apps/garbage/node_modules/rn-sample');
+      fs.mkdirSync(garbage, { recursive: true });
+      fs.writeFileSync(
+        path.join(garbage, 'package.json'),
+        JSON.stringify({ name: 'rn-sample', version: 'not-a-version' })
+      );
+      fs.writeFileSync(path.join(repoRoot, 'apps/garbage/package.json'), '{}');
+
+      const installDir = writeWorkspaceWithDep(repoRoot, 'apps/ok', 'rn-sample', '5.7.0');
+      const result = await resolveInstalledPackage('rn-sample', '^5.0.0', {
+        repoRoot,
+        workspacePatterns: ['apps/*'],
+      });
+      assert.deepEqual(result, { version: '5.7.0', path: installDir });
+    });
   });
 });

--- a/tools/src/prebuilds/resolvePackage.test.ts
+++ b/tools/src/prebuilds/resolvePackage.test.ts
@@ -37,17 +37,19 @@ function installInWorkspace(
   return fs.realpathSync(installDir);
 }
 
+const resolve = (repoRoot: string, name: string, range: string) =>
+  resolveInstalledPackage(name, range, { repoRoot, workspacePatterns: ['apps/*'] });
+
 describe('resolveInstalledPackage', () => {
   it('returns the install when exactly one workspace has a satisfying version', () => {
     withTempRepo((repoRoot) => {
       const installDir = installInWorkspace(repoRoot, 'apps/expo-go', 'rn-sample', '5.7.0');
       // A second workspace without the dep is skipped.
       fs.mkdirSync(path.join(repoRoot, 'apps/empty'), { recursive: true });
-      const result = resolveInstalledPackage('rn-sample', '~5.7.0', {
-        repoRoot,
-        workspacePatterns: ['apps/*'],
+      assert.deepEqual(resolve(repoRoot, 'rn-sample', '~5.7.0'), {
+        version: '5.7.0',
+        path: installDir,
       });
-      assert.deepEqual(result, { version: '5.7.0', path: installDir });
     });
   });
 
@@ -55,11 +57,7 @@ describe('resolveInstalledPackage', () => {
     withTempRepo((repoRoot) => {
       installInWorkspace(repoRoot, 'apps/bare-expo', 'rn-sample', '5.6.2');
       installInWorkspace(repoRoot, 'apps/expo-go', 'rn-sample', '5.7.0');
-      const result = resolveInstalledPackage('rn-sample', '^5.6.0', {
-        repoRoot,
-        workspacePatterns: ['apps/*'],
-      });
-      assert.equal(result?.version, '5.7.0');
+      assert.equal(resolve(repoRoot, 'rn-sample', '^5.6.0')?.version, '5.7.0');
     });
   });
 
@@ -71,22 +69,17 @@ describe('resolveInstalledPackage', () => {
         '@shopify/react-native-skia',
         '2.6.2'
       );
-      const result = resolveInstalledPackage('@shopify/react-native-skia', '2.6.2', {
-        repoRoot,
-        workspacePatterns: ['apps/*'],
+      assert.deepEqual(resolve(repoRoot, '@shopify/react-native-skia', '2.6.2'), {
+        version: '2.6.2',
+        path: installDir,
       });
-      assert.deepEqual(result, { version: '2.6.2', path: installDir });
     });
   });
 
   it('returns null when no workspace has a satisfying version', () => {
     withTempRepo((repoRoot) => {
       installInWorkspace(repoRoot, 'apps/bare-expo', 'rn-sample', '5.6.2');
-      const result = resolveInstalledPackage('rn-sample', '~5.7.0', {
-        repoRoot,
-        workspacePatterns: ['apps/*'],
-      });
-      assert.equal(result, null);
+      assert.equal(resolve(repoRoot, 'rn-sample', '~5.7.0'), null);
     });
   });
 
@@ -94,20 +87,15 @@ describe('resolveInstalledPackage', () => {
     withTempRepo((repoRoot) => {
       installInWorkspace(repoRoot, 'apps/garbage', 'rn-sample', 'not-a-version');
       const installDir = installInWorkspace(repoRoot, 'apps/ok', 'rn-sample', '5.7.0');
-      const result = resolveInstalledPackage('rn-sample', '^5.0.0', {
-        repoRoot,
-        workspacePatterns: ['apps/*'],
+      assert.deepEqual(resolve(repoRoot, 'rn-sample', '^5.0.0'), {
+        version: '5.7.0',
+        path: installDir,
       });
-      assert.deepEqual(result, { version: '5.7.0', path: installDir });
     });
   });
 
   it('returns null without throwing when the repo root does not exist', () => {
     const missing = path.join(os.tmpdir(), `mono-missing-${Date.now()}`);
-    const result = resolveInstalledPackage('rn-sample', '1.0.0', {
-      repoRoot: missing,
-      workspacePatterns: ['apps/*'],
-    });
-    assert.equal(result, null);
+    assert.equal(resolve(missing, 'rn-sample', '1.0.0'), null);
   });
 });

--- a/tools/src/prebuilds/resolvePackage.test.ts
+++ b/tools/src/prebuilds/resolvePackage.test.ts
@@ -58,7 +58,9 @@ describe('resolvePackageFromPnpmStore', () => {
         storeRoot,
       });
       assert.equal(result?.version, '2.6.2');
-      assert.ok(result?.path.endsWith(path.join(entry, 'node_modules', '@shopify', 'react-native-skia')));
+      assert.ok(
+        result?.path.endsWith(path.join(entry, 'node_modules', '@shopify', 'react-native-skia'))
+      );
     });
   });
 

--- a/tools/src/prebuilds/resolvePackage.ts
+++ b/tools/src/prebuilds/resolvePackage.ts
@@ -1,4 +1,6 @@
+import fs from 'fs';
 import path from 'path';
+import semver from 'semver';
 
 import { getExpoRepositoryRootDir } from '../Directories';
 
@@ -16,4 +18,40 @@ export function resolvePackagePath(packageName: string): string {
     const rnDir = path.dirname(require.resolve('react-native/package.json', { paths: [appDir] }));
     return path.dirname(require.resolve(`${packageName}/package.json`, { paths: [rnDir] }));
   }
+}
+
+/**
+ * Returns the install of `packageName` in the pnpm content-addressable store at
+ * the highest version satisfying `range`, decoupling the precompile from
+ * `apps/bare-expo`'s drift-prone pin. `null` if nothing satisfies.
+ */
+export function resolvePackageFromPnpmStore(
+  packageName: string,
+  range: string,
+  opts: { storeRoot?: string } = {}
+): { path: string; version: string } | null {
+  const storeRoot =
+    opts.storeRoot ?? path.join(getExpoRepositoryRootDir(), 'node_modules', '.pnpm');
+  // pnpm encodes scoped names by replacing `/` with `+`. Entry names look like
+  // `<encoded>@<version>[_<peer-deps-or-patch-suffix>]`.
+  const prefix = `${packageName.replace('/', '+')}@`;
+
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(storeRoot);
+  } catch {
+    return null;
+  }
+
+  let best: { path: string; version: string } | null = null;
+  for (const entry of entries) {
+    if (!entry.startsWith(prefix)) continue;
+    const version = entry.slice(prefix.length).split('_')[0];
+    if (!semver.valid(version) || !semver.satisfies(version, range)) continue;
+    if (best && semver.lte(version, best.version)) continue;
+    const sourcePath = path.join(storeRoot, entry, 'node_modules', packageName);
+    if (!fs.existsSync(path.join(sourcePath, 'package.json'))) continue;
+    best = { path: sourcePath, version };
+  }
+  return best;
 }

--- a/tools/src/prebuilds/resolvePackage.ts
+++ b/tools/src/prebuilds/resolvePackage.ts
@@ -39,19 +39,16 @@ export function resolveInstalledPackage(
   for (const pattern of patterns) {
     for (const ws of globSync(pattern, { cwd: repoRoot, absolute: true })) {
       let pkgJson: string;
+      let version: string | undefined;
       try {
         pkgJson = require.resolve(`${packageName}/package.json`, { paths: [ws] });
+        version = JSON.parse(fs.readFileSync(pkgJson, 'utf8')).version;
       } catch {
         continue;
       }
-      let version: string | undefined;
-      try {
-        version = JSON.parse(fs.readFileSync(pkgJson, 'utf8')).version;
-      } catch {
-        /* skip */
-      }
       if (!version || !semver.valid(version) || !semver.satisfies(version, range)) continue;
-      if (!best || semver.gt(version, best.version)) best = { path: path.dirname(pkgJson), version };
+      if (!best || semver.gt(version, best.version))
+        best = { path: path.dirname(pkgJson), version };
     }
   }
   return best;

--- a/tools/src/prebuilds/resolvePackage.ts
+++ b/tools/src/prebuilds/resolvePackage.ts
@@ -1,8 +1,21 @@
 import fs from 'fs';
+import { glob } from 'glob';
 import path from 'path';
 import semver from 'semver';
 
 import { getExpoRepositoryRootDir } from '../Directories';
+
+// Mirrors the `packages:` globs in `pnpm-workspace.yaml`. Kept in sync by hand —
+// if the workspace layout changes, update here. Parsing yaml just for this would
+// add a dep this resolver doesn't otherwise need.
+const WORKSPACE_GLOBS = [
+  'apps/*',
+  'packages/*',
+  'packages/@expo/*',
+  'tools',
+  'apps/brownfield-tester/expo-app',
+  'apps/bare-expo/e2e/image-comparison',
+];
 
 /**
  * Resolves the filesystem path to an npm package that isn't a direct dependency
@@ -21,37 +34,54 @@ export function resolvePackagePath(packageName: string): string {
 }
 
 /**
- * Returns the install of `packageName` in the pnpm content-addressable store at
- * the highest version satisfying `range`, decoupling the precompile from
- * `apps/bare-expo`'s drift-prone pin. `null` if nothing satisfies.
+ * Finds the highest installed version of `packageName` across all monorepo
+ * workspaces that satisfies `range`. Used by the precompile to align built
+ * XCFrameworks with `packages/expo/bundledNativeModules.json` rather than any
+ * single workspace's pin (which drifts — see `apps/bare-expo`).
+ *
+ * Resolution goes through Node's own algorithm (`require.resolve`) from each
+ * workspace dir, so the result is whatever the package manager symlinked or
+ * hoisted there — no assumptions about pnpm's store dir-name shape, the
+ * lockfile format, or peer/patch suffix encoding. Whatever resolves, resolves.
+ *
+ * Returns `null` if no workspace has a satisfying install.
  */
-export function resolvePackageFromPnpmStore(
+export async function resolveInstalledPackage(
   packageName: string,
   range: string,
-  opts: { storeRoot?: string } = {}
-): { path: string; version: string } | null {
-  const storeRoot =
-    opts.storeRoot ?? path.join(getExpoRepositoryRootDir(), 'node_modules', '.pnpm');
-  // pnpm encodes scoped names by replacing `/` with `+`. Entry names look like
-  // `<encoded>@<version>[_<peer-deps-or-patch-suffix>]`.
-  const prefix = `${packageName.replace('/', '+')}@`;
+  opts: { repoRoot?: string; workspacePatterns?: string[] } = {}
+): Promise<{ path: string; version: string } | null> {
+  const repoRoot = opts.repoRoot ?? getExpoRepositoryRootDir();
+  const patterns = opts.workspacePatterns ?? WORKSPACE_GLOBS;
 
-  let entries: string[];
-  try {
-    entries = fs.readdirSync(storeRoot);
-  } catch {
-    return null;
-  }
-
+  const seen = new Set<string>();
   let best: { path: string; version: string } | null = null;
-  for (const entry of entries) {
-    if (!entry.startsWith(prefix)) continue;
-    const version = entry.slice(prefix.length).split('_')[0];
-    if (!semver.valid(version) || !semver.satisfies(version, range)) continue;
-    if (best && semver.lte(version, best.version)) continue;
-    const sourcePath = path.join(storeRoot, entry, 'node_modules', packageName);
-    if (!fs.existsSync(path.join(sourcePath, 'package.json'))) continue;
-    best = { path: sourcePath, version };
+
+  for (const pattern of patterns) {
+    const workspaces = await glob(pattern, { cwd: repoRoot, absolute: true });
+    for (const workspaceDir of workspaces) {
+      let resolvedPkgJson: string;
+      try {
+        resolvedPkgJson = require.resolve(`${packageName}/package.json`, {
+          paths: [workspaceDir],
+        });
+      } catch {
+        continue;
+      }
+      const pkgDir = path.dirname(resolvedPkgJson);
+      if (seen.has(pkgDir)) continue;
+      seen.add(pkgDir);
+
+      let version: string;
+      try {
+        version = JSON.parse(fs.readFileSync(resolvedPkgJson, 'utf8')).version;
+      } catch {
+        continue;
+      }
+      if (!semver.valid(version) || !semver.satisfies(version, range)) continue;
+      if (best && semver.lte(version, best.version)) continue;
+      best = { path: pkgDir, version };
+    }
   }
   return best;
 }

--- a/tools/src/prebuilds/resolvePackage.ts
+++ b/tools/src/prebuilds/resolvePackage.ts
@@ -1,21 +1,11 @@
 import fs from 'fs';
-import { glob } from 'glob';
+import { globSync } from 'glob';
 import path from 'path';
 import semver from 'semver';
 
 import { getExpoRepositoryRootDir } from '../Directories';
 
-// Mirrors the `packages:` globs in `pnpm-workspace.yaml`. Kept in sync by hand —
-// if the workspace layout changes, update here. Parsing yaml just for this would
-// add a dep this resolver doesn't otherwise need.
-const WORKSPACE_GLOBS = [
-  'apps/*',
-  'packages/*',
-  'packages/@expo/*',
-  'tools',
-  'apps/brownfield-tester/expo-app',
-  'apps/bare-expo/e2e/image-comparison',
-];
+const WORKSPACE_GLOBS = ['apps/*', 'packages/*', 'packages/@expo/*', 'tools'];
 
 /**
  * Resolves the filesystem path to an npm package that isn't a direct dependency
@@ -34,53 +24,34 @@ export function resolvePackagePath(packageName: string): string {
 }
 
 /**
- * Finds the highest installed version of `packageName` across all monorepo
- * workspaces that satisfies `range`. Used by the precompile to align built
- * XCFrameworks with `packages/expo/bundledNativeModules.json` rather than any
- * single workspace's pin (which drifts — see `apps/bare-expo`).
- *
- * Resolution goes through Node's own algorithm (`require.resolve`) from each
- * workspace dir, so the result is whatever the package manager symlinked or
- * hoisted there — no assumptions about pnpm's store dir-name shape, the
- * lockfile format, or peer/patch suffix encoding. Whatever resolves, resolves.
- *
- * Returns `null` if no workspace has a satisfying install.
+ * Returns the highest version of `packageName` installed in any monorepo
+ * workspace satisfying `range`, or `null`. Goes through Node's `require.resolve`
+ * — no assumptions about pnpm store / lockfile shape.
  */
-export async function resolveInstalledPackage(
+export function resolveInstalledPackage(
   packageName: string,
   range: string,
   opts: { repoRoot?: string; workspacePatterns?: string[] } = {}
-): Promise<{ path: string; version: string } | null> {
+): { path: string; version: string } | null {
   const repoRoot = opts.repoRoot ?? getExpoRepositoryRootDir();
   const patterns = opts.workspacePatterns ?? WORKSPACE_GLOBS;
-
-  const seen = new Set<string>();
   let best: { path: string; version: string } | null = null;
-
   for (const pattern of patterns) {
-    const workspaces = await glob(pattern, { cwd: repoRoot, absolute: true });
-    for (const workspaceDir of workspaces) {
-      let resolvedPkgJson: string;
+    for (const ws of globSync(pattern, { cwd: repoRoot, absolute: true })) {
+      let pkgJson: string;
       try {
-        resolvedPkgJson = require.resolve(`${packageName}/package.json`, {
-          paths: [workspaceDir],
-        });
+        pkgJson = require.resolve(`${packageName}/package.json`, { paths: [ws] });
       } catch {
         continue;
       }
-      const pkgDir = path.dirname(resolvedPkgJson);
-      if (seen.has(pkgDir)) continue;
-      seen.add(pkgDir);
-
-      let version: string;
+      let version: string | undefined;
       try {
-        version = JSON.parse(fs.readFileSync(resolvedPkgJson, 'utf8')).version;
+        version = JSON.parse(fs.readFileSync(pkgJson, 'utf8')).version;
       } catch {
-        continue;
+        /* skip */
       }
-      if (!semver.valid(version) || !semver.satisfies(version, range)) continue;
-      if (best && semver.lte(version, best.version)) continue;
-      best = { path: pkgDir, version };
+      if (!version || !semver.valid(version) || !semver.satisfies(version, range)) continue;
+      if (!best || semver.gt(version, best.version)) best = { path: path.dirname(pkgJson), version };
     }
   }
   return best;


### PR DESCRIPTION
## Why

Previously `BareExpo's` `node_modules` folder was used as the source of truth for selecting which 3rd party versions to pick. This failed when we forgot to update BareExpo's package.json after updating `bundlednativeVersions.json`.

## How

Now package resolving is done against the pnpm store instead of BareExpo.

## Test-plan

✅ Ran `et prebuild -f Debug react-native-safe-area-context` when RNCSafeAreaContext was set to 5.6.2 in BareEXpo and 5.7.0 in bundledNativeVersions.json - built 5.7.0 correctly.