### PR TITLE
[docs] Run `pnpm lint` tools serially to avoid CI ENOMEM

### DIFF
--- a/docs/scripts/lint.js
+++ b/docs/scripts/lint.js
@@ -99,42 +99,37 @@ const oxlintExts = ['js', 'cjs', 'ts', 'jsx', 'tsx'];
 const oxfmtChangedFiles = getChangedFiles(oxfmtExts);
 const oxlintChangedFiles = getChangedFiles(oxlintExts);
 
-let oxfmtPromise;
+let oxfmtResult;
 if (oxfmtChangedFiles !== null && oxfmtChangedFiles.length === 0) {
-  oxfmtPromise = Promise.resolve({ status: 0, output: 'No formattable files changed.' });
+  oxfmtResult = { status: 0, output: 'No formattable files changed.' };
 } else if (oxfmtChangedFiles !== null) {
-  oxfmtPromise = runAsync('oxfmt', ['--check', ...oxfmtChangedFiles]);
+  oxfmtResult = await runAsync('oxfmt', ['--check', ...oxfmtChangedFiles]);
 } else {
   const mdxFiles = globSync('**/*.mdx', { cwd: process.cwd() });
-  oxfmtPromise = runAsync('oxfmt', ['--check', process.cwd(), ...mdxFiles]);
+  oxfmtResult = await runAsync('oxfmt', ['--check', process.cwd(), ...mdxFiles]);
 }
 
-let oxlintPromise;
+let oxlintResult;
 if (oxlintChangedFiles !== null && oxlintChangedFiles.length === 0) {
-  oxlintPromise = Promise.resolve({ status: 0, output: 'No lintable files changed.' });
+  oxlintResult = { status: 0, output: 'No lintable files changed.' };
 } else if (oxlintChangedFiles !== null) {
-  oxlintPromise = runAsync('oxlint', [
+  oxlintResult = await runAsync('oxlint', [
     ...oxlintChangedFiles,
     '--type-aware',
     ...(isCI ? ['--format=github'] : []),
-  ]).then(result => {
-    if (result.status !== 0 && result.output.includes('No files found to lint')) {
-      return {
-        status: 0,
-        output: 'No lintable files changed (all changed files are in ignorePatterns).',
-      };
-    }
-    return result;
-  });
+  ]);
+  if (oxlintResult.status !== 0 && oxlintResult.output.includes('No files found to lint')) {
+    oxlintResult = {
+      status: 0,
+      output: 'No lintable files changed (all changed files are in ignorePatterns).',
+    };
+  }
 } else {
-  oxlintPromise = runAsync('oxlint', oxlintArgs);
+  oxlintResult = await runAsync('oxlint', oxlintArgs);
 }
-const tscPromise = runAsync('tsc', ['--noEmit', '--pretty']);
-const eslintPromise = runEslint();
-const oxfmtResult = await oxfmtPromise;
-const oxlintResult = await oxlintPromise;
-const tscResult = await tscPromise;
-const eslintResult = await eslintPromise;
+
+const tscResult = await runAsync('tsc', ['--noEmit', '--pretty']);
+const eslintResult = await runEslint();
 
 /** Rebase annotation file paths from cwd-relative to repo-root-relative for GitHub Actions. */
 const workingDir = basename(process.cwd());

--- a/docs/scripts/lint.js
+++ b/docs/scripts/lint.js
@@ -87,7 +87,7 @@ function getChangedFiles(extensions) {
 const isCI = process.env.CI === 'true';
 const oxlintArgs = [process.cwd(), '--type-aware'];
 if (isCI) {
-  oxlintArgs.push('--format=github');
+  oxlintArgs.push('--format=github', '--threads=1');
 }
 
 // oxfmt formats JS/TS and markdown; oxlint only lints JS/TS (md/mdx are in its ignorePatterns).
@@ -116,7 +116,7 @@ if (oxlintChangedFiles !== null && oxlintChangedFiles.length === 0) {
   oxlintResult = await runAsync('oxlint', [
     ...oxlintChangedFiles,
     '--type-aware',
-    ...(isCI ? ['--format=github'] : []),
+    ...(isCI ? ['--format=github', '--threads=1'] : []),
   ]);
   if (oxlintResult.status !== 0 && oxlintResult.output.includes('No files found to lint')) {
     oxlintResult = {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

<img width="2424" height="288" alt="CleanShot 2026-05-22 at 17 27 59@2x" src="https://github.com/user-attachments/assets/0b081876-4f7d-4ffd-b441-e8bb20530d81" />

Docs CI logs repeated `[oxlint-tailwindcss] Failed to load design system ... spawnSync ... ENOMEM` lines on every run. The `oxlint-tailwindcss` plugin spawns a Node helper to read `styles/global.css`, and on GitHub-hosted runners that fork fails when `oxfmt`, `oxlint`, `tsc`, and `eslint` are all running at once. The failure is non-fatal (oxlint still exits 0), but Tailwind class validation is silently skipped on those runs.

Example: https://github.com/expo/expo/actions/runs/26285812556/job/77373083131?pr=46150

# How

- In `scripts/lint.js`, dispatch the four tools sequentially instead of with `Promise.all`. Serial execution removes the ENOMEM warnings on CI and also makes `pnpm lint` faster locally because each tool now gets the full machine without contention. See: https://github.com/expo/expo/actions/runs/26286809439/job/77376381883?pr=46152
- On CI, cap `oxlint` to 1 thread.

<img width="3444" height="686" alt="CleanShot 2026-05-22 at 17 39 32@2x" src="https://github.com/user-attachments/assets/0f6dff76-01b1-4159-acb5-8487a93eb423" />


# Test Plan

- Run `pnpm lint` locally and confirm it finishes cleanly.
- On CI, confirm the `Lint Docs website code` job no longer prints `[oxlint-tailwindcss] Failed to load design system ... ENOMEM` lines and that all four tools still report their normal results.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).