### PR TITLE
[cli] Avoid stringifying pairRecord in LockdowndClient

### DIFF
--- a/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
+++ b/packages/@expo/cli/src/run/ios/appleDevice/client/LockdowndClient.ts
@@ -116,7 +116,7 @@ export class LockdowndClient extends ServiceClient<LockdownProtocolClient> {
   }
 
   async startSession(pairRecord: UsbmuxdPairRecord) {
-    debug(`startSession: ${pairRecord}`);
+    debug('startSession');
 
     const resp = await this.protocolClient.sendMessage({
       Request: 'StartSession',


### PR DESCRIPTION
### Why

`LockdowndClient.startSession` currently interpolates `pairRecord` into a debug string. In some environments, this crashes `expo run:ios --device` because the pair record object cannot be coerced to a primitive.

The pair record contents also do not add useful value to the debug message and can include device pairing material, so logging the object is unnecessary.

### What changed

Replaced the pair record interpolation with a static `startSession` debug message.

### Test plan

- Reproduced the crash before this change with a blank Expo template: https://github.com/ezgna/expo-lockdownd-repro
- `git diff --check`
- From `packages/@expo/cli`: `corepack pnpm exec eslint src`
- From `packages/@expo/cli`: `corepack pnpm exec tsc --noEmit`

Fixes #46123