### PR TITLE
[template-bare-minimum] gitignore generated gradle-daemon-jvm.properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
-- [templates] Ignore generated `android/gradle/gradle-daemon-jvm.properties` in `expo-template-bare-minimum`. ([#46233](https://github.com/expo/expo/pull/46233) by [@tomekzaw](https://github.com/tomekzaw))
-
 ## 55.0.0 — 2026-02-25
 
 ### 🛠 Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Package-specific changes not released in any SDK will be added here just before 
 
 ### 🐛 Bug fixes
 
+- [templates] Ignore generated `android/gradle/gradle-daemon-jvm.properties` in `expo-template-bare-minimum`. ([#46233](https://github.com/expo/expo/pull/46233) by [@tomekzaw](https://github.com/tomekzaw))
+
 ## 55.0.0 — 2026-02-25
 
 ### 🛠 Breaking changes

--- a/templates/expo-template-bare-minimum/android/gitignore
+++ b/templates/expo-template-bare-minimum/android/gitignore
@@ -11,6 +11,7 @@ local.properties
 *.iml
 *.hprof
 .cxx/
+gradle/gradle-daemon-jvm.properties
 
 # generated inline modules
 app/src/main/java/inline/


### PR DESCRIPTION
# Why

The `android/gradle/gradle-daemon-jvm.properties` file is generated automatically by Gradle's `updateDaemonJvm` task (its first line is `#This file is generated by updateDaemonJvm`). It stores machine/architecture-specific toolchain download URLs (per-OS foojay.io redirect IDs) and the resolved toolchain version, so its contents differ across developer machines and shouldn't be tracked in source control. After running an Android build in a project created from `expo-template-bare-minimum`, the file currently shows up as untracked in `git status`.

# How

Add `gradle/gradle-daemon-jvm.properties` to `templates/expo-template-bare-minimum/android/gitignore`. The other Expo templates ignore `/android` entirely at the project root, so no change is needed in them.

# Test Plan

- Created a project from `expo-template-bare-minimum`.
- Ran an Android build that triggers daemon-JVM resolution; observed `android/gradle/gradle-daemon-jvm.properties` is created.
- Verified `git status` no longer reports the file as untracked with this change.

# Checklist

- [x] I added a `changelog.md` entry — added under "🐛 Bug fixes" in the root `CHANGELOG.md` (no package applies for a templates-only change).
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build.
- [x] Conforms with the Documentation Writing Style Guide.