### PR TITLE
[docs] Add Vale rule for <kbd> keyboard shortcut formatting

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/KeyboardShortcuts.yml
+++ b/docs/.vale/writing-styles/expo-docs/KeyboardShortcuts.yml
@@ -1,0 +1,13 @@
+extends: existence
+message: 'Use separate <kbd> elements for keyboard shortcuts. Capitalize key names and keep plus signs outside the elements.'
+link: 'https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md#referencing-keyboard-shortcuts'
+level: error
+scope: raw
+nonword: true
+tokens:
+  - '`\s*(?:⌘|cmd|Cmd|ctrl|Ctrl|alt|Alt|option|Option|shift|Shift|command|Command)(?:\s*\+\s*(?:⌘|cmd|Cmd|ctrl|Ctrl|alt|Alt|option|Option|shift|Shift|command|Command|Space|Return|Enter|Esc|Escape|Tab|Delete|Backspace|Up|Down|Left|Right|[A-Za-z0-9?]))+\s*`'
+  - '⌘\s*\+\s*(?:Space|Return|Enter|Esc|Escape|Tab|Delete|Backspace|Up|Down|Left|Right|[A-Za-z0-9?])\b'
+  - '<kbd>[^<]*\+[^<]*</kbd>'
+  - '</kbd>\+\s*<kbd>'
+  - '</kbd>\s\+<kbd>'
+  - '<kbd>(?:[a-z]|shift|ctrl|cmd|alt|option|return|enter|space|tab|esc|escape|delete|backspace|up|down|left|right)</kbd>'

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "format": "oxfmt --write .",
     "lint": "NODE_OPTIONS='--no-warnings' node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
-    "lint-prose": ".vale/bin/vale --config='.vale.ini' --glob='!{pages/versions/latest,pages/versions/latest/**,pages/internal,pages/internal/**}' pages scenes README.md",
+    "lint-prose": ".vale/bin/vale --config='.vale.ini' --glob='!{pages/versions/latest,pages/versions/latest/**,pages/internal,pages/internal/**}' pages scenes",
     "watch": "tsc --noEmit -w",
     "test": "pnpm generate-static-resources && node --experimental-strip-types --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",


### PR DESCRIPTION
# Why

Fix ENG-21385

Follow-up https://github.com/expo/expo/pull/46102

# How

Add Vale rule for <kbd> keyboard shortcut formatting


# Test Plan

Run `pnpm lint-prose` against the current `main` and confirm zero new warnings. 

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).