### PR TITLE
[prebuild-config] mock @expo/require-utils.resolveFrom for memfs tests

### DIFF
--- a/packages/@expo/prebuild-config/__mocks__/@expo/require-utils.ts
+++ b/packages/@expo/prebuild-config/__mocks__/@expo/require-utils.ts
@@ -1,0 +1,30 @@
+// Replace `resolveFrom` so it resolves via the mocked `fs` (memfs) instead of
+// falling back to Node's native `Module._resolveFilename`, which reads the real
+// on-disk filesystem and breaks tests that use memfs fixtures.
+
+const actual = jest.requireActual('@expo/require-utils');
+
+function mockResolveFrom(fromDirectory: string, moduleId: string): string | null {
+  const fs = require('fs');
+  const path = require('path');
+  try {
+    fromDirectory = fs.realpathSync(fromDirectory);
+  } catch (error: any) {
+    if (error.code === 'ENOENT') {
+      fromDirectory = path.resolve(fromDirectory);
+    } else {
+      return null;
+    }
+  }
+
+  const outputPath = path.join(fromDirectory, 'node_modules', moduleId);
+  if (fs.existsSync(outputPath)) {
+    return outputPath;
+  }
+  return null;
+}
+
+module.exports = {
+  ...actual,
+  resolveFrom: mockResolveFrom,
+};


### PR DESCRIPTION
# Why

`CI=1 pnpm test` in `packages/@expo/prebuild-config` fails with `ENOENT: ... expo-updates/package.json` in `withDefaultPlugins-test.ts` and `prebuild-testing-lib.test.ts`.

#45990 swapped `resolve-from` for `@expo/require-utils.resolveFrom` in `@expo/config-plugins`, but the existing setup in `prebuild-config` only had a manual mock for `resolve-from`. The new `resolveFrom` falls back to Node's native `Module._resolveFilename`, so it resolves `expo-updates/package.json` to the real on-disk path under `packages/expo-updates/`. `getExpoUpdatesPackageVersion` then calls `fs.readFileSync`, which doesn't have that path.

# How

Mirror the old `__mocks__/resolve-from.ts` for the new module: add `packages/@expo/prebuild-config/__mocks__/@expo/require-utils.ts` that walks `node_modules` via the mocked `fs` (memfs), so resolution stays inside the virtual test filesystem. All other exports pass through `jest.requireActual`.

# Test Plan

1. `CI=1 pnpm test` in `packages/@expo/prebuild-config` — 12 suites / 69 tests pass.
2. CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)