### PR TITLE
[docs] Add Workflows REST API page

### DIFF
--- a/docs/constants/navigation.js
+++ b/docs/constants/navigation.js
@@ -453,6 +453,7 @@ export const eas = [
     makePage('eas/workflows/pre-packaged-jobs.mdx'),
     makePage('eas/workflows/syntax.mdx'),
     makePage('eas/workflows/automating-eas-cli.mdx'),
+    makePage('eas/workflows/rest-api.mdx'),
     makePage('eas/workflows/limitations.mdx'),
     makeGroup('Examples', [
       makePage('eas/workflows/examples/introduction.mdx'),

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -35,7 +35,7 @@ Resolves the workflow file on the given Git ref, validates `inputs` against the 
 
 | Field      | Type          | Required | Description                                                                                                                  |
 | ---------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `appId`    | string (UUID) | Yes      | The EAS project ID. Find it on the project page or in **app.json** under `extra.eas.projectId`.                              |
+| `appId`    | string (UUID) | Yes      | The EAS project ID. Find it on the project page or in [app config](/workflow/configuration/) under `extra.eas.projectId`.                              |
 | `gitRef`   | string        | Yes      | A branch name (`main`), tag (`v1.0.0`), commit SHA, or fully qualified ref (`refs/heads/main`, `refs/tags/v1.0.0`).          |
 | `fileName` | string        | Yes      | The workflow file name only, such as **deploy.yml**. Do not include the **.eas/workflows/** prefix or any other path segments. |
 | `inputs`   | object        | No       | Values for inputs declared under `on.workflow_dispatch.inputs` in the workflow file. Validated against the declared schema.  |

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -37,7 +37,7 @@ Resolves the workflow file on the given Git ref, validates `inputs` against the 
 | ---------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `appId`    | string (UUID) | Yes      | The EAS project ID. Find it on the project page or in **app.json** under `extra.eas.projectId`.                              |
 | `gitRef`   | string        | Yes      | A branch name (`main`), tag (`v1.0.0`), commit SHA, or fully qualified ref (`refs/heads/main`, `refs/tags/v1.0.0`).          |
-| `fileName` | string        | Yes      | The workflow file name only, such as `deploy.yml`. Do not include the **.eas/workflows/** prefix or any other path segments. |
+| `fileName` | string        | Yes      | The workflow file name only, such as **deploy.yml**. Do not include the **.eas/workflows/** prefix or any other path segments. |
 | `inputs`   | object        | No       | Values for inputs declared under `on.workflow_dispatch.inputs` in the workflow file. Validated against the declared schema.  |
 
 ### Response

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -1,7 +1,7 @@
 ---
 title: Workflows REST API
 sidebar_title: REST API
-description: Trigger an EAS Workflow and check its status from your own systems with the EAS REST API.
+description: Trigger a workflow and check its status from your own systems with the EAS REST API.
 ---
 
 import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -16,7 +16,7 @@ All endpoints described below live under `https://api.expo.dev` and accept and r
 
 Both endpoints require an EAS access token, sent as a bearer token in the `Authorization` header.
 
-For production integrations, create a [robot user](/accounts/programmatic-access/#robot-users-and-access-tokens) on the account that owns the project and give it a scoped role. The token then represents the bot, not a person, and you can revoke it without affecting any user. A [personal access token](/accounts/programmatic-access/#personal-access-tokens) also works for one-off scripts.
+For production integrations, create a [robot user](/accounts/programmatic-access/#robot-users-and-access-tokens) on the account that owns the project and give it a scoped role. The token then represents the bot, not a person. You can revoke it without affecting any user. A [personal access token](/accounts/programmatic-access/#personal-access-tokens) also works for one-off scripts.
 
 ```text
 Authorization: Bearer <EXPO_TOKEN>

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -7,10 +7,9 @@ description: Trigger a workflow and check its status from your own systems with 
 import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 
 import { BoxLink } from '~/ui/components/BoxLink';
+import { Terminal } from '~/ui/components/Snippet';
 
-The EAS REST API lets you trigger a workflow and check its status without going through the EAS CLI. Use it from your own CI system, a chat bot, an internal dashboard, or any service that can make HTTP requests.
-
-All endpoints described below live under `https://api.expo.dev` and accept and return JSON.
+The EAS REST API exposes endpoints for triggering a workflow and reading run details. All endpoints live under `https://api.expo.dev` and accept and return JSON.
 
 ## Authentication
 
@@ -33,12 +32,12 @@ Resolves the workflow file on the given Git ref, validates `inputs` against the 
 
 ### Request body
 
-| Field      | Type          | Required | Description                                                                                                                  |
-| ---------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `appId`    | string (UUID) | Yes      | The EAS project ID. Find it on the project page or in [app config](/workflow/configuration/) under `extra.eas.projectId`.                              |
-| `gitRef`   | string        | Yes      | A branch name (`main`), tag (`v1.0.0`), commit SHA, or fully qualified ref (`refs/heads/main`, `refs/tags/v1.0.0`).          |
+| Field      | Type          | Required | Description                                                                                                                    |
+| ---------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `appId`    | string (UUID) | Yes      | The EAS project ID. Find it on the project page or in [app config](/workflow/configuration/) under `extra.eas.projectId`.      |
+| `gitRef`   | string        | Yes      | A branch name (`main`), tag (`v1.0.0`), commit SHA, or fully qualified ref (`refs/heads/main`, `refs/tags/v1.0.0`).            |
 | `fileName` | string        | Yes      | The workflow file name only, such as **deploy.yml**. Do not include the **.eas/workflows/** prefix or any other path segments. |
-| `inputs`   | object        | No       | Values for inputs declared under `on.workflow_dispatch.inputs` in the workflow file. Validated against the declared schema.  |
+| `inputs`   | object        | No       | Values for inputs declared under `on.workflow_dispatch.inputs` in the workflow file. Validated against the declared schema.    |
 
 ### Response
 
@@ -144,11 +143,11 @@ Each entry in `jobs` includes its own `status`, one of:
 | `canceled`        | The job was canceled. Terminal.                                      |
 | `skipped`         | The job was skipped because a required upstream job did not succeed. |
 
-`outputs` contains any values the job set with `outputs:` in the workflow file. Secrets that were referenced when those values were written are replaced with placeholders before being returned. `buildId` and `submissionId` are present on jobs of `type: build` and `type: submission` and link to the underlying EAS Build or EAS Submit record.
+`outputs` contains any values the job set with `outputs:` in the workflow file, with referenced secrets replaced by placeholders. Jobs of `type: build` include `buildId`, and jobs of `type: submission` include `submissionId`, which link to the underlying EAS Build or EAS Submit record.
 
 ### Example
 
-Trigger a run and poll until it reaches a terminal status:
+Save the following as a shell script (or paste into your terminal) to trigger a run and poll until it reaches a terminal status:
 
 ```bash
 RUN_ID=$(curl -s -X POST "https://api.expo.dev/v2/workflows/dispatch" \

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -75,13 +75,13 @@ curl -X POST "https://api.expo.dev/v2/workflows/dispatch" \
 | 403    | The token does not have access to the given `appId`.                                                |
 | 404    | The Git ref does not exist in the linked repository, or the workflow file is not found on that ref. |
 
-## Check a workflow run's status
+## Get a workflow run
 
 ```text
-GET /v2/workflows/runs/:workflowRunId/status
+GET /v2/workflows/runs/:workflowRunId
 ```
 
-Use this to poll for completion after triggering a run. The endpoint returns the run's current status only, so it is cheap to call on a short interval.
+Returns the workflow run and the jobs it contains. Use it to poll for completion after triggering a run, or to render a run's details in your own UI.
 
 ### Response
 
@@ -89,12 +89,36 @@ Use this to poll for completion after triggering a run. The endpoint returns the
 {
   "data": {
     "id": "019d9d17-013a-7e05-89aa-4aa83ff68c32",
-    "status": "in-progress"
+    "status": "in-progress",
+    "url": "https://expo.dev/accounts/acme/projects/example/workflows/019d9d17-013a-7e05-89aa-4aa83ff68c32",
+    "gitCommitHash": "564b61ebdd403d28b5dc616a12ce160b91585b5b",
+    "gitCommitMessage": "Add home screen",
+    "requestedGitRef": "refs/heads/main",
+    "triggerEventType": "MANUAL",
+    "createdAt": "2026-05-22T15:04:11.000Z",
+    "updatedAt": "2026-05-22T15:05:42.000Z",
+    "jobs": [
+      {
+        "id": "019d9d17-1a3f-7c10-bdee-5f2811a9d6ad",
+        "key": "build_ios",
+        "name": "Build iOS",
+        "type": "build",
+        "status": "in-progress",
+        "requiredJobKeys": [],
+        "environment": "production",
+        "outputs": {},
+        "errors": [],
+        "buildId": "f9609423-5072-4ea2-a0a5-c345eedf2c2a",
+        "submissionId": null,
+        "createdAt": "2026-05-22T15:04:11.000Z",
+        "updatedAt": "2026-05-22T15:04:42.000Z"
+      }
+    ]
   }
 }
 ```
 
-`status` is one of:
+`status` on the run is one of:
 
 | Value             | Meaning                                                             |
 | ----------------- | ------------------------------------------------------------------- |
@@ -104,6 +128,21 @@ Use this to poll for completion after triggering a run. The endpoint returns the
 | `success`         | The run finished and every job succeeded. Terminal.                 |
 | `failure`         | The run finished with at least one failed job. Terminal.            |
 | `canceled`        | The run was canceled before it finished. Terminal.                  |
+
+Each entry in `jobs` includes its own `status`, one of:
+
+| Value             | Meaning                                                              |
+| ----------------- | -------------------------------------------------------------------- |
+| `new`             | The job is queued.                                                   |
+| `in-progress`     | The job is running.                                                  |
+| `action-required` | The job is paused and waiting on a manual action, such as approval.  |
+| `pending-cancel`  | A cancellation has been requested but the job has not stopped yet.   |
+| `success`         | The job succeeded. Terminal.                                         |
+| `failure`         | The job failed. Terminal.                                            |
+| `canceled`        | The job was canceled. Terminal.                                      |
+| `skipped`         | The job was skipped because a required upstream job did not succeed. |
+
+`outputs` contains any values the job set with `outputs:` in the workflow file. Secrets that were referenced when those values were written are replaced with placeholders before being returned. `buildId` and `submissionId` are present on jobs of `type: build` and `type: submission` and link to the underlying EAS Build or EAS Submit record.
 
 ### Example
 
@@ -117,7 +156,7 @@ RUN_ID=$(curl -s -X POST "https://api.expo.dev/v2/workflows/dispatch" \
   | jq -r '.data.id')
 
 while true; do
-  STATUS=$(curl -s "https://api.expo.dev/v2/workflows/runs/$RUN_ID/status" \
+  STATUS=$(curl -s "https://api.expo.dev/v2/workflows/runs/$RUN_ID" \
     -H "Authorization: Bearer $EXPO_TOKEN" \
     | jq -r '.data.status')
   echo "status: $STATUS"

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -150,7 +150,7 @@ Each entry in `jobs` includes its own `status`, one of:
 
 Trigger a run and poll until it reaches a terminal status:
 
-```sh
+```bash
 RUN_ID=$(curl -s -X POST "https://api.expo.dev/v2/workflows/dispatch" \
   -H "Authorization: Bearer $EXPO_TOKEN" \
   -H "Content-Type: application/json" \

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -1,0 +1,146 @@
+---
+title: Workflows REST API
+sidebar_title: REST API
+description: Trigger an EAS Workflow and check its status from your own systems with the EAS REST API.
+---
+
+import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
+
+import { BoxLink } from '~/ui/components/BoxLink';
+
+The EAS REST API lets you trigger a workflow and check its status without going through the EAS CLI. Use it from your own CI system, a chat bot, an internal dashboard, or any service that can make HTTP requests.
+
+All endpoints described below live under `https://api.expo.dev` and accept and return JSON.
+
+## Authentication
+
+Both endpoints require an EAS access token, sent as a bearer token in the `Authorization` header.
+
+For production integrations, create a [robot user](/accounts/programmatic-access/#robot-users-and-access-tokens) on the account that owns the project and give it a scoped role. The token then represents the bot, not a person, and you can revoke it without affecting any user. A [personal access token](/accounts/programmatic-access/#personal-access-tokens) also works for one-off scripts.
+
+```text
+Authorization: Bearer <EXPO_TOKEN>
+Content-Type: application/json
+```
+
+## Trigger a workflow
+
+```text
+POST /v2/workflows/dispatch
+```
+
+Resolves the workflow file on the given Git ref, validates `inputs` against the `workflow_dispatch` schema declared in the workflow, and enqueues a new run.
+
+### Request body
+
+| Field      | Type          | Required | Description                                                                                                                  |
+| ---------- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `appId`    | string (UUID) | Yes      | The EAS project ID. Find it on the project page or in **app.json** under `extra.eas.projectId`.                              |
+| `gitRef`   | string        | Yes      | A branch name (`main`), tag (`v1.0.0`), commit SHA, or fully qualified ref (`refs/heads/main`, `refs/tags/v1.0.0`).          |
+| `fileName` | string        | Yes      | The workflow file name only, such as `deploy.yml`. Do not include the **.eas/workflows/** prefix or any other path segments. |
+| `inputs`   | object        | No       | Values for inputs declared under `on.workflow_dispatch.inputs` in the workflow file. Validated against the declared schema.  |
+
+### Response
+
+Returns `200 OK` with the new workflow run ID and a link to the run in the dashboard:
+
+```json
+{
+  "data": {
+    "id": "019d9d17-013a-7e05-89aa-4aa83ff68c32",
+    "url": "https://expo.dev/accounts/acme/projects/example/workflows/019d9d17-013a-7e05-89aa-4aa83ff68c32"
+  }
+}
+```
+
+### Example
+
+```sh
+curl -X POST "https://api.expo.dev/v2/workflows/dispatch" \
+  -H "Authorization: Bearer $EXPO_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "appId": "a415eac6-231a-4b38-b481-3255a59f13b8",
+    "gitRef": "main",
+    "fileName": "deploy.yml",
+    "inputs": { "environment": "production" }
+  }'
+```
+
+### Errors
+
+| Status | Reason                                                                                              |
+| ------ | --------------------------------------------------------------------------------------------------- |
+| 400    | The request body fails schema validation, or `inputs` do not match the workflow's declared schema.  |
+| 403    | The token does not have access to the given `appId`.                                                |
+| 404    | The Git ref does not exist in the linked repository, or the workflow file is not found on that ref. |
+
+## Check a workflow run's status
+
+```text
+GET /v2/workflows/runs/:workflowRunId/status
+```
+
+Use this to poll for completion after triggering a run. The endpoint returns the run's current status only, so it is cheap to call on a short interval.
+
+### Response
+
+```json
+{
+  "data": {
+    "id": "019d9d17-013a-7e05-89aa-4aa83ff68c32",
+    "status": "in-progress"
+  }
+}
+```
+
+`status` is one of:
+
+| Value             | Meaning                                                             |
+| ----------------- | ------------------------------------------------------------------- |
+| `new`             | The run is queued and has not started yet.                          |
+| `in-progress`     | At least one job is running.                                        |
+| `action-required` | The run is paused and waiting on a manual action, such as approval. |
+| `success`         | The run finished and every job succeeded. Terminal.                 |
+| `failure`         | The run finished with at least one failed job. Terminal.            |
+| `canceled`        | The run was canceled before it finished. Terminal.                  |
+
+### Example
+
+Trigger a run and poll until it reaches a terminal status:
+
+```sh
+RUN_ID=$(curl -s -X POST "https://api.expo.dev/v2/workflows/dispatch" \
+  -H "Authorization: Bearer $EXPO_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"appId":"...","gitRef":"main","fileName":"deploy.yml"}' \
+  | jq -r '.data.id')
+
+while true; do
+  STATUS=$(curl -s "https://api.expo.dev/v2/workflows/runs/$RUN_ID/status" \
+    -H "Authorization: Bearer $EXPO_TOKEN" \
+    | jq -r '.data.status')
+  echo "status: $STATUS"
+  case "$STATUS" in
+    success|failure|canceled) break ;;
+  esac
+  sleep 10
+done
+```
+
+### Errors
+
+| Status | Reason                                               |
+| ------ | ---------------------------------------------------- |
+| 400    | `workflowRunId` is not a valid UUID.                 |
+| 403    | The token does not have access to the run's project. |
+| 404    | No workflow run exists with that ID.                 |
+
+## Next step
+
+<BoxLink
+  href="/eas/workflows/syntax/"
+  title="Workflow syntax"
+  description="Reference for the workflow YAML file, including the workflow_dispatch trigger and input schema."
+  Icon={Dataflow03Icon}
+/>

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -55,17 +55,19 @@ Returns `200 OK` with the new workflow run ID and a link to the run in the dashb
 
 ### Example
 
-```sh
-curl -X POST "https://api.expo.dev/v2/workflows/dispatch" \
-  -H "Authorization: Bearer $EXPO_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "appId": "a415eac6-231a-4b38-b481-3255a59f13b8",
-    "gitRef": "main",
-    "fileName": "deploy.yml",
-    "inputs": { "environment": "production" }
-  }'
-```
+<Terminal
+  cmd={[
+    `$ curl -X POST "https://api.expo.dev/v2/workflows/dispatch" \\`,
+    `    -H "Authorization: Bearer $EXPO_TOKEN" \\`,
+    `    -H "Content-Type: application/json" \\`,
+    `    -d '{`,
+    `      "appId": "a415eac6-231a-4b38-b481-3255a59f13b8",`,
+    `      "gitRef": "main",`,
+    `      "fileName": "deploy.yml",`,
+    `      "inputs": { "environment": "production" }`,
+    `    }'`,
+  ]}
+/>
 
 ### Errors
 

--- a/docs/pages/eas/workflows/rest-api.mdx
+++ b/docs/pages/eas/workflows/rest-api.mdx
@@ -9,13 +9,13 @@ import { Dataflow03Icon } from '@expo/styleguide-icons/outline/Dataflow03Icon';
 import { BoxLink } from '~/ui/components/BoxLink';
 import { Terminal } from '~/ui/components/Snippet';
 
-The EAS REST API exposes endpoints for triggering a workflow and reading run details. All endpoints live under `https://api.expo.dev` and accept and return JSON.
+The EAS REST API exposes endpoints for triggering a workflow and reading run details. All endpoints live under `https://api.expo.dev`. Requests and responses are JSON.
 
 ## Authentication
 
 Both endpoints require an EAS access token, sent as a bearer token in the `Authorization` header.
 
-For production integrations, create a [robot user](/accounts/programmatic-access/#robot-users-and-access-tokens) on the account that owns the project and give it a scoped role. The token then represents the bot, not a person. You can revoke it without affecting any user. A [personal access token](/accounts/programmatic-access/#personal-access-tokens) also works for one-off scripts.
+For production integrations, create a [robot user](/accounts/programmatic-access/#robot-users-and-access-tokens) on the account that owns the project and give it a scoped role. The token then represents the robot user, not a person. You can revoke it without affecting any user. A [personal access token](/accounts/programmatic-access/#personal-access-tokens) also works for one-off scripts.
 
 ```text
 Authorization: Bearer <EXPO_TOKEN>
@@ -82,7 +82,7 @@ Returns `200 OK` with the new workflow run ID and a link to the run in the dashb
 GET /v2/workflows/runs/:workflowRunId
 ```
 
-Returns the workflow run and the jobs it contains. Use it to poll for completion after triggering a run, or to render a run's details in your own UI.
+Returns the workflow run and the jobs it contains. Use this endpoint to poll for completion after triggering a run, or to render a run's details in your own UI.
 
 ### Response
 
@@ -119,7 +119,7 @@ Returns the workflow run and the jobs it contains. Use it to poll for completion
 }
 ```
 
-`status` on the run is one of:
+The run's `status` is one of:
 
 | Value             | Meaning                                                             |
 | ----------------- | ------------------------------------------------------------------- |
@@ -143,7 +143,7 @@ Each entry in `jobs` includes its own `status`, one of:
 | `canceled`        | The job was canceled. Terminal.                                      |
 | `skipped`         | The job was skipped because a required upstream job did not succeed. |
 
-`outputs` contains any values the job set with `outputs:` in the workflow file, with referenced secrets replaced by placeholders. Jobs of `type: build` include `buildId`, and jobs of `type: submission` include `submissionId`, which link to the underlying EAS Build or EAS Submit record.
+`outputs` contains any values the job sets with `outputs:` in the workflow file. Any referenced secrets appear as placeholders in the response. Jobs of `type: build` include `buildId`, and jobs of `type: submission` include `submissionId`. Each ID links to the underlying EAS Build or EAS Submit record.
 
 ### Example
 


### PR DESCRIPTION
## Why

Document the new `POST /v2/workflows/dispatch` route  and the upcoming `GET /v2/workflows/runs/:workflowRunId` route so external integrations have a single, discoverable home for triggering workflows and reading run details.

## How

New page **pages/eas/workflows/rest-api.mdx** linked into the EAS Workflows sidebar between `automating-eas-cli` and `limitations`. Covers:

- Authentication via robot user or personal access token (links to `programmatic-access`).
- `POST /v2/workflows/dispatch` — request body, accepted `gitRef` forms, `fileName` basename rule, `inputs` validation, response, errors, curl example.
- `GET /v2/workflows/runs/:workflowRunId` — request, full run payload (run fields + jobs array), run and job status enums (terminal states marked), errors, a poll-until-terminal bash snippet.

## Test Plan

- `pnpm lint-prose` — 0 errors, 0 warnings, 0 suggestions
- `pnpm lint-links` — clean
- `pnpm lint` — `tsc` and `eslint` clean; `oxfmt --check` clean on touched files