### PR TITLE
[ci] bump xcode to 26.4, use maestro 2.4.0 on android

### DIFF
--- a/.github/workflows/ios-static-frameworks.yml
+++ b/.github/workflows/ios-static-frameworks.yml
@@ -15,14 +15,14 @@ concurrency:
 jobs:
   build:
     if: github.event_name != 'schedule' || github.repository == 'expo/expo'
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 💎 Setup Ruby

--- a/.github/workflows/ios-unit-tests.yml
+++ b/.github/workflows/ios-unit-tests.yml
@@ -37,15 +37,15 @@ concurrency:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 75
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 💎 Setup Ruby and install gems

--- a/.github/workflows/test-react-native-nightly.yml
+++ b/.github/workflows/test-react-native-nightly.yml
@@ -25,12 +25,12 @@ jobs:
       fail-fast: true
       matrix:
         build-type: [debug, release]
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/.github/workflows/test-suite-macos.yml
+++ b/.github/workflows/test-suite-macos.yml
@@ -49,14 +49,14 @@ concurrency:
 
 jobs:
   macos-build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -118,10 +118,7 @@ jobs:
           sudo xcodebuild -runFirstLaunch
       - name: 🍺 Install Maestro
         run: |
-          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
-          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
-          # the Android emulator in CI.
-          curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.4.0 bash
+          curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   ios-build:
     if: github.repository == 'expo/expo'
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -31,8 +31,8 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.x
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true
@@ -90,7 +90,7 @@ jobs:
   ios-test:
     if: github.repository == 'expo/expo'
     needs: ios-build
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -100,8 +100,8 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.x
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds

--- a/.github/workflows/test-suite-nightly.yml
+++ b/.github/workflows/test-suite-nightly.yml
@@ -118,7 +118,10 @@ jobs:
           sudo xcodebuild -runFirstLaunch
       - name: 🍺 Install Maestro
         run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
+          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
+          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
+          # the Android emulator in CI.
+          curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.4.0 bash
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -239,7 +242,10 @@ jobs:
           path: apps/bare-expo/android/app/build/outputs/apk
       - name: 🍺 Install Maestro
         run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
+          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
+          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
+          # the Android emulator in CI.
+          curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.4.0 bash
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -136,7 +136,7 @@ jobs:
             "!packages/**/{ios,android}/**",
             "!apps/bare-expo/**/{ios,android}/**"
   ios-build:
-    runs-on: macos-15
+    runs-on: macos-26
     needs: detect-platform-changes
     if: needs.detect-platform-changes.outputs.should_build_ios == 'true'
     permissions:
@@ -149,8 +149,8 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.x
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: 🍺 Install required tools
         run: |
           brew install watchman || true
@@ -239,7 +239,7 @@ jobs:
   ios-test-e2e:
     needs: [ios-build, detect-platform-changes]
     if: needs.detect-platform-changes.outputs.should_test_ios == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: 👀 Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
@@ -249,8 +249,8 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.x
-      - name: 🔨 Switch to Xcode 26.2
-        run: sudo xcode-select --switch /Applications/Xcode_26.2.app
+      - name: 🔨 Switch to Xcode 26.4.1
+        run: sudo xcode-select --switch /Applications/Xcode_26.4.1.app
       - name: ➕ Add `bin` to GITHUB_PATH
         run: echo "$(pwd)/bin" >> $GITHUB_PATH
       - name: 🌠 Download builds

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -267,10 +267,7 @@ jobs:
           sudo xcodebuild -runFirstLaunch
       - name: 🍺 Install Maestro
         run: |
-          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
-          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
-          # the Android emulator in CI.
-          curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.4.0 bash
+          curl -Ls "https://get.maestro.mobile.dev" | bash
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -267,7 +267,10 @@ jobs:
           sudo xcodebuild -runFirstLaunch
       - name: 🍺 Install Maestro
         run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
+          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
+          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
+          # the Android emulator in CI.
+          curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.4.0 bash
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
@@ -457,7 +460,10 @@ jobs:
           path: apps/bare-expo/android/app/build/outputs/apk/release
       - name: 🍺 Install Maestro
         run: |
-          curl -Ls "https://get.maestro.mobile.dev" | bash
+          # Pinned to 2.4.0 — 2.5.0+ replaces TCP port forwarding with a direct ADB
+          # socket gRPC connection that fails (UNAVAILABLE / tcp:7001 closed) against
+          # the Android emulator in CI.
+          curl -Ls "https://get.maestro.mobile.dev" | MAESTRO_VERSION=2.4.0 bash
           echo "${HOME}/.maestro/bin" >> $GITHUB_PATH
       - name: 🔨 Install pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4

--- a/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
+++ b/apps/bare-expo/e2e/image-comparison/src/viewCropper.ts
@@ -31,13 +31,22 @@ interface ViewNode {
 
 async function dumpViewHierarchy(platform: 'ios' | 'android'): Promise<ViewNode> {
   const startTime = Date.now();
-  const result = await spawnAsync('maestro', [`--platform=${platform}`, 'hierarchy'], {
-    stdio: 'pipe',
-    env: {
-      ...process.env,
-      ...MAESTRO_ENV_VARS,
-    },
-  });
+  let result;
+  try {
+    result = await spawnAsync('maestro', [`--platform=${platform}`, 'hierarchy'], {
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        ...MAESTRO_ENV_VARS,
+      },
+    });
+  } catch (e: any) {
+    throw new Error(
+      `maestro --platform=${platform} hierarchy failed (exit ${e?.status}, signal ${e?.signal}):\n` +
+        `--- stderr ---\n${e?.stderr ?? '(empty)'}\n` +
+        `--- stdout ---\n${e?.stdout ?? '(empty)'}`
+    );
+  }
   const duration = Date.now() - startTime;
 
   console.log(`Maestro took ${duration}ms to capture the ${platform} view hierarchy`);

--- a/apps/bare-expo/scripts/lib/e2e-common.ts
+++ b/apps/bare-expo/scripts/lib/e2e-common.ts
@@ -139,6 +139,27 @@ export function prettyPrintTestSuiteLogs(logs: string[]) {
   return result.join('\n');
 }
 
+export async function printImageComparisonServerLogs(): Promise<void> {
+  const dir = path.join(process.env.HOME || '', '.maestro', 'tests');
+  try {
+    const entries = await fs.readdir(dir);
+    const matches = entries.filter((name) => name.startsWith('screenshot-server-logs'));
+    if (matches.length === 0) {
+      return;
+    }
+    const stats = await Promise.all(
+      matches.map(async (name) => ({ name, mtime: (await fs.stat(path.join(dir, name))).mtimeMs }))
+    );
+    stats.sort((a, b) => b.mtime - a.mtime);
+    const latest = path.join(dir, stats[0].name);
+    const contents = await fs.readFile(latest, 'utf8');
+    console.log(`\n\n  📜 Image comparison server logs (${latest}):\n`);
+    console.log(contents);
+  } catch (e: any) {
+    console.warn(`\n  ⚠️  Could not read image comparison server logs: ${e?.message ?? e}`);
+  }
+}
+
 export function setupLogger(command: string, signal: AbortSignal): () => Promise<string[]> {
   const [cmd, ...params] = command.split(' ');
   const loggerProcess = spawnAsync(cmd, params);

--- a/apps/bare-expo/scripts/start-android-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-android-e2e-test.ts
@@ -12,6 +12,7 @@ import {
   getStartMode,
   retryAsync,
   prettyPrintTestSuiteLogs,
+  printImageComparisonServerLogs,
   setupLogger,
   runCustomMaestroFlowsAsync,
   MAESTRO_ENV_VARS,
@@ -125,6 +126,7 @@ async function testAsync(
     console.warn(`\n⚠️ Maestro flow failed, because:\n\n`);
     const logs = await getLogs();
     console.log(prettyPrintTestSuiteLogs(logs));
+    await printImageComparisonServerLogs();
     if (!(await isAppRunning())) {
       if (logs.length > 0) {
         console.warn(

--- a/apps/bare-expo/scripts/start-ios-e2e-test.ts
+++ b/apps/bare-expo/scripts/start-ios-e2e-test.ts
@@ -14,6 +14,7 @@ import {
   getStartMode,
   retryAsync,
   prettyPrintTestSuiteLogs,
+  printImageComparisonServerLogs,
   runCustomMaestroFlowsAsync,
   MAESTRO_ENV_VARS,
   TEST_DURATION_LABEL,
@@ -244,6 +245,7 @@ async function testAsync(
       console.warn(`\n⚠️ Maestro flow failed, because:\n\n`);
 
       console.log(prettyPrintTestSuiteLogs(await getTestSuiteLogs()));
+      await printImageComparisonServerLogs();
       // we need to always get these logs since it stops listener process
       const nativeLogs = await getNativeErrorLogs();
       if (!(await isAppRunning())) {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -182,13 +182,15 @@ platform :ios do
     run_tests(
       workspace: workspace,
       scheme: generated_scheme,
-      devices: ["iPhone 17 Pro"],
+      # Bypass fastlane's `simctl runtime match list` lookup, which crashes on
+      # Xcode 26.4. xcodebuild resolves the destination directly.
+      destination: "platform=iOS Simulator,name=iPhone 17 Pro",
+      skip_detect_devices: true,
       configuration: 'Debug',
       clean: false,
       skip_build: true,
       # .github/workflows/ios-unit-tests.yml runs XCTests w/o needing a simulator
       prelaunch_simulator: false,
-      skip_detect_devices: false,
       skip_package_dependencies_resolution: true,
       derived_data_path: "/tmp/ExpoUnitTestsDerivedData",
       result_bundle: true,


### PR DESCRIPTION
# Why

The new minimum as claimed in https://expo.dev/changelog/sdk-56-beta#tool-version-bumps is 26.4.

I'd like to bump so that CI can build some features that depend on using xcode 26 without workarounds (not critical though in case we want to keep mac 15 runners longer for some reason).

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- green CI

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)