### PR TITLE
[expo-widgets] Inherit ios.deploymentTarget for widget extension

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- Inherit `ios.deploymentTarget` from app config for generated widget extension targets.
+- [plugin] Inherit `ios.deploymentTarget` from app config for generated widget extension targets. ([#46193](https://github.com/expo/expo/pull/46193) by [@eliotgevers](https://github.com/eliotgevers))
 
 ### 💡 Others
 

--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Inherit `ios.deploymentTarget` from app config for generated widget extension targets.
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-21

--- a/packages/expo-widgets/plugin/build/withWidgets.js
+++ b/packages/expo-widgets/plugin/build/withWidgets.js
@@ -15,7 +15,7 @@ const withTargetXcodeProject_1 = __importDefault(require("./xcode/withTargetXcod
 const pkg = require('../../package.json');
 const withWidgets = (config, props) => {
     let plugins = [];
-    const deploymentTarget = '16.4';
+    const deploymentTarget = config.ios?.deploymentTarget ?? '16.4';
     const targetName = 'ExpoWidgetsTarget';
     let bundleIdentifier = props?.bundleIdentifier;
     if (!bundleIdentifier) {

--- a/packages/expo-widgets/plugin/src/withWidgets.ts
+++ b/packages/expo-widgets/plugin/src/withWidgets.ts
@@ -26,7 +26,7 @@ export type ExpoWidgetsConfigPluginProps = {
 
 const withWidgets: ConfigPlugin<ExpoWidgetsConfigPluginProps | undefined> = (config, props) => {
   let plugins: (StaticPlugin | ConfigPlugin | string)[] = [];
-  const deploymentTarget = '16.4';
+  const deploymentTarget = config.ios?.deploymentTarget ?? '16.4';
   const targetName = 'ExpoWidgetsTarget';
 
   let bundleIdentifier = props?.bundleIdentifier;


### PR DESCRIPTION
## Why

`expo-widgets` currently hardcodes the generated widget extension target deployment version to `16.4`. Apps that set a newer `ios.deploymentTarget` can therefore end up with the containing app target and `ExpoWidgetsTarget` using different deployment targets.

This is especially relevant for apps whose dependencies require a newer iOS version, because native objects may be built for the newer app target and then linked into a widget extension still targeting `16.4`, producing warnings such as:

```text
object file was built for newer 'iOS-simulator' version (17.0) than being linked (16.4)
```

Closes #46192

## How

Use `config.ios?.deploymentTarget` for the generated widget extension target when it is configured, and keep the existing `16.4` fallback otherwise.

## Test Plan

- `git diff --check`
- Verified with the minimal repro from #46192 that `ExpoWidgetsTarget` changes from `IPHONEOS_DEPLOYMENT_TARGET = 16.4` to `IPHONEOS_DEPLOYMENT_TARGET = 17.0` after this patch.
