### PR TITLE
fix(cli): Disable sextant QR code rendering for Zed

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- Disable sextant QR code rendering for Zed due to regression ([#46148](https://github.com/expo/expo/pull/46148) by [@kitten](https://github.com/kitten))
+
 ## 56.1.10 — 2026-05-21
 
 _This version does not introduce any user-facing changes._

--- a/packages/@expo/cli/src/utils/qr.ts
+++ b/packages/@expo/cli/src/utils/qr.ts
@@ -31,8 +31,10 @@ function supportsSextants() {
   const isWindowsTerminal = process.platform === 'win32' && !!process.env.WT_SESSION?.length;
   const isGhostty = process.env.TERM_PROGRAM === 'ghostty';
   const isWezterm = process.env.TERM_PROGRAM === 'WezTerm';
+  // NOTE(@kitten): Zed regressed on rendering sextants
+  const isZed = process.env.TERM_PROGRAM === 'zed';
   const isKitty = !!process.env.KITTY_WINDOW_ID?.length;
-  const isAlacritty = !!process.env.ALACRITTY_WINDOW_ID?.length;
+  const isAlacritty = !!process.env.ALACRITTY_WINDOW_ID?.length && !isZed;
   return isWindowsTerminal || isGhostty || isWezterm || isKitty || isAlacritty;
 }
 


### PR DESCRIPTION
## Summary

It seems like sextant QR code rendering is broken in Zed's terminal, and it's neither falling back to the necessary characters from a fallback font nor rendering these block characters manually. This is still working on Alacritty, but just not on the Zed editor's terminal anymore.

I previously tested this, but looks like this regressed and needs to be disabled for it.

<img width="319" height="259" alt="image" src="https://github.com/user-attachments/assets/f6e166ed-e9be-4555-9972-d4f332c78d3e" />

See: https://github.com/zed-industries/zed/issues/50158

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
