### PR TITLE
fix(expo-updates): harden cold-start log purge against parse failures

### DIFF
--- a/packages/expo-updates/CHANGELOG.md
+++ b/packages/expo-updates/CHANGELOG.md
@@ -8,7 +8,12 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Widen `UpdatesLogEntry.create`'s catch from `JSONException` to `Exception` so log-line parse failures consistently degrade to "skip the entry" instead of propagating. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
+- [Android] Correct `UpdatesLogReader.ONE_DAY_MILLISECONDS` from `86400` (seconds) to `86_400_000` (milliseconds), so the "older than one day" purge filter actually retains a day's worth of entries instead of ~86 seconds' worth. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
+
 ### 💡 Others
+
+- [Android] Log purge completion errors via `android.util.Log.e` directly instead of `logger.error`, so the failure path doesn't re-enter the `PersistentFileLog` dispatch queue from inside one of its own tasks. ([#46182](https://github.com/expo/expo/pull/46182) by [@jakequade-pc](https://github.com/jakequade-pc))
 
 ## 56.0.17 — 2026-05-26
 

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/EnabledUpdatesController.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Context
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import com.facebook.react.ReactHost
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.devsupport.interfaces.DevSupportManager
@@ -18,7 +19,6 @@ import expo.modules.updates.events.IUpdatesEventManager
 import expo.modules.updates.events.UpdatesEventManager
 import expo.modules.updates.launcher.Launcher.LauncherCallback
 import expo.modules.updates.loader.FileDownloader
-import expo.modules.updates.logging.UpdatesErrorCode
 import expo.modules.updates.logging.UpdatesLogReader
 import expo.modules.updates.logging.UpdatesLogger
 import expo.modules.updates.manifest.EmbeddedManifestUtils
@@ -90,7 +90,12 @@ class EnabledUpdatesController(
   private fun purgeUpdatesLogsOlderThanOneDay() {
     UpdatesLogReader(context.filesDir).purgeLogEntries {
       if (it != null) {
-        logger.error("UpdatesLogReader: error in purgeLogEntries", it, UpdatesErrorCode.Unknown)
+        // Log directly via android.util.Log rather than through `logger.error`,
+        // which writes via the PersistentFileLog dispatch queue. This callback
+        // is invoked from inside one of that queue's own tasks, so feeding
+        // another entry back into the queue from here re-enters it. Bypassing
+        // the queue keeps the failure path off its own back.
+        Log.e("expo-updates", "UpdatesLogReader: error in purgeLogEntries", it)
       }
     }
   }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogEntry.kt
@@ -3,7 +3,6 @@ package expo.modules.updates.logging
 import expo.modules.jsonutils.getNullable
 import expo.modules.jsonutils.require
 import org.json.JSONArray
-import org.json.JSONException
 import org.json.JSONObject
 
 /**
@@ -59,7 +58,11 @@ data class UpdatesLogEntry(
             List(jsonArray.length()) { i -> jsonArray.getString(i) }
           }
         )
-      } catch (e: JSONException) {
+      } catch (e: Exception) {
+        // `JSONObject.require<T>` can surface a ClassCastException via a blind
+        // cast in the catch-all branch (e.g. an int-sized numeric `duration`
+        // token surfaces as `Integer`), which would otherwise escape and
+        // propagate to the caller.
         null
       }
     }

--- a/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
+++ b/packages/expo-updates/android/src/main/java/expo/modules/updates/logging/UpdatesLogReader.kt
@@ -54,6 +54,6 @@ class UpdatesLogReader(
   }
 
   companion object {
-    private const val ONE_DAY_MILLISECONDS = 86400
+    private const val ONE_DAY_MILLISECONDS = 86_400_000L
   }
 }


### PR DESCRIPTION
# Why

Hi there, I was debugging some EAS updates and noticed some unresponsive white screens on Android. My setup:

- Device: Android phone (CMF Nothing 3 pro)
- Expo version: 54
- Expo updates version: 29.0.16
- Expo JSON utils: 0.15.0
- Expo modules core: 3.0.29

It's my work app, and we. have a useFocusEffect for checking for eas updates and reloading when one is found. I noticed that, while a `reloadAsync()` would go through successfully, the next cold open would cause a white screen on Android. Multiple force-closes wouldn't fix it, only waiting for the unresponsive processes to get dropped. It was a combination of three things:

- Log buffer choking during startup, which looks like [it has been solved](https://github.com/expo/expo/pull/45058) in a later expo-modules-core fix.
- An incorrect `(Long) Int` casting adding to the buffer issues, which [I've opened here](https://github.com/expo/expo/pull/46181).
- Incorrect error typings (non-JSONException) causing more logs to accumulate in the buffer that was already choking

Also, unrelated:
- A small miscalculation I noticed on "day" log periods (86400 milliseconds should be 86,400,000 m) when trying to pull logs from previous runs

I can appreciate that some of these might not be issues for most people, so I respect your choice if it's better to close this PR - just wanted to raise the issues a bit more proactively than a simple github issue (always feels like a complaint, hah). I did read the contributing.md but I apologise if I've missed anything.

# Test Plan

Existing CI on `packages/expo-updates`. Behaviour verified end-to-end on a Nothing Phone 3a Pro (Android 16) running SDK 54 with the equivalent local patches applied. Cold-start after OTA no longer white-screens, log file no longer grows unbounded.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
