### PR TITLE
chore(expo-router): improve error message when using NativeTabs on an unsupported platform

### DIFF
--- a/packages/expo-router/src/native-tabs/NativeTabsView.tsx
+++ b/packages/expo-router/src/native-tabs/NativeTabsView.tsx
@@ -7,6 +7,6 @@ import type { NativeTabsViewProps } from './types';
 
 export function NativeTabsView(_props: NativeTabsViewProps): null {
   throw new Error(
-    'You are using NativeTabs on unsupported platform. This is likely an internal Expo Router bug.'
+    'You are using NativeTabs on an unsupported platform. This is likely an internal Expo Router bug.'
   );
 }


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
