### PR TITLE
[expo-notifications] Guard against broken localStorage in ServerRegistrationModule.web

### DIFF
--- a/packages/expo-notifications/src/ServerRegistrationModule.web.ts
+++ b/packages/expo-notifications/src/ServerRegistrationModule.web.ts
@@ -16,6 +16,9 @@ export default {
     let installationId;
 
     try {
+      if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
+        return getFallbackInstallationId();
+      }
       installationId = localStorage.getItem(INSTALLATION_ID_KEY);
       if (!installationId || typeof installationId !== 'string') {
         installationId = uuid.v4();
@@ -28,7 +31,7 @@ export default {
     return installationId;
   },
   getRegistrationInfoAsync: async () => {
-    if (typeof localStorage === 'undefined') {
+    if (typeof localStorage === 'undefined' || typeof localStorage.getItem !== 'function') {
       return null;
     }
     return localStorage.getItem(REGISTRATION_INFO_KEY);


### PR DESCRIPTION
## Why

Node.js v22+ provides an experimental `localStorage` global when run with `--localstorage-file`. Expo's static rendering for web uses this, but the experimental localStorage can report as `defined` while having broken methods (e.g., `getItem` is present but throws because no valid file path was provided).

This causes a crash during `npx expo export --platform web`:

```
TypeError: localStorage.getItem is not a function
    at Object.getRegistrationInfoAsync (ServerRegistrationModule.web.js:28:29)
```

## What

Adds `typeof localStorage.getItem !== 'function'` guards alongside the existing `typeof localStorage === 'undefined'` checks in both `getInstallationIdAsync` and `getRegistrationInfoAsync`. When the experimental localStorage is available but non-functional, these methods now fall back gracefully instead of throwing.

## How to reproduce

1. Use Node.js 22+ (tested on v25.0.0)
2. `npx expo export --platform web` in a project using expo-notifications
3. Observe the crash during static rendering

## Test plan

- [x] Existing `ServerRegistrationModule` tests pass
- [x] Manual: `expo export --platform web` succeeds on Node.js 22+