### PR TITLE
chore: update react-native-view-shot dependency

### DIFF
--- a/packages/expo/bundledNativeModules.json
+++ b/packages/expo/bundledNativeModules.json
@@ -110,7 +110,7 @@
   "react-native-screens": "4.25.2",
   "react-native-safe-area-context": "~5.7.0",
   "react-native-svg": "15.15.4",
-  "react-native-view-shot": "4.0.3",
+  "react-native-view-shot": "5.1.0",
   "react-native-webview": "13.16.1",
   "react-server-dom-webpack": "~19.2.4",
   "sentry-expo": "~7.0.0",


### PR DESCRIPTION
# Why

react-native-view-shot v4.0.3 does not build with expo 56 on iOS

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How



bump to 5.1.0

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

build in separate playground app

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)