### PR TITLE
docs(metro): Update `metro.config.js` link and note on config file discovery

### DIFF
--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -30,7 +30,7 @@ const config = getDefaultConfig(__dirname);
 module.exports = config;
 ```
 
-See [**metro.config.js** documentation](https://metrobundler.dev/docs/configuration/) for more information.
+See [**metro.config.js** documentation](/versions/latest/config/metro) for more information.
 
 ## Assets
 

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -32,6 +32,8 @@ module.exports = config;
 
 See [**metro.config.js** documentation](/versions/latest/config/metro) for more information.
 
+> **info** Expo locks down some Metro configuration options to prevent projects from breaking. Not every option upstream Metro accepts can be customized or is supported. Expo also doesn't support loading Metro configs from YAML files (deprecated upstream) or any Metro configs located outside your repository.
+
 ## Assets
 
 Metro resolves files as either source code or assets. Source code is JavaScript, TypeScript, JSON, and other files used by your application. [Assets](/develop/user-interface/assets/) are images, fonts, and other files that should not be transformed by Metro. To accommodate large-scale codebases, Metro requires all extensions for both source code and assets to be explicitly defined before starting the bundler. This is done by adding the `resolver.sourceExts` and `resolver.assetExts` options to the Metro configuration. By default, the following extensions are included:


### PR DESCRIPTION
## Summary

Follow-up to #46155

- We're loading Metro configs ourselves, as of the above PR, which means `metro.config.yml` (and similar YAML configs) will now be unsupported and refuse to load
- Similarly, that PR is restricting config discovery to the server root (and `package.json:metro` to the project root)

We may also want to link to our **metro.config.js** page and clarify that we may not have perfect 1:1 coverage with every customization that Metro usually allows

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
