### PR TITLE
[docs] document observe events

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -595,6 +595,7 @@ export const eas = [
     makePage('eas/observe/introduction.mdx'),
     makePage('eas/observe/get-started.mdx'),
     makePage('eas/observe/dashboard.mdx'),
+    makePage('eas/observe/events.mdx'),
     makePage('eas/observe/configuration.mdx'),
     makePage('eas/observe/integrations/expo-router.mdx'),
     makeGroup('Reference', [

--- a/docs/pages/eas/observe/events.mdx
+++ b/docs/pages/eas/observe/events.mdx
@@ -19,7 +19,7 @@ function handleSignupComplete() {
 }
 ```
 
-The first argument is the event name. Use a stable, dot-separated identifier - the dashboard groups events by exact name.
+The first argument is the event name. Use a stable, dot-separated identifier. The dashboard groups events by exact name.
 
 ## Attach attributes
 
@@ -67,23 +67,25 @@ AppMetrics.logEvent('subscription.expired', {
 
 - Use lowercase, dot-separated names: `task.completed`, `onboarding.skipped`, `cart.checkout`.
 - Pick a vocabulary and stick to it. The dashboard groups by exact event name, so `cart_checkout` and `cart.checkout` will appear as separate rows.
-- Avoid PII in event names, attribute keys, and attribute values. Everything you pass is visible in the dashboard and is dispatched off-device.
+- Avoid Personally Identifiable Information (PII) in event names, attribute keys, and attribute values. Everything you pass is visible in the dashboard and is dispatched off-device.
 
 ## View events
 
-In the dashboard: open your project and navigate to **Observe → Events**. The default view lists distinct event names with their counts in the selected time range. Click an event name to see individual events with their timestamps, attributes, and the session they belong to.
+In the dashboard: open your project and navigate to [**Observe > Events**](https://expo.dev/accounts/[account]/projects/[project]/observe). The default view lists distinct event names with their counts in the selected time range. Click an event name to see individual events with their timestamps, attributes, and the session they belong to.
 
 From the CLI:
 
-```bash
-# List event names with counts
-$ eas observe:events
-
-# Show individual events for a specific event name
-$ eas observe:events cart.checkout
-
-# Show all events across all names (JSON output)
-$ eas observe:events --all-events --json
-```
+<Terminal
+  cmd={[
+    '# List event names with counts',
+    '$ eas observe:events',
+    '',
+    '# Show individual events for a specific event name',
+    '$ eas observe:events cart.checkout',
+    '',
+    '# Show all events across all names (JSON output)',
+    '$ eas observe:events --all-events --json',
+  ]}
+/>
 
 Run `eas observe:events --help` for the full list of flags (time range, platform, session ID, and more).

--- a/docs/pages/eas/observe/events.mdx
+++ b/docs/pages/eas/observe/events.mdx
@@ -1,0 +1,93 @@
+---
+title: User-defined events
+description: Log named events from your app with AppMetrics.logEvent to track product flows, feature usage, and other custom signals visible in the EAS Observe dashboard.
+---
+
+User-defined events let you record arbitrary, named events from your app. Use them to track product flows (such as signup or checkout completion), feature engagement, or any signal specific to your app that the built-in performance metrics do not cover.
+
+Events are persisted on-device, batched, and dispatched on the next flush as OpenTelemetry log records. They appear in the **Events** tab of the EAS Observe dashboard and are queryable from the EAS CLI.
+
+## Log an event
+
+Call `AppMetrics.logEvent` from anywhere in your app:
+
+```tsx
+import { AppMetrics } from 'expo-observe';
+
+function handleSignupComplete() {
+  AppMetrics.logEvent('signup.completed');
+}
+```
+
+The first argument is the event name. Use a stable, dot-separated identifier — the dashboard groups events by exact name.
+
+## Attach attributes
+
+Pass an `attributes` map to record context with the event:
+
+```tsx
+AppMetrics.logEvent('cart.checkout', {
+  attributes: {
+    itemCount: 3,
+    totalUsd: 42.5,
+    coupon: 'WELCOME10',
+    items: ['sku-1', 'sku-2', 'sku-3'],
+  },
+});
+```
+
+Supported attribute value types: `string`, `number`, `boolean`, arrays, and nested objects. Other JS values (`Date`, `undefined`, functions) are dropped.
+
+## Severity
+
+Events default to `"info"` severity. Override with the `severity` option for warnings or errors you want to surface separately in the dashboard:
+
+```tsx
+AppMetrics.logEvent('payment.failed', {
+  severity: 'error',
+  attributes: { reason: 'card_declined' },
+});
+```
+
+Supported severities, from lowest to highest: `"trace"`, `"debug"`, `"info"`, `"warn"`, `"error"`, `"fatal"`.
+
+## Body
+
+Use `body` for a free-form message that complements the structured attributes:
+
+```tsx
+AppMetrics.logEvent('subscription.expired', {
+  body: 'Subscription expired while user was offline; downgrading to free tier.',
+  severity: 'warn',
+  attributes: { previousPlan: 'pro' },
+});
+```
+
+## Naming conventions
+
+- Use lowercase, dot-separated names: `task.completed`, `onboarding.skipped`, `cart.checkout`.
+- Pick a vocabulary and stick to it. The dashboard groups by exact event name, so `cart_checkout` and `cart.checkout` will appear as separate rows.
+- Avoid PII in event names, attribute keys, and attribute values. Everything you pass is visible in the dashboard and is dispatched off-device.
+
+## View events
+
+In the dashboard: open your project and navigate to **Observe → Events**. The default view lists distinct event names with their counts in the selected time range. Click an event name to see individual events with their timestamps, attributes, and the session they belong to.
+
+From the CLI:
+
+```bash
+# List event names with counts
+$ eas observe:events
+
+# Show individual events for a specific event name
+$ eas observe:events cart.checkout
+
+# Show all events across all names (JSON output)
+$ eas observe:events --all-events --json
+```
+
+Run `eas observe:events --help` for the full list of flags (time range, platform, session ID, and more).
+
+## Sampling and retention
+
+Events follow the same dispatch and sampling rules as the rest of EAS Observe. See [Configuration](/eas/observe/configuration) for the `sampleRate` and `dispatchInDebug` options.

--- a/docs/pages/eas/observe/events.mdx
+++ b/docs/pages/eas/observe/events.mdx
@@ -1,9 +1,9 @@
 ---
 title: User-defined events
-description: Log named events from your app with AppMetrics.logEvent to track product flows, feature usage, and other custom signals visible in the EAS Observe dashboard.
+description: Log named events from your app to track custom signals visible in the EAS Observe dashboard.
 ---
 
-User-defined events let you record arbitrary, named events from your app. Use them to track product flows (such as signup or checkout completion), feature engagement, or any signal specific to your app that the built-in performance metrics do not cover.
+User-defined events let you record arbitrary, named events from your app. Use them to track any signal specific to your app that the built-in performance metrics do not cover.
 
 Events are persisted on-device, batched, and dispatched on the next flush as OpenTelemetry log records. They appear in the **Events** tab of the EAS Observe dashboard and are queryable from the EAS CLI.
 
@@ -19,7 +19,7 @@ function handleSignupComplete() {
 }
 ```
 
-The first argument is the event name. Use a stable, dot-separated identifier — the dashboard groups events by exact name.
+The first argument is the event name. Use a stable, dot-separated identifier - the dashboard groups events by exact name.
 
 ## Attach attributes
 
@@ -87,7 +87,3 @@ $ eas observe:events --all-events --json
 ```
 
 Run `eas observe:events --help` for the full list of flags (time range, platform, session ID, and more).
-
-## Sampling and retention
-
-Events follow the same dispatch and sampling rules as the rest of EAS Observe. See [Configuration](/eas/observe/configuration) for the `sampleRate` and `dispatchInDebug` options.

--- a/docs/pages/eas/observe/events.mdx
+++ b/docs/pages/eas/observe/events.mdx
@@ -3,6 +3,8 @@ title: User-defined events
 description: Log named events from your app to track custom signals visible in the EAS Observe dashboard.
 ---
 
+import { Terminal } from '~/ui/components/Snippet';
+
 User-defined events let you record arbitrary, named events from your app. Use them to track any signal specific to your app that the built-in performance metrics do not cover.
 
 Events are persisted on-device, batched, and dispatched on the next flush as OpenTelemetry log records. They appear in the **Events** tab of the EAS Observe dashboard and are queryable from the EAS CLI.

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -226,7 +226,7 @@ You can also query metrics from the terminal using the EAS CLI:
 - `eas observe:versions`: Lists app versions along with their build IDs, update group IDs, and release dates. Useful for finding the version identifiers needed to filter the other commands.
 - `eas observe:metric-summary`: Shows aggregated performance metric statistics (such as median, p75, and p95 values) grouped by app version. Use this to compare overall startup performance across releases.
 - `eas observe:metrics`: Shows individual performance metric events ordered by value, including session and device metadata. Use this to investigate specific slow sessions or outliers.
-- `eas observe:events`: Shows individual events emitted by your app via `AppMetrics.logEvent`. See [User-defined events](/eas/observe/events) for details.
+- `eas observe:events`: Shows individual events emitted by your app via `AppMetrics.logEvent`. See [User-defined events](/eas/observe/events/) for details.
 
 Run any of these commands with `--help` to see the available flags and arguments.
 

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -224,8 +224,9 @@ For details on filtering, release comparison, and session investigation, see the
 You can also query metrics from the terminal using the EAS CLI:
 
 - `eas observe:versions`: Lists app versions along with their build IDs, update group IDs, and release dates. Useful for finding the version identifiers needed to filter the other commands.
-- `eas observe:metrics`: Shows aggregated performance metrics (such as median, p75, and p95 values) grouped by app version. Use this to compare overall startup performance across releases.
-- `eas observe:events`: Shows individual performance events ordered by metric value, including session and device metadata. Use this to investigate specific slow sessions or outliers.
+- `eas observe:metric-summary`: Shows aggregated performance metric statistics (such as median, p75, and p95 values) grouped by app version. Use this to compare overall startup performance across releases.
+- `eas observe:metrics`: Shows individual performance metric events ordered by value, including session and device metadata. Use this to investigate specific slow sessions or outliers.
+- `eas observe:events`: Shows individual events emitted by your app via `AppMetrics.logEvent`. See [User-defined events](/eas/observe/events) for details.
 
 Run any of these commands with `--help` to see the available flags and arguments.
 

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -224,7 +224,7 @@ For details on filtering, release comparison, and session investigation, see the
 You can also query metrics from the terminal using the EAS CLI:
 
 - `eas observe:versions`: Lists app versions along with their build IDs, update group IDs, and release dates. Useful for finding the version identifiers needed to filter the other commands.
-- `eas observe:metric-summary`: Shows aggregated performance metric statistics (such as median, p75, and p95 values) grouped by app version. Use this to compare overall startup performance across releases.
+- `eas observe:metrics-summary`: Shows aggregated performance metric statistics (such as median, p75, and p95 values) grouped by app version. Use this to compare overall startup performance across releases.
 - `eas observe:metrics`: Shows individual performance metric events ordered by value, including session and device metadata. Use this to investigate specific slow sessions or outliers.
 - `eas observe:events`: Shows individual events emitted by your app via `AppMetrics.logEvent`. See [User-defined events](/eas/observe/events/) for details.
 


### PR DESCRIPTION
# Why

Resolves ENG-21384

Depends on https://github.com/expo/eas-cli/pull/3778

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Add documentation for user-defined events in Observe.

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Review the docs on the preview or locally: http://localhost:3002/eas/observe/events/

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
