### PR TITLE
[tools] Respect force

### DIFF
--- a/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
+++ b/tools/src/publish-packages/tasks/selectPackagesToPublish.ts
@@ -361,7 +361,7 @@ async function selectParcelsToPublish(
     if (
       !(parcel.state.releaseVersion === null || parcel.state.releaseVersion === undefined) ||
       skipped.has(packageName) ||
-      !isParcelUnpublished(parcel)
+      (!options.force && !isParcelUnpublished(parcel))
     ) {
       // Skip prompting if a release version is already set (chosen version or explicitly null)
       // or if the user previously chose to skip this package.


### PR DESCRIPTION
# Why
We accept -f but don't use it

# How
Wire up the flag in `et publish-packages` which was defined but never used in the package selection logic
