### PR TITLE
fix(background-task) fixed prebuilds

### DIFF
--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Fix precompiled XCFramework builds resolving the task service helper.
+- [iOS] Fix precompiled XCFramework builds resolving the task service helper. ([#46188](https://github.com/expo/expo/pull/46188) by [@chrfalch](https://github.com/chrfalch))
 
 ### 💡 Others
 

--- a/packages/expo-background-task/CHANGELOG.md
+++ b/packages/expo-background-task/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix precompiled XCFramework builds resolving the task service helper.
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-21

--- a/packages/expo-background-task/ios/EXTaskServiceHelper.m
+++ b/packages/expo-background-task/ios/EXTaskServiceHelper.m
@@ -1,10 +1,17 @@
 #import "EXTaskServiceHelper.h"
-#import <ExpoTaskManager/EXTaskService.h>
 
 @implementation EXTaskServiceHelper
 
 + (nullable id<EXTaskServiceInterface>)sharedTaskService {
-  return (id<EXTaskServiceInterface>)EXTaskService.shared;
+  Class taskServiceClass = NSClassFromString(@"EXTaskService");
+  if (![taskServiceClass respondsToSelector:@selector(shared)]) {
+    return nil;
+  }
+  id instance = [taskServiceClass performSelector:@selector(shared)];
+  if (![instance conformsToProtocol:@protocol(EXTaskServiceInterface)]) {
+    return nil;
+  }
+  return (id<EXTaskServiceInterface>)instance;
 }
 
 @end

--- a/packages/expo-background-task/ios/Tests/BackgroundTaskSchedulerTests.swift
+++ b/packages/expo-background-task/ios/Tests/BackgroundTaskSchedulerTests.swift
@@ -9,6 +9,10 @@ final class BackgroundTaskSchedulerTests: XCTestCase {
     try await super.tearDown()
   }
 
+  func testTaskServiceHelperResolvesSharedTaskService() {
+    XCTAssertNotNil(EXTaskServiceHelper.sharedTaskService())
+  }
+
   func testConcurrentScheduleWorkerCallsDoNotOverlapCancel() async throws {
     let scheduler = OverlapDetectingScheduler()
 

--- a/packages/expo-background-task/spm.config.json
+++ b/packages/expo-background-task/spm.config.json
@@ -15,6 +15,26 @@
       ],
       "targets": [
         {
+          "type": "objc",
+          "name": "ExpoBackgroundTask_ios_objc",
+          "moduleName": "ExpoBackgroundTask",
+          "path": "ios",
+          "pattern": "**/*.m",
+          "headerPattern": "**/*.h",
+          "dependencies": [
+            "ReactNativeDependencies",
+            "React",
+            "Hermes",
+            "expo-modules-core/ExpoModulesCore"
+          ],
+          "linkedFrameworks": [
+            "Foundation"
+          ],
+          "includeDirectories": [
+            "."
+          ]
+        },
+        {
           "type": "swift",
           "name": "ExpoBackgroundTask",
           "path": "ios",
@@ -26,7 +46,8 @@
             "Hermes",
             "React",
             "ReactNativeDependencies",
-            "expo-modules-core/ExpoModulesCore"
+            "expo-modules-core/ExpoModulesCore",
+            "ExpoBackgroundTask_ios_objc"
           ],
           "linkedFrameworks": [
             "Foundation",


### PR DESCRIPTION
## Why:

expo-backgorund-task isn't distributed as precompiled xcframeworks, but it should be able to build as one. Currently it fails.

## How:

Fixed the XCFramework compile issue by moving EXTaskServiceHelper into an Objective-C SPM target that the Swift target depends on, so Swift can see EXTaskServiceHelper during precompile builds.

## Test-plan

✅ Added swift test for getting the task service, asserting that `EXTaskServiceHelper.sharedTaskService()` resolves correctly. ✅ Tested with BareExpo on Device on iOIS

## Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
