### PR TITLE
fix(expo-constants): default BUNDLE_FORMAT and mkdir for shallow iOS bundle format

### DIFF
--- a/packages/expo-constants/ios/EXConstants.podspec
+++ b/packages/expo-constants/ios/EXConstants.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   env_vars = ENV['PROJECT_ROOT'] ? "PROJECT_ROOT=#{ENV['PROJECT_ROOT']} " : ""
   script_phase = {
     :name => 'Generate app.config for prebuilt Constants.manifest',
-    :script => "bash -l -c \"#{env_vars}$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh\"",
+    :script => "bash -l -c \"#{env_vars}bash '$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh'\"",
     :execution_position => :before_compile
   }
   # :always_out_of_date is only available in CocoaPods 1.13.0 and later

--- a/packages/expo-constants/scripts/get-app-config-ios.sh
+++ b/packages/expo-constants/scripts/get-app-config-ios.sh
@@ -22,8 +22,12 @@ PROJECT_ROOT=${PROJECT_ROOT:-"$EXPO_CONSTANTS_PACKAGE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
 
+# Default to "shallow" when BUNDLE_FORMAT is unset (iOS simulator builds may not set this variable)
+BUNDLE_FORMAT=${BUNDLE_FORMAT:-"shallow"}
+
 if [ "$BUNDLE_FORMAT" == "shallow" ]; then
   RESOURCE_DEST="$DEST/$RESOURCE_BUNDLE_NAME"
+  mkdir -p "$RESOURCE_DEST"
 elif [ "$BUNDLE_FORMAT" == "deep" ]; then
   RESOURCE_DEST="$DEST/$RESOURCE_BUNDLE_NAME/Contents/Resources"
   mkdir -p "$RESOURCE_DEST"


### PR DESCRIPTION
## Why

The `get-app-config-ios.sh` and `with-node.sh` scripts are published to npm without execute permissions (`-rw-r--r--` / mode 644). Although these files are marked executable in the git repository, the npm publish process strips the execute bit from the tarball.

The CocoaPods script phase invokes `get-app-config-ios.sh` directly as an executable, resulting in:

```
bash: .../node_modules/expo-constants/scripts/get-app-config-ios.sh: Permission denied
Command PhaseScriptExecution failed with a nonzero exit code
```

This breaks all iOS builds (local and EAS remote) that install from npm.

Additionally, `get-app-config-ios.sh` has two logic bugs triggered once the script can run:

1. **Missing `mkdir -p` for `shallow` bundle format** — the `deep` (macOS Catalyst) branch creates `$RESOURCE_DEST` via `mkdir -p`, but the `shallow` (iOS) branch does not. `getAppConfig.js` writes into that directory and may fail if it doesn't exist.

2. **No default for `BUNDLE_FORMAT`** — on some iOS build environments (EAS remote builds, newer SDKs), `BUNDLE_FORMAT` may not be set. The `else` branch fires and exits 1 with `"Unsupported bundle format: "`.

Closes #15809

## How

- **Podspec**: change the script invocation from `"... $PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh"` to `"... bash '$PODS_TARGET_SRCROOT/../scripts/get-app-config-ios.sh'"` — invoking via `bash` explicitly avoids the execute permission requirement entirely, making this robust against future npm publish permission loss
- **Script content**: add `BUNDLE_FORMAT=${BUNDLE_FORMAT:-"shallow"}` before the `if` block to default to the iOS flat format when the variable is unset
- **Script content**: add `mkdir -p "$RESOURCE_DEST"` to the `shallow` branch (matching what already exists for `deep`)

## Test Plan

- iOS simulator build: `npx expo run:ios` — script runs without permission error, app config written into flat `EXConstants.bundle/`
- macOS Catalyst build: `BUNDLE_FORMAT=deep` path unchanged, still writes to `Contents/Resources/`
- Unset `BUNDLE_FORMAT`: defaults to `shallow` instead of `exit 1`

## Checklist

- [x] Documentation is up to date to reflect these changes (eg: https://docs.expo.dev and README.md).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin)