### PR TITLE
refactor(@expo/config-plugins): create backwards-compatible shim for `XcodeProject` built on `@bacons/xcode`

### DIFF
--- a/packages/@expo/config-plugins/package.json
+++ b/packages/@expo/config-plugins/package.json
@@ -84,6 +84,7 @@
     "paths"
   ],
   "dependencies": {
+    "@bacons/xcode": "1.0.0-alpha.33",
     "@expo/config-types": "workspace:^56.0.5",
     "@expo/json-file": "workspace:~10.2.0",
     "@expo/plist": "workspace:^0.7.0",

--- a/packages/@expo/config-plugins/src/ios/__tests__/Name-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/Name-test.ts
@@ -4,7 +4,8 @@ import { vol } from 'memfs';
 
 import rnFixture from '../../plugins/__tests__/fixtures/react-native-project';
 import { getName, setDisplayName, setName, setProductName } from '../Name';
-import { getPbxproj, isBuildConfig, isNotComment } from '../utils/Xcodeproj';
+import { findFirstNativeTarget } from '../Target';
+import { getBuildConfigurationsForListId, getPbxproj } from '../utils/Xcodeproj';
 
 jest.mock('fs');
 
@@ -46,21 +47,35 @@ describe(setProductName, () => {
     vol.reset();
   });
 
-  it(`sets the iOS PRODUCT_NAME value`, () => {
+  it(`sets the iOS PRODUCT_NAME value on every build configuration of the application target`, () => {
     for (const [input, output] of [
       ['My Cool Thing', `"MyCoolThing"`],
       ['h"&<world/>🚀', `"hworld"`],
     ]) {
       // Ensure the value can be parsed and written.
       const project = setProductNameForRoot({ name: input, slug: '' }, projectRoot);
-      expect(
-        Object.entries(project.pbxXCBuildConfigurationSection())
-          .filter(isNotComment)
-          // @ts-ignore
-          .filter(isBuildConfig)[0][1]?.buildSettings?.PRODUCT_NAME
-        // Ensure the value is wrapped in quotes.
-      ).toBe(output);
+
+      const [, nativeTarget] = findFirstNativeTarget(project);
+      const buildConfigurations = getBuildConfigurationsForListId(
+        project,
+        nativeTarget.buildConfigurationList
+      );
+
+      // PRODUCT_NAME should be set (and quoted) on every configuration of the app target.
+      expect(buildConfigurations.length).toBeGreaterThan(0);
+      for (const [, buildConfig] of buildConfigurations) {
+        expect(buildConfig.buildSettings.PRODUCT_NAME).toBe(output);
+      }
     }
+  });
+
+  it(`writes the PRODUCT_NAME to the serialized pbxproj`, () => {
+    const project = setProductNameForRoot({ name: 'My Cool Thing', slug: '' }, projectRoot);
+    const output = project.writeSync();
+    // The new PRODUCT_NAME should be present in the serialized output.
+    expect(output).toContain('PRODUCT_NAME = "MyCoolThing"');
+    // The default PRODUCT_NAME (HelloWorld) should no longer be referenced as the value.
+    expect(output).not.toMatch(/PRODUCT_NAME = HelloWorld;/);
   });
 });
 

--- a/packages/@expo/config-plugins/src/ios/__tests__/PrivacyInfo-test.ts
+++ b/packages/@expo/config-plugins/src/ios/__tests__/PrivacyInfo-test.ts
@@ -1,37 +1,17 @@
 import { vol } from 'memfs';
 import path from 'path';
 
+import rnFixture from '../../plugins/__tests__/fixtures/react-native-project';
 import type { PrivacyInfo } from '../PrivacyInfo';
 import { setPrivacyInfo } from '../PrivacyInfo';
+import { getPbxproj } from '../utils/Xcodeproj';
+
 jest.mock('fs');
 
-jest.mock('../utils/Xcodeproj', () => ({
-  getProjectName: () => 'testproject',
-  addResourceFileToGroup: jest.fn(),
-}));
+const originalFs = jest.requireActual('fs');
 
-const projectRoot = 'myapp';
-
-const project = {
-  name: 'test',
-  slug: 'test',
-};
-
-const mockConfig = {
-  //fill in relevant data here
-  modResults: {
-    hasFile: () => false,
-  },
-  modRequest: {
-    projectRoot,
-    platformProjectRoot: path.join(projectRoot, 'ios'),
-    modName: 'test',
-    platform: 'ios' as const,
-    introspect: false,
-  },
-  modRawConfig: project,
-  ...project,
-} as any;
+const projectRoot = '/myapp';
+const project = { name: 'HelloWorld', slug: 'helloworld' };
 
 const privacyManifests: PrivacyInfo = {
   NSPrivacyAccessedAPITypes: [
@@ -45,17 +25,14 @@ const privacyManifests: PrivacyInfo = {
   NSPrivacyTrackingDomains: ['test.com'],
 };
 
-const filePath = 'ios/testproject/PrivacyInfo.xcprivacy';
-
-const originalFs = jest.requireActual('fs');
-
 describe('withPrivacyInfo', () => {
   afterEach(() => vol.reset());
-  it('adds PrivacyInfo.xcprivacy file to the project and merges with existing file', async () => {
-    // mock the data in the PrivacyInfo.xcprivacy file using vol
+
+  it('adds PrivacyInfo.xcprivacy file to the project and merges with existing file', () => {
     vol.fromJSON(
       {
-        [filePath]: originalFs.readFileSync(
+        ...rnFixture,
+        'ios/HelloWorld/PrivacyInfo.xcprivacy': originalFs.readFileSync(
           path.join(__dirname, 'fixtures/PrivacyInfo.xcprivacy'),
           'utf-8'
         ),
@@ -63,7 +40,36 @@ describe('withPrivacyInfo', () => {
       projectRoot
     );
 
+    const pbxproj = getPbxproj(projectRoot);
+
+    const mockConfig = {
+      modResults: pbxproj,
+      modRequest: {
+        projectRoot,
+        platformProjectRoot: path.join(projectRoot, 'ios'),
+        modName: 'xcodeproj',
+        platform: 'ios' as const,
+        introspect: false,
+      },
+      modRawConfig: project,
+      ...project,
+    } as any;
+
     setPrivacyInfo(mockConfig, privacyManifests);
-    expect(vol.readFileSync(path.join(projectRoot, filePath), 'utf-8')).toMatchSnapshot();
+
+    // The PrivacyInfo.xcprivacy file on disk reflects the merged manifests.
+    expect(
+      vol.readFileSync(path.join(projectRoot, 'ios/HelloWorld/PrivacyInfo.xcprivacy'), 'utf-8')
+    ).toMatchSnapshot();
+
+    // The PrivacyInfo file is now registered in the pbxproj.
+    expect(pbxproj.hasFile('HelloWorld/PrivacyInfo.xcprivacy')).toBeTruthy();
+
+    // The file is wired into the resources build phase.
+    const output = pbxproj.writeSync();
+    const resourcesRegion = output.match(
+      /Begin PBXResourcesBuildPhase[\s\S]*?End PBXResourcesBuildPhase/
+    );
+    expect(resourcesRegion?.[0]).toContain('PrivacyInfo.xcprivacy');
   });
 });

--- a/packages/@expo/config-plugins/src/ios/utils/Xcodeproj.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/Xcodeproj.ts
@@ -19,10 +19,10 @@ import type {
   XCConfigurationList,
   XcodeProject,
 } from 'xcode';
-import xcode from 'xcode';
 import pbxFile from 'xcode/lib/pbxFile';
 
 import { trimQuotes } from './string';
+import { openXcodeProject } from './xcodeShim/backend';
 import { addWarningIOS } from '../../utils/warnings';
 import * as Paths from '../Paths';
 
@@ -335,9 +335,7 @@ export function ensureGroupRecursively(project: XcodeProject, filepath: string):
  */
 export function getPbxproj(projectRoot: string): XcodeProject {
   const projectPath = Paths.getPBXProjectPath(projectRoot);
-  const project = xcode.project(projectPath);
-  project.parseSync();
-  return project;
+  return openXcodeProject(projectPath);
 }
 
 /**

--- a/packages/@expo/config-plugins/src/ios/utils/__tests__/Xcodeproj-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/__tests__/Xcodeproj-test.ts
@@ -1,4 +1,24 @@
-import { resolveXcodeBuildSetting, sanitizedName } from '../Xcodeproj';
+import { vol } from 'memfs';
+
+import type { XcodeProject } from '../../../Plugin.types';
+import rnFixture from '../../../plugins/__tests__/fixtures/react-native-project';
+import {
+  addBuildSourceFileToGroup,
+  addFramework,
+  addResourceFileToGroup,
+  ensureGroupRecursively,
+  getApplicationNativeTarget,
+  getBuildConfigurationForListIdAndName,
+  getBuildConfigurationsForListId,
+  getPbxproj,
+  getProductName,
+  getXCConfigurationListEntries,
+  resolvePathOrProject,
+  resolveXcodeBuildSetting,
+  sanitizedName,
+} from '../Xcodeproj';
+
+jest.mock('fs');
 
 describe(sanitizedName, () => {
   it(`formats basic name`, () => {
@@ -96,5 +116,201 @@ describe(resolveXcodeBuildSetting, () => {
         (setting) => ({ PRODUCT_NAME: 'foo_-bar' })[setting]
       )
     ).toBe('org.reactjs.native.example.foo--bar');
+  });
+});
+
+describe('Xcodeproj pbxproj utilities', () => {
+  const projectRoot = '/app';
+  const pbxProjPath = 'ios/HelloWorld.xcodeproj/project.pbxproj';
+  let project: XcodeProject;
+
+  beforeEach(() => {
+    vol.fromJSON(
+      { [pbxProjPath]: rnFixture['ios/HelloWorld.xcodeproj/project.pbxproj'] },
+      projectRoot
+    );
+    project = getPbxproj(projectRoot);
+  });
+
+  afterEach(() => vol.reset());
+
+  describe(resolvePathOrProject, () => {
+    it('returns the project when given a parsed XcodeProject', () => {
+      expect(resolvePathOrProject(project)).toBe(project);
+    });
+
+    it('loads and parses the project when given a project root', () => {
+      const loaded = resolvePathOrProject(projectRoot);
+      expect(loaded).not.toBeNull();
+      expect(loaded!.filepath).toContain('project.pbxproj');
+    });
+
+    it('returns null when the project does not exist', () => {
+      expect(resolvePathOrProject('/does-not-exist')).toBeNull();
+    });
+  });
+
+  describe(getApplicationNativeTarget, () => {
+    it('returns the application target matching the project name', () => {
+      const target = getApplicationNativeTarget({ project, projectName: 'HelloWorld' });
+      expect(target.target.name).toBe('HelloWorld');
+      expect(target.target.productType).toContain('com.apple.product-type.application');
+    });
+
+    it('throws when the project name does not match the application target', () => {
+      expect(() => getApplicationNativeTarget({ project, projectName: 'WrongName' })).toThrow();
+    });
+  });
+
+  describe(getProductName, () => {
+    it('returns the productName build setting', () => {
+      expect(getProductName(project)).toBe('HelloWorld');
+    });
+  });
+
+  describe(getXCConfigurationListEntries, () => {
+    it('returns configuration list entries without _comment keys', () => {
+      const entries = getXCConfigurationListEntries(project);
+      expect(entries.length).toBeGreaterThan(0);
+      for (const [key] of entries) {
+        expect(key.endsWith('_comment')).toBe(false);
+      }
+    });
+  });
+
+  describe(getBuildConfigurationsForListId, () => {
+    it('returns the Debug and Release build configurations for the application target', () => {
+      const target = getApplicationNativeTarget({ project, projectName: 'HelloWorld' });
+      const entries = getBuildConfigurationsForListId(
+        project,
+        target.target.buildConfigurationList
+      );
+      const names = entries.map(([, c]) => c.name).sort();
+      expect(names).toEqual(['Debug', 'Release']);
+    });
+  });
+
+  describe(getBuildConfigurationForListIdAndName, () => {
+    it('returns the configuration that matches the requested name', () => {
+      const target = getApplicationNativeTarget({ project, projectName: 'HelloWorld' });
+      const [, debug] = getBuildConfigurationForListIdAndName(project, {
+        configurationListId: target.target.buildConfigurationList,
+        buildConfiguration: 'Debug',
+      });
+      expect(debug.name).toBe('Debug');
+    });
+
+    it('throws when the requested configuration does not exist', () => {
+      const target = getApplicationNativeTarget({ project, projectName: 'HelloWorld' });
+      expect(() =>
+        getBuildConfigurationForListIdAndName(project, {
+          configurationListId: target.target.buildConfigurationList,
+          buildConfiguration: 'Bogus',
+        })
+      ).toThrow();
+    });
+  });
+
+  describe(ensureGroupRecursively, () => {
+    it('creates nested groups under an existing group', () => {
+      const group = ensureGroupRecursively(project, 'HelloWorld/Generated/Sources');
+      expect(group).not.toBeNull();
+      expect(group!.name).toBe('Sources');
+      expect(project.pbxGroupByName('Generated')).toBeDefined();
+      expect(project.pbxGroupByName('Sources')).toBeDefined();
+    });
+
+    it('returns the same group when called twice for the same path', () => {
+      ensureGroupRecursively(project, 'HelloWorld/Generated');
+      const first = project.pbxGroupByName('Generated');
+      ensureGroupRecursively(project, 'HelloWorld/Generated');
+      const second = project.pbxGroupByName('Generated');
+      expect(first).toBe(second);
+    });
+  });
+
+  describe(addResourceFileToGroup, () => {
+    it('registers the file reference and adds it to the resources build phase', () => {
+      const filepath = 'HelloWorld/new-resource.png';
+      addResourceFileToGroup({
+        filepath,
+        groupName: 'HelloWorld',
+        project,
+        isBuildFile: true,
+      });
+
+      // file reference registered
+      expect(project.hasFile(filepath)).toBeTruthy();
+
+      // file appears as a child of the HelloWorld group
+      const group = project.pbxGroupByName('HelloWorld');
+      expect(group?.children.some((child: any) => child.comment === 'new-resource.png')).toBe(true);
+
+      // file appears in the resources build phase section of the serialized output
+      const output = project.writeSync();
+      const resourcesRegion = output.match(
+        /Begin PBXResourcesBuildPhase[\s\S]*?End PBXResourcesBuildPhase/
+      );
+      expect(resourcesRegion?.[0]).toContain('new-resource.png');
+    });
+
+    it('does not duplicate a file that is already present in the group', () => {
+      const filepath = 'HelloWorld/dup-resource.png';
+      addResourceFileToGroup({ filepath, groupName: 'HelloWorld', project, isBuildFile: true });
+
+      const fileRefCountBefore = Object.keys(project.pbxFileReferenceSection()).length;
+      addResourceFileToGroup({ filepath, groupName: 'HelloWorld', project, isBuildFile: true });
+      const fileRefCountAfter = Object.keys(project.pbxFileReferenceSection()).length;
+
+      expect(fileRefCountAfter).toBe(fileRefCountBefore);
+    });
+
+    it('skips adding to the build file section when isBuildFile is false', () => {
+      const buildFileCountBefore = Object.keys(project.pbxBuildFileSection()).length;
+      addResourceFileToGroup({
+        filepath: 'HelloWorld/readme-only.txt',
+        groupName: 'HelloWorld',
+        project,
+        isBuildFile: false,
+      });
+      const buildFileCountAfter = Object.keys(project.pbxBuildFileSection()).length;
+      expect(buildFileCountAfter).toBe(buildFileCountBefore);
+    });
+  });
+
+  describe(addBuildSourceFileToGroup, () => {
+    it('registers the file reference and adds it to the sources build phase', () => {
+      const filepath = 'HelloWorld/MyClass.swift';
+      addBuildSourceFileToGroup({
+        filepath,
+        groupName: 'HelloWorld',
+        project,
+      });
+
+      expect(project.hasFile(filepath)).toBeTruthy();
+
+      // file appears in the sources build phase section of the serialized output
+      const output = project.writeSync();
+      const sourcesRegion = output.match(
+        /Begin PBXSourcesBuildPhase[\s\S]*?End PBXSourcesBuildPhase/
+      );
+      expect(sourcesRegion?.[0]).toContain('MyClass.swift');
+    });
+  });
+
+  describe(addFramework, () => {
+    it('adds the framework to the application target', () => {
+      addFramework({
+        project,
+        projectName: 'HelloWorld',
+        framework: 'StoreKit.framework',
+      });
+
+      const output = project.writeSync();
+      const frameworksRegion = output.match(
+        /Begin PBXFrameworksBuildPhase[\s\S]*?End PBXFrameworksBuildPhase/
+      );
+      expect(frameworksRegion?.[0]).toContain('StoreKit.framework');
+    });
   });
 });

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -2,6 +2,8 @@ import { XcodeProject } from '@bacons/xcode';
 import { build } from '@bacons/xcode/json';
 import path from 'path';
 
+import { legacyRefArray } from './legacyRefArray';
+
 function notImplemented(method: string): never {
   throw new Error(`XcodeProjectShim.${method} is not implemented yet`);
 }
@@ -61,6 +63,48 @@ export class XcodeProjectShim {
     return new Set<string>(configs.map((config: any) => config.uuid));
   }
 
+  // `@bacons`'s getObject throws on miss; legacy returns null/undefined.
+  private safeGetObject(uuid: string): any {
+    try {
+      return this.inner.getObject(uuid);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Legacy-shaped view of a group: references as UUIDs, `children` as a live array. */
+  private legacyGroup(model: any): any {
+    const project = this.inner;
+    return {
+      uuid: model.uuid,
+      isa: model.isa,
+      name: model.props.name,
+      path: model.props.path,
+      sourceTree: model.props.sourceTree,
+      get children() {
+        return legacyRefArray(model.props.children, project);
+      },
+    };
+  }
+
+  /** Legacy-shaped view of the root project: references as UUIDs, `targets` as a live array. */
+  private legacyProject(): any {
+    const project = this.inner;
+    const props = this.inner.rootObject.props;
+    return {
+      mainGroup: props.mainGroup?.uuid,
+      productRefGroup: props.productRefGroup?.uuid,
+      buildConfigurationList: props.buildConfigurationList?.uuid,
+      knownRegions: props.knownRegions,
+      attributes: props.attributes,
+      compatibilityVersion: props.compatibilityVersion,
+      developmentRegion: props.developmentRegion,
+      get targets() {
+        return legacyRefArray(props.targets, project);
+      },
+    };
+  }
+
   // === Lifecycle / IO ===
 
   parseSync(): this {
@@ -111,8 +155,9 @@ export class XcodeProjectShim {
   xcVersionGroupSection(..._args: any[]): any {
     notImplemented('xcVersionGroupSection');
   }
-  pbxGroupByName(..._args: any[]): any {
-    notImplemented('pbxGroupByName');
+  pbxGroupByName(name: string): any {
+    const model = this.modelsOfIsa('PBXGroup').find((g) => g.getDisplayName() === name);
+    return model ? this.legacyGroup(model) : null;
   }
   pbxResourcesBuildPhaseObj(..._args: any[]): any {
     notImplemented('pbxResourcesBuildPhaseObj');
@@ -135,8 +180,8 @@ export class XcodeProjectShim {
   buildPhaseObject(..._args: any[]): any {
     notImplemented('buildPhaseObject');
   }
-  getFirstProject(..._args: any[]): any {
-    notImplemented('getFirstProject');
+  getFirstProject(): any {
+    return { uuid: this.inner.rootObject.uuid, firstProject: this.legacyProject() };
   }
   getFirstTarget(..._args: any[]): any {
     notImplemented('getFirstTarget');
@@ -144,8 +189,9 @@ export class XcodeProjectShim {
   getTarget(..._args: any[]): any {
     notImplemented('getTarget');
   }
-  getPBXGroupByKey(..._args: any[]): any {
-    notImplemented('getPBXGroupByKey');
+  getPBXGroupByKey(key: string): any {
+    const model = this.safeGetObject(key);
+    return model && model.isa === 'PBXGroup' ? this.legacyGroup(model) : undefined;
   }
   getPBXGroupByKeyAndType(..._args: any[]): any {
     notImplemented('getPBXGroupByKeyAndType');
@@ -323,11 +369,13 @@ export class XcodeProjectShim {
 
   // === Mutate: groups ===
 
-  pbxCreateGroup(..._args: any[]): any {
-    notImplemented('pbxCreateGroup');
+  pbxCreateGroup(name: string, pathName?: string): string {
+    return this.pbxCreateGroupWithType(name, pathName, 'PBXGroup');
   }
-  pbxCreateGroupWithType(..._args: any[]): any {
-    notImplemented('pbxCreateGroupWithType');
+  pbxCreateGroupWithType(name: string, pathName: string | undefined, groupType: string): string {
+    const opts: any = { isa: groupType, name, children: [], sourceTree: '<group>' };
+    if (pathName) opts.path = unquoteForWrite(pathName);
+    return this.inner.createModel(opts).uuid;
   }
   pbxCreateVariantGroup(..._args: any[]): any {
     notImplemented('pbxCreateVariantGroup');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -3,6 +3,7 @@ import { build } from '@bacons/xcode/json';
 import path from 'path';
 
 import { legacyRefArray } from './legacyRefArray';
+import { PbxFile } from './pbxFile';
 
 function notImplemented(method: string): never {
   throw new Error(`XcodeProjectShim.${method} is not implemented yet`);
@@ -254,8 +255,9 @@ export class XcodeProjectShim {
     const model = this.safeGetObject(key);
     return model && model.isa === 'PBXGroup' ? this.legacyGroup(model) : undefined;
   }
-  getPBXGroupByKeyAndType(..._args: any[]): any {
-    notImplemented('getPBXGroupByKeyAndType');
+  getPBXGroupByKeyAndType(key: string, groupType: string): any {
+    const model = this.safeGetObject(key);
+    return model && model.isa === groupType ? this.legacyGroup(model) : undefined;
   }
   getPBXVariantGroupByKey(..._args: any[]): any {
     notImplemented('getPBXVariantGroupByKey');
@@ -454,20 +456,57 @@ export class XcodeProjectShim {
   pbxCreateVariantGroup(..._args: any[]): any {
     notImplemented('pbxCreateVariantGroup');
   }
-  addPbxGroup(..._args: any[]): any {
-    notImplemented('addPbxGroup');
+  addPbxGroup(
+    filePathsArray: string[],
+    name?: string,
+    groupPath?: string,
+    sourceTree?: string
+  ): any {
+    const existing = new Map<string, any>();
+    for (const ref of this.modelsOfIsa('PBXFileReference')) existing.set(ref.props.path, ref);
+
+    const group = this.createObjectWithUuid(this.generateUuid(), {
+      isa: 'PBXGroup',
+      children: [],
+      name,
+      path: groupPath,
+      sourceTree: sourceTree ? unquoteForWrite(sourceTree) : '<group>',
+    });
+
+    for (const filePath of filePathsArray) {
+      const found = existing.get(filePath) ?? existing.get(`"${filePath}"`);
+      if (found) {
+        group.props.children.push(found);
+        continue;
+      }
+      const file = new PbxFile(filePath);
+      file.uuid = this.generateUuid();
+      file.fileRef = this.generateUuid();
+      this.addToPbxFileReferenceSection(file);
+      this.addToPbxBuildFileSection(file);
+      group.props.children.push(this.inner.getObject(file.fileRef));
+    }
+
+    return { uuid: group.uuid, pbxGroup: this.legacyGroup(group) };
   }
   removePbxGroup(..._args: any[]): any {
     notImplemented('removePbxGroup');
   }
-  addToPbxGroup(..._args: any[]): any {
-    notImplemented('addToPbxGroup');
+  addToPbxGroup(file: any, groupKey: string): void {
+    this.addToPbxGroupType(file, groupKey, 'PBXGroup');
   }
-  addToPbxGroupType(..._args: any[]): any {
-    notImplemented('addToPbxGroupType');
+  addToPbxGroupType(file: any, groupKey: string, groupType: string): void {
+    const group = this.getPBXGroupByKeyAndType(groupKey, groupType);
+    if (!group?.children) return;
+    if (typeof file === 'string') {
+      const child = this.safeGetObject(file);
+      group.children.push({ value: file, comment: child?.getDisplayName?.() ?? file });
+    } else {
+      group.children.push({ value: file.fileRef, comment: file.basename });
+    }
   }
-  addToPbxVariantGroup(..._args: any[]): any {
-    notImplemented('addToPbxVariantGroup');
+  addToPbxVariantGroup(file: any, groupKey: string): void {
+    this.addToPbxGroupType(file, groupKey, 'PBXVariantGroup');
   }
   removeFromPbxGroup(..._args: any[]): any {
     notImplemented('removeFromPbxGroup');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -931,7 +931,12 @@ export class XcodeProjectShim {
     return this.pbxCreateGroupWithType(name, pathName, 'PBXGroup');
   }
   pbxCreateGroupWithType(name: string, pathName: string | undefined, groupType: string): string {
-    const opts: any = { isa: groupType, name, children: [], sourceTree: '<group>' };
+    const opts: any = {
+      isa: groupType,
+      name: unquoteForWrite(name),
+      children: [],
+      sourceTree: '<group>',
+    };
     if (pathName) opts.path = unquoteForWrite(pathName);
     return this.inner.createModel(opts).uuid;
   }
@@ -950,8 +955,8 @@ export class XcodeProjectShim {
     const group = this.createObjectWithUuid(this.generateUuid(), {
       isa: 'PBXGroup',
       children: [],
-      name,
-      path: groupPath,
+      name: unquoteForWrite(name),
+      path: unquoteForWrite(groupPath),
       sourceTree: sourceTree ? unquoteForWrite(sourceTree) : '<group>',
     });
 

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -23,6 +23,56 @@ function unquoteForWrite(value: any): any {
 // `$(inherited)`, stored unquoted (`@bacons` re-quotes at serialize).
 const INHERITED = '$(inherited)';
 
+// Copy-files phase destination lookups, ported from legacy `xcode`.
+const DESTINATION_BY_TARGETTYPE: Record<string, string> = {
+  application: 'wrapper',
+  app_extension: 'plugins',
+  bundle: 'wrapper',
+  command_line_tool: 'wrapper',
+  dynamic_library: 'products_directory',
+  framework: 'shared_frameworks',
+  frameworks: 'frameworks',
+  static_library: 'products_directory',
+  unit_test_bundle: 'wrapper',
+  watch_app: 'wrapper',
+  watch2_app: 'products_directory',
+  watch_extension: 'plugins',
+  watch2_extension: 'plugins',
+};
+const SUBFOLDERSPEC_BY_DESTINATION: Record<string, number> = {
+  absolute_path: 0,
+  executables: 6,
+  frameworks: 10,
+  java_resources: 15,
+  plugins: 13,
+  products_directory: 16,
+  resources: 7,
+  shared_frameworks: 11,
+  shared_support: 12,
+  wrapper: 1,
+  xpc_services: 0,
+};
+
+function copyFilesPhaseProps(folderType: string, subfolderPath: string | undefined, name: string) {
+  return {
+    name,
+    dstPath: subfolderPath ? trimQuotes(subfolderPath) : '',
+    dstSubfolderSpec: SUBFOLDERSPEC_BY_DESTINATION[DESTINATION_BY_TARGETTYPE[folderType] ?? ''],
+  };
+}
+
+function shellScriptPhaseProps(options: any, name: string) {
+  // Stored unquoted; `@bacons` escapes/quotes the script and re-quotes the paths
+  // at serialize (legacy stores paths verbatim and never quotes them).
+  return {
+    name,
+    inputPaths: (options.inputPaths || []).map(unquoteForWrite),
+    outputPaths: (options.outputPaths || []).map(unquoteForWrite),
+    shellPath: options.shellPath,
+    shellScript: options.shellScript,
+  };
+}
+
 /**
  * Backwards-compatible facade exposing the legacy `xcode` `XcodeProject` API on
  * top of a typed `@bacons/xcode` project. The substrate (construct / parse /
@@ -123,6 +173,28 @@ export class XcodeProjectShim {
   private buildPhaseForTarget(isa: string, targetUuid?: string): any {
     const target = (targetUuid && this.safeGetObject(targetUuid)) || this.firstTargetModel();
     return (target?.props?.buildPhases ?? []).find((phase: any) => phase.isa === isa);
+  }
+
+  /** Legacy-shaped view of a build phase: scalars pass through, `files` is a live array. */
+  private legacyBuildPhase(model: any): any {
+    const project = this.inner;
+    const props = model.props;
+    return {
+      uuid: model.uuid,
+      isa: model.isa,
+      name: props.name,
+      buildActionMask: props.buildActionMask,
+      runOnlyForDeploymentPostprocessing: props.runOnlyForDeploymentPostprocessing,
+      shellPath: props.shellPath,
+      shellScript: props.shellScript,
+      inputPaths: props.inputPaths,
+      outputPaths: props.outputPaths,
+      dstPath: props.dstPath,
+      dstSubfolderSpec: props.dstSubfolderSpec,
+      get files() {
+        return legacyRefArray(props.files, project);
+      },
+    };
   }
 
   // Append a build file to a target's phase. A missing build file (e.g. a file
@@ -234,26 +306,32 @@ export class XcodeProjectShim {
     const model = this.modelsOfIsa('PBXGroup').find((g) => g.getDisplayName() === name);
     return model ? this.legacyGroup(model) : null;
   }
-  pbxResourcesBuildPhaseObj(..._args: any[]): any {
-    notImplemented('pbxResourcesBuildPhaseObj');
+  pbxResourcesBuildPhaseObj(target?: string): any {
+    return this.buildPhaseObject('PBXResourcesBuildPhase', 'Resources', target);
   }
-  pbxSourcesBuildPhaseObj(..._args: any[]): any {
-    notImplemented('pbxSourcesBuildPhaseObj');
+  pbxSourcesBuildPhaseObj(target?: string): any {
+    return this.buildPhaseObject('PBXSourcesBuildPhase', 'Sources', target);
   }
-  pbxFrameworksBuildPhaseObj(..._args: any[]): any {
-    notImplemented('pbxFrameworksBuildPhaseObj');
+  pbxFrameworksBuildPhaseObj(target?: string): any {
+    return this.buildPhaseObject('PBXFrameworksBuildPhase', 'Frameworks', target);
   }
-  pbxEmbedFrameworksBuildPhaseObj(..._args: any[]): any {
-    notImplemented('pbxEmbedFrameworksBuildPhaseObj');
+  pbxEmbedFrameworksBuildPhaseObj(target?: string): any {
+    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Embed Frameworks', target);
   }
-  pbxCopyfilesBuildPhaseObj(..._args: any[]): any {
-    notImplemented('pbxCopyfilesBuildPhaseObj');
+  pbxCopyfilesBuildPhaseObj(target?: string): any {
+    return this.buildPhaseObject('PBXCopyFilesBuildPhase', 'Copy Files', target);
   }
   buildPhase(..._args: any[]): any {
     notImplemented('buildPhase');
   }
-  buildPhaseObject(..._args: any[]): any {
-    notImplemented('buildPhaseObject');
+  buildPhaseObject(isa: string, name: string, target?: string): any {
+    const targetModel = (target && this.safeGetObject(target)) || this.firstTargetModel();
+    // Unnamed built-in phases (Sources/Frameworks/Resources) match by isa; named
+    // phases (copy-files, shell scripts) disambiguate by name.
+    const phase = (targetModel?.props?.buildPhases ?? []).find(
+      (p: any) => p.isa === isa && (p.props.name == null || trimQuotes(p.props.name) === name)
+    );
+    return phase ? this.legacyBuildPhase(phase) : null;
   }
   getFirstProject(): any {
     return { uuid: this.inner.rootObject.uuid, firstProject: this.legacyProject() };
@@ -460,8 +538,49 @@ export class XcodeProjectShim {
   removeFromPbxCopyfilesBuildPhase(..._args: any[]): any {
     notImplemented('removeFromPbxCopyfilesBuildPhase');
   }
-  addBuildPhase(..._args: any[]): any {
-    notImplemented('addBuildPhase');
+  addBuildPhase(
+    filePathsArray: string[],
+    buildPhaseType: string,
+    comment: string,
+    target?: string,
+    optionsOrFolderType?: any,
+    subfolderPath?: string
+  ): any {
+    const targetModel = (target && this.safeGetObject(target)) || this.firstTargetModel();
+
+    let extra: Record<string, any> = {};
+    if (buildPhaseType === 'PBXCopyFilesBuildPhase') {
+      extra = copyFilesPhaseProps(optionsOrFolderType, subfolderPath, comment);
+    } else if (buildPhaseType === 'PBXShellScriptBuildPhase') {
+      extra = shellScriptPhaseProps(optionsOrFolderType, comment);
+    }
+
+    const phase = this.createObjectWithUuid(this.generateUuid(), {
+      isa: buildPhaseType,
+      buildActionMask: 2147483647,
+      files: [],
+      runOnlyForDeploymentPostprocessing: 0,
+      ...extra,
+    });
+    targetModel.props.buildPhases.push(phase);
+
+    for (const filePath of filePathsArray) {
+      const existing = this.modelsOfIsa('PBXBuildFile').find(
+        (bf) => bf.props.fileRef?.props?.path === filePath
+      );
+      if (existing) {
+        phase.props.files.push(existing);
+        continue;
+      }
+      const file = new PbxFile(filePath);
+      file.uuid = this.generateUuid();
+      file.fileRef = this.generateUuid();
+      this.addToPbxFileReferenceSection(file);
+      this.addToPbxBuildFileSection(file);
+      phase.props.files.push(this.inner.getObject(file.uuid));
+    }
+
+    return { uuid: phase.uuid, buildPhase: this.legacyBuildPhase(phase) };
   }
 
   // === Mutate: groups ===

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -171,8 +171,13 @@ export class XcodeProjectShim {
   getPBXObject(..._args: any[]): any {
     notImplemented('getPBXObject');
   }
-  hasFile(..._args: any[]): any {
-    notImplemented('hasFile');
+  hasFile(filePath: string): any {
+    for (const ref of this.modelsOfIsa('PBXFileReference')) {
+      if (trimQuotes(ref.props.path) === filePath) {
+        return ref;
+      }
+    }
+    return false;
   }
   getBuildProperty(prop: string, build?: string, targetName?: string): any {
     const scoped = targetName ? this.configUuidsForTarget(this.findTargetByName(targetName)) : null;

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -23,6 +23,15 @@ function unquoteForWrite(value: any): any {
 // `$(inherited)`, stored unquoted (`@bacons` re-quotes at serialize).
 const INHERITED = '$(inherited)';
 
+// Strip outer quotes from build-setting values (and array elements) on write.
+function unquoteBuildSettings(buildSettings: Record<string, any> = {}): Record<string, any> {
+  const out: Record<string, any> = {};
+  for (const [key, value] of Object.entries(buildSettings)) {
+    out[key] = Array.isArray(value) ? value.map(unquoteForWrite) : unquoteForWrite(value);
+  }
+  return out;
+}
+
 // Copy-files phase destination lookups, ported from legacy `xcode`.
 const DESTINATION_BY_TARGETTYPE: Record<string, string> = {
   application: 'wrapper',
@@ -224,6 +233,21 @@ export class XcodeProjectShim {
     }
   }
 
+  /** Legacy-shaped view of an XCConfigurationList: `buildConfigurations` as a live array. */
+  private legacyConfigList(model: any): any {
+    const project = this.inner;
+    const props = model.props;
+    return {
+      uuid: model.uuid,
+      isa: model.isa,
+      defaultConfigurationName: props.defaultConfigurationName,
+      defaultConfigurationIsVisible: props.defaultConfigurationIsVisible,
+      get buildConfigurations() {
+        return legacyRefArray(props.buildConfigurations, project);
+      },
+    };
+  }
+
   /** Legacy section dict: `{ uuid: object, uuid_comment: name }` for each model of an isa. */
   private legacySection(isa: string): Record<string, any> {
     const section: Record<string, any> = {};
@@ -268,7 +292,17 @@ export class XcodeProjectShim {
   }
 
   get hash(): any {
-    return notImplemented('hash');
+    const self = this;
+    return {
+      project: {
+        objects: new Proxy(
+          {},
+          {
+            get: (_t, isa: string) => self.legacySection(isa),
+          }
+        ),
+      },
+    };
   }
 
   allUuids(..._args: any[]): any {
@@ -295,8 +329,8 @@ export class XcodeProjectShim {
   pbxXCBuildConfigurationSection(..._args: any[]): any {
     notImplemented('pbxXCBuildConfigurationSection');
   }
-  pbxXCConfigurationList(..._args: any[]): any {
-    notImplemented('pbxXCConfigurationList');
+  pbxXCConfigurationList(): any {
+    return this.legacySection('XCConfigurationList');
   }
   pbxFileReferenceSection(): any {
     return this.legacySection('PBXFileReference');
@@ -362,14 +396,20 @@ export class XcodeProjectShim {
   getPBXVariantGroupByKey(..._args: any[]): any {
     notImplemented('getPBXVariantGroupByKey');
   }
-  pbxTargetByName(..._args: any[]): any {
-    notImplemented('pbxTargetByName');
+  pbxTargetByName(name: string): any {
+    const model = this.modelsOfIsa('PBXNativeTarget').find(
+      (t) => trimQuotes(t.props.name) === name
+    );
+    return model ? this.legacyTarget(model) : null;
   }
   pbxItemByComment(..._args: any[]): any {
     notImplemented('pbxItemByComment');
   }
-  findTargetKey(..._args: any[]): any {
-    notImplemented('findTargetKey');
+  findTargetKey(name: string): any {
+    const model = this.modelsOfIsa('PBXNativeTarget').find(
+      (t) => trimQuotes(t.props.name) === name
+    );
+    return model ? model.uuid : null;
   }
   findPBXGroupKey(..._args: any[]): any {
     notImplemented('findPBXGroupKey');
@@ -377,8 +417,8 @@ export class XcodeProjectShim {
   findPBXGroupKeyAndType(..._args: any[]): any {
     notImplemented('findPBXGroupKeyAndType');
   }
-  getPBXObject(..._args: any[]): any {
-    notImplemented('getPBXObject');
+  getPBXObject(name: string): any {
+    return this.legacySection(name);
   }
   hasFile(filePath: string): any {
     for (const ref of this.modelsOfIsa('PBXFileReference')) {
@@ -759,17 +799,48 @@ export class XcodeProjectShim {
   addTargetDependency(..._args: any[]): any {
     notImplemented('addTargetDependency');
   }
-  addXCConfigurationList(..._args: any[]): any {
-    notImplemented('addXCConfigurationList');
+  addXCConfigurationList(
+    configurationObjectsArray: any[],
+    defaultConfigurationName: string,
+    _comment?: string
+  ): any {
+    const buildConfigurations = configurationObjectsArray.map((configuration) =>
+      this.createObjectWithUuid(this.generateUuid(), {
+        isa: 'XCBuildConfiguration',
+        name: configuration.name,
+        buildSettings: unquoteBuildSettings(configuration.buildSettings),
+      })
+    );
+    const list = this.createObjectWithUuid(this.generateUuid(), {
+      isa: 'XCConfigurationList',
+      buildConfigurations,
+      defaultConfigurationIsVisible: 0,
+      defaultConfigurationName,
+    });
+    return { uuid: list.uuid, xcConfigurationList: this.legacyConfigList(list) };
   }
-  addProductFile(..._args: any[]): any {
-    notImplemented('addProductFile');
+  addProductFile(targetPath: string, opt: any = {}): any {
+    const file = new PbxFile(targetPath, opt);
+    file.includeInIndex = 0;
+    file.fileRef = this.generateUuid();
+    file.target = opt.target;
+    file.group = opt.group;
+    file.uuid = this.generateUuid();
+    file.path = file.basename;
+    this.addToPbxFileReferenceSection(file);
+    this.addToProductsPbxGroup(file);
+    return file;
   }
   removeProductFile(..._args: any[]): any {
     notImplemented('removeProductFile');
   }
-  addToProductsPbxGroup(..._args: any[]): any {
-    notImplemented('addToProductsPbxGroup');
+  addToProductsPbxGroup(file: any): void {
+    const group = this.pbxGroupByName('Products');
+    if (!group) {
+      this.addPbxGroup([file.path], 'Products');
+    } else {
+      group.children.push({ value: file.fileRef, comment: file.basename });
+    }
   }
   addTargetAttribute(..._args: any[]): any {
     notImplemented('addTargetAttribute');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -23,13 +23,65 @@ function unquoteForWrite(value: any): any {
 // `$(inherited)`, stored unquoted (`@bacons` re-quotes at serialize).
 const INHERITED = '$(inherited)';
 
+// Array-valued build settings written directly (e.g. HEADER_SEARCH_PATHS) are
+// unquoted on push/index-set so `@bacons` doesn't double-quote pre-quoted entries.
+function unquotingArray(arr: any[]): any[] {
+  return new Proxy(arr, {
+    set(target, prop, value) {
+      if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+        target[Number(prop)] = unquoteForWrite(value);
+        return true;
+      }
+      return Reflect.set(target, prop, value);
+    },
+  });
+}
+
 // Build settings written directly through a section view (bypassing
-// addBuildProperty) are unquoted on assignment so `@bacons` doesn't double-quote.
+// addBuildProperty) are unquoted so `@bacons` doesn't double-quote. Scalar and
+// array-element assignments are unquoted, and array reads return an unquoting
+// view so later `.push(...)` of quoted values is normalized too.
 function buildSettingsProxy(buildSettings: Record<string, any>): Record<string, any> {
   return new Proxy(buildSettings, {
+    get(target, key) {
+      const value = target[key as string];
+      return Array.isArray(value) ? unquotingArray(value) : value;
+    },
     set(target, key, value) {
-      target[key as string] = typeof key === 'string' ? unquoteForWrite(value) : value;
+      if (typeof key !== 'string') {
+        target[key as any] = value;
+      } else {
+        target[key] = Array.isArray(value) ? value.map(unquoteForWrite) : unquoteForWrite(value);
+      }
       return true;
+    },
+  });
+}
+
+// Object fields that hold arrays of references (even when currently empty).
+const REF_ARRAY_FIELDS = new Set([
+  'children',
+  'files',
+  'buildPhases',
+  'dependencies',
+  'buildConfigurations',
+  'buildRules',
+  'targets',
+]);
+
+// Define a legacy-shaped ref-array property with both get (live view) and set
+// (wholesale reassignment, which legacy plugins do e.g. `group.children = [...]`).
+function defineLiveRefArray(view: any, key: string, backing: any[], project: XcodeProject): void {
+  Object.defineProperty(view, key, {
+    enumerable: true,
+    configurable: true,
+    get() {
+      return legacyRefArray(backing, project);
+    },
+    set(entries: any[]) {
+      backing.length = 0;
+      const arr = legacyRefArray(backing, project);
+      for (const entry of entries ?? []) arr.push(entry);
     },
   });
 }
@@ -177,17 +229,15 @@ export class XcodeProjectShim {
 
   /** Legacy-shaped view of a group: references as UUIDs, `children` as a live array. */
   private legacyGroup(model: any): any {
-    const project = this.inner;
-    return {
+    const view: any = {
       uuid: model.uuid,
       isa: model.isa,
       name: model.props.name,
       path: model.props.path,
       sourceTree: model.props.sourceTree,
-      get children() {
-        return legacyRefArray(model.props.children, project);
-      },
     };
+    defineLiveRefArray(view, 'children', model.props.children, this.inner);
+    return view;
   }
 
   // `createObject` builds a model with a caller-chosen uuid but does not register
@@ -209,22 +259,18 @@ export class XcodeProjectShim {
 
   /** Legacy-shaped view of a native target: references as UUIDs, ref arrays live. */
   private legacyTarget(model: any): any {
-    const project = this.inner;
     const props = model.props;
-    return {
+    const view: any = {
       uuid: model.uuid,
       isa: model.isa,
       name: props.name,
       productName: props.productName,
       productType: props.productType,
       buildConfigurationList: props.buildConfigurationList?.uuid,
-      get dependencies() {
-        return legacyRefArray(props.dependencies, project);
-      },
-      get buildPhases() {
-        return legacyRefArray(props.buildPhases, project);
-      },
     };
+    defineLiveRefArray(view, 'dependencies', props.dependencies, this.inner);
+    defineLiveRefArray(view, 'buildPhases', props.buildPhases, this.inner);
+    return view;
   }
 
   private targetModel(targetUuid?: string): any {
@@ -239,9 +285,8 @@ export class XcodeProjectShim {
 
   /** Legacy-shaped view of a build phase: scalars pass through, `files` is a live array. */
   private legacyBuildPhase(model: any): any {
-    const project = this.inner;
     const props = model.props;
-    return {
+    const view: any = {
       uuid: model.uuid,
       isa: model.isa,
       name: props.name,
@@ -253,10 +298,9 @@ export class XcodeProjectShim {
       outputPaths: props.outputPaths,
       dstPath: props.dstPath,
       dstSubfolderSpec: props.dstSubfolderSpec,
-      get files() {
-        return legacyRefArray(props.files, project);
-      },
     };
+    defineLiveRefArray(view, 'files', props.files, this.inner);
+    return view;
   }
 
   // Append a build file to a target's phase. A missing build file (e.g. a file
@@ -283,17 +327,15 @@ export class XcodeProjectShim {
 
   /** Legacy-shaped view of an XCConfigurationList: `buildConfigurations` as a live array. */
   private legacyConfigList(model: any): any {
-    const project = this.inner;
     const props = model.props;
-    return {
+    const view: any = {
       uuid: model.uuid,
       isa: model.isa,
       defaultConfigurationName: props.defaultConfigurationName,
       defaultConfigurationIsVisible: props.defaultConfigurationIsVisible,
-      get buildConfigurations() {
-        return legacyRefArray(props.buildConfigurations, project);
-      },
     };
+    defineLiveRefArray(view, 'buildConfigurations', props.buildConfigurations, this.inner);
+    return view;
   }
 
   // Legacy-shaped view of one object's props: references become UUID strings,
@@ -316,10 +358,10 @@ export class XcodeProjectShim {
         out[key] = value.uuid;
       } else if (
         Array.isArray(value) &&
-        value.length > 0 &&
-        value.every((v) => v && typeof v.uuid === 'string')
+        (REF_ARRAY_FIELDS.has(key) ||
+          (value.length > 0 && value.every((v) => v && typeof v.uuid === 'string')))
       ) {
-        out[key] = legacyRefArray(value, project);
+        defineLiveRefArray(out, key, value, project);
       } else {
         out[key] = value;
       }
@@ -339,9 +381,8 @@ export class XcodeProjectShim {
 
   /** Legacy-shaped view of the root project: references as UUIDs, `targets` as a live array. */
   private legacyProject(): any {
-    const project = this.inner;
     const props = this.inner.rootObject.props;
-    return {
+    const view: any = {
       mainGroup: props.mainGroup?.uuid,
       productRefGroup: props.productRefGroup?.uuid,
       buildConfigurationList: props.buildConfigurationList?.uuid,
@@ -349,10 +390,9 @@ export class XcodeProjectShim {
       attributes: props.attributes,
       compatibilityVersion: props.compatibilityVersion,
       developmentRegion: props.developmentRegion,
-      get targets() {
-        return legacyRefArray(props.targets, project);
-      },
     };
+    defineLiveRefArray(view, 'targets', props.targets, this.inner);
+    return view;
   }
 
   // === Lifecycle / IO ===
@@ -451,9 +491,15 @@ export class XcodeProjectShim {
     const targetModel = (target && this.safeGetObject(target)) || this.firstTargetModel();
     // Unnamed built-in phases (Sources/Frameworks/Resources) match by isa; named
     // phases (copy-files, shell scripts) disambiguate by name.
-    const phase = (targetModel?.props?.buildPhases ?? []).find(
+    let phase = (targetModel?.props?.buildPhases ?? []).find(
       (p: any) => p.isa === isa && (p.props.name == null || trimQuotes(p.props.name) === name)
     );
+    // Legacy fallback: when the passed target doesn't own the named phase, match
+    // it by name across the whole section (e.g. a phase that lives on the app
+    // target is looked up via a freshly-created extension target).
+    if (!phase) {
+      phase = this.modelsOfIsa(isa).find((p) => trimQuotes(p.props.name ?? '') === name);
+    }
     return phase ? this.legacyBuildPhase(phase) : null;
   }
   getFirstProject(): any {
@@ -613,9 +659,12 @@ export class XcodeProjectShim {
     notImplemented('removeFromPbxFileReferenceSection');
   }
   addToPbxBuildFileSection(file: any): void {
+    // Tolerate link-before-register: some plugins add the build file before its
+    // file reference. A stand-in carrying the uuid serializes the right ref once
+    // the file reference is registered (moments later).
     this.createObjectWithUuid(file.uuid, {
       isa: 'PBXBuildFile',
-      fileRef: this.inner.getObject(file.fileRef),
+      fileRef: this.safeGetObject(file.fileRef) ?? { uuid: file.fileRef },
       settings: file.settings,
     });
   }

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -23,10 +23,30 @@ function unquoteForWrite(value: any): any {
 // `$(inherited)`, stored unquoted (`@bacons` re-quotes at serialize).
 const INHERITED = '$(inherited)';
 
+// Re-quote a value on read the way pbxproj serialization would, so reads
+// reproduce legacy's verbatim (quoted) form — plugins that compare against
+// quoted strings (e.g. `productType === '"…application"'`) keep working. Mirrors
+// `@bacons`'s `ensureQuotes` (hyphen is NOT a safe char, so product types quote).
+function quoteForRead(value: any): any {
+  if (typeof value !== 'string') return value;
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t');
+  return /^[\w$/:.]+$/.test(escaped) ? escaped : `"${escaped}"`;
+}
+
 // Array-valued build settings written directly (e.g. HEADER_SEARCH_PATHS) are
 // unquoted on push/index-set so `@bacons` doesn't double-quote pre-quoted entries.
 function unquotingArray(arr: any[]): any[] {
   return new Proxy(arr, {
+    get(target, prop) {
+      if (typeof prop === 'string' && /^\d+$/.test(prop)) {
+        return quoteForRead(target[Number(prop)]);
+      }
+      return Reflect.get(target, prop);
+    },
     set(target, prop, value) {
       if (typeof prop === 'string' && /^\d+$/.test(prop)) {
         target[Number(prop)] = unquoteForWrite(value);
@@ -45,7 +65,8 @@ function buildSettingsProxy(buildSettings: Record<string, any>): Record<string, 
   return new Proxy(buildSettings, {
     get(target, key) {
       const value = target[key as string];
-      return Array.isArray(value) ? unquotingArray(value) : value;
+      if (Array.isArray(value)) return unquotingArray(value);
+      return typeof value === 'string' ? quoteForRead(value) : value;
     },
     set(target, key, value) {
       if (typeof key !== 'string') {
@@ -232,9 +253,9 @@ export class XcodeProjectShim {
     const view: any = {
       uuid: model.uuid,
       isa: model.isa,
-      name: model.props.name,
-      path: model.props.path,
-      sourceTree: model.props.sourceTree,
+      name: quoteForRead(model.props.name),
+      path: quoteForRead(model.props.path),
+      sourceTree: quoteForRead(model.props.sourceTree),
     };
     defineLiveRefArray(view, 'children', model.props.children, this.inner);
     return view;
@@ -263,9 +284,9 @@ export class XcodeProjectShim {
     const view: any = {
       uuid: model.uuid,
       isa: model.isa,
-      name: props.name,
-      productName: props.productName,
-      productType: props.productType,
+      name: quoteForRead(props.name),
+      productName: quoteForRead(props.productName),
+      productType: quoteForRead(props.productType),
       buildConfigurationList: props.buildConfigurationList?.uuid,
     };
     defineLiveRefArray(view, 'dependencies', props.dependencies, this.inner);
@@ -289,14 +310,18 @@ export class XcodeProjectShim {
     const view: any = {
       uuid: model.uuid,
       isa: model.isa,
-      name: props.name,
+      name: quoteForRead(props.name),
       buildActionMask: props.buildActionMask,
       runOnlyForDeploymentPostprocessing: props.runOnlyForDeploymentPostprocessing,
-      shellPath: props.shellPath,
-      shellScript: props.shellScript,
-      inputPaths: props.inputPaths,
-      outputPaths: props.outputPaths,
-      dstPath: props.dstPath,
+      shellPath: quoteForRead(props.shellPath),
+      shellScript: quoteForRead(props.shellScript),
+      inputPaths: Array.isArray(props.inputPaths)
+        ? props.inputPaths.map(quoteForRead)
+        : props.inputPaths,
+      outputPaths: Array.isArray(props.outputPaths)
+        ? props.outputPaths.map(quoteForRead)
+        : props.outputPaths,
+      dstPath: quoteForRead(props.dstPath),
       dstSubfolderSpec: props.dstSubfolderSpec,
     };
     defineLiveRefArray(view, 'files', props.files, this.inner);
@@ -331,7 +356,7 @@ export class XcodeProjectShim {
     const view: any = {
       uuid: model.uuid,
       isa: model.isa,
-      defaultConfigurationName: props.defaultConfigurationName,
+      defaultConfigurationName: quoteForRead(props.defaultConfigurationName),
       defaultConfigurationIsVisible: props.defaultConfigurationIsVisible,
     };
     defineLiveRefArray(view, 'buildConfigurations', props.buildConfigurations, this.inner);
@@ -363,7 +388,7 @@ export class XcodeProjectShim {
       ) {
         defineLiveRefArray(out, key, value, project);
       } else {
-        out[key] = value;
+        out[key] = quoteForRead(value);
       }
     }
     return out;
@@ -388,8 +413,8 @@ export class XcodeProjectShim {
       buildConfigurationList: props.buildConfigurationList?.uuid,
       knownRegions: props.knownRegions,
       attributes: props.attributes,
-      compatibilityVersion: props.compatibilityVersion,
-      developmentRegion: props.developmentRegion,
+      compatibilityVersion: quoteForRead(props.compatibilityVersion),
+      developmentRegion: quoteForRead(props.developmentRegion),
     };
     defineLiveRefArray(view, 'targets', props.targets, this.inner);
     return view;
@@ -569,7 +594,7 @@ export class XcodeProjectShim {
         }
       }
     }
-    return result;
+    return quoteForRead(result);
   }
   getBuildConfigByName(..._args: any[]): any {
     notImplemented('getBuildConfigByName');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -6,6 +6,17 @@ function notImplemented(method: string): never {
   throw new Error(`XcodeProjectShim.${method} is not implemented yet`);
 }
 
+function trimQuotes(value: string): string {
+  return value.replace(/^"(.*)"$/, '$1');
+}
+
+// Legacy callers pass values verbatim-quoted (e.g. `'"com.example"'`).
+// `@bacons` stores values unquoted and re-quotes at serialize, so strip one
+// layer of outer quotes on write to avoid double-quoting.
+function unquoteForWrite(value: any): any {
+  return typeof value === 'string' ? trimQuotes(value) : value;
+}
+
 /**
  * Backwards-compatible facade exposing the legacy `xcode` `XcodeProject` API on
  * top of a typed `@bacons/xcode` project. The substrate (construct / parse /
@@ -28,6 +39,26 @@ export class XcodeProjectShim {
       );
     }
     return this.project;
+  }
+
+  private models(): any[] {
+    return [...this.inner.values()];
+  }
+
+  private modelsOfIsa(isa: string): any[] {
+    return this.models().filter((model) => model.isa === isa);
+  }
+
+  private findTargetByName(name: string): any | null {
+    return (
+      this.modelsOfIsa('PBXNativeTarget').find((t) => trimQuotes(t.props.name) === name) ?? null
+    );
+  }
+
+  /** UUIDs of the build configurations belonging to a target's configuration list. */
+  private configUuidsForTarget(target: any): Set<string> {
+    const configs = target?.props?.buildConfigurationList?.props?.buildConfigurations ?? [];
+    return new Set<string>(configs.map((config: any) => config.uuid));
   }
 
   // === Lifecycle / IO ===
@@ -143,8 +174,18 @@ export class XcodeProjectShim {
   hasFile(..._args: any[]): any {
     notImplemented('hasFile');
   }
-  getBuildProperty(..._args: any[]): any {
-    notImplemented('getBuildProperty');
+  getBuildProperty(prop: string, build?: string, targetName?: string): any {
+    const scoped = targetName ? this.configUuidsForTarget(this.findTargetByName(targetName)) : null;
+    let result: any;
+    for (const config of this.modelsOfIsa('XCBuildConfiguration')) {
+      if (scoped && !scoped.has(config.uuid)) continue;
+      if (build === undefined || config.props.name === build) {
+        if (config.props.buildSettings[prop] !== undefined) {
+          result = config.props.buildSettings[prop];
+        }
+      }
+    }
+    return result;
   }
   getBuildConfigByName(..._args: any[]): any {
     notImplemented('getBuildConfigByName');
@@ -155,17 +196,34 @@ export class XcodeProjectShim {
 
   // === Mutate: build settings ===
 
-  addBuildProperty(..._args: any[]): any {
-    notImplemented('addBuildProperty');
+  addBuildProperty(prop: string, value: any, buildName?: string): void {
+    for (const config of this.modelsOfIsa('XCBuildConfiguration')) {
+      if (!buildName || config.props.name === buildName) {
+        config.props.buildSettings[prop] = unquoteForWrite(value);
+      }
+    }
   }
-  removeBuildProperty(..._args: any[]): any {
-    notImplemented('removeBuildProperty');
+
+  removeBuildProperty(prop: string, buildName?: string): void {
+    for (const config of this.modelsOfIsa('XCBuildConfiguration')) {
+      if (!buildName || config.props.name === buildName) {
+        delete config.props.buildSettings[prop];
+      }
+    }
   }
-  updateBuildProperty(..._args: any[]): any {
-    notImplemented('updateBuildProperty');
+
+  updateBuildProperty(prop: string, value: any, build?: string | null, targetName?: string): void {
+    const scoped = targetName ? this.configUuidsForTarget(this.findTargetByName(targetName)) : null;
+    for (const config of this.modelsOfIsa('XCBuildConfiguration')) {
+      if (scoped && !scoped.has(config.uuid)) continue;
+      if (!build || config.props.name === build) {
+        config.props.buildSettings[prop] = unquoteForWrite(value);
+      }
+    }
   }
-  updateProductName(..._args: any[]): any {
-    notImplemented('updateProductName');
+
+  updateProductName(name: string): void {
+    this.updateBuildProperty('PRODUCT_NAME', name);
   }
   addToBuildSettings(..._args: any[]): any {
     notImplemented('addToBuildSettings');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -170,9 +170,14 @@ export class XcodeProjectShim {
     };
   }
 
+  private targetModel(targetUuid?: string): any {
+    return (targetUuid && this.safeGetObject(targetUuid)) || this.firstTargetModel();
+  }
+
   private buildPhaseForTarget(isa: string, targetUuid?: string): any {
-    const target = (targetUuid && this.safeGetObject(targetUuid)) || this.firstTargetModel();
-    return (target?.props?.buildPhases ?? []).find((phase: any) => phase.isa === isa);
+    return (this.targetModel(targetUuid)?.props?.buildPhases ?? []).find(
+      (phase: any) => phase.isa === isa
+    );
   }
 
   /** Legacy-shaped view of a build phase: scalars pass through, `files` is a live array. */
@@ -456,9 +461,6 @@ export class XcodeProjectShim {
   removeFromLibrarySearchPaths(..._args: any[]): any {
     notImplemented('removeFromLibrarySearchPaths');
   }
-  addToFrameworkSearchPaths(..._args: any[]): any {
-    notImplemented('addToFrameworkSearchPaths');
-  }
   removeFromFrameworkSearchPaths(..._args: any[]): any {
     notImplemented('removeFromFrameworkSearchPaths');
   }
@@ -520,14 +522,8 @@ export class XcodeProjectShim {
   removeFromPbxSourcesBuildPhase(..._args: any[]): any {
     notImplemented('removeFromPbxSourcesBuildPhase');
   }
-  addToPbxFrameworksBuildPhase(..._args: any[]): any {
-    notImplemented('addToPbxFrameworksBuildPhase');
-  }
   removeFromPbxFrameworksBuildPhase(..._args: any[]): any {
     notImplemented('removeFromPbxFrameworksBuildPhase');
-  }
-  addToPbxEmbedFrameworksBuildPhase(..._args: any[]): any {
-    notImplemented('addToPbxEmbedFrameworksBuildPhase');
   }
   removeFromPbxEmbedFrameworksBuildPhase(..._args: any[]): any {
     notImplemented('removeFromPbxEmbedFrameworksBuildPhase');
@@ -657,14 +653,78 @@ export class XcodeProjectShim {
 
   // === Mutate: frameworks / files ===
 
-  addFramework(..._args: any[]): any {
-    notImplemented('addFramework');
+  addFramework(fpath: string, opt: any = {}): any {
+    const customFramework = opt.customFramework === true;
+    const link = opt.link === undefined || opt.link;
+    const embed = !!opt.embed;
+
+    const file = new PbxFile(fpath, { ...opt, embed: false });
+    file.uuid = this.generateUuid();
+    file.fileRef = this.generateUuid();
+    file.target = opt.target;
+
+    if (file.path && this.hasFile(file.path)) return false;
+
+    // Create the file reference before the build file that points at it (legacy's
+    // untyped hash tolerated the reverse order; the typed model needs the ref first).
+    this.addToPbxFileReferenceSection(file);
+    this.addToPbxBuildFileSection(file);
+    this.addToFrameworksPbxGroup(file);
+    if (link) this.addToPbxFrameworksBuildPhase(file);
+
+    if (customFramework) {
+      this.addToFrameworkSearchPaths(file);
+      if (embed) {
+        const embeddedFile = new PbxFile(fpath, { ...opt, embed: true });
+        embeddedFile.uuid = this.generateUuid();
+        embeddedFile.fileRef = file.fileRef;
+        embeddedFile.target = opt.target;
+        this.addToPbxBuildFileSection(embeddedFile);
+        this.addToPbxEmbedFrameworksBuildPhase(embeddedFile);
+        return embeddedFile;
+      }
+    }
+    return file;
   }
   removeFramework(..._args: any[]): any {
     notImplemented('removeFramework');
   }
-  addToFrameworksPbxGroup(..._args: any[]): any {
-    notImplemented('addToFrameworksPbxGroup');
+  addToFrameworksPbxGroup(file: any): void {
+    const group = this.pbxGroupByName('Frameworks');
+    if (!group) {
+      this.addPbxGroup([file.path], 'Frameworks');
+    } else {
+      group.children.push({ value: file.fileRef, comment: file.basename });
+    }
+  }
+  addToPbxFrameworksBuildPhase(file: any): void {
+    this.addBuildFileToPhase('PBXFrameworksBuildPhase', file);
+  }
+  // Custom frameworks add their containing dir (as a quoted path) to the
+  // app target's FRAMEWORK_SEARCH_PATHS.
+  addToFrameworkSearchPaths(file: any): void {
+    const value = `"${file.dirname}"`;
+    const productName = this.productName;
+    for (const config of this.modelsOfIsa('XCBuildConfiguration')) {
+      const buildSettings = config.props.buildSettings;
+      if (trimQuotes(buildSettings.PRODUCT_NAME ?? '') !== productName) continue;
+      if (
+        !buildSettings.FRAMEWORK_SEARCH_PATHS ||
+        buildSettings.FRAMEWORK_SEARCH_PATHS === INHERITED
+      ) {
+        buildSettings.FRAMEWORK_SEARCH_PATHS = [INHERITED];
+      }
+      buildSettings.FRAMEWORK_SEARCH_PATHS.push(value);
+    }
+  }
+  // Mirrors the legacy quirk: only links into an existing "Embed Frameworks"
+  // copy-files phase; if none exists it silently no-ops.
+  addToPbxEmbedFrameworksBuildPhase(file: any): void {
+    const phase = (this.targetModel(file.target)?.props?.buildPhases ?? []).find(
+      (p: any) =>
+        p.isa === 'PBXCopyFilesBuildPhase' && trimQuotes(p.props.name ?? '') === 'Embed Frameworks'
+    );
+    if (phase) phase.props.files.push(this.inner.getObject(file.uuid));
   }
   addFile(..._args: any[]): any {
     notImplemented('addFile');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -87,6 +87,58 @@ export class XcodeProjectShim {
     };
   }
 
+  // `createObject` builds a model with a caller-chosen uuid but does not register
+  // it; `set` adds it to the project so it serializes. Undefined fields are
+  // dropped so the shim never emits `= undefined`.
+  private createObjectWithUuid(uuid: string, json: Record<string, any>): any {
+    const clean: Record<string, any> = {};
+    for (const [key, value] of Object.entries(json)) {
+      if (value !== undefined) clean[key] = value;
+    }
+    const model = this.inner.createObject(uuid, clean as any);
+    this.inner.set(uuid, model);
+    return model;
+  }
+
+  private firstTargetModel(): any {
+    return this.inner.rootObject.props.targets[0];
+  }
+
+  /** Legacy-shaped view of a native target: references as UUIDs. */
+  private legacyTarget(model: any): any {
+    return {
+      uuid: model.uuid,
+      isa: model.isa,
+      name: model.props.name,
+      productName: model.props.productName,
+      productType: model.props.productType,
+      buildConfigurationList: model.props.buildConfigurationList?.uuid,
+    };
+  }
+
+  private buildPhaseForTarget(isa: string, targetUuid?: string): any {
+    const target = (targetUuid && this.safeGetObject(targetUuid)) || this.firstTargetModel();
+    return (target?.props?.buildPhases ?? []).find((phase: any) => phase.isa === isa);
+  }
+
+  // Append a build file to a target's phase. A missing build file (e.g. a file
+  // added without a PBXBuildFile) is skipped rather than linked as a dangling ref.
+  private addBuildFileToPhase(isa: string, file: any): void {
+    const buildFile = this.safeGetObject(file.uuid);
+    if (!buildFile) return;
+    this.buildPhaseForTarget(isa, file.target).props.files.push(buildFile);
+  }
+
+  /** Legacy section dict: `{ uuid: object, uuid_comment: name }` for each model of an isa. */
+  private legacySection(isa: string): Record<string, any> {
+    const section: Record<string, any> = {};
+    for (const model of this.modelsOfIsa(isa)) {
+      section[model.uuid] = model.props;
+      section[`${model.uuid}_comment`] = model.getDisplayName?.() ?? model.uuid;
+    }
+    return section;
+  }
+
   /** Legacy-shaped view of the root project: references as UUIDs, `targets` as a live array. */
   private legacyProject(): any {
     const project = this.inner;
@@ -128,8 +180,13 @@ export class XcodeProjectShim {
     notImplemented('allUuids');
   }
 
-  generateUuid(..._args: any[]): any {
-    notImplemented('generateUuid');
+  generateUuid(): string {
+    let id: string;
+    do {
+      id = '';
+      for (let i = 0; i < 24; i++) id += '0123456789ABCDEF'[Math.floor(Math.random() * 16)];
+    } while (this.inner.has(id));
+    return id;
   }
 
   // === Read / query ===
@@ -146,11 +203,11 @@ export class XcodeProjectShim {
   pbxXCConfigurationList(..._args: any[]): any {
     notImplemented('pbxXCConfigurationList');
   }
-  pbxFileReferenceSection(..._args: any[]): any {
-    notImplemented('pbxFileReferenceSection');
+  pbxFileReferenceSection(): any {
+    return this.legacySection('PBXFileReference');
   }
-  pbxBuildFileSection(..._args: any[]): any {
-    notImplemented('pbxBuildFileSection');
+  pbxBuildFileSection(): any {
+    return this.legacySection('PBXBuildFile');
   }
   xcVersionGroupSection(..._args: any[]): any {
     notImplemented('xcVersionGroupSection');
@@ -183,11 +240,15 @@ export class XcodeProjectShim {
   getFirstProject(): any {
     return { uuid: this.inner.rootObject.uuid, firstProject: this.legacyProject() };
   }
-  getFirstTarget(..._args: any[]): any {
-    notImplemented('getFirstTarget');
+  getFirstTarget(): any {
+    const model = this.firstTargetModel();
+    return { uuid: model.uuid, firstTarget: this.legacyTarget(model) };
   }
-  getTarget(..._args: any[]): any {
-    notImplemented('getTarget');
+  getTarget(productType: string): any {
+    const model = this.modelsOfIsa('PBXNativeTarget').find(
+      (t) => trimQuotes(t.props.productType) === productType
+    );
+    return model ? { uuid: model.uuid, target: this.legacyTarget(model) } : null;
   }
   getPBXGroupByKey(key: string): any {
     const model = this.safeGetObject(key);
@@ -309,14 +370,27 @@ export class XcodeProjectShim {
 
   // === Mutate: sections ===
 
-  addToPbxFileReferenceSection(..._args: any[]): any {
-    notImplemented('addToPbxFileReferenceSection');
+  addToPbxFileReferenceSection(file: any): void {
+    this.createObjectWithUuid(file.fileRef, {
+      isa: 'PBXFileReference',
+      name: file.basename,
+      path: file.path,
+      sourceTree: unquoteForWrite(file.sourceTree),
+      fileEncoding: file.fileEncoding,
+      lastKnownFileType: file.lastKnownFileType,
+      explicitFileType: unquoteForWrite(file.explicitFileType),
+      includeInIndex: file.includeInIndex,
+    });
   }
   removeFromPbxFileReferenceSection(..._args: any[]): any {
     notImplemented('removeFromPbxFileReferenceSection');
   }
-  addToPbxBuildFileSection(..._args: any[]): any {
-    notImplemented('addToPbxBuildFileSection');
+  addToPbxBuildFileSection(file: any): void {
+    this.createObjectWithUuid(file.uuid, {
+      isa: 'PBXBuildFile',
+      fileRef: this.inner.getObject(file.fileRef),
+      settings: file.settings,
+    });
   }
   removeFromPbxBuildFileSection(..._args: any[]): any {
     notImplemented('removeFromPbxBuildFileSection');
@@ -333,14 +407,14 @@ export class XcodeProjectShim {
 
   // === Mutate: build phases ===
 
-  addToPbxResourcesBuildPhase(..._args: any[]): any {
-    notImplemented('addToPbxResourcesBuildPhase');
+  addToPbxResourcesBuildPhase(file: any): void {
+    this.addBuildFileToPhase('PBXResourcesBuildPhase', file);
   }
   removeFromPbxResourcesBuildPhase(..._args: any[]): any {
     notImplemented('removeFromPbxResourcesBuildPhase');
   }
-  addToPbxSourcesBuildPhase(..._args: any[]): any {
-    notImplemented('addToPbxSourcesBuildPhase');
+  addToPbxSourcesBuildPhase(file: any): void {
+    this.addBuildFileToPhase('PBXSourcesBuildPhase', file);
   }
   removeFromPbxSourcesBuildPhase(..._args: any[]): any {
     notImplemented('removeFromPbxSourcesBuildPhase');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -70,6 +70,35 @@ function copyFilesPhaseProps(folderType: string, subfolderPath: string | undefin
   };
 }
 
+const PRODUCTTYPE_BY_TARGETTYPE: Record<string, string> = {
+  application: 'com.apple.product-type.application',
+  app_extension: 'com.apple.product-type.app-extension',
+  bundle: 'com.apple.product-type.bundle',
+  command_line_tool: 'com.apple.product-type.tool',
+  dynamic_library: 'com.apple.product-type.library.dynamic',
+  framework: 'com.apple.product-type.framework',
+  static_library: 'com.apple.product-type.library.static',
+  unit_test_bundle: 'com.apple.product-type.bundle.unit-test',
+  watch_app: 'com.apple.product-type.application.watchapp',
+  watch2_app: 'com.apple.product-type.application.watchapp2',
+  watch_extension: 'com.apple.product-type.watchkit-extension',
+  watch2_extension: 'com.apple.product-type.watchkit2-extension',
+};
+const FILETYPE_BY_PRODUCTTYPE: Record<string, string> = {
+  'com.apple.product-type.application': '"wrapper.application"',
+  'com.apple.product-type.app-extension': '"wrapper.app-extension"',
+  'com.apple.product-type.bundle': '"wrapper.plug-in"',
+  'com.apple.product-type.tool': '"compiled.mach-o.dylib"',
+  'com.apple.product-type.library.dynamic': '"compiled.mach-o.dylib"',
+  'com.apple.product-type.framework': '"wrapper.framework"',
+  'com.apple.product-type.library.static': '"archive.ar"',
+  'com.apple.product-type.bundle.unit-test': '"wrapper.cfbundle"',
+  'com.apple.product-type.application.watchapp': '"wrapper.application"',
+  'com.apple.product-type.application.watchapp2': '"wrapper.application"',
+  'com.apple.product-type.watchkit-extension': '"wrapper.app-extension"',
+  'com.apple.product-type.watchkit2-extension': '"wrapper.app-extension"',
+};
+
 function shellScriptPhaseProps(options: any, name: string) {
   // Stored unquoted; `@bacons` escapes/quotes the script and re-quotes the paths
   // at serialize (legacy stores paths verbatim and never quotes them).
@@ -167,15 +196,23 @@ export class XcodeProjectShim {
     return this.inner.rootObject.props.targets[0];
   }
 
-  /** Legacy-shaped view of a native target: references as UUIDs. */
+  /** Legacy-shaped view of a native target: references as UUIDs, ref arrays live. */
   private legacyTarget(model: any): any {
+    const project = this.inner;
+    const props = model.props;
     return {
       uuid: model.uuid,
       isa: model.isa,
-      name: model.props.name,
-      productName: model.props.productName,
-      productType: model.props.productType,
-      buildConfigurationList: model.props.buildConfigurationList?.uuid,
+      name: props.name,
+      productName: props.productName,
+      productType: props.productType,
+      buildConfigurationList: props.buildConfigurationList?.uuid,
+      get dependencies() {
+        return legacyRefArray(props.dependencies, project);
+      },
+      get buildPhases() {
+        return legacyRefArray(props.buildPhases, project);
+      },
     };
   }
 
@@ -298,7 +335,12 @@ export class XcodeProjectShim {
         objects: new Proxy(
           {},
           {
-            get: (_t, isa: string) => self.legacySection(isa),
+            // Legacy has no section dict for an isa with no objects; mirror that
+            // (a present-but-empty section would read as truthy).
+            get: (_t, isa: string) => {
+              const section = self.legacySection(String(isa));
+              return Object.keys(section).length ? section : undefined;
+            },
           }
         ),
       },
@@ -538,11 +580,22 @@ export class XcodeProjectShim {
   removeFromPbxBuildFileSection(..._args: any[]): any {
     notImplemented('removeFromPbxBuildFileSection');
   }
-  addToPbxProjectSection(..._args: any[]): any {
-    notImplemented('addToPbxProjectSection');
+  addToPbxProjectSection(target: any): void {
+    this.inner.rootObject.props.targets.push(this.inner.getObject(target.uuid));
   }
-  addToPbxNativeTargetSection(..._args: any[]): any {
-    notImplemented('addToPbxNativeTargetSection');
+  addToPbxNativeTargetSection(target: any): void {
+    const nt = target.pbxNativeTarget;
+    this.createObjectWithUuid(target.uuid, {
+      isa: 'PBXNativeTarget',
+      name: trimQuotes(nt.name),
+      productName: trimQuotes(nt.productName),
+      productReference: this.inner.getObject(nt.productReference),
+      productType: trimQuotes(nt.productType),
+      buildConfigurationList: this.inner.getObject(nt.buildConfigurationList),
+      buildPhases: [],
+      buildRules: [],
+      dependencies: [],
+    });
   }
   addToXcVersionGroupSection(..._args: any[]): any {
     notImplemented('addToXcVersionGroupSection');
@@ -568,8 +621,13 @@ export class XcodeProjectShim {
   removeFromPbxEmbedFrameworksBuildPhase(..._args: any[]): any {
     notImplemented('removeFromPbxEmbedFrameworksBuildPhase');
   }
-  addToPbxCopyfilesBuildPhase(..._args: any[]): any {
-    notImplemented('addToPbxCopyfilesBuildPhase');
+  addToPbxCopyfilesBuildPhase(file: any): void {
+    // Legacy falls back to a project-wide search by name when the file's target
+    // doesn't own the "Copy Files" phase (it lives on the host app target).
+    const phase = this.modelsOfIsa('PBXCopyFilesBuildPhase').find(
+      (p) => trimQuotes(p.props.name ?? '') === 'Copy Files'
+    );
+    if (phase) phase.props.files.push(this.inner.getObject(file.uuid));
   }
   removeFromPbxCopyfilesBuildPhase(..._args: any[]): any {
     notImplemented('removeFromPbxCopyfilesBuildPhase');
@@ -793,11 +851,112 @@ export class XcodeProjectShim {
 
   // === Mutate: targets ===
 
-  addTarget(..._args: any[]): any {
-    notImplemented('addTarget');
+  addTarget(name: string, type: string, subfolder?: string, bundleId?: string): any {
+    const targetUuid = this.generateUuid();
+    const targetSubfolder = subfolder || name;
+    const targetName = name.trim();
+    if (!targetName) throw new Error('Target name missing.');
+    if (!type) throw new Error('Target type missing.');
+    const productType = PRODUCTTYPE_BY_TARGETTYPE[type];
+    if (!productType) throw new Error('Target type invalid: ' + type);
+
+    // Quote placement mirrors legacy `xcode` (the trailing quote lands inside join).
+    const infoPlist = '"' + path.join(targetSubfolder, targetSubfolder + '-Info.plist"');
+    const runpath = '"$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"';
+    const debug: Record<string, any> = {
+      GCC_PREPROCESSOR_DEFINITIONS: ['"DEBUG=1"', '"$(inherited)"'],
+      INFOPLIST_FILE: infoPlist,
+      LD_RUNPATH_SEARCH_PATHS: runpath,
+      PRODUCT_NAME: '"' + targetName + '"',
+      SKIP_INSTALL: 'YES',
+    };
+    const release: Record<string, any> = {
+      INFOPLIST_FILE: infoPlist,
+      LD_RUNPATH_SEARCH_PATHS: runpath,
+      PRODUCT_NAME: '"' + targetName + '"',
+      SKIP_INSTALL: 'YES',
+    };
+    if (bundleId) {
+      debug.PRODUCT_BUNDLE_IDENTIFIER = '"' + bundleId + '"';
+      release.PRODUCT_BUNDLE_IDENTIFIER = '"' + bundleId + '"';
+    }
+
+    const buildConfigurations = this.addXCConfigurationList(
+      [
+        { name: 'Debug', isa: 'XCBuildConfiguration', buildSettings: debug },
+        { name: 'Release', isa: 'XCBuildConfiguration', buildSettings: release },
+      ],
+      'Release',
+      'Build configuration list for PBXNativeTarget "' + targetName + '"'
+    );
+
+    const productFile = this.addProductFile(targetName, {
+      group: 'Copy Files',
+      target: targetUuid,
+      explicitFileType: FILETYPE_BY_PRODUCTTYPE[productType],
+    });
+    this.addToPbxBuildFileSection(productFile);
+
+    const target = {
+      uuid: targetUuid,
+      pbxNativeTarget: {
+        isa: 'PBXNativeTarget',
+        name: '"' + targetName + '"',
+        productName: '"' + targetName + '"',
+        productReference: productFile.fileRef,
+        productType: '"' + productType + '"',
+        buildConfigurationList: buildConfigurations.uuid,
+        buildPhases: [],
+        buildRules: [],
+        dependencies: [],
+      },
+    };
+    this.addToPbxNativeTargetSection(target);
+
+    if (type === 'app_extension') {
+      this.addBuildPhase(
+        [],
+        'PBXCopyFilesBuildPhase',
+        'Copy Files',
+        this.getFirstTarget().uuid,
+        type
+      );
+      this.addToPbxCopyfilesBuildPhase(productFile);
+    }
+
+    this.addToPbxProjectSection(target);
+    this.addTargetDependency(this.getFirstTarget().uuid, [target.uuid]);
+
+    return target;
   }
-  addTargetDependency(..._args: any[]): any {
-    notImplemented('addTargetDependency');
+  addTargetDependency(targetUuid: string, dependencyTargets: string[]): any {
+    if (!targetUuid) return undefined;
+    const targetModel = this.safeGetObject(targetUuid);
+    if (!targetModel) throw new Error('Invalid target: ' + targetUuid);
+    for (const dep of dependencyTargets) {
+      if (!this.safeGetObject(dep)) throw new Error('Invalid target: ' + dep);
+    }
+    // Legacy only wires dependencies when both sections already exist in the project.
+    const sectionsExist =
+      this.modelsOfIsa('PBXTargetDependency').length > 0 &&
+      this.modelsOfIsa('PBXContainerItemProxy').length > 0;
+    for (const depUuid of sectionsExist ? dependencyTargets : []) {
+      const depModel = this.safeGetObject(depUuid);
+      const itemProxy = this.createObjectWithUuid(this.generateUuid(), {
+        isa: 'PBXContainerItemProxy',
+        containerPortal: this.inner.rootObject,
+        proxyType: 1,
+        remoteGlobalIDString: depUuid,
+        remoteInfo: trimQuotes(depModel.props.name),
+      });
+      const targetDependency = this.createObjectWithUuid(this.generateUuid(), {
+        isa: 'PBXTargetDependency',
+        target: depModel,
+        targetProxy: itemProxy,
+      });
+      targetModel.props.dependencies.push(targetDependency);
+    }
+    return { uuid: targetUuid, target: this.legacyTarget(targetModel) };
   }
   addXCConfigurationList(
     configurationObjectsArray: any[],

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -206,6 +206,11 @@ export class XcodeProjectShim {
 
   private project: XcodeProject | null = null;
 
+  // ISAs whose section was explicitly created via `hash.project.objects[ISA] = …`
+  // (legacy treats a present-but-empty section as existing; the typed model has
+  // no empty sections, so track them here).
+  private hashCreatedSections = new Set<string>();
+
   constructor(filePath: string) {
     this.filepath = path.resolve(filePath);
   }
@@ -404,6 +409,62 @@ export class XcodeProjectShim {
     return section;
   }
 
+  private sectionExists(isa: string): boolean {
+    return this.modelsOfIsa(isa).length > 0 || this.hashCreatedSections.has(isa);
+  }
+
+  // Create a model from a legacy-shaped plain object written via the hash bridge
+  // (`objects[ISA][uuid] = obj`): resolve uuid-string ref fields to model
+  // instances and unquote values, then register it.
+  private createFromLegacyObject(uuid: string, obj: any): void {
+    if (!obj || typeof obj !== 'object' || this.safeGetObject(uuid)) return;
+    const resolveMaybeRef = (v: any) =>
+      typeof v === 'string' ? (this.safeGetObject(trimQuotes(v)) ?? unquoteForWrite(v)) : v;
+    const json: Record<string, any> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      if (key.endsWith('_comment')) continue;
+      if (key === 'buildSettings' && value && typeof value === 'object' && !Array.isArray(value)) {
+        json[key] = unquoteBuildSettings(value as Record<string, any>);
+      } else if (Array.isArray(value)) {
+        json[key] = value.map(resolveMaybeRef);
+      } else {
+        json[key] = resolveMaybeRef(value);
+      }
+    }
+    this.createObjectWithUuid(uuid, json);
+  }
+
+  // A live, read-write `hash.project.objects[ISA]` section: reads project the
+  // models (`{ uuid: object, uuid_comment }`); writes create models.
+  private hashSection(isa: string): any {
+    const self = this;
+    return new Proxy(
+      {},
+      {
+        get(_t, key) {
+          if (typeof key !== 'string') return undefined;
+          if (key.endsWith('_comment')) {
+            return self.safeGetObject(key.slice(0, -'_comment'.length))?.getDisplayName?.();
+          }
+          const model = self.safeGetObject(key);
+          return model && model.isa === isa ? self.toLegacyObject(model) : undefined;
+        },
+        set(_t, key, value) {
+          if (typeof key === 'string' && !key.endsWith('_comment')) {
+            self.createFromLegacyObject(key, value);
+          }
+          return true;
+        },
+        ownKeys() {
+          return self.modelsOfIsa(isa).flatMap((m) => [m.uuid, `${m.uuid}_comment`]);
+        },
+        getOwnPropertyDescriptor() {
+          return { enumerable: true, configurable: true };
+        },
+      }
+    );
+  }
+
   /** Legacy-shaped view of the root project: references as UUIDs, `targets` as a live array. */
   private legacyProject(): any {
     const props = this.inner.rootObject.props;
@@ -442,11 +503,19 @@ export class XcodeProjectShim {
         objects: new Proxy(
           {},
           {
-            // Legacy has no section dict for an isa with no objects; mirror that
-            // (a present-but-empty section would read as truthy).
-            get: (_t, isa: string) => {
-              const section = self.legacySection(String(isa));
-              return Object.keys(section).length ? section : undefined;
+            // Absent sections read as undefined (legacy has no dict for an isa
+            // with no objects); assigning one records its existence and creates
+            // any objects it carries.
+            get: (_t, isa: string) =>
+              self.sectionExists(String(isa)) ? self.hashSection(String(isa)) : undefined,
+            set: (_t, isa: string, value: any) => {
+              self.hashCreatedSections.add(String(isa));
+              if (value && typeof value === 'object') {
+                for (const [key, obj] of Object.entries(value)) {
+                  if (!key.endsWith('_comment')) self.createFromLegacyObject(key, obj);
+                }
+              }
+              return true;
             },
           }
         ),
@@ -573,7 +642,7 @@ export class XcodeProjectShim {
     notImplemented('findPBXGroupKeyAndType');
   }
   getPBXObject(name: string): any {
-    return this.legacySection(name);
+    return this.hashSection(name);
   }
   hasFile(filePath: string): any {
     for (const ref of this.modelsOfIsa('PBXFileReference')) {
@@ -1052,10 +1121,10 @@ export class XcodeProjectShim {
     for (const dep of dependencyTargets) {
       if (!this.safeGetObject(dep)) throw new Error('Invalid target: ' + dep);
     }
-    // Legacy only wires dependencies when both sections already exist in the project.
+    // Legacy only wires dependencies when both sections already exist (plugins
+    // pre-create them via `hash.project.objects[ISA] ??= {}`).
     const sectionsExist =
-      this.modelsOfIsa('PBXTargetDependency').length > 0 &&
-      this.modelsOfIsa('PBXContainerItemProxy').length > 0;
+      this.sectionExists('PBXTargetDependency') && this.sectionExists('PBXContainerItemProxy');
     for (const depUuid of sectionsExist ? dependencyTargets : []) {
       const depModel = this.safeGetObject(depUuid);
       const itemProxy = this.createObjectWithUuid(this.generateUuid(), {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -368,35 +368,58 @@ export class XcodeProjectShim {
     return view;
   }
 
-  // Legacy-shaped view of one object's props: references become UUID strings,
-  // ref arrays become live `{ value, comment }` arrays, and `buildSettings` is a
-  // write-through unquoting Proxy. Scalars/plain dicts are shared by reference so
-  // direct mutations (e.g. `obj.buildSettings.X = …`) reach the model.
+  // Live legacy-shaped view of one object's props. Fields are read+write-through
+  // so plugins that mutate the object obtained from a section (e.g.
+  // `target.buildConfigurationList = uuid`) reach the model: references read as
+  // UUIDs / write by resolving, ref arrays are live `{ value, comment }` arrays,
+  // `buildSettings` is an unquoting Proxy, and scalars read-quote / write-unquote.
   private toLegacyObject(model: any): any {
-    const project = this.inner;
+    const self = this;
+    const props = model.props;
     const out: Record<string, any> = {};
-    for (const key of Object.keys(model.props)) {
-      const value = model.props[key];
+    for (const key of Object.keys(props)) {
+      const value = props[key];
       if (key === 'buildSettings' && value && typeof value === 'object' && !Array.isArray(value)) {
         out[key] = buildSettingsProxy(value);
+      } else if (
+        Array.isArray(value) &&
+        (REF_ARRAY_FIELDS.has(key) ||
+          (value.length > 0 && value.every((v) => v && typeof v.uuid === 'string')))
+      ) {
+        defineLiveRefArray(out, key, value, this.inner);
       } else if (
         value &&
         typeof value === 'object' &&
         !Array.isArray(value) &&
         typeof value.uuid === 'string'
       ) {
-        out[key] = value.uuid;
-      } else if (
-        Array.isArray(value) &&
-        (REF_ARRAY_FIELDS.has(key) ||
-          (value.length > 0 && value.every((v) => v && typeof v.uuid === 'string')))
-      ) {
-        defineLiveRefArray(out, key, value, project);
+        Object.defineProperty(out, key, {
+          enumerable: true,
+          configurable: true,
+          get: () => props[key]?.uuid,
+          set: (v) => {
+            props[key] = self.resolveRef(v);
+          },
+        });
       } else {
-        out[key] = quoteForRead(value);
+        Object.defineProperty(out, key, {
+          enumerable: true,
+          configurable: true,
+          get: () => quoteForRead(props[key]),
+          set: (v) => {
+            props[key] = typeof v === 'string' ? unquoteForWrite(v) : v;
+          },
+        });
       }
     }
     return out;
+  }
+
+  // Resolve a reference assignment to a model (or a stand-in relinked at write).
+  private resolveRef(value: any): any {
+    if (value && typeof value === 'object') return value;
+    const uuid = trimQuotes(String(value));
+    return this.safeGetObject(uuid) ?? { uuid };
   }
 
   /** Legacy section dict: `{ uuid: object, uuid_comment: name }` for each model of an isa. */
@@ -493,7 +516,33 @@ export class XcodeProjectShim {
   }
 
   writeSync(): string {
+    this.relinkStandIns();
     return build(this.inner.toJSON());
+  }
+
+  // Stand-ins (`{ uuid }`) pushed for link-before-register are replaced with the
+  // now-registered model before serialization (`@bacons` can't serialize a bare
+  // `{ uuid }` in a single-reference field).
+  private relinkStandIns(): void {
+    const isStandIn = (v: any) =>
+      v && typeof v === 'object' && !Array.isArray(v) && typeof v.uuid === 'string' && !v.props;
+    for (const model of this.models()) {
+      const props = model.props;
+      for (const key of Object.keys(props)) {
+        const value = props[key];
+        if (isStandIn(value)) {
+          const real = this.safeGetObject(value.uuid);
+          if (real) props[key] = real;
+        } else if (Array.isArray(value)) {
+          value.forEach((entry, i) => {
+            if (isStandIn(entry)) {
+              const real = this.safeGetObject(entry.uuid);
+              if (real) value[i] = real;
+            }
+          });
+        }
+      }
+    }
   }
 
   get hash(): any {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -23,6 +23,17 @@ function unquoteForWrite(value: any): any {
 // `$(inherited)`, stored unquoted (`@bacons` re-quotes at serialize).
 const INHERITED = '$(inherited)';
 
+// Build settings written directly through a section view (bypassing
+// addBuildProperty) are unquoted on assignment so `@bacons` doesn't double-quote.
+function buildSettingsProxy(buildSettings: Record<string, any>): Record<string, any> {
+  return new Proxy(buildSettings, {
+    set(target, key, value) {
+      target[key as string] = typeof key === 'string' ? unquoteForWrite(value) : value;
+      return true;
+    },
+  });
+}
+
 // Strip outer quotes from build-setting values (and array elements) on write.
 function unquoteBuildSettings(buildSettings: Record<string, any> = {}): Record<string, any> {
   const out: Record<string, any> = {};
@@ -285,11 +296,42 @@ export class XcodeProjectShim {
     };
   }
 
+  // Legacy-shaped view of one object's props: references become UUID strings,
+  // ref arrays become live `{ value, comment }` arrays, and `buildSettings` is a
+  // write-through unquoting Proxy. Scalars/plain dicts are shared by reference so
+  // direct mutations (e.g. `obj.buildSettings.X = …`) reach the model.
+  private toLegacyObject(model: any): any {
+    const project = this.inner;
+    const out: Record<string, any> = {};
+    for (const key of Object.keys(model.props)) {
+      const value = model.props[key];
+      if (key === 'buildSettings' && value && typeof value === 'object' && !Array.isArray(value)) {
+        out[key] = buildSettingsProxy(value);
+      } else if (
+        value &&
+        typeof value === 'object' &&
+        !Array.isArray(value) &&
+        typeof value.uuid === 'string'
+      ) {
+        out[key] = value.uuid;
+      } else if (
+        Array.isArray(value) &&
+        value.length > 0 &&
+        value.every((v) => v && typeof v.uuid === 'string')
+      ) {
+        out[key] = legacyRefArray(value, project);
+      } else {
+        out[key] = value;
+      }
+    }
+    return out;
+  }
+
   /** Legacy section dict: `{ uuid: object, uuid_comment: name }` for each model of an isa. */
   private legacySection(isa: string): Record<string, any> {
     const section: Record<string, any> = {};
     for (const model of this.modelsOfIsa(isa)) {
-      section[model.uuid] = model.props;
+      section[model.uuid] = this.toLegacyObject(model);
       section[`${model.uuid}_comment`] = model.getDisplayName?.() ?? model.uuid;
     }
     return section;
@@ -362,14 +404,14 @@ export class XcodeProjectShim {
 
   // === Read / query ===
 
-  pbxProjectSection(..._args: any[]): any {
-    notImplemented('pbxProjectSection');
+  pbxProjectSection(): any {
+    return this.legacySection('PBXProject');
   }
-  pbxNativeTargetSection(..._args: any[]): any {
-    notImplemented('pbxNativeTargetSection');
+  pbxNativeTargetSection(): any {
+    return this.legacySection('PBXNativeTarget');
   }
-  pbxXCBuildConfigurationSection(..._args: any[]): any {
-    notImplemented('pbxXCBuildConfigurationSection');
+  pbxXCBuildConfigurationSection(): any {
+    return this.legacySection('XCBuildConfiguration');
   }
   pbxXCConfigurationList(): any {
     return this.legacySection('XCConfigurationList');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -211,6 +211,10 @@ export class XcodeProjectShim {
   // no empty sections, so track them here).
   private hashCreatedSections = new Set<string>();
 
+  // Comment a build phase was created with (legacy looks phases up by comment;
+  // `@bacons` doesn't store a comment on unnamed built-in phases like Resources).
+  private buildPhaseComments = new Map<string, string>();
+
   constructor(filePath: string) {
     this.filepath = path.resolve(filePath);
   }
@@ -630,19 +634,28 @@ export class XcodeProjectShim {
   buildPhase(..._args: any[]): any {
     notImplemented('buildPhase');
   }
-  buildPhaseObject(isa: string, name: string, target?: string): any {
-    const targetModel = (target && this.safeGetObject(target)) || this.firstTargetModel();
-    // Unnamed built-in phases (Sources/Frameworks/Resources) match by isa; named
-    // phases (copy-files, shell scripts) disambiguate by name.
-    let phase = (targetModel?.props?.buildPhases ?? []).find(
-      (p: any) => p.isa === isa && (p.props.name == null || trimQuotes(p.props.name) === name)
+  // The comment a phase is known by: its creation comment, else its `name` prop.
+  private phaseComment(phase: any): string | undefined {
+    return (
+      this.buildPhaseComments.get(phase.uuid) ??
+      (phase.props.name != null ? trimQuotes(phase.props.name) : undefined)
     );
-    // Legacy fallback: when the passed target doesn't own the named phase, match
-    // it by name across the whole section (e.g. a phase that lives on the app
-    // target is looked up via a freshly-created extension target).
-    if (!phase) {
-      phase = this.modelsOfIsa(isa).find((p) => trimQuotes(p.props.name ?? '') === name);
+  }
+
+  buildPhaseObject(isa: string, name: string, target?: string): any {
+    // Within the passed target, an unnamed built-in phase (no comment) matches the
+    // conventional name (Sources/Frameworks/Resources); a commented phase must match.
+    if (target) {
+      const t = this.safeGetObject(target);
+      const owned = (t?.props?.buildPhases ?? []).find((p: any) => {
+        if (p.isa !== isa) return false;
+        const comment = this.phaseComment(p);
+        return comment == null || comment === name;
+      });
+      if (owned) return this.legacyBuildPhase(owned);
     }
+    // No target (or not owned): legacy scans the whole section by comment.
+    const phase = this.modelsOfIsa(isa).find((p) => this.phaseComment(p) === name);
     return phase ? this.legacyBuildPhase(phase) : null;
   }
   getFirstProject(): any {
@@ -891,6 +904,7 @@ export class XcodeProjectShim {
       ...extra,
     });
     targetModel.props.buildPhases.push(phase);
+    this.buildPhaseComments.set(phase.uuid, comment);
 
     for (const filePath of filePathsArray) {
       const existing = this.modelsOfIsa('PBXBuildFile').find(

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -1,0 +1,371 @@
+import { XcodeProject } from '@bacons/xcode';
+import { build } from '@bacons/xcode/json';
+import path from 'path';
+
+function notImplemented(method: string): never {
+  throw new Error(`XcodeProjectShim.${method} is not implemented yet`);
+}
+
+/**
+ * Backwards-compatible facade exposing the legacy `xcode` `XcodeProject` API on
+ * top of a typed `@bacons/xcode` project. The substrate (construct / parse /
+ * serialize) is live; every legacy query/mutation method is stubbed until the
+ * differential harness drives its implementation.
+ */
+export class XcodeProjectShim {
+  filepath: string;
+
+  private project: XcodeProject | null = null;
+
+  constructor(filePath: string) {
+    this.filepath = path.resolve(filePath);
+  }
+
+  private get inner(): XcodeProject {
+    if (!this.project) {
+      throw new Error(
+        `XcodeProjectShim: the project has not been parsed. Call parseSync() before reading or writing it.`
+      );
+    }
+    return this.project;
+  }
+
+  // === Lifecycle / IO ===
+
+  parseSync(): this {
+    this.project = XcodeProject.open(this.filepath);
+    return this;
+  }
+
+  parse(..._args: any[]): any {
+    notImplemented('parse');
+  }
+
+  writeSync(): string {
+    return build(this.inner.toJSON());
+  }
+
+  get hash(): any {
+    return notImplemented('hash');
+  }
+
+  allUuids(..._args: any[]): any {
+    notImplemented('allUuids');
+  }
+
+  generateUuid(..._args: any[]): any {
+    notImplemented('generateUuid');
+  }
+
+  // === Read / query ===
+
+  pbxProjectSection(..._args: any[]): any {
+    notImplemented('pbxProjectSection');
+  }
+  pbxNativeTargetSection(..._args: any[]): any {
+    notImplemented('pbxNativeTargetSection');
+  }
+  pbxXCBuildConfigurationSection(..._args: any[]): any {
+    notImplemented('pbxXCBuildConfigurationSection');
+  }
+  pbxXCConfigurationList(..._args: any[]): any {
+    notImplemented('pbxXCConfigurationList');
+  }
+  pbxFileReferenceSection(..._args: any[]): any {
+    notImplemented('pbxFileReferenceSection');
+  }
+  pbxBuildFileSection(..._args: any[]): any {
+    notImplemented('pbxBuildFileSection');
+  }
+  xcVersionGroupSection(..._args: any[]): any {
+    notImplemented('xcVersionGroupSection');
+  }
+  pbxGroupByName(..._args: any[]): any {
+    notImplemented('pbxGroupByName');
+  }
+  pbxResourcesBuildPhaseObj(..._args: any[]): any {
+    notImplemented('pbxResourcesBuildPhaseObj');
+  }
+  pbxSourcesBuildPhaseObj(..._args: any[]): any {
+    notImplemented('pbxSourcesBuildPhaseObj');
+  }
+  pbxFrameworksBuildPhaseObj(..._args: any[]): any {
+    notImplemented('pbxFrameworksBuildPhaseObj');
+  }
+  pbxEmbedFrameworksBuildPhaseObj(..._args: any[]): any {
+    notImplemented('pbxEmbedFrameworksBuildPhaseObj');
+  }
+  pbxCopyfilesBuildPhaseObj(..._args: any[]): any {
+    notImplemented('pbxCopyfilesBuildPhaseObj');
+  }
+  buildPhase(..._args: any[]): any {
+    notImplemented('buildPhase');
+  }
+  buildPhaseObject(..._args: any[]): any {
+    notImplemented('buildPhaseObject');
+  }
+  getFirstProject(..._args: any[]): any {
+    notImplemented('getFirstProject');
+  }
+  getFirstTarget(..._args: any[]): any {
+    notImplemented('getFirstTarget');
+  }
+  getTarget(..._args: any[]): any {
+    notImplemented('getTarget');
+  }
+  getPBXGroupByKey(..._args: any[]): any {
+    notImplemented('getPBXGroupByKey');
+  }
+  getPBXGroupByKeyAndType(..._args: any[]): any {
+    notImplemented('getPBXGroupByKeyAndType');
+  }
+  getPBXVariantGroupByKey(..._args: any[]): any {
+    notImplemented('getPBXVariantGroupByKey');
+  }
+  pbxTargetByName(..._args: any[]): any {
+    notImplemented('pbxTargetByName');
+  }
+  pbxItemByComment(..._args: any[]): any {
+    notImplemented('pbxItemByComment');
+  }
+  findTargetKey(..._args: any[]): any {
+    notImplemented('findTargetKey');
+  }
+  findPBXGroupKey(..._args: any[]): any {
+    notImplemented('findPBXGroupKey');
+  }
+  findPBXGroupKeyAndType(..._args: any[]): any {
+    notImplemented('findPBXGroupKeyAndType');
+  }
+  getPBXObject(..._args: any[]): any {
+    notImplemented('getPBXObject');
+  }
+  hasFile(..._args: any[]): any {
+    notImplemented('hasFile');
+  }
+  getBuildProperty(..._args: any[]): any {
+    notImplemented('getBuildProperty');
+  }
+  getBuildConfigByName(..._args: any[]): any {
+    notImplemented('getBuildConfigByName');
+  }
+  get productName(): any {
+    return notImplemented('productName');
+  }
+
+  // === Mutate: build settings ===
+
+  addBuildProperty(..._args: any[]): any {
+    notImplemented('addBuildProperty');
+  }
+  removeBuildProperty(..._args: any[]): any {
+    notImplemented('removeBuildProperty');
+  }
+  updateBuildProperty(..._args: any[]): any {
+    notImplemented('updateBuildProperty');
+  }
+  updateProductName(..._args: any[]): any {
+    notImplemented('updateProductName');
+  }
+  addToBuildSettings(..._args: any[]): any {
+    notImplemented('addToBuildSettings');
+  }
+  removeFromBuildSettings(..._args: any[]): any {
+    notImplemented('removeFromBuildSettings');
+  }
+  addToHeaderSearchPaths(..._args: any[]): any {
+    notImplemented('addToHeaderSearchPaths');
+  }
+  removeFromHeaderSearchPaths(..._args: any[]): any {
+    notImplemented('removeFromHeaderSearchPaths');
+  }
+  addToLibrarySearchPaths(..._args: any[]): any {
+    notImplemented('addToLibrarySearchPaths');
+  }
+  removeFromLibrarySearchPaths(..._args: any[]): any {
+    notImplemented('removeFromLibrarySearchPaths');
+  }
+  addToFrameworkSearchPaths(..._args: any[]): any {
+    notImplemented('addToFrameworkSearchPaths');
+  }
+  removeFromFrameworkSearchPaths(..._args: any[]): any {
+    notImplemented('removeFromFrameworkSearchPaths');
+  }
+  addToOtherLinkerFlags(..._args: any[]): any {
+    notImplemented('addToOtherLinkerFlags');
+  }
+  removeFromOtherLinkerFlags(..._args: any[]): any {
+    notImplemented('removeFromOtherLinkerFlags');
+  }
+
+  // === Mutate: sections ===
+
+  addToPbxFileReferenceSection(..._args: any[]): any {
+    notImplemented('addToPbxFileReferenceSection');
+  }
+  removeFromPbxFileReferenceSection(..._args: any[]): any {
+    notImplemented('removeFromPbxFileReferenceSection');
+  }
+  addToPbxBuildFileSection(..._args: any[]): any {
+    notImplemented('addToPbxBuildFileSection');
+  }
+  removeFromPbxBuildFileSection(..._args: any[]): any {
+    notImplemented('removeFromPbxBuildFileSection');
+  }
+  addToPbxProjectSection(..._args: any[]): any {
+    notImplemented('addToPbxProjectSection');
+  }
+  addToPbxNativeTargetSection(..._args: any[]): any {
+    notImplemented('addToPbxNativeTargetSection');
+  }
+  addToXcVersionGroupSection(..._args: any[]): any {
+    notImplemented('addToXcVersionGroupSection');
+  }
+
+  // === Mutate: build phases ===
+
+  addToPbxResourcesBuildPhase(..._args: any[]): any {
+    notImplemented('addToPbxResourcesBuildPhase');
+  }
+  removeFromPbxResourcesBuildPhase(..._args: any[]): any {
+    notImplemented('removeFromPbxResourcesBuildPhase');
+  }
+  addToPbxSourcesBuildPhase(..._args: any[]): any {
+    notImplemented('addToPbxSourcesBuildPhase');
+  }
+  removeFromPbxSourcesBuildPhase(..._args: any[]): any {
+    notImplemented('removeFromPbxSourcesBuildPhase');
+  }
+  addToPbxFrameworksBuildPhase(..._args: any[]): any {
+    notImplemented('addToPbxFrameworksBuildPhase');
+  }
+  removeFromPbxFrameworksBuildPhase(..._args: any[]): any {
+    notImplemented('removeFromPbxFrameworksBuildPhase');
+  }
+  addToPbxEmbedFrameworksBuildPhase(..._args: any[]): any {
+    notImplemented('addToPbxEmbedFrameworksBuildPhase');
+  }
+  removeFromPbxEmbedFrameworksBuildPhase(..._args: any[]): any {
+    notImplemented('removeFromPbxEmbedFrameworksBuildPhase');
+  }
+  addToPbxCopyfilesBuildPhase(..._args: any[]): any {
+    notImplemented('addToPbxCopyfilesBuildPhase');
+  }
+  removeFromPbxCopyfilesBuildPhase(..._args: any[]): any {
+    notImplemented('removeFromPbxCopyfilesBuildPhase');
+  }
+  addBuildPhase(..._args: any[]): any {
+    notImplemented('addBuildPhase');
+  }
+
+  // === Mutate: groups ===
+
+  pbxCreateGroup(..._args: any[]): any {
+    notImplemented('pbxCreateGroup');
+  }
+  pbxCreateGroupWithType(..._args: any[]): any {
+    notImplemented('pbxCreateGroupWithType');
+  }
+  pbxCreateVariantGroup(..._args: any[]): any {
+    notImplemented('pbxCreateVariantGroup');
+  }
+  addPbxGroup(..._args: any[]): any {
+    notImplemented('addPbxGroup');
+  }
+  removePbxGroup(..._args: any[]): any {
+    notImplemented('removePbxGroup');
+  }
+  addToPbxGroup(..._args: any[]): any {
+    notImplemented('addToPbxGroup');
+  }
+  addToPbxGroupType(..._args: any[]): any {
+    notImplemented('addToPbxGroupType');
+  }
+  addToPbxVariantGroup(..._args: any[]): any {
+    notImplemented('addToPbxVariantGroup');
+  }
+  removeFromPbxGroup(..._args: any[]): any {
+    notImplemented('removeFromPbxGroup');
+  }
+  removeFromPbxGroupAndType(..._args: any[]): any {
+    notImplemented('removeFromPbxGroupAndType');
+  }
+
+  // === Mutate: frameworks / files ===
+
+  addFramework(..._args: any[]): any {
+    notImplemented('addFramework');
+  }
+  removeFramework(..._args: any[]): any {
+    notImplemented('removeFramework');
+  }
+  addToFrameworksPbxGroup(..._args: any[]): any {
+    notImplemented('addToFrameworksPbxGroup');
+  }
+  addFile(..._args: any[]): any {
+    notImplemented('addFile');
+  }
+  removeFile(..._args: any[]): any {
+    notImplemented('removeFile');
+  }
+  addSourceFile(..._args: any[]): any {
+    notImplemented('addSourceFile');
+  }
+  removeSourceFile(..._args: any[]): any {
+    notImplemented('removeSourceFile');
+  }
+  addResourceFile(..._args: any[]): any {
+    notImplemented('addResourceFile');
+  }
+  removeResourceFile(..._args: any[]): any {
+    notImplemented('removeResourceFile');
+  }
+  addStaticLibrary(..._args: any[]): any {
+    notImplemented('addStaticLibrary');
+  }
+  addCopyfile(..._args: any[]): any {
+    notImplemented('addCopyfile');
+  }
+
+  // === Mutate: targets ===
+
+  addTarget(..._args: any[]): any {
+    notImplemented('addTarget');
+  }
+  addTargetDependency(..._args: any[]): any {
+    notImplemented('addTargetDependency');
+  }
+  addXCConfigurationList(..._args: any[]): any {
+    notImplemented('addXCConfigurationList');
+  }
+  addProductFile(..._args: any[]): any {
+    notImplemented('addProductFile');
+  }
+  removeProductFile(..._args: any[]): any {
+    notImplemented('removeProductFile');
+  }
+  addToProductsPbxGroup(..._args: any[]): any {
+    notImplemented('addToProductsPbxGroup');
+  }
+  addTargetAttribute(..._args: any[]): any {
+    notImplemented('addTargetAttribute');
+  }
+  removeTargetAttribute(..._args: any[]): any {
+    notImplemented('removeTargetAttribute');
+  }
+
+  // === Mutate: regions / variant groups ===
+
+  addKnownRegion(..._args: any[]): any {
+    notImplemented('addKnownRegion');
+  }
+  removeKnownRegion(..._args: any[]): any {
+    notImplemented('removeKnownRegion');
+  }
+  hasKnownRegion(..._args: any[]): any {
+    notImplemented('hasKnownRegion');
+  }
+  addLocalizationVariantGroup(..._args: any[]): any {
+    notImplemented('addLocalizationVariantGroup');
+  }
+}

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/XcodeProjectShim.ts
@@ -20,6 +20,9 @@ function unquoteForWrite(value: any): any {
   return typeof value === 'string' ? trimQuotes(value) : value;
 }
 
+// `$(inherited)`, stored unquoted (`@bacons` re-quotes at serialize).
+const INHERITED = '$(inherited)';
+
 /**
  * Backwards-compatible facade exposing the legacy `xcode` `XcodeProject` API on
  * top of a typed `@bacons/xcode` project. The substrate (construct / parse /
@@ -128,6 +131,20 @@ export class XcodeProjectShim {
     const buildFile = this.safeGetObject(file.uuid);
     if (!buildFile) return;
     this.buildPhaseForTarget(isa, file.target).props.files.push(buildFile);
+  }
+
+  // Append a value to an array-valued build setting, on the configs of the app
+  // target (legacy scopes these to configs whose PRODUCT_NAME is the productName).
+  private appendScopedArraySetting(key: string, value: any): void {
+    const productName = this.productName;
+    for (const config of this.modelsOfIsa('XCBuildConfiguration')) {
+      const buildSettings = config.props.buildSettings;
+      if (trimQuotes(buildSettings.PRODUCT_NAME ?? '') !== productName) continue;
+      if (!buildSettings[key] || buildSettings[key] === INHERITED) {
+        buildSettings[key] = [INHERITED];
+      }
+      buildSettings[key].push(unquoteForWrite(value));
+    }
   }
 
   /** Legacy section dict: `{ uuid: object, uuid_comment: name }` for each model of an isa. */
@@ -305,7 +322,11 @@ export class XcodeProjectShim {
     notImplemented('getBuildConfigByName');
   }
   get productName(): any {
-    return notImplemented('productName');
+    for (const config of this.modelsOfIsa('XCBuildConfiguration')) {
+      const name = config.props.buildSettings.PRODUCT_NAME;
+      if (name) return trimQuotes(name);
+    }
+    return undefined;
   }
 
   // === Mutate: build settings ===
@@ -345,8 +366,8 @@ export class XcodeProjectShim {
   removeFromBuildSettings(..._args: any[]): any {
     notImplemented('removeFromBuildSettings');
   }
-  addToHeaderSearchPaths(..._args: any[]): any {
-    notImplemented('addToHeaderSearchPaths');
+  addToHeaderSearchPaths(file: any): void {
+    this.appendScopedArraySetting('HEADER_SEARCH_PATHS', file);
   }
   removeFromHeaderSearchPaths(..._args: any[]): any {
     notImplemented('removeFromHeaderSearchPaths');
@@ -363,8 +384,8 @@ export class XcodeProjectShim {
   removeFromFrameworkSearchPaths(..._args: any[]): any {
     notImplemented('removeFromFrameworkSearchPaths');
   }
-  addToOtherLinkerFlags(..._args: any[]): any {
-    notImplemented('addToOtherLinkerFlags');
+  addToOtherLinkerFlags(flag: any): void {
+    this.appendScopedArraySetting('OTHER_LDFLAGS', flag);
   }
   removeFromOtherLinkerFlags(..._args: any[]): any {
     notImplemented('removeFromOtherLinkerFlags');
@@ -580,14 +601,16 @@ export class XcodeProjectShim {
 
   // === Mutate: regions / variant groups ===
 
-  addKnownRegion(..._args: any[]): any {
-    notImplemented('addKnownRegion');
+  addKnownRegion(name: string): void {
+    const props = this.inner.rootObject.props;
+    if (!props.knownRegions) props.knownRegions = [];
+    if (!this.hasKnownRegion(name)) props.knownRegions.push(name);
   }
   removeKnownRegion(..._args: any[]): any {
     notImplemented('removeKnownRegion');
   }
-  hasKnownRegion(..._args: any[]): any {
-    notImplemented('hasKnownRegion');
+  hasKnownRegion(name: string): boolean {
+    return (this.inner.rootObject.props.knownRegions ?? []).includes(name);
   }
   addLocalizationVariantGroup(..._args: any[]): any {
     notImplemented('addLocalizationVariantGroup');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
@@ -32,6 +32,20 @@ describe('stubbed surface', () => {
   });
 });
 
+describe('read re-quoting (legacy-faithful)', () => {
+  it('quotes values pbxproj would quote on read, leaves safe ones bare', () => {
+    const p = project(fixturePath('bareMinimum')).parseSync();
+    const target: any = Object.values(p.pbxNativeTargetSection()).find(
+      (t: any) => t && t.isa === 'PBXNativeTarget'
+    );
+    // Hyphen isn't a safe pbxproj identifier char, so productType reads quoted —
+    // matching legacy (and plugins that strict-compare the quoted form).
+    expect(target.productType).toBe('"com.apple.product-type.application"');
+    // A safe identifier reads bare.
+    expect(target.name).toBe('HelloWorld');
+  });
+});
+
 describe('pbxFile', () => {
   it('derives file metadata from the path', () => {
     const file = new PbxFile('HelloWorld/Foo.swift');

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
@@ -30,8 +30,14 @@ describe('stubbed surface', () => {
     expect(() => p.addTarget()).toThrow(/not implemented yet/);
     expect(() => p.pbxProjectSection()).toThrow(/not implemented yet/);
   });
+});
 
-  it('throws "not implemented yet" when constructing a pbxFile', () => {
-    expect(() => new PbxFile('Foo.swift')).toThrow(/not implemented yet/);
+describe('pbxFile', () => {
+  it('derives file metadata from the path', () => {
+    const file = new PbxFile('HelloWorld/Foo.swift');
+    expect(file.basename).toBe('Foo.swift');
+    expect(file.lastKnownFileType).toBe('sourcecode.swift');
+    expect(file.group).toBe('Sources');
+    expect(file.sourceTree).toBe('"<group>"');
   });
 });

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
@@ -26,9 +26,9 @@ describe('substrate', () => {
 describe('stubbed surface', () => {
   it('throws "not implemented yet" for unimplemented methods', () => {
     const p = project(fixturePath('bareMinimum')).parseSync();
-    expect(() => p.addTarget()).toThrow(/not implemented yet/);
-    expect(() => p.pbxProjectSection()).toThrow(/not implemented yet/);
-    expect(() => p.pbxNativeTargetSection()).toThrow(/not implemented yet/);
+    expect(() => p.addToBuildSettings()).toThrow(/not implemented yet/);
+    expect(() => p.removePbxGroup()).toThrow(/not implemented yet/);
+    expect(() => p.pbxItemByComment()).toThrow(/not implemented yet/);
   });
 });
 

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
@@ -1,0 +1,37 @@
+import path from 'path';
+
+import { fixturePath } from './fixtures';
+import { PbxFile, project, XcodeProjectShim } from '../index';
+
+describe('substrate', () => {
+  it('resolves filepath without reading the file', () => {
+    const p = project('ios/HelloWorld.xcodeproj/project.pbxproj');
+    expect(p).toBeInstanceOf(XcodeProjectShim);
+    expect(p.filepath).toBe(path.resolve('ios/HelloWorld.xcodeproj/project.pbxproj'));
+  });
+
+  it('parses and serializes a real project', () => {
+    const p = project(fixturePath('bareMinimum'));
+    expect(p.parseSync()).toBe(p);
+    const output = p.writeSync();
+    expect(output).toContain('// !$*UTF8*$!');
+    expect(output).toContain('PBXProject');
+  });
+
+  it('throws a helpful error when serializing before parsing', () => {
+    expect(() => project(fixturePath('bareMinimum')).writeSync()).toThrow(/parseSync/);
+  });
+});
+
+describe('stubbed surface', () => {
+  it('throws "not implemented yet" for unimplemented methods', () => {
+    const p = project(fixturePath('bareMinimum')).parseSync();
+    expect(() => p.addBuildPhase()).toThrow(/not implemented yet/);
+    expect(() => p.addTarget()).toThrow(/not implemented yet/);
+    expect(() => p.pbxProjectSection()).toThrow(/not implemented yet/);
+  });
+
+  it('throws "not implemented yet" when constructing a pbxFile', () => {
+    expect(() => new PbxFile('Foo.swift')).toThrow(/not implemented yet/);
+  });
+});

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/XcodeProjectShim-test.ts
@@ -26,9 +26,9 @@ describe('substrate', () => {
 describe('stubbed surface', () => {
   it('throws "not implemented yet" for unimplemented methods', () => {
     const p = project(fixturePath('bareMinimum')).parseSync();
-    expect(() => p.addBuildPhase()).toThrow(/not implemented yet/);
     expect(() => p.addTarget()).toThrow(/not implemented yet/);
     expect(() => p.pbxProjectSection()).toThrow(/not implemented yet/);
+    expect(() => p.pbxNativeTargetSection()).toThrow(/not implemented yet/);
   });
 });
 

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
@@ -7636,7 +7636,6 @@ exports[`legacy xcode golden baseline files/add-resource-file-no-build 1`] = `
 				UUID-0005 /* Expo.plist in Resources */,
 				UUID-0001 /* Images.xcassets in Resources */,
 				UUID-0003 /* SplashScreen.storyboard in Resources */,
-				UUID-0032 /* readme-only.txt in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7719,7 +7718,7 @@ exports[`legacy xcode golden baseline files/add-resource-file-no-build 1`] = `
 /* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
-		UUID-0033 /* Debug */ = {
+		UUID-0032 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -7752,7 +7751,7 @@ exports[`legacy xcode golden baseline files/add-resource-file-no-build 1`] = `
 			};
 			name = Debug;
 		};
-		UUID-0034 /* Release */ = {
+		UUID-0033 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -7779,7 +7778,7 @@ exports[`legacy xcode golden baseline files/add-resource-file-no-build 1`] = `
 			};
 			name = Release;
 		};
-		UUID-0035 /* Debug */ = {
+		UUID-0034 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -7838,7 +7837,7 @@ exports[`legacy xcode golden baseline files/add-resource-file-no-build 1`] = `
 			};
 			name = Debug;
 		};
-		UUID-0036 /* Release */ = {
+		UUID-0035 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -7896,8 +7895,8 @@ exports[`legacy xcode golden baseline files/add-resource-file-no-build 1`] = `
 		UUID-0024 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				UUID-0033 /* Debug */,
-				UUID-0034 /* Release */,
+				UUID-0032 /* Debug */,
+				UUID-0033 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -7905,8 +7904,8 @@ exports[`legacy xcode golden baseline files/add-resource-file-no-build 1`] = `
 		UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				UUID-0035 /* Debug */,
-				UUID-0036 /* Release */,
+				UUID-0034 /* Debug */,
+				UUID-0035 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
@@ -702,7 +702,7 @@ exports[`legacy xcode golden baseline build-phases/add-shell-script 1`] = `
 			runOnlyForDeploymentPostprocessing = 0;
 			name = "Upload Source Maps";
 			inputPaths = (
-				$(SRCROOT)/main.jsbundle,
+				"$(SRCROOT)/main.jsbundle",
 			);
 			outputPaths = (
 			);
@@ -923,7 +923,7 @@ exports[`legacy xcode golden baseline build-phases/add-shell-script 1`] = `
 ",
   "result": {
     "inputPaths": [
-      "$(SRCROOT)/main.jsbundle",
+      ""$(SRCROOT)/main.jsbundle"",
     ],
     "isa": "PBXShellScriptBuildPhase",
     "name": ""Upload Source Maps"",

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
@@ -9808,6 +9808,461 @@ exports[`legacy xcode golden baseline files/build-file-before-file-reference 1`]
 }
 `;
 
+exports[`legacy xcode golden baseline files/create-group-quoted-name 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+		UUID-0022 /* "My Stickers" */ = {
+			isa = "PBXGroup";
+			children = (
+			);
+			name = "My Stickers";
+			sourceTree = "<group>";
+			path = "";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0023 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0024 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0025 /* [CP] Check Pods Manifest.lock */,
+				UUID-0026 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0027 /* Resources */,
+				UUID-0028 /* Bundle React Native code and images */,
+				UUID-0029 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0030 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0023 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0023 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0027 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0028 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0025 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0029 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0026 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0032 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0033 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0024 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0032 /* Debug */,
+				UUID-0033 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0034 /* Debug */,
+				UUID-0035 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0030 /* Project object */;
+}
+",
+  "result": {
+    "name": ""My Stickers"",
+  },
+}
+`;
+
 exports[`legacy xcode golden baseline files/ensure-group-recursively 1`] = `
 {
   "pbxproj": "// !$*UTF8*$!

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
@@ -14444,6 +14444,541 @@ exports[`legacy xcode golden baseline targets/add-xc-configuration-list 1`] = `
 }
 `;
 
+exports[`legacy xcode golden baseline targets/hash-precreated-target-dependency 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* Widget.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Widget.appex */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* Widget.appex */ = {isa = PBXFileReference; name = "Widget.appex"; path = "Widget.appex"; sourceTree = BUILT_PRODUCTS_DIR; fileEncoding = undefined; lastKnownFileType = undefined; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+				UUID-0012 /* Widget.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+				UUID-0031 /* Copy Files */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				UUID-0032 /* PBXTargetDependency */,
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+		UUID-0033 /* "Widget" */ = {
+			isa = PBXNativeTarget;
+			name = "Widget";
+			productName = "Widget";
+			productReference = UUID-0012;
+			productType = "com.apple.product-type.app-extension";
+			buildConfigurationList = UUID-0034;
+			buildPhases = (
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0035 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0036 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+				UUID-0033 /* "Widget" */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0037 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0038 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0039 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0040 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		UUID-0041 /* Debug */ = {
+			name = Debug;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Widget/Widget-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "Widget";
+				SKIP_INSTALL = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Widget";
+			};
+		};
+		UUID-0042 /* Release */ = {
+			name = Release;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "Widget/Widget-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "Widget";
+				SKIP_INSTALL = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Widget";
+			};
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0037 /* Debug */,
+				UUID-0038 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0036 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0039 /* Debug */,
+				UUID-0040 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0034 /* Build configuration list for PBXNativeTarget "Widget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0041 /* Debug */,
+				UUID-0042 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		UUID-0031 /* Copy Files */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* Widget.appex in Copy Files */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Copy Files";
+			dstPath = "";
+			dstSubfolderSpec = 13;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		UUID-0032 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = UUID-0033 /* "Widget" */;
+			targetProxy = UUID-0043 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXContainerItemProxy section */
+		UUID-0043 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = UUID-0035 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = UUID-0033;
+			remoteInfo = "Widget";
+		};
+/* End PBXContainerItemProxy section */
+	};
+	rootObject = UUID-0035 /* Project object */;
+}
+",
+  "result": {
+    "appDependencyCount": 1,
+    "hasContainerItemProxy": true,
+  },
+}
+`;
+
 exports[`legacy xcode golden baseline targets/pbx-target-by-name 1`] = `
 {
   "pbxproj": "// !$*UTF8*$!

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
@@ -1381,6 +1381,531 @@ exports[`legacy xcode golden baseline build-phases/build-phase-object 1`] = `
 }
 `;
 
+exports[`legacy xcode golden baseline build-phases/phase-lookup-by-comment 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* Stickers.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Stickers.appex */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* Stickers.appex */ = {isa = PBXFileReference; name = "Stickers.appex"; path = "Stickers.appex"; sourceTree = BUILT_PRODUCTS_DIR; fileEncoding = undefined; lastKnownFileType = undefined; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+				UUID-0012 /* Stickers.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+				UUID-0031 /* Copy Files */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+		UUID-0032 /* "Stickers" */ = {
+			isa = PBXNativeTarget;
+			name = "Stickers";
+			productName = "Stickers";
+			productReference = UUID-0012;
+			productType = "com.apple.product-type.app-extension";
+			buildConfigurationList = UUID-0033;
+			buildPhases = (
+				UUID-0034 /* Stickers Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0035 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0036 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+				UUID-0032 /* "Stickers" */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		UUID-0034 /* Stickers Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0037 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0038 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0039 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0040 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		UUID-0041 /* Debug */ = {
+			name = Debug;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Stickers/Stickers-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "Stickers";
+				SKIP_INSTALL = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Stickers";
+			};
+		};
+		UUID-0042 /* Release */ = {
+			name = Release;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "Stickers/Stickers-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "Stickers";
+				SKIP_INSTALL = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Stickers";
+			};
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0037 /* Debug */,
+				UUID-0038 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0036 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0039 /* Debug */,
+				UUID-0040 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0033 /* Build configuration list for PBXNativeTarget "Stickers" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0041 /* Debug */,
+				UUID-0042 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		UUID-0031 /* Copy Files */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* Stickers.appex in Copy Files */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Copy Files";
+			dstPath = "";
+			dstSubfolderSpec = 13;
+		};
+/* End PBXCopyFilesBuildPhase section */
+	};
+	rootObject = UUID-0035 /* Project object */;
+}
+",
+  "result": {
+    "fileCount": 0,
+    "found": true,
+    "isa": "PBXResourcesBuildPhase",
+  },
+}
+`;
+
 exports[`legacy xcode golden baseline build-settings/add-header-search-paths 1`] = `
 {
   "pbxproj": "// !$*UTF8*$!

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
@@ -8833,6 +8833,456 @@ exports[`legacy xcode golden baseline files/add-to-pbx-group 1`] = `
 }
 `;
 
+exports[`legacy xcode golden baseline files/build-file-before-file-reference 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* Sticker.png in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Sticker.png */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* Sticker.png */ = {isa = PBXFileReference; name = "Sticker.png"; path = "Sticker.png"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0031 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+				UUID-0011 /* Sticker.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0031 /* Project object */;
+}
+",
+  "result": {
+    "hasFile": true,
+  },
+}
+`;
+
 exports[`legacy xcode golden baseline files/ensure-group-recursively 1`] = `
 {
   "pbxproj": "// !$*UTF8*$!
@@ -15641,6 +16091,476 @@ exports[`legacy xcode golden baseline targets/pbx-target-by-name 1`] = `
     "found": true,
     "key": "UUID-0001",
     "productType": ""com.apple.product-type.app-extension"",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline targets/reassign-build-configuration-list 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			name = Debug;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "X";
+			};
+		};
+		UUID-0036 /* Release */ = {
+			name = Release;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "X";
+			};
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0037 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0023 /* Build configuration list for PBXNativeTarget "X" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "reassigned": true,
   },
 }
 `;

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/__snapshots__/golden-legacy-test.ts.snap
@@ -1,0 +1,15112 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`legacy xcode golden baseline build-phases/add-copy-files 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+				UUID-0029 /* Copy Files */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0030 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0032 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0033 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0032 /* Debug */,
+				UUID-0033 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0034 /* Debug */,
+				UUID-0035 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		UUID-0029 /* Copy Files */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Copy Files";
+			dstPath = "";
+			dstSubfolderSpec = 10;
+		};
+/* End PBXCopyFilesBuildPhase section */
+	};
+	rootObject = UUID-0030 /* Project object */;
+}
+",
+  "result": {
+    "dstPath": """",
+    "dstSubfolderSpec": 10,
+    "isa": "PBXCopyFilesBuildPhase",
+    "name": ""Copy Files"",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-phases/add-shell-script 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+				UUID-0029 /* Upload Source Maps */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0030 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0029 /* Upload Source Maps */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Upload Source Maps";
+			inputPaths = (
+				$(SRCROOT)/main.jsbundle,
+			);
+			outputPaths = (
+			);
+			shellPath = /bin/sh;
+			shellScript = "echo \\"uploading\\"";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0032 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0033 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0032 /* Debug */,
+				UUID-0033 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0034 /* Debug */,
+				UUID-0035 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0030 /* Project object */;
+}
+",
+  "result": {
+    "inputPaths": [
+      "$(SRCROOT)/main.jsbundle",
+    ],
+    "isa": "PBXShellScriptBuildPhase",
+    "name": ""Upload Source Maps"",
+    "shellPath": "/bin/sh",
+    "shellScript": ""echo \\"uploading\\""",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-phases/build-phase-object 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "fileCount": 2,
+    "isa": "PBXSourcesBuildPhase",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/add-header-search-paths 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/foo/include",
+				);
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../node_modules/foo/include",
+				);
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "value": [
+      ""$(inherited)"",
+      ""$(SRCROOT)/../node_modules/foo/include"",
+    ],
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/add-other-linker-flags 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+					-ObjC,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+					-ObjC,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "value": [
+      ""$(inherited)"",
+      ""-ObjC"",
+      ""-lc++"",
+      "-ObjC",
+    ],
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/set-bundle-identifier 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.differential";
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.differential";
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.differential";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.differential";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "value": "com.example.differential",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/set-deployment-target 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "value": "15.1",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/set-development-team 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				DEVELOPMENT_TEAM = J5FM626PE2;
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				DEVELOPMENT_TEAM = J5FM626PE2;
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				DEVELOPMENT_TEAM = J5FM626PE2;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				DEVELOPMENT_TEAM = J5FM626PE2;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "value": "J5FM626PE2",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/set-device-family 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "value": "1,2",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/set-entitlements 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				CODE_SIGN_ENTITLEMENTS = "HelloWorld/HelloWorld.entitlements";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				CODE_SIGN_ENTITLEMENTS = "HelloWorld/HelloWorld.entitlements";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "debug": null,
+    "release": "HelloWorld/HelloWorld.entitlements",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/toggle-bitcode 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "afterAdd": "YES",
+    "afterRemove": null,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/update-product-name 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = "RenamedApp";
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = "RenamedApp";
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				PRODUCT_NAME = "RenamedApp";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				PRODUCT_NAME = "RenamedApp";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "value": "RenamedApp",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline build-settings/update-property-for-target 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* AppDelegate.m */; };
+		UUID-0003 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* LaunchScreen.xib */; };
+		UUID-0005 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Images.xcassets */; };
+		UUID-0007 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* main.m */; };
+		UUID-0009 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SplashScreen.storyboard */; };
+		UUID-0011 /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* ShareViewController.m */; };
+		UUID-0013 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0014 /* MainInterface.storyboard */; };
+		UUID-0015 /* shareextension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = UUID-0016 /* shareextension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		UUID-0017 /* libPods-multitarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = UUID-0018 /* libPods-multitarget.a */; };
+		UUID-0019 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0020 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		UUID-0021 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = UUID-0022 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = UUID-0023;
+			remoteInfo = shareextension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		UUID-0024 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				UUID-0015 /* shareextension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		UUID-0025 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		UUID-0026 /* multitarget.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = multitarget.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0027 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = multitarget/AppDelegate.h; sourceTree = "<group>"; };
+		UUID-0002 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = multitarget/AppDelegate.m; sourceTree = "<group>"; };
+		UUID-0028 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		UUID-0006 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = multitarget/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0029 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = multitarget/Info.plist; sourceTree = "<group>"; };
+		UUID-0008 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = multitarget/main.m; sourceTree = "<group>"; };
+		UUID-0018 /* libPods-multitarget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-multitarget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0016 /* shareextension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = shareextension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0030 /* ShareViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = "<group>"; };
+		UUID-0012 /* ShareViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = "<group>"; };
+		UUID-0031 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		UUID-0032 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		UUID-0033 /* Pods-multitarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-multitarget.debug.xcconfig"; path = "Target Support Files/Pods-multitarget/Pods-multitarget.debug.xcconfig"; sourceTree = "<group>"; };
+		UUID-0034 /* Pods-multitarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-multitarget.release.xcconfig"; path = "Target Support Files/Pods-multitarget/Pods-multitarget.release.xcconfig"; sourceTree = "<group>"; };
+		UUID-0010 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = multitarget/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0020 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0035 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0036 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0037 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0017 /* libPods-multitarget.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		UUID-0038 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0039 /* multitarget */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0040 /* Supporting */,
+				UUID-0025 /* main.jsbundle */,
+				UUID-0027 /* AppDelegate.h */,
+				UUID-0002 /* AppDelegate.m */,
+				UUID-0006 /* Images.xcassets */,
+				UUID-0029 /* Info.plist */,
+				UUID-0004 /* LaunchScreen.xib */,
+				UUID-0008 /* main.m */,
+				UUID-0010 /* SplashScreen.storyboard */,
+			);
+			name = multitarget;
+			sourceTree = "<group>";
+		};
+		UUID-0041 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0035 /* JavaScriptCore.framework */,
+				UUID-0036 /* JavaScriptCore.framework */,
+				UUID-0018 /* libPods-multitarget.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0042 /* shareextension */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0030 /* ShareViewController.h */,
+				UUID-0012 /* ShareViewController.m */,
+				UUID-0014 /* MainInterface.storyboard */,
+				UUID-0032 /* Info.plist */,
+			);
+			path = shareextension;
+			sourceTree = "<group>";
+		};
+		UUID-0043 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0044 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0039 /* multitarget */,
+				UUID-0043 /* Libraries */,
+				UUID-0042 /* shareextension */,
+				UUID-0045 /* Products */,
+				UUID-0041 /* Frameworks */,
+				UUID-0046 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0045 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0026 /* multitarget.app */,
+				UUID-0016 /* shareextension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0040 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0020 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = multitarget/Supporting;
+			sourceTree = "<group>";
+		};
+		UUID-0046 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0033 /* Pods-multitarget.debug.xcconfig */,
+				UUID-0034 /* Pods-multitarget.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0047 /* multitarget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0048 /* Build configuration list for PBXNativeTarget "multitarget" */;
+			buildPhases = (
+				UUID-0049 /* [CP] Check Pods Manifest.lock */,
+				UUID-0050 /* Start Packager */,
+				UUID-0051 /* Sources */,
+				UUID-0037 /* Frameworks */,
+				UUID-0052 /* Resources */,
+				UUID-0053 /* Bundle React Native code and images */,
+				UUID-0054 /* [CP] Copy Pods Resources */,
+				UUID-0024 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				UUID-0055 /* PBXTargetDependency */,
+			);
+			name = multitarget;
+			productName = multitarget;
+			productReference = UUID-0026 /* multitarget.app */;
+			productType = "com.apple.product-type.application";
+		};
+		UUID-0023 /* shareextension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0056 /* Build configuration list for PBXNativeTarget "shareextension" */;
+			buildPhases = (
+				UUID-0057 /* Sources */,
+				UUID-0038 /* Frameworks */,
+				UUID-0058 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = shareextension;
+			productName = shareextension;
+			productReference = UUID-0016 /* shareextension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0022 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0047 = {
+						DevelopmentTeam = QL76XYH73P;
+						LastSwiftMigration = 1120;
+					};
+					UUID-0023 = {
+						CreatedOnToolsVersion = 12.5;
+						DevelopmentTeam = QL76XYH73P;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0059 /* Build configuration list for PBXProject "multitarget" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0044;
+			productRefGroup = UUID-0045 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0047 /* multitarget */,
+				UUID-0023 /* shareextension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0052 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0019 /* Expo.plist in Resources */,
+				UUID-0005 /* Images.xcassets in Resources */,
+				UUID-0003 /* LaunchScreen.xib in Resources */,
+				UUID-0009 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		UUID-0058 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0013 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0053 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f /Users/dsokal/.volta/bin/node ]]; then\\n  export NODE_BINARY=/Users/dsokal/.volta/bin/node\\nelse\\n  export NODE_BINARY=node\\nfi\\n../node_modules/react-native/scripts/react-native-xcode.sh\\n../node_modules/expo-constants/scripts/get-app-config-ios.sh\\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\\n";
+		};
+		UUID-0049 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-multitarget-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0054 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0050 /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Start Packager";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export RCT_METRO_PORT=\\"\${RCT_METRO_PORT:=8081}\\"\\necho \\"export RCT_METRO_PORT=\${RCT_METRO_PORT}\\" > \\"\${SRCROOT}/../node_modules/react-native/scripts/.packager.env\\"\\nif [ -z \\"\${RCT_NO_LAUNCH_PACKAGER+xxx}\\" ] ; then\\n  if nc -w 5 -z localhost \${RCT_METRO_PORT} ; then\\n    if ! curl -s \\"http://localhost:\${RCT_METRO_PORT}/status\\" | grep -q \\"packager-status:running\\" ; then\\n      echo \\"Port \${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\\"\\n      exit 2\\n    fi\\n  else\\n    open \\"$SRCROOT/../node_modules/expo/scripts/launchPackager.command\\" || echo \\"Can't start packager automatically\\"\\n  fi\\nfi\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0051 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0001 /* AppDelegate.m in Sources */,
+				UUID-0007 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		UUID-0057 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* ShareViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		UUID-0055 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = UUID-0023 /* shareextension */;
+			targetProxy = UUID-0021 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		UUID-0004 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				UUID-0028 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = multitarget;
+			sourceTree = "<group>";
+		};
+		UUID-0014 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				UUID-0031 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0060 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = UUID-0033 /* Pods-multitarget.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.debug;
+				PRODUCT_NAME = multitarget;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0061 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = UUID-0034 /* Pods-multitarget.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget;
+				PRODUCT_NAME = multitarget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0062 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.share";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		UUID-0063 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.share";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		UUID-0064 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\"",
+					"\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\"",
+					"\\"$(inherited)\\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0065 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\"",
+					"\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\"",
+					"\\"$(inherited)\\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0048 /* Build configuration list for PBXNativeTarget "multitarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0060 /* Debug */,
+				UUID-0061 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0056 /* Build configuration list for PBXNativeTarget "shareextension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0062 /* Debug */,
+				UUID-0063 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0059 /* Build configuration list for PBXProject "multitarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0064 /* Debug */,
+				UUID-0065 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0022 /* Project object */;
+}
+",
+  "result": {
+    "share": "com.example.share",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline files/add-duplicate-resource 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* dup-resource.png in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* dup-resource.png */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* dup-resource.png */ = {isa = PBXFileReference; name = "dup-resource.png"; path = "HelloWorld/dup-resource.png"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+				UUID-0012 /* dup-resource.png */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0031 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+				UUID-0011 /* dup-resource.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0031 /* Project object */;
+}
+",
+  "result": {
+    "firstAdded": true,
+    "refsUnchanged": true,
+    "secondAdded": false,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline files/add-pbx-group 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* Widget.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Widget.swift */; };
+		UUID-0013 /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0014 /* Info.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0015 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0016 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0017 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0018 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* Widget.swift */ = {isa = PBXFileReference; name = "Widget.swift"; path = "Widget/Widget.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; name = "Info.plist"; path = "Widget/Info.plist"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = text.plist.xml; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0019 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0020 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0018 /* HelloWorld-Bridging-Header.h */,
+				UUID-0021 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0016 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0022 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0017 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0023 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0024 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0020 /* HelloWorld */,
+				UUID-0023 /* Libraries */,
+				UUID-0025 /* Products */,
+				UUID-0022 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0025 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+		UUID-0026 /* Widget */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0012 /* Widget.swift */,
+				UUID-0014 /* Info.plist */,
+			);
+			name = Widget;
+			path = Widget;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0027 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0028 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0029 /* [CP] Check Pods Manifest.lock */,
+				UUID-0030 /* Sources */,
+				UUID-0019 /* Frameworks */,
+				UUID-0031 /* Resources */,
+				UUID-0032 /* Bundle React Native code and images */,
+				UUID-0033 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0015 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0034 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0027 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0035 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0024;
+			productRefGroup = UUID-0025 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0027 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0031 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0032 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0029 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0033 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0030 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0036 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0037 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0038 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0039 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0028 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0036 /* Debug */,
+				UUID-0037 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0035 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0038 /* Debug */,
+				UUID-0039 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0034 /* Project object */;
+}
+",
+  "result": {
+    "childCount": 2,
+    "name": "Widget",
+    "path": "Widget",
+    "registered": true,
+    "sourceTree": ""<group>"",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline files/add-resource-file 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* new-resource.png in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* new-resource.png */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* new-resource.png */ = {isa = PBXFileReference; name = "new-resource.png"; path = "HelloWorld/new-resource.png"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+				UUID-0012 /* new-resource.png */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0031 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+				UUID-0011 /* new-resource.png in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0031 /* Project object */;
+}
+",
+  "result": {
+    "added": true,
+    "basename": "new-resource.png",
+    "hasFile": true,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline files/add-resource-file-no-build 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0015 /* readme-only.txt */ = {isa = PBXFileReference; name = "readme-only.txt"; path = "HelloWorld/readme-only.txt"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0016 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0017 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0018 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+				UUID-0015 /* readme-only.txt */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0021 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0017 /* HelloWorld */,
+				UUID-0020 /* Libraries */,
+				UUID-0022 /* Products */,
+				UUID-0019 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0022 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0023 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0024 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0025 /* [CP] Check Pods Manifest.lock */,
+				UUID-0026 /* Sources */,
+				UUID-0016 /* Frameworks */,
+				UUID-0027 /* Resources */,
+				UUID-0028 /* Bundle React Native code and images */,
+				UUID-0029 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0030 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0023 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0021;
+			productRefGroup = UUID-0022 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0023 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0027 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+				UUID-0032 /* readme-only.txt in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0028 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0025 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0029 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0026 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0024 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0030 /* Project object */;
+}
+",
+  "result": {
+    "buildFileCountUnchanged": true,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline files/add-source-file 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* MyClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* MyClass.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* MyClass.swift */ = {isa = PBXFileReference; name = "MyClass.swift"; path = "HelloWorld/MyClass.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+				UUID-0012 /* MyClass.swift */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0031 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+				UUID-0011 /* MyClass.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0031 /* Project object */;
+}
+",
+  "result": {
+    "added": true,
+    "basename": "MyClass.swift",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline files/add-to-pbx-group 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0015 /* Thing.swift */ = {isa = PBXFileReference; name = "Thing.swift"; path = "Extras/Thing.swift"; sourceTree = "<group>"; fileEncoding = 4; lastKnownFileType = sourcecode.swift; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0016 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0017 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0018 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0021 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0017 /* HelloWorld */,
+				UUID-0020 /* Libraries */,
+				UUID-0022 /* Products */,
+				UUID-0019 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0022 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+		UUID-0023 /* Extras */ = {
+			isa = "PBXGroup";
+			children = (
+				UUID-0015 /* Thing.swift */,
+			);
+			name = Extras;
+			sourceTree = "<group>";
+			path = Extras;
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0016 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0031 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0021;
+			productRefGroup = UUID-0022 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0031 /* Project object */;
+}
+",
+  "result": {
+    "childComments": [
+      "Thing.swift",
+    ],
+    "groupName": "Extras",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline files/ensure-group-recursively 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+				UUID-0018 /* Generated */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0021 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0020 /* Libraries */,
+				UUID-0022 /* Products */,
+				UUID-0019 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0022 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Generated */ = {
+			isa = "PBXGroup";
+			children = (
+				UUID-0023 /* Sources */,
+			);
+			name = Generated;
+			sourceTree = "<group>";
+			path = "";
+		};
+		UUID-0023 /* Sources */ = {
+			isa = "PBXGroup";
+			children = (
+			);
+			name = Sources;
+			sourceTree = "<group>";
+			path = "";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0031 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0021;
+			productRefGroup = UUID-0022 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0031 /* Project object */;
+}
+",
+  "result": {
+    "created": "Sources",
+    "hasGenerated": true,
+    "hasSources": true,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline files/has-file 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "absent": false,
+    "present": true,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline frameworks/add-custom-framework-embed-sign 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* Adjust.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Adjust.framework */; };
+		UUID-0013 /* Adjust.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Adjust.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0014 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0015 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0016 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0017 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* Adjust.framework */ = {isa = PBXFileReference; name = "Adjust.framework"; path = "vendor/Adjust.framework"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.framework; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* Adjust.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0019 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0017 /* HelloWorld-Bridging-Header.h */,
+				UUID-0020 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0015 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* JavaScriptCore.framework */,
+				UUID-0012 /* Adjust.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0022 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0023 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0019 /* HelloWorld */,
+				UUID-0022 /* Libraries */,
+				UUID-0024 /* Products */,
+				UUID-0021 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0024 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0014 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0025 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0026 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0027 /* [CP] Check Pods Manifest.lock */,
+				UUID-0028 /* Sources */,
+				UUID-0018 /* Frameworks */,
+				UUID-0029 /* Resources */,
+				UUID-0030 /* Bundle React Native code and images */,
+				UUID-0031 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0014 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0032 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0025 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0033 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0023;
+			productRefGroup = UUID-0024 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0025 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0029 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0030 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0027 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0031 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0028 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\\"vendor\\"",
+				);
+			};
+			name = Debug;
+		};
+		UUID-0035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\\"vendor\\"",
+				);
+			};
+			name = Release;
+		};
+		UUID-0036 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0037 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0026 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0034 /* Debug */,
+				UUID-0035 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0033 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0036 /* Debug */,
+				UUID-0037 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0032 /* Project object */;
+}
+",
+  "result": {
+    "basename": "Adjust.framework",
+    "settings": {
+      "ATTRIBUTES": [
+        "CodeSignOnCopy",
+      ],
+    },
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline frameworks/add-framework 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* StoreKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* StoreKit.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* StoreKit.framework */ = {isa = PBXFileReference; name = "StoreKit.framework"; path = "System/Library/Frameworks/StoreKit.framework"; sourceTree = SDKROOT; fileEncoding = undefined; lastKnownFileType = wrapper.framework; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* StoreKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+				UUID-0012 /* StoreKit.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0031 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0031 /* Project object */;
+}
+",
+  "result": {
+    "basename": "StoreKit.framework",
+    "group": "Frameworks",
+    "path": "System/Library/Frameworks/StoreKit.framework",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline frameworks/add-framework-weak 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* CoreNFC.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* CoreNFC.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* CoreNFC.framework */ = {isa = PBXFileReference; name = "CoreNFC.framework"; path = "System/Library/Frameworks/CoreNFC.framework"; sourceTree = SDKROOT; fileEncoding = undefined; lastKnownFileType = wrapper.framework; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* CoreNFC.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+				UUID-0012 /* CoreNFC.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0031 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0036 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0032 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0031 /* Project object */;
+}
+",
+  "result": {
+    "basename": "CoreNFC.framework",
+    "settings": {
+      "ATTRIBUTES": [
+        "Weak",
+      ],
+    },
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline frameworks/embed-frameworks-phase 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* Embed.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Embed.framework */; };
+		UUID-0013 /* Embed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Embed.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0014 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0015 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0016 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0017 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* Embed.framework */ = {isa = PBXFileReference; name = "Embed.framework"; path = "vendor/Embed.framework"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.framework; explicitFileType = undefined; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* Embed.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0019 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0017 /* HelloWorld-Bridging-Header.h */,
+				UUID-0020 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0015 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* JavaScriptCore.framework */,
+				UUID-0012 /* Embed.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0022 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0023 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0019 /* HelloWorld */,
+				UUID-0022 /* Libraries */,
+				UUID-0024 /* Products */,
+				UUID-0021 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0024 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0014 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0025 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0026 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0027 /* [CP] Check Pods Manifest.lock */,
+				UUID-0028 /* Sources */,
+				UUID-0018 /* Frameworks */,
+				UUID-0029 /* Resources */,
+				UUID-0030 /* Bundle React Native code and images */,
+				UUID-0031 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0014 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0032 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0025 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0033 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0023;
+			productRefGroup = UUID-0024 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0025 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0029 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0030 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0027 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0031 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0028 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\\"vendor\\"",
+				);
+			};
+			name = Debug;
+		};
+		UUID-0035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"\\"vendor\\"",
+				);
+			};
+			name = Release;
+		};
+		UUID-0036 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0037 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0026 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0034 /* Debug */,
+				UUID-0035 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0033 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0036 /* Debug */,
+				UUID-0037 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0032 /* Project object */;
+}
+",
+  "result": {
+    "existedBefore": false,
+    "existsAfter": false,
+    "fileCount": 0,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline misc/add-known-region 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+				fr,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "hasFr": true,
+    "regions": [
+      "en",
+      "Base",
+      "fr",
+    ],
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline misc/direct-hash-objects 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "nativeTargetCount": 1,
+    "swiftVersion": "5.0",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline targets/add-app-extension 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* Stickers.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Stickers.appex */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* Stickers.appex */ = {isa = PBXFileReference; name = "Stickers.appex"; path = "Stickers.appex"; sourceTree = BUILT_PRODUCTS_DIR; fileEncoding = undefined; lastKnownFileType = undefined; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+				UUID-0012 /* Stickers.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+				UUID-0031 /* Copy Files */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+		UUID-0032 /* "Stickers" */ = {
+			isa = PBXNativeTarget;
+			name = "Stickers";
+			productName = "Stickers";
+			productReference = UUID-0012;
+			productType = "com.apple.product-type.app-extension";
+			buildConfigurationList = UUID-0033;
+			buildPhases = (
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0034 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0035 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+				UUID-0032 /* "Stickers" */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0036 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0037 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0038 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0039 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		UUID-0040 /* Debug */ = {
+			name = Debug;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Stickers/Stickers-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "Stickers";
+				SKIP_INSTALL = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Stickers";
+			};
+		};
+		UUID-0041 /* Release */ = {
+			name = Release;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "Stickers/Stickers-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "Stickers";
+				SKIP_INSTALL = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Stickers";
+			};
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0036 /* Debug */,
+				UUID-0037 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0035 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0038 /* Debug */,
+				UUID-0039 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0033 /* Build configuration list for PBXNativeTarget "Stickers" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0040 /* Debug */,
+				UUID-0041 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		UUID-0031 /* Copy Files */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* Stickers.appex in Copy Files */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Copy Files";
+			dstPath = "";
+			dstSubfolderSpec = 13;
+		};
+/* End PBXCopyFilesBuildPhase section */
+	};
+	rootObject = UUID-0034 /* Project object */;
+}
+",
+  "result": {
+    "hasConfigList": true,
+    "name": ""Stickers"",
+    "productName": ""Stickers"",
+    "productType": ""com.apple.product-type.app-extension"",
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline targets/add-product-file 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0015 /* Widget.appex */ = {isa = PBXFileReference; name = "Widget.appex"; path = "Widget.appex"; sourceTree = BUILT_PRODUCTS_DIR; fileEncoding = undefined; lastKnownFileType = undefined; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0016 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0017 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0018 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0021 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0017 /* HelloWorld */,
+				UUID-0020 /* Libraries */,
+				UUID-0022 /* Products */,
+				UUID-0019 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0022 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+				UUID-0015 /* Widget.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0023 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0024 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0025 /* [CP] Check Pods Manifest.lock */,
+				UUID-0026 /* Sources */,
+				UUID-0016 /* Frameworks */,
+				UUID-0027 /* Resources */,
+				UUID-0028 /* Bundle React Native code and images */,
+				UUID-0029 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0030 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0023 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0021;
+			productRefGroup = UUID-0022 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0023 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0027 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0028 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0025 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0029 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0026 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0032 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0033 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0034 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0035 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0024 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0032 /* Debug */,
+				UUID-0033 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0031 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0034 /* Debug */,
+				UUID-0035 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0030 /* Project object */;
+}
+",
+  "result": {
+    "basename": "Widget.appex",
+    "explicitFileType": ""wrapper.app-extension"",
+    "includeInIndex": 0,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline targets/add-target-dependency 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+		UUID-0011 /* Widget.appex in Copy Files */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* Widget.appex */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0013 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0014 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0015 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0016 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+		UUID-0012 /* Widget.appex */ = {isa = PBXFileReference; name = "Widget.appex"; path = "Widget.appex"; sourceTree = BUILT_PRODUCTS_DIR; fileEncoding = undefined; lastKnownFileType = undefined; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0017 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0018 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0016 /* HelloWorld-Bridging-Header.h */,
+				UUID-0019 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0014 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0020 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0015 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0021 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0022 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0018 /* HelloWorld */,
+				UUID-0021 /* Libraries */,
+				UUID-0023 /* Products */,
+				UUID-0020 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0023 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* HelloWorld.app */,
+				UUID-0012 /* Widget.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0024 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0026 /* [CP] Check Pods Manifest.lock */,
+				UUID-0027 /* Sources */,
+				UUID-0017 /* Frameworks */,
+				UUID-0028 /* Resources */,
+				UUID-0029 /* Bundle React Native code and images */,
+				UUID-0030 /* [CP] Copy Pods Resources */,
+				UUID-0031 /* Copy Files */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0013 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+		UUID-0032 /* "Widget" */ = {
+			isa = PBXNativeTarget;
+			name = "Widget";
+			productName = "Widget";
+			productReference = UUID-0012;
+			productType = "com.apple.product-type.app-extension";
+			buildConfigurationList = UUID-0033;
+			buildPhases = (
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0034 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0024 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0035 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0022;
+			productRefGroup = UUID-0023 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0024 /* HelloWorld */,
+				UUID-0032 /* "Widget" */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0028 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0029 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0026 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0030 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0027 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0036 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0037 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0038 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0039 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		UUID-0040 /* Debug */ = {
+			name = Debug;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "Widget/Widget-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "Widget";
+				SKIP_INSTALL = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Widget";
+			};
+		};
+		UUID-0041 /* Release */ = {
+			name = Release;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = "Widget/Widget-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				PRODUCT_NAME = "Widget";
+				SKIP_INSTALL = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.example.app.Widget";
+			};
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0025 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0036 /* Debug */,
+				UUID-0037 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0035 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0038 /* Debug */,
+				UUID-0039 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0033 /* Build configuration list for PBXNativeTarget "Widget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0040 /* Debug */,
+				UUID-0041 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		UUID-0031 /* Copy Files */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* Widget.appex in Copy Files */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			name = "Copy Files";
+			dstPath = "";
+			dstSubfolderSpec = 13;
+		};
+/* End PBXCopyFilesBuildPhase section */
+	};
+	rootObject = UUID-0034 /* Project object */;
+}
+",
+  "result": {
+    "dependencyCount": 0,
+    "hasContainerItemProxy": false,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline targets/add-xc-configuration-list 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* Images.xcassets */; };
+		UUID-0003 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* SplashScreen.storyboard */; };
+		UUID-0005 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Expo.plist */; };
+		UUID-0007 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* AppDelegate.swift */; };
+		UUID-0009 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SceneDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		UUID-0011 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0002 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = HelloWorld/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0012 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = HelloWorld/Info.plist; sourceTree = "<group>"; };
+		UUID-0004 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = HelloWorld/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0006 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0013 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0008 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = HelloWorld/AppDelegate.swift; sourceTree = "<group>"; };
+		UUID-0010 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = HelloWorld/SceneDelegate.swift; sourceTree = "<group>"; };
+		UUID-0014 /* HelloWorld-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "HelloWorld-Bridging-Header.h"; path = "HelloWorld/HelloWorld-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0015 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0016 /* HelloWorld */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0008 /* AppDelegate.swift */,
+				UUID-0010 /* SceneDelegate.swift */,
+				UUID-0014 /* HelloWorld-Bridging-Header.h */,
+				UUID-0017 /* Supporting */,
+				UUID-0002 /* Images.xcassets */,
+				UUID-0012 /* Info.plist */,
+				UUID-0004 /* SplashScreen.storyboard */,
+			);
+			name = HelloWorld;
+			sourceTree = "<group>";
+		};
+		UUID-0018 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0013 /* JavaScriptCore.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0019 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0020 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0016 /* HelloWorld */,
+				UUID-0019 /* Libraries */,
+				UUID-0021 /* Products */,
+				UUID-0018 /* Frameworks */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0021 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0011 /* HelloWorld.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0017 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0006 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = HelloWorld/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0022 /* HelloWorld */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */;
+			buildPhases = (
+				UUID-0024 /* [CP] Check Pods Manifest.lock */,
+				UUID-0025 /* Sources */,
+				UUID-0015 /* Frameworks */,
+				UUID-0026 /* Resources */,
+				UUID-0027 /* Bundle React Native code and images */,
+				UUID-0028 /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = HelloWorld;
+			productName = HelloWorld;
+			productReference = UUID-0011 /* HelloWorld.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0029 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0022 = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0020;
+			productRefGroup = UUID-0021 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0022 /* HelloWorld */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0026 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0005 /* Expo.plist in Resources */,
+				UUID-0001 /* Images.xcassets in Resources */,
+				UUID-0003 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0027 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \\"$PODS_ROOT/../.xcode.env\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env\\"\\nfi\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n# The project root by default is one level up from the ios directory\\nexport PROJECT_ROOT=\\"$PROJECT_DIR\\"/..\\n\\nif [[ \\"$CONFIGURATION\\" = *Debug* ]]; then\\n  export SKIP_BUNDLING=1\\nfi\\nif [[ -z \\"$ENTRY_FILE\\" ]]; then\\n  # Set the entry JS file using the bundler's entry resolution.\\n  export ENTRY_FILE=\\"$(\\"$NODE_BINARY\\" -e \\"require('expo/scripts/resolveAppEntry')\\" \\"$PROJECT_ROOT\\" ios absolute | tail -n 1)\\"\\nfi\\n\\nif [[ -z \\"$CLI_PATH\\" ]]; then\\n  # Use Expo CLI\\n  export CLI_PATH=\\"$(\\"$NODE_BINARY\\" --print \\"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\\")\\"\\nfi\\nif [[ -z \\"$BUNDLE_COMMAND\\" ]]; then\\n  # Default Expo CLI command for bundling\\n  export BUNDLE_COMMAND=\\"export:embed\\"\\nfi\\n\\n# Source .xcode.env.updates if it exists to allow\\n# SKIP_BUNDLING to be unset if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.updates\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.updates\\"\\nfi\\n# Source local changes to allow overrides\\n# if needed\\nif [[ -f \\"$PODS_ROOT/../.xcode.env.local\\" ]]; then\\n  source \\"$PODS_ROOT/../.xcode.env.local\\"\\nfi\\n\\n\`\\"$NODE_BINARY\\" --print \\"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\\"\`\\n\\n";
+		};
+		UUID-0024 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-HelloWorld-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0028 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/EXUpdates/EXUpdates.bundle",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/RCTI18nStrings.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXUpdates.bundle",
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/RCTI18nStrings.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-HelloWorld/Pods-HelloWorld-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0025 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0007 /* AppDelegate.swift in Sources */,
+				UUID-0009 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0031 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0032 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = HelloWorld/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.name.HelloWorld;
+				PRODUCT_NAME = HelloWorld;
+				SWIFT_OBJC_BRIDGING_HEADER = "HelloWorld/HelloWorld-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0033 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0034 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "\\"$(inherited)\\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		UUID-0035 /* Debug */ = {
+			name = Debug;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "Ext";
+			};
+		};
+		UUID-0036 /* Release */ = {
+			name = Release;
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				PRODUCT_NAME = "Ext";
+			};
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0023 /* Build configuration list for PBXNativeTarget "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0031 /* Debug */,
+				UUID-0032 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0030 /* Build configuration list for PBXProject "HelloWorld" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0033 /* Debug */,
+				UUID-0034 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0037 /* Build configuration list for PBXNativeTarget "Ext" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0035 /* Debug */,
+				UUID-0036 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0029 /* Project object */;
+}
+",
+  "result": {
+    "buildConfigurationCount": 2,
+    "defaultConfigurationName": "Release",
+    "registered": true,
+  },
+}
+`;
+
+exports[`legacy xcode golden baseline targets/pbx-target-by-name 1`] = `
+{
+  "pbxproj": "// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		UUID-0001 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0002 /* AppDelegate.m */; };
+		UUID-0003 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0004 /* LaunchScreen.xib */; };
+		UUID-0005 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0006 /* Images.xcassets */; };
+		UUID-0007 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0008 /* main.m */; };
+		UUID-0009 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0010 /* SplashScreen.storyboard */; };
+		UUID-0011 /* ShareViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = UUID-0012 /* ShareViewController.m */; };
+		UUID-0013 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0014 /* MainInterface.storyboard */; };
+		UUID-0015 /* shareextension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = UUID-0016 /* shareextension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		UUID-0017 /* libPods-multitarget.a in Frameworks */ = {isa = PBXBuildFile; fileRef = UUID-0018 /* libPods-multitarget.a */; };
+		UUID-0019 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = UUID-0020 /* Expo.plist */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		UUID-0021 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = UUID-0022 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = UUID-0023;
+			remoteInfo = shareextension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		UUID-0024 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				UUID-0015 /* shareextension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		UUID-0025 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
+		UUID-0026 /* multitarget.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = multitarget.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0027 /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = multitarget/AppDelegate.h; sourceTree = "<group>"; };
+		UUID-0002 /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = AppDelegate.m; path = multitarget/AppDelegate.m; sourceTree = "<group>"; };
+		UUID-0028 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		UUID-0006 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = multitarget/Images.xcassets; sourceTree = "<group>"; };
+		UUID-0029 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = multitarget/Info.plist; sourceTree = "<group>"; };
+		UUID-0008 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = multitarget/main.m; sourceTree = "<group>"; };
+		UUID-0018 /* libPods-multitarget.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-multitarget.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0016 /* shareextension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = shareextension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		UUID-0030 /* ShareViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShareViewController.h; sourceTree = "<group>"; };
+		UUID-0012 /* ShareViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ShareViewController.m; sourceTree = "<group>"; };
+		UUID-0031 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		UUID-0032 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		UUID-0033 /* Pods-multitarget.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-multitarget.debug.xcconfig"; path = "Target Support Files/Pods-multitarget/Pods-multitarget.debug.xcconfig"; sourceTree = "<group>"; };
+		UUID-0034 /* Pods-multitarget.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-multitarget.release.xcconfig"; path = "Target Support Files/Pods-multitarget/Pods-multitarget.release.xcconfig"; sourceTree = "<group>"; };
+		UUID-0010 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = multitarget/SplashScreen.storyboard; sourceTree = "<group>"; };
+		UUID-0020 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		UUID-0035 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		UUID-0036 /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS12.0.sdk/System/Library/Frameworks/JavaScriptCore.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		UUID-0037 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0017 /* libPods-multitarget.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		UUID-0038 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		UUID-0039 /* multitarget */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0040 /* Supporting */,
+				UUID-0025 /* main.jsbundle */,
+				UUID-0027 /* AppDelegate.h */,
+				UUID-0002 /* AppDelegate.m */,
+				UUID-0006 /* Images.xcassets */,
+				UUID-0029 /* Info.plist */,
+				UUID-0004 /* LaunchScreen.xib */,
+				UUID-0008 /* main.m */,
+				UUID-0010 /* SplashScreen.storyboard */,
+			);
+			name = multitarget;
+			sourceTree = "<group>";
+		};
+		UUID-0041 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0035 /* JavaScriptCore.framework */,
+				UUID-0036 /* JavaScriptCore.framework */,
+				UUID-0018 /* libPods-multitarget.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		UUID-0042 /* shareextension */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0030 /* ShareViewController.h */,
+				UUID-0012 /* ShareViewController.m */,
+				UUID-0014 /* MainInterface.storyboard */,
+				UUID-0032 /* Info.plist */,
+			);
+			path = shareextension;
+			sourceTree = "<group>";
+		};
+		UUID-0043 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		UUID-0044 = {
+			isa = PBXGroup;
+			children = (
+				UUID-0039 /* multitarget */,
+				UUID-0043 /* Libraries */,
+				UUID-0042 /* shareextension */,
+				UUID-0045 /* Products */,
+				UUID-0041 /* Frameworks */,
+				UUID-0046 /* Pods */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		UUID-0045 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0026 /* multitarget.app */,
+				UUID-0016 /* shareextension.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		UUID-0040 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0020 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = multitarget/Supporting;
+			sourceTree = "<group>";
+		};
+		UUID-0046 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				UUID-0033 /* Pods-multitarget.debug.xcconfig */,
+				UUID-0034 /* Pods-multitarget.release.xcconfig */,
+			);
+			path = Pods;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		UUID-0047 /* multitarget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0048 /* Build configuration list for PBXNativeTarget "multitarget" */;
+			buildPhases = (
+				UUID-0049 /* [CP] Check Pods Manifest.lock */,
+				UUID-0050 /* Start Packager */,
+				UUID-0051 /* Sources */,
+				UUID-0037 /* Frameworks */,
+				UUID-0052 /* Resources */,
+				UUID-0053 /* Bundle React Native code and images */,
+				UUID-0054 /* [CP] Copy Pods Resources */,
+				UUID-0024 /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				UUID-0055 /* PBXTargetDependency */,
+			);
+			name = multitarget;
+			productName = multitarget;
+			productReference = UUID-0026 /* multitarget.app */;
+			productType = "com.apple.product-type.application";
+		};
+		UUID-0023 /* shareextension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = UUID-0056 /* Build configuration list for PBXNativeTarget "shareextension" */;
+			buildPhases = (
+				UUID-0057 /* Sources */,
+				UUID-0038 /* Frameworks */,
+				UUID-0058 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = shareextension;
+			productName = shareextension;
+			productReference = UUID-0016 /* shareextension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		UUID-0022 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					UUID-0047 = {
+						DevelopmentTeam = QL76XYH73P;
+						LastSwiftMigration = 1120;
+					};
+					UUID-0023 = {
+						CreatedOnToolsVersion = 12.5;
+						DevelopmentTeam = QL76XYH73P;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = UUID-0059 /* Build configuration list for PBXProject "multitarget" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = UUID-0044;
+			productRefGroup = UUID-0045 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				UUID-0047 /* multitarget */,
+				UUID-0023 /* shareextension */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		UUID-0052 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0019 /* Expo.plist in Resources */,
+				UUID-0005 /* Images.xcassets in Resources */,
+				UUID-0003 /* LaunchScreen.xib in Resources */,
+				UUID-0009 /* SplashScreen.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		UUID-0058 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0013 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		UUID-0053 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f /Users/dsokal/.volta/bin/node ]]; then\\n  export NODE_BINARY=/Users/dsokal/.volta/bin/node\\nelse\\n  export NODE_BINARY=node\\nfi\\n../node_modules/react-native/scripts/react-native-xcode.sh\\n../node_modules/expo-constants/scripts/get-app-config-ios.sh\\n../node_modules/expo-updates/scripts/create-manifest-ios.sh\\n";
+		};
+		UUID-0049 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"\${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"\${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-multitarget-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \\"\${PODS_PODFILE_DIR_PATH}/Podfile.lock\\" \\"\${PODS_ROOT}/Manifest.lock\\" > /dev/null\\nif [ $? != 0 ] ; then\\n    # print error to STDERR\\n    echo \\"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\\" >&2\\n    exit 1\\nfi\\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\\necho \\"SUCCESS\\" > \\"\${SCRIPT_OUTPUT_FILE_0}\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0054 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"\${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh",
+				"\${PODS_CONFIGURATION_BUILD_DIR}/React-Core/AccessibilityResources.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"\${TARGET_BUILD_DIR}/\${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\\"\${PODS_ROOT}/Target Support Files/Pods-multitarget/Pods-multitarget-resources.sh\\"\\n";
+			showEnvVarsInLog = 0;
+		};
+		UUID-0050 /* Start Packager */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Start Packager";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export RCT_METRO_PORT=\\"\${RCT_METRO_PORT:=8081}\\"\\necho \\"export RCT_METRO_PORT=\${RCT_METRO_PORT}\\" > \\"\${SRCROOT}/../node_modules/react-native/scripts/.packager.env\\"\\nif [ -z \\"\${RCT_NO_LAUNCH_PACKAGER+xxx}\\" ] ; then\\n  if nc -w 5 -z localhost \${RCT_METRO_PORT} ; then\\n    if ! curl -s \\"http://localhost:\${RCT_METRO_PORT}/status\\" | grep -q \\"packager-status:running\\" ; then\\n      echo \\"Port \${RCT_METRO_PORT} already in use, packager is either not running or not running correctly\\"\\n      exit 2\\n    fi\\n  else\\n    open \\"$SRCROOT/../node_modules/expo/scripts/launchPackager.command\\" || echo \\"Can't start packager automatically\\"\\n  fi\\nfi\\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		UUID-0051 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0001 /* AppDelegate.m in Sources */,
+				UUID-0007 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		UUID-0057 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				UUID-0011 /* ShareViewController.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		UUID-0055 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = UUID-0023 /* shareextension */;
+			targetProxy = UUID-0021 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		UUID-0004 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				UUID-0028 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			path = multitarget;
+			sourceTree = "<group>";
+		};
+		UUID-0014 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				UUID-0031 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		UUID-0060 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = UUID-0033 /* Pods-multitarget.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.debug;
+				PRODUCT_NAME = multitarget;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		UUID-0061 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = UUID-0034 /* Pods-multitarget.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = multitarget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget;
+				PRODUCT_NAME = multitarget;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_VERSION = 5.0;
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		UUID-0062 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		UUID-0063 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = QL76XYH73P;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = shareextension/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.swmansion.dominik.multitarget.shareextension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		UUID-0064 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\"",
+					"\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\"",
+					"\\"$(inherited)\\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		UUID-0065 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = "/usr/lib/swift $(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"\\"$(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME)\\"",
+					"\\"$(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)\\"",
+					"\\"$(inherited)\\"",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		UUID-0048 /* Build configuration list for PBXNativeTarget "multitarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0060 /* Debug */,
+				UUID-0061 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0056 /* Build configuration list for PBXNativeTarget "shareextension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0062 /* Debug */,
+				UUID-0063 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		UUID-0059 /* Build configuration list for PBXProject "multitarget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				UUID-0064 /* Debug */,
+				UUID-0065 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = UUID-0022 /* Project object */;
+}
+",
+  "result": {
+    "found": true,
+    "key": "UUID-0001",
+    "productType": ""com.apple.product-type.app-extension"",
+  },
+}
+`;

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/adapters.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/adapters.ts
@@ -1,6 +1,8 @@
 import xcode from 'xcode';
 import LegacyPbxFile from 'xcode/lib/pbxFile';
 
+import { PbxFile as ShimPbxFile, project as shimProject } from '../index';
+
 /**
  * The project object + matching `pbxFile` constructor a scenario operates on.
  * Scenarios use only this surface so the same sequence runs against the legacy
@@ -23,5 +25,14 @@ export const legacyBackend: Backend = {
     const project = xcode.project(fixturePath);
     project.parseSync();
     return { project, PbxFile: LegacyPbxFile };
+  },
+};
+
+export const shimBackend: Backend = {
+  name: 'shim',
+  load(fixturePath: string): ScenarioContext {
+    const project = shimProject(fixturePath);
+    project.parseSync();
+    return { project, PbxFile: ShimPbxFile };
   },
 };

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/adapters.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/adapters.ts
@@ -1,0 +1,27 @@
+import xcode from 'xcode';
+import LegacyPbxFile from 'xcode/lib/pbxFile';
+
+/**
+ * The project object + matching `pbxFile` constructor a scenario operates on.
+ * Scenarios use only this surface so the same sequence runs against the legacy
+ * library and the shim.
+ */
+export interface ScenarioContext {
+  project: any;
+  PbxFile: any;
+}
+
+/** Loads a fixture into a {@link ScenarioContext} for one backend. */
+export interface Backend {
+  readonly name: 'legacy' | 'shim';
+  load(fixturePath: string): ScenarioContext;
+}
+
+export const legacyBackend: Backend = {
+  name: 'legacy',
+  load(fixturePath: string): ScenarioContext {
+    const project = xcode.project(fixturePath);
+    project.parseSync();
+    return { project, PbxFile: LegacyPbxFile };
+  },
+};

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
@@ -142,6 +142,10 @@ describe('compareResults', () => {
   it('treats read quoting as cosmetic', () => {
     expect(compareResults({ sourceTree: '"<group>"' }, { sourceTree: '<group>' }).equal).toBe(true);
   });
+
+  it('normalizes escaped quotes in read values', () => {
+    expect(compareResults({ s: '"echo \\"hi\\""' }, { s: 'echo "hi"' }).equal).toBe(true);
+  });
 });
 
 describe('normalizedTextDiff', () => {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
@@ -138,6 +138,10 @@ describe('compareResults', () => {
   it('catches a differing scalar', () => {
     expect(compareResults({ value: 'en' }, { value: 'fr' }).equal).toBe(false);
   });
+
+  it('treats read quoting as cosmetic', () => {
+    expect(compareResults({ sourceTree: '"<group>"' }, { sourceTree: '<group>' }).equal).toBe(true);
+  });
 });
 
 describe('normalizedTextDiff', () => {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
@@ -80,6 +80,15 @@ describe('compareGraphs (semantic, UUID-independent)', () => {
     expect(compareGraphs(mk(1), mk(101))).toEqual({ equal: true });
   });
 
+  it('treats a field valued "undefined" (legacy unset) as absent', () => {
+    const a = {
+      rootObject: hex(1),
+      objects: { [hex(1)]: { isa: 'PBXFileReference', path: 'A', explicitFileType: 'undefined' } },
+    };
+    const b = { rootObject: hex(1), objects: { [hex(1)]: { isa: 'PBXFileReference', path: 'A' } } };
+    expect(compareGraphs(a, b).equal).toBe(true);
+  });
+
   it('compares UUID-keyed dicts (TargetAttributes) structurally', () => {
     const mk = (base: number) => ({
       rootObject: hex(base),

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
@@ -53,6 +53,16 @@ describe('compareGraphs (semantic, UUID-independent)', () => {
     expect(diff.shim).toBe('fr');
   });
 
+  it('treats numeric-value quoting as cosmetic ("1" vs 1)', () => {
+    const mk = (value: any) => ({
+      rootObject: hex(1),
+      objects: {
+        [hex(1)]: { isa: 'XCBuildConfiguration', buildSettings: { TARGETED_DEVICE_FAMILY: value } },
+      },
+    });
+    expect(compareGraphs(mk('1'), mk(1)).equal).toBe(true);
+  });
+
   it('catches a missing object via the isa histogram', () => {
     const a = {
       rootObject: hex(1),

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator-test.ts
@@ -1,0 +1,140 @@
+import { build } from '@bacons/xcode/json';
+
+import { compareGraphs, compareResults, compareSemantics, normalizedTextDiff } from './comparator';
+
+const hex = (n: number) => n.toString(16).toUpperCase().padStart(24, '0');
+
+describe('compareGraphs (semantic, UUID-independent)', () => {
+  it('treats identical structure with different UUIDs as equal', () => {
+    const mk = (base: number) => ({
+      rootObject: hex(base),
+      objects: {
+        [hex(base)]: { isa: 'PBXProject', mainGroup: hex(base + 1), targets: [hex(base + 2)] },
+        [hex(base + 1)]: { isa: 'PBXGroup', children: [] },
+        [hex(base + 2)]: {
+          isa: 'PBXNativeTarget',
+          name: 'App',
+          buildConfigurationList: hex(base + 3),
+        },
+        [hex(base + 3)]: { isa: 'XCConfigurationList', buildConfigurations: [] },
+      },
+    });
+    expect(compareGraphs(mk(1), mk(101))).toEqual({ equal: true });
+  });
+
+  it('ignores dictionary key order', () => {
+    const a = { rootObject: hex(1), objects: { [hex(1)]: { isa: 'PBXProject', a: 1, b: 2 } } };
+    const b = { rootObject: hex(1), objects: { [hex(1)]: { isa: 'PBXProject', b: 2, a: 1 } } };
+    expect(compareGraphs(a, b).equal).toBe(true);
+  });
+
+  it('is order-sensitive for arrays', () => {
+    const mk = (children: string[]) => ({
+      rootObject: hex(1),
+      objects: {
+        [hex(1)]: { isa: 'PBXProject', mainGroup: hex(2) },
+        [hex(2)]: { isa: 'PBXGroup', children },
+        [hex(3)]: { isa: 'PBXFileReference', path: 'A' },
+        [hex(4)]: { isa: 'PBXFileReference', path: 'B' },
+      },
+    });
+    expect(compareGraphs(mk([hex(3), hex(4)]), mk([hex(4), hex(3)])).equal).toBe(false);
+  });
+
+  it('catches a scalar divergence with a path', () => {
+    const mk = (region: string) => ({
+      rootObject: hex(1),
+      objects: { [hex(1)]: { isa: 'PBXProject', developmentRegion: region } },
+    });
+    const diff = compareGraphs(mk('en'), mk('fr'));
+    expect(diff.equal).toBe(false);
+    expect(diff.path).toContain('developmentRegion');
+    expect(diff.legacy).toBe('en');
+    expect(diff.shim).toBe('fr');
+  });
+
+  it('catches a missing object via the isa histogram', () => {
+    const a = {
+      rootObject: hex(1),
+      objects: {
+        [hex(1)]: { isa: 'PBXProject', targets: [hex(2)] },
+        [hex(2)]: { isa: 'PBXNativeTarget', name: 'App' },
+      },
+    };
+    const b = { rootObject: hex(1), objects: { [hex(1)]: { isa: 'PBXProject', targets: [] } } };
+    const diff = compareGraphs(a, b);
+    expect(diff.equal).toBe(false);
+    expect(diff.path).toContain('objectsByIsa');
+  });
+
+  it('terminates on reference cycles (containerPortal back to root)', () => {
+    const mk = (base: number) => ({
+      rootObject: hex(base),
+      objects: {
+        [hex(base)]: { isa: 'PBXProject', targets: [hex(base + 1)] },
+        [hex(base + 1)]: { isa: 'PBXNativeTarget', dependencies: [hex(base + 2)] },
+        [hex(base + 2)]: { isa: 'PBXTargetDependency', targetProxy: hex(base + 3) },
+        [hex(base + 3)]: { isa: 'PBXContainerItemProxy', containerPortal: hex(base) },
+      },
+    });
+    expect(compareGraphs(mk(1), mk(101))).toEqual({ equal: true });
+  });
+
+  it('compares UUID-keyed dicts (TargetAttributes) structurally', () => {
+    const mk = (base: number) => ({
+      rootObject: hex(base),
+      objects: {
+        [hex(base)]: {
+          isa: 'PBXProject',
+          targets: [hex(base + 1)],
+          attributes: { TargetAttributes: { [hex(base + 1)]: { LastSwiftMigration: 1250 } } },
+        },
+        [hex(base + 1)]: { isa: 'PBXNativeTarget', name: 'App' },
+      },
+    });
+    expect(compareGraphs(mk(1), mk(101))).toEqual({ equal: true });
+  });
+});
+
+describe('compareSemantics (text → parse → compare)', () => {
+  const base = build({
+    archiveVersion: 1,
+    objectVersion: 46,
+    classes: {},
+    rootObject: hex(1),
+    objects: { [hex(1)]: { isa: 'PBXProject', myFlag: 'SAFE' } },
+  });
+
+  it('ignores quoting of safe values', () => {
+    const quoted = base.replace('myFlag = SAFE;', 'myFlag = "SAFE";');
+    expect(quoted).not.toBe(base);
+    expect(compareSemantics(base, quoted)).toEqual({ equal: true });
+  });
+
+  it('catches a real value change', () => {
+    const changed = base.replace('myFlag = SAFE;', 'myFlag = OTHER;');
+    const diff = compareSemantics(base, changed);
+    expect(diff.equal).toBe(false);
+    expect(diff.path).toContain('myFlag');
+  });
+});
+
+describe('compareResults', () => {
+  it('matches results that differ only in UUID values', () => {
+    expect(compareResults({ key: hex(1), name: 'App' }, { key: hex(99), name: 'App' })).toEqual({
+      equal: true,
+    });
+  });
+
+  it('catches a differing scalar', () => {
+    expect(compareResults({ value: 'en' }, { value: 'fr' }).equal).toBe(false);
+  });
+});
+
+describe('normalizedTextDiff', () => {
+  it('reports lines unique to each side', () => {
+    const r = normalizedTextDiff('a\nb\nc', 'a\nx\nc');
+    expect(r.onlyLegacy).toEqual(['b']);
+    expect(r.onlyShim).toEqual(['x']);
+  });
+});

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
@@ -20,6 +20,11 @@ const EQUAL: Diff = { equal: true };
 // A reference is any string value that names an object in the graph. Detecting
 // refs by membership (not by UUID charset) is robust to both legacy's hex UUIDs
 // and `@bacons`'s `XX…XX` content-hash UUIDs.
+function isScalar(value: unknown): boolean {
+  const t = typeof value;
+  return t === 'string' || t === 'number' || t === 'boolean';
+}
+
 function isRef(value: unknown, objects: Record<string, any>): value is string {
   return typeof value === 'string' && value in objects;
 }
@@ -90,6 +95,9 @@ function fingerprintObject(obj: any, objects: Record<string, any>, stack: Set<st
  */
 function deepDiff(a: any, b: any, path: string): Diff {
   if (a === b) return EQUAL;
+  // Numeric-value quoting is cosmetic: legacy quotes e.g. TARGETED_DEVICE_FAMILY as
+  // `"1"` (string) while `@bacons` emits a bare `1` (number) — same value to Xcode.
+  if (isScalar(a) && isScalar(b) && String(a) === String(b)) return EQUAL;
   if (typeof a !== typeof b || a === null || b === null) {
     return { equal: false, path, legacy: a, shim: b };
   }

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
@@ -154,9 +154,27 @@ export function compareSemantics(legacyText: string, shimText: string): Diff {
   return compareGraphs(legacy, shim);
 }
 
-/** Compare scenario read results, normalizing UUIDs by first appearance. */
+// Strip one layer of outer quotes from every string. Reads aren't re-quoted by
+// the shim (a documented behavior change), so quoting is cosmetic when comparing
+// read results — `'"<group>"'` and `'<group>'` are the same value.
+function stripQuotesDeep(value: any): any {
+  if (typeof value === 'string') return value.replace(/^"(.*)"$/, '$1');
+  if (Array.isArray(value)) return value.map(stripQuotesDeep);
+  if (value && typeof value === 'object') {
+    const out: Record<string, any> = {};
+    for (const key of Object.keys(value)) out[key] = stripQuotesDeep(value[key]);
+    return out;
+  }
+  return value;
+}
+
+/** Compare scenario read results, normalizing UUIDs by first appearance and quoting. */
 export function compareResults(legacy: unknown, shim: unknown): Diff {
-  return deepDiff(normalizeResult(legacy), normalizeResult(shim), '');
+  return deepDiff(
+    stripQuotesDeep(normalizeResult(legacy)),
+    stripQuotesDeep(normalizeResult(shim)),
+    ''
+  );
 }
 
 /**

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
@@ -1,0 +1,172 @@
+import { parse } from '@bacons/xcode/json';
+
+import { normalizeResult, normalizeUuids } from './normalize';
+
+const UUID_RE = /^[0-9A-F]{24}$/;
+
+interface Graph {
+  objects: Record<string, any>;
+  rootObject: string;
+}
+
+export interface Diff {
+  equal: boolean;
+  /** Dotted path to the first divergence (only when `equal` is false). */
+  path?: string;
+  legacy?: unknown;
+  shim?: unknown;
+}
+
+const EQUAL: Diff = { equal: true };
+
+function isRef(value: unknown, objects: Record<string, any>): value is string {
+  return typeof value === 'string' && UUID_RE.test(value) && value in objects;
+}
+
+function isRefKeyedDict(value: any, objects: Record<string, any>): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const keys = Object.keys(value);
+  return keys.length > 0 && keys.every((k) => UUID_RE.test(k) && k in objects);
+}
+
+function stableStringify(value: any): string {
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${stableStringify(value[k])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/**
+ * UUID-independent structural fingerprint. References (bare UUIDs / arrays of
+ * UUIDs / UUID-keyed dicts) are resolved to the fingerprint of what they point
+ * to, so legacy's random UUIDs and `@bacons`'s content-hash UUIDs compare equal
+ * as long as the graph structure matches. Cycles (e.g. `containerPortal` back to
+ * the root project) collapse to an isa marker.
+ */
+function fingerprint(value: any, objects: Record<string, any>, stack: Set<string>): any {
+  if (isRef(value, objects)) {
+    if (stack.has(value)) return { __cycle: objects[value]?.isa ?? true };
+    const next = new Set(stack).add(value);
+    return { __ref: fingerprintObject(objects[value], objects, next) };
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => fingerprint(entry, objects, stack));
+  }
+  if (value && typeof value === 'object') {
+    if (isRefKeyedDict(value, objects)) {
+      const pairs = Object.entries(value).map(([k, v]) => [
+        fingerprint(k, objects, stack),
+        fingerprint(v, objects, stack),
+      ]);
+      pairs.sort((a, b) => stableStringify(a).localeCompare(stableStringify(b)));
+      return { __refMap: pairs };
+    }
+    return fingerprintObject(value, objects, stack);
+  }
+  return value;
+}
+
+function fingerprintObject(obj: any, objects: Record<string, any>, stack: Set<string>): any {
+  const out: Record<string, any> = {};
+  for (const key of Object.keys(obj)) {
+    out[key] = fingerprint(obj[key], objects, stack);
+  }
+  return out;
+}
+
+/**
+ * Deep structural diff. Objects are compared key-order-independently
+ * (dictionaries), arrays are compared order-sensitively (ordered slots like
+ * `buildPhases` / `files` / `children`). Returns the first divergence.
+ */
+function deepDiff(a: any, b: any, path: string): Diff {
+  if (a === b) return EQUAL;
+  if (typeof a !== typeof b || a === null || b === null) {
+    return { equal: false, path, legacy: a, shim: b };
+  }
+  if (Array.isArray(a) || Array.isArray(b)) {
+    if (!Array.isArray(a) || !Array.isArray(b)) return { equal: false, path, legacy: a, shim: b };
+    if (a.length !== b.length) {
+      return { equal: false, path: `${path}.length`, legacy: a.length, shim: b.length };
+    }
+    for (let i = 0; i < a.length; i++) {
+      const diff = deepDiff(a[i], b[i], `${path}[${i}]`);
+      if (!diff.equal) return diff;
+    }
+    return EQUAL;
+  }
+  if (typeof a === 'object') {
+    const ak = Object.keys(a).sort();
+    const bk = Object.keys(b).sort();
+    if (ak.join('\0') !== bk.join('\0')) {
+      return { equal: false, path: `${path} (keys)`, legacy: ak, shim: bk };
+    }
+    for (const key of ak) {
+      const diff = deepDiff(a[key], b[key], path ? `${path}.${key}` : key);
+      if (!diff.equal) return diff;
+    }
+    return EQUAL;
+  }
+  return { equal: false, path, legacy: a, shim: b };
+}
+
+function isaHistogram(objects: Record<string, any>): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const obj of Object.values(objects)) {
+    const isa = obj?.isa ?? '<no-isa>';
+    counts[isa] = (counts[isa] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/** Compare two already-parsed pbxproj graphs semantically. */
+export function compareGraphs(legacy: Graph, shim: Graph): Diff {
+  const histo = deepDiff(isaHistogram(legacy.objects), isaHistogram(shim.objects), 'objectsByIsa');
+  if (!histo.equal) return histo;
+  const fa = fingerprint(legacy.rootObject, legacy.objects, new Set());
+  const fb = fingerprint(shim.rootObject, shim.objects, new Set());
+  return deepDiff(fa, fb, '');
+}
+
+/** Parse both serialized pbxproj strings with one parser, then compare semantically. */
+export function compareSemantics(legacyText: string, shimText: string): Diff {
+  let legacy: Graph;
+  let shim: Graph;
+  try {
+    legacy = parse(legacyText) as Graph;
+  } catch (e: any) {
+    return { equal: false, path: '<parse legacy>', legacy: e.message };
+  }
+  try {
+    shim = parse(shimText) as Graph;
+  } catch (e: any) {
+    return { equal: false, path: '<parse shim>', shim: e.message };
+  }
+  return compareGraphs(legacy, shim);
+}
+
+/** Compare scenario read results, normalizing UUIDs by first appearance. */
+export function compareResults(legacy: unknown, shim: unknown): Diff {
+  return deepDiff(normalizeResult(legacy), normalizeResult(shim), '');
+}
+
+/**
+ * Secondary, non-failing report: UUID-normalized line diff of the two serialized
+ * outputs. Every entry is triaged as cosmetic-and-accepted or a real semantic
+ * difference that the primary gate should also catch.
+ */
+export function normalizedTextDiff(
+  legacyText: string,
+  shimText: string
+): { onlyLegacy: string[]; onlyShim: string[] } {
+  const legacyLines = new Set(normalizeUuids(legacyText).split('\n'));
+  const shimLines = new Set(normalizeUuids(shimText).split('\n'));
+  return {
+    onlyLegacy: [...legacyLines].filter((l) => !shimLines.has(l) && l.trim()),
+    onlyShim: [...shimLines].filter((l) => !legacyLines.has(l) && l.trim()),
+  };
+}

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
@@ -74,7 +74,11 @@ function fingerprint(value: any, objects: Record<string, any>, stack: Set<string
 function fingerprintObject(obj: any, objects: Record<string, any>, stack: Set<string>): any {
   const out: Record<string, any> = {};
   for (const key of Object.keys(obj)) {
-    out[key] = fingerprint(obj[key], objects, stack);
+    const value = obj[key];
+    // Legacy serializes unset fields as the bareword `undefined` (parsed back as
+    // the string "undefined"); an unset field is semantically absent.
+    if (value === undefined || value === 'undefined') continue;
+    out[key] = fingerprint(value, objects, stack);
   }
   return out;
 }

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
@@ -158,7 +158,14 @@ export function compareSemantics(legacyText: string, shimText: string): Diff {
 // the shim (a documented behavior change), so quoting is cosmetic when comparing
 // read results — `'"<group>"'` and `'<group>'` are the same value.
 function stripQuotesDeep(value: any): any {
-  if (typeof value === 'string') return value.replace(/^"(.*)"$/, '$1');
+  if (typeof value === 'string') {
+    // Strip outer quotes and unescape, so legacy's `"echo \"hi\""` and the shim's
+    // raw `echo "hi"` compare equal.
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+      return value.slice(1, -1).replace(/\\(["\\])/g, '$1');
+    }
+    return value;
+  }
   if (Array.isArray(value)) return value.map(stripQuotesDeep);
   if (value && typeof value === 'object') {
     const out: Record<string, any> = {};

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/comparator.ts
@@ -2,8 +2,6 @@ import { parse } from '@bacons/xcode/json';
 
 import { normalizeResult, normalizeUuids } from './normalize';
 
-const UUID_RE = /^[0-9A-F]{24}$/;
-
 interface Graph {
   objects: Record<string, any>;
   rootObject: string;
@@ -19,14 +17,17 @@ export interface Diff {
 
 const EQUAL: Diff = { equal: true };
 
+// A reference is any string value that names an object in the graph. Detecting
+// refs by membership (not by UUID charset) is robust to both legacy's hex UUIDs
+// and `@bacons`'s `XX…XX` content-hash UUIDs.
 function isRef(value: unknown, objects: Record<string, any>): value is string {
-  return typeof value === 'string' && UUID_RE.test(value) && value in objects;
+  return typeof value === 'string' && value in objects;
 }
 
 function isRefKeyedDict(value: any, objects: Record<string, any>): boolean {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const keys = Object.keys(value);
-  return keys.length > 0 && keys.every((k) => UUID_RE.test(k) && k in objects);
+  return keys.length > 0 && keys.every((k) => k in objects);
 }
 
 function stableStringify(value: any): string {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -19,6 +19,10 @@ const IMPLEMENTED = new Set<string>([
   'build-settings/update-property-for-target',
   'files/has-file',
   'files/ensure-group-recursively',
+  'files/add-resource-file',
+  'files/add-resource-file-no-build',
+  'files/add-source-file',
+  'files/add-duplicate-resource',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -35,6 +35,10 @@ const IMPLEMENTED = new Set<string>([
   'frameworks/add-framework-weak',
   'frameworks/add-custom-framework-embed-sign',
   'frameworks/embed-frameworks-phase',
+  'targets/pbx-target-by-name',
+  'targets/add-product-file',
+  'targets/add-xc-configuration-list',
+  'misc/direct-hash-objects',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -18,6 +18,7 @@ const IMPLEMENTED = new Set<string>([
   'build-settings/set-entitlements',
   'build-settings/update-property-for-target',
   'files/has-file',
+  'files/ensure-group-recursively',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -39,6 +39,8 @@ const IMPLEMENTED = new Set<string>([
   'targets/add-product-file',
   'targets/add-xc-configuration-list',
   'misc/direct-hash-objects',
+  'targets/add-app-extension',
+  'targets/add-target-dependency',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -17,6 +17,7 @@ const IMPLEMENTED = new Set<string>([
   'build-settings/update-product-name',
   'build-settings/set-entitlements',
   'build-settings/update-property-for-target',
+  'files/has-file',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -31,6 +31,7 @@ const IMPLEMENTED = new Set<string>([
   'build-phases/add-shell-script',
   'build-phases/add-copy-files',
   'build-phases/build-phase-object',
+  'build-phases/phase-lookup-by-comment',
   'frameworks/add-framework',
   'frameworks/add-framework-weak',
   'frameworks/add-custom-framework-embed-sign',

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -41,6 +41,7 @@ const IMPLEMENTED = new Set<string>([
   'misc/direct-hash-objects',
   'targets/add-app-extension',
   'targets/add-target-dependency',
+  'targets/hash-precreated-target-dependency',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -25,6 +25,9 @@ const IMPLEMENTED = new Set<string>([
   'files/add-duplicate-resource',
   'files/add-pbx-group',
   'files/add-to-pbx-group',
+  'build-settings/add-header-search-paths',
+  'build-settings/add-other-linker-flags',
+  'misc/add-known-region',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -8,7 +8,16 @@ import { compareResults, compareSemantics, normalizedTextDiff } from './comparat
 import { FIXTURES, FixtureName, fixturePath } from './fixtures';
 import { Scenario, scenarios } from './scenarios';
 
-const IMPLEMENTED = new Set<string>([]);
+const IMPLEMENTED = new Set<string>([
+  'build-settings/set-bundle-identifier',
+  'build-settings/set-development-team',
+  'build-settings/set-deployment-target',
+  'build-settings/toggle-bitcode',
+  'build-settings/set-device-family',
+  'build-settings/update-product-name',
+  'build-settings/set-entitlements',
+  'build-settings/update-property-for-target',
+]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {
   const ctx = backend.load(fixturePath(scenario.fixture));

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -31,6 +31,10 @@ const IMPLEMENTED = new Set<string>([
   'build-phases/add-shell-script',
   'build-phases/add-copy-files',
   'build-phases/build-phase-object',
+  'frameworks/add-framework',
+  'frameworks/add-framework-weak',
+  'frameworks/add-custom-framework-embed-sign',
+  'frameworks/embed-frameworks-phase',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -23,6 +23,8 @@ const IMPLEMENTED = new Set<string>([
   'files/add-resource-file-no-build',
   'files/add-source-file',
   'files/add-duplicate-resource',
+  'files/add-pbx-group',
+  'files/add-to-pbx-group',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -28,6 +28,9 @@ const IMPLEMENTED = new Set<string>([
   'build-settings/add-header-search-paths',
   'build-settings/add-other-linker-flags',
   'misc/add-known-region',
+  'build-phases/add-shell-script',
+  'build-phases/add-copy-files',
+  'build-phases/build-phase-object',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -18,6 +18,7 @@ const IMPLEMENTED = new Set<string>([
   'build-settings/set-entitlements',
   'build-settings/update-property-for-target',
   'files/has-file',
+  'files/create-group-quoted-name',
   'files/ensure-group-recursively',
   'files/add-resource-file',
   'files/add-resource-file-no-build',

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -42,6 +42,8 @@ const IMPLEMENTED = new Set<string>([
   'targets/add-app-extension',
   'targets/add-target-dependency',
   'targets/hash-precreated-target-dependency',
+  'files/build-file-before-file-reference',
+  'targets/reassign-build-configuration-list',
 ]);
 
 function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/differential-test.ts
@@ -1,0 +1,82 @@
+// Runs every scenario against legacy `xcode` and the shim and asserts they agree
+// semantically. Scenarios whose shim methods are implemented (IMPLEMENTED) must
+// match; the rest must still throw "not implemented yet" — that set is the
+// commit 4..N worklist and keeps this suite green as it shrinks.
+
+import { Backend, legacyBackend, shimBackend } from './adapters';
+import { compareResults, compareSemantics, normalizedTextDiff } from './comparator';
+import { FIXTURES, FixtureName, fixturePath } from './fixtures';
+import { Scenario, scenarios } from './scenarios';
+
+const IMPLEMENTED = new Set<string>([]);
+
+function runOn(backend: Backend, scenario: Scenario): { result: unknown; pbxproj: string } {
+  const ctx = backend.load(fixturePath(scenario.fixture));
+  const result = scenario.run(ctx);
+  return { result, pbxproj: ctx.project.writeSync() };
+}
+
+describe('substrate: unmutated legacy vs shim are semantically equal', () => {
+  for (const name of Object.keys(FIXTURES) as FixtureName[]) {
+    it(name, () => {
+      const legacy = legacyBackend.load(fixturePath(name)).project.writeSync();
+      const shim = shimBackend.load(fixturePath(name)).project.writeSync();
+      const diff = compareSemantics(legacy, shim);
+      if (!diff.equal) {
+        throw new Error(
+          `semantic divergence at "${diff.path}"\n  legacy: ${JSON.stringify(diff.legacy)}\n  shim:   ${JSON.stringify(diff.shim)}`
+        );
+      }
+    });
+  }
+});
+
+const textReport: { name: string; onlyLegacy: string[]; onlyShim: string[] }[] = [];
+
+describe('differential: legacy vs shim', () => {
+  for (const scenario of scenarios) {
+    const implemented = IMPLEMENTED.has(scenario.name);
+
+    it(scenario.name, () => {
+      const legacy = runOn(legacyBackend, scenario);
+
+      if (!implemented) {
+        expect(() => runOn(shimBackend, scenario)).toThrow(/not implemented yet/);
+        return;
+      }
+
+      const shim = runOn(shimBackend, scenario);
+
+      const semantic = compareSemantics(legacy.pbxproj, shim.pbxproj);
+      if (!semantic.equal) {
+        throw new Error(
+          `semantic divergence at "${semantic.path}"\n  legacy: ${JSON.stringify(semantic.legacy)}\n  shim:   ${JSON.stringify(semantic.shim)}`
+        );
+      }
+
+      const results = compareResults(legacy.result, shim.result);
+      if (!results.equal) {
+        throw new Error(
+          `read-result divergence at "${results.path}"\n  legacy: ${JSON.stringify(results.legacy)}\n  shim:   ${JSON.stringify(results.shim)}`
+        );
+      }
+
+      const diff = normalizedTextDiff(legacy.pbxproj, shim.pbxproj);
+      if (diff.onlyLegacy.length || diff.onlyShim.length) {
+        textReport.push({ name: scenario.name, ...diff });
+      }
+    });
+  }
+
+  afterAll(() => {
+    if (textReport.length) {
+      // Secondary, non-failing: accepted-cosmetic text divergences to triage.
+      console.log('\nAccepted text divergences (semantically equal):');
+      for (const entry of textReport) {
+        console.log(`\n• ${entry.name}`);
+        entry.onlyLegacy.forEach((l) => console.log(`  - legacy: ${l.trim()}`));
+        entry.onlyShim.forEach((l) => console.log(`  + shim:   ${l.trim()}`));
+      }
+    }
+  });
+});

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/fixtures.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/fixtures.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+
+// `src/ios/utils/xcodeShim/__tests__` -> package root (`@expo/config-plugins`).
+const PACKAGE_ROOT = path.join(__dirname, '../../../../..');
+// package root -> monorepo root (`config-plugins` -> `@expo` -> `packages` -> root).
+const REPO_ROOT = path.join(PACKAGE_ROOT, '../../..');
+
+const IOS_FIXTURES = path.join(PACKAGE_ROOT, 'src/ios/__tests__/fixtures');
+
+// Read off disk verbatim so every backend starts from byte-identical input.
+export const FIXTURES = {
+  /** Bare React Native template the prebuild flow scaffolds. */
+  bareMinimum: path.join(
+    REPO_ROOT,
+    'templates/expo-template-bare-minimum/ios/HelloWorld.xcodeproj/project.pbxproj'
+  ),
+  /** App + share-extension target. */
+  multitarget: path.join(IOS_FIXTURES, 'project-multitarget.pbxproj'),
+  watch: path.join(IOS_FIXTURES, 'watch.pbxproj'),
+  framework: path.join(IOS_FIXTURES, 'project-with-framework.pbxproj'),
+  entitlements: path.join(IOS_FIXTURES, 'project-with-entitlements.pbxproj'),
+} as const;
+
+export type FixtureName = keyof typeof FIXTURES;
+
+export function fixturePath(name: FixtureName): string {
+  return FIXTURES[name];
+}

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/golden-legacy-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/golden-legacy-test.ts
@@ -1,0 +1,26 @@
+// Runs every scenario against the real legacy `xcode` library and snapshots the
+// result: the golden baseline the shim must reproduce. Commit 3 reuses
+// `scenarios` to diff the same sequences against `XcodeProjectShim`.
+
+import { legacyBackend } from './adapters';
+import { fixturePath } from './fixtures';
+import { normalizeResult, normalizeUuids } from './normalize';
+import { scenarios } from './scenarios';
+
+describe('legacy xcode golden baseline', () => {
+  it('covers every scenario with a unique name', () => {
+    const names = scenarios.map((s) => s.name);
+    expect(new Set(names).size).toBe(names.length);
+    expect(names.length).toBeGreaterThan(0);
+  });
+
+  for (const scenario of scenarios) {
+    it(scenario.name, () => {
+      const ctx = legacyBackend.load(fixturePath(scenario.fixture));
+      const result = scenario.run(ctx);
+      const pbxproj = normalizeUuids(ctx.project.writeSync());
+
+      expect({ result: normalizeResult(result), pbxproj }).toMatchSnapshot();
+    });
+  }
+});

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/legacyRefArray-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/legacyRefArray-test.ts
@@ -1,0 +1,88 @@
+import { legacyRefArray } from '../legacyRefArray';
+
+function makeProject() {
+  const registry = new Map<string, any>();
+  const project: any = {
+    getObject(uuid: string) {
+      if (!registry.has(uuid)) throw new Error(`missing ${uuid}`);
+      return registry.get(uuid);
+    },
+  };
+  const add = (uuid: string, name: string) => {
+    const model = { uuid, isa: 'PBXFileReference', getDisplayName: () => name };
+    registry.set(uuid, model);
+    return model;
+  };
+  return { project, add };
+}
+
+describe('legacyRefArray', () => {
+  it('projects backing models to { value, comment } on read', () => {
+    const { project, add } = makeProject();
+    const arr = legacyRefArray([add('AAA', 'A.swift'), add('BBB', 'B.swift')], project);
+    expect(arr.length).toBe(2);
+    expect(arr[0]).toEqual({ value: 'AAA', comment: 'A.swift' });
+    expect(arr.map((e) => e.value)).toEqual(['AAA', 'BBB']);
+    expect(arr.find((e) => e.comment === 'B.swift')).toEqual({ value: 'BBB', comment: 'B.swift' });
+    expect(arr.some((e) => e.comment === 'A.swift')).toBe(true);
+    expect([...arr]).toEqual([
+      { value: 'AAA', comment: 'A.swift' },
+      { value: 'BBB', comment: 'B.swift' },
+    ]);
+  });
+
+  it('push writes through to the backing as a model instance', () => {
+    const { project, add } = makeProject();
+    const backing: any[] = [];
+    add('CCC', 'C.swift');
+    const arr = legacyRefArray(backing, project);
+    arr.push({ value: 'CCC', comment: 'C.swift' });
+    expect(backing).toHaveLength(1);
+    expect(backing[0].uuid).toBe('CCC');
+    expect(arr[0]).toEqual({ value: 'CCC', comment: 'C.swift' });
+  });
+
+  it('is never stale: reflects backing mutations made by another path', () => {
+    const { project, add } = makeProject();
+    const backing = [add('AAA', 'A')];
+    const arr = legacyRefArray(backing, project);
+    expect(arr.length).toBe(1);
+    backing.push(add('BBB', 'B'));
+    expect(arr.length).toBe(2);
+    expect(arr[1]).toEqual({ value: 'BBB', comment: 'B' });
+  });
+
+  it('splice removes from the backing and returns projected entries', () => {
+    const { project, add } = makeProject();
+    const backing = [add('AAA', 'A'), add('BBB', 'B'), add('CCC', 'C')];
+    const arr = legacyRefArray(backing, project);
+    expect(arr.splice(1, 1)).toEqual([{ value: 'BBB', comment: 'B' }]);
+    expect(backing.map((m) => m.uuid)).toEqual(['AAA', 'CCC']);
+  });
+
+  it('index assignment writes through', () => {
+    const { project, add } = makeProject();
+    const backing = [add('AAA', 'A')];
+    add('ZZZ', 'Z');
+    const arr = legacyRefArray(backing, project);
+    arr[0] = { value: 'ZZZ', comment: 'Z' };
+    expect(backing[0].uuid).toBe('ZZZ');
+  });
+
+  it('throws a clear error when referencing an unmaterialized object', () => {
+    const { project } = makeProject();
+    const arr = legacyRefArray([], project);
+    expect(() => arr.push({ value: 'NOPE', comment: 'x' })).toThrow(/must be added to the project/);
+  });
+
+  it('throws on unsupported mutators rather than silently dropping writes', () => {
+    const { project, add } = makeProject();
+    const arr = legacyRefArray([add('AAA', 'A')], project);
+    expect(() => (arr as any).pop()).toThrow(/not supported/);
+  });
+
+  it('reports Array.isArray true', () => {
+    const { project } = makeProject();
+    expect(Array.isArray(legacyRefArray([], project))).toBe(true);
+  });
+});

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/legacyRefArray-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/legacyRefArray-test.ts
@@ -69,10 +69,14 @@ describe('legacyRefArray', () => {
     expect(backing[0].uuid).toBe('ZZZ');
   });
 
-  it('throws a clear error when referencing an unmaterialized object', () => {
+  it('tolerates linking a not-yet-registered reference (legacy behavior)', () => {
     const { project } = makeProject();
-    const arr = legacyRefArray([], project);
-    expect(() => arr.push({ value: 'NOPE', comment: 'x' })).toThrow(/must be added to the project/);
+    const backing: any[] = [];
+    const arr = legacyRefArray(backing, project);
+    arr.push({ value: 'NOPE', comment: 'x' });
+    // A stand-in carrying the uuid is stored so serialization emits the reference.
+    expect(backing[0].uuid).toBe('NOPE');
+    expect(arr[0]).toEqual({ value: 'NOPE', comment: 'x' });
   });
 
   it('throws on unsupported mutators rather than silently dropping writes', () => {

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/normalize.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/normalize.ts
@@ -1,0 +1,23 @@
+const UUID_TOKEN = /\b[0-9A-F]{24}\b/g;
+
+/**
+ * Replace each pbxproj UUID with a stable placeholder in first-appearance
+ * order. Legacy `xcode` mints random UUIDs, so raw output is non-deterministic;
+ * a shared UUID maps to a shared placeholder, so references stay checkable.
+ */
+export function normalizeUuids(text: string): string {
+  const map = new Map<string, string>();
+  return text.replace(UUID_TOKEN, (match) => {
+    let placeholder = map.get(match);
+    if (!placeholder) {
+      placeholder = `UUID-${String(map.size + 1).padStart(4, '0')}`;
+      map.set(match, placeholder);
+    }
+    return placeholder;
+  });
+}
+
+export function normalizeResult(value: unknown): unknown {
+  if (value === undefined) return null;
+  return JSON.parse(normalizeUuids(JSON.stringify(value)));
+}

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/normalize.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/normalize.ts
@@ -1,4 +1,5 @@
-const UUID_TOKEN = /\b[0-9A-F]{24}\b/g;
+// 24-char pbxproj identifier: legacy hex, or `@bacons`'s `XX…XX` content-hash form.
+const UUID_TOKEN = /\b[0-9A-FX]{24}\b/g;
 
 /**
  * Replace each pbxproj UUID with a stable placeholder in first-appearance

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/rig-smoke-test.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/rig-smoke-test.ts
@@ -1,0 +1,65 @@
+// Plumbing smoke test for the A/B build rig: confirms `EXPO_USE_LEGACY_XCODE`
+// selects the backend that both `getPbxproj` and the `mods.ios.xcodeproj` provider
+// route through (`openXcodeProject`), and that the two backends produce a
+// semantically-equal pbxproj for a real mutation. The full prebuild + Xcode-build
+// matrix across all plugins is a separate, heavier gate.
+
+import { compareSemantics } from './comparator';
+import { fixturePath } from './fixtures';
+import { openXcodeProject } from '../backend';
+
+function withLegacyXcode<T>(value: string | undefined, fn: () => T): T {
+  const previous = process.env.EXPO_USE_LEGACY_XCODE;
+  if (value === undefined) delete process.env.EXPO_USE_LEGACY_XCODE;
+  else process.env.EXPO_USE_LEGACY_XCODE = value;
+  try {
+    return fn();
+  } finally {
+    if (previous === undefined) delete process.env.EXPO_USE_LEGACY_XCODE;
+    else process.env.EXPO_USE_LEGACY_XCODE = previous;
+  }
+}
+
+describe('EXPO_USE_LEGACY_XCODE backend toggle', () => {
+  it('selects legacy by default and the shim when disabled', () => {
+    const def = withLegacyXcode(
+      undefined,
+      () => openXcodeProject(fixturePath('bareMinimum')).constructor.name
+    );
+    const legacy = withLegacyXcode(
+      '1',
+      () => openXcodeProject(fixturePath('bareMinimum')).constructor.name
+    );
+    const shim = withLegacyXcode(
+      '0',
+      () => openXcodeProject(fixturePath('bareMinimum')).constructor.name
+    );
+
+    expect(def).toBe(legacy);
+    expect(shim).toBe('XcodeProjectShim');
+    expect(shim).not.toBe(legacy);
+  });
+
+  it('legacy and shim backends produce a semantically-equal pbxproj', () => {
+    const mutate = (project: any) =>
+      project.addBuildProperty('PRODUCT_BUNDLE_IDENTIFIER', '"com.example.rig"');
+
+    const legacy = withLegacyXcode('1', () => {
+      const project = openXcodeProject(fixturePath('bareMinimum'));
+      mutate(project);
+      return project.writeSync();
+    });
+    const shim = withLegacyXcode('0', () => {
+      const project = openXcodeProject(fixturePath('bareMinimum'));
+      mutate(project);
+      return project.writeSync();
+    });
+
+    const diff = compareSemantics(legacy, shim);
+    if (!diff.equal) {
+      throw new Error(
+        `semantic divergence at "${diff.path}": ${JSON.stringify(diff.legacy)} vs ${JSON.stringify(diff.shim)}`
+      );
+    }
+  });
+});

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
@@ -470,6 +470,24 @@ export const scenarios: Scenario[] = [
     },
   },
   {
+    name: 'targets/hash-precreated-target-dependency',
+    description:
+      'pre-create dependency sections via hash, then addTargetDependency (widgets pattern)',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const app = project.getFirstTarget();
+      const ext = project.addTarget('Widget', 'app_extension', 'Widget', 'com.example.app.Widget');
+      const objects = project.hash.project.objects;
+      objects.PBXTargetDependency ??= {};
+      objects.PBXContainerItemProxy ??= {};
+      project.addTargetDependency(app.uuid, [ext.uuid]);
+      return {
+        appDependencyCount: project.getFirstTarget().firstTarget.dependencies.length,
+        hasContainerItemProxy: !!project.hash.project.objects['PBXContainerItemProxy'],
+      };
+    },
+  },
+  {
     name: 'targets/add-xc-configuration-list',
     description: 'addXCConfigurationList registers build configs + a config list',
     fixture: 'bareMinimum',

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
@@ -425,6 +425,27 @@ export const scenarios: Scenario[] = [
     },
   },
   {
+    name: 'build-phases/phase-lookup-by-comment',
+    description:
+      'buildPhaseObject finds a phase by its comment with no target (ios-stickers pattern)',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const ext = project.addTarget(
+        'Stickers',
+        'app_extension',
+        'Stickers',
+        'com.example.app.Stickers'
+      );
+      project.addBuildPhase([], 'PBXResourcesBuildPhase', 'Stickers Resources', ext.uuid);
+      const phase = project.buildPhaseObject(
+        'PBXResourcesBuildPhase',
+        'Stickers Resources',
+        undefined
+      );
+      return { found: !!phase, isa: phase?.isa, fileCount: phase?.files?.length ?? 0 };
+    },
+  },
+  {
     name: 'build-phases/build-phase-object',
     description: 'buildPhaseObject resolves an existing phase by name + target',
     fixture: 'bareMinimum',

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
@@ -389,7 +389,8 @@ export const scenarios: Scenario[] = [
         {
           shellPath: '/bin/sh',
           shellScript: 'echo "uploading"',
-          inputPaths: ['$(SRCROOT)/main.jsbundle'],
+          // Paths are passed pre-quoted, the way Xcode represents them.
+          inputPaths: ['"$(SRCROOT)/main.jsbundle"'],
           outputPaths: [],
         }
       );

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
@@ -488,6 +488,45 @@ export const scenarios: Scenario[] = [
     },
   },
   {
+    name: 'files/build-file-before-file-reference',
+    description:
+      'addToPbxBuildFileSection before addToPbxFileReferenceSection (ios-stickers pattern)',
+    fixture: 'bareMinimum',
+    run({ project, PbxFile }) {
+      const file = new PbxFile('Sticker.png');
+      file.uuid = project.generateUuid();
+      file.fileRef = project.generateUuid();
+      file.target = appTarget(project).uuid;
+      // Link the build file before its file reference exists; the ref is added next.
+      project.addToPbxBuildFileSection(file);
+      project.addToPbxFileReferenceSection(file);
+      project.addToPbxResourcesBuildPhase(file);
+      return { hasFile: !!project.hasFile('Sticker.png') };
+    },
+  },
+  {
+    name: 'targets/reassign-build-configuration-list',
+    description:
+      'reassign a target buildConfigurationList via pbxNativeTargetSection (brownfield pattern)',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const { uuid: listUuid } = project.addXCConfigurationList(
+        [
+          { name: 'Debug', isa: 'XCBuildConfiguration', buildSettings: { PRODUCT_NAME: '"X"' } },
+          { name: 'Release', isa: 'XCBuildConfiguration', buildSettings: { PRODUCT_NAME: '"X"' } },
+        ],
+        'Release',
+        'Build configuration list for PBXNativeTarget "X"'
+      );
+      const section = project.pbxNativeTargetSection();
+      const entry = Object.entries(section).find(
+        ([, v]: any) => v && v.isa === 'PBXNativeTarget'
+      ) as any;
+      entry[1].buildConfigurationList = listUuid;
+      return { reassigned: entry[1].buildConfigurationList === listUuid };
+    },
+  },
+  {
     name: 'targets/add-xc-configuration-list',
     description: 'addXCConfigurationList registers build configs + a config list',
     fixture: 'bareMinimum',

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
@@ -1,0 +1,575 @@
+// Operation scenarios derived from real first- and third-party config-plugin
+// call patterns. Each performs one read/mutation sequence using only the legacy
+// `xcode` surface, so it runs unchanged against the legacy library (golden
+// baseline) and `XcodeProjectShim` (differential harness). A scenario never
+// loads a fixture or serializes — the harness owns both so it can compare.
+
+import type { ScenarioContext } from './adapters';
+import type { FixtureName } from './fixtures';
+
+const APPLICATION_PRODUCT_TYPE = 'com.apple.product-type.application';
+
+export interface Scenario {
+  /** Stable identifier; also the snapshot key. */
+  name: string;
+  description: string;
+  fixture: FixtureName;
+  /** Optionally returns a JSON-serializable summary of read results to compare. */
+  run: (ctx: ScenarioContext) => unknown;
+}
+
+function appTarget(project: any): { uuid: string; target: any } {
+  const target = project.getTarget(APPLICATION_PRODUCT_TYPE);
+  if (!target) {
+    throw new Error('Fixture is missing an application PBXNativeTarget');
+  }
+  return target;
+}
+
+/**
+ * Mirrors `Xcodeproj.addFileToGroupAndLink`: create a `pbxFile`, dedupe against
+ * the group, assign uuids, register it in the requested sections, and push it
+ * into the group's children. Returns the file's resolved basename + whether it
+ * was added (false on duplicate), with UUIDs left for the harness to compare.
+ */
+function addFileToGroup(
+  { project, PbxFile }: ScenarioContext,
+  {
+    filepath,
+    groupName,
+    isBuildFile,
+    phase,
+  }: {
+    filepath: string;
+    groupName: string;
+    isBuildFile: boolean;
+    phase: 'resources' | 'sources';
+  }
+): { basename: string; added: boolean } {
+  const { firstProject } = project.getFirstProject();
+  let group = project.getPBXGroupByKey(firstProject.mainGroup);
+  for (const component of groupName.split('/')) {
+    const child = group?.children?.find((c: any) => c.comment === component);
+    const next = child ? project.getPBXGroupByKey(child.value) : null;
+    if (!next) break;
+    group = next;
+  }
+
+  const file = new PbxFile(filepath);
+  if (group.children.find((c: any) => c.comment === file.basename)) {
+    return { basename: file.basename, added: false };
+  }
+
+  file.target = appTarget(project).uuid;
+  file.uuid = project.generateUuid();
+  file.fileRef = project.generateUuid();
+
+  project.addToPbxFileReferenceSection(file);
+  if (isBuildFile) {
+    project.addToPbxBuildFileSection(file);
+  }
+  if (phase === 'resources') {
+    project.addToPbxResourcesBuildPhase(file);
+  } else {
+    project.addToPbxSourcesBuildPhase(file);
+  }
+  group.children.push({ value: file.fileRef, comment: file.basename });
+  return { basename: file.basename, added: true };
+}
+
+/** Strip surrounding quotes the way the wrapper's `unquote` does. */
+function unquote(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return value.match(/^"(.*)"$/)?.[1] ?? value;
+}
+
+// --- scenarios ------------------------------------------------------------
+
+export const scenarios: Scenario[] = [
+  // === Build settings ===
+  {
+    name: 'build-settings/set-bundle-identifier',
+    description: 'addBuildProperty PRODUCT_BUNDLE_IDENTIFIER across all configs',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addBuildProperty('PRODUCT_BUNDLE_IDENTIFIER', '"com.example.differential"');
+      return { value: unquote(project.getBuildProperty('PRODUCT_BUNDLE_IDENTIFIER')) };
+    },
+  },
+  {
+    name: 'build-settings/set-development-team',
+    description: 'addBuildProperty DEVELOPMENT_TEAM',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addBuildProperty('DEVELOPMENT_TEAM', 'J5FM626PE2');
+      return { value: project.getBuildProperty('DEVELOPMENT_TEAM') };
+    },
+  },
+  {
+    name: 'build-settings/set-deployment-target',
+    description: 'addBuildProperty IPHONEOS_DEPLOYMENT_TARGET',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addBuildProperty('IPHONEOS_DEPLOYMENT_TARGET', '15.1');
+      return { value: project.getBuildProperty('IPHONEOS_DEPLOYMENT_TARGET') };
+    },
+  },
+  {
+    name: 'build-settings/toggle-bitcode',
+    description: 'add then remove ENABLE_BITCODE',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addBuildProperty('ENABLE_BITCODE', 'YES');
+      const afterAdd = project.getBuildProperty('ENABLE_BITCODE');
+      project.removeBuildProperty('ENABLE_BITCODE');
+      return { afterAdd, afterRemove: project.getBuildProperty('ENABLE_BITCODE') ?? null };
+    },
+  },
+  {
+    name: 'build-settings/set-device-family',
+    description: 'addBuildProperty TARGETED_DEVICE_FAMILY',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addBuildProperty('TARGETED_DEVICE_FAMILY', '"1,2"');
+      return { value: unquote(project.getBuildProperty('TARGETED_DEVICE_FAMILY')) };
+    },
+  },
+  {
+    name: 'build-settings/update-product-name',
+    description: 'updateProductName updates PRODUCT_NAME on every config',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.updateProductName('RenamedApp');
+      return { value: unquote(project.getBuildProperty('PRODUCT_NAME')) };
+    },
+  },
+  {
+    name: 'build-settings/set-entitlements',
+    description: 'addBuildProperty CODE_SIGN_ENTITLEMENTS',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addBuildProperty(
+        'CODE_SIGN_ENTITLEMENTS',
+        '"HelloWorld/HelloWorld.entitlements"',
+        'Release'
+      );
+      return {
+        release: unquote(project.getBuildProperty('CODE_SIGN_ENTITLEMENTS', 'Release')),
+        debug: project.getBuildProperty('CODE_SIGN_ENTITLEMENTS', 'Debug') ?? null,
+      };
+    },
+  },
+  {
+    name: 'build-settings/update-property-for-target',
+    description: 'updateBuildProperty scoped to a named target (multi-target)',
+    fixture: 'multitarget',
+    run({ project }) {
+      project.updateBuildProperty(
+        'PRODUCT_BUNDLE_IDENTIFIER',
+        '"com.example.share"',
+        null,
+        'shareextension'
+      );
+      return {
+        share: unquote(
+          project.getBuildProperty('PRODUCT_BUNDLE_IDENTIFIER', undefined, 'shareextension')
+        ),
+      };
+    },
+  },
+
+  // === Files & groups ===
+  {
+    name: 'files/add-resource-file',
+    description: 'addResourceFileToGroup: file ref + build file + resources phase',
+    fixture: 'bareMinimum',
+    run(ctx) {
+      const r = addFileToGroup(ctx, {
+        filepath: 'HelloWorld/new-resource.png',
+        groupName: 'HelloWorld',
+        isBuildFile: true,
+        phase: 'resources',
+      });
+      return { ...r, hasFile: !!ctx.project.hasFile('HelloWorld/new-resource.png') };
+    },
+  },
+  {
+    name: 'files/add-resource-file-no-build',
+    description: 'addResourceFileToGroup with isBuildFile=false (no PBXBuildFile)',
+    fixture: 'bareMinimum',
+    run(ctx) {
+      const before = Object.keys(ctx.project.pbxBuildFileSection()).length;
+      addFileToGroup(ctx, {
+        filepath: 'HelloWorld/readme-only.txt',
+        groupName: 'HelloWorld',
+        isBuildFile: false,
+        phase: 'resources',
+      });
+      const after = Object.keys(ctx.project.pbxBuildFileSection()).length;
+      return { buildFileCountUnchanged: before === after };
+    },
+  },
+  {
+    name: 'files/add-source-file',
+    description: 'addBuildSourceFileToGroup: file ref + build file + sources phase',
+    fixture: 'bareMinimum',
+    run(ctx) {
+      return addFileToGroup(ctx, {
+        filepath: 'HelloWorld/MyClass.swift',
+        groupName: 'HelloWorld',
+        isBuildFile: true,
+        phase: 'sources',
+      });
+    },
+  },
+  {
+    name: 'files/add-duplicate-resource',
+    description: 'adding the same file twice is a no-op the second time',
+    fixture: 'bareMinimum',
+    run(ctx) {
+      const first = addFileToGroup(ctx, {
+        filepath: 'HelloWorld/dup-resource.png',
+        groupName: 'HelloWorld',
+        isBuildFile: true,
+        phase: 'resources',
+      });
+      const refsAfterFirst = Object.keys(ctx.project.pbxFileReferenceSection()).length;
+      const second = addFileToGroup(ctx, {
+        filepath: 'HelloWorld/dup-resource.png',
+        groupName: 'HelloWorld',
+        isBuildFile: true,
+        phase: 'resources',
+      });
+      const refsAfterSecond = Object.keys(ctx.project.pbxFileReferenceSection()).length;
+      return {
+        firstAdded: first.added,
+        secondAdded: second.added,
+        refsUnchanged: refsAfterFirst === refsAfterSecond,
+      };
+    },
+  },
+  {
+    name: 'files/ensure-group-recursively',
+    description: 'ensureGroupRecursively creates nested PBXGroups',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const components = 'HelloWorld/Generated/Sources'.split('/');
+      const { firstProject } = project.getFirstProject();
+      let group = project.getPBXGroupByKey(firstProject.mainGroup);
+      for (const name of components) {
+        if (group && !group.children.find((c: any) => c.comment === name)) {
+          group.children.push({ comment: name, value: project.pbxCreateGroup(name, '""') });
+        }
+        group = project.pbxGroupByName(name);
+      }
+      return {
+        created: group?.name,
+        hasGenerated: !!project.pbxGroupByName('Generated'),
+        hasSources: !!project.pbxGroupByName('Sources'),
+      };
+    },
+  },
+  {
+    name: 'files/add-pbx-group',
+    description: 'addPbxGroup creates a group with file references',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const { uuid, pbxGroup } = project.addPbxGroup(
+        ['Widget/Widget.swift', 'Widget/Info.plist'],
+        'Widget',
+        'Widget'
+      );
+      return {
+        name: pbxGroup.name,
+        path: pbxGroup.path,
+        sourceTree: pbxGroup.sourceTree,
+        childCount: pbxGroup.children.length,
+        registered: !!project.getPBXGroupByKey(uuid),
+      };
+    },
+  },
+  {
+    name: 'files/add-to-pbx-group',
+    description: 'pbxCreateGroupWithType + addToPbxGroup links a file into a group',
+    fixture: 'bareMinimum',
+    run({ project, PbxFile }) {
+      const key = project.pbxCreateGroupWithType('Extras', 'Extras', 'PBXGroup');
+      const file = new PbxFile('Extras/Thing.swift');
+      file.uuid = project.generateUuid();
+      file.fileRef = project.generateUuid();
+      project.addToPbxFileReferenceSection(file);
+      project.addToPbxGroup(file, key);
+      const group = project.getPBXGroupByKey(key);
+      return { groupName: group.name, childComments: group.children.map((c: any) => c.comment) };
+    },
+  },
+  {
+    name: 'files/has-file',
+    description: 'hasFile read against an existing file reference',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      return {
+        present: !!project.hasFile('HelloWorld/Images.xcassets'),
+        absent: project.hasFile('does/not/exist.swift'),
+      };
+    },
+  },
+
+  // === Frameworks ===
+  {
+    name: 'frameworks/add-framework',
+    description: 'addFramework links a system framework to the app target',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const target = appTarget(project);
+      const file = project.addFramework('StoreKit.framework', { target: target.uuid });
+      return { basename: file.basename, path: file.path, group: file.group };
+    },
+  },
+  {
+    name: 'frameworks/add-framework-weak',
+    description: 'addFramework with { weak: true } sets the Weak attribute',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const target = appTarget(project);
+      const file = project.addFramework('CoreNFC.framework', { weak: true, target: target.uuid });
+      return { basename: file.basename, settings: file.settings };
+    },
+  },
+  {
+    name: 'frameworks/add-custom-framework-embed-sign',
+    description: 'addFramework custom + embed + sign (react-native-adjust pattern)',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const target = appTarget(project);
+      const file = project.addFramework('vendor/Adjust.framework', {
+        customFramework: true,
+        embed: true,
+        sign: true,
+        target: target.uuid,
+      });
+      return { basename: file.basename, settings: file.settings };
+    },
+  },
+  {
+    name: 'frameworks/embed-frameworks-phase',
+    description: 'pbxEmbedFrameworksBuildPhaseObj resolves the Embed Frameworks copy phase',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const target = appTarget(project);
+      const before = project.pbxEmbedFrameworksBuildPhaseObj(target.uuid);
+      project.addFramework('vendor/Embed.framework', {
+        customFramework: true,
+        embed: true,
+        target: target.uuid,
+      });
+      const after = project.pbxEmbedFrameworksBuildPhaseObj(target.uuid);
+      return {
+        existedBefore: !!before,
+        existsAfter: !!after,
+        fileCount: after ? after.files.length : 0,
+      };
+    },
+  },
+
+  // === Build phases ===
+  {
+    name: 'build-phases/add-shell-script',
+    description: 'addBuildPhase PBXShellScriptBuildPhase',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const target = appTarget(project);
+      const { buildPhase } = project.addBuildPhase(
+        [],
+        'PBXShellScriptBuildPhase',
+        'Upload Source Maps',
+        target.uuid,
+        {
+          shellPath: '/bin/sh',
+          shellScript: 'echo "uploading"',
+          inputPaths: ['$(SRCROOT)/main.jsbundle'],
+          outputPaths: [],
+        }
+      );
+      return {
+        isa: buildPhase.isa,
+        name: buildPhase.name,
+        shellPath: buildPhase.shellPath,
+        shellScript: buildPhase.shellScript,
+        inputPaths: buildPhase.inputPaths,
+      };
+    },
+  },
+  {
+    name: 'build-phases/add-copy-files',
+    description: 'addBuildPhase PBXCopyFilesBuildPhase with a folder spec',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const target = appTarget(project);
+      const { buildPhase } = project.addBuildPhase(
+        [],
+        'PBXCopyFilesBuildPhase',
+        'Copy Files',
+        target.uuid,
+        'frameworks'
+      );
+      return {
+        isa: buildPhase.isa,
+        name: buildPhase.name,
+        dstSubfolderSpec: buildPhase.dstSubfolderSpec,
+        dstPath: buildPhase.dstPath,
+      };
+    },
+  },
+  {
+    name: 'build-phases/build-phase-object',
+    description: 'buildPhaseObject resolves an existing phase by name + target',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const target = appTarget(project);
+      const sources = project.buildPhaseObject('PBXSourcesBuildPhase', 'Sources', target.uuid);
+      return { isa: sources?.isa, fileCount: sources?.files?.length ?? 0 };
+    },
+  },
+
+  // === Targets / extensions ===
+  {
+    name: 'targets/add-app-extension',
+    description: 'addTarget app_extension (sticker / share-extension pattern)',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const target = project.addTarget(
+        'Stickers',
+        'app_extension',
+        'Stickers',
+        'com.example.app.Stickers'
+      );
+      return {
+        name: target.pbxNativeTarget.name,
+        productType: target.pbxNativeTarget.productType,
+        productName: target.pbxNativeTarget.productName,
+        hasConfigList: !!target.pbxNativeTarget.buildConfigurationList,
+      };
+    },
+  },
+  {
+    name: 'targets/add-target-dependency',
+    description: 'addTargetDependency wires a new target as a dependency of the app',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const app = project.getFirstTarget();
+      const ext = project.addTarget('Widget', 'app_extension', 'Widget', 'com.example.app.Widget');
+      const result = project.addTargetDependency(app.uuid, [ext.uuid]);
+      return {
+        dependencyCount: result.target.dependencies.length,
+        hasContainerItemProxy: !!project.hash.project.objects['PBXContainerItemProxy'],
+      };
+    },
+  },
+  {
+    name: 'targets/add-xc-configuration-list',
+    description: 'addXCConfigurationList registers build configs + a config list',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const { uuid, xcConfigurationList } = project.addXCConfigurationList(
+        [
+          { name: 'Debug', isa: 'XCBuildConfiguration', buildSettings: { PRODUCT_NAME: '"Ext"' } },
+          {
+            name: 'Release',
+            isa: 'XCBuildConfiguration',
+            buildSettings: { PRODUCT_NAME: '"Ext"' },
+          },
+        ],
+        'Release',
+        'Build configuration list for PBXNativeTarget "Ext"'
+      );
+      return {
+        registered: !!project.pbxXCConfigurationList()[uuid],
+        defaultConfigurationName: xcConfigurationList.defaultConfigurationName,
+        buildConfigurationCount: xcConfigurationList.buildConfigurations.length,
+      };
+    },
+  },
+  {
+    name: 'targets/add-product-file',
+    description: 'addProductFile registers a product reference in Products',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const file = project.addProductFile('Widget', {
+        group: 'Copy Files',
+        target: project.getFirstTarget().uuid,
+        explicitFileType: '"wrapper.app-extension"',
+      });
+      return {
+        basename: file.basename,
+        includeInIndex: file.includeInIndex,
+        explicitFileType: file.explicitFileType,
+      };
+    },
+  },
+  {
+    name: 'targets/pbx-target-by-name',
+    description: 'pbxTargetByName + findTargetKey resolve an existing target',
+    fixture: 'multitarget',
+    run({ project }) {
+      const target = project.pbxTargetByName('shareextension');
+      return {
+        found: !!target,
+        productType: target?.productType,
+        key: project.findTargetKey('shareextension'),
+      };
+    },
+  },
+
+  // === Header search paths / linker flags ===
+  {
+    name: 'build-settings/add-header-search-paths',
+    description: 'addToHeaderSearchPaths appends to the app target configs',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addToHeaderSearchPaths('"$(SRCROOT)/../node_modules/foo/include"');
+      return { value: project.getBuildProperty('HEADER_SEARCH_PATHS') };
+    },
+  },
+  {
+    name: 'build-settings/add-other-linker-flags',
+    description: 'addToOtherLinkerFlags appends -ObjC (callkeep pattern)',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addToOtherLinkerFlags('-ObjC');
+      return { value: project.getBuildProperty('OTHER_LDFLAGS') };
+    },
+  },
+
+  // === Misc / direct manipulation ===
+  {
+    name: 'misc/add-known-region',
+    description: 'addKnownRegion adds a locale to the project',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      project.addKnownRegion('fr');
+      return {
+        hasFr: project.hasKnownRegion('fr'),
+        regions: project.getFirstProject().firstProject.knownRegions,
+      };
+    },
+  },
+  {
+    name: 'misc/direct-hash-objects',
+    description: 'direct hash.project.objects access + mutation (sticker plugin pattern)',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const targets = project.getPBXObject('PBXNativeTarget');
+      const configs = project.hash.project.objects['XCBuildConfiguration'];
+      // Write a setting directly into every non-comment build configuration.
+      for (const key of Object.keys(configs)) {
+        if (key.endsWith('_comment')) continue;
+        configs[key].buildSettings.SWIFT_VERSION = '5.0';
+      }
+      return {
+        nativeTargetCount: Object.keys(targets).filter((k) => !k.endsWith('_comment')).length,
+        swiftVersion: unquote(project.getBuildProperty('SWIFT_VERSION')),
+      };
+    },
+  },
+];

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
@@ -65,13 +65,15 @@ function addFileToGroup(
   file.fileRef = project.generateUuid();
 
   project.addToPbxFileReferenceSection(file);
+  // Real callers always add resource/source files as build files; a non-build
+  // file is just a file reference in a group, not linked into a build phase.
   if (isBuildFile) {
     project.addToPbxBuildFileSection(file);
-  }
-  if (phase === 'resources') {
-    project.addToPbxResourcesBuildPhase(file);
-  } else {
-    project.addToPbxSourcesBuildPhase(file);
+    if (phase === 'resources') {
+      project.addToPbxResourcesBuildPhase(file);
+    } else {
+      project.addToPbxSourcesBuildPhase(file);
+    }
   }
   group.children.push({ value: file.fileRef, comment: file.basename });
   return { basename: file.basename, added: true };

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/__tests__/scenarios.ts
@@ -306,6 +306,17 @@ export const scenarios: Scenario[] = [
     },
   },
   {
+    name: 'files/create-group-quoted-name',
+    description:
+      'pbxCreateGroup with a pre-quoted name is not double-quoted (ios-stickers pattern)',
+    fixture: 'bareMinimum',
+    run({ project }) {
+      const key = project.pbxCreateGroup('"My Stickers"', '""');
+      const group = project.getPBXGroupByKey(key);
+      return { name: group.name };
+    },
+  },
+  {
     name: 'files/has-file',
     description: 'hasFile read against an existing file reference',
     fixture: 'bareMinimum',

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/backend.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/backend.ts
@@ -1,0 +1,19 @@
+import getenv from 'getenv';
+import type { XcodeProject } from 'xcode';
+import xcode from 'xcode';
+
+import { project as shimProject } from './index';
+
+// Whether iOS pbxproj handling uses the legacy `xcode` package. Defaults to true
+// during Phase 1 of the `@bacons/xcode` migration (the shim is opt-in via
+// `EXPO_USE_LEGACY_XCODE=0`, used by the A/B build rig); Phase 3 flips the default.
+export function shouldUseLegacyXcode(): boolean {
+  return getenv.boolish('EXPO_USE_LEGACY_XCODE', true);
+}
+
+/** Open and parse a `project.pbxproj`, routed through legacy `xcode` or the shim. */
+export function openXcodeProject(filePath: string): XcodeProject {
+  const project = shouldUseLegacyXcode() ? xcode.project(filePath) : shimProject(filePath);
+  project.parseSync();
+  return project as XcodeProject;
+}

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/index.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/index.ts
@@ -1,0 +1,21 @@
+import { XcodeProjectShim } from './XcodeProjectShim';
+
+export { XcodeProjectShim };
+export { PbxFile } from './pbxFile';
+
+/**
+ * Drop-in replacement for the legacy `xcode.project(filepath)` factory. The
+ * returned shim mirrors the old library's two-phase init on top of
+ * `@bacons/xcode`:
+ *
+ *     const project = shim.project(filepath);
+ *     project.parseSync();
+ *     // ...mutate...
+ *     fs.writeFileSync(project.filepath, project.writeSync());
+ *
+ * @deprecated Bridge for the legacy `xcode` package API; to be removed in a
+ * future major of `@expo/config-plugins`.
+ */
+export function project(filePath: string): XcodeProjectShim {
+  return new XcodeProjectShim(filePath);
+}

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/legacyRefArray.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/legacyRefArray.ts
@@ -19,9 +19,10 @@ function resolve(project: XcodeProject, entry: any): any {
   try {
     return project.getObject(uuid);
   } catch {
-    throw new Error(
-      `XcodeProjectShim: object ${JSON.stringify(uuid)} must be added to the project before being linked into a group or build phase.`
-    );
+    // Legacy tolerates linking a reference before its object is registered (the
+    // object is usually added moments later). Push a stand-in carrying the uuid
+    // so serialization emits the right reference once it exists.
+    return { uuid, getDisplayName: () => entry?.comment ?? uuid };
   }
 }
 

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/legacyRefArray.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/legacyRefArray.ts
@@ -1,0 +1,85 @@
+import type { XcodeProject } from '@bacons/xcode';
+
+export interface LegacyRef {
+  value: string;
+  comment: string;
+}
+
+const INDEX = /^\d+$/;
+// Array mutators that aren't translated; throw rather than silently dropping
+// writes that wouldn't reach the backing model.
+const UNSUPPORTED = new Set(['pop', 'shift', 'unshift', 'sort', 'reverse', 'fill', 'copyWithin']);
+
+function projectEntry(model: any): LegacyRef {
+  return { value: model.uuid, comment: model.getDisplayName?.() ?? model.uuid };
+}
+
+function resolve(project: XcodeProject, entry: any): any {
+  const uuid = entry?.value ?? entry;
+  try {
+    return project.getObject(uuid);
+  } catch {
+    throw new Error(
+      `XcodeProjectShim: object ${JSON.stringify(uuid)} must be added to the project before being linked into a group or build phase.`
+    );
+  }
+}
+
+/**
+ * Live `{ value, comment }[]` view over a `@bacons` ref-array (`children` /
+ * `files` / `targets`, which hold model instances). Reads project each backing
+ * model lazily, so the view is never stale; `push` / `splice` / index writes
+ * resolve back to model instances and mutate the backing in place.
+ */
+export function legacyRefArray(backing: any[], project: XcodeProject): LegacyRef[] {
+  const handler: ProxyHandler<any[]> = {
+    get(target, prop) {
+      if (typeof prop === 'string' && INDEX.test(prop)) {
+        const model = target[Number(prop)];
+        return model === undefined ? undefined : projectEntry(model);
+      }
+      if (prop === 'length') return target.length;
+      if (prop === 'push') {
+        return (...entries: any[]) => {
+          for (const entry of entries) target.push(resolve(project, entry));
+          return target.length;
+        };
+      }
+      if (prop === 'splice') {
+        return (start: number, deleteCount?: number, ...items: any[]) => {
+          const models = items.map((item) => resolve(project, item));
+          const removed =
+            deleteCount === undefined
+              ? target.splice(start)
+              : target.splice(start, deleteCount, ...models);
+          return removed.map(projectEntry);
+        };
+      }
+      if (typeof prop === 'string' && UNSUPPORTED.has(prop)) {
+        throw new Error(`legacyRefArray: ${prop}() is not supported`);
+      }
+      if (prop === Symbol.iterator) {
+        return function* () {
+          for (const model of target) yield projectEntry(model);
+        };
+      }
+      // Read-only helpers (find/map/some/…) run on a projected snapshot.
+      const snapshot = target.map(projectEntry);
+      const value = (snapshot as any)[prop];
+      return typeof value === 'function' ? value.bind(snapshot) : value;
+    },
+    set(target, prop, value) {
+      if (typeof prop === 'string' && INDEX.test(prop)) {
+        target[Number(prop)] = resolve(project, value);
+        return true;
+      }
+      if (prop === 'length') {
+        target.length = value;
+        return true;
+      }
+      return Reflect.set(target, prop, value);
+    },
+  };
+
+  return new Proxy(backing, handler) as unknown as LegacyRef[];
+}

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/pbxFile.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/pbxFile.ts
@@ -1,10 +1,183 @@
 // Mirror of `xcode/lib/pbxFile`. Deep-imported by the `Xcodeproj.ts` wrapper,
 // `@expo/cli`, and community plugins (e.g. ios-stickers), so Phase 3 must expose
-// this at a compatible import path.
+// this at a compatible import path. The logic is a faithful port of the legacy
+// constructor so file descriptors carry identical fields.
+
+import path from 'path';
+
+const DEFAULT_SOURCETREE = '"<group>"';
+const DEFAULT_PRODUCT_SOURCETREE = 'BUILT_PRODUCTS_DIR';
+const DEFAULT_GROUP = 'Resources';
+const DEFAULT_FILETYPE = 'unknown';
+
+const FILETYPE_BY_EXTENSION: Record<string, string> = {
+  a: 'archive.ar',
+  app: 'wrapper.application',
+  appex: 'wrapper.app-extension',
+  bundle: 'wrapper.plug-in',
+  dylib: 'compiled.mach-o.dylib',
+  framework: 'wrapper.framework',
+  h: 'sourcecode.c.h',
+  m: 'sourcecode.c.objc',
+  markdown: 'text',
+  mdimporter: 'wrapper.cfbundle',
+  octest: 'wrapper.cfbundle',
+  pch: 'sourcecode.c.h',
+  plist: 'text.plist.xml',
+  sh: 'text.script.sh',
+  swift: 'sourcecode.swift',
+  tbd: 'sourcecode.text-based-dylib-definition',
+  xcassets: 'folder.assetcatalog',
+  xcconfig: 'text.xcconfig',
+  xcdatamodel: 'wrapper.xcdatamodel',
+  xcodeproj: 'wrapper.pb-project',
+  xctest: 'wrapper.cfbundle',
+  xib: 'file.xib',
+  strings: 'text.plist.strings',
+};
+
+const GROUP_BY_FILETYPE: Record<string, string> = {
+  'archive.ar': 'Frameworks',
+  'compiled.mach-o.dylib': 'Frameworks',
+  'sourcecode.text-based-dylib-definition': 'Frameworks',
+  'wrapper.framework': 'Frameworks',
+  'embedded.framework': 'Embed Frameworks',
+  'sourcecode.c.h': 'Resources',
+  'sourcecode.c.objc': 'Sources',
+  'sourcecode.swift': 'Sources',
+};
+
+const PATH_BY_FILETYPE: Record<string, string> = {
+  'compiled.mach-o.dylib': 'usr/lib/',
+  'sourcecode.text-based-dylib-definition': 'usr/lib/',
+  'wrapper.framework': 'System/Library/Frameworks/',
+};
+
+const SOURCETREE_BY_FILETYPE: Record<string, string> = {
+  'compiled.mach-o.dylib': 'SDKROOT',
+  'sourcecode.text-based-dylib-definition': 'SDKROOT',
+  'wrapper.framework': 'SDKROOT',
+};
+
+const ENCODING_BY_FILETYPE: Record<string, number> = {
+  'sourcecode.c.h': 4,
+  'sourcecode.c.objc': 4,
+  'sourcecode.swift': 4,
+  text: 4,
+  'text.plist.xml': 4,
+  'text.script.sh': 4,
+  'text.xcconfig': 4,
+  'text.plist.strings': 4,
+};
+
+function unquoted(text: string | null | undefined): string {
+  return text == null ? '' : text.replace(/(^")|("$)/g, '');
+}
+
+function detectType(filePath: string): string {
+  const extension = path.extname(filePath).substring(1);
+  return FILETYPE_BY_EXTENSION[unquoted(extension)] ?? DEFAULT_FILETYPE;
+}
+
+function defaultExtension(fileRef: PbxFile): string | undefined {
+  const filetype =
+    fileRef.lastKnownFileType && fileRef.lastKnownFileType !== DEFAULT_FILETYPE
+      ? fileRef.lastKnownFileType
+      : fileRef.explicitFileType;
+  for (const extension in FILETYPE_BY_EXTENSION) {
+    if (FILETYPE_BY_EXTENSION[unquoted(extension)] === unquoted(filetype)) return extension;
+  }
+  return undefined;
+}
+
+function defaultEncoding(fileRef: PbxFile): number | undefined {
+  const filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+  return ENCODING_BY_FILETYPE[unquoted(filetype)];
+}
+
+function detectGroup(fileRef: PbxFile, opt: any): string {
+  const extension = path.extname(fileRef.basename).substring(1);
+  const filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+  const groupName = GROUP_BY_FILETYPE[unquoted(filetype)];
+  if (extension === 'xcdatamodeld') return 'Sources';
+  if (opt.customFramework && opt.embed)
+    return GROUP_BY_FILETYPE['embedded.framework'] ?? DEFAULT_GROUP;
+  return groupName ?? DEFAULT_GROUP;
+}
+
+function detectSourcetree(fileRef: PbxFile): string {
+  const filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+  const sourcetree = SOURCETREE_BY_FILETYPE[unquoted(filetype)];
+  if (fileRef.explicitFileType) return DEFAULT_PRODUCT_SOURCETREE;
+  if (fileRef.customFramework) return DEFAULT_SOURCETREE;
+  return sourcetree ?? DEFAULT_SOURCETREE;
+}
+
+function defaultPath(fileRef: PbxFile, filePath: string): string {
+  const filetype = fileRef.lastKnownFileType || fileRef.explicitFileType;
+  const byType = PATH_BY_FILETYPE[unquoted(filetype)];
+  if (fileRef.customFramework) return filePath;
+  if (byType) return path.join(byType, path.basename(filePath));
+  return filePath;
+}
 
 export class PbxFile {
-  constructor(..._args: any[]) {
-    throw new Error('XcodeProjectShim pbxFile is not implemented yet');
+  basename: string;
+  lastKnownFileType?: string;
+  explicitFileType?: string;
+  group?: string;
+  customFramework?: boolean;
+  dirname?: string;
+  path?: string;
+  fileEncoding?: number;
+  defaultEncoding?: number;
+  sourceTree: string;
+  includeInIndex: number;
+  settings?: any;
+
+  // Assigned by the project after construction.
+  uuid?: string;
+  fileRef?: string;
+  target?: string;
+
+  constructor(filepath: string, opt: any = {}) {
+    this.basename = path.basename(filepath);
+    this.lastKnownFileType = opt.lastKnownFileType || detectType(filepath);
+    this.group = detectGroup(this, opt);
+
+    if (opt.customFramework === true) {
+      this.customFramework = true;
+      this.dirname = path.dirname(filepath).replace(/\\/g, '/');
+    }
+
+    this.path = defaultPath(this, filepath).replace(/\\/g, '/');
+    this.defaultEncoding = opt.defaultEncoding || defaultEncoding(this);
+    this.fileEncoding = this.defaultEncoding;
+
+    if (opt.explicitFileType) {
+      this.explicitFileType = opt.explicitFileType;
+      this.basename = this.basename + '.' + defaultExtension(this);
+      delete this.path;
+      delete this.lastKnownFileType;
+      delete this.group;
+      delete this.defaultEncoding;
+    }
+
+    this.sourceTree = opt.sourceTree || detectSourcetree(this);
+    this.includeInIndex = 0;
+
+    if (opt.weak === true) this.settings = { ATTRIBUTES: ['Weak'] };
+
+    if (opt.compilerFlags) {
+      if (!this.settings) this.settings = {};
+      this.settings.COMPILER_FLAGS = `"${opt.compilerFlags}"`;
+    }
+
+    if (opt.embed && opt.sign) {
+      if (!this.settings) this.settings = {};
+      if (!this.settings.ATTRIBUTES) this.settings.ATTRIBUTES = [];
+      this.settings.ATTRIBUTES.push('CodeSignOnCopy');
+    }
   }
 }
 

--- a/packages/@expo/config-plugins/src/ios/utils/xcodeShim/pbxFile.ts
+++ b/packages/@expo/config-plugins/src/ios/utils/xcodeShim/pbxFile.ts
@@ -1,0 +1,11 @@
+// Mirror of `xcode/lib/pbxFile`. Deep-imported by the `Xcodeproj.ts` wrapper,
+// `@expo/cli`, and community plugins (e.g. ios-stickers), so Phase 3 must expose
+// this at a compatible import path.
+
+export class PbxFile {
+  constructor(..._args: any[]) {
+    throw new Error('XcodeProjectShim pbxFile is not implemented yet');
+  }
+}
+
+export default PbxFile;

--- a/packages/@expo/config-plugins/src/plugins/withIosBaseMods.ts
+++ b/packages/@expo/config-plugins/src/plugins/withIosBaseMods.ts
@@ -15,6 +15,7 @@ import { ensureApplicationTargetEntitlementsFileConfigured } from '../ios/Entitl
 import type { InfoPlist } from '../ios/IosConfig.types';
 import { getPbxproj } from '../ios/utils/Xcodeproj';
 import { getInfoPlistPathFromPbxproj } from '../ios/utils/getInfoPlistPath';
+import { openXcodeProject } from '../ios/utils/xcodeShim/backend';
 import { fileExists } from '../utils/modules';
 import { sortObject } from '../utils/sortObject';
 import { addWarningIOS } from '../utils/warnings';
@@ -118,9 +119,7 @@ const defaultProviders = {
       return Paths.getPBXProjectPath(projectRoot);
     },
     async read(filePath) {
-      const project = xcode.project(filePath);
-      project.parseSync();
-      return project;
+      return openXcodeProject(filePath);
     },
     async write(filePath, { modResults }) {
       await writeFile(filePath, modResults.writeSync());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2171,6 +2171,9 @@ importers:
 
   packages/@expo/config-plugins:
     dependencies:
+      '@bacons/xcode':
+        specifier: 1.0.0-alpha.33
+        version: 1.0.0-alpha.33
       '@expo/config-types':
         specifier: workspace:^56.0.5
         version: link:../config-types
@@ -7125,6 +7128,9 @@ packages:
 
   '@bacons/xcode@1.0.0-alpha.29':
     resolution: {integrity: sha512-b2P+Y6ovdlie3A8Tx6QBFlbfQPhXe0vDS83W0DVob6732e3TukgVMbVcE9umn36BaeGzmJVjMFtqEyhWetjRWg==}
+
+  '@bacons/xcode@1.0.0-alpha.33':
+    resolution: {integrity: sha512-+vwXK3mLnW8NOYSHNpCa7sAYR7qWmIHM3xBbBkLailN81F1CdSVsJBH1TAnTMHb+rDEh5ehsZ8AQRNVxvhWR/Q==}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -16621,6 +16627,14 @@ snapshots:
       - supports-color
 
   '@bacons/xcode@1.0.0-alpha.29':
+    dependencies:
+      '@expo/plist': 0.0.18
+      debug: 4.4.3
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@bacons/xcode@1.0.0-alpha.33':
     dependencies:
       '@expo/plist': 0.0.18
       debug: 4.4.3


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
