### PR TITLE
 [docs] Clarify expo-battery web browser compatibility

### DIFF
--- a/docs/pages/versions/unversioned/sdk/battery.mdx
+++ b/docs/pages/versions/unversioned/sdk/battery.mdx
@@ -13,6 +13,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-battery` provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
+> **info** **Note:** On web, `expo-battery` relies on the [Battery Status API](https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API), which is only implemented in Chromium-based browsers (Chrome, Edge, Opera). On unsupported browsers, [`getBatteryLevelAsync()`](#getbatterylevelasync) resolves to `-1` and [`getBatteryStateAsync()`](#getbatterystateasync) resolves to `BatteryState.UNKNOWN`.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v54.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/battery.mdx
@@ -13,6 +13,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-battery` provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
+> **info** **Note:** On web, `expo-battery` relies on the [Battery Status API](https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API), which is only implemented in Chromium-based browsers (Chrome, Edge, Opera). On unsupported browsers, [`getBatteryLevelAsync()`](#getbatterylevelasync) resolves to `-1` and [`getBatteryStateAsync()`](#getbatterystateasync) resolves to `BatteryState.UNKNOWN`.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v55.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/battery.mdx
@@ -13,6 +13,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-battery` provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
+> **info** **Note:** On web, `expo-battery` relies on the [Battery Status API](https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API), which is only implemented in Chromium-based browsers (Chrome, Edge, Opera). On unsupported browsers, [`getBatteryLevelAsync()`](#getbatterylevelasync) resolves to `-1` and [`getBatteryStateAsync()`](#getbatterystateasync) resolves to `BatteryState.UNKNOWN`.
+
 ## Installation
 
 <APIInstallSection />

--- a/docs/pages/versions/v56.0.0/sdk/battery.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/battery.mdx
@@ -13,6 +13,8 @@ import { SnackInline } from '~/ui/components/Snippet';
 
 `expo-battery` provides battery information for the physical device (such as battery level, whether or not the device is charging, and more) as well as corresponding event listeners.
 
+> **info** **Note:** On web, `expo-battery` relies on the [Battery Status API](https://developer.mozilla.org/en-US/docs/Web/API/Battery_Status_API), which is only implemented in Chromium-based browsers (Chrome, Edge, Opera). On unsupported browsers, [`getBatteryLevelAsync()`](#getbatterylevelasync) resolves to `-1` and [`getBatteryStateAsync()`](#getbatterystateasync) resolves to `BatteryState.UNKNOWN`.
+
 ## Installation
 
 <APIInstallSection />


### PR DESCRIPTION
# Why

Fix ENG-21411

# How

Added an info callout to `pages/versions/unversioned/sdk/battery.mdx` after the introduction that provides info on the Chromium-only browser support and documents the `-1` and `BatteryState.UNKNOWN` fallback values returned by `getBatteryLevelAsync()` and `getBatteryStateAsync()` on unsupported browsers.

# Test Plan

Proofread.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).
