### PR TITLE
fix(expo-modules-core): escape file separator in build.gradle for win…

### DIFF
--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -290,7 +290,7 @@ def generateStubPCHTask = tasks.register("generateStubPCH") {
         if (!pchFile.exists() || pchFile.length() == 0) {
           def stubHeader = new File(entry.directory, "stub_pch.hxx")
           stubHeader.text = ""
-		  
+
           def stubHeaderPath = stubHeader.absolutePath.replace('\\', '/')
 
           def cmd = entry.command

--- a/packages/expo-modules-core/android/build.gradle
+++ b/packages/expo-modules-core/android/build.gradle
@@ -290,12 +290,14 @@ def generateStubPCHTask = tasks.register("generateStubPCH") {
         if (!pchFile.exists() || pchFile.length() == 0) {
           def stubHeader = new File(entry.directory, "stub_pch.hxx")
           stubHeader.text = ""
+		  
+          def stubHeaderPath = stubHeader.absolutePath.replace('\\', '/')
 
           def cmd = entry.command
             // Replace the forced-include path: `-Xclang -include -Xclang <path>/cmake_pch.hxx`
-            .replaceAll(/-Xclang -include -Xclang [^\s]+cmake_pch\.hxx(?=\s)/, "-Xclang -include -Xclang ${stubHeader.absolutePath}")
+            .replaceAll(/-Xclang -include -Xclang [^\s]+cmake_pch\.hxx(?=\s)/, java.util.regex.Matcher.quoteReplacement("-Xclang -include -Xclang ${stubHeaderPath}"))
             // Replace the source file operand: `<path>/cmake_pch.hxx.cxx`
-            .replaceAll(/[^\s]+cmake_pch\.hxx\.cxx/, stubHeader.absolutePath)
+            .replaceAll(/[^\s]+cmake_pch\.hxx\.cxx/, java.util.regex.Matcher.quoteReplacement(stubHeaderPath))
 
           def process = new ProcessBuilder(cmd.split(" ").toList())
             .directory(new File(entry.directory))


### PR DESCRIPTION
…dows

# Why

Closes #46240.

Fixes a Windows-specific path escaping issue in `expo-modules-core/android/build.gradle`.

The `generateStubPCH` task uses regex replacement when modifying the CMake compile command. On Windows, paths contain backslashes, and unescaped backslashes in replacement strings can be interpreted by `String.replaceAll(...)`, resulting in invalid paths such as:

`C:projectnode_modulesexpo-modules-coreandroid...stub_pch.hxx`

This causes the first Android Studio Gradle sync to fail for a freshly prebuilt SDK 56 Android project on Windows.

# How

Escaped the replacement value used when rewriting the compile command by using `Matcher.quoteReplacement(...)`.

This ensures Windows path separators are treated as literal characters during regex replacement instead of being consumed as escape characters.

# Test Plan

Tested on a Windows environment by running `npx expo prebuild --clean --platform android` and opening the project in Android Studio; the Gradle sync now completes successfully without errors.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)