### PR TITLE
[ui][ios] Use non-selection List initializer when selection prop is not provided

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Use non-selection `List` initializer in `List` when `selection` prop is not provided. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Use non-selection `List` initializer in `List` when `selection` prop is not provided. ([#46101](https://github.com/expo/expo/pull/46101) by [@nishan](https://github.com/intergalacticspacehighway))
 
 ### 💡 Others
 

--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Use non-selection `List` initializer in `List` when `selection` prop is not provided. ([#XXXX](https://github.com/expo/expo/pull/XXXX) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 56.0.10 — 2026-05-20

--- a/packages/expo-ui/ios/ListView.swift
+++ b/packages/expo-ui/ios/ListView.swift
@@ -13,17 +13,23 @@ struct ListView: ExpoSwiftUI.View {
   @State private var selection = Set<AnyHashable>()
 
   var body: some View {
-    List(selection: $selection) {
-      Children()
-    }
-    .onAppear {
-      selection = Self.getHashableSetFromEither(props.selection)
-    }
-    .onChange(of: props.selection) { newValue in
-      selection = Self.getHashableSetFromEither(newValue)
-    }
-    .onChange(of: selection) { newSelection in
-      handleSelectionChange(selection: newSelection)
+    if props.selection != nil {
+      List(selection: $selection) {
+        Children()
+      }
+      .onAppear {
+        selection = Self.getHashableSetFromEither(props.selection)
+      }
+      .onChange(of: props.selection) { newValue in
+        selection = Self.getHashableSetFromEither(newValue)
+      }
+      .onChange(of: selection) { newSelection in
+        handleSelectionChange(selection: newSelection)
+      }
+    } else {
+      List {
+        Children()
+      }
     }
   }
 


### PR DESCRIPTION
## Why

`List(selection:)` opts into SwiftUI's selection-aware list rendering, which changes row behavior (e.g. edit-mode chevrons, tap handling) even when no selection is provided. 

## How

Branch on `props.selection != nil` in `ListView.body`. When a `selection` prop is provided, use the existing `List(selection:)` path with the selection sync modifiers. Otherwise, fall back to the plain `List { … }` initializer with no selection wiring.

## Test Plan

- Render `<List>` without a `selection` prop and confirm rows behave as plain rows (no selection chrome).
- Render `<List selection={…} onSelectionChange={…}>` and confirm selection still works (initial value, prop updates, and `onSelectionChange` callback).