### PR TITLE
[audio][android] Fix crash in `AudioControlsService`

### DIFF
--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [Android] Fix `RemoteServiceException` crash when the system starts `AudioControlsService` via `startForegroundService()`.
+- [Android] Fix `RemoteServiceException` crash when the system starts `AudioControlsService` via `startForegroundService()`. ([#46147](https://github.com/expo/expo/pull/46147) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-audio/CHANGELOG.md
+++ b/packages/expo-audio/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fix `RemoteServiceException` crash when the system starts `AudioControlsService` via `startForegroundService()`.
+
 ### 💡 Others
 
 ## 56.0.9 — 2026-05-21

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -64,8 +64,14 @@ class AudioControlsService : MediaSessionService() {
   var playbackListener: Player.Listener? = null
 
   override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-    val currentPlayerRef = currentPlayer?.ref ?: return super.onStartCommand(intent, flags, startId)
-    val context = appContext ?: return super.onStartCommand(intent, flags, startId)
+    ensureForegroundNotification()
+
+    val currentPlayerRef = currentPlayer?.ref
+    val context = appContext
+    if (currentPlayerRef == null || context == null) {
+      stopForeground(STOP_FOREGROUND_REMOVE)
+      return super.onStartCommand(intent, flags, startId)
+    }
 
     context.mainQueue.launch {
       when (intent?.action) {
@@ -90,6 +96,35 @@ class AudioControlsService : MediaSessionService() {
     postOrStartForegroundNotification(startInForeground = false)
     return super.onStartCommand(intent, flags, startId)
   }
+
+  private fun ensureForegroundNotification() {
+    val notification = buildNotification() ?: buildPlaceholderNotification()
+    try {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        startForeground(
+          notificationId,
+          notification,
+          ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+        )
+      } else {
+        startForeground(notificationId, notification)
+      }
+    } catch (e: Exception) {
+      appContext?.jsLogger?.error(
+        getPlaybackServiceErrorMessage("Failed to promote the expo-audio playback service to foreground"),
+        e
+      )
+    }
+  }
+
+  private fun buildPlaceholderNotification(): Notification =
+    NotificationCompat.Builder(this, CHANNEL_ID)
+      .setSmallIcon(androidx.media3.session.R.drawable.media3_icon_circular_play)
+      .setContentTitle("‎")
+      .setCategory(NotificationCompat.CATEGORY_TRANSPORT)
+      .setSilent(true)
+      .setShowWhen(false)
+      .build()
 
   override fun onCreate() {
     super.onCreate()
@@ -244,11 +279,17 @@ class AudioControlsService : MediaSessionService() {
   }
 
   private fun postOrStartForegroundNotification(startInForeground: Boolean) {
+    if (startInForeground) {
+      // Foreground promotion must run synchronously: dispatching through mainQueue can blow
+      // the 5s startForegroundService() deadline on slower devices or a busy main thread.
+      postOrStartForegroundNotificationNow(startInForeground = true)
+      return
+    }
     appContext?.let {
       it.mainQueue.launch {
-        postOrStartForegroundNotificationNow(startInForeground)
+        postOrStartForegroundNotificationNow(startInForeground = false)
       }
-    } ?: postOrStartForegroundNotificationNow(startInForeground)
+    } ?: postOrStartForegroundNotificationNow(startInForeground = false)
   }
 
   private fun postOrStartForegroundNotificationNow(startInForeground: Boolean) {

--- a/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
+++ b/packages/expo-audio/android/src/main/java/expo/modules/audio/service/AudioControlsService.kt
@@ -280,8 +280,6 @@ class AudioControlsService : MediaSessionService() {
 
   private fun postOrStartForegroundNotification(startInForeground: Boolean) {
     if (startInForeground) {
-      // Foreground promotion must run synchronously: dispatching through mainQueue can blow
-      // the 5s startForegroundService() deadline on slower devices or a busy main thread.
       postOrStartForegroundNotificationNow(startInForeground = true)
       return
     }


### PR DESCRIPTION
# Why
Closes #46137

[Android's foreground service contract](https://developer.android.com/develop/background-work/services/fgs/troubleshooting) requires that a service started via `Context.startForegroundService()` call `Service.startForeground()` "within a few seconds", missing that window raises an exception with the message `Context.startForegroundService()` did not then call `Service.startForeground()`.

The exact deadline is configurable in AOSP  currently `DEFAULT_SERVICE_START_FOREGROUND_TIMEOUT_MS = 30 * 1000` plus an additional `DEFAULT_SERVICE_START_FOREGROUND_ANR_DELAY_MS = 10 * 1000` in [`ActivityManagerConstants`](https://github.com/aosp-mirror/platform_frameworks_base/blob/master/services/core/java/com/android/server/am/ActivityManagerConstants.java), and has historically been tighter. 

`AudioControlsService.onStartCommand` had two paths where this could happen

1. Early returns when `currentPlayer` or `appContext` were null skips foreground promotion entirely.
2. `startForeground()` was reached through three `mainQueue.launch` hops (two in `setActivePlayerInternal`, one in `postOrStartForegroundNotification`), any of which can stall behind unrelated main-thread work and miss the deadline.

# How

- New synchronous `ensureForegroundNotification()` helper, called at the top of `onStartCommand` before any early return or coroutine hop. Prefers the real notification when `mediaSession` is set, falls back to a minimal placeholder so there is no visual flicker when the service is already foreground.
- `postOrStartForegroundNotification(startInForeground = true)` now runs synchronously instead of dispatching through `mainQueue.launch`. All callers are already on the main thread .

# Test Plan
Bare expo
