### PR TITLE
chore(precompile) updated patch/config for skia prebuilds

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Update `@shopify/react-native-skia` precompile config for the 2.6.x source layout
+
 ### 💡 Others
 
 ## 56.0.9 — 2026-05-20

--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Update `@shopify/react-native-skia` precompile config for the 2.6.x source layout
+- [iOS] Update `@shopify/react-native-skia` precompile config for the 2.6.x source layout ([#46081](https://github.com/expo/expo/pull/46081) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
+++ b/packages/expo-modules-autolinking/external-configs/ios/@shopify/react-native-skia/spm.config.json
@@ -1,209 +1,199 @@
 {
-    "$schema": "../../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
-    "products": [
+  "$schema": "../../../../../../tools/src/prebuilds/schemas/spm.config.schema.json",
+  "products": [
+    {
+      "name": "RNSkia",
+      "podName": "react-native-skia",
+      "codegenName": "rnskia",
+      "platforms": ["iOS(.v16)"],
+      "externalDependencies": ["ReactNativeDependencies", "React", "Hermes"],
+      "targets": [
         {
-            "name": "RNSkia",
-            "podName": "react-native-skia",
-            "codegenName": "rnskia",
-            "platforms": [
-                "iOS(.v16)"
-            ],
-            "externalDependencies": [
-                "ReactNativeDependencies",
-                "React",
-                "Hermes"
-            ],
-            "targets": [
-                {
-                    "type": "framework",
-                    "name": "libskia",
-                    "path": "libs/apple/ios/libskia.xcframework"
-                },
-                {
-                    "type": "framework",
-                    "name": "libsvg",
-                    "path": "libs/apple/ios/libsvg.xcframework"
-                },
-                {
-                    "type": "framework",
-                    "name": "libskshaper",
-                    "path": "libs/apple/ios/libskshaper.xcframework"
-                },
-                {
-                    "type": "framework",
-                    "name": "libskparagraph",
-                    "path": "libs/apple/ios/libskparagraph.xcframework"
-                },
-                {
-                    "type": "framework",
-                    "name": "libskunicode_core",
-                    "path": "libs/apple/ios/libskunicode_core.xcframework"
-                },
-                {
-                    "type": "framework",
-                    "name": "libskunicode_libgrapheme",
-                    "path": "libs/apple/ios/libskunicode_libgrapheme.xcframework"
-                },
-                {
-                    "type": "framework",
-                    "name": "libskottie",
-                    "path": "libs/apple/ios/libskottie.xcframework"
-                },
-                {
-                    "type": "framework",
-                    "name": "libsksg",
-                    "path": "libs/apple/ios/libsksg.xcframework"
-                },
-                {
-                    "type": "objc",
-                    "name": "rnskia_codegen_modules",
-                    "moduleName": "rnskia",
-                    "path": ".build/codegen/build/generated/ios/ReactCodegen/rnskia",
-                    "pattern": "**/*.mm",
-                    "headerPattern": "**/*.h",
-                    "dependencies": [
-                        "React",
-                        "ReactNativeDependencies"
-                    ],
-                    "includeDirectories": [ ".." ]
-                },
-                {
-                    "type": "cpp",
-                    "name": "rnskia_codegen_components",
-                    "moduleName": "rnskia",
-                    "path": ".build/codegen/build/generated/ios/ReactCodegen/react/renderer/components/rnskia",
-                    "pattern": "**/*.cpp",
-                    "headerPattern": "**/*.h",
-                    "dependencies": [
-                        "React",
-                        "ReactNativeDependencies"
-                    ],
-                    "includeDirectories": [ "../../../.." ],
-                    "compilerFlags": {
-                        "common": {
-                            "cxx": [ "-fno-cxx-modules" ]
-                        }
-                    }
-                },
-                {
-                    "type": "cpp",
-                    "name": "RNSkia_cpp",
-                    "moduleName": "rnskia",
-                    "path": "cpp",
-                    "pattern": "**/*.cpp",
-                    "headerPattern": "**/*.h",
-                    "exclude": [
-                        "rnskia/RNDawnContext.h",
-                        "rnskia/RNDawnUtils.h",
-                        "rnskia/RNDawnWindowContext.h",
-                        "rnskia/RNDawnWindowContext.cpp",
-                        "rnskia/RNImageProvider.h",
-                        "rnwgpu/**",
-                        "skia/include/**",
-                        "skia/modules/skottie/**",
-                        "skia/modules/skparagraph/**",
-                        "skia/modules/sksg/**",
-                        "skia/modules/skshaper/**",
-                        "skia/modules/skunicode/**",
-                        "skia/modules/svg/**",
-                        "skia/src/**"
-                    ],
-                    "dependencies": [
-                        "React",
-                        "ReactNativeDependencies",
-                        "Hermes",
-                        "libskia",
-                        "libsvg",
-                        "libskshaper",
-                        "libskparagraph",
-                        "libskunicode_core",
-                        "libskunicode_libgrapheme",
-                        "libskottie",
-                        "libsksg"
-                    ],
-                    "includeDirectories": [
-                        ".",
-                        "api",
-                        "skia",
-                        "../.build/codegen/build/generated/ios/ReactCodegen"
-                    ],
-                    "compilerFlags": {
-                        "common": {
-                            "c": [
-                                "-DSK_METAL=1",
-                                "-DSK_GANESH=1",
-                                "-DSK_IMAGE_READ_PIXELS_DISABLE_LEGACY_API=1",
-                                "-DSK_DISABLE_LEGACY_SHAPER_FACTORY=1"
-                            ],
-                            "cxx": [
-                                "-fno-cxx-modules",
-                                "-DSK_METAL=1",
-                                "-DSK_GANESH=1",
-                                "-DSK_IMAGE_READ_PIXELS_DISABLE_LEGACY_API=1",
-                                "-DSK_DISABLE_LEGACY_SHAPER_FACTORY=1"
-                            ]
-                        },
-                        "debug": [ "-DHERMES_ENABLE_DEBUGGER=1" ]
-                    },
-                    "publicHeaders": false
-                },
-                {
-                    "type": "objc",
-                    "name": "RNSkia",
-                    "path": "apple",
-                    "pattern": "**/*.{m,mm}",
-                    "headerPattern": "**/*.h",
-                    "dependencies": [
-                        "Hermes",
-                        "React",
-                        "ReactNativeDependencies",
-                        "libskia",
-                        "libsvg",
-                        "libskshaper",
-                        "libskparagraph",
-                        "libskunicode_core",
-                        "libskunicode_libgrapheme",
-                        "libskottie",
-                        "libsksg",
-                        "rnskia_codegen_modules",
-                        "rnskia_codegen_components",
-                        "RNSkia_cpp"
-                    ],
-                    "includeDirectories": [
-                        ".",
-                        "../cpp",
-                        "../cpp/rnskia",
-                        "../cpp/jsi",
-                        "../cpp/api",
-                        "../cpp/utils",
-                        "../cpp/skia",
-                        "../.build/codegen/build/generated/ios/ReactCodegen"
-                    ],
-                    "linkedFrameworks": [
-                        "Foundation",
-                        "UIKit",
-                        "Metal",
-                        "MetalKit",
-                        "AVFoundation",
-                        "AVKit",
-                        "CoreMedia",
-                        "QuartzCore",
-                        "CoreGraphics",
-                        "CoreText",
-                        "CoreVideo",
-                        "CoreImage",
-                        "IOSurface"
-                    ],
-                    "compilerFlags": [
-                        "-include", "Foundation/Foundation.h",
-                        "-include", "UIKit/UIKit.h",
-                        "-DSK_METAL=1",
-                        "-DSK_GANESH=1",
-                        "-DSK_IMAGE_READ_PIXELS_DISABLE_LEGACY_API=1",
-                        "-DSK_DISABLE_LEGACY_SHAPER_FACTORY=1"
-                    ]
-                }
-            ]
+          "type": "framework",
+          "name": "libskia",
+          "path": "libs/ios/libskia.xcframework"
+        },
+        {
+          "type": "framework",
+          "name": "libsvg",
+          "path": "libs/ios/libsvg.xcframework"
+        },
+        {
+          "type": "framework",
+          "name": "libskshaper",
+          "path": "libs/ios/libskshaper.xcframework"
+        },
+        {
+          "type": "framework",
+          "name": "libskparagraph",
+          "path": "libs/ios/libskparagraph.xcframework"
+        },
+        {
+          "type": "framework",
+          "name": "libskunicode_core",
+          "path": "libs/ios/libskunicode_core.xcframework"
+        },
+        {
+          "type": "framework",
+          "name": "libskunicode_libgrapheme",
+          "path": "libs/ios/libskunicode_libgrapheme.xcframework"
+        },
+        {
+          "type": "framework",
+          "name": "libskottie",
+          "path": "libs/ios/libskottie.xcframework"
+        },
+        {
+          "type": "framework",
+          "name": "libsksg",
+          "path": "libs/ios/libsksg.xcframework"
+        },
+        {
+          "type": "objc",
+          "name": "rnskia_codegen_modules",
+          "moduleName": "rnskia",
+          "path": ".build/codegen/build/generated/ios/ReactCodegen/rnskia",
+          "pattern": "**/*.mm",
+          "headerPattern": "**/*.h",
+          "dependencies": ["React", "ReactNativeDependencies"],
+          "includeDirectories": [".."]
+        },
+        {
+          "type": "cpp",
+          "name": "rnskia_codegen_components",
+          "moduleName": "rnskia",
+          "path": ".build/codegen/build/generated/ios/ReactCodegen/react/renderer/components/rnskia",
+          "pattern": "**/*.cpp",
+          "headerPattern": "**/*.h",
+          "dependencies": ["React", "ReactNativeDependencies"],
+          "includeDirectories": ["../../../.."],
+          "compilerFlags": {
+            "common": {
+              "cxx": ["-fno-cxx-modules"]
+            }
+          }
+        },
+        {
+          "type": "cpp",
+          "name": "RNSkia_cpp",
+          "moduleName": "rnskia",
+          "path": "cpp",
+          "pattern": "**/*.cpp",
+          "headerPattern": "**/*.h",
+          "exclude": [
+            "rnskia/RNDawnContext.h",
+            "rnskia/RNDawnUtils.h",
+            "rnskia/RNDawnWindowContext.h",
+            "rnskia/RNDawnWindowContext.cpp",
+            "rnskia/RNImageProvider.h",
+            "rnwgpu/**",
+            "skia/include/**",
+            "skia/modules/skottie/**",
+            "skia/modules/skparagraph/**",
+            "skia/modules/sksg/**",
+            "skia/modules/skshaper/**",
+            "skia/modules/skunicode/**",
+            "skia/modules/svg/**",
+            "skia/src/**"
+          ],
+          "dependencies": [
+            "React",
+            "ReactNativeDependencies",
+            "Hermes",
+            "libskia",
+            "libsvg",
+            "libskshaper",
+            "libskparagraph",
+            "libskunicode_core",
+            "libskunicode_libgrapheme",
+            "libskottie",
+            "libsksg"
+          ],
+          "includeDirectories": [
+            ".",
+            "api",
+            "skia",
+            "../.build/codegen/build/generated/ios/ReactCodegen"
+          ],
+          "compilerFlags": {
+            "common": {
+              "c": [
+                "-DSK_METAL=1",
+                "-DSK_GANESH=1",
+                "-DSK_IMAGE_READ_PIXELS_DISABLE_LEGACY_API=1",
+                "-DSK_DISABLE_LEGACY_SHAPER_FACTORY=1"
+              ],
+              "cxx": [
+                "-fno-cxx-modules",
+                "-DSK_METAL=1",
+                "-DSK_GANESH=1",
+                "-DSK_IMAGE_READ_PIXELS_DISABLE_LEGACY_API=1",
+                "-DSK_DISABLE_LEGACY_SHAPER_FACTORY=1"
+              ]
+            },
+            "debug": ["-DHERMES_ENABLE_DEBUGGER=1"]
+          },
+          "publicHeaders": false
+        },
+        {
+          "type": "objc",
+          "name": "RNSkia",
+          "path": "apple",
+          "pattern": "**/*.{m,mm}",
+          "headerPattern": "**/*.h",
+          "dependencies": [
+            "Hermes",
+            "React",
+            "ReactNativeDependencies",
+            "libskia",
+            "libsvg",
+            "libskshaper",
+            "libskparagraph",
+            "libskunicode_core",
+            "libskunicode_libgrapheme",
+            "libskottie",
+            "libsksg",
+            "rnskia_codegen_modules",
+            "rnskia_codegen_components",
+            "RNSkia_cpp"
+          ],
+          "includeDirectories": [
+            ".",
+            "../cpp",
+            "../cpp/rnskia",
+            "../cpp/jsi",
+            "../cpp/api",
+            "../cpp/utils",
+            "../cpp/skia",
+            "../.build/codegen/build/generated/ios/ReactCodegen"
+          ],
+          "linkedFrameworks": [
+            "Foundation",
+            "UIKit",
+            "Metal",
+            "MetalKit",
+            "AVFoundation",
+            "AVKit",
+            "CoreMedia",
+            "QuartzCore",
+            "CoreGraphics",
+            "CoreText",
+            "CoreVideo",
+            "CoreImage",
+            "IOSurface"
+          ],
+          "compilerFlags": [
+            "-include",
+            "Foundation/Foundation.h",
+            "-include",
+            "UIKit/UIKit.h",
+            "-DSK_METAL=1",
+            "-DSK_GANESH=1",
+            "-DSK_IMAGE_READ_PIXELS_DISABLE_LEGACY_API=1",
+            "-DSK_DISABLE_LEGACY_SHAPER_FACTORY=1"
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/patches/@shopify__react-native-skia@2.6.2.patch
+++ b/patches/@shopify__react-native-skia@2.6.2.patch
@@ -1,0 +1,13 @@
+diff --git a/apple/SkiaWebGPUView.mm b/apple/SkiaWebGPUView.mm
+index 2e2c142263c18eba80ca4576a1fe4023e25f477e..c334b728d270aec8e737e19b794bf300ef876179 100644
+--- a/apple/SkiaWebGPUView.mm
++++ b/apple/SkiaWebGPUView.mm
+@@ -7,7 +7,7 @@
+ #import <react/renderer/components/rnskia/Props.h>
+ #import <react/renderer/components/rnskia/RCTComponentViewHelpers.h>
+
+-#import "RCTFabricComponentsPlugins.h"
++#import <React/RCTFabricComponentsPlugins.h>
+ #import "WebGPUMetalView.h"
+
+ using namespace facebook::react;


### PR DESCRIPTION
## Why

After starting to use the right version of RNSkia through #46079 we had a few build errors due to changes in RNSkia itself.

Merge after #46079

## How

This fixes the spm config and patches skia for prebuild.

## Test-plan

✅ Ran et prebuild @shopify/react-native-skia

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
