### PR TITLE
[docs] Improve naming consistency

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -591,7 +591,7 @@ export const eas = [
     ),
   ]),
   makeSection('EAS Insights', [makePage('eas-insights/introduction.mdx')]),
-  makeSection('Expo Observe', [
+  makeSection('EAS Observe', [
     makePage('eas/observe/introduction.mdx'),
     makePage('eas/observe/get-started.mdx'),
     makePage('eas/observe/dashboard.mdx'),

--- a/docs/pages/eas/index.mdx
+++ b/docs/pages/eas/index.mdx
@@ -70,7 +70,7 @@ Read the full pitch at [expo.dev/eas](https://expo.dev/eas), or follow the links
 />
 
 <BoxLink
-  title="Expo Observe (in private preview)"
+  title="EAS Observe (in private preview)"
   description="Monitor your app's performance in production."
   href="/eas/observe/introduction/"
   Icon={ActivityIcon}

--- a/docs/pages/eas/observe/configuration.mdx
+++ b/docs/pages/eas/observe/configuration.mdx
@@ -1,14 +1,14 @@
 ---
-title: Configure Observe
+title: Configure EAS Observe
 sidebar_title: Configuration
-description: Control how Observe collects and dispatches metrics, including environment settings, development mode, and custom endpoints.
+description: Control how EAS Observe collects and dispatches metrics, including environment settings, development mode, and custom endpoints.
 ---
 
-Configure Observe at runtime to fit your app's build setup, environment, and data routing. This page covers the `configure()` and `dispatchEvents()`, enabling metrics in development, using a custom endpoint, and separating data by environment.
+Configure EAS Observe at runtime to fit your app's build setup, environment, and data routing. This page covers the `configure()` and `dispatchEvents()`, enabling metrics in development, using a custom endpoint, and separating data by environment.
 
 ## `configure()`
 
-Use the `configure()` method to control how Observe behaves at runtime:
+Use the `configure()` method to control how EAS Observe behaves at runtime:
 
 ```tsx
 import ExpoObserve from 'expo-observe';
@@ -61,7 +61,7 @@ A few details worth knowing:
 
 ## Enable metrics in development
 
-By default, metrics collected from debug builds are not dispatched. To dispatch them anyway (for example, while testing your Observe integration), set `dispatchInDebug` to `true` when calling `configure()`:
+By default, metrics collected from debug builds are not dispatched. To dispatch them anyway (for example, while testing your EAS Observe integration), set `dispatchInDebug` to `true` when calling `configure()`:
 
 ```tsx
 import ExpoObserve from 'expo-observe';
@@ -75,7 +75,7 @@ A build is treated as a debug build if either the native app is a debug build or
 
 `dispatchInDebug` has no effect on release builds, which always dispatch (subject to [`dispatchingEnabled`](#configure) and [`sampleRate`](#sampling)). If `dispatchingEnabled` is `false` or this installation is out-of-sample, nothing dispatches regardless of `dispatchInDebug`.
 
-> **warning** Enable this only when testing your Observe integration. Development/debug performance differs significantly from production, so collecting development/debug metrics may distort the results shown in your dashboard.
+> **warning** Enable this only when testing your EAS Observe integration. Development/debug performance differs significantly from production, so collecting development/debug metrics may distort the results shown in your dashboard.
 
 ## Custom endpoint
 

--- a/docs/pages/eas/observe/configuration.mdx
+++ b/docs/pages/eas/observe/configuration.mdx
@@ -1,14 +1,14 @@
 ---
-title: Configure Expo Observe
+title: Configure Observe
 sidebar_title: Configuration
-description: Control how Expo Observe collects and dispatches metrics, including environment settings, development mode, and custom endpoints.
+description: Control how Observe collects and dispatches metrics, including environment settings, development mode, and custom endpoints.
 ---
 
-Configure Expo Observe at runtime to fit your app's build setup, environment, and data routing. This page covers the `configure()` and `dispatchEvents()`, enabling metrics in development, using a custom endpoint, and separating data by environment.
+Configure Observe at runtime to fit your app's build setup, environment, and data routing. This page covers the `configure()` and `dispatchEvents()`, enabling metrics in development, using a custom endpoint, and separating data by environment.
 
 ## `configure()`
 
-Use the `configure()` method to control how Expo Observe behaves at runtime:
+Use the `configure()` method to control how Observe behaves at runtime:
 
 ```tsx
 import ExpoObserve from 'expo-observe';
@@ -61,7 +61,7 @@ A few details worth knowing:
 
 ## Enable metrics in development
 
-By default, metrics collected from debug builds are not dispatched. To dispatch them anyway (for example, while testing your Expo Observe integration), set `dispatchInDebug` to `true` when calling `configure()`:
+By default, metrics collected from debug builds are not dispatched. To dispatch them anyway (for example, while testing your Observe integration), set `dispatchInDebug` to `true` when calling `configure()`:
 
 ```tsx
 import ExpoObserve from 'expo-observe';
@@ -75,7 +75,7 @@ A build is treated as a debug build if either the native app is a debug build or
 
 `dispatchInDebug` has no effect on release builds, which always dispatch (subject to [`dispatchingEnabled`](#configure) and [`sampleRate`](#sampling)). If `dispatchingEnabled` is `false` or this installation is out-of-sample, nothing dispatches regardless of `dispatchInDebug`.
 
-> **warning** Enable this only when testing your Expo Observe integration. Development/debug performance differs significantly from production, so collecting development/debug metrics may distort the results shown in your dashboard.
+> **warning** Enable this only when testing your Observe integration. Development/debug performance differs significantly from production, so collecting development/debug metrics may distort the results shown in your dashboard.
 
 ## Custom endpoint
 

--- a/docs/pages/eas/observe/dashboard.mdx
+++ b/docs/pages/eas/observe/dashboard.mdx
@@ -1,15 +1,15 @@
 ---
-title: Observe dashboard
+title: EAS Observe dashboard
 sidebar_title: Dashboard
-description: View performance metrics, filter by platform or version, and investigate individual sessions in the Observe dashboard.
+description: View performance metrics, filter by platform or version, and investigate individual sessions in the EAS Observe dashboard.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';
 
-The Observe dashboard provides a visual overview of your app's performance metrics. Open your project and in EAS dashboard, select [**Observe**](https://expo.dev/accounts/[account]/projects/[project]/observe) from the navigation menu.
+The EAS Observe dashboard provides a visual overview of your app's performance metrics. Open your project and in EAS dashboard, select [**Observe**](https://expo.dev/accounts/[account]/projects/[project]/observe) from the navigation menu.
 
 <ContentSpotlight
-  alt="The Observe dashboard showing startup metrics, release markers, and statistical breakdowns for an app."
+  alt="The EAS Observe dashboard showing startup metrics, release markers, and statistical breakdowns for an app."
   src="/static/images/expo-observe/dashboard.png"
 />
 

--- a/docs/pages/eas/observe/dashboard.mdx
+++ b/docs/pages/eas/observe/dashboard.mdx
@@ -1,7 +1,7 @@
 ---
-title: Expo Observe dashboard
+title: Observe dashboard
 sidebar_title: Dashboard
-description: View performance metrics, filter by platform or version, and investigate individual sessions in the Expo Observe dashboard.
+description: View performance metrics, filter by platform or version, and investigate individual sessions in the Observe dashboard.
 ---
 
 import { ContentSpotlight } from '~/ui/components/ContentSpotlight';

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -1,7 +1,7 @@
 ---
-title: Set up Observe
+title: Set up EAS Observe
 sidebar_title: Get started
-description: Learn how to install Observe and start collecting performance metrics from your production app.
+description: Learn how to install EAS Observe and start collecting performance metrics from your production app.
 searchRank: 9
 ---
 
@@ -10,22 +10,22 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-Observe tracks your app's startup performance in production. This guide walks you through installing the library, setting up your app, and viewing your first metrics.
+EAS Observe tracks your app's startup performance in production. This guide walks you through installing the library, setting up your app, and viewing your first metrics.
 
 ## Prerequisites
 
 <Prerequisites>
-  <Requirement title="Access to the Observe preview">
-    Observe is in Private Preview and access is granted on request. [Request access
+  <Requirement title="Access to the EAS Observe preview">
+    EAS Observe is in Private Preview and access is granted on request. [Request access
     here](https://expo.dev/changelog/introducing-expo-observe).
   </Requirement>
   <Requirement title="An Expo user account">
-    Observe is available to anyone with an Expo account. You can sign up at
+    EAS Observe is available to anyone with an Expo account. You can sign up at
     [expo.dev/signup](https://expo.dev/signup).
   </Requirement>
   <Requirement title="Expo SDK 55 or later">
-    Observe requires SDK 55 or later. Run `npx expo-doctor` to check your SDK version and `npx expo
-    install --fix` to update dependencies.
+    EAS Observe requires SDK 55 or later. Run `npx expo-doctor` to check your SDK version and `npx
+    expo install --fix` to update dependencies.
   </Requirement>
   <Requirement title="An EAS project">
     Your app must be linked to an EAS project. Ensure `extra.eas.projectId` in your app config

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -24,8 +24,8 @@ Observe tracks your app's startup performance in production. This guide walks yo
     [expo.dev/signup](https://expo.dev/signup).
   </Requirement>
   <Requirement title="Expo SDK 55 or later">
-    Observe requires SDK 55 or later. Run `npx expo-doctor` to check your SDK version and `npx
-    expo install --fix` to update dependencies.
+    Observe requires SDK 55 or later. Run `npx expo-doctor` to check your SDK version and `npx expo
+    install --fix` to update dependencies.
   </Requirement>
   <Requirement title="An EAS project">
     Your app must be linked to an EAS project. Ensure `extra.eas.projectId` in your app config

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -1,7 +1,7 @@
 ---
-title: Set up Expo Observe
+title: Set up Observe
 sidebar_title: Get started
-description: Learn how to install Expo Observe and start collecting performance metrics from your production app.
+description: Learn how to install Observe and start collecting performance metrics from your production app.
 searchRank: 9
 ---
 
@@ -10,21 +10,21 @@ import { Tabs, Tab } from '~/ui/components/Tabs';
 import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 
-Expo Observe tracks your app's startup performance in production. This guide walks you through installing the library, setting up your app, and viewing your first metrics.
+Observe tracks your app's startup performance in production. This guide walks you through installing the library, setting up your app, and viewing your first metrics.
 
 ## Prerequisites
 
 <Prerequisites>
-  <Requirement title="Access to the Expo Observe preview">
-    Expo Observe is in Private Preview and access is granted on request. [Request access
+  <Requirement title="Access to the Observe preview">
+    Observe is in Private Preview and access is granted on request. [Request access
     here](https://expo.dev/changelog/introducing-expo-observe).
   </Requirement>
   <Requirement title="An Expo user account">
-    Expo Observe is available to anyone with an Expo account. You can sign up at
+    Observe is available to anyone with an Expo account. You can sign up at
     [expo.dev/signup](https://expo.dev/signup).
   </Requirement>
   <Requirement title="Expo SDK 55 or later">
-    Expo Observe requires SDK 55 or later. Run `npx expo-doctor` to check your SDK version and `npx
+    Observe requires SDK 55 or later. Run `npx expo-doctor` to check your SDK version and `npx
     expo install --fix` to update dependencies.
   </Requirement>
   <Requirement title="An EAS project">

--- a/docs/pages/eas/observe/index.mdx
+++ b/docs/pages/eas/observe/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Expo Observe
+title: EAS Observe
 ---
 
 import Redirect from '~/components/plugins/Redirect';

--- a/docs/pages/eas/observe/integrations/expo-router.mdx
+++ b/docs/pages/eas/observe/integrations/expo-router.mdx
@@ -1,13 +1,13 @@
 ---
 title: Expo Router integration
 sidebar_title: Expo Router
-description: Track per-route render and interactive timings by enabling the Expo Router integration for Expo Observe.
+description: Track per-route render and interactive timings by enabling the Expo Router integration for Observe.
 ---
 
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Step } from '~/ui/components/Step';
 
-Expo Observe ships an opt-in integration for [Expo Router](/router/introduction/) that collects per-route metrics tagged with the route pattern (for example, `/(tabs)/sessions/[sessionId]`). This lets you compare navigation performance by route in the dashboard instead of looking only at app-wide aggregates.
+Observe ships an opt-in integration for [Expo Router](/router/introduction/) that collects per-route metrics tagged with the route pattern (for example, `/(tabs)/sessions/[sessionId]`). This lets you compare navigation performance by route in the dashboard instead of looking only at app-wide aggregates.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ Expo Observe ships an opt-in integration for [Expo Router](/router/introduction/
     The Expo Router integration is available on SDK 56 and later. On earlier SDKs, `expo-observe`
     still tracks app-wide metrics, but per-route navigation events are not emitted.
   </Requirement>
-  <Requirement title="An app already using Expo Observe">
+  <Requirement title="An app already using Observe">
     Follow [Get started](/eas/observe/get-started/) to install `expo-observe` and create your first
     build.
   </Requirement>
@@ -118,4 +118,4 @@ Emitted at most once per screen instance within a session.
 - The integration only activates if `expo-router` is installed at runtime. If it is not installed, `useObserve()` and `ObserveRoot` continue to work but no per-route navigation metrics are emitted.
 - The integration must be enabled before mount via `ExpoObserve.configure({ integrations: { 'expo-router': true } })`. Toggling it after the app has mounted throws.
 - If `markInteractive()` logs `Calling markInteractive on unmounted screen` or `No metadata available for the current screen`, the call ran outside a screen component or after unmount. Move the call into a `useEffect` inside the screen component.
-- For general issues with Expo Observe, see [Troubleshooting](/eas/observe/reference/troubleshooting/).
+- For general issues with Observe, see [Troubleshooting](/eas/observe/reference/troubleshooting/).

--- a/docs/pages/eas/observe/integrations/expo-router.mdx
+++ b/docs/pages/eas/observe/integrations/expo-router.mdx
@@ -1,13 +1,13 @@
 ---
 title: Expo Router integration
 sidebar_title: Expo Router
-description: Track per-route render and interactive timings by enabling the Expo Router integration for Observe.
+description: Track per-route render and interactive timings by enabling the Expo Router integration for EAS Observe.
 ---
 
 import { Prerequisites, Requirement } from '~/ui/components/Prerequisites';
 import { Step } from '~/ui/components/Step';
 
-Observe ships an opt-in integration for [Expo Router](/router/introduction/) that collects per-route metrics tagged with the route pattern (for example, `/(tabs)/sessions/[sessionId]`). This lets you compare navigation performance by route in the dashboard instead of looking only at app-wide aggregates.
+EAS Observe ships an opt-in integration for [Expo Router](/router/introduction/) that collects per-route metrics tagged with the route pattern (for example, `/(tabs)/sessions/[sessionId]`). This lets you compare navigation performance by route in the dashboard instead of looking only at app-wide aggregates.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ Observe ships an opt-in integration for [Expo Router](/router/introduction/) tha
     The Expo Router integration is available on SDK 56 and later. On earlier SDKs, `expo-observe`
     still tracks app-wide metrics, but per-route navigation events are not emitted.
   </Requirement>
-  <Requirement title="An app already using Observe">
+  <Requirement title="An app already using EAS Observe">
     Follow [Get started](/eas/observe/get-started/) to install `expo-observe` and create your first
     build.
   </Requirement>
@@ -118,4 +118,4 @@ Emitted at most once per screen instance within a session.
 - The integration only activates if `expo-router` is installed at runtime. If it is not installed, `useObserve()` and `ObserveRoot` continue to work but no per-route navigation metrics are emitted.
 - The integration must be enabled before mount via `ExpoObserve.configure({ integrations: { 'expo-router': true } })`. Toggling it after the app has mounted throws.
 - If `markInteractive()` logs `Calling markInteractive on unmounted screen` or `No metadata available for the current screen`, the call ran outside a screen component or after unmount. Move the call into a `useEffect` inside the screen component.
-- For general issues with Observe, see [Troubleshooting](/eas/observe/reference/troubleshooting/).
+- For general issues with EAS Observe, see [Troubleshooting](/eas/observe/reference/troubleshooting/).

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -1,7 +1,7 @@
 ---
-title: Introduction to Observe
+title: Introduction to EAS Observe
 sidebar_title: Introduction
-description: Observe is a performance monitoring service that tracks how your app performs in production across real devices and conditions.
+description: EAS Observe is a performance monitoring service that tracks how your app performs in production across real devices and conditions.
 searchRank: 10
 ---
 
@@ -13,11 +13,11 @@ import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **important** **Observe** is in [Private Preview](/more/release-statuses/#preview) and subject to breaking changes. Access is granted on request ([request here](https://expo.dev/changelog/introducing-expo-observe)). While in preview, it is free to use.
+> **important** **EAS Observe** is in [Private Preview](/more/release-statuses/#preview) and subject to breaking changes. Access is granted on request ([request here](https://expo.dev/changelog/introducing-expo-observe)). While in preview, it is free to use.
 
-**Observe** is a performance monitoring service from Expo for tracking how your app performs in production. It gives you visibility into real-world startup times, rendering performance, and user experience across different devices, networks, and conditions.
+**EAS Observe** is a performance monitoring service from Expo for tracking how your app performs in production. It gives you visibility into real-world startup times, rendering performance, and user experience across different devices, networks, and conditions.
 
-Debugging performance in React Native has traditionally been limited to development tools. Observe focuses on production, where performance characteristics differ significantly from what you see during development.
+Debugging performance in React Native has traditionally been limited to development tools. EAS Observe focuses on production, where performance characteristics differ significantly from what you see during development.
 
 ## Quick start
 
@@ -25,16 +25,16 @@ Debugging performance in React Native has traditionally been limited to developm
 
 Wrap your root layout with the `AppMetricsRoot` component (SDK 55) or the `ObserveRoot` component (SDK 56 and later) and call `markInteractive()` when your app is ready for user input. See [Get started](/eas/observe/get-started/) for the full setup guide.
 
-## Why Observe
+## Why EAS Observe
 
-Traditional development-time profiling tools show how your app performs on your machine. Observe shows how it performs for real users:
+Traditional development-time profiling tools show how your app performs on your machine. EAS Observe shows how it performs for real users:
 
 - **Production performance data**: Track startup times, render performance, and bundle load times from real user sessions across a range of devices
 - **Release comparison**: See how metrics change between app versions and OTA updates to catch regressions early
 - **Session investigation**: Drill into individual user sessions to understand why certain devices or conditions lead to slower performance
 - **CLI and dashboard access**: Query metrics from the terminal with `eas observe:` commands or view them in the EAS dashboard
 
-## When to use Observe
+## When to use EAS Observe
 
 | Scenario                                            | Recommendation |
 | --------------------------------------------------- | -------------- |
@@ -48,27 +48,27 @@ Traditional development-time profiling tools show how your app performs on your 
 
 **Development-time profiling and debugging**: Use [React Native DevTools](/debugging/tools/#debugging-with-react-native-devtools) for debugging and [Expo Atlas](/guides/analyzing-bundles/) for bundle inspection.
 
-**Crash reporting and error tracking**: This is a planned addition for Observe in the future. In the interim we suggest a crash reporting service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).
+**Crash reporting and error tracking**: This is a planned addition for EAS Observe in the future. In the interim we suggest a crash reporting service such as [Sentry](/guides/using-sentry/) or [BugSnag](/guides/using-bugsnag/).
 
-**Custom analytics and event tracking**: This is a planned addition for Observe in the future. In the interim, choose an analytics provider from the [React Native analytics guide](/guides/using-analytics/), for example PostHog, Amplitude, or Firebase Analytics.
+**Custom analytics and event tracking**: This is a planned addition for EAS Observe in the future. In the interim, choose an analytics provider from the [React Native analytics guide](/guides/using-analytics/), for example PostHog, Amplitude, or Firebase Analytics.
 
 ## Frequently asked questions (FAQ)
 
 <FAQ>
 
-<Collapsible summary="What metrics does Observe track?">
+<Collapsible summary="What metrics does EAS Observe track?">
 
-Observe focuses on startup metrics: cold launch time, warm launch time, time to first render, time to interactive, and bundle load time. See the [Metrics reference](/eas/observe/reference/metrics/) for detailed descriptions of each metric.
+EAS Observe focuses on startup metrics: cold launch time, warm launch time, time to first render, time to interactive, and bundle load time. See the [Metrics reference](/eas/observe/reference/metrics/) for detailed descriptions of each metric.
 
 </Collapsible>
 
 <Collapsible summary="Which platforms are supported?">
 
-Observe supports Android and iOS. Metrics are collected from production builds and can be filtered by platform in both the dashboard and CLI.
+EAS Observe supports Android and iOS. Metrics are collected from production builds and can be filtered by platform in both the dashboard and CLI.
 
 </Collapsible>
 
-<Collapsible summary="Does Observe collect personally identifiable information?">
+<Collapsible summary="Does EAS Observe collect personally identifiable information?">
 
 No. Users are identified by an anonymous ID that is unique per app installation. This ID is not personally identifiable and is reset if the user uninstalls and reinstalls the app. See [Metrics reference: User](/eas/observe/reference/metrics/#user) for more details.
 
@@ -97,14 +97,14 @@ Metric data is retained for a minimum of 60 days.
 ## Get started
 
 <BoxLink
-  title="Set up Observe"
+  title="Set up EAS Observe"
   description="Install the library and start collecting metrics from your production app."
   href="/eas/observe/get-started"
   Icon={ActivityIcon}
 />
 
 <BoxLink
-  title="Observe dashboard"
+  title="EAS Observe dashboard"
   description="View metrics, filter by platform or version, and investigate individual sessions."
   href="/eas/observe/dashboard"
   Icon={ActivityIcon}

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -1,7 +1,7 @@
 ---
-title: Introduction to Expo Observe
+title: Introduction to Observe
 sidebar_title: Introduction
-description: Expo Observe is a performance monitoring service that tracks how your app performs in production across real devices and conditions.
+description: Observe is a performance monitoring service that tracks how your app performs in production across real devices and conditions.
 searchRank: 10
 ---
 
@@ -13,11 +13,11 @@ import { NoIcon, YesIcon } from '~/ui/components/DocIcons';
 import { FAQ } from '~/ui/components/FAQ';
 import { Terminal } from '~/ui/components/Snippet';
 
-> **important** **Expo Observe** is in [Private Preview](/more/release-statuses/#preview) and subject to breaking changes. Access is granted on request ([request here](https://expo.dev/changelog/introducing-expo-observe)). While in preview, it is free to use.
+> **important** **Observe** is in [Private Preview](/more/release-statuses/#preview) and subject to breaking changes. Access is granted on request ([request here](https://expo.dev/changelog/introducing-expo-observe)). While in preview, it is free to use.
 
-**Expo Observe** is a performance monitoring service from Expo for tracking how your app performs in production. It gives you visibility into real-world startup times, rendering performance, and user experience across different devices, networks, and conditions.
+**Observe** is a performance monitoring service from Expo for tracking how your app performs in production. It gives you visibility into real-world startup times, rendering performance, and user experience across different devices, networks, and conditions.
 
-Debugging performance in React Native has traditionally been limited to development tools. Expo Observe focuses on production, where performance characteristics differ significantly from what you see during development.
+Debugging performance in React Native has traditionally been limited to development tools. Observe focuses on production, where performance characteristics differ significantly from what you see during development.
 
 ## Quick start
 
@@ -25,16 +25,16 @@ Debugging performance in React Native has traditionally been limited to developm
 
 Wrap your root layout with the `AppMetricsRoot` component (SDK 55) or the `ObserveRoot` component (SDK 56 and later) and call `markInteractive()` when your app is ready for user input. See [Get started](/eas/observe/get-started/) for the full setup guide.
 
-## Why Expo Observe
+## Why Observe
 
-Traditional development-time profiling tools show how your app performs on your machine. Expo Observe shows how it performs for real users:
+Traditional development-time profiling tools show how your app performs on your machine. Observe shows how it performs for real users:
 
 - **Production performance data**: Track startup times, render performance, and bundle load times from real user sessions across a range of devices
 - **Release comparison**: See how metrics change between app versions and OTA updates to catch regressions early
 - **Session investigation**: Drill into individual user sessions to understand why certain devices or conditions lead to slower performance
 - **CLI and dashboard access**: Query metrics from the terminal with `eas observe:` commands or view them in the EAS dashboard
 
-## When to use Expo Observe
+## When to use Observe
 
 | Scenario                                            | Recommendation |
 | --------------------------------------------------- | -------------- |
@@ -56,19 +56,19 @@ Traditional development-time profiling tools show how your app performs on your 
 
 <FAQ>
 
-<Collapsible summary="What metrics does Expo Observe track?">
+<Collapsible summary="What metrics does Observe track?">
 
-Expo Observe focuses on startup metrics: cold launch time, warm launch time, time to first render, time to interactive, and bundle load time. See the [Metrics reference](/eas/observe/reference/metrics/) for detailed descriptions of each metric.
+Observe focuses on startup metrics: cold launch time, warm launch time, time to first render, time to interactive, and bundle load time. See the [Metrics reference](/eas/observe/reference/metrics/) for detailed descriptions of each metric.
 
 </Collapsible>
 
 <Collapsible summary="Which platforms are supported?">
 
-Expo Observe supports Android and iOS. Metrics are collected from production builds and can be filtered by platform in both the dashboard and CLI.
+Observe supports Android and iOS. Metrics are collected from production builds and can be filtered by platform in both the dashboard and CLI.
 
 </Collapsible>
 
-<Collapsible summary="Does Expo Observe collect personally identifiable information?">
+<Collapsible summary="Does Observe collect personally identifiable information?">
 
 No. Users are identified by an anonymous ID that is unique per app installation. This ID is not personally identifiable and is reset if the user uninstalls and reinstalls the app. See [Metrics reference: User](/eas/observe/reference/metrics/#user) for more details.
 
@@ -97,7 +97,7 @@ Metric data is retained for a minimum of 60 days.
 ## Get started
 
 <BoxLink
-  title="Set up Expo Observe"
+  title="Set up Observe"
   description="Install the library and start collecting metrics from your production app."
   href="/eas/observe/get-started"
   Icon={ActivityIcon}

--- a/docs/pages/eas/observe/reference/metrics.mdx
+++ b/docs/pages/eas/observe/reference/metrics.mdx
@@ -1,12 +1,12 @@
 ---
 title: Metrics reference
 sidebar_title: Metrics
-description: A reference of each performance metric tracked by Observe, including concepts and data handling.
+description: A reference of each performance metric tracked by EAS Observe, including concepts and data handling.
 ---
 
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-Reference for the performance metrics Observe collects, the core concepts used to organize events (sessions and users), and how collected data is retained.
+Reference for the performance metrics EAS Observe collects, the core concepts used to organize events (sessions and users), and how collected data is retained.
 
 ## Concepts
 

--- a/docs/pages/eas/observe/reference/metrics.mdx
+++ b/docs/pages/eas/observe/reference/metrics.mdx
@@ -1,12 +1,12 @@
 ---
 title: Metrics reference
 sidebar_title: Metrics
-description: A reference of each performance metric tracked by Expo Observe, including concepts and data handling.
+description: A reference of each performance metric tracked by Observe, including concepts and data handling.
 ---
 
 import { Tabs, Tab } from '~/ui/components/Tabs';
 
-Reference for the performance metrics Expo Observe collects, the core concepts used to organize events (sessions and users), and how collected data is retained.
+Reference for the performance metrics Observe collects, the core concepts used to organize events (sessions and users), and how collected data is retained.
 
 ## Concepts
 

--- a/docs/pages/eas/observe/reference/troubleshooting.mdx
+++ b/docs/pages/eas/observe/reference/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
-title: Troubleshooting Expo Observe
+title: Troubleshooting Observe
 sidebar_title: Troubleshooting
-description: Solutions for common Expo Observe issues.
+description: Solutions for common Observe issues.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/eas/observe/reference/troubleshooting.mdx
+++ b/docs/pages/eas/observe/reference/troubleshooting.mdx
@@ -1,7 +1,7 @@
 ---
-title: Troubleshooting Observe
+title: Troubleshooting EAS Observe
 sidebar_title: Troubleshooting
-description: Solutions for common Observe issues.
+description: Solutions for common EAS Observe issues.
 ---
 
 import { Collapsible } from '~/ui/components/Collapsible';

--- a/docs/pages/monitoring/services.mdx
+++ b/docs/pages/monitoring/services.mdx
@@ -34,10 +34,10 @@ Get started with the following guide:
 
 ## EAS Observe
 
-[Observe](/eas/observe/introduction/) is a performance monitoring service from Expo that tracks how your app performs in production. It gives you visibility in startup metrics (such as cold launch time, time to first render, and time to interactive) from real app user sessions, rendering performance, and app user experience across different devices, networks, and conditions.
+[EAS Observe](/eas/observe/introduction/) is a performance monitoring service from Expo that tracks how your app performs in production. It gives you visibility in startup metrics (such as cold launch time, time to first render, and time to interactive) from real app user sessions, rendering performance, and app user experience across different devices, networks, and conditions.
 
 <ContentSpotlight
-  alt="Performance metrics on the Observe dashboard."
+  alt="Performance metrics on the EAS Observe dashboard."
   src="/static/images/expo-observe/dashboard.png"
 />
 
@@ -45,7 +45,7 @@ Get started with the following guide:
 
 <BoxLink
   title="EAS Observe"
-  description="Learn how to use Observe to monitor your app's performance."
+  description="Learn how to use EAS Observe to monitor your app's performance."
   href="/eas/observe/introduction/"
   Icon={ActivityIcon}
 />

--- a/docs/pages/monitoring/services.mdx
+++ b/docs/pages/monitoring/services.mdx
@@ -32,20 +32,20 @@ Get started with the following guide:
   Icon={DataIcon}
 />
 
-## Expo Observe
+## EAS Observe
 
-[Expo Observe](/eas/observe/introduction/) is a performance monitoring service from Expo that tracks how your app performs in production. It gives you visibility in startup metrics (such as cold launch time, time to first render, and time to interactive) from real app user sessions, rendering performance, and app user experience across different devices, networks, and conditions.
+[Observe](/eas/observe/introduction/) is a performance monitoring service from Expo that tracks how your app performs in production. It gives you visibility in startup metrics (such as cold launch time, time to first render, and time to interactive) from real app user sessions, rendering performance, and app user experience across different devices, networks, and conditions.
 
 <ContentSpotlight
-  alt="Performance metrics on the Expo Observe dashboard."
+  alt="Performance metrics on the Observe dashboard."
   src="/static/images/expo-observe/dashboard.png"
 />
 
 Get started with the following guide:
 
 <BoxLink
-  title="Expo Observe"
-  description="Learn how to use Expo Observe to monitor your app's performance."
+  title="EAS Observe"
+  description="Learn how to use Observe to monitor your app's performance."
   href="/eas/observe/introduction/"
   Icon={ActivityIcon}
 />

--- a/docs/pages/more/glossary-of-terms.mdx
+++ b/docs/pages/more/glossary-of-terms.mdx
@@ -126,7 +126,7 @@ The development server is typically hosted on `http://localhost:8081`. It hosts 
 
 ### Expo Application Services (EAS)
 
-[Expo Application Services (EAS)](/eas) are deeply integrated cloud services for Expo and React Native apps, such as [EAS Build](/build/introduction/), [EAS Submit](/submit/introduction/), [EAS Update](/eas-update/introduction/), [EAS Metadata](/eas/metadata/), [EAS Insights](/eas-insights/introduction/), [EAS Hosting](/eas/hosting/introduction/), [EAS Workflows](/eas/workflows/introduction/), and [Expo Observe](/eas/observe/introduction/).
+[Expo Application Services (EAS)](/eas) are deeply integrated cloud services for Expo and React Native apps, such as [EAS Build](/build/introduction/), [EAS Submit](/submit/introduction/), [EAS Update](/eas-update/introduction/), [EAS Metadata](/eas/metadata/), [EAS Insights](/eas-insights/introduction/), [EAS Hosting](/eas/hosting/introduction/), [EAS Workflows](/eas/workflows/introduction/), and [EAS Observe](/eas/observe/introduction/).
 
 ### EAS Build
 
@@ -151,6 +151,10 @@ The **eas.json** file used to configure [EAS CLI](#eas-cli). For more informatio
 ### EAS Metadata
 
 A command-line tool for uploading and downloading Apple App Store metadata as JSON. This tool is available in the [EAS CLI](#eas-cli) package and should be used to improve the iOS submission process. For more information, see [EAS Metadata](/eas/metadata/).
+
+### EAS Observe
+
+[EAS Observe](/eas/observe/introduction/) is a performance monitoring service that tracks how an app performs in production, including cold and warm launch times, time to first render, and time to interactive. It uses the `expo-observe` library to collect metrics from production builds, which can then be viewed in the Observe dashboard.
 
 ### EAS Update
 
@@ -222,10 +226,6 @@ A file named **expo-module.config.json** that lives in the root directory of a [
 ### Expo Modules API
 
 [Expo Modules API](/modules/module-api/) is a cross-platform API for writing native modules in Kotlin and Swift to add new capabilities to your apps. This API is provided by the library `expo-modules-core` which is included in the `expo` package.
-
-### Expo Observe
-
-[Expo Observe](/eas/observe/introduction/) is a performance monitoring service that tracks how an app performs in production, including cold and warm launch times, time to first render, and time to interactive. It uses the `expo-observe` library to collect metrics from production builds, which can then be viewed in the Observe dashboard.
 
 ### Expo Orbit
 

--- a/docs/pages/troubleshooting/overview.mdx
+++ b/docs/pages/troubleshooting/overview.mdx
@@ -159,7 +159,7 @@ This page lists a collection of various troubleshooting guides for Expo and EAS.
 
 <BoxLink
   title="EAS Observe: Troubleshooting"
-  description="Solutions for common issues when setting up and using Observe."
+  description="Solutions for common issues when setting up and using EAS Observe."
   href="/eas/observe/reference/troubleshooting/"
   Icon={ActivityIcon}
 />

--- a/docs/pages/troubleshooting/overview.mdx
+++ b/docs/pages/troubleshooting/overview.mdx
@@ -158,8 +158,8 @@ This page lists a collection of various troubleshooting guides for Expo and EAS.
 />
 
 <BoxLink
-  title="Expo Observe: Troubleshooting"
-  description="Solutions for common issues when setting up and using Expo Observe."
+  title="EAS Observe: Troubleshooting"
+  description="Solutions for common issues when setting up and using Observe."
   href="/eas/observe/reference/troubleshooting/"
   Icon={ActivityIcon}
 />

--- a/docs/ui/components/Sidebar/SidebarGroup.tsx
+++ b/docs/ui/components/Sidebar/SidebarGroup.tsx
@@ -255,7 +255,7 @@ function getIconElement(iconName?: string) {
       return Dataflow03Icon;
     case 'EAS Hosting':
       return Cloud01Icon;
-    case 'Expo Observe':
+    case 'EAS Observe':
       return ActivityIcon;
     case 'Expo Modules API':
       return CpuChip01Icon;


### PR DESCRIPTION
# Why

Observe is an EAS product and in the EAS section. It is confusing for it to not be called "EAS Observe".

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Rename the product "Expo Observe" -> "EAS Observe". ~in the sidebar. Use "Expo Observe" -> "Observe" inline.~

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

👀 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
