### PR TITLE
[expo] Improve `ccache` config

### DIFF
--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -171,18 +171,14 @@ runs:
         # The key is divided into two parts:
         #
         # PART 1 - used in key and restore-keys
-        # If these files change, we MUST completely invalidate the cache.
-        # Otherwise, ccache's `system_headers` and `pch_defines` sloppiness options would cause incorrect cache hits,
-        # by silently reusing outdated NDK files or precompiled headers.
-        # - pnpm-lock.yaml: Tracks NDK version and external dependencies.
-        # - pch.h: Tracks modifications to the precompiled header.
+        # pnpm-lock.yaml keeps track of the react native version, which tracks the NDK version, if it changes, we need to invalidate the cache.
         #
         # PART 2 - used only in the exact key
         # ccache tracks these files without any sloppiness issues.
         # - C/C++ source files
         # - Gradle files: see https://github.com/expo/expo/pull/44884
-        key: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml', 'apps/bare-expo/android/app/src/main/jni/pch.h')}}-${{ hashFiles('packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/build.gradle', 'packages/**/build.gradle.kts', 'packages/**/settings.gradle', 'packages/**/settings.gradle.kts', 'apps/bare-expo/**/build.gradle', 'apps/bare-expo/**/settings.gradle') }}
-        restore-keys: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml', 'apps/bare-expo/android/app/src/main/jni/pch.h')}}
+        key: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml')}}-${{ hashFiles('packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/build.gradle', 'packages/**/build.gradle.kts', 'packages/**/settings.gradle', 'packages/**/settings.gradle.kts', 'apps/bare-expo/**/build.gradle', 'apps/bare-expo/**/settings.gradle', 'apps/bare-expo/android/app/src/main/jni/pch.h') }}
+        restore-keys: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml')}}
 
     - name: 🔍️ Get cache key of Git LFS files
       if: inputs.git-lfs == 'true'

--- a/.github/actions/expo-caches/action.yml
+++ b/.github/actions/expo-caches/action.yml
@@ -168,8 +168,21 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ${{ runner.temp }}/.ccache
-        key: ${{ runner.os }}-ccache-${{ hashFiles('pnpm-lock.yaml', 'packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/build.gradle', 'packages/**/build.gradle.kts', 'packages/**/settings.gradle', 'packages/**/settings.gradle.kts', 'apps/bare-expo/**/build.gradle', 'apps/bare-expo/**/settings.gradle') }}
-        restore-keys: ${{ runner.os }}-ccache-
+        # The key is divided into two parts:
+        #
+        # PART 1 - used in key and restore-keys
+        # If these files change, we MUST completely invalidate the cache.
+        # Otherwise, ccache's `system_headers` and `pch_defines` sloppiness options would cause incorrect cache hits,
+        # by silently reusing outdated NDK files or precompiled headers.
+        # - pnpm-lock.yaml: Tracks NDK version and external dependencies.
+        # - pch.h: Tracks modifications to the precompiled header.
+        #
+        # PART 2 - used only in the exact key
+        # ccache tracks these files without any sloppiness issues.
+        # - C/C++ source files
+        # - Gradle files: see https://github.com/expo/expo/pull/44884
+        key: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml', 'apps/bare-expo/android/app/src/main/jni/pch.h')}}-${{ hashFiles('packages/**/*.c', 'packages/**/*.cpp', 'packages/**/*.h', 'packages/**/build.gradle', 'packages/**/build.gradle.kts', 'packages/**/settings.gradle', 'packages/**/settings.gradle.kts', 'apps/bare-expo/**/build.gradle', 'apps/bare-expo/**/settings.gradle') }}
+        restore-keys: ${{ runner.os }}-ccache-${{hashFiles('pnpm-lock.yaml', 'apps/bare-expo/android/app/src/main/jni/pch.h')}}
 
     - name: 🔍️ Get cache key of Git LFS files
       if: inputs.git-lfs == 'true'

--- a/.github/actions/setup-ccache/action.yml
+++ b/.github/actions/setup-ccache/action.yml
@@ -37,7 +37,10 @@ runs:
         # time_macros might help if in included modules there are macros like __TIME__ which would trigger a cache miss.
         # system_headers: avoids hashing thousands of Apple SDK headers.
         # modules, clang_index_store, ivfsoverlay: without these, hit rate on iOS would be 0%.
-        echo "CCACHE_SLOPPINESS=include_file_mtime,include_file_ctime,time_macros,modules,clang_index_store,system_headers,ivfsoverlay" >> $GITHUB_ENV
+        echo "CCACHE_SLOPPINESS=include_file_mtime,include_file_ctime,time_macros,modules,clang_index_store,system_headers,ivfsoverlay,pch_defines" >> $GITHUB_ENV
+
+        # Calculate hash based on a relative path - this prevents cache misses when an absolute path changes.
+        echo "CCACHE_BASEDIR=${{ github.workspace }}" >> $GITHUB_ENV
 
         # Speeds up the process on cache misses by skipping the preprocessing step.
         echo "CCACHE_DEPEND=true" >> $GITHUB_ENV
@@ -71,7 +74,11 @@ runs:
         # Sloppiness options disable some of the ccache checks to increase hit rate.
         # In our case we exclude ctime and mtime so cache is hit based on file content.
         # time_macros might help if in included modules there are macros like __TIME__ which would trigger a cache miss.
-        echo "CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros" >> $GITHUB_ENV
+        # system_headers: avoids hashing NDK sysroot headers that don't change between builds.
+        echo "CCACHE_SLOPPINESS=include_file_ctime,include_file_mtime,time_macros,system_headers,pch_defines" >> $GITHUB_ENV
+
+        # Speeds up the process on cache misses by skipping the preprocessing step.
+        echo "CCACHE_DEPEND=true" >> $GITHUB_ENV
 
         # Replaces compiler with ccache.
         echo "CMAKE_C_COMPILER_LAUNCHER=$(which ccache)" >> $GITHUB_ENV


### PR DESCRIPTION
# Why

Improves our `ccache` config.

# How

| Change | Platform | Why |
|--------|----------|-----|
| `pch_defines` sloppiness | iOS + Android | Improves hit rate when using precompiled headers by not requiring `#define`s to match exactly at PCH inclusion point |
| `CCACHE_BASEDIR` | iOS | Normalizes absolute paths to relative, preventing full cache invalidation if the workspace path changes |
| `system_headers` sloppiness | Android | Skips re-hashing stable NDK sysroot headers that don't change between builds |
| `CCACHE_DEPEND=true` | Android | Uses compiler-generated `-MD` dependency info instead of a separate preprocessor pass, reducing cache-miss overhead |


# Test Plan

- CI ✅ 