### PR TITLE
[core][Android] Create Compose props without View

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [Android] Create Compose props without View. ([#46256](https://github.com/expo/expo/pull/46256) by [@jakex7](https://github.com/jakex7))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeProps.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeProps.kt
@@ -1,7 +1,42 @@
 package expo.modules.kotlin.views
 
+import com.facebook.react.bridge.ReadableMap
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.recycle
+
 /**
  * A marker interface for props classes that are used to pass data to Compose views.
  * Needed for the R8 to not remove needed  signatures that are used to receive prop types.
  */
 interface ComposeProps
+
+inline fun <reified Props : ComposeProps> createComposeProps(
+  propsMap: ReadableMap?,
+  appContext: AppContext? = null
+): Props {
+  val propsParsingStrategy = toPropsParsingStrategy<Props>()
+  val propsInstance = propsParsingStrategy.createNewInstance()
+
+  if (propsMap == null) {
+    return propsInstance
+  }
+
+  val props = propsParsingStrategy.props()
+  val iterator = propsMap.keySetIterator()
+
+  while (iterator.hasNextKey()) {
+    val name = iterator.nextKey()
+    val prop = props[name] ?: continue
+
+    propsMap.getDynamic(name).recycle {
+      @Suppress("UNCHECKED_CAST")
+      prop.setPropDirectly(
+        prop = this,
+        currentProps = propsInstance,
+        appContext = appContext
+      ) as Props
+    }
+  }
+
+  return propsInstance
+}

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ComposeViewProp.kt
@@ -20,11 +20,16 @@ class ComposeViewProp(
 
   @Suppress("UNCHECKED_CAST")
   override fun set(prop: Dynamic, onView: View, appContext: AppContext?) {
-    setPropDirectly(prop, onView, appContext)
+    setPropDirectly(prop = prop, onView = onView, appContext = appContext)
   }
 
   override fun set(prop: Any?, onView: View, appContext: AppContext?) {
-    setPropDirectly(prop, onView, appContext)
+    setPropDirectly(prop = prop, onView = onView, appContext = appContext)
+  }
+
+  @PublishedApi
+  internal fun setPropDirectly(prop: Dynamic, currentProps: Any, appContext: AppContext?): Any {
+    return copyPropsWithNewValue(prop, currentProps, appContext) ?: currentProps
   }
 
   @Suppress("UNCHECKED_CAST")
@@ -37,15 +42,7 @@ class ComposeViewProp(
       if (onView is ComposeFunctionHolder<*>) {
         // Use current props state, not the initial props instance
         val currentProps = onView.propsMutableState.value
-        // TODO(@lukmccall): We should remove the copy call
-        val copy = currentProps::class.memberFunctions.firstOrNull { it.name == "copy" }
-        if (copy == null) {
-          logger.warn("⚠️ Props are not a data class with default values for all properties, cannot set prop $name dynamically.")
-          return@exceptionDecorator
-        }
-        val instanceParam = copy.instanceParameter!!
-        val newPropParam = copy.parameters.firstOrNull { it.name == name } ?: return@exceptionDecorator
-        val result = copy.callBy(mapOf(instanceParam to currentProps, newPropParam to type.convert(prop, appContext)))
+        val result = copyPropsWithNewValue(prop, currentProps, appContext) ?: return@exceptionDecorator
         // Set the new props instance back to the onView
         (onView.propsMutableState as MutableState<Any?>).value = result
         return@exceptionDecorator
@@ -58,6 +55,18 @@ class ComposeViewProp(
         logger.warn("⚠️ Property $name is not a MutableState in ${onView::class.java}")
       }
     }
+  }
+
+  private fun copyPropsWithNewValue(prop: Any?, currentProps: Any, appContext: AppContext?): Any? {
+    // TODO(@lukmccall): We should remove the copy call
+    val copy = currentProps::class.memberFunctions.firstOrNull { it.name == "copy" }
+    if (copy == null) {
+      logger.warn("⚠️ Props are not a data class with default values for all properties, cannot set prop $name dynamically.")
+      return null
+    }
+    val instanceParam = copy.instanceParameter!!
+    val newPropParam = copy.parameters.firstOrNull { it.name == name } ?: return null
+    return copy.callBy(mapOf(instanceParam to currentProps, newPropParam to type.convert(prop, appContext)))
   }
 
   fun asStateProp(): ComposeViewProp {


### PR DESCRIPTION
# Why

To recreate props in Widgets, we need to be able to create ComposeProps without a view.

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Added `createComposeProps` function

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Not yet.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)