### PR TITLE
[JSI] Propagate promise construction errors

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Propagate async-function promise construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -14,7 +14,6 @@ internal protocol AnyAsyncFunctionDefinition: AnyFunctionDefinition {
   func runOnQueue(_ queue: DispatchQueue?) -> Self
 }
 
-
 /**
  The default queue used for module's async function calls.
  */
@@ -187,7 +186,7 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
       guard let appContext else {
         throw Exceptions.AppContextLost()
       }
-      let promise = try JavaScriptPromise(deferredIn: appContext.runtime)
+      let promise = try JavaScriptPromise(appContext.runtime)
       let promiseValue = promise.asValue()
 
       self.call(appContext, this: this, arguments: arguments) { [promise] result in
@@ -210,4 +209,3 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
     return self
   }
 }
-

--- a/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
+++ b/packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift
@@ -14,6 +14,7 @@ internal protocol AnyAsyncFunctionDefinition: AnyFunctionDefinition {
   func runOnQueue(_ queue: DispatchQueue?) -> Self
 }
 
+
 /**
  The default queue used for module's async function calls.
  */
@@ -186,7 +187,7 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
       guard let appContext else {
         throw Exceptions.AppContextLost()
       }
-      let promise = JavaScriptPromise(try appContext.runtime)
+      let promise = try JavaScriptPromise(deferredIn: appContext.runtime)
       let promiseValue = promise.asValue()
 
       self.call(appContext, this: this, arguments: arguments) { [promise] result in
@@ -209,5 +210,4 @@ public class AsyncFunctionDefinition<Args, FirstArgType, ReturnType>: AnyAsyncFu
     return self
   }
 }
