### PR TITLE
Switch typed plugins bridge file to CommonJS

### DIFF
--- a/packages/expo-apple-authentication/CHANGELOG.md
+++ b/packages/expo-apple-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-apple-authentication/plugin/index.d.ts
+++ b/packages/expo-apple-authentication/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-apple-authentication/plugin/index.js
+++ b/packages/expo-apple-authentication/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.8 — 2026-05-20

--- a/packages/expo-audio/plugin/index.d.ts
+++ b/packages/expo-audio/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-audio/plugin/index.js
+++ b/packages/expo-audio/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-background-fetch/CHANGELOG.md
+++ b/packages/expo-background-fetch/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-background-fetch/plugin/index.d.ts
+++ b/packages/expo-background-fetch/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-background-fetch/plugin/index.js
+++ b/packages/expo-background-fetch/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-background-task/plugin/index.d.ts
+++ b/packages/expo-background-task/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-background-task/plugin/index.js
+++ b/packages/expo-background-task/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-brightness/CHANGELOG.md
+++ b/packages/expo-brightness/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-13

--- a/packages/expo-brightness/plugin/index.d.ts
+++ b/packages/expo-brightness/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-brightness/plugin/index.js
+++ b/packages/expo-brightness/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.7 — 2026-05-20

--- a/packages/expo-calendar/plugin/index.d.ts
+++ b/packages/expo-calendar/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-calendar/plugin/index.js
+++ b/packages/expo-calendar/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-21

--- a/packages/expo-camera/plugin/index.d.ts
+++ b/packages/expo-camera/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-camera/plugin/index.js
+++ b/packages/expo-camera/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-cellular/CHANGELOG.md
+++ b/packages/expo-cellular/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-13

--- a/packages/expo-cellular/plugin/index.d.ts
+++ b/packages/expo-cellular/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-cellular/plugin/index.js
+++ b/packages/expo-cellular/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.6 — 2026-05-20

--- a/packages/expo-contacts/plugin/index.d.ts
+++ b/packages/expo-contacts/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-contacts/plugin/index.js
+++ b/packages/expo-contacts/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-dev-client/CHANGELOG.md
+++ b/packages/expo-dev-client/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-20

--- a/packages/expo-dev-client/plugin/index.d.ts
+++ b/packages/expo-dev-client/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-dev-client/plugin/index.js
+++ b/packages/expo-dev-client/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-20

--- a/packages/expo-dev-launcher/plugin/index.d.ts
+++ b/packages/expo-dev-launcher/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-dev-launcher/plugin/index.js
+++ b/packages/expo-dev-launcher/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-dev-menu/CHANGELOG.md
+++ b/packages/expo-dev-menu/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.12 — 2026-05-20

--- a/packages/expo-dev-menu/plugin/index.d.ts
+++ b/packages/expo-dev-menu/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-dev-menu/plugin/index.js
+++ b/packages/expo-dev-menu/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-document-picker/CHANGELOG.md
+++ b/packages/expo-document-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-document-picker/plugin/index.d.ts
+++ b/packages/expo-document-picker/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-document-picker/plugin/index.js
+++ b/packages/expo-document-picker/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-image-picker/CHANGELOG.md
+++ b/packages/expo-image-picker/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-image-picker/plugin/index.d.ts
+++ b/packages/expo-image-picker/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-image-picker/plugin/index.js
+++ b/packages/expo-image-picker/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
 - [Android] Fixed `useImage` crashing on SVG sources, and made `maxWidth`/`maxHeight` preserve the SVG's aspect ratio. ([#46077](https://github.com/expo/expo/pull/46077) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others

--- a/packages/expo-image/plugin/index.d.ts
+++ b/packages/expo-image/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-image/plugin/index.js
+++ b/packages/expo-image/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-local-authentication/CHANGELOG.md
+++ b/packages/expo-local-authentication/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-local-authentication/plugin/index.d.ts
+++ b/packages/expo-local-authentication/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-local-authentication/plugin/index.js
+++ b/packages/expo-local-authentication/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-localization/CHANGELOG.md
+++ b/packages/expo-localization/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-19

