### PR TITLE
[ncl] Fix broken import in `benchmark-helper`

### DIFF
--- a/apps/bare-expo/modules/benchmark-helper/src/index.ts
+++ b/apps/bare-expo/modules/benchmark-helper/src/index.ts
@@ -1,4 +1,4 @@
-import { NativeModule, Platform, requireNativeModule } from 'expo';
+import { NativeModule, Platform, requireNativeModule } from 'expo-modules-core';
 
 declare class BenchmarkHelperModule extends NativeModule {
   reportFullyDrawn(): void;


### PR DESCRIPTION
# Why

Bare expo fails to open the ncl app, due to 

```
 ERROR  [runtime not ready]: TypeError: Cannot read property 'OS' of undefined
```

# How

Update the import in benchmark helper to import from `expo-modules-core` instead of `expo`. 

We can also fix it by re-exporting `Platform` from `expo` but I'm not sure which solution is prefferred.

# Test Plan

Tested by opening the bare expo app on iOS.