-
 

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Propagate deferred `JavaScriptPromise` construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
+
 ### 💡 Others
 
 ## 56.0.7 — 2026-05-20

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Propagate deferred `JavaScriptPromise` construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
+- [iOS] Propagate `JavaScriptPromise` setup failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -367,7 +367,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   @JavaScriptActor
   public func createAsyncFunction(_ name: String, _ function: sending @escaping AsyncFunctionClosure) -> JavaScriptFunction {
     return createFunction(name) { this, arguments in
-      let promise = try JavaScriptPromise(deferredIn: self)
+      let promise = try JavaScriptPromise(self)
 
       // Arguments buffer needs to be copied to ensure safe async access.
       let argumentsRef = arguments.copy().ref()

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -367,7 +367,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
   @JavaScriptActor
   public func createAsyncFunction(_ name: String, _ function: sending @escaping AsyncFunctionClosure) -> JavaScriptFunction {
     return createFunction(name) { this, arguments in
-      let promise = JavaScriptPromise(self)
+      let promise = try JavaScriptPromise(deferredIn: self)
 
       // Arguments buffer needs to be copied to ensure safe async access.
       let argumentsRef = arguments.copy().ref()

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -36,16 +36,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
    Creates a new promise whose resolver or rejecter must be called from the outside (also known as a deferred promise).
    */
   @JavaScriptActor
-  public init(_ runtime: JavaScriptRuntime) {
-    try! self.init(deferredIn: runtime)
-  }
-
-  /**
-   Creates a new promise whose resolver or rejecter must be called from the outside,
-   propagating construction failures to the caller.
-   */
-  @JavaScriptActor
-  public init(deferredIn runtime: JavaScriptRuntime) throws {
+  public init(_ runtime: JavaScriptRuntime) throws {
     self.runtime = runtime
 
     // Create function that is the promise setup. It is called immediately on `callAsConstructor`.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -37,6 +37,15 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
    */
   @JavaScriptActor
   public init(_ runtime: JavaScriptRuntime) {
+    try! self.init(deferredIn: runtime)
+  }
+
+  /**
+   Creates a new promise whose resolver or rejecter must be called from the outside,
+   propagating construction failures to the caller.
+   */
+  @JavaScriptActor
+  public init(deferredIn runtime: JavaScriptRuntime) throws {
     self.runtime = runtime
 
     // Create function that is the promise setup. It is called immediately on `callAsConstructor`.
@@ -46,13 +55,13 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
       return .undefined
     }
 
-    self.object = try! runtime
+    self.object = try runtime
       .global()
       .getPropertyAsFunction(.cached(runtime, "Promise"))
       .callAsConstructor(setup.asValue())
       .getObject()
 
-    try! setUpCallbacks()
+    try setUpCallbacks()
   }
 
   @JavaScriptActor

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -26,10 +26,10 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
    It cannot be resolved/rejected from the outside, i.e. `resolve` and `reject` functions are no-op.
    */
   @JavaScriptActor
-  public init(_ runtime: JavaScriptRuntime, _ object: consuming JavaScriptObject) {
+  public init(_ runtime: JavaScriptRuntime, _ object: consuming JavaScriptObject) throws {
     self.runtime = runtime
     self.object = object
-    try! setUpCallbacks()
+    try setUpCallbacks()
   }
 
   /**
@@ -59,8 +59,8 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   }
 
   @JavaScriptActor
-  internal init(_ runtime: JavaScriptRuntime, _ object: consuming facebook.jsi.Object) {
-    self.init(runtime, JavaScriptObject(runtime, object))
+  internal init(_ runtime: JavaScriptRuntime, _ object: consuming facebook.jsi.Object) throws {
+    try self.init(runtime, JavaScriptObject(runtime, object))
   }
 
   public var isDeferred: Bool {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift
@@ -13,7 +13,7 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   private typealias PromiseContinuation = CheckedContinuation<JavaScriptValue.Ref, any Error>
 
   private weak let runtime: JavaScriptRuntime?
-  private let object: JavaScriptObject
+  private var object: JavaScriptObject
   private let deferredPromise = DeferredPromise()
 
   // Create refs for resolve and reject functions.
@@ -38,6 +38,9 @@ public struct JavaScriptPromise: JavaScriptType, ~Copyable {
   @JavaScriptActor
   public init(_ runtime: JavaScriptRuntime) throws {
     self.runtime = runtime
+    // Initialize the non-copyable field before any throwing work. Swift requires a
+    // consistently initialized value on every throwing initializer path.
+    self.object = runtime.createObject()
 
     // Create function that is the promise setup. It is called immediately on `callAsConstructor`.
     let setup = runtime.createFunction { [weak resolveFunction, weak rejectFunction] this, arguments in

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -335,12 +335,12 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
    Returns the value as a promise, or asserts if it is not a promise.
    */
   @JavaScriptActor
-  public func getPromise() -> JavaScriptPromise {
+  public func getPromise() throws -> JavaScriptPromise {
     guard let runtime else {
       FatalError.runtimeLost()
     }
     assert(self.is("Promise"), "Value is not a promise")
-    return JavaScriptPromise(runtime, getObject())
+    return try JavaScriptPromise(runtime, getObject())
   }
 
   // MARK: - Throwing conversions ("as functions")
@@ -418,11 +418,11 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
   }
 
   @JavaScriptActor
-  public func asPromise() throws(TypeError) -> JavaScriptPromise {
+  public func asPromise() throws -> JavaScriptPromise {
     guard self.is("Promise") else {
       throw TypeError(type: JavaScriptPromise.self)
     }
-    return getPromise()
+    return try getPromise()
   }
 
   /**

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -7,15 +7,33 @@ struct JavaScriptPromiseTests {
   @Test
   func `create deferred promise`() async throws {
     let runtime = JavaScriptRuntime()
+    let promise = try JavaScriptPromise(deferredIn: runtime)
+
+    #expect(promise.isDeferred == true)
+}
+
+  @Test
+  func `create deferred promise with convenience initializer`() {
+    let runtime = JavaScriptRuntime()
     let promise = JavaScriptPromise(runtime)
 
     #expect(promise.isDeferred == true)
   }
 
   @Test
+  func `deferred promise construction throws when Promise constructor is unavailable`() throws {
+    let runtime = JavaScriptRuntime()
+    try runtime.eval("globalThis.Promise = undefined")
+
+    #expect(throws: Error.self) {
+      _ = try JavaScriptPromise(deferredIn: runtime)
+    }
+  }
+
+  @Test
   func `resolve promise with value`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     promise.resolve(JavaScriptValue(runtime, 42))
 
@@ -26,7 +44,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve promise with string`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     promise.resolve(JavaScriptValue(runtime, "hello"))
 
@@ -37,7 +55,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve promise with object`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     let obj = runtime.createObject()
     obj.setProperty("value", value: 42)
@@ -51,7 +69,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `reject promise with error`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     struct TestError: Error {
       var localizedDescription: String { "Test error message" }
@@ -93,9 +111,9 @@ struct JavaScriptPromiseTests {
   }
 
   @Test
-  func `asValue returns promise object`() {
+  func `asValue returns promise object`() throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
     let value = promise.asValue()
 
     #expect(value.isObject())
@@ -104,7 +122,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `promise can be passed to JavaScript`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     runtime.global().setProperty("testPromise", value: promise.asValue())
     promise.resolve(42)
@@ -117,7 +135,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `promise can be chained in JavaScript`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     runtime.global().setProperty("testPromise", value: promise.asValue())
 
@@ -135,7 +153,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve with boolean`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     promise.resolve(JavaScriptValue(runtime, true))
 
@@ -146,7 +164,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve with null`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     promise.resolve(JavaScriptValue.null)
 
@@ -157,7 +175,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve with undefined`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     promise.resolve(JavaScriptValue.undefined)
 
@@ -168,7 +186,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve with array`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     promise.resolve([1, 2, 3])
 
@@ -183,8 +201,8 @@ struct JavaScriptPromiseTests {
   @Test
   func `multiple promises resolve independently`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise1 = JavaScriptPromise(runtime)
-    let promise2 = JavaScriptPromise(runtime)
+    let promise1 = try JavaScriptPromise(deferredIn: runtime)
+    let promise2 = try JavaScriptPromise(deferredIn: runtime)
 
     promise1.resolve(10)
     promise2.resolve(20)
@@ -239,7 +257,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve promise from a task`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(deferredIn: runtime)
 
     // Resolve from a task
     Task.detached {
@@ -255,9 +273,9 @@ struct JavaScriptPromiseTests {
   func `promise all`() async throws {
     let runtime = JavaScriptRuntime()
 
-    let promise1 = JavaScriptPromise(runtime)
-    let promise2 = JavaScriptPromise(runtime)
-    let promise3 = JavaScriptPromise(runtime)
+    let promise1 = try JavaScriptPromise(deferredIn: runtime)
+    let promise2 = try JavaScriptPromise(deferredIn: runtime)
+    let promise3 = try JavaScriptPromise(deferredIn: runtime)
 
     runtime.global().setProperty("p1", value: promise1.asValue())
     runtime.global().setProperty("p2", value: promise2.asValue())
@@ -283,8 +301,8 @@ struct JavaScriptPromiseTests {
   func `promise race`() async throws {
     let runtime = JavaScriptRuntime()
 
-    let promise1 = JavaScriptPromise(runtime)
-    let promise2 = JavaScriptPromise(runtime)
+    let promise1 = try JavaScriptPromise(deferredIn: runtime)
+    let promise2 = try JavaScriptPromise(deferredIn: runtime)
 
     runtime.global().setProperty("p1", value: promise1.asValue())
     runtime.global().setProperty("p2", value: promise2.asValue())

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -94,6 +94,20 @@ struct JavaScriptPromiseTests {
   }
 
   @Test
+  func `wrapped promise setup throws when then is unavailable`() throws {
+    let runtime = JavaScriptRuntime()
+    let promiseValue = try runtime.eval("""
+    const promise = Promise.resolve(42);
+    promise.then = undefined;
+    promise;
+    """)
+
+    #expect(throws: Error.self) {
+      _ = try promiseValue.getPromise()
+    }
+  }
+
+  @Test
   func `wrap pending promise that resolves later`() async throws {
     let runtime = JavaScriptRuntime()
     let pendingPromise = try runtime.eval("new Promise((resolve) => { setImmediate(() => resolve(100)) })").getPromise()

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift
@@ -7,15 +7,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `create deferred promise`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
-
-    #expect(promise.isDeferred == true)
-}
-
-  @Test
-  func `create deferred promise with convenience initializer`() {
-    let runtime = JavaScriptRuntime()
-    let promise = JavaScriptPromise(runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     #expect(promise.isDeferred == true)
   }
@@ -26,14 +18,14 @@ struct JavaScriptPromiseTests {
     try runtime.eval("globalThis.Promise = undefined")
 
     #expect(throws: Error.self) {
-      _ = try JavaScriptPromise(deferredIn: runtime)
+      _ = try JavaScriptPromise(runtime)
     }
   }
 
   @Test
   func `resolve promise with value`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     promise.resolve(JavaScriptValue(runtime, 42))
 
@@ -44,7 +36,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve promise with string`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     promise.resolve(JavaScriptValue(runtime, "hello"))
 
@@ -55,7 +47,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve promise with object`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     let obj = runtime.createObject()
     obj.setProperty("value", value: 42)
@@ -69,7 +61,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `reject promise with error`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     struct TestError: Error {
       var localizedDescription: String { "Test error message" }
@@ -113,7 +105,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `asValue returns promise object`() throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
     let value = promise.asValue()
 
     #expect(value.isObject())
@@ -122,7 +114,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `promise can be passed to JavaScript`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     runtime.global().setProperty("testPromise", value: promise.asValue())
     promise.resolve(42)
@@ -135,7 +127,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `promise can be chained in JavaScript`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     runtime.global().setProperty("testPromise", value: promise.asValue())
 
@@ -153,7 +145,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve with boolean`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     promise.resolve(JavaScriptValue(runtime, true))
 
@@ -164,7 +156,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve with null`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     promise.resolve(JavaScriptValue.null)
 
@@ -175,7 +167,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve with undefined`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     promise.resolve(JavaScriptValue.undefined)
 
@@ -186,7 +178,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve with array`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     promise.resolve([1, 2, 3])
 
@@ -201,8 +193,8 @@ struct JavaScriptPromiseTests {
   @Test
   func `multiple promises resolve independently`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise1 = try JavaScriptPromise(deferredIn: runtime)
-    let promise2 = try JavaScriptPromise(deferredIn: runtime)
+    let promise1 = try JavaScriptPromise(runtime)
+    let promise2 = try JavaScriptPromise(runtime)
 
     promise1.resolve(10)
     promise2.resolve(20)
@@ -257,7 +249,7 @@ struct JavaScriptPromiseTests {
   @Test
   func `resolve promise from a task`() async throws {
     let runtime = JavaScriptRuntime()
-    let promise = try JavaScriptPromise(deferredIn: runtime)
+    let promise = try JavaScriptPromise(runtime)
 
     // Resolve from a task
     Task.detached {
@@ -273,9 +265,9 @@ struct JavaScriptPromiseTests {
   func `promise all`() async throws {
     let runtime = JavaScriptRuntime()
 
-    let promise1 = try JavaScriptPromise(deferredIn: runtime)
-    let promise2 = try JavaScriptPromise(deferredIn: runtime)
-    let promise3 = try JavaScriptPromise(deferredIn: runtime)
+    let promise1 = try JavaScriptPromise(runtime)
+    let promise2 = try JavaScriptPromise(runtime)
+    let promise3 = try JavaScriptPromise(runtime)
 
     runtime.global().setProperty("p1", value: promise1.asValue())
     runtime.global().setProperty("p2", value: promise2.asValue())
@@ -301,8 +293,8 @@ struct JavaScriptPromiseTests {
   func `promise race`() async throws {
     let runtime = JavaScriptRuntime()
 
-    let promise1 = try JavaScriptPromise(deferredIn: runtime)
-    let promise2 = try JavaScriptPromise(deferredIn: runtime)
+    let promise1 = try JavaScriptPromise(runtime)
+    let promise2 = try JavaScriptPromise(runtime)
 
     runtime.global().setProperty("p1", value: promise1.asValue())
     runtime.global().setProperty("p2", value: promise2.asValue())
@@ -324,4 +316,3 @@ struct JavaScriptPromiseTests {
     #expect(promise.isDeferred == false)
   }
 }
-

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -579,6 +579,19 @@ struct JavaScriptRuntimeTests {
   }
 
   @Test
+  func `async function propagates promise construction failure`() throws {
+    let fn = runtime.createAsyncFunction("asyncFn") { this, arguments in
+      return JavaScriptValue(self.runtime, 42)
+    }
+    runtime.global().setProperty("asyncFn", value: fn.asValue())
+    try runtime.eval("globalThis.Promise = undefined")
+
+    #expect(throws: Error.self) {
+      _ = try runtime.eval("globalThis.asyncFn()")
+    }
+  }
+
+  @Test
   func `async function resolves with value`() async throws {
     let fn = runtime.createAsyncFunction("asyncFn") { this, arguments in
       return JavaScriptValue(self.runtime, 42)


### PR DESCRIPTION
Why:

- Fixes https://github.com/expo/expo/issues/46106.
- `JavaScriptPromise` deferred construction force-unwrapped the JSI `Promise` lookup/construction and callback setup path with `try!`. If that path threw while an Expo async native function was creating its return promise, Swift turned the error into a process trap instead of letting the host function report a normal JS/JSI exception.

How:

- Added a throwing deferred `JavaScriptPromise(deferredIn:)` initializer that propagates `Promise` construction and callback setup failures.
- Updated `expo-modules-jsi` async host functions and `expo-modules-core` `AsyncFunctionDefinition` to use the throwing initializer.
- Kept the existing `JavaScriptPromise(runtime)` convenience initializer source-compatible for current callers, while moving Expo async-function internals to the non-trapping path.
- Added Swift tests for missing `globalThis.Promise` during direct deferred-promise construction and async host-function invocation.

Test Plan:

- `git diff --check`
- `xcrun swiftc -parse -enable-bare-slash-regex packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptPromise.swift packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift packages/expo-modules-jsi/apple/Tests/JavaScriptPromiseTests.swift packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift packages/expo-modules-core/ios/Core/Functions/AsyncFunctionDefinition.swift`
- `pnpm --filter expo-modules-core test -- --runInBand --passWithNoTests` (22 suites, 168 tests passed)
- `pnpm --filter expo-modules-core lint` (exited 0; existing unrelated Prettier warnings in `src/polyfill/CoreModule.ts` and `src/ts-declarations/SharedRef.ts`)
- `pnpm --filter expo-modules-jsi test` could not run in this checkout because `apps/bare-expo/ios/Pods` is missing; the script fails before compiling with `PODS_ROOT does not exist`.

Risk:

- File-count summary: 3 Swift source files, 2 Swift test files, and 2 package changelogs.
- No generated output.
- The existing convenience initializer remains source-compatible; the Expo async-function path now propagates construction failures through the host-function `throws` path instead of trapping.
