### PR TITLE
[ui][ios] Fix dotted line beneath `Slider` track when no label slots are provided

### DIFF
--- a/packages/expo-ui/CHANGELOG.md
+++ b/packages/expo-ui/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Fix dotted line beneath Slider track when no label slots are provided ([#46218](https://github.com/expo/expo/pull/46218) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-23

--- a/packages/expo-ui/ios/SliderView.swift
+++ b/packages/expo-ui/ios/SliderView.swift
@@ -53,51 +53,82 @@ struct SliderView: ExpoSwiftUI.View {
     let label = props.children?.slot("label")
     let minimumValueLabel = props.children?.slot("minimum")
     let maximumValueLabel = props.children?.slot("maximum")
+    let hasAnyLabel = label != nil || minimumValueLabel != nil || maximumValueLabel != nil
+
+    let handleEditingChanged: (Bool) -> Void = { isEditing in
+      self.isEditing = isEditing
+      props.onEditingChanged(["isEditing": isEditing])
+    }
 
     if let min = props.min, let max = props.max, let step = props.step {
-      Slider(
-        value: clampedBinding,
-        in: min...max,
-        step: step,
-        label: { label },
-        minimumValueLabel: { minimumValueLabel },
-        maximumValueLabel: { maximumValueLabel }
-      ) { isEditing in
-        self.isEditing = isEditing
-        props.onEditingChanged(["isEditing": isEditing])
+      if hasAnyLabel {
+        Slider(
+          value: clampedBinding,
+          in: min...max,
+          step: step,
+          label: { label },
+          minimumValueLabel: { minimumValueLabel },
+          maximumValueLabel: { maximumValueLabel },
+          onEditingChanged: handleEditingChanged
+        )
+      } else {
+        Slider(
+          value: clampedBinding,
+          in: min...max,
+          step: step,
+          onEditingChanged: handleEditingChanged
+        )
       }
     } else if let min = props.min, let max = props.max {
-      Slider(
-        value: clampedBinding,
-        in: min...max,
-        label: { label },
-        minimumValueLabel: { minimumValueLabel },
-        maximumValueLabel: { maximumValueLabel }
-      ) { isEditing in
-        self.isEditing = isEditing
-        props.onEditingChanged(["isEditing": isEditing])
+      if hasAnyLabel {
+        Slider(
+          value: clampedBinding,
+          in: min...max,
+          label: { label },
+          minimumValueLabel: { minimumValueLabel },
+          maximumValueLabel: { maximumValueLabel },
+          onEditingChanged: handleEditingChanged
+        )
+      } else {
+        Slider(
+          value: clampedBinding,
+          in: min...max,
+          onEditingChanged: handleEditingChanged
+        )
       }
     } else if let step = props.step {
-      Slider(
-        value: clampedBinding,
-        in: 0...1,
-        step: step,
-        label: { label },
-        minimumValueLabel: { minimumValueLabel },
-        maximumValueLabel: { maximumValueLabel }
-      ) { isEditing in
-        self.isEditing = isEditing
-        props.onEditingChanged(["isEditing": isEditing])
+      if hasAnyLabel {
+        Slider(
+          value: clampedBinding,
+          in: 0...1,
+          step: step,
+          label: { label },
+          minimumValueLabel: { minimumValueLabel },
+          maximumValueLabel: { maximumValueLabel },
+          onEditingChanged: handleEditingChanged
+        )
+      } else {
+        Slider(
+          value: clampedBinding,
+          in: 0...1,
+          step: step,
+          onEditingChanged: handleEditingChanged
+        )
       }
     } else {
-      Slider(
-        value: clampedBinding,
-        label: { label },
-        minimumValueLabel: { minimumValueLabel },
-        maximumValueLabel: { maximumValueLabel }
-      ) { isEditing in
-        self.isEditing = isEditing
-        props.onEditingChanged(["isEditing": isEditing])
+      if hasAnyLabel {
+        Slider(
+          value: clampedBinding,
+          label: { label },
+          minimumValueLabel: { minimumValueLabel },
+          maximumValueLabel: { maximumValueLabel },
+          onEditingChanged: handleEditingChanged
+        )
+      } else {
+        Slider(
+          value: clampedBinding,
+          onEditingChanged: handleEditingChanged
+        )
       }
     }
   }


### PR DESCRIPTION

# Why
Fixes https://github.com/expo/expo/issues/46154

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

SwiftUI's labeled Slider(value:in:step:label:minimumValueLabel:maximumValueLabel:onEditingChanged:) initializer reserves a dotted line beneath the track even when all label closures resolve to nil. SliderView.swift always called this initializer, so every unlabeled slider got a stray gray line on iOS 17+.
Compute hasAnyLabel from the three slot() lookups in SliderView.sliderContent and branch to the unlabeled Slider(...) initializer when none of the slots are provided, across all four (range, range+step, step-only, default) cases.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested in NCL sliderscreen
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
