### PR TITLE
[autolinking] automatically bump autolinked expo modules deployment target

### DIFF
--- a/packages/expo-modules-autolinking/CHANGELOG.md
+++ b/packages/expo-modules-autolinking/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Align precompile feature flags for `react-native-worklets@0.8.3` and `react-native-reanimated@4.3.1` with upstream defaults. ([#46221](https://github.com/expo/expo/pull/46221) by [@chrfalch](https://github.com/chrfalch))
+- [iOS] Raise every autolinked Expo module's deployment target to at least `ExpoModulesCore`'s during `pod install`, so adapters whose podspecs declare a lower platform value no longer fail. ([#46175](https://github.com/expo/expo/pull/46175) by [@vonovak](https://github.com/vonovak))
 
 ### 💡 Others
 

--- a/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
@@ -108,6 +108,7 @@ module Expo
 
             # Install the pod.
             @podfile.pod(pod.pod_name, pod_options)
+            @podfile.expo_autolinked_pod_names << pod.pod_name
 
             # TODO: Can remove this once we move all the interfaces into the core.
             next if pod.pod_name.end_with?('Interface')

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -100,16 +100,19 @@ module Pod
 
     private
 
-    # Mapping from Pod::Platform symbol to the Xcode build setting key
-    # that stores its deployment target.
-    EXPO_DEPLOYMENT_TARGET_KEYS = {
-      ios: 'IPHONEOS_DEPLOYMENT_TARGET',
-      osx: 'MACOSX_DEPLOYMENT_TARGET',
-      tvos: 'TVOS_DEPLOYMENT_TARGET',
-    }.freeze
-
     # See call site in perform_post_install_actions for rationale.
+    # This runs AFTER the user's `post_install` hook, so it will overwrite any
+    # deployment target a consumer set there for an Expo module. That is
+    # intentional — the bumped pod list is logged so the override is visible.
     def reconcile_expo_module_deployment_targets
+      # Mapping from Pod::Platform symbol to the Xcode build setting key
+      # that stores its deployment target.
+      deployment_target_keys = {
+        ios: 'IPHONEOS_DEPLOYMENT_TARGET',
+        osx: 'MACOSX_DEPLOYMENT_TARGET',
+        tvos: 'TVOS_DEPLOYMENT_TARGET',
+      }
+
       expo_pod_names = @podfile.expo_autolinked_pod_names.to_set
       return if expo_pod_names.empty?
 
@@ -117,14 +120,17 @@ module Pod
       core_spec = core_target&.root_spec
       return if core_spec.nil?
 
-      required = EXPO_DEPLOYMENT_TARGET_KEYS
+      required = deployment_target_keys
         .map { |platform, key| [key, core_spec.deployment_target(platform)] }
         .reject { |_, value| value.nil? || value.empty? }
         .to_h
       return if required.empty?
 
       bumped = []
-      self.target_installation_results.pod_target_installation_results.each do |pod_name, result|
+      self.target_installation_results.pod_target_installation_results.each_value do |result|
+        # Keys in pod_target_installation_results are target names, which can
+        # differ from pod names under scoped targets — use pod_name explicitly.
+        pod_name = result.target.pod_name
         next unless expo_pod_names.include?(pod_name)
         next if pod_name == 'ExpoModulesCore'
 
@@ -133,7 +139,9 @@ module Pod
           required.each do |key, required_version|
             current = config.build_settings[key]
             # nil means the pod doesn't target this platform — don't create a setting for it.
-            next if current.nil?
+            # Empty string or an xcconfig reference (e.g. `$(inherited)`) means we can't
+            # compare versions, so leave it alone.
+            next if current.nil? || current.empty? || current.start_with?('$')
             if Gem::Version.new(current) < Gem::Version.new(required_version)
               config.build_settings[key] = required_version
               target_bumped = true
@@ -144,9 +152,9 @@ module Pod
       end
 
       unless bumped.empty?
-        ios_required = required['IPHONEOS_DEPLOYMENT_TARGET'] || '?'
+        summary = required.map { |key, value| "#{key.sub('_DEPLOYMENT_TARGET', '')}=#{value}" }.join(' ')
         Pod::UI.puts "[Expo] ".blue +
-          "Raised deployment target to #{ios_required} for #{bumped.size} Expo modules (matching ExpoModulesCore)".yellow
+          "Raised deployment target (#{summary}) for #{bumped.size} Expo modules matching ExpoModulesCore: #{bumped.join(', ')}".yellow
         self.pods_project.save
       end
     end

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -106,11 +106,11 @@ module Pod
     # intentional — the bumped pod list is logged so the override is visible.
     def reconcile_expo_module_deployment_targets
       # Mapping from Pod::Platform symbol to the Xcode build setting key
-      # that stores its deployment target.
-      deployment_target_keys = {
-        ios: 'IPHONEOS_DEPLOYMENT_TARGET',
-        osx: 'MACOSX_DEPLOYMENT_TARGET',
-        tvos: 'TVOS_DEPLOYMENT_TARGET',
+      # that stores its deployment target and a human-readable label.
+      deployment_targets = {
+        ios:  { key: 'IPHONEOS_DEPLOYMENT_TARGET', label: 'iOS'   },
+        osx:  { key: 'MACOSX_DEPLOYMENT_TARGET',   label: 'macOS' },
+        tvos: { key: 'TVOS_DEPLOYMENT_TARGET',     label: 'tvOS'  },
       }
 
       expo_pod_names = @podfile.expo_autolinked_pod_names.to_set
@@ -120,13 +120,13 @@ module Pod
       core_spec = core_target&.root_spec
       return if core_spec.nil?
 
-      required = deployment_target_keys
-        .map { |platform, key| [key, core_spec.deployment_target(platform)] }
-        .reject { |_, value| value.nil? || value.empty? }
+      required = deployment_targets
+        .map { |platform, info| [info[:key], { label: info[:label], version: core_spec.deployment_target(platform) }] }
+        .reject { |_, info| info[:version].nil? || info[:version].empty? }
         .to_h
       return if required.empty?
 
-      bumped = []
+      bumped = {} # pod_name => Array of bumped platform labels
       self.target_installation_results.pod_target_installation_results.each_value do |result|
         # Keys in pod_target_installation_results are target names, which can
         # differ from pod names under scoped targets — use pod_name explicitly.
@@ -134,27 +134,29 @@ module Pod
         next unless expo_pod_names.include?(pod_name)
         next if pod_name == 'ExpoModulesCore'
 
-        target_bumped = false
+        bumped_platforms = []
         result.native_target.build_configurations.each do |config|
-          required.each do |key, required_version|
+          required.each do |key, info|
             current = config.build_settings[key]
             # nil means the pod doesn't target this platform — don't create a setting for it.
             # Empty string or an xcconfig reference (e.g. `$(inherited)`) means we can't
             # compare versions, so leave it alone.
             next if current.nil? || current.empty? || current.start_with?('$')
-            if Gem::Version.new(current) < Gem::Version.new(required_version)
-              config.build_settings[key] = required_version
-              target_bumped = true
-            end
+            next unless Gem::Version.new(current) < Gem::Version.new(info[:version])
+            config.build_settings[key] = info[:version]
+            bumped_platforms << info[:label] unless bumped_platforms.include?(info[:label])
           end
         end
-        bumped << pod_name if target_bumped
+        bumped[pod_name] = bumped_platforms unless bumped_platforms.empty?
       end
 
       unless bumped.empty?
-        summary = required.map { |key, value| "#{key.sub('_DEPLOYMENT_TARGET', '')}=#{value}" }.join(' ')
-        Pod::UI.puts "[Expo] ".blue +
-          "Raised deployment target (#{summary}) for #{bumped.size} Expo modules matching ExpoModulesCore: #{bumped.join(', ')}".yellow
+        versions_by_label = required.values.map { |info| [info[:label], info[:version]] }.to_h
+        Pod::UI.puts "[Expo] ".blue + "Raised deployment target for Expo modules matching ExpoModulesCore:".yellow
+        bumped.each do |pod_name, platforms|
+          summary = platforms.map { |label| "#{label}=#{versions_by_label[label]}" }.join(' ')
+          Pod::UI.puts "  #{pod_name} (#{summary})".yellow
+        end
         self.pods_project.save
       end
     end

--- a/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
+++ b/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
@@ -19,6 +19,14 @@ module Pod
     def expo_add_modules_to_patch(modules)
       framework_modules_to_patch.concat(modules)
     end
+
+    # Pod names of Expo modules registered by `use_expo_modules!`.
+    # Used at post-install time to reconcile their deployment targets
+    # with ExpoModulesCore's, so an adapter declaring a lower platform
+    # value in its podspec doesn't fail the Swift module-import check.
+    def expo_autolinked_pod_names
+      @expo_autolinked_pod_names ||= []
+    end
   end
 
   class Installer
@@ -50,6 +58,14 @@ module Pod
 
       # Run all precompiled module post-install configuration
       Expo::PrecompiledModules.perform_post_install(self)
+
+      # Raise every autolinked Expo module's deployment target to at least
+      # ExpoModulesCore's. CocoaPods + react_native_post_install only raise
+      # pods to RN's iOS floor, which can leave Expo adapters declaring a
+      # lower platform value below ExpoModulesCore's requirement, leading to
+      # "Compiling for iOS 15.1, but module 'ExpoModulesCore' has a minimum deployment target of iOS 16.4"
+      # type of message
+      reconcile_expo_module_deployment_targets()
     end
 
     define_method(:run_podfile_pre_install_hooks) do
@@ -83,6 +99,57 @@ module Pod
     end
 
     private
+
+    # Mapping from Pod::Platform symbol to the Xcode build setting key
+    # that stores its deployment target.
+    EXPO_DEPLOYMENT_TARGET_KEYS = {
+      ios: 'IPHONEOS_DEPLOYMENT_TARGET',
+      osx: 'MACOSX_DEPLOYMENT_TARGET',
+      tvos: 'TVOS_DEPLOYMENT_TARGET',
+    }.freeze
+
+    # See call site in perform_post_install_actions for rationale.
+    def reconcile_expo_module_deployment_targets
+      expo_pod_names = @podfile.expo_autolinked_pod_names.to_set
+      return if expo_pod_names.empty?
+
+      core_target = self.pod_targets.find { |t| t.pod_name == 'ExpoModulesCore' }
+      core_spec = core_target&.root_spec
+      return if core_spec.nil?
+
+      required = EXPO_DEPLOYMENT_TARGET_KEYS
+        .map { |platform, key| [key, core_spec.deployment_target(platform)] }
+        .reject { |_, value| value.nil? || value.empty? }
+        .to_h
+      return if required.empty?
+
+      bumped = []
+      self.target_installation_results.pod_target_installation_results.each do |pod_name, result|
+        next unless expo_pod_names.include?(pod_name)
+        next if pod_name == 'ExpoModulesCore'
+
+        target_bumped = false
+        result.native_target.build_configurations.each do |config|
+          required.each do |key, required_version|
+            current = config.build_settings[key]
+            # nil means the pod doesn't target this platform — don't create a setting for it.
+            next if current.nil?
+            if Gem::Version.new(current) < Gem::Version.new(required_version)
+              config.build_settings[key] = required_version
+              target_bumped = true
+            end
+          end
+        end
+        bumped << pod_name if target_bumped
+      end
+
+      unless bumped.empty?
+        ios_required = required['IPHONEOS_DEPLOYMENT_TARGET'] || '?'
+        Pod::UI.puts "[Expo] ".blue +
+          "Raised deployment target to #{ios_required} for #{bumped.size} Expo modules (matching ExpoModulesCore)".yellow
+        self.pods_project.save
+      end
+    end
 
     # Ensures every slice declared by ExpoModulesJSI's podspec exists in
     # `Products/ExpoModulesJSI.xcframework`. CocoaPods only runs


### PR DESCRIPTION
# Why

Bumping the deployment target to 16.4 in SDK 56 is causing issues for consumers of `ExpoModulesCore` [issues](https://github.com/search?q=%22compiling+for+iOS+15.1%2C+but+module+%27ExpoModulesCore%27+has+a+minimum+deployment+target+of+iOS+16.4%22&type=issues) - "Compiling for iOS 15.1, but module 'ExpoModulesCore' has a minimum deployment target of iOS 16.4".

Usually people offer [this kind ](https://github.com/EvanBacon/expo-quick-actions/pull/58/changes#diff-e33aa8a237150b7b621dcf3d4b96411fa475be3429816ef2f12badf2512fa900L13)of fix but that's breaking.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

In expo-modules-autolinking's pod install post-install hook, after CocoaPods has finished, we read ExpoModulesCore's iOS deployment target off its already-loaded spec and raise every autolinked Expo module's IPHONEOS_DEPLOYMENT_TARGET (and macOS/tvOS equivalents) to at least that value if it's currently lower.

edit: RN core does similar thing [here](https://github.com/facebook/react-native/blob/09fc0432d1eb799c3c1c2ae2ef0dc3acb2944e35/packages/react-native/scripts/cocoapods/utils.rb#L362)

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan



<details>
<summary>Details</summary>

# Autolinking fix — staged verification

> Paths in **angle brackets** below need to be filled in by you:
> - `<scratch-dir>` — any directory you don't mind creating a throwaway project in
> - `<expo-checkout>` — your local clone of `expo/expo` with the fix applied (e.g. the branch/PR being reviewed)

## Stage 1 — Create project and reproduce bug

```bash
cd <scratch-dir>
rm -rf deployment-target-test
npx create-expo-app@latest deployment-target-test --template default@sdk-56
cd deployment-target-test
npx expo install expo-quick-actions expo-build-properties
npx expo prebuild -p ios --clean
cd ios && pod install && cd ..
```

**Check 1:**
```bash
grep EXPO_USE_PRECOMPILED_MODULES ios/Podfile.properties.json
```
Expect: `"EXPO_USE_PRECOMPILED_MODULES": "false"` (that's another bug resolved by #46159)

**Check 2:**
```bash
cd ios && ruby -rxcodeproj -e '
p = Xcodeproj::Project.open("Pods/Pods.xcodeproj")
%w[ExpoQuickActions ExpoModulesCore].each { |n|
  t = p.targets.find { |x| x.name == n }
  puts "#{n}: #{t.build_configurations.first.build_settings["IPHONEOS_DEPLOYMENT_TARGET"]}"
}' && cd ..
```
Expect:
```
ExpoQuickActions: 15.1
ExpoModulesCore: 16.4
```

**Check 3:**
```bash
cd ios && xcodebuild -workspace deploymenttargettest.xcworkspace \
  -scheme ExpoQuickActions -configuration Debug \
  -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build 2>&1 \
  | grep -E "error:|BUILD (FAILED|SUCCEEDED)" | head -3
cd ..
```
Expect: `error: compiling for iOS 15.1, but module 'ExpoModulesCore' has a minimum deployment target of iOS 16.4` + `** BUILD FAILED **`

If any check fails, stop — bug isn't reproducing.

## Stage 2 — Apply fix

```bash
cp <expo-checkout>/packages/expo-modules-autolinking/scripts/ios/autolinking_manager.rb \
   node_modules/expo-modules-autolinking/scripts/ios/autolinking_manager.rb
cp <expo-checkout>/packages/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb \
   node_modules/expo-modules-autolinking/scripts/ios/cocoapods/installer.rb
```

## Stage 3 — Verify

```bash
cd ios && pod install 2>&1 | grep "Raised deployment target"
```
**Check 4** — expect: `[Expo] Raised deployment target to 16.4 for 1 Expo modules (matching ExpoModulesCore)`

**Check 5:**
```bash
ruby -rxcodeproj -e '
p = Xcodeproj::Project.open("Pods/Pods.xcodeproj")
%w[ExpoQuickActions ExpoModulesCore React-Core Yoga RCTRequired].each { |n|
  t = p.targets.find { |x| x.name == n }
  next puts "#{n}: (not found)" unless t
  puts "#{n}: #{t.build_configurations.first.build_settings["IPHONEOS_DEPLOYMENT_TARGET"]}"
}'
```
Expect:
```
ExpoQuickActions: 16.4
ExpoModulesCore: 16.4
React-Core: 15.1
Yoga: 15.1
RCTRequired: 15.1
```

**Check 6:**
```bash
xcodebuild -workspace deploymenttargettest.xcworkspace \
  -scheme ExpoQuickActions -configuration Debug \
  -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build 2>&1 \
  | grep -E "error:|BUILD (FAILED|SUCCEEDED)" | head -3
cd ..
```
Expect: `** BUILD SUCCEEDED **`


## Pass criteria

All 6 checks match. If Check 5 shows `React-Core`/`Yoga`/`RCTRequired` at 16.4 → filter over-broad. If Check 6 fails despite Check 5 passing → hook ran but didn't fix root cause.


</details>

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)