### PR TITLE
[dev-launcher] Fix build phase ordering

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix xcode build phase ordering.
+- [iOS] Fix xcode build phase ordering. ([#46125](https://github.com/expo/expo/pull/46125) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix xcode build phase ordering.
+
 ### 💡 Others
 
 ## 56.0.14 — 2026-05-21

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -31,6 +31,7 @@ const withStripLocalNetworkKeysForRelease = (config) => {
         }
         project.addBuildPhase([], 'PBXShellScriptBuildPhase', buildPhaseName, nativeTargetId, {
             shellPath: '/bin/sh',
+            inputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
             shellScript: `# Strip dev-launcher-specific local network permission keys from non-Debug builds
 # This only removes _expo._tcp Bonjour services and the dev-launcher usage description.
 # Other Bonjour services and custom descriptions are preserved for production use.

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -46,6 +46,7 @@ const withStripLocalNetworkKeysForRelease: ConfigPlugin = (config) => {
 
     project.addBuildPhase([], 'PBXShellScriptBuildPhase', buildPhaseName, nativeTargetId, {
       shellPath: '/bin/sh',
+      inputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
       shellScript: `# Strip dev-launcher-specific local network permission keys from non-Debug builds
 # This only removes _expo._tcp Bonjour services and the dev-launcher usage description.
 # Other Bonjour services and custom descriptions are preserved for production use.


### PR DESCRIPTION
# Why
Closes #46099
The build phase script to strip our bonjour permissions had no declared inputPaths, so wasn't guaranteed to run after `ProcessInfoPlistFile`. On some Xcode versions, the script would execute before the processed plist, silently no-oping.

# How
Adds `$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)` as an input path so Xcode always runs the script after the plist is processed.

# Test Plan
Clean release build, keys are stripped