### PR TITLE
[expo-router] clean up tests log output

### DIFF
--- a/packages/expo-router/src/__tests__/SuspenseFallback.test.ios.tsx
+++ b/packages/expo-router/src/__tests__/SuspenseFallback.test.ios.tsx
@@ -12,6 +12,35 @@ const renderFallback = (route: string, testID = 'custom-fallback') => (
   </View>
 );
 
+// TODO(@ubax): this is only a workaround to clean-up CI outputs. Find a better solution
+// Tests in this file use a never-resolving promise to keep a route in its Suspense fallback.
+// React 19 schedules passive effects for the suspended subtree via reconnectPassiveEffects,
+// and PreventRemoveProvider (mounted by the implicit Stack navigator) updates a parent
+// provider's state from one of those effects after the render's act wrapper has closed.
+// That update is harmless (it's part of the suspended boundary's own bookkeeping and the
+// tests never assert against it), but React's test renderer surfaces it as an act warning.
+// Silence only that specific warning so other unexpected console.error output still fails CI.
+let consoleErrorSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  const originalError = console.error;
+  consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    const format = typeof args[0] === 'string' ? args[0] : '';
+    const componentName = typeof args[1] === 'string' ? args[1] : '';
+    if (
+      format.startsWith('An update to %s inside a test was not wrapped in act') &&
+      componentName === 'PreventRemoveProvider'
+    ) {
+      return;
+    }
+    originalError(...args);
+  });
+});
+
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
+});
+
 it('inherits `<SuspenseFallback>` from the nearest layout in sync mode', () => {
   const pending = new Promise<string>(() => {});
 

--- a/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarButton.test.ios.tsx
+++ b/packages/expo-router/src/layouts/stack-utils/__tests__/StackToolbarButton.test.ios.tsx
@@ -252,55 +252,6 @@ describe('StackToolbarButton component', () => {
     );
   });
 
-  it('passes imageRenderingMode as template when tintColor is set', () => {
-    render(
-      <ToolbarPlacementContext.Provider value="bottom">
-        <StackToolbarButton icon={{ uri: 'image' }} tintColor="blue">
-          Test
-        </StackToolbarButton>
-      </ToolbarPlacementContext.Provider>
-    );
-
-    expect(MockedRouterToolbarItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        imageRenderingMode: 'template',
-      }),
-      undefined
-    );
-  });
-
-  it('passes imageRenderingMode as original when no tintColor', () => {
-    render(
-      <ToolbarPlacementContext.Provider value="bottom">
-        <StackToolbarButton icon={{ uri: 'image' }}>Test</StackToolbarButton>
-      </ToolbarPlacementContext.Provider>
-    );
-
-    expect(MockedRouterToolbarItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        imageRenderingMode: 'original',
-      }),
-      undefined
-    );
-  });
-
-  it('uses explicit iconRenderingMode prop', () => {
-    render(
-      <ToolbarPlacementContext.Provider value="bottom">
-        <StackToolbarButton icon={{ uri: 'image' }} iconRenderingMode="template">
-          Test
-        </StackToolbarButton>
-      </ToolbarPlacementContext.Provider>
-    );
-
-    expect(MockedRouterToolbarItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        imageRenderingMode: 'template',
-      }),
-      undefined
-    );
-  });
-
   it('passes xcassetName from StackToolbarIcon xcasset child', () => {
     render(
       <ToolbarPlacementContext.Provider value="bottom">
@@ -386,23 +337,6 @@ describe('StackToolbarButton component', () => {
       expect.objectContaining({
         xcassetName: 'custom-icon',
         imageRenderingMode: 'original',
-      }),
-      undefined
-    );
-  });
-
-  it('Icon child renderingMode overrides parent iconRenderingMode for src icon', () => {
-    render(
-      <ToolbarPlacementContext.Provider value="bottom">
-        <StackToolbarButton iconRenderingMode="original">
-          <StackToolbarIcon src={{ uri: 'image' }} renderingMode="template" />
-        </StackToolbarButton>
-      </ToolbarPlacementContext.Provider>
-    );
-
-    expect(MockedRouterToolbarItem).toHaveBeenCalledWith(
-      expect.objectContaining({
-        imageRenderingMode: 'template',
       }),
       undefined
     );

--- a/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/missing-dependency.test.ios.tsx
+++ b/packages/expo-router/src/react-navigation/material-top-tabs/__tests__/missing-dependency.test.ios.tsx
@@ -1,5 +1,13 @@
 import { expect, test } from '@jest/globals';
 
+jest.mock(
+  'react-native-tab-view',
+  () => {
+    throw new Error("Cannot find module 'react-native-tab-view'");
+  },
+  { virtual: true }
+);
+
 test('throws an error when react-native-tab-view is not installed', () => {
   expect(() => require('../index')).toThrow(
     "Install the 'react-native-tab-view' package and its peer dependencies to use the Expo Router's TopTabs."


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
