### PR TITLE
[router][docs] Collapse huge mixed literal unions in Native tabs reference

### DIFF
--- a/docs/components/plugins/APISection.test.tsx
+++ b/docs/components/plugins/APISection.test.tsx
@@ -91,4 +91,20 @@ describe('APISection', () => {
     expect(screen.queryAllByText('Props')).toHaveLength(0);
     expect(screen.queryAllByText('Enums')).toHaveLength(0);
   });
+
+  test('expo-router/native-tabs collapses huge mixed literal unions', () => {
+    const { container } = renderWithHeadings(
+      <APISection
+        packageName="expo-router/native-tabs"
+        forceVersion="unversioned"
+        testRequire={require}
+      />
+    );
+
+    expect(screen.queryAllByText(/See description for available values\./).length).toBeGreaterThan(
+      0
+    );
+    expect(container.innerHTML).not.toContain("'discover_tune'");
+    expect(container.innerHTML.length).toBeLessThan(500_000);
+  });
 });

--- a/docs/components/plugins/api/APISectionUtils.tsx
+++ b/docs/components/plugins/api/APISectionUtils.tsx
@@ -262,13 +262,24 @@ export const resolveTypeName = (
       }
       return elementType.name + type;
     } else if (type === 'union' && types?.length) {
-      const isLargeLiteralUnion =
-        types.length > LITERAL_UNION_COLLAPSE_THRESHOLD &&
-        types.every((t: TypeDefinitionData) =>
-          ['literal', 'templateLiteral', 'intrinsic', 'reference', 'tuple'].includes(t.type)
+      const COLLAPSIBLE_LITERAL_KINDS = new Set(['literal', 'templateLiteral']);
+      const literalMembers = types.filter((t: TypeDefinitionData) =>
+        COLLAPSIBLE_LITERAL_KINDS.has(t.type)
+      );
+      if (literalMembers.length > LITERAL_UNION_COLLAPSE_THRESHOLD) {
+        const nonLiteralMembers = types.filter(
+          (t: TypeDefinitionData) => !COLLAPSIBLE_LITERAL_KINDS.has(t.type)
         );
-      if (isLargeLiteralUnion) {
-        return 'See description for available values.';
+        if (nonLiteralMembers.length === 0) {
+          return 'See description for available values.';
+        }
+        return (
+          <>
+            {renderUnion(nonLiteralMembers, { sdkVersion })}
+            <span className="text-quaternary"> | </span>
+            See description for available values.
+          </>
+        );
       }
       return renderUnion(types, { sdkVersion });
     } else if (elementType?.type === 'union' && elementType?.types?.length) {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21389

Algolia crawler fails to index `/versions/latest/sdk/router/native-tabs/` with a 279KB record vs. 97KB limit. `MaterialIcon.md` is a union of 4,055 string literals plus one reflection, which the existing collapse logic skipped because not every member was literal-ish.

# How

Change the union branch in `resolveTypeName` (`components/plugins/api/APISectionUtils.tsx`) to collapse based on the count of literal/templateLiteral members. Mixed unions render non-literal members normally and append `See description for available values.` for the rest, since description already contains link.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2620" height="968" alt="CleanShot 2026-05-22 at 00 20 10@2x" src="https://github.com/user-attachments/assets/61c7643d-608e-4ffe-8d31-76da3c60a1e2" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
