### PR TITLE
[expo-cli] Fix flaky api tests

### DIFF
--- a/packages/@expo/cli/src/install/utils/__tests__/checkPackagesCompatibility-test.ts
+++ b/packages/@expo/cli/src/install/utils/__tests__/checkPackagesCompatibility-test.ts
@@ -49,16 +49,17 @@ describe(checkPackagesCompatibility, () => {
   });
 
   it(`does not warn about supported or unknown package`, async () => {
-    nock('https://reactnative.directory')
+    const request = nock('https://reactnative.directory')
       .get('/api/libraries/check')
-      .query({ packages: 'expo-image,@expo-google-fonts/inter' })
+      .query({ packages: 'expo-image,react-native-unknown-package' })
       .reply(200, {
         'expo-image': { newArchitecture: 'supported' },
-        '@expo-google-fonts/inter': { newArchitecture: undefined },
+        'react-native-unknown-package': { newArchitecture: undefined },
       });
 
-    await checkPackagesCompatibility(['expo-image', '@expo-google-fonts/inter']);
+    await checkPackagesCompatibility(['expo-image', 'react-native-unknown-package']);
 
+    expect(request.isDone()).toBe(true);
     expect(Log.warn).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
+++ b/packages/@expo/cli/src/start/server/__tests__/DevelopmentSession-test.ts
@@ -78,7 +78,7 @@ describe(`startAsync`, () => {
     const runtime = 'native';
 
     // Server is down
-    nock(getExpoApiBaseUrl())
+    const startScope = nock(getExpoApiBaseUrl())
       .post('/v2/development-sessions/notify-alive?deviceId=123&deviceId=456')
       .reply(500, '');
 
@@ -89,6 +89,11 @@ describe(`startAsync`, () => {
         runtime,
       })
     ).resolves.toBeUndefined();
+
+    // startAsync is fire-and-forget; wait for the interceptor to reply so the
+    // in-flight request settles before afterEach() calls nock.cleanAll().
+    await new Promise<void>((resolve) => startScope.once('replied', () => resolve()));
+    expect(startScope.isDone()).toBe(true);
   });
 
   it('is skipped on CI', async () => {


### PR DESCRIPTION
# Why

The `does not warn about supported or unknown package` and `gracefully handles server outages` cli tests are flakey.

1. does not warn about supported or unknown package - this test checks for ignored `@expo-google-fonts/inter` - https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/install/utils/checkPackagesCompatibility.ts#L24 dependency
2. gracefully handles server outages - does not wait for the request to complete

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
