### PR TITLE
[docs] Fix <kbd> formatting and casing in keyboard shortcuts

### DIFF
--- a/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
+++ b/docs/pages/app-signing/apple-developer-program-roles-and-permissions.mdx
@@ -55,7 +55,7 @@ As a developer on the team, when running `eas build -p ios` in the terminal wind
   ]}
 />
 
-Press <kbd>n</kbd> to skip logging into Apple Developer account if you don't have access (and avoid logging into your personal Apple Developer account, if any). The CLI displays message about skipping provisioning profile validation and other app signing credential validation and will continue creating the EAS Build with existing credentials
+Press <kbd>N</kbd> to skip logging into Apple Developer account if you don't have access (and avoid logging into your personal Apple Developer account, if any). The CLI displays message about skipping provisioning profile validation and other app signing credential validation and will continue creating the EAS Build with existing credentials
 
 The EAS CLI needs to use the provisioning profile associated with the Expo account to create a build for iOS. When you skip login, the EAS Build will use the last provisioning profile and other credentials that were updated by the Apple Developer account's authorized user in your organization's Expo account.
 

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -31,7 +31,7 @@ For a detailed installation guide, see [Install Expo modules](/bare/installing-e
 
 Expo CLI commands provide several benefits over the similar commands in `@react-native-community/cli`, which includes:
 
-- Instant access to Hermes debugger with <kbd>j</kbd> keystroke.
+- Instant access to Hermes debugger with <kbd>J</kbd> keystroke.
 - The debugger ships with [React Native DevTools](/debugging/tools/#debugging-with-react-native-devtools).
 - [Continuous Native Generation (CNG)](/workflow/continuous-native-generation/) support with [`expo prebuild`](/more/glossary-of-terms/#prebuild) for upgrades, white-labeling, easy third-party package setup, and better maintainability of the codebase (by reducing the surface area).
 - Support for file-based routing with [`expo-router`](/router/introduction/).
@@ -49,7 +49,7 @@ Expo CLI commands provide several benefits over the similar commands in `@react-
 - Automated `pod install` execution when using `npx expo run:ios`.
 - `npx expo install` selects compatible dependency versions for well-known packages.
 - Automatic port detection when running `npx expo run:[android|ios]` and `npx expo start`. If another app is running on the default port, a different port is used.
-- Android or iOS device launch selection shortcuts using <kbd>Shift</kbd> + <kbd>a</kbd> or <kbd>Shift</kbd> + <kbd>i</kbd> from the interactive prompt.
+- Android or iOS device launch selection shortcuts using <kbd>Shift</kbd> + <kbd>A</kbd> or <kbd>Shift</kbd> + <kbd>I</kbd> from the interactive prompt.
 - Built-in support for serving your app over an [ngrok tunnel](/develop/development-builds/development-workflows/#tunnel-urls).
 - Develop on any port with any entry JavaScript file.
 

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -57,7 +57,7 @@ For example, a dev tools plugin that inspects [React Native Firebase](/guides/us
 
 ## Using a dev tools plugin
 
-After installing the dev tools plugin and adding the connecting required code to your project, you can start the dev server up with `npx expo start`. Then press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of available dev tools plugins. Select the plugin you want to use, and it will open in a new Chrome window.
+After installing the dev tools plugin and adding the connecting required code to your project, you can start the dev server up with `npx expo start`. Then press <kbd>Shift</kbd> + <kbd>M</kbd> to open the list of available dev tools plugins. Select the plugin you want to use, and it will open in a new Chrome window.
 
 > When starting the dev server with the Expo CLI, there is an option to press <kbd>?</kbd> to **show all commands**. This shows additional commands, including the shortcut to open **more tools**. Dev tools plugins can also be selected in this menu.
 
@@ -119,7 +119,7 @@ return (
 
 </Tabs>
 
-In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select the React Navigation plugin. This will open the plugin's web interface, showing your navigation history as you navigate through your app.
+In the terminal, run `npx expo start`, press <kbd>Shift</kbd> + <kbd>M</kbd> to open the list of dev tools, and then select the React Navigation plugin. This will open the plugin's web interface, showing your navigation history as you navigate through your app.
 
 ### Apollo Client
 
@@ -147,7 +147,7 @@ export default function App() {
 }
 ```
 
-In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select the Apollo Client plugin. This will open the plugin's web interface, showing your query history, cache, and mutations as your app performs Apollo Client operations.
+In the terminal, run `npx expo start`, press <kbd>Shift</kbd> + <kbd>M</kbd> to open the list of dev tools, and then select the Apollo Client plugin. This will open the plugin's web interface, showing your query history, cache, and mutations as your app performs Apollo Client operations.
 
 ### React Query
 
@@ -172,7 +172,7 @@ export default function App() {
 }
 ```
 
-In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select the React Query plugin. This will open the plugin's web interface, displaying queries as they are used in your app.
+In the terminal, run `npx expo start`, press <kbd>Shift</kbd> + <kbd>M</kbd> to open the list of dev tools, and then select the React Query plugin. This will open the plugin's web interface, displaying queries as they are used in your app.
 
 ### Redux
 
@@ -194,7 +194,7 @@ const store = configureStore({
 });
 ```
 
-In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select `redux-devtools-expo-dev-plugin`. This will open the plugin's web interface, displaying the actions and contents of your store as actions are dispatched.
+In the terminal, run `npx expo start`, press <kbd>Shift</kbd> + <kbd>M</kbd> to open the list of dev tools, and then select `redux-devtools-expo-dev-plugin`. This will open the plugin's web interface, displaying the actions and contents of your store as actions are dispatched.
 
 For complete installation and usage instructions, including if you're using `redux` directly rather than `@reduxjs/toolkit`, [see the project's README](https://github.com/matt-oakes/redux-devtools-expo-dev-plugin).
 
@@ -222,4 +222,4 @@ export default function App() {
 }
 ```
 
-In the terminal, run `npx expo start`, press <kbd>shift</kbd> + <kbd>m</kbd> to open the list of dev tools, and then select the Tinybase plugin. This will open the plugin's web interface, displaying the contents of your store as it is modified.
+In the terminal, run `npx expo start`, press <kbd>Shift</kbd> + <kbd>M</kbd> to open the list of dev tools, and then select the Tinybase plugin. This will open the plugin's web interface, displaying the contents of your store as it is modified.

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -91,7 +91,7 @@ Open the project in Xcode by running the command which is a shortcut to open the
 
 <Step label="3">
 
-Build the app with <kbd>Cmd ⌘</kbd> + <kbd>r</kbd> or by pressing the play button in the upper left corner of Xcode.
+Build the app with <kbd>Cmd ⌘</kbd> + <kbd>R</kbd> or by pressing the play button in the upper left corner of Xcode.
 
 </Step>
 

--- a/docs/pages/debugging/tools.mdx
+++ b/docs/pages/debugging/tools.mdx
@@ -12,13 +12,13 @@ React Native consists of both JavaScript and native code. Making this distinctio
 
 ## Developer menu
 
-The **Developer menu** provides access to useful debugging functions. It is built into dev clients and Expo Go. If you are using an emulator, simulator, or have a device connected via USB, you can open this menu by pressing <kbd>m</kbd> in the terminal where Expo CLI has started the development server.
+The **Developer menu** provides access to useful debugging functions. It is built into dev clients and Expo Go. If you are using an emulator, simulator, or have a device connected via USB, you can open this menu by pressing <kbd>M</kbd> in the terminal where Expo CLI has started the development server.
 
 <Collapsible summary="Alternative options to open the Developer menu">
 
 - Android device (without USB): Shake the device vertically.
 - Android Emulator or device (with USB):
-  - Press <kbd>Cmd ⌘</kbd> + <kbd>m</kbd> or <kbd>Ctrl</kbd> + <kbd>m</kbd>.
+  - Press <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> or <kbd>Ctrl</kbd> + <kbd>M</kbd>.
   - Run the following command in the terminal to simulate pressing the menu button:
     <Terminal cmd={['$ adb shell input keyevent 82']} />
 
@@ -26,7 +26,7 @@ The **Developer menu** provides access to useful debugging functions. It is buil
   - Shake the device.
   - Touch three fingers to the screen.
 - iOS Simulator or device (with USB):
-  - Press <kbd>Ctrl</kbd> + <kbd>Cmd ⌘</kbd> + <kbd>z</kbd> or <kbd>Cmd ⌘</kbd> + <kbd>d</kbd>
+  - Press <kbd>Ctrl</kbd> + <kbd>Cmd ⌘</kbd> + <kbd>Z</kbd> or <kbd>Cmd ⌘</kbd> + <kbd>D</kbd>
 
 </Collapsible>
 
@@ -82,7 +82,7 @@ This overlay has capabilities to:
 
 **React Native DevTools** is a modern debugging tool for Expo and React Native apps. It allows you to gain insights into the JavaScript code of your app by accessing the [Console](#interacting-with-the-console), [Sources](#pausing-on-breakpoints), [Network](#inspecting-network-requests-expo-only) (**Expo only**), and [Memory](#inspecting-memory) tabs. It also has **built-in support for React DevTools** such as [Components](#inspecting-components) and [Profiler](#profiling-javascript-performance) tabs. All of these inspectors can be accessed using [dev clients](/more/glossary-of-terms/#dev-clients) or Expo Go.
 
-You can use the React Native DevTools on any app using [Hermes](/guides/using-hermes/). **To open it, start your app and press <kbd>j</kbd> in the terminal where Expo was started**. Once you have opened the React Native DevTools, it will appear as below:
+You can use the React Native DevTools on any app using [Hermes](/guides/using-hermes/). **To open it, start your app and press <kbd>J</kbd> in the terminal where Expo was started**. Once you have opened the React Native DevTools, it will appear as below:
 
 <ContentSpotlight
   alt="The React Native DevTools showing one of the files under the Sources tab."
@@ -185,7 +185,7 @@ You can use this debugger with the [Expo Tools](https://github.com/expo/vscode-e
 To start debugging:
 
 - Connect your app
-- Open VS Code command palette (based on your computer, it's either <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>p</kbd> or <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>p</kbd>)
+- Open VS Code command palette (based on your computer, it's either <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>)
 - Run the **Expo: Debug ...** VS Code command.
 
 This will attach VS Code to your running app.
@@ -216,7 +216,7 @@ You can install it via the [release page](https://github.com/jhen0409/react-nati
 
 ### Startup
 
-After firing up React Native Debugger, you'll need to specify the port (shortcuts: <kbd>Cmd ⌘</kbd> + <kbd>t</kbd> on macOS, <kbd>Ctrl</kbd> + <kbd>t</kbd> on Linux/Windows) to `8081`. After that, run your project with `npx expo start`, and select `Debug remote JS` from the Developer Menu. The debugger should automatically connect.
+After firing up React Native Debugger, you'll need to specify the port (shortcuts: <kbd>Cmd ⌘</kbd> + <kbd>T</kbd> on macOS, <kbd>Ctrl</kbd> + <kbd>T</kbd> on Linux/Windows) to `8081`. After that, run your project with `npx expo start`, and select `Debug remote JS` from the Developer Menu. The debugger should automatically connect.
 
 In the debugger console, you can see the Element tree, as well as the props, state, and children of whatever element you select. You also have the Chrome console on the right, and if you type `$r` in the console, you will see the breakdown of your selected element.
 

--- a/docs/pages/develop/development-builds/use-development-builds.mdx
+++ b/docs/pages/develop/development-builds/use-development-builds.mdx
@@ -17,7 +17,7 @@ To start developing, run the following command to start the development server:
 
 To open the project inside your development client:
 
-- Press <kbd>a</kbd> or <kbd>i</kbd> keys to open your project on an Android Emulator or an iOS Simulator.
+- Press <kbd>A</kbd> or <kbd>I</kbd> keys to open your project on an Android Emulator or an iOS Simulator.
 - On a physical device, scan the QR code from your system's camera or a QR code reader to open the project on your device.
 
 ## The launcher screen
@@ -38,6 +38,6 @@ If you add a library to your project that contains native code APIs, for example
 
 ## Debug a development build
 
-When you need to, you can access the menu by pressing <kbd>Cmd ⌘</kbd> + <kbd>d</kbd> or <kbd>Ctrl</kbd> + <kbd>d</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, any debugging functionality you need, or switch to a different version of your app.
+When you need to, you can access the menu by pressing <kbd>Cmd ⌘</kbd> + <kbd>D</kbd> or <kbd>Ctrl</kbd> + <kbd>D</kbd> in Expo CLI or by shaking your phone or tablet. Here you'll be able to access all of the functions of your development build, any debugging functionality you need, or switch to a different version of your app.
 
 See [Debugging](/debugging/runtime-issues/) guide for more information.

--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -176,4 +176,4 @@ While you are developing your project, you can change your simulator's or device
 
 - If using an Android Emulator, you can run `adb shell "cmd uimode night yes"` to enable dark mode, and `adb shell "cmd uimode night no"` to disable dark mode.
 - If using a physical Android device or an Android Emulator, you can toggle the system dark mode setting in the device's settings.
-- If working with an iOS emulator locally, you can use the <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>a</kbd> shortcut to toggle between light and dark modes.
+- If working with an iOS emulator locally, you can use the <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>A</kbd> shortcut to toggle between light and dark modes.

--- a/docs/pages/get-started/start-developing.mdx
+++ b/docs/pages/get-started/start-developing.mdx
@@ -24,7 +24,7 @@ To start the development server, run the following command:
 
 After running the command above, you will see a QR code in your terminal. Scan this QR code to open the app on your device.
 
-If you're using an Android Emulator or iOS Simulator, you can press <kbd>a</kbd> or <kbd>i</kbd> respectively to open the app.
+If you're using an Android Emulator or iOS Simulator, you can press <kbd>A</kbd> or <kbd>I</kbd> respectively to open the app.
 
 <Collapsible summary="Having problems?">
 

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -123,7 +123,7 @@ If your project has any native modifications (changes to the **android** or **io
 
 - Check to see if your changes overlap with the built-in [app config fields](/versions/latest/config/app/). For example, if you have an app icon, be sure to define it as `expo.icon` in the **app.json** then re-run `npx expo prebuild`.
 - Look up if any of the packages you are using require an [Expo config plugin][config-plugins]. If a package in your project requires additional changes inside the **android** or **ios** directories, then you will probably need a Config Plugin. Some plugins can be automatically added by running `npx expo install` with all of the packages in your **package.json** dependencies. If a package requires a plugin but doesn't supply one, then you can try checking the community plugins at [`expo/config-plugins`](https://github.com/expo/config-plugins) to see if one already exists.
-- You can use the [VS Code Expo extension][vs-code-expo] to introspect your changes and debug if prebuild is generating the native code you expect. Just press <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>p</kbd>, type "Expo: Preview Modifier", and select the native file you wish to introspect.
+- You can use the [VS Code Expo extension][vs-code-expo] to introspect your changes and debug if prebuild is generating the native code you expect. Just press <kbd>Cmd ⌘</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>, type "Expo: Preview Modifier", and select the native file you wish to introspect.
 - Additionally, you can develop local config plugins to fit your needs. [Learn more](/config-plugins/development-and-debugging/#develop-a-plugin).
 
 ## Add more features

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -22,7 +22,7 @@ The libraries used in a project influence the size of the production JavaScript 
 
 You can use Expo Atlas with the local development server. This method allows Atlas to update whenever you change any code in your project.
 
-Once your app is running using the local development server on Android, iOS, and/or web, you can open Atlas through the [dev tools plugin menu](/debugging/devtools-plugins/#using-a-dev-tools-plugin) using <kbd>shift</kbd> + <kbd>m</kbd>.
+Once your app is running using the local development server on Android, iOS, and/or web, you can open Atlas through the [dev tools plugin menu](/debugging/devtools-plugins/#using-a-dev-tools-plugin) using <kbd>Shift</kbd> + <kbd>M</kbd>.
 
 <Terminal
   cmd={['# Start the local development server with Atlas', '$ EXPO_ATLAS=true npx expo start']}

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -53,7 +53,7 @@ Once the app is compiled and installed on your device or emulator, you don't nee
 
 <Terminal cmd={['$ npx expo start']} />
 
-Then press <kbd>a</kbd> for Android or <kbd>i</kbd> for iOS in the terminal to launch the already-installed app. Metro serves your updated JavaScript bundle without recompiling native code, so the app loads in seconds instead of minutes.
+Then press <kbd>A</kbd> for Android or <kbd>I</kbd> for iOS in the terminal to launch the already-installed app. Metro serves your updated JavaScript bundle without recompiling native code, so the app loads in seconds instead of minutes.
 
 | Command                                     | What it does                                          | When to use it                                                                  |
 | ------------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------- |

--- a/docs/pages/guides/permissions.mdx
+++ b/docs/pages/guides/permissions.mdx
@@ -103,4 +103,4 @@ On the web, permissions like the `Camera` and `Location` can only be requested f
 
 Often you want to be able to test what happens when a user rejects permissions, to ensure your app reacts gracefully. An operating-system level restriction on both Android and iOS prohibits an app from asking for the same permission more than once (you can imagine how this could be annoying for the user to be repeatedly prompted for permissions after rejecting them). To test different flows involving permissions in development, you may need to uninstall and reinstall the native app.
 
-When testing in [Expo Go](https://expo.dev/go), you can delete the app and reinstall it by running `npx expo start` and pressing <kbd>i</kbd> or <kbd>a</kbd> in the [Expo CLI](/more/expo-cli/) Terminal UI.
+When testing in [Expo Go](https://expo.dev/go), you can delete the app and reinstall it by running `npx expo start` and pressing <kbd>I</kbd> or <kbd>A</kbd> in the [Expo CLI](/more/expo-cli/) Terminal UI.

--- a/docs/pages/guides/using-hermes.mdx
+++ b/docs/pages/guides/using-hermes.mdx
@@ -36,7 +36,7 @@ Note that the Hermes bytecode format may change between different Hermes version
 
 ## JavaScript debugger
 
-To debug JavaScript code running with Hermes, you can start your project with `npx expo start` then press <kbd>j</kbd> to open the debugger in Google Chrome or Microsoft Edge. The developer menu of development builds and Expo Go also have the **Open DevTools** (formerly **Open JS Debugger**) option to do the same.
+To debug JavaScript code running with Hermes, you can start your project with `npx expo start` then press <kbd>J</kbd> to open the debugger in Google Chrome or Microsoft Edge. The developer menu of development builds and Expo Go also have the **Open DevTools** (formerly **Open JS Debugger**) option to do the same.
 
 Alternatively, you can use the JavaScript inspector by opening [Google Chrome DevTools manually](https://reactnative.dev/docs/other-debugging-methods#remote-javascript-debugging-deprecated)
 
@@ -47,7 +47,7 @@ Alternatively, you can use the JavaScript inspector by opening [Google Chrome De
 - Make sure you [set up Hermes in the `jsEngine` field](#setup).
 - If your app is built by `eas build`, `npx expo run:android` or `npx expo run:ios`, make sure it is a debug build.
 - Internally, the app will establish a WebSocket connection, make sure your app is connected to the development server.
-  - Try to reload the app by pressing <kbd>r</kbd> in the Expo CLI Terminal UI.
+  - Try to reload the app by pressing <kbd>R</kbd> in the Expo CLI Terminal UI.
   - Test debugging availability by running the command: `curl http://127.0.0.1:8081/json/list` (adjust the `127.0.0.1:8081` to match your dev server URL). The HTTP response should be an array, as shown below. If it is an empty response, add either the `--localhost` or `--tunnel` flag to the `npx expo start` command.
 
   ```json

--- a/docs/pages/modules/native-module-tutorial.mdx
+++ b/docs/pages/modules/native-module-tutorial.mdx
@@ -30,7 +30,7 @@ First, create a new module. For this tutorial, the module is named `expo-setting
 
 <Terminal cmd={['$ npx create-expo-module expo-settings']} />
 
-> **info** Since you aren't going to actually ship this library, you can hit <kbd>return</kbd> for all the prompts to accept the default values.
+> **info** Since you aren't going to actually ship this library, you can hit <kbd>Return</kbd> for all the prompts to accept the default values.
 
 </Step>
 

--- a/docs/pages/modules/native-view-tutorial.mdx
+++ b/docs/pages/modules/native-view-tutorial.mdx
@@ -22,7 +22,7 @@ Create a new module by running the following command and name the example module
 
 <Terminal cmd={['$ npx create-expo-module expo-web-view']} />
 
-> **info** Since this is an example library and won't be published, press <kbd>return</kbd> for all prompts to accept the default values.
+> **info** Since this is an example library and won't be published, press <kbd>Return</kbd> for all prompts to accept the default values.
 
 </Step>
 

--- a/docs/pages/modules/third-party-library.mdx
+++ b/docs/pages/modules/third-party-library.mdx
@@ -57,7 +57,7 @@ Create a new empty Expo module that can be published on npm and utilized in any 
 
 <Terminal cmd={['$ npx create-expo-module expo-radial-chart']} />
 
-> **info** **Tip**: If you aren't going to ship this library, press <kbd>return</kbd> for all the prompts to accept the default values in the terminal window.
+> **info** **Tip**: If you aren't going to ship this library, press <kbd>Return</kbd> for all the prompts to accept the default values in the terminal window.
 
 Now, open the newly created `expo-radial-chart` directory to start editing the native code.
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -47,7 +47,7 @@ Now, you can start your project by running:
 <Terminal cmd={['$ npx expo start']} />
 
 - To view your app on a mobile device, we recommend starting with [Expo Go](/get-started/set-up-your-environment/#how-would-you-like-to-develop). As your application grows in complexity and you need more control, you can create a [development build](/develop/development-builds/introduction/).
-- Open the project in a web browser by pressing <kbd>w</kbd> in the Terminal UI. Press <kbd>a</kbd> for Android (Android Studio is required), or <kbd>i</kbd> for iOS (macOS with Xcode is required).
+- Open the project in a web browser by pressing <kbd>W</kbd> in the Terminal UI. Press <kbd>A</kbd> for Android (Android Studio is required), or <kbd>I</kbd> for iOS (macOS with Xcode is required).
 
 </Step>
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -9,7 +9,7 @@ import { Terminal } from '~/ui/components/Snippet';
 
 This can happen if your Chrome DevTools has exclusions within its ignore list. To fix the issue, use [React Native DevTools](https://reactnative.dev/docs/react-native-devtools):
 
-1. Start the React Native DevTools by pressing <kbd>j</kbd> from the development server running in the terminal window
+1. Start the React Native DevTools by pressing <kbd>J</kbd> from the development server running in the terminal window
 2. Open **Settings** by clicking the gear icon
 3. Under **Extensions**, click **Restore defaults and reload**
 4. Open **Settings** again, and go to **Ignore List** tab

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -124,7 +124,7 @@ After running the above command:
 
 1. The development server will start, and you'll see a QR code inside the terminal window.
 2. Scan that QR code to open the app on the device. On Android, use the Expo Go > **Scan QR code** option. On iOS, use the default camera app.
-3. To run the web app, press <kbd>w</kbd> in the terminal. It will open the web app in the default web browser.
+3. To run the web app, press <kbd>W</kbd> in the terminal. It will open the web app in the default web browser.
 
 Once it is running on all platforms, the app should look like this:
 

--- a/docs/pages/tutorial/eas/android-development-build.mdx
+++ b/docs/pages/tutorial/eas/android-development-build.mdx
@@ -39,7 +39,7 @@ To create a **.apk**:
 
 This command prompts us with the following questions:
 
-- **What would you like your Android application id to be?** Press <kbd>return</kbd> to select the default value provided for this prompt. This will add [`android.package`](/versions/latest/config/app/#package) in **app.json**.
+- **What would you like your Android application id to be?** Press <kbd>Return</kbd> to select the default value provided for this prompt. This will add [`android.package`](/versions/latest/config/app/#package) in **app.json**.
 - **Generate a new Android Keystore**? Press <kbd>Y</kbd>.
 
 After responding, the build will queue up, and we can track its progress via a provided link by the EAS CLI in the EAS dashboard:
@@ -128,7 +128,7 @@ The **Install** button in the **Build artifact** generates a QR code for install
 
 ### Run development build
 
-Start the development server by running `npx expo start` from the project directory. Once the server is running, press <kbd>a</kbd> in the terminal window to open the project:
+Start the development server by running `npx expo start` from the project directory. Once the server is running, press <kbd>A</kbd> in the terminal window to open the project:
 
 <Terminal cmd={['$ npx expo start']} />
 
@@ -160,7 +160,7 @@ Alternatively, [Expo Orbit](/build/orbit/) can be used for installation. From **
 
 ### Run the development build
 
-Start the development server by running `npx expo start` from the project directory. Once the server is running, press <kbd>a</kbd> in the terminal window to open the project:
+Start the development server by running `npx expo start` from the project directory. Once the server is running, press <kbd>A</kbd> in the terminal window to open the project:
 
 <Terminal cmd={['$ npx expo start']} />
 

--- a/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-devices.mdx
@@ -112,7 +112,7 @@ To create a development build on an iOS device, make sure that under the `build.
 
 This command prompts us with the following questions when we create the build for the first time:
 
-- **What would you like your iOS bundle identifier to be?** Press <kbd>return</kbd> to select the default value provided for this prompt. This will add [`ios.bundleIdentifier`](/versions/latest/config/app/#package) in **app.json** if it isn't already defined.
+- **What would you like your iOS bundle identifier to be?** Press <kbd>Return</kbd> to select the default value provided for this prompt. This will add [`ios.bundleIdentifier`](/versions/latest/config/app/#package) in **app.json** if it isn't already defined.
 - **Do you want to log in to your Apple account?**. Since we are creating a development build for the first time, it will ask us to **Generate a new Apple Distribution Certificate**. Press <kbd>Y</kbd> both times.
 - **Select a device for ad hoc build**. This is the key part, which is why we had to register a provisioning profile before. We can select one or all of our registered devices here and then press return to install that build on those devices later.
 

--- a/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
+++ b/docs/pages/tutorial/eas/ios-development-build-for-simulators.mdx
@@ -73,7 +73,7 @@ Run the `eas build` command with `ios` as a platform and `ios-simulator` as the 
 
 This command prompts us with the following questions when we create the build for the first time:
 
-- **What would you like your iOS bundle identifier to be?** Press <kbd>return</kbd> to select the default value provided for this prompt. This will add [`ios.bundleIdentifier`](/versions/latest/config/app/#package) in **app.json**.
+- **What would you like your iOS bundle identifier to be?** Press <kbd>Return</kbd> to select the default value provided for this prompt. This will add [`ios.bundleIdentifier`](/versions/latest/config/app/#package) in **app.json**.
 - **iOS app only uses standard/exempt encryption?** Press <kbd>Y</kbd> to select the default value provided for this prompt. Since our app doesn't use encryption, it sets `ITSAppUsesNonExemptEncryption` in the **Info.plist** file to `NO` and manages the compliance check for the same when you are releasing your app to TestFlight/Apple App Store. When you are releasing your own app, and it uses encryption, you can select `N` to skip this prompt next time.
 
 After responding to the prompts, our EAS Build is queued, and the EAS CLI provides a link to view build details and track progress on the EAS dashboard:
@@ -130,7 +130,7 @@ Start the development server by running the `npx expo start` command from the pr
 
 <Terminal cmd={['$ npx expo start']} />
 
-Press <kbd>i</kbd> in the terminal window to open the project on the iOS Simulator.
+Press <kbd>I</kbd> in the terminal window to open the project on the iOS Simulator.
 
 </Step>
 

--- a/docs/pages/tutorial/eas/ios-production-build.mdx
+++ b/docs/pages/tutorial/eas/ios-production-build.mdx
@@ -49,7 +49,7 @@ Run the `eas credentials` command in the terminal and then answer the following 
 - **What do you want to do?** Select **Build credentials** and choose **All: Set up all the required credentials to build your project**.
 - Now, it will prompt whether we want to re-use the previous Distribution Certificate. Press <kbd>Y</kbd>.
 - **Generate a new Apple Provisioning Profile?** Press <kbd>Y</kbd>. This will be the provisioning profile for the production app.
-- Once the profiles are created, press any <kbd>ctrl</kbd> + <kbd>c</kbd> to exit the EAS CLI.
+- Once the profiles are created, press any <kbd>Ctrl</kbd> + <kbd>C</kbd> to exit the EAS CLI.
 
 </Step>
 

--- a/docs/pages/tutorial/image-picker.mdx
+++ b/docs/pages/tutorial/image-picker.mdx
@@ -29,13 +29,13 @@ We'll use [`expo-image-picker`](/versions/latest/sdk/imagepicker), a library fro
 
 ## Install expo-image-picker
 
-To install the `expo-image-picker` library, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal, then run the following command:
+To install the `expo-image-picker` library, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> in the terminal, then run the following command:
 
 <Terminal cmd={['$ npx expo install expo-image-picker']} />
 
 The [`npx expo install`](/more/expo-cli/#installation) command will install the library and add it to the project's dependencies in **package.json**.
 
-> **info** **Tip:** Any time we install a new library in the project, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>c</kbd> in the terminal and then run the installation command. After the installation completes, start the development server again by running `npx expo start`.
+> **info** **Tip:** Any time we install a new library in the project, stop the development server by pressing <kbd>Ctrl</kbd> + <kbd>C</kbd> in the terminal and then run the installation command. After the installation completes, start the development server again by running `npx expo start`.
 
 </Step>
 

--- a/docs/pages/tutorial/platform-differences.mdx
+++ b/docs/pages/tutorial/platform-differences.mdx
@@ -36,7 +36,7 @@ Stop the development server and run the following command to install the library
 
 > **Note:** The `dom-to-image` library is used here for illustrative purposes. For production apps, you may want to explore other solutions or APIs that better suit your specific use case.
 
-After installing it, make sure to restart the development server and press <kbd>w</kbd> in the terminal.
+After installing it, make sure to restart the development server and press <kbd>W</kbd> in the terminal.
 
 </Step>
 

--- a/docs/pages/versions/unversioned/sdk/background-fetch.mdx
+++ b/docs/pages/versions/unversioned/sdk/background-fetch.mdx
@@ -164,7 +164,7 @@ Background fetches can be difficult to test because they can happen inconsistent
 
 For iOS, you can use the `Instruments` app on macOS to manually trigger background fetches:
 
-1. Open the Instruments app. The Instruments app can be searched through Spotlight (⌘ + Space) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
+1. Open the Instruments app. The Instruments app can be searched through Spotlight (<kbd>Cmd ⌘</kbd> + <kbd>Space</kbd>) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
 2. Select `Time Profiler`
 3. Select your device / simulator and pick the `Expo Go` app
 4. Press the `Record` button in the top left corner

--- a/docs/pages/versions/unversioned/sdk/sqlite.mdx
+++ b/docs/pages/versions/unversioned/sdk/sqlite.mdx
@@ -521,7 +521,7 @@ expect(row.data).toEqual(blob);
 
 ### Browse an on-device database
 
-The `expo-sqlite` library includes a built-in DevTools inspector plugin that is automatically enabled in development and requires no extra setup. It lets you browse tables, view and edit rows, run SQL queries, and export databases directly from your browser. To open it, press <kbd>shift+m</kbd> in the Expo CLI terminal to open the dev tools menu, and then select **Open expo-sqlite** to launch the inspector.
+The `expo-sqlite` library includes a built-in DevTools inspector plugin that is automatically enabled in development and requires no extra setup. It lets you browse tables, view and edit rows, run SQL queries, and export databases directly from your browser. To open it, press <kbd>Shift</kbd> + <kbd>M</kbd> in the Expo CLI terminal to open the dev tools menu, and then select **Open expo-sqlite** to launch the inspector.
 
 <ContentSpotlight
   alt="SQLite inspector showing a data browser with table rows, edit/delete actions, and a sidebar listing tables"

--- a/docs/pages/versions/v53.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/background-fetch.mdx
@@ -164,7 +164,7 @@ Background fetches can be difficult to test because they can happen inconsistent
 
 For iOS, you can use the `Instruments` app on macOS to manually trigger background fetches:
 
-1. Open the Instruments app. The Instruments app can be searched through Spotlight (<kbd>Cmd ⌘</kbd> + <kbd>Space</kbd>) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
+1. Open the Instruments app. The Instruments app can be searched through Spotlight (⌘ + Space) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
 2. Select `Time Profiler`
 3. Select your device / simulator and pick the `Expo Go` app
 4. Press the `Record` button in the top left corner

--- a/docs/pages/versions/v53.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v53.0.0/sdk/background-fetch.mdx
@@ -164,7 +164,7 @@ Background fetches can be difficult to test because they can happen inconsistent
 
 For iOS, you can use the `Instruments` app on macOS to manually trigger background fetches:
 
-1. Open the Instruments app. The Instruments app can be searched through Spotlight (⌘ + Space) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
+1. Open the Instruments app. The Instruments app can be searched through Spotlight (<kbd>Cmd ⌘</kbd> + <kbd>Space</kbd>) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
 2. Select `Time Profiler`
 3. Select your device / simulator and pick the `Expo Go` app
 4. Press the `Record` button in the top left corner

--- a/docs/pages/versions/v54.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/background-fetch.mdx
@@ -164,7 +164,7 @@ Background fetches can be difficult to test because they can happen inconsistent
 
 For iOS, you can use the `Instruments` app on macOS to manually trigger background fetches:
 
-1. Open the Instruments app. The Instruments app can be searched through Spotlight (⌘ + Space) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
+1. Open the Instruments app. The Instruments app can be searched through Spotlight (<kbd>Cmd ⌘</kbd> + <kbd>Space</kbd>) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
 2. Select `Time Profiler`
 3. Select your device / simulator and pick the `Expo Go` app
 4. Press the `Record` button in the top left corner

--- a/docs/pages/versions/v55.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/background-fetch.mdx
@@ -164,7 +164,7 @@ Background fetches can be difficult to test because they can happen inconsistent
 
 For iOS, you can use the `Instruments` app on macOS to manually trigger background fetches:
 
-1. Open the Instruments app. The Instruments app can be searched through Spotlight (⌘ + Space) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
+1. Open the Instruments app. The Instruments app can be searched through Spotlight (<kbd>Cmd ⌘</kbd> + <kbd>Space</kbd>) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
 2. Select `Time Profiler`
 3. Select your device / simulator and pick the `Expo Go` app
 4. Press the `Record` button in the top left corner

--- a/docs/pages/versions/v55.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/sqlite.mdx
@@ -521,7 +521,7 @@ expect(row.data).toEqual(blob);
 
 ### Browse an on-device database
 
-The `expo-sqlite` library includes a built-in DevTools inspector plugin that is automatically enabled in development and requires no extra setup. It lets you browse tables, view and edit rows, run SQL queries, and export databases directly from your browser. To open it, press <kbd>shift+m</kbd> in the Expo CLI terminal to open the dev tools menu, and then select **Open expo-sqlite** to launch the inspector.
+The `expo-sqlite` library includes a built-in DevTools inspector plugin that is automatically enabled in development and requires no extra setup. It lets you browse tables, view and edit rows, run SQL queries, and export databases directly from your browser. To open it, press <kbd>Shift</kbd> + <kbd>M</kbd> in the Expo CLI terminal to open the dev tools menu, and then select **Open expo-sqlite** to launch the inspector.
 
 <ContentSpotlight
   alt="SQLite inspector showing a data browser with table rows, edit/delete actions, and a sidebar listing tables"

--- a/docs/pages/versions/v56.0.0/sdk/background-fetch.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/background-fetch.mdx
@@ -164,7 +164,7 @@ Background fetches can be difficult to test because they can happen inconsistent
 
 For iOS, you can use the `Instruments` app on macOS to manually trigger background fetches:
 
-1. Open the Instruments app. The Instruments app can be searched through Spotlight (⌘ + Space) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
+1. Open the Instruments app. The Instruments app can be searched through Spotlight (<kbd>Cmd ⌘</kbd> + <kbd>Space</kbd>) or opened from `/Applications/Xcode.app/Contents/Applications/Instruments.app`
 2. Select `Time Profiler`
 3. Select your device / simulator and pick the `Expo Go` app
 4. Press the `Record` button in the top left corner

--- a/docs/pages/versions/v56.0.0/sdk/sqlite.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/sqlite.mdx
@@ -521,7 +521,7 @@ expect(row.data).toEqual(blob);
 
 ### Browse an on-device database
 
-The `expo-sqlite` library includes a built-in DevTools inspector plugin that is automatically enabled in development and requires no extra setup. It lets you browse tables, view and edit rows, run SQL queries, and export databases directly from your browser. To open it, press <kbd>shift+m</kbd> in the Expo CLI terminal to open the dev tools menu, and then select **Open expo-sqlite** to launch the inspector.
+The `expo-sqlite` library includes a built-in DevTools inspector plugin that is automatically enabled in development and requires no extra setup. It lets you browse tables, view and edit rows, run SQL queries, and export databases directly from your browser. To open it, press <kbd>Shift</kbd> + <kbd>M</kbd> in the Expo CLI terminal to open the dev tools menu, and then select **Open expo-sqlite** to launch the inspector.
 
 <ContentSpotlight
   alt="SQLite inspector showing a data browser with table rows, edit/delete actions, and a sidebar listing tables"

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -23,13 +23,13 @@ This guide explains how to install the iOS Simulator on your Mac for app develop
 
 ### Try it out
 
-Run your app with `npx expo start` and press <kbd>i</kbd> from the command line.
+Run your app with `npx expo start` and press <kbd>I</kbd> from the command line.
 
 You may get a warning about needing to accept the Xcode license. Run the command that it suggests. Open your app again to see if it was successful. If not, check the [troubleshooting](#troubleshooting) tips below.
 
 <ContentSpotlight file="open-in-ios-simulator.mp4" />
 
-You can also press <kbd>shift</kbd> + <kbd>i</kbd> in the Expo CLI to interactively select a simulator to open.
+You can also press <kbd>Shift</kbd> + <kbd>I</kbd> in the Expo CLI to interactively select a simulator to open.
 
 <ContentSpotlight
   alt="List of iOS Simulators in the Expo CLI UI."
@@ -98,6 +98,6 @@ Create a project with the desired SDK version and open it in a simulator to inst
 
 For miscellaneous errors, try the following:
 
-- Manually uninstall Expo Go on your simulator and reinstall by pressing <kbd>shift</kbd> + <kbd>i</kbd> in the Expo CLI Terminal UI and selecting the desired simulator.
+- Manually uninstall Expo Go on your simulator and reinstall by pressing <kbd>Shift</kbd> + <kbd>I</kbd> in the Expo CLI Terminal UI and selecting the desired simulator.
 - If that doesn't help, focus the simulator window and in the Mac toolbar choose **Device** &gt; **Erase All Content and Settings...**<br/>
   This will reinitialize your simulator from a blank image. This is sometimes useful for cases where your computer is low on memory and the simulator fails to store some internal files, leaving the device in a corrupt state.

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedExpoGo.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedExpoGo.mdx
@@ -8,4 +8,4 @@ import AndroidStudioInstructions from './_androidStudioInstructions.mdx';
 
 ## Install Expo Go
 
-When you start a development server with `npx expo start` on the [start developing](/get-started/start-developing) page, press <kbd>a</kbd> to open the Android Emulator. Expo CLI will install Expo Go automatically.
+When you start a development server with `npx expo start` on the [start developing](/get-started/start-developing) page, press <kbd>A</kbd> to open the Android Emulator. Expo CLI will install Expo Go automatically.

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedExpoGo.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedExpoGo.mdx
@@ -8,4 +8,4 @@ import XcodeInstructions from './_xcodeInstructions.mdx';
 
 ## Install Expo Go
 
-When you start a development server with `npx expo start` on the [start developing](/get-started/start-developing) page, press <kbd>i</kbd> to open the iOS Simulator. Expo CLI will install Expo Go automatically.
+When you start a development server with `npx expo start` on the [start developing](/get-started/start-developing) page, press <kbd>I</kbd> to open the iOS Simulator. Expo CLI will install Expo Go automatically.

--- a/docs/scenes/get-started/start-developing/TemplateFeatures/features/platforms.mdx
+++ b/docs/scenes/get-started/start-developing/TemplateFeatures/features/platforms.mdx
@@ -2,4 +2,4 @@ import { RawH3 } from '~/ui/components/Text';
 
 <RawH3>Android, iOS, and web support</RawH3>
 
-You can open this project on Android, iOS, and the web. To open the web version, press <kbd>w</kbd> in the terminal after running the project.
+You can open this project on Android, iOS, and the web. To open the web version, press <kbd>W</kbd> in the terminal after running the project.


### PR DESCRIPTION
# Why

The Expo writing style guide specifies that keyboard shortcuts should use `<kbd>` elements with capitalized key names and a literal `+` between separate tags (for example, `<kbd>Cmd ⌘</kbd> + <kbd>T</kbd>`). A two-pass audit of `.mdx` files under `pages/` surfaced three categories of violations: bare unicode symbols like `(⌘ + Space)` written as prose, malformed tags like `<kbd>shift+m</kbd>` that crammed multiple keys into one element, and existing `<kbd>` tags with lowercase content such as `<kbd>a</kbd>` or `<kbd>return</kbd>`.

Style guide reference: https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-keyboard-shortcuts

# How

Each bare unicode shortcut is wrapped in separate `<kbd>` tags, combined-key tags are split into one tag per key, and key names inside every `<kbd>` element are capitalized to match the style guide. 

# Test Plan

Proofread.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).