### PR TITLE
fix(docs): initialize AuthContext with null

### DIFF
--- a/docs/pages/router/advanced/authentication.mdx
+++ b/docs/pages/router/advanced/authentication.mdx
@@ -58,12 +58,7 @@ const AuthContext = createContext<{
   signOut: () => void;
   session?: string | null;
   isLoading: boolean;
-}>({
-  signIn: () => null,
-  signOut: () => null,
-  session: null,
-  isLoading: false,
-});
+} | null>(null);
 
 // Use this hook to access the user info.
 export function useSession() {


### PR DESCRIPTION
# Why

The `AuthContext` is initialized with a non-null default object, which makes the `useSession` guard unreachable. When a component calls `useSession` outside of `<SessionProvider />`, `useContext` returns the default object — never `null` — so this check:

```ts
if (!value) {
  throw new Error('useSession must be wrapped in a <SessionProvider />');
}
```

...never fires. The missing Provider goes silently undetected, and `signIn`/`signOut` silently no-op instead of surfacing a helpful error to the developer.


# Fix

Initialize `AuthContext` with `null` and add `| null` to the type:

```ts
const AuthContext = createContext<{
  signIn: () => void;
  signOut: () => void;
  session?: string | null;
  isLoading: boolean;
} | null>(null);
```

Now `useContext` returns `null` when no Provider is present, the guard fires correctly, and developers get the intended error message.