### PR TITLE
[guides] Update package managers reference in writing style guide

### DIFF
--- a/guides/Expo Documentation Writing Style Guide.md
+++ b/guides/Expo Documentation Writing Style Guide.md
@@ -261,12 +261,25 @@ A few points to remember:
 
 Do not use emojis in the documentation.
 
-### When to use npm or Yarn
+### Referencing package managers in install commands
 
-To avoid inconsistency when referencing to install global packages with a package manager like npm or Yarn, use npm.
+For install commands shown to readers, use the `<Terminal cmd={{ npm, yarn, pnpm, bun }}>` component so all supported package managers appear as selectable tabs:
 
-- Correct: npm install expo-cli
-- Incorrect: yarn install expo-cli
+```mdx
+<Terminal
+  cmd={{
+    npm: ["$ npx create-expo-app@latest"],
+    yarn: ["$ yarn create expo-app"],
+    pnpm: ["$ pnpm create expo-app"],
+    bun: ["$ bun create expo"],
+  }}
+/>
+```
+
+When a single command must be shown inline (for example, in a paragraph or a one-off shell example), default to npx to keep examples consistent:
+
+- Correct: `npx expo install <package>`
+- Avoid: `yarn add <package>`
 
 ### For collapsible components
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The section on using npm vs yarn is outdated: https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#when-to-use-npm-or-yarn.

For installation commands, we have been using a pattern with `Terminal` component to show commands for all 4 package managers. This is the pattern we are following in docs for consistency and so style guide should be updated.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update the section.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
