### PR TITLE
Fix jest-expo nested expo-modules-core resolution

### DIFF
--- a/packages/jest-expo/CHANGELOG.md
+++ b/packages/jest-expo/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Resolve `expo-modules-core` from the installed `expo` package when npm nests it there. ([#44647](https://github.com/expo/expo/issues/44647) by [@mvincentong](https://github.com/mvincentong)) ([#46104](https://github.com/expo/expo/pull/46104) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.4 — 2026-05-20

--- a/packages/jest-expo/src/preset/resolveExpoModulesCore.js
+++ b/packages/jest-expo/src/preset/resolveExpoModulesCore.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+
+function resolveExpoModulesCoreModuleId(
+  moduleId = 'expo-modules-core',
+  resolver = require.resolve
+) {
+  try {
+    return resolver(moduleId);
+  } catch {}
+
+  try {
+    const expoPackageJsonPath = resolver('expo/package.json');
+    return resolver(moduleId, {
+      paths: [path.dirname(expoPackageJsonPath)],
+    });
+  } catch {}
+
+  return moduleId;
+}
+
+module.exports = {
+  resolveExpoModulesCoreModuleId,
+};

--- a/packages/jest-expo/src/preset/setup.js
+++ b/packages/jest-expo/src/preset/setup.js
@@ -13,6 +13,7 @@ const stackTrace = require('stacktrace-js');
 const publicExpoModules = require('./moduleMocks/expoModules');
 const internalExpoModules = require('./moduleMocks/internalExpoModules');
 const thirdPartyModules = require('./moduleMocks/thirdPartyModules');
+const { resolveExpoModulesCoreModuleId } = require('./resolveExpoModulesCore');
 
 // window isn't defined as of react-native 0.45+ it seems
 if (typeof window !== 'object') {
@@ -231,7 +232,7 @@ function attemptLookup(moduleName) {
 
 // TODO(@kitten): This is an invalid dependency chain
 jest.doMock('expo-modules-core', () => {
-  const ExpoModulesCore = jest.requireActual('expo-modules-core');
+  const ExpoModulesCore = jest.requireActual(resolveExpoModulesCoreModuleId());
 
   const { EventEmitter, NativeModule, SharedObject } = globalThis.expo;
 
@@ -316,7 +317,9 @@ jest.doMock('expo-modules-core', () => {
 });
 
 // Installs web implementations of the global.expo object for all platforms to polyfill APIs that are normally installed through JSI.
-require('expo-modules-core/src/polyfill/dangerous-internal').installExpoGlobalPolyfill();
+require(
+  resolveExpoModulesCoreModuleId('expo-modules-core/src/polyfill/dangerous-internal')
+).installExpoGlobalPolyfill();
 
 // `expo/fetch` defines `class FetchResponse extends ExpoFetchModule.NativeResponse`
 // at module load — provide stub classes so tests that transitively import fetch

--- a/packages/jest-expo/tests/__tests__/resolveExpoModulesCore-test.js
+++ b/packages/jest-expo/tests/__tests__/resolveExpoModulesCore-test.js
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { resolveExpoModulesCoreModuleId } from '../../src/preset/resolveExpoModulesCore';
+
+function createResolver(resolutions) {
+  return (moduleId, options) => {
+    const lookupKey = options?.paths?.length
+      ? `${moduleId}\0${options.paths.join('\0')}`
+      : moduleId;
+    const resolution = resolutions[lookupKey];
+
+    if (resolution) {
+      return resolution;
+    }
+
+    throw Object.assign(new Error(`Cannot find module '${moduleId}'`), {
+      code: 'MODULE_NOT_FOUND',
+    });
+  };
+}
+
+it('resolves expo-modules-core directly when it is available at the project root', () => {
+  expect(
+    resolveExpoModulesCoreModuleId(
+      'expo-modules-core',
+      createResolver({
+        'expo-modules-core': '/app/node_modules/expo-modules-core/index.js',
+      })
+    )
+  ).toBe('/app/node_modules/expo-modules-core/index.js');
+});
+
+it('resolves expo-modules-core through expo when npm nests the dependency', () => {
+  expect(
+    resolveExpoModulesCoreModuleId(
+      'expo-modules-core',
+      createResolver({
+        'expo/package.json': '/app/node_modules/expo/package.json',
+        'expo-modules-core\0/app/node_modules/expo':
+          '/app/node_modules/expo/node_modules/expo-modules-core/index.js',
+      })
+    )
+  ).toBe('/app/node_modules/expo/node_modules/expo-modules-core/index.js');
+});
+
+it('resolves expo-modules-core subpaths through expo when npm nests the dependency', () => {
+  expect(
+    resolveExpoModulesCoreModuleId(
+      'expo-modules-core/src/polyfill/dangerous-internal',
+      createResolver({
+        'expo/package.json': '/app/node_modules/expo/package.json',
+        'expo-modules-core/src/polyfill/dangerous-internal\0/app/node_modules/expo':
+          '/app/node_modules/expo/node_modules/expo-modules-core/src/polyfill/dangerous-internal.js',
+      })
+    )
+  ).toBe(
+    '/app/node_modules/expo/node_modules/expo-modules-core/src/polyfill/dangerous-internal.js'
+  );
+});
+
+it('uses Node resolution paths for expo nested dependencies', () => {
+  const fixtureRoot = fs.mkdtempSync(
+    path.join(fs.realpathSync(os.tmpdir()), 'jest-expo-modules-core-')
+  );
+  const expoDir = path.join(fixtureRoot, 'node_modules', 'expo');
+  const expoModulesCoreDir = path.join(expoDir, 'node_modules', 'expo-modules-core');
+
+  try {
+    fs.mkdirSync(path.join(expoModulesCoreDir, 'src', 'polyfill'), { recursive: true });
+    fs.writeFileSync(path.join(expoDir, 'package.json'), '{}');
+    fs.writeFileSync(path.join(expoModulesCoreDir, 'package.json'), '{"main":"index.js"}');
+    fs.writeFileSync(path.join(expoModulesCoreDir, 'index.js'), '');
+    fs.writeFileSync(path.join(expoModulesCoreDir, 'src', 'polyfill', 'dangerous-internal.js'), '');
+
+    const resolver = (moduleId, options) => {
+      if (moduleId === 'expo/package.json') {
+        return path.join(expoDir, 'package.json');
+      }
+      if (!options) {
+        throw new Error(`Cannot find module '${moduleId}'`);
+      }
+      return require.resolve(moduleId, options);
+    };
+
+    expect(resolveExpoModulesCoreModuleId('expo-modules-core', resolver)).toBe(
+      path.join(expoModulesCoreDir, 'index.js')
+    );
+    expect(
+      resolveExpoModulesCoreModuleId('expo-modules-core/src/polyfill/dangerous-internal', resolver)
+    ).toBe(path.join(expoModulesCoreDir, 'src', 'polyfill', 'dangerous-internal.js'));
+  } finally {
+    fs.rmSync(fixtureRoot, { force: true, recursive: true });
+  }
+});
+
+it('falls back to the original module id so Jest reports the normal resolver error', () => {
+  expect(resolveExpoModulesCoreModuleId('expo-modules-core', createResolver({}))).toBe(
+    'expo-modules-core'
+  );
+});


### PR DESCRIPTION
## Why

Fixes [#44647](https://github.com/expo/expo/issues/44647).

`jest-expo`'s setup file mocks `expo-modules-core` and loads its global polyfill. PR [#44874](https://github.com/expo/expo/pull/44874) originally fixed npm installs by adding `expo-modules-core` as a direct `jest-expo` dependency, but PR [#45048](https://github.com/expo/expo/pull/45048) later removed that dependency to avoid monorepo package cycles.

That leaves npm-style installs vulnerable again when `expo-modules-core` is nested under `expo/node_modules` instead of hoisted to the project root: the setup file resolves from `jest-expo`, cannot see the nested package, and Jest fails before tests run.

## How

- Add a small `resolveExpoModulesCoreModuleId` helper in `packages/jest-expo/src/preset`.
- Resolve `expo-modules-core` normally first, preserving hoisted and workspace installs.
- If that fails, resolve `expo/package.json`, then resolve `expo-modules-core` from the installed `expo` package directory so npm's nested layout works.
- Use the helper for both `jest.requireActual('expo-modules-core')` and the `dangerous-internal` polyfill subpath.
- Add focused resolver tests for direct, nested, subpath, fallback behavior, and actual Node `require.resolve` fallback options.

## Test Plan

- `git diff --check`
- `git diff --check upstream/main...HEAD`
- `pnpm --filter jest-expo test -- tests/__tests__/resolveExpoModulesCore-test.js --runInBand`
- `pnpm --filter jest-expo exec jest --runInBand`
- `pnpm --filter jest-expo exec eslint --max-warnings 0 src/preset/resolveExpoModulesCore.js src/preset/setup.js tests/__tests__/resolveExpoModulesCore-test.js`
- `pnpm --filter jest-expo lint`

Note: `pnpm --filter jest-expo test -- --runInBand` is not the right full-suite command here; pnpm forwards it as `jest -- --runInBand`, so Jest treats `--runInBand` as a pattern and reports no tests.

`pnpm --filter jest-expo lint` exits 0, but still reports one existing Prettier warning in `packages/jest-expo/jest-preset.js`, outside this branch's diff.

## Risk

Diff is limited to `jest-expo` setup resolution, one helper test, and the package changelog. The normal resolution path is unchanged when `expo-modules-core` is hoisted or directly resolvable. The fallback only runs after direct resolution fails and only resolves through the installed `expo` package.
