### PR TITLE
[brownfield]  Make ReactNativeHostManager accessible directly to Objective-C

### DIFF
--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### 🎉 New features
 
-- [iOS] Make `ReactNativeHostManager` accessible directly to Objective-C. ([@gabrieldonadel](https://github.com/gabrieldonadel))
+- [iOS] Make `ReactNativeHostManager` accessible directly to Objective-C. ([#46227](https://github.com/expo/expo/pull/46227) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Make `ReactNativeHostManager` accessible directly to Objective-C. ([@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
@@ -10,8 +10,9 @@ import UIKit
 internal import EXDevMenu
 #endif
 
-public class ReactNativeHostManager {
-  public static let shared = ReactNativeHostManager()
+@objc
+public class ReactNativeHostManager: NSObject {
+  @objc public static let shared = ReactNativeHostManager()
 
   private var reactNativeDelegate: ExpoReactNativeFactoryDelegate?
   private var reactNativeFactory: RCTReactNativeFactory?
@@ -19,11 +20,14 @@ public class ReactNativeHostManager {
   private var devMenuInitialized: Bool = false
   private var turboModuleClasses: [String: AnyClass] = [:]
 
+  private override init() {
+    super.init()
+  }
   /**
    * Initializes ReactNativeHostManager instance
    * Instance can be initialized only once
    */
-  public func initialize(turboModuleClasses: [String: AnyClass] = [:]) {
+  @objc public func initialize(turboModuleClasses: [String: AnyClass] = [:]) {
     if firstLoadInitialized {
       return
     }
@@ -38,7 +42,7 @@ public class ReactNativeHostManager {
   /**
    * Creates the React Native view using RCTReactNativeFactory
    */
-  public func loadView(
+  @objc public func loadView(
     moduleName: String = "main",
     initialProps: [AnyHashable: Any]?,
     launchOptions: [AnyHashable: Any]?
@@ -72,7 +76,7 @@ public class ReactNativeHostManager {
    * Cleans up the previous instance of React Native
    * to prevent memory leaks
    */
-  public func cleanupPreviousInstance() {
+  @objc public func cleanupPreviousInstance() {
     if let rootViewFactory = reactNativeFactory?.rootViewFactory {
       rootViewFactory.setValue(nil, forKey: "_reactHost")
       reactNativeDelegate = nil

--- a/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
+++ b/packages/expo-brownfield/plugin/templates/ios/ReactNativeHostManager.swift
@@ -65,7 +65,7 @@ public class ReactNativeHostManager: NSObject {
  /**
   * Initializes a React Native instance
   */
-  public func initializeInstance() {
+  @objc public func initializeInstance() {
     let delegate = ReactNativeDelegate(turboModuleClasses: turboModuleClasses)
     reactNativeFactory = ExpoReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()


### PR DESCRIPTION
# Why

Host apps written in Objective-C currently can't call `ReactNativeHostManager.shared.initialize(...)` directly. The class has no`@objc` exposure, so integrators have been forced to add a small Swift shim

# How

`ReactNativeHostManager` now inherits from `NSObject` and its public surface (`shared`, `initialize(turboModuleClasses:)`, `loadView(...)`, `cleanupPreviousInstance()`) is annotated `@objc`, so it bridges to Objective-C without any wrapper.

# Test Plan

- Verified that an Objective-C host app can call `[ReactNativeHostManager.shared initializeWithTurboModuleClasses:@{}]`, `[[ReactNativeHostManager shared] loadView…]`, and `[[ReactNativeHostManager shared] cleanupPreviousInstance]` directly, with no Swift wrapper. 
- Ran the brownfield-tester isolated iOS target 
