### PR TITLE
[docs] pick screen orientation advice to sdk-55

### DIFF
--- a/docs/pages/versions/v55.0.0/sdk/screen-orientation.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/screen-orientation.mdx
@@ -80,6 +80,23 @@ You can configure `expo-screen-orientation` using its built-in [config plugin](/
 
 </ConfigReactNative>
 
+## Per-screen orientation with Expo Router
+
+If you use [Expo Router](/router/introduction/), you can set the orientation per screen using the `orientation` option on [`Stack.Screen`](/router/advanced/stack/). This is powered by `react-native-screens` and is the recommended approach for per-screen orientation in stack navigators.
+
+```tsx src/app/_layout.tsx
+import { Stack } from 'expo-router';
+
+export default function Layout() {
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ orientation: 'portrait' }} />
+      <Stack.Screen name="landscape" options={{ orientation: 'landscape' }} />
+    </Stack>
+  );
+}
+```
+
 ## API
 
 ```js


### PR DESCRIPTION
# Why

already present in sdk 56 docs but valid for 56 too https://docs.expo.dev/versions/v56.0.0/sdk/screen-orientation/#per-screen-orientation-with-expo-router

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)