### PR TITLE
[docs] Add SDK 56 build image details

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -277,6 +277,7 @@ cd expo/packages/expo-constants
 - Then, open **.ts** file in your code editor/IDE where you want to make changes/updates.
 - Start the TypeScript build compilation in watch mode using `pnpm build` in the terminal window.
 - Make the update. For example, we want to update the TypeDoc description of [`expoConfig` property](https://docs.expo.dev/versions/latest/sdk/constants/#nativeconstants)
+
   - Inside the **src/** directory, open **Constants.types.ts** file.
   - Search for `expoConfig` property. It has a current description as shown below:
 
@@ -677,7 +678,7 @@ modificationDate: April 8th, 2024
 ---
 ```
 
-This pattern is used for some of the pages where we manually update the modification date, such as [Build server infrastructure](/docs/pages/build-reference/infrastructure.mdx).
+This pattern is used for some of the pages where we manually update the modification date, such as [Build server infrastructure](/docs/pages/build-reference/infrastructure.mdx). When updating build image details on that page, update its `modificationDate` in the same change.
 
 > Docs areas that are excluded or do not include an updated date are SDK API references and Tutorials sections under Learn.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -277,7 +277,6 @@ cd expo/packages/expo-constants
 - Then, open **.ts** file in your code editor/IDE where you want to make changes/updates.
 - Start the TypeScript build compilation in watch mode using `pnpm build` in the terminal window.
 - Make the update. For example, we want to update the TypeDoc description of [`expoConfig` property](https://docs.expo.dev/versions/latest/sdk/constants/#nativeconstants)
-
   - Inside the **src/** directory, open **Constants.types.ts** file.
   - Search for `expoConfig` property. It has a current description as shown below:
 

--- a/docs/pages/build-reference/infrastructure.mdx
+++ b/docs/pages/build-reference/infrastructure.mdx
@@ -1,5 +1,5 @@
 ---
-modificationDate: May 12th, 2026
+modificationDate: May 21st, 2026
 title: Build server infrastructure
 sidebar_title: Server infrastructure
 maxHeadingDepth: 4
@@ -20,11 +20,12 @@ Linux runners are hosted in Google Cloud Platform. macOS runners are hosted in o
 
 Images for each platform have one specific version of Node.js, Yarn, CocoaPods, Xcode, Ruby, Fastlane, and so on. You can override some of the versions in [eas.json](/build/eas-json). If there is no dedicated configuration option you are looking for, you can use [npm hooks](/build-reference/npm-hooks) to install or update any system dependencies with `apt-get` or `brew`. Consider that those customizations are applied during the build and will increase your build times.
 
-When selecting an image for the build you can use the full name provided below or one of the aliases: `auto`, `latest`, or for a particular SDK such as `sdk-55`.
+When selecting an image for the build you can use the full name provided below or one of the aliases: `auto`, `latest`, or for a particular SDK such as `sdk-56`.
 
 - The use of a specific name guarantees a consistent environment with only minor updates.
 - When using the `auto` alias, the build image will be selected based on the project configuration, Expo SDK version, and React Native version. You can check what image is used for a build in the **Spin up build environment** build logs section.
 - The `latest` alias will be assigned to the image with the most up-to-date versions of the software.
+- The `sdk-56` alias will be assigned to the image best suited for SDK 56 builds.
 - The `sdk-55` alias will be assigned to the image best suited for SDK 55 builds.
 - The `sdk-54` alias will be assigned to the image best suited for SDK 54 builds.
 - The `sdk-53` alias will be assigned to the image best suited for SDK 53 builds.
@@ -87,6 +88,23 @@ The worker also sets these top-level Gradle properties on `GRADLE_OPTS`:
 You can replace the worker default by setting `GRADLE_OPTS` under a build profile's [`env`](/eas/json/#env) in **eas.json**, in a [workflow file](/eas/workflows/syntax/#jobsjob_idenv), or with [EAS Environment Variables](/eas/environment-variables/). Project environment values take precedence over the worker's default values.
 
 ### Android server images
+
+#### <CopyTextButton>`ubuntu-26.04-jdk-17-ndk-r27b` (`sdk-56`)</CopyTextButton>
+
+<Collapsible summary="Details">
+
+- GCE image: `ubuntu-2604-resolute-amd64-v20260505`
+- NDK 27.1.12297006
+- Node.js 22.22.2
+- Bun 1.3.13
+- Yarn 1.22.22
+- pnpm 10.33.3
+- npm 10.9.4
+- Java 17
+- node-gyp 12.3.0
+- Maestro 2.5.1
+
+</Collapsible>
 
 #### <CopyTextButton>`ubuntu-24.04-jdk-17-ndk-r27b-sdk-55` (`latest`, `sdk-55`)</CopyTextButton>
 
@@ -340,6 +358,25 @@ iOS builder VMs run on Mac mini hosts in an isolated environment. Every build ge
   ```
 
 ### iOS server images
+
+#### <CopyTextButton>`macos-tahoe-26.4-xcode-26.4` (`sdk-56`)</CopyTextButton>
+
+<Collapsible summary="Details">
+
+- macOS Tahoe 26.4.1
+- Xcode 26.4 (17E202)
+- Node.js 22.22.2
+- Bun 1.3.13
+- Yarn 1.22.22
+- pnpm 10.33.3
+- npm 10.9.4
+- fastlane 2.233.1
+- CocoaPods 1.16.2
+- Ruby 3.2
+- node-gyp 12.3.0
+- Maestro 2.5.1
+
+</Collapsible>
 
 #### <CopyTextButton>`macos-sequoia-15.6-xcode-26.2` (`latest`, `sdk-55`)</CopyTextButton>
 


### PR DESCRIPTION
## Summary

- add SDK 56 Android image details for `ubuntu-26.04-jdk-17-ndk-r27b`
- add SDK 56 iOS image details for `macos-tahoe-26.4-xcode-26.4`
- document `sdk-56` as an available SDK image alias while leaving `latest` on the existing SDK 55 images
- bump the Build server infrastructure modification date and document that build image updates should do this in the future

## Test Plan

- `yarn prettier --check docs/pages/build-reference/infrastructure.mdx docs/README.md`
