### PR TITLE
fix(expo-brownfield): drop invalid mangling defines and skip script-only pods

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Drop invalid mangling defines and skip script-only pods when `multipleFrameworks: true` is enabled, fixing `Macro name must be an identifier` and `Argument list too long` build failures. ([#46208](https://github.com/expo/expo/pull/46208) by [@ShadiBlitz](https://github.com/ShadiBlitz))
+
 ### 💡 Others
 
 ## 56.0.14 — 2026-05-23

--- a/packages/expo-brownfield/cli/build/utils/mangle.js
+++ b/packages/expo-brownfield/cli/build/utils/mangle.js
@@ -34,7 +34,10 @@ const SWIFT_SYMBOL_PATTERNS = [
     /_\w+_swiftoverride_/,
     /_Z\w+swift/,
     /get_witness_table /,
+    /get_type_metadata /,
+    /type metadata accessor /,
 ];
+const VALID_C_IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const isSwiftSymbol = (line) => SWIFT_SYMBOL_PATTERNS.some((re) => re.test(line));
 const LOG_FILE_NAME = 'expo-brownfield-mangle.log';
 /**
@@ -186,7 +189,9 @@ const extractCategorySelectors = (lines, classes) => {
     }
     return Array.from(new Set(selectors));
 };
-const prefixSymbols = (prefix, symbols) => symbols.map((sym) => `${sym}=${prefix}${sym}`);
+const prefixSymbols = (prefix, symbols) => symbols
+    .filter((sym) => VALID_C_IDENT.test(sym))
+    .map((sym) => `${sym}=${prefix}${sym}`);
 /**
  * Property setter/getter pairs need symmetric handling so that `setFoo:` →
  * `set<Prefix>Foo:` and `foo` → `<Prefix>foo` both round-trip. Lifted from

--- a/packages/expo-brownfield/scripts/ios/mangle.rb
+++ b/packages/expo-brownfield/scripts/ios/mangle.rb
@@ -89,6 +89,12 @@ module ExpoBrownfield
     def self.pod_xcconfig_paths(installer)
       paths = []
       installer.pods_project.targets.each do |target|
+        next unless target.respond_to?(:build_phases)
+        sources_phase = target.build_phases.find do |p|
+          p.is_a?(Xcodeproj::Project::Object::PBXSourcesBuildPhase)
+        end
+        next if sources_phase.nil? || sources_phase.files_references.empty?
+        
         target.build_configurations.each do |config|
           ref = config.base_configuration_reference
           next if ref.nil?


### PR DESCRIPTION

# Why

Fixes 2 of the 3 failures documented in #46207. After #45838 made `MANGLING_DEFINES` populated rather than empty, enabling `multipleFrameworks: true` on a real-world SDK 56 brownfield app trips two immediate build errors that prevent `pod install` and `expo-brownfield build:ios` from completing:

1. `error: Macro name must be an identifier` from clang on the first TU to consume the mangle xcconfig (`libwebp` in my graph). The mangler harvests symbols via `nm -gU` and emits one `-D foo=Prefix_foo` per symbol, but some Swift metadata symbols (`get_type_metadata 15ExpoModulesCore16Generic…`, `type metadata accessor …`) contain a literal space and aren't matched by `SWIFT_SYMBOL_PATTERNS`, so they slip through as malformed `name=value` pairs whose lhs starts with a digit.

2. `error: unable to spawn process '/bin/sh' (Argument list too long)` from every `[CP-User] Replace …` Run Script build phase in the prebuilt-wrapper pods (`hermes-engine`, `ReactNativeDependencies`, `React-Core-prebuilt`, `ExpoModulesJSI`, `React-RCTFBReactNativeSpec`). The mangle xcconfig is `#include`d into every pod's xcconfig including these wrappers, which compile zero source files of their own and only have script phases. Xcode propagates every effective build setting to script-phase env as a variable, and the ~5 MB resolved `GCC_PREPROCESSOR_DEFINITIONS` blows past `MAX_ARG_PAGES` at `execve` time.

Failure 3 from #46207 (`PrecompileModule` failures in clang explicit-modules) needs the larger `-D` → prefix-header architectural rewrite I sketched in the issue and is deliberately left for a follow-up to keep this PR reviewable.

# How

Two narrow patches.

**`cli/utils/mangle.ts` — drop entries that aren't valid C identifiers**

- Added `/get_type_metadata /` and `/type metadata accessor /` to `SWIFT_SYMBOL_PATTERNS` so these Swift internal symbols get filtered upfront alongside the existing `/get_witness_table /` etc.
- Added a defensive C-identifier guard inside `prefixSymbols`:
  ```ts
  const VALID_C_IDENT = /^[A-Za-z_][A-Za-z0-9_]*$/;
  const prefixSymbols = (prefix: string, symbols: string[]) =>
    symbols
      .filter((sym) => VALID_C_IDENT.test(sym))
      .map((sym) => `${sym}=${prefix}${sym}`);
  ```
  Belt-and-suspenders against future Swift symbol shapes the regex list doesn't cover — a malformed token gets silently dropped instead of producing an unbuildable xcconfig.

**`scripts/ios/mangle.rb` — skip pods with no compile-sources phase**

`pod_xcconfig_paths` was passing every pod's xcconfig to the JS worker. The prebuilt-wrapper pods don't compile any source files and don't need mangling — they only have Run Script build phases that copy prebuilt xcframeworks into place. Filtered them out:

```ruby
def self.pod_xcconfig_paths(installer)
  paths = []
  installer.pods_project.targets.each do |target|
    next unless target.respond_to?(:build_phases)
    sources_phase = target.build_phases.find do |p|
      p.is_a?(Xcodeproj::Project::Object::PBXSourcesBuildPhase)
    end
    next if sources_phase.nil? || sources_phase.files_references.empty?

    target.build_configurations.each do |config|
      ref = config.base_configuration_reference
      next if ref.nil?
      paths << ref.real_path.to_s
    end
  end
  paths.uniq
end
```

Aggregate targets without a `PBXSourcesBuildPhase` are skipped (covers `hermes-engine`, `React-Core-prebuilt`, etc.), and native targets whose sources phase exists but is empty are also skipped (covers privacy-bundle resource aggregators).

# Test Plan

Reproduced both failures and the fixes against a real-world brownfield app (~110 pod dependencies, including `react-native-screens`, `react-native-svg`, `react-native-reanimated`, `react-native-maps`, `expo-image`, etc.) configured with:

```json
["expo-brownfield", {
  "ios": {
    "targetName": "MyApp",
    "multipleFrameworks": true
  }
}]
```

Steps:
```bash
cd my-app
npx expo prebuild --platform ios --clean
cd ios && pod install
cd .. && npx expo-brownfield build:ios -d -a ./artifacts --verbose
```

**Before patch 1:** the generated `expo-brownfield-mangle.xcconfig` contained 24,213 tokens in `MANGLING_DEFINES`, 234 of which were malformed (e.g. `get_type_metadata 15ExpoModulesCore16GenericExceptionCySSG.1=MyApp_get_type_metadata 15ExpoModulesCore16GenericExceptionCySSG.1`). First clang TU to read the xcconfig fails with 147+ `Macro name must be an identifier` errors in `libwebp`.

**After patch 1:** 23,979 tokens, **0 malformed** — clang accepts all `-D` flags.

**Before patch 2:** the mangle xcconfig was `#include`d into 190 pod xcconfigs (every pod × debug+release). Brownfield build fails with:

```
PhaseScriptExecution [CP-User]\ [Hermes]\ Replace\ Hermes\ for\ the\ right\ configuration,\ if\ needed
  /…/hermes-engine.build/Script-…sh (in target 'hermes-engine' from project 'Pods')
error: unable to spawn process '/bin/sh' (Argument list too long)
```

Same failure in `ReactNativeDependencies`.

**After patch 2:** dry-running the filter against the same `Pods.xcodeproj` returns 45 included pods (writing 90 xcconfig paths to patch, debug+release) and 82 correctly skipped (every `React-*` wrapper, `hermes-engine`, `ExpoModulesJSI`, `ReactNativeDependencies`, `React-RCTFBReactNativeSpec`, `Yoga`, plus all privacy-bundle aggregators).

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — N/A, no documentation changes.

---

**Related:**
- Fixes 2 of 3 failures in #46207
- Follow-up to #45838 — that PR made `MANGLING_DEFINES` non-empty; this PR makes the resulting xcconfig actually usable
- A follow-up PR will address Failure 3 from #46207 by switching from `-D` flags to a generated prefix header (which also obviates the need for the script-phase skip in this PR — the giant env var goes away entirely). Kept separate to keep this PR reviewable.
```
