### PR TITLE
[docs] Note Android 14 requirement on Location FGS plugin prop

### DIFF
--- a/docs/pages/versions/unversioned/sdk/location.mdx
+++ b/docs/pages/versions/unversioned/sdk/location.mdx
@@ -90,7 +90,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'isAndroidForegroundServiceEnabled',
       platform: 'android',
       description:
-        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
+        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location) (required on Android 14 and later when running a location foreground service). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
     },
     {
       name: 'androidForegroundServiceIcon',

--- a/docs/pages/versions/v54.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/location.mdx
@@ -90,7 +90,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'isAndroidForegroundServiceEnabled',
       platform: 'android',
       description:
-        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
+        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location) (required on Android 14 and later when running a location foreground service). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
     },
   ]}
 />

--- a/docs/pages/versions/v55.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/location.mdx
@@ -90,7 +90,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'isAndroidForegroundServiceEnabled',
       platform: 'android',
       description:
-        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
+        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location) (required on Android 14 and later when running a location foreground service). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
     },
     {
       name: 'androidForegroundServiceIcon',

--- a/docs/pages/versions/v56.0.0/sdk/location.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/location.mdx
@@ -90,7 +90,7 @@ You can configure `expo-location` using its built-in [config plugin](/config-plu
       name: 'isAndroidForegroundServiceEnabled',
       platform: 'android',
       description:
-        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
+        'A boolean to enable the [`FOREGROUND_SERVICE`](#permission-foreground_service) permission and [`FOREGROUND_SERVICE_LOCATION`](#permission-foreground_service_location) (required on Android 14 and later when running a location foreground service). Defaults to `true` if `isAndroidBackgroundLocationEnabled` is `true`, otherwise `false`.',
     },
     {
       name: 'androidForegroundServiceIcon',


### PR DESCRIPTION
# Why


Fix ENG-21408

The description for `isAndroidForegroundServiceEnabled` doesn't mention that `FOREGROUND_SERVICE_LOCATION` is only required as of Android 14, so developers reading the config table miss context already documented further down the same page.

# How

Update the description string in the `<ConfigPluginProperties>` entry for `isAndroidForegroundServiceEnabled` in `pages/versions/v56.0.0/sdk/location.mdx` to surface the Android 14 requirement, reusing the phrasing already in the page's "Permissions" section.

# Test Plan

Proofread

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
