### PR TITLE
fix(cli): Remove stringifying `UsbmusxdPairRecord`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix launching apps on physical iOS devices causing system-dependent crashes ([#46128](https://github.com/expo/expo/pull/46128) by [@kitten](https://github.com/kitten))
+
 ### 💡 Others
 
 ## 56.1.9 — 2026-05-21

--- a/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
@@ -116,7 +116,7 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
   }
 
   async startSession(pairRecord: UsbmuxdPairRecord) {
-    debug(`startSession: ${pairRecord}`);
+    debug('startSession');
 
     const resp = await this.protocolClient.sendMessage({
       Request: 'StartSession',


### PR DESCRIPTION
## Summary

Resolves #46123
Resolves #46066
Resolves #46114

Remove stringification of `UsbmuxdPairRecord` which isn't necessary just for a debug string (but is an object, so stringification is likely non-sensical), but causes crashes reportedly.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
