### PR TITLE
[dev-launcher] Fix build phase output paths

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `defaultLaunchURL` being ignored on cold start when no recently-opened app was cached. ([#46185](https://github.com/expo/expo/pull/46185) by [@kaihirota](https://github.com/kaihirota))
-- [iOS] Declare matching `outputPaths` on build phase to prevent a dependency cycle when the main target embeds an app extension. ([#46224](https://github.com/expo/expo/pull/46224) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Order the build phase by array position to avoid a dependency cycle when the main target embeds an app extension. ([#46224](https://github.com/expo/expo/pull/46224) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `defaultLaunchURL` being ignored on cold start when no recently-opened app was cached. ([#46185](https://github.com/expo/expo/pull/46185) by [@kaihirota](https://github.com/kaihirota))
+- [iOS] Declare matching `outputPaths` on build phase to prevent a dependency cycle when the main target embeds an app extension. ([#46204](https://github.com/expo/expo/issues/46204) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### 🐛 Bug fixes
 
 - [iOS] Fixed `defaultLaunchURL` being ignored on cold start when no recently-opened app was cached. ([#46185](https://github.com/expo/expo/pull/46185) by [@kaihirota](https://github.com/kaihirota))
-- [iOS] Declare matching `outputPaths` on build phase to prevent a dependency cycle when the main target embeds an app extension. ([#46204](https://github.com/expo/expo/issues/46204) by [@alanjhughes](https://github.com/alanjhughes))
+- [iOS] Declare matching `outputPaths` on build phase to prevent a dependency cycle when the main target embeds an app extension. ([#46224](https://github.com/expo/expo/pull/46224) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -31,8 +31,6 @@ const withStripLocalNetworkKeysForRelease = (config) => {
         }
         project.addBuildPhase([], 'PBXShellScriptBuildPhase', buildPhaseName, nativeTargetId, {
             shellPath: '/bin/sh',
-            inputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
-            outputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
             shellScript: `# Strip dev-launcher-specific local network permission keys from non-Debug builds
 # This only removes _expo._tcp Bonjour services and the dev-launcher usage description.
 # Other Bonjour services and custom descriptions are preserved for production use.
@@ -69,6 +67,16 @@ if [ "$CONFIGURATION" != "Debug" ]; then
 fi
 `,
         });
+        const targetPhases = project.pbxNativeTargetSection()[nativeTargetId]?.buildPhases ?? [];
+        const addedIdx = targetPhases.findIndex((p) => p.comment === buildPhaseName);
+        if (addedIdx >= 0) {
+            const [added] = targetPhases.splice(addedIdx, 1);
+            if (added) {
+                const firstEmbedIdx = targetPhases.findIndex((p) => /^Embed |^\[CP\] Embed /.test(p.comment ?? ''));
+                const insertIdx = firstEmbedIdx >= 0 ? firstEmbedIdx : targetPhases.length;
+                targetPhases.splice(insertIdx, 0, added);
+            }
+        }
         return config;
     });
 };

--- a/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
+++ b/packages/expo-dev-launcher/plugin/build/withDevLauncher.js
@@ -32,6 +32,7 @@ const withStripLocalNetworkKeysForRelease = (config) => {
         project.addBuildPhase([], 'PBXShellScriptBuildPhase', buildPhaseName, nativeTargetId, {
             shellPath: '/bin/sh',
             inputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
+            outputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
             shellScript: `# Strip dev-launcher-specific local network permission keys from non-Debug builds
 # This only removes _expo._tcp Bonjour services and the dev-launcher usage description.
 # Other Bonjour services and custom descriptions are preserved for production use.

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -46,8 +46,6 @@ const withStripLocalNetworkKeysForRelease: ConfigPlugin = (config) => {
 
     project.addBuildPhase([], 'PBXShellScriptBuildPhase', buildPhaseName, nativeTargetId, {
       shellPath: '/bin/sh',
-      inputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
-      outputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
       shellScript: `# Strip dev-launcher-specific local network permission keys from non-Debug builds
 # This only removes _expo._tcp Bonjour services and the dev-launcher usage description.
 # Other Bonjour services and custom descriptions are preserved for production use.
@@ -84,6 +82,20 @@ if [ "$CONFIGURATION" != "Debug" ]; then
 fi
 `,
     });
+
+    const targetPhases: { value: string; comment?: string }[] =
+      project.pbxNativeTargetSection()[nativeTargetId]?.buildPhases ?? [];
+    const addedIdx = targetPhases.findIndex((p) => p.comment === buildPhaseName);
+    if (addedIdx >= 0) {
+      const [added] = targetPhases.splice(addedIdx, 1);
+      if (added) {
+        const firstEmbedIdx = targetPhases.findIndex((p) =>
+          /^Embed |^\[CP\] Embed /.test(p.comment ?? '')
+        );
+        const insertIdx = firstEmbedIdx >= 0 ? firstEmbedIdx : targetPhases.length;
+        targetPhases.splice(insertIdx, 0, added);
+      }
+    }
 
     return config;
   });

--- a/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
+++ b/packages/expo-dev-launcher/plugin/src/withDevLauncher.ts
@@ -47,6 +47,7 @@ const withStripLocalNetworkKeysForRelease: ConfigPlugin = (config) => {
     project.addBuildPhase([], 'PBXShellScriptBuildPhase', buildPhaseName, nativeTargetId, {
       shellPath: '/bin/sh',
       inputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
+      outputPaths: ['"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)"'],
       shellScript: `# Strip dev-launcher-specific local network permission keys from non-Debug builds
 # This only removes _expo._tcp Bonjour services and the dev-launcher usage description.
 # Other Bonjour services and custom descriptions are preserved for production use.


### PR DESCRIPTION
# Why
Closes #46204

# How
~~Declare a matching `outputPaths` so Xcode treats the script as an in-place transform of Info.plist~~
Had to use a different approach.
Drop `inputPaths` entirely and instead position the phase in the target's `buildPhases[]` immediately before the first `Embed` phase.

This gives us the same ordering #46125 was trying to achieve. Strip runs after `Resources` / `Bundle React Native code and images` (which produce Info.plist) and before any embed phase that would re-stamp it, but without entering Xcode's dependency-graph at all. 

# Test Plan
Fixed in the provided repro