--- a/packages/expo-localization/plugin/index.d.ts
+++ b/packages/expo-localization/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-localization/plugin/index.js
+++ b/packages/expo-localization/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-location/CHANGELOG.md
+++ b/packages/expo-location/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-location/plugin/index.d.ts
+++ b/packages/expo-location/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-location/plugin/index.js
+++ b/packages/expo-location/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-mail-composer/CHANGELOG.md
+++ b/packages/expo-mail-composer/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-mail-composer/plugin/index.d.ts
+++ b/packages/expo-mail-composer/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-mail-composer/plugin/index.js
+++ b/packages/expo-mail-composer/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-maps/CHANGELOG.md
+++ b/packages/expo-maps/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
 - [Android] Fixed SVG drawables not rendering as Google Maps marker icons, and memoized marker rasterization across recompositions. ([#46077](https://github.com/expo/expo/pull/46077) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others

--- a/packages/expo-maps/plugin/index.d.ts
+++ b/packages/expo-maps/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-maps/plugin/index.js
+++ b/packages/expo-maps/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-media-library/CHANGELOG.md
+++ b/packages/expo-media-library/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.5 — 2026-05-20

--- a/packages/expo-media-library/plugin/index.d.ts
+++ b/packages/expo-media-library/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-media-library/plugin/index.js
+++ b/packages/expo-media-library/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-notifications/plugin/index.d.ts
+++ b/packages/expo-notifications/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-notifications/plugin/index.js
+++ b/packages/expo-notifications/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-router/CHANGELOG.md
+++ b/packages/expo-router/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.2.4 — 2026-05-21

--- a/packages/expo-router/plugin/index.d.ts
+++ b/packages/expo-router/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-router/plugin/index.js
+++ b/packages/expo-router/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-screen-orientation/CHANGELOG.md
+++ b/packages/expo-screen-orientation/CHANGELOG.md
@@ -8,14 +8,16 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-13
 
 ### 🐛 Bug fixes
 
-- [iOS] Fixed `EXC_BAD_ACCESS` crash from recursive `supportedInterfaceOrientations` when `react-native-screens` per-screen orientation is set.                                   
-([#45733](https://github.com/expo/expo/pull/45733) by [@rayabelcode](https://github.com/rayabelcode))
+- [iOS] Fixed `EXC_BAD_ACCESS` crash from recursive `supportedInterfaceOrientations` when `react-native-screens` per-screen orientation is set.  
+  ([#45733](https://github.com/expo/expo/pull/45733) by [@rayabelcode](https://github.com/rayabelcode))
 
 ## 56.0.3 — 2026-05-06
 

--- a/packages/expo-screen-orientation/plugin/index.d.ts
+++ b/packages/expo-screen-orientation/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-screen-orientation/plugin/index.js
+++ b/packages/expo-screen-orientation/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-secure-store/CHANGELOG.md
+++ b/packages/expo-secure-store/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-secure-store/plugin/index.d.ts
+++ b/packages/expo-secure-store/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-secure-store/plugin/index.js
+++ b/packages/expo-secure-store/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-sensors/CHANGELOG.md
+++ b/packages/expo-sensors/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-13

--- a/packages/expo-sensors/plugin/index.d.ts
+++ b/packages/expo-sensors/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-sensors/plugin/index.js
+++ b/packages/expo-sensors/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-sharing/CHANGELOG.md
+++ b/packages/expo-sharing/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-sharing/plugin/index.d.ts
+++ b/packages/expo-sharing/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-sharing/plugin/index.js
+++ b/packages/expo-sharing/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-sqlite/CHANGELOG.md
+++ b/packages/expo-sqlite/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-06

--- a/packages/expo-sqlite/plugin/index.d.ts
+++ b/packages/expo-sqlite/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-sqlite/plugin/index.js
+++ b/packages/expo-sqlite/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-system-ui/CHANGELOG.md
+++ b/packages/expo-system-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-06

--- a/packages/expo-system-ui/plugin/index.d.ts
+++ b/packages/expo-system-ui/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-system-ui/plugin/index.js
+++ b/packages/expo-system-ui/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-task-manager/CHANGELOG.md
+++ b/packages/expo-task-manager/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-task-manager/plugin/index.d.ts
+++ b/packages/expo-task-manager/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-task-manager/plugin/index.js
+++ b/packages/expo-task-manager/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-tracking-transparency/CHANGELOG.md
+++ b/packages/expo-tracking-transparency/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-13

--- a/packages/expo-tracking-transparency/plugin/index.d.ts
+++ b/packages/expo-tracking-transparency/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-tracking-transparency/plugin/index.js
+++ b/packages/expo-tracking-transparency/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.14 — 2026-05-20

--- a/packages/expo-updates/plugin/index.d.ts
+++ b/packages/expo-updates/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-updates/plugin/index.js
+++ b/packages/expo-updates/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.1.1 — 2026-05-15

--- a/packages/expo-video/plugin/index.d.ts
+++ b/packages/expo-video/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-video/plugin/index.js
+++ b/packages/expo-video/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-web-browser/CHANGELOG.md
+++ b/packages/expo-web-browser/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-06

--- a/packages/expo-web-browser/plugin/index.d.ts
+++ b/packages/expo-web-browser/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-web-browser/plugin/index.js
+++ b/packages/expo-web-browser/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix an ES module import error in the typed config plugin. ([#46089](https://github.com/expo/expo/pull/46089) by [@zoontek](https://github.com/zoontek))
+
 ### 💡 Others
 
 ## 56.0.11 — 2026-05-20

--- a/packages/expo-widgets/plugin/index.d.ts
+++ b/packages/expo-widgets/plugin/index.d.ts
@@ -1,0 +1,1 @@
+export { default } from './build';

--- a/packages/expo-widgets/plugin/index.js
+++ b/packages/expo-widgets/plugin/index.js
@@ -1,1 +1,1 @@
-export { default } from './build';
+module.exports = require('./build');


### PR DESCRIPTION
# Why

Fix https://github.com/expo/expo/issues/46082

# How

Some packages doesn't have a package.json exports map, so for them we used an `index.js` bridge file that re-export what' inside `/build`. Those cannot be ES modules.

# Test Plan

- Clone https://github.com/LeonDvlpmnt/typed-config-plugins-reproducer
- Edit `node_modules/expo-camera/plugin/index.js` and add `node_modules/expo-camera/plugin/index.d.ts`
- Restart the TS language server
- Run `expo start`, `expo prebuild`

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
