### PR TITLE
Update SharedObjectRegistry.swift

### DIFF
--- a/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
+++ b/packages/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
@@ -34,7 +34,7 @@ public final class SharedObjectRegistry: Sendable {
   /**
    Weak reference to the app context for the registry.
    */
-  private weak let appContext: AppContext?
+  private weak var appContext: AppContext?
 
   internal struct State: Sendable {
     /**


### PR DESCRIPTION
change let to var because the property should be mutable for it pass swift 6 check in expo 56

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
