### PR TITLE
[expo-go] Fix method signature

### DIFF
--- a/apps/expo-go/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledDevLoadingView.m
+++ b/apps/expo-go/ios/Exponent/Versioned/Core/Internal/DevSupport/EXDisabledDevLoadingView.m
@@ -22,7 +22,7 @@ RCT_EXPORT_METHOD(hide)
   }
 }
 
-RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor)
+RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor dismissButton:(BOOL)dismissButton)
 {
   RCTDevSettings *settings =  [self.bridge devSettings];
   BOOL isFastRefreshEnabled = [settings isHotLoadingEnabled];
@@ -60,9 +60,6 @@ RCT_EXPORT_METHOD(showMessage:(NSString *)message color:(UIColor *)color backgro
 
 - (void)updateProgress:(RCTLoadingProgress *)progress
 {
-}
-
-- (void)showMessage:(NSString *)message color:(UIColor *)color backgroundColor:(UIColor *)backgroundColor dismissButton:(BOOL)dismissButton {
 }
 
 @end


### PR DESCRIPTION
# Why
React Native's JS side was updated to pass 4 arguments to showMessage but in `EXDisabledDevLoadingView`, the impl only accepted three. 

# How
Add the parameter to the impl and remove the stub. We can both satisfy the protocol and implement in a single method

# Test Plan
Expo go. Hot reloading works without error

