### PR TITLE
[build-properties] default ios.usePrecompiledModules to true

### DIFF
--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Default `ios.usePrecompiledModules` to `true` so the plugin matches the Podfile default (precompiled modules enabled) instead of silently disabling them.
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-21

--- a/packages/expo-build-properties/CHANGELOG.md
+++ b/packages/expo-build-properties/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Default `ios.usePrecompiledModules` to `true` so the plugin matches the Podfile default (precompiled modules enabled) instead of silently disabling them.
+- [iOS] Default `ios.usePrecompiledModules` to `true` so the plugin matches the Podfile default (precompiled modules enabled) instead of silently disabling them. ([#46159](https://github.com/expo/expo/pull/46159) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-build-properties/build/ios.js
+++ b/packages/expo-build-properties/build/ios.js
@@ -42,7 +42,7 @@ exports.withIosBuildProperties = createBuildPodfilePropsConfigPlugin([
     },
     {
         propName: 'EXPO_USE_PRECOMPILED_MODULES',
-        propValueGetter: (config) => (config.ios?.usePrecompiledModules ?? false).toString(),
+        propValueGetter: (config) => (config.ios?.usePrecompiledModules ?? true).toString(),
     },
 ], 'withIosBuildProperties');
 /** @deprecated use built-in `ios.deploymentTarget` property instead. */

--- a/packages/expo-build-properties/build/pluginConfig.d.ts
+++ b/packages/expo-build-properties/build/pluginConfig.d.ts
@@ -372,7 +372,7 @@ export interface PluginConfigTypeIos extends SharedBuildConfigFields {
      * When enabled, sets the `EXPO_USE_PRECOMPILED_MODULES` environment variable to `1`
      * during `pod install`, which causes matching modules to be linked as vendored frameworks.
      *
-     * @default false
+     * @default true
      */
     usePrecompiledModules?: boolean;
 }

--- a/packages/expo-build-properties/src/ios.ts
+++ b/packages/expo-build-properties/src/ios.ts
@@ -47,7 +47,7 @@ export const withIosBuildProperties = createBuildPodfilePropsConfigPlugin<Plugin
     },
     {
       propName: 'EXPO_USE_PRECOMPILED_MODULES',
-      propValueGetter: (config) => (config.ios?.usePrecompiledModules ?? false).toString(),
+      propValueGetter: (config) => (config.ios?.usePrecompiledModules ?? true).toString(),
     },
   ],
   'withIosBuildProperties'

--- a/packages/expo-build-properties/src/pluginConfig.ts
+++ b/packages/expo-build-properties/src/pluginConfig.ts
@@ -442,7 +442,7 @@ export interface PluginConfigTypeIos extends SharedBuildConfigFields {
    * When enabled, sets the `EXPO_USE_PRECOMPILED_MODULES` environment variable to `1`
    * during `pod install`, which causes matching modules to be linked as vendored frameworks.
    *
-   * @default false
+   * @default true
    */
   usePrecompiledModules?: boolean;
 }


### PR DESCRIPTION
# Why



`ios.usePrecompiledModules` defaulted to false, so any project using the plugin without explicitly setting it wrote "EXPO_USE_PRECOMPILED_MODULES": "false" to Podfile.properties.json — silently overriding the Podfile template's default-to-enabled behavior (https://github.com/expo/expo/blob/main/templates/expo-template-bare-minimum/ios/Podfile#L19).


# How

align the defaults 

# Test Plan

tested locally on a fresh project

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)