### PR TITLE
chore(metro-config): Drop internal `/exports` entrypoint

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - Switch Metro config resolution to `@expo/require-utils`, aligning with `@expo/config` and `@expo/config-plugins` ([#46155](https://github.com/expo/expo/pull/46155) by [@kitten](https://github.com/kitten))
 - Drop support for loading Metro configs outside the server root, from yaml files, and from `package.json:metro` outside the project root ([#46155](https://github.com/expo/expo/pull/46155) by [@kitten](https://github.com/kitten))
+- [Internal] Remove `@expo/metro-config/exports` ([#46164](https://github.com/expo/expo/pull/46164) by [@kitten](https://github.com/kitten))
 
 ## 56.0.11 — 2026-05-20
 

--- a/packages/@expo/metro-config/build/exports.d.ts
+++ b/packages/@expo/metro-config/build/exports.d.ts
@@ -1,1 +1,0 @@
-export { resolveBabelrcName } from './loadBabelConfig';

--- a/packages/@expo/metro-config/build/exports.js
+++ b/packages/@expo/metro-config/build/exports.js
@@ -1,6 +1,0 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.resolveBabelrcName = void 0;
-var loadBabelConfig_1 = require("./loadBabelConfig");
-Object.defineProperty(exports, "resolveBabelrcName", { enumerable: true, get: function () { return loadBabelConfig_1.resolveBabelrcName; } });
-//# sourceMappingURL=exports.js.map

--- a/packages/@expo/metro-config/build/exports.js.map
+++ b/packages/@expo/metro-config/build/exports.js.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"exports.js","sourceRoot":"","sources":["../src/exports.ts"],"names":[],"mappings":";;;AAAA,qDAAuD;AAA9C,qHAAA,kBAAkB,OAAA"}

--- a/packages/@expo/metro-config/exports.d.ts
+++ b/packages/@expo/metro-config/exports.d.ts
@@ -1,2 +1,0 @@
-// WARN: Internal re-export, you should avoid relying on this, if possible. Expect breaking changes between SDK releases
-export * from './build/exports';

--- a/packages/@expo/metro-config/exports.js
+++ b/packages/@expo/metro-config/exports.js
@@ -1,2 +1,0 @@
-// WARN: Internal re-export, you should avoid relying on this, if possible. Expect breaking changes between SDK releases
-module.exports = require('./build/exports');

--- a/packages/@expo/metro-config/package.json
+++ b/packages/@expo/metro-config/package.json
@@ -10,11 +10,6 @@
       "require": "./build/index.js",
       "default": "./build/index.js"
     },
-    "./exports": {
-      "types": "./build/exports.d.ts",
-      "require": "./build/exports.js",
-      "default": "./build/exports.js"
-    },
     "./babel-transformer": {
       "types": "./build/babel-transformer.d.ts",
       "require": "./build/babel-transformer.js",
@@ -57,9 +52,7 @@
   "files": [
     "build",
     "file-store",
-    "babel-transformer",
-    "exports.d.ts",
-    "exports.js"
+    "babel-transformer"
   ],
   "dependencies": {
     "@babel/code-frame": "^7.20.0",

--- a/packages/@expo/metro-config/src/exports.ts
+++ b/packages/@expo/metro-config/src/exports.ts
@@ -1,1 +1,0 @@
-export { resolveBabelrcName } from './loadBabelConfig';


### PR DESCRIPTION
## Summary

Follow-up to #46155

The `@expo/metro-config/exports` entrypoint was an internal re-export for `@expo/cli` that's now obsolete after the above PR. It wasn't used for anything else but exposing the Babel config resolution function.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
