### PR TITLE
[go][android] Reinforce edge-to-edge in Theme.Exponent

### DIFF
--- a/apps/expo-go/android/expoview/src/main/res/values/styles.xml
+++ b/apps/expo-go/android/expoview/src/main/res/values/styles.xml
@@ -8,6 +8,9 @@
   </style>
 
   <style name="Theme.Exponent.Light" parent="Theme.MaterialComponents.Light.NoActionBar">
+    <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+    <item name="android:fitsSystemWindows">false</item>
+    <item name="android:navigationBarColor">@android:color/transparent</item>
     <item name="android:windowLightStatusBar">false</item>
     <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="colorPrimary">@color/colorPrimary</item>
@@ -17,6 +20,9 @@
   </style>
 
   <style name="Theme.Exponent.Dark" parent="Theme.MaterialComponents.Light.NoActionBar">
+    <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+    <item name="android:fitsSystemWindows">false</item>
+    <item name="android:navigationBarColor">@android:color/transparent</item>
     <item name="android:windowLightStatusBar">false</item>
     <item name="android:statusBarColor">@android:color/transparent</item>
     <item name="colorPrimary">@color/colorPrimary</item>


### PR DESCRIPTION
# Why

Following [#35718](https://github.com/expo/expo/pull/35718) (`[go][android][1/n] Roll out edge-to-edge`), Expo Go calls `enableEdgeToEdge()` at runtime in `LauncherActivity`, `HomeActivity`, `ExperienceActivity`, and `ErrorActivity`. However, `Theme.Exponent.Light/Dark` in `apps/expo-go/android` were not updated alongside — they still lack `windowDrawsSystemBarBackgrounds=true`, an explicit `fitsSystemWindows=false`, and a transparent `navigationBarColor`. These are part of what `react-native-edge-to-edge`'s `Theme.EdgeToEdge.*` themes apply on dev/standalone builds via the config plugin.

The result is a behavioral inconsistency between Expo Go and dev/standalone builds. With the same JS code (`headerStyle.backgroundColor: '#ef4444'` on a native-stack screen):

- **Dev build (`expo run:android` / EAS development build):** status bar is a transparent overlay; the header's reserved `headerStatusBarHeight` area is drawn under it — visually flush.
- **Expo Go:** status bar stays opaque; the header's reserved `headerStatusBarHeight` area is drawn *below* the opaque status bar — appearing as an extra status-bar-height of empty header background above the title/back-button row.

# How

The symptom looks like a "double inset" but the underlying mechanism is simpler. React Navigation's native-stack header correctly reserves `headerStatusBarHeight = WindowInsets.systemBars.top` so the action row clears the status bar. In both build types this reservation is the same — what differs is whether the status bar is a transparent overlay or an opaque strip:

- With `windowDrawsSystemBarBackgrounds=true` (dev build via `react-native-edge-to-edge`), the activity gets `FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS`, the system bar becomes a transparent overlay, and the header's reserved top region is hidden beneath it.
- Without it (Expo Go's current `Theme.Exponent.*`), the system bar is opaque and pushed above the app's content; the header's reserved top region renders *below* the bar as visible empty background.

`enableEdgeToEdge()` at runtime calls `WindowCompat.setDecorFitsSystemWindows(window, false)` but does **not** set `FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS` — that flag has to come from the theme (or an explicit `window.addFlags` call). Hence the theme-level fix.

This PR adds three attributes to both `Theme.Exponent.Light` and `Theme.Exponent.Dark` in `apps/expo-go/android/expoview/src/main/res/values/styles.xml`:

```xml
<item name="android:windowDrawsSystemBarBackgrounds">true</item>
<item name="android:fitsSystemWindows">false</item>
<item name="android:navigationBarColor">@android:color/transparent</item>
```

`windowDrawsSystemBarBackgrounds=true` is the load-bearing change — it sets `FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS`, making the system bar a transparent overlay. `navigationBarColor=transparent` does the same for the bottom bar. `fitsSystemWindows=false` is defensive — `WindowCompat.setDecorFitsSystemWindows(false)` covers it on API 30+, but the explicit attribute makes intent unambiguous and matches what `Theme.EdgeToEdge.*` ships.

### Deliberately minimal

- **Parent kept as `Theme.MaterialComponents.*`** — not switching to `Theme.AppCompat.*` (which is what `react-native-edge-to-edge` uses) to minimize blast radius on MaterialComponents widget styling used elsewhere in Expo Go.
- **No `enforceNavigationBarContrast` / `enforceSystemBarsLightTheme`** — those are AppCompat-namespaced attributes; not needed for this specific symptom.

# Test Plan

> [!NOTE]
> I was unable to build Expo Go locally to verify this change — my machine (24 GB M4 Pro) cannot accommodate the `-Xmx20g` Gradle config without freezing. Would appreciate maintainer verification on a device, or guidance if there is a lighter way to validate this change locally that I missed.

Suggested manual verification on a device:

1. `npx create-expo-app` → set `headerStyle: { backgroundColor: '#ef4444' }` on any native-stack screen.
2. Open via Expo Go on Android. Without this PR: a red status-bar-height strip appears above the header row, header content sits low. With this PR: the red background and header content should be flush, with the system bar overlaying the top of the header.
3. Smoke-test for regressions: Expo Go home screen, dev menu overlay, error overlay, dark-mode variant.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting) — N/A, this PR only touches `apps/expo-go/android` resources; no package source changes.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin). — N/A, no config plugin / prebuild surface touched.
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md) — N/A, no docs changed.
