### PR TITLE
[cli] Fix ESLint not found on first lint run

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -36,6 +36,7 @@
 - Switch `ManifestMiddleware` to `expo-server`'s response helpers to avoid cancellations being surfaced as exceptions ([#48700](https://github.com/expo/expo/pull/48700) by [@kitten](https://github.com/kitten))
 - Support npm@12's dictionary-based `npm pack --json` format ([#48761](https://github.com/expo/expo/pull/48761) by [@kitten](https://github.com/kitten))
 - Fix wirelessly connected iOS 16 and older devices being omitted from `expo run:ios --device` selection. ([#48127](https://github.com/expo/expo/pull/48127) by [@davellanedam](https://github.com/davellanedam))
+- Fix resolution of ESLint failing in `expo lint` after prerequisites check installs it ([#46223](https://github.com/expo/expo/pull/46223) by [@claritystorm](https://github.com/claritystorm))
 
 ### 💡 Others
 

--- a/packages/@expo/cli/src/lint/lintAsync.ts
+++ b/packages/@expo/cli/src/lint/lintAsync.ts
@@ -33,19 +33,16 @@ export const lintAsync = async (
 
   // TODO(@kitten): The direct require is fine, since we assume `expo > @expo/cli` does not depend on eslint
   // However, it'd be safer to replace this with resolve-from, or another way of requiring via the project root
-  const { loadESLint } = require('eslint');
+  const mod = require('eslint') as typeof import('eslint');
 
-  const mod = await import('eslint');
-
-  let ESLint: typeof import('eslint').ESLint;
   // loadESLint is >= 8.57.0 (https://github.com/eslint/eslint/releases/tag/v8.57.0) https://github.com/eslint/eslint/pull/18098
-  if ('loadESLint' in mod) {
-    ESLint = await loadESLint({ cwd: options.projectRoot });
-  } else {
+  if (!('loadESLint' in mod)) {
     throw new CommandError(
       'npx expo lint requires ESLint version 8.57.0 or greater. Upgrade eslint or use npx eslint directly.'
     );
   }
+
+  const ESLint = await mod.loadESLint({ cwd: options.projectRoot });
 
   const version = ESLint?.version;
 

--- a/packages/@expo/cli/src/lint/lintAsync.ts
+++ b/packages/@expo/cli/src/lint/lintAsync.ts
@@ -31,19 +31,16 @@ export const lintAsync = async (
 
   // TODO(@kitten): The direct require is fine, since we assume `expo > @expo/cli` does not depend on eslint
   // However, it'd be safer to replace this with resolve-from, or another way of requiring via the project root
-  const { loadESLint } = require('eslint');
+  const mod = require('eslint') as typeof import('eslint');
 
-  const mod = await import('eslint');
-
-  let ESLint: typeof import('eslint').ESLint;
   // loadESLint is >= 8.57.0 (https://github.com/eslint/eslint/releases/tag/v8.57.0) https://github.com/eslint/eslint/pull/18098
-  if ('loadESLint' in mod) {
-    ESLint = await loadESLint({ cwd: options.projectRoot });
-  } else {
+  if (!('loadESLint' in mod)) {
     throw new CommandError(
       'npx expo lint requires ESLint version 8.57.0 or greater. Upgrade eslint or use npx eslint directly.'
     );
   }
+
+  const ESLint = await mod.loadESLint({ cwd: options.projectRoot });
 
   const version = ESLint?.version;
 

--- a/packages/@expo/cli/src/lint/lintAsync.ts
+++ b/packages/@expo/cli/src/lint/lintAsync.ts
@@ -1,4 +1,5 @@
 import { createForProject } from '@expo/package-manager';
+import { resolveFrom, loadModuleSync } from '@expo/require-utils';
 import fs from 'node:fs';
 import path from 'node:path';
 import semver from 'semver';
@@ -11,6 +12,15 @@ import { event } from './events';
 import type { Options } from './resolveOptions';
 
 const DEFAULT_INPUTS = ['src', 'app', 'components'];
+
+function loadEslint(projectRoot: string): typeof import('eslint') | null {
+  const resolvedPath = resolveFrom(projectRoot, 'eslint', { skipNodePath: false });
+  if (!resolvedPath) {
+    return null;
+  } else {
+    return loadModuleSync(resolvedPath);
+  }
+}
 
 export const lintAsync = async (
   inputs: string[],
@@ -29,19 +39,15 @@ export const lintAsync = async (
     await prerequisite.bootstrapAsync();
   }
 
-  // TODO(@kitten): The direct require is fine, since we assume `expo > @expo/cli` does not depend on eslint
-  // However, it'd be safer to replace this with resolve-from, or another way of requiring via the project root
-  const mod = require('eslint') as typeof import('eslint');
-
+  const mod = loadEslint(projectRoot);
   // loadESLint is >= 8.57.0 (https://github.com/eslint/eslint/releases/tag/v8.57.0) https://github.com/eslint/eslint/pull/18098
-  if (!('loadESLint' in mod)) {
+  if (mod == null || !('loadESLint' in mod)) {
     throw new CommandError(
       'npx expo lint requires ESLint version 8.57.0 or greater. Upgrade eslint or use npx eslint directly.'
     );
   }
 
-  const ESLint = await mod.loadESLint({ cwd: options.projectRoot });
-
+  const ESLint = await mod.loadESLint({ cwd: options.projectRoot } as any);
   const version = ESLint?.version;
 
   if (!version || semver.lt(version, '8.57.0')) {


### PR DESCRIPTION
# Why

`npx expo lint` installs ESLint when it is missing and then immediately loads it within the same process. `await import()` cannot resolve a module installed mid-process, causing "Cannot find module 'eslint'" on the first run.

# How

Replace `await import('eslint')` with `require('eslint')`, which can resolve a module installed mid-process.

Edit by `@kitten`: Replace resolution and loading with `@expo/require-utils`

# Test Plan

1. Create a new Expo project.
2. Run `npx expo lint` for the first time, without adding ESLint or a configuration file beforehand.
3. Verify that lint ran successfully on the first run of `npx expo lint`.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)