### PR TITLE
[crypto] use OptimizedFunction for randomUUID

### DIFF
--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
@@ -1,15 +1,7 @@
 import { BridgeModule, ExpoModule, TurboModule } from 'benchmarking';
-import { requireOptionalNativeModule } from 'expo';
 import { Platform } from 'react-native';
 
 import { BenchmarkRun } from './ModulesBenchmarksHistory';
-
-type ExpoCryptoNativeModule = {
-  randomUUID?: () => string;
-  randomUUIDOptimized?: () => string;
-};
-
-const ExpoCryptoModule = requireOptionalNativeModule<ExpoCryptoNativeModule>('ExpoCrypto');
 
 const DEFAULT_ITERATIONS = 100_000;
 const DEFAULT_ASYNC_ITERATIONS = Platform.OS === 'ios' ? DEFAULT_ITERATIONS : 25_000;
@@ -445,36 +437,6 @@ export const GROUPS: Group[] = [
           BridgeModule.foldArray(numbers);
           return timeSync(iterations, () => {
             BridgeModule.foldArray(numbers);
-          });
-        },
-      },
-    ],
-  },
-  {
-    id: 'randomUUID',
-    title: 'randomUUID()',
-    description:
-      'Synchronous no-argument call that returns a freshly generated UUIDv4 string. Compares the baseline expo-crypto host function against the `@OptimizedFunction` JSI bridge variant.',
-    benchmarks: [
-      {
-        id: 'expo',
-        label: 'ExpoCrypto (baseline)',
-        available: ExpoCryptoModule?.randomUUID != null,
-        async run(iterations) {
-          ExpoCryptoModule!.randomUUID!();
-          return timeSync(iterations, () => {
-            ExpoCryptoModule!.randomUUID!();
-          });
-        },
-      },
-      {
-        id: 'expo-optimized',
-        label: 'ExpoCrypto (optimized)',
-        available: ExpoCryptoModule?.randomUUIDOptimized != null,
-        async run(iterations) {
-          ExpoCryptoModule!.randomUUIDOptimized!();
-          return timeSync(iterations, () => {
-            ExpoCryptoModule!.randomUUIDOptimized!();
           });
         },
       },

--- a/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
+++ b/apps/native-component-list/src/screens/ModulesCore/Benchmarks/benchmarks.ts
@@ -1,7 +1,15 @@
 import { BridgeModule, ExpoModule, TurboModule } from 'benchmarking';
+import { requireOptionalNativeModule } from 'expo';
 import { Platform } from 'react-native';
 
 import { BenchmarkRun } from './ModulesBenchmarksHistory';
+
+type ExpoCryptoNativeModule = {
+  randomUUID?: () => string;
+  randomUUIDOptimized?: () => string;
+};
+
+const ExpoCryptoModule = requireOptionalNativeModule<ExpoCryptoNativeModule>('ExpoCrypto');
 
 const DEFAULT_ITERATIONS = 100_000;
 const DEFAULT_ASYNC_ITERATIONS = Platform.OS === 'ios' ? DEFAULT_ITERATIONS : 25_000;
@@ -437,6 +445,36 @@ export const GROUPS: Group[] = [
           BridgeModule.foldArray(numbers);
           return timeSync(iterations, () => {
             BridgeModule.foldArray(numbers);
+          });
+        },
+      },
+    ],
+  },
+  {
+    id: 'randomUUID',
+    title: 'randomUUID()',
+    description:
+      'Synchronous no-argument call that returns a freshly generated UUIDv4 string. Compares the baseline expo-crypto host function against the `@OptimizedFunction` JSI bridge variant.',
+    benchmarks: [
+      {
+        id: 'expo',
+        label: 'ExpoCrypto (baseline)',
+        available: ExpoCryptoModule?.randomUUID != null,
+        async run(iterations) {
+          ExpoCryptoModule!.randomUUID!();
+          return timeSync(iterations, () => {
+            ExpoCryptoModule!.randomUUID!();
+          });
+        },
+      },
+      {
+        id: 'expo-optimized',
+        label: 'ExpoCrypto (optimized)',
+        available: ExpoCryptoModule?.randomUUIDOptimized != null,
+        async run(iterations) {
+          ExpoCryptoModule!.randomUUIDOptimized!();
+          return timeSync(iterations, () => {
+            ExpoCryptoModule!.randomUUIDOptimized!();
           });
         },
       },

--- a/packages/expo-crypto/CHANGELOG.md
+++ b/packages/expo-crypto/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Improve `randomUUID()` performance on iOS. ([#46122](https://github.com/expo/expo/pull/46122) by [@kudo](https://github.com/kudo))
+
 ## 56.0.3 — 2026-05-06
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -15,15 +15,11 @@ public class CryptoModule: Module {
 
     Function("digest", digest)
 
-    Function("randomUUID") {
-      UUID().uuidString.lowercased()
-    }
-
-    Function("randomUUIDOptimized", randomUUIDOptimized())
+    Function("randomUUID", randomUUID())
   }
 
   @OptimizedFunction
-  private func randomUUIDOptimized() -> String {
+  private func randomUUID() -> String {
     return UUID().uuidString.lowercased()
   }
 }

--- a/packages/expo-crypto/ios/CryptoModule.swift
+++ b/packages/expo-crypto/ios/CryptoModule.swift
@@ -18,6 +18,13 @@ public class CryptoModule: Module {
     Function("randomUUID") {
       UUID().uuidString.lowercased()
     }
+
+    Function("randomUUIDOptimized", randomUUIDOptimized())
+  }
+
+  @OptimizedFunction
+  private func randomUUIDOptimized() -> String {
+    return UUID().uuidString.lowercased()
   }
 }
 


### PR DESCRIPTION
# Why

dogfooding OptimizedFunction

# How

- migrate randomUUID to use `@OptimizedFunction`

# Test Plan

- test `randomUUID` returns expected random uuid

- benchmark (keep the change in git history).
<img width="1205" height="751" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-22 at 03 08 23" src="https://github.com/user-attachments/assets/580790a6-2352-4493-ac5f-f6503f708df6" />


# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
