### PR TITLE
fix(cli): Force post-rewrite resolutions to resolve from `projectRoot`

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - Fix launching apps on physical iOS devices causing system-dependent crashes ([#46128](https://github.com/expo/expo/pull/46128) by [@kitten](https://github.com/kitten))
+- Fix post-rewrite resolutions failing since they may be resolved from a random module path ([#46172](https://github.com/expo/expo/pull/46172) by [@kitten](https://github.com/kitten))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
+++ b/packages/@expo/cli/src/start/server/metro/withMetroMultiPlatform.ts
@@ -605,10 +605,18 @@ export function withExtendedResolver(
       moduleName: string,
       platform: string | null
     ) {
-      const doResolve = getStrictResolver(context, platform);
+      // TODO(@kitten): replace and abstract doResolve logic, since it's unsafe and inefficient
+      function doResolve(moduleName: string) {
+        const projectRootContext: ResolutionContext = {
+          ...context,
+          nodeModulesPaths: [],
+          originModulePath: projectRootOriginPath,
+          disableHierarchicalLookup: false,
+        };
+        return getStrictResolver(projectRootContext, platform)(moduleName);
+      }
 
-      const result = doResolve(moduleName);
-
+      const result = getStrictResolver(context, platform)(moduleName);
       if (result.type !== 'sourceFile') {
         return result;
       }
@@ -742,6 +750,7 @@ export function withExtendedResolver(
         if (hmrModule) return hmrModule;
 
         if (useExpoUnstableLogBox) {
+          // TODO(@kitten): This can never resolve with isolated dependencies
           const logBoxModule = doReplace(
             'react-native/Libraries/LogBox/LogBoxInspectorContainer.js',
             '@expo/log-box/swap-rn-logbox.js'


### PR DESCRIPTION
## Summary

These resolutions may fail and break the project, since they don't account for isolated dependencies **outside** of the `projectRoot`. Instead of a hard failure, we should resolve against the `projectRoot` forcefully.

This isn't 100% correct and doesn't take into account that some resolutions here are already invalid, e.g. `@expo/log-box`, but this fix is preferable to breaking projects with isolated dependencies outside of the project root.

## Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
