### PR TITLE
chore: update react-native-view-shot dependency

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -110,7 +110,7 @@
   "react-native-screens": "4.25.1",
   "react-native-safe-area-context": "~5.7.0",
   "react-native-svg": "15.15.4",
-  "react-native-view-shot": "4.0.3",
+  "react-native-view-shot": "5.1.0",
   "react-native-webview": "13.16.1",
   "react-server-dom-webpack": "~19.2.4",
   "sentry-expo": "~7.0.0",


### PR DESCRIPTION
This PR updates the expo doctor check compatibility to react-native-view-shot v5.1.0

The existing v4.0.3 does not build with expo 56. The v5.1.0 builds correctly with Android and iOS