### PR TITLE
fix(expo-json-utils): use javaObjectType in JSONObject.require<T>

### DIFF
--- a/packages/expo-json-utils/CHANGELOG.md
+++ b/packages/expo-json-utils/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Use `javaObjectType` in `JSONObject.require<T>` so primitive type arms (`Long`/`Int`/`Double`/`Boolean`) match instead of silently falling into the catch-all `else` and throwing `ClassCastException`. ([#46181](https://github.com/expo/expo/pull/46181) by [@jakequade-pc](https://github.com/jakequade-pc))
+
 ### 💡 Others
 
 ## 56.0.0 — 2026-05-05

--- a/packages/expo-json-utils/android/src/androidTest/java/expo/modules/jsonutils/JSONObjectUtilsTest.kt
+++ b/packages/expo-json-utils/android/src/androidTest/java/expo/modules/jsonutils/JSONObjectUtilsTest.kt
@@ -48,4 +48,33 @@ class JSONObjectUtilsTest {
     jsonObject.getNullable<JSONArray>("jsonarray") shouldBeEqualTo innerJSONArray
     jsonObject.getNullable<JSONObject>("jsonobject") shouldBeEqualTo innerJSONObject
   }
+
+  @Test
+  @Throws(Exception::class)
+  fun testRequireLongRoundTripsForIntSizedValues() {
+    val parsed = JSONObject(JSONObject(mapOf("duration" to 6000L)).toString())
+    val out: Long = parsed.require("duration")
+    out shouldBeEqualTo 6000L
+  }
+
+  @Test
+  @Throws(Exception::class)
+  fun testRequireIntRoundTrips() {
+    val parsed = JSONObject(JSONObject(mapOf("count" to 42)).toString())
+    parsed.require<Int>("count") shouldBeEqualTo 42
+  }
+
+  @Test
+  @Throws(Exception::class)
+  fun testRequireDoubleRoundTrips() {
+    val parsed = JSONObject(JSONObject(mapOf("ratio" to 1.5)).toString())
+    parsed.require<Double>("ratio") shouldBeEqualTo 1.5
+  }
+
+  @Test
+  @Throws(Exception::class)
+  fun testRequireBooleanRoundTrips() {
+    val parsed = JSONObject(JSONObject(mapOf("flag" to true)).toString())
+    parsed.require<Boolean>("flag") shouldBeEqualTo true
+  }
 }

--- a/packages/expo-json-utils/android/src/main/java/expo/modules/jsonutils/JSONObjectUtils.kt
+++ b/packages/expo-json-utils/android/src/main/java/expo/modules/jsonutils/JSONObjectUtils.kt
@@ -6,14 +6,14 @@ import org.json.JSONObject
 
 @Throws(JSONException::class)
 inline fun <reified T : Any> JSONObject.require(key: String): T {
-  return when (T::class) {
-    String::class -> this.getString(key) as T
-    Double::class -> this.getDouble(key) as T
-    Int::class -> this.getInt(key) as T
-    Long::class -> this.getLong(key) as T
-    Boolean::class -> this.getBoolean(key) as T
-    JSONArray::class -> this.getJSONArray(key) as T
-    JSONObject::class -> this.getJSONObject(key) as T
+  return when (T::class.javaObjectType) {
+    String::class.javaObjectType -> this.getString(key) as T
+    Double::class.javaObjectType -> this.getDouble(key) as T
+    Int::class.javaObjectType -> this.getInt(key) as T
+    Long::class.javaObjectType -> this.getLong(key) as T
+    Boolean::class.javaObjectType -> this.getBoolean(key) as T
+    JSONArray::class.javaObjectType -> this.getJSONArray(key) as T
+    JSONObject::class.javaObjectType -> this.getJSONObject(key) as T
     else -> this.get(key) as T
   }
 }


### PR DESCRIPTION
# Why

Based on some findings while testing EAS updates on physical android. A bit more context is in [this accompanying PR](https://github.com/expo/expo/pull/46182).

We hit `ClassCastException: java.lang.Integer cannot be cast to java.lang.Long` in `JSONObject.require<Long>` while parsing a persisted `duration` field. The trace pointed at the catch-all `else` of the `when (T::class)` chain, which does `(T) JSONObject.get(key)`. `org.json.JSONObject` returns int-sized numeric tokens as `Integer`, not `Long`. 

The named `Long::class` arm doesn't catch it because the compiler resolves `T::class` (for `T = Long`) to `java.lang.Long` while the literal `Long::class` resolves to primitive `Long.TYPE`; the two `KClass` instances aren't equal, so the branch is silently skipped. Same shape applies to `Int`, `Double`, and `Boolean`.

# How

Compare on `T::class.javaObjectType` so both sides resolve to the wrapper `Class<*>`. The named branches match again and the blind-cast `else` is no longer reachable for the primitive types.

# Test Plan

Added four androidTest cases in `JSONObjectUtilsTest` covering `Long`/`Int`/`Double`/`Boolean` round-tripping through `JSONObject.toString()` + parse. Run with `./gradlew :expo-json-utils:connectedAndroidTest`. Without the fix, the `Long` case throws `ClassCastException`; with it, all four pass.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
