### PR TITLE
[expo-camera][iOS] add Mac Catalyst build support

### DIFF
--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Gate `VisionKit` usage behind `targetEnvironment(macCatalyst)` so the module compiles when targeting Mac Catalyst. `isModernBarcodeScannerAvailable` returns `false` and `launchScanner` throws `CameraScannerUnavailableException` on Catalyst, where `DataScannerViewController` is unavailable. ([@skrtdev](https://github.com/skrtdev))
+- [iOS] Gate `VisionKit` usage behind `targetEnvironment(macCatalyst)` so the module compiles when targeting Mac Catalyst. `isModernBarcodeScannerAvailable` returns `false` and `launchScanner` throws `CameraScannerUnavailableException` on Catalyst, where `DataScannerViewController` is unavailable. ([#46119](https://github.com/expo/expo/pull/46119) by [@skrtdev](https://github.com/skrtdev))
 
 ### 💡 Others
 

--- a/packages/expo-camera/CHANGELOG.md
+++ b/packages/expo-camera/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Gate `VisionKit` usage behind `targetEnvironment(macCatalyst)` so the module compiles when targeting Mac Catalyst. `isModernBarcodeScannerAvailable` returns `false` and `launchScanner` throws `CameraScannerUnavailableException` on Catalyst, where `DataScannerViewController` is unavailable. ([@skrtdev](https://github.com/skrtdev))
+
 ### 💡 Others
 
 ## 56.0.7 — 2026-05-21

--- a/packages/expo-camera/ios/CameraViewModule.swift
+++ b/packages/expo-camera/ios/CameraViewModule.swift
@@ -2,7 +2,9 @@
 
 import AVFoundation
 import ExpoModulesCore
+#if !targetEnvironment(macCatalyst)
 import VisionKit
+#endif
 
 let cameraEvents = ["onCameraReady", "onMountError", "onPictureSaved", "onBarcodeScanned", "onResponsiveOrientationChanged", "onAvailableLensesChanged"]
 
@@ -31,7 +33,11 @@ public final class CameraViewModule: Module, ScannerResultHandler {
     }
 
     Property("isModernBarcodeScannerAvailable") {
+      #if targetEnvironment(macCatalyst)
+      false
+      #else
       if #available(iOS 16.0, *) { true } else { false }
+      #endif
     }
 
     Property("toggleRecordingAsyncAvailable") {
@@ -328,6 +334,9 @@ public final class CameraViewModule: Module, ScannerResultHandler {
     }
 
     AsyncFunction("launchScanner") { (options: VisionScannerOptions?) in
+      #if targetEnvironment(macCatalyst)
+      throw CameraScannerUnavailableException()
+      #else
       if #available(iOS 16.0, *) {
         try await MainActor.run {
           guard DataScannerViewController.isSupported, DataScannerViewController.isAvailable else {
@@ -338,14 +347,17 @@ public final class CameraViewModule: Module, ScannerResultHandler {
           launchScanner(with: options)
         }
       }
+      #endif
     }
 
     AsyncFunction("dismissScanner") {
+      #if !targetEnvironment(macCatalyst)
       if #available(iOS 16.0, *) {
         await MainActor.run {
           dismissScanner()
         }
       }
+      #endif
     }
 
     AsyncFunction("getCameraPermissionsAsync") { (promise: Promise) in
@@ -389,6 +401,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
     }
   }
 
+  #if !targetEnvironment(macCatalyst)
   @available(iOS 16.0, *)
   @MainActor
   private func launchScanner(with options: VisionScannerOptions?) {
@@ -423,6 +436,7 @@ public final class CameraViewModule: Module, ScannerResultHandler {
       self?.onScannerDismissed()
     }
   }
+  #endif
 
   func onItemScanned(result: [String: Any]) {
     sendEvent("onModernBarcodeScanned", result)
@@ -430,11 +444,13 @@ public final class CameraViewModule: Module, ScannerResultHandler {
 
   @MainActor
   func onScannerDismissed() {
+    #if !targetEnvironment(macCatalyst)
     if #available(iOS 16.0, *) {
       if let controller = scannerContext?.controller as? DataScannerViewController {
         controller.stopScanning()
       }
     }
+    #endif
     scannerContext = nil
   }
 

--- a/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
+++ b/packages/expo-camera/ios/Current/BarcodeScannerUtils.swift
@@ -60,6 +60,7 @@ class BarcodeScannerUtils {
     return result
   }
 
+  #if !targetEnvironment(macCatalyst)
   @available(iOS 16.0, *)
   static func visionDataScannerObjectToDictionary(item: RecognizedItem.Barcode) -> [String: Any] {
     var result = [String: Any]()
@@ -82,6 +83,7 @@ class BarcodeScannerUtils {
 
     return result
   }
+  #endif
 
   static func addEmptyCornerPoints(to result: inout [String: Any]) {
     result["cornerPoints"] = []

--- a/packages/expo-camera/ios/Current/VisionScannerDelegate.swift
+++ b/packages/expo-camera/ios/Current/VisionScannerDelegate.swift
@@ -1,11 +1,14 @@
-import VisionKit
 import ExpoModulesCore
+#if !targetEnvironment(macCatalyst)
+import VisionKit
+#endif
 
 protocol ScannerResultHandler {
   func onItemScanned(result: [String: Any])
   @MainActor func onScannerDismissed()
 }
 
+#if !targetEnvironment(macCatalyst)
 @available(iOS 16.0, *)
 class VisionScannerDelegate: NSObject, DataScannerViewControllerDelegate, UIAdaptivePresentationControllerDelegate {
   private let handler: ScannerResultHandler
@@ -32,3 +35,4 @@ class VisionScannerDelegate: NSObject, DataScannerViewControllerDelegate, UIAdap
     handler.onScannerDismissed()
   }
 }
+#endif


### PR DESCRIPTION
# Why

`expo-camera` currently fails to build when targeting Mac Catalyst because it unconditionally imports `VisionKit` and references `DataScannerViewController`, neither of which is available in the Mac Catalyst SDK.

This mirrors the same fix shipped for `expo-image` in #24880, where `ImageAnalyzer` (also a VisionKit API) was gated for Catalyst.

There is no official Mac Catalyst support commitment from Expo — but per [@brentvatne's guidance on #17009](https://github.com/expo/expo/issues/17009#issuecomment-1212018048), community PRs that unblock individual modules are welcome.

# How

Gate every `VisionKit`-touching code path behind `#if !targetEnvironment(macCatalyst)`:

- **`CameraViewModule.swift`**: skip the `import VisionKit`; `isModernBarcodeScannerAvailable` returns `false`; `launchScanner` throws `CameraScannerUnavailableException`; `dismissScanner` / `onScannerDismissed` no-op; the two private scanner helpers (`launchScanner(with:)`, `dismissScanner()`) are excluded from compilation.
- **`Current/BarcodeScannerUtils.swift`**: `visionDataScannerObjectToDictionary` (which takes `RecognizedItem.Barcode`) is excluded.
- **`Current/VisionScannerDelegate.swift`**: the entire delegate, which conforms to `DataScannerViewControllerDelegate`, is excluded.

iOS / iPadOS / tvOS behavior is unchanged — only Catalyst takes a different branch. The user-visible contract on Catalyst is that the modern (VisionKit-based) barcode scanner reports itself as unavailable, which matches how the property is already meant to be consumed (callers gate on `isModernBarcodeScannerAvailable` before calling `launchScanner`).

# Test Plan

- Built `expo-camera` as part of an app targeting Mac Catalyst (Xcode 16, iOS 18 SDK / macOS 15 SDK). Before this change: `error: cannot find type 'DataScannerViewController' in scope` and several related diagnostics. After: clean build.
- Verified iOS device + simulator builds are unaffected (no diff in the `iphoneos` / `iphonesimulator` slices' compilation behavior).
- Camera preview, photo capture, and the legacy (AVFoundation) barcode scanner continue to work on iOS as before.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)