### PR TITLE
[image][ios] Fix asset catalog names not loading

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix loading local assets.
+
 ### 💡 Others
 
 ## 56.0.8 — 2026-05-21

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix loading local assets.
+- [iOS] Fix loading local assets. ([#46169](https://github.com/expo/expo/pull/46169) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -840,7 +840,16 @@ public final class ImageView: ExpoView {
 }
 
 func localAssetName(from url: URL?) -> String? {
-  guard let url, url.scheme == nil else {
+  guard let url else {
+    return nil
+  }
+
+  if url.scheme == "file", !FileManager.default.fileExists(atPath: url.path) {
+    let name = url.lastPathComponent
+    return name.isEmpty ? nil : name
+  }
+
+  guard url.scheme == nil else {
     return nil
   }
 


### PR DESCRIPTION
# Why
Closes #46167

# How
 `convertToUrl()` assumes any schemeless string is a file path and wraps it with `URL(fileURLWithPath:)`, giving it a `file://` scheme. `localAssetName()` checks `url.scheme == nil` and bails, so the image falls through to SDWebImage which fails to load it as a URL.

# Test Plan
In the provided repro. Assets load as expected

