### PR TITLE
[docs] Sync app clip skill in Expo Skills

### DIFF
--- a/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
+++ b/docs/ui/components/ExpoSkillsTable/data/expo-skills.json
@@ -2,10 +2,15 @@
   "source": {
     "repo": "expo/skills",
     "url": "https://api.github.com/repos/expo/skills/contents/plugins/expo/skills",
-    "fetchedAt": "2026-05-21T11:09:35.811Z"
+    "fetchedAt": "2026-05-25T01:22:55.986Z"
   },
-  "totalSkills": 14,
+  "totalSkills": 15,
   "skills": [
+    {
+      "name": "add-app-clip",
+      "description": "Add an iOS App Clip target to an Expo app. Use when the user mentions App Clip, AASA, apple-app-site-association, appclips, smart app banner, or wants to ship a lightweight iOS Clip invoked from a URL alongside their parent app.",
+      "githubUrl": "https://github.com/expo/skills/blob/main/plugins/expo/skills/add-app-clip/SKILL.md"
+    },
     {
       "name": "building-native-ui",
       "description": "Complete guide for building beautiful apps with Expo Router. Covers fundamentals, styling, components, navigation, animations, patterns, and native tabs.",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Sync app clip skill in Expo Skills.

# How

<!--
How did you build this feature or fix this bug and why?
-->

Run `pnpm expo-skills-sync`.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

N/A

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
