### PR TITLE
[cli] Support TypeScript ESLint config files

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -54,6 +54,7 @@
 - Bump to `multitars@1.0.2` to address symlink and unicode bugs ([#48833](https://github.com/expo/expo/pull/48833) by [@kitten](https://github.com/kitten))
 - [Internal] Move static HTML asset injection into `getStaticContent()`. ([#47006](https://github.com/expo/expo/pull/47006) by [@hassankhan](https://github.com/hassankhan))
 - Prewarm Metro transform workers while waiting for the first development bundle request ([#48836](https://github.com/expo/expo/pull/48836) by [@kitten](https://github.com/kitten))
+- Discover `.ts`, `.mts`, and `.cts` ESLint configs as well when checking for prerequisites for ESLint ([#46225](https://github.com/expo/expo/pull/46225) by [@claritystorm](https://github.com/claritystorm))
 
 ## 57.0.11 - 2026-07-29
 

--- a/packages/@expo/cli/src/lint/ESlintPrerequisite.ts
+++ b/packages/@expo/cli/src/lint/ESlintPrerequisite.ts
@@ -133,7 +133,14 @@ async function isLegacyEslintConfigured(projectRoot: string) {
 async function isEslintConfigured(projectRoot: string) {
   debug('Ensuring ESLint is configured in', projectRoot);
 
-  const eslintConfigFiles = ['eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs'];
+  const eslintConfigFiles = [
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.ts',
+    'eslint.config.mts',
+    'eslint.config.cts',
+  ];
   for (const configFile of eslintConfigFiles) {
     const configPath = findFileInParents(projectRoot, configFile);
 

--- a/packages/@expo/cli/src/lint/ESlintPrerequisite.ts
+++ b/packages/@expo/cli/src/lint/ESlintPrerequisite.ts
@@ -125,7 +125,14 @@ async function isLegacyEslintConfigured(projectRoot: string) {
 
 /** Check for flat config. */
 async function isEslintConfigured(projectRoot: string) {
-  const eslintConfigFiles = ['eslint.config.js', 'eslint.config.mjs', 'eslint.config.cjs'];
+  const eslintConfigFiles = [
+    'eslint.config.js',
+    'eslint.config.mjs',
+    'eslint.config.cjs',
+    'eslint.config.ts',
+    'eslint.config.mts',
+    'eslint.config.cts',
+  ];
   for (const configFile of eslintConfigFiles) {
     const configPath = findFileInParents(projectRoot, configFile);
 


### PR DESCRIPTION
# Why

Adds TypeScript ESLint configuration file support (`eslint.config.ts`, `.mts`, `.cts`), following native TypeScript configuration support in ESLint v9.18.0 (January 2025), fixing "No ESLint config found" output from `npx expo lint` with `eslint.config.ts`.

# How

Extended configuration file resolution to check for `.ts`, `.mts`, and `.cts` extensions.

# Test Plan

```
npx create-expo-app@latest test --yes && cd test
npx expo lint # Creates eslint.config.js
mv eslint.config.{js,ts}
npx expo lint # Runs ESLint
```

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
