### PR TITLE
[docs] Fix lint job failing when all changed JS/TS files match oxlint ignorePatterns

### DIFF
--- a/docs/scripts/lint.js
+++ b/docs/scripts/lint.js
@@ -117,7 +117,15 @@ if (oxlintChangedFiles !== null && oxlintChangedFiles.length === 0) {
     ...oxlintChangedFiles,
     '--type-aware',
     ...(isCI ? ['--format=github'] : []),
-  ]);
+  ]).then(result => {
+    if (result.status !== 0 && result.output.includes('No files found to lint')) {
+      return {
+        status: 0,
+        output: 'No lintable files changed (all changed files are in ignorePatterns).',
+      };
+    }
+    return result;
+  });
 } else {
   oxlintPromise = runAsync('oxlint', oxlintArgs);
 }


### PR DESCRIPTION
# Why

The docs lint job fails on PRs whose only JS/TS-changed files live under a path covered by `.oxlintrc.json` `ignorePatterns` (such as `**/public`). In that case oxlint receives one explicit input, finds it's ignored, and exits 1 with `No files found to lint`. 

see: https://github.com/expo/expo/actions/runs/26284933466/job/77370147199

# How

In `scripts/lint.js`, when CI passes oxlint an explicit changed-files list and oxlint exits non-zero with `No files found to lint`, fold the result back to success with a clear note. This generalizes the existing md/mdx-only safeguard (see the comment around `oxlintExts`) to every path in `ignorePatterns`. Real violations on non-ignored files still fail because the override is gated on that exact message.

# Test Plan

Run `pnpm lint` locally.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
