### PR TITLE
[docs] Fix lint-prose script

### DIFF
--- a/docs/.vale.ini
+++ b/docs/.vale.ini
@@ -33,3 +33,4 @@ BasedOnStyles =
 # README.md is contributor docs, not user-facing pages, so the <Prerequisites> component does not apply there.
 [**/README.md]
 expo-docs.Prerequisites = NO
+expo-docs.KeyboardShortcuts = NO

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "format": "oxfmt --write .",
     "lint": "NODE_OPTIONS='--no-warnings' node scripts/lint.js --max-warnings 0",
     "lint-links": "remark -u validate-links ./pages",
-    "lint-prose": ".vale/bin/vale --config='.vale.ini' --glob='!{pages/versions/latest,pages/versions/latest/**,pages/internal,pages/internal/**}' pages scenes",
+    "lint-prose": ".vale/bin/vale --config='.vale.ini' --glob='!{pages/versions/latest,pages/versions/latest/**,pages/internal,pages/internal/**}' pages scenes README.md",
     "watch": "tsc --noEmit -w",
     "test": "pnpm generate-static-resources && node --experimental-strip-types --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "remove-version": "node --unhandled-rejections=strict ./scripts/remove-version.js",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
Follow-up https://github.com/expo/expo/pull/46107 & https://github.com/expo/expo/actions/runs/26288337421/job/77381564930

<img width="3518" height="904" alt="CleanShot 2026-05-22 at 18 25 50@2x" src="https://github.com/user-attachments/assets/01c3057d-e351-4c5f-9275-5e5a9091299a" />



# How

<!--
How did you build this feature or fix this bug and why?
-->

- Fix lint-prose script to include `docs/README.md`, matching the CI workflows patterns for Docs PR jobs.
- Ignore the keyboard rule for `docs/README.md`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Run `pnpm lint-prose` and there should be no errors locally.

<img width="2014" height="366" alt="CleanShot 2026-05-22 at 18 25 23@2x" src="https://github.com/user-attachments/assets/11ec97a1-746d-408a-bf38-a3b5c24e78a3" />


On CI, there are no errors left. The following screenshot is from the CI run from Docs PR job in this PR:

<img width="3410" height="916" alt="CleanShot 2026-05-22 at 18 32 10@2x" src="https://github.com/user-attachments/assets/20b0b6c2-4388-49ea-8894-24ecd3d2a676" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
