### PR TITLE
[tools] allow precompile for ios macros

### DIFF
--- a/tools/src/prebuilds/SPMPackage.test.ts
+++ b/tools/src/prebuilds/SPMPackage.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
+import path from 'node:path';
 import { describe, it } from 'node:test';
 
-import type { SPMProduct } from './SPMConfig.types';
+import type { SPMProduct, SwiftTarget } from './SPMConfig.types';
 import {
+  buildSwiftSettings,
   expandTransitiveExternalDeps,
   findSiblingProductDependencies,
   type ExternalDepResolver,
@@ -110,5 +112,83 @@ describe('expandTransitiveExternalDeps', () => {
   it('terminates on cycles', () => {
     const resolver = makeResolver({ 'pkg-a/A': ['pkg-b/B'], 'pkg-b/B': ['pkg-a/A'] });
     assert.deepEqual(expandTransitiveExternalDeps(['pkg-a/A'], resolver), ['pkg-a/A', 'pkg-b/B']);
+  });
+});
+
+describe('buildSwiftSettings ExpoModulesMacros plugin flags', () => {
+  const makeSwiftTarget = (name: string): SwiftTarget => ({
+    type: 'swift',
+    name,
+    path: 'ios',
+    pattern: '**/*.swift',
+  });
+
+  const hasMacroPluginFlags = (settings: string[]): boolean =>
+    settings.some(
+      (line) => line.includes('-load-plugin-executable') && line.includes('#ExpoModulesMacros')
+    );
+
+  const macroToolPathSegment = path.join(
+    'node_modules',
+    '@expo',
+    'expo-modules-macros-plugin',
+    'apple',
+    'ExpoModulesMacros-tool'
+  );
+
+  it('should emit load-plugin-executable flags for the ExpoModulesCore swift target', () => {
+    const settings = buildSwiftSettings(
+      ['ReactNativeDependencies', 'React', 'Hermes', 'expo-modules-jsi/ExpoModulesJSI'],
+      null,
+      '/tmp/pkg',
+      'Debug',
+      makeSwiftTarget('ExpoModulesCore')
+    );
+    assert.ok(
+      hasMacroPluginFlags(settings),
+      `expected macro plugin flags in swiftSettings, got:\n${settings.join('\n')}`
+    );
+    assert.ok(
+      settings.some((line) => line.includes(macroToolPathSegment)),
+      `expected macro plugin executable path in swiftSettings, got:\n${settings.join('\n')}`
+    );
+  });
+
+  it('should emit load-plugin-executable flags for a target that depends directly on ExpoModulesCore', () => {
+    const settings = buildSwiftSettings(
+      ['Hermes', 'React', 'ExpoModulesCore'],
+      null,
+      '/tmp/pkg',
+      'Debug',
+      makeSwiftTarget('ExpoModulesWorklets')
+    );
+    assert.ok(hasMacroPluginFlags(settings));
+  });
+
+  it('should emit load-plugin-executable flags for a target that depends on ExpoModulesCore via the cross-package form', () => {
+    const settings = buildSwiftSettings(
+      ['Hermes', 'expo-modules-core/ExpoModulesCore'],
+      null,
+      '/tmp/pkg',
+      'Debug',
+      makeSwiftTarget('ExpoCrypto')
+    );
+    assert.ok(hasMacroPluginFlags(settings));
+  });
+
+  it('should not emit load-plugin-executable flags for a target unrelated to ExpoModulesCore', () => {
+    const settings = buildSwiftSettings(
+      ['Hermes', 'React', 'ReactNativeDependencies'],
+      null,
+      '/tmp/pkg',
+      'Debug',
+      makeSwiftTarget('ExpoModulesJSI')
+    );
+    assert.equal(hasMacroPluginFlags(settings), false);
+  });
+
+  it('should not emit load-plugin-executable flags when no swift target is provided', () => {
+    const settings = buildSwiftSettings(['ExpoModulesCore'], null, '/tmp/pkg', 'Debug');
+    assert.equal(hasMacroPluginFlags(settings), false);
   });
 });

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -878,7 +878,7 @@ async function resolveSourceTarget(
  * @param artifactPaths - Paths to downloaded artifacts from centralized cache
  * @param packageSwiftDir - Directory where Package.swift will be located
  */
-function buildSwiftSettings(
+export function buildSwiftSettings(
   externalDeps: string[],
   artifactPaths: ArtifactPaths | null,
   packageSwiftDir: string,

--- a/tools/src/prebuilds/SPMPackage.ts
+++ b/tools/src/prebuilds/SPMPackage.ts
@@ -107,6 +107,57 @@ function getReactNativeMinorVersion(pkgPath: string): number {
 
 const _packageVersionCache: Record<string, string> = {};
 
+let _macroPluginFlagsCache: string[] | null = null;
+
+/**
+ * Returns the Swift compiler `-Xfrontend -load-plugin-executable` flags that load the
+ * ExpoModules macros plugin (e.g. `@OptimizedFunction`). The plugin executable ships
+ * inside `expo-modules-core`'s hoisted `node_modules`. Mirrors the Cocoapods path used
+ * by `project_integrator.rb#integrate_core_macro_plugins` so SPM and Pods agree on
+ * which binary implements the macros.
+ */
+function getExpoModulesMacroPluginFlags(): string[] {
+  if (_macroPluginFlagsCache !== null) {
+    return _macroPluginFlagsCache;
+  }
+  const corePkg = getPackageByName('expo-modules-core');
+  if (!corePkg) {
+    throw new Error(
+      `Could not locate the "expo-modules-core" package while generating Package.swift. ` +
+        `The ExpoModules macros plugin executable (used to expand @OptimizedFunction etc.) ships ` +
+        `under "expo-modules-core/node_modules/@expo/expo-modules-macros-plugin/apple". ` +
+        `Ensure expo-modules-core is installed in the workspace before running the prebuild.`
+    );
+  }
+  const macrosToolPath = path.join(
+    corePkg.path,
+    'node_modules',
+    '@expo',
+    'expo-modules-macros-plugin',
+    'apple',
+    'ExpoModulesMacros-tool'
+  );
+  _macroPluginFlagsCache = [
+    '-Xfrontend',
+    '-load-plugin-executable',
+    '-Xfrontend',
+    `${macrosToolPath}#ExpoModulesMacros`,
+  ];
+  return _macroPluginFlagsCache;
+}
+
+/**
+ * Returns true when a Swift target should load the ExpoModules macros plugin —
+ * either it is ExpoModulesCore itself, or it depends on ExpoModulesCore directly
+ * (`"ExpoModulesCore"`) or via the cross-package form (`"expo-modules-core/ExpoModulesCore"`).
+ */
+function targetUsesExpoModulesMacros(targetName: string, dependencies: string[]): boolean {
+  if (targetName === 'ExpoModulesCore') {
+    return true;
+  }
+  return dependencies.some((dep) => dep === 'ExpoModulesCore' || dep.endsWith('/ExpoModulesCore'));
+}
+
 /**
  * Resolves the package version from the package.json in the given path.
  * @param pkgPath Path to the package (e.g., /workspace/external-configs/ios/react-native-worklets)
@@ -857,6 +908,13 @@ function buildSwiftSettings(
 
   // Always emit common flags (modules)
   pushUnsafeFlags([settings], commonCxxFlags);
+
+  // Load the ExpoModules macros plugin so Swift can expand macros like @OptimizedFunction.
+  // Required for ExpoModulesCore itself and any Swift target that depends on it; without
+  // this the compiler errors with "external macro implementation type ... could not be found".
+  if (target && targetUsesExpoModulesMacros(target.name, externalDeps)) {
+    pushUnsafeFlags([settings], getExpoModulesMacroPluginFlags());
+  }
 
   // Debug/release-specific include paths (wrapped with -Xcc for Swift→Clang)
   pushUnsafeFlags(


### PR DESCRIPTION
# Why

fix precompile error for #46122

# How

add macro plugin tool to Package.swift when linking

# Test Plan

precompile ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
