### PR TITLE
[expo-image][iOS] Fix loading images from the asset catalog (xcassets)

### DIFF
--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix `placeholder` failing to load images from the asset catalog (xcassets).
+
 ### 💡 Others
 
 ## 56.0.8 — 2026-05-21

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fix `placeholder` failing to load images from the asset catalog (xcassets).
+- [iOS] Fix native asset names (xcassets) not loading when passed from JS, since `ExpoModulesCore` wraps scheme-less URIs as `file://` URLs that the new `localAssetName` helper was rejecting (regression after #45686)
 
 ### 💡 Others
 

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix `placeholder` failing to load images from the asset catalog (xcassets).
-- [iOS] Fix native asset names (xcassets) not loading when passed from JS, since `ExpoModulesCore` wraps scheme-less URIs as `file://` URLs that the new `localAssetName` helper was rejecting (regression after #45686)
+- [iOS] Fix `placeholder` failing to load images from the asset catalog (xcassets). ([#46170](https://github.com/expo/expo/pull/46170) by [@zhelezkov](https://github.com/zhelezkov))
+- [iOS] Fix xcasset images not loading from JS due to `file://` scheme mismatch. ([#46170](https://github.com/expo/expo/pull/46170) by [@zhelezkov](https://github.com/zhelezkov))
 
 ### 💡 Others
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -352,14 +352,19 @@ public final class ImageView: ExpoView {
   }
 
   private func maybeRenderLocalAsset(from source: ImageSource) -> Bool {
-    let path = localAssetName(from: source.uri)
-
-    if let path, let local = UIImage(named: path) {
+    if let local = localAssetImage(from: source) {
       renderSourceImage(local)
       return true
     }
 
     return false
+  }
+
+  private func localAssetImage(from source: ImageSource) -> UIImage? {
+    guard let path = localAssetName(from: source.uri) else {
+      return nil
+    }
+    return UIImage(named: path)
   }
 
   // MARK: - Placeholder
@@ -409,6 +414,14 @@ public final class ImageView: ExpoView {
     // Exit early if placeholder is not set or there is already an image attached to the view.
     // The placeholder is only used until the first image is loaded.
     guard canDisplayPlaceholder, let placeholder = bestPlaceholder else {
+      return
+    }
+
+    // Asset catalog (xcassets) images aren't resolvable by SDWebImage, so try the
+    // local lookup first — mirroring the proper source path in `maybeRenderLocalAsset`.
+    if let localImage = localAssetImage(from: placeholder) {
+      placeholderImage = localImage
+      displayPlaceholderIfNecessary()
       return
     }
 

--- a/packages/expo-image/ios/ImageView.swift
+++ b/packages/expo-image/ios/ImageView.swift
@@ -853,18 +853,23 @@ public final class ImageView: ExpoView {
 }
 
 func localAssetName(from url: URL?) -> String? {
-  guard let url, url.scheme == nil else {
+  guard let url else {
     return nil
   }
 
-  var path = url.path
-  guard !path.isEmpty else {
+  // `ExpoModulesCore` converts scheme-less URI strings from JS via
+  // `URL(fileURLWithPath:)`, so asset names like "my_image" arrive here with
+  // `scheme == "file"`. Accept those alongside truly scheme-less URLs; reject
+  // remote/SF Symbol/blurhash/etc. schemes.
+  if let scheme = url.scheme, scheme != "file" {
     return nil
   }
 
+  // Use `relativePath` so we recover the original input ("my_image") instead of
+  // the absolute path it resolves to against the file:// base
+  var path = url.relativePath
   if path.hasPrefix("/") {
     path.removeFirst()
   }
-
   return path.isEmpty ? nil : path
 }

--- a/packages/expo-image/ios/Tests/ImageResizingSpec.swift
+++ b/packages/expo-image/ios/Tests/ImageResizingSpec.swift
@@ -137,6 +137,14 @@ class ImageResizingSpec: ExpoSpec {
         expect(localAssetName(from: URL(string: "/app_icon"))) == "app_icon"
       }
 
+      it("handles file URLs produced by ExpoModulesCore for scheme-less JS strings") {
+        // `ExpoModulesCore`'s `convertToUrl` wraps scheme-less JS strings via
+        // `URL(fileURLWithPath:)`, which is how asset names actually reach the native side.
+        expect(localAssetName(from: URL(fileURLWithPath: "app_icon"))) == "app_icon"
+        expect(localAssetName(from: URL(fileURLWithPath: "/app_icon"))) == "app_icon"
+        expect(localAssetName(from: URL(fileURLWithPath: "Images/MyIcon"))) == "Images/MyIcon"
+      }
+
       it("ignores urls with a scheme") {
         expect(localAssetName(from: URL(string: "https://example.com/app_icon.png"))).to(beNil())
         expect(localAssetName(from: URL(string: "sf:/star"))).to(beNil())


### PR DESCRIPTION
Hey, I had PR #45874, but it was closed in favor of PR #45686, which unfortunately breaks completely how images from assets catalog loads. Plus it doesn't fix what was addressed in my PR.

Just in case I know how hard it review the massive amount of PRs you have, but I'm not just another AI bot that spams PRs, I tested everything manually 😭

---
# Why

Two related issues prevent images from the iOS asset catalog from loading correctly:

1. Regression from #45686. That PR added a `localAssetName(from:)` helper that rejects URLs whose `scheme != nil`. But ExpoModulesCore's convertToUrl (`packages/expo-modules-core/ios/Utilities/Utilities.swift:82-83`) re-wraps every scheme-less JS string via `URL(fileURLWithPath:)`, so by the time an asset name like "my_image" reaches the native side it's `file:///my_image` with `scheme == "file"`. The guard rejects all of them and `<Image source={{ uri: 'my_image' }} />` silently fails to load on devices.
2. placeholder ignores xcasset names. When the placeholder prop is set to an image bundled in Assets.xcassets, it never appears — setPlaceholder only goes through SDWebImage, which can't resolve asset-catalog names. Only the main source had the local-asset lookup.

The upstream tests for localAssetName constructed URLs with `URL(string: "app_icon")` directly, which bypasses the JS→native conversion path, so the regression slipped through.

# How

- `maybeRenderLocalAsset` extracted to a reusable `localAssetImage(from:)` method so setPlaceholder can use the same xcasset lookup before falling through to SDWebImage.
- setPlaceholder now tries localAssetImage first and short-circuits when an asset is found, mirroring how source is handled.
- `localAssetName(from:)` accepts file-scheme URLs in addition to scheme-less ones, since ExpoModulesCore produces the former for bare asset names.

# Test Plan

- Added a small test in `ImageResizingSpec.swift` that exercises the real JS→native form via `URL(fileURLWithPath:)` ("app_icon", "/app_icon", "Images/MyIcon"), so the regression can't slip through again. Existing tests for raw URL(string:) inputs still pass.
- Manually verified in a React Native app:
  - `<Image source={{ uri: 'my_image' }} />` where my_image is in Assets.xcassets — image renders.
  - `<Image source={{ uri: 'https://example.com/foo.png' }} placeholder={{ uri: 'my_image' }} />` — placeholder shows before the remote image arrives.
  - Remote, file://, sf:, blurhash:, and thumbhash: sources still route through their normal paths and are unaffected.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
