### PR TITLE
[bare-expo] enable running on web

### DIFF
--- a/apps/bare-expo/modules/benchmark-helper/src/index.ts
+++ b/apps/bare-expo/modules/benchmark-helper/src/index.ts
@@ -1,4 +1,5 @@
-import { NativeModule, Platform, requireNativeModule } from 'expo';
+import { NativeModule, requireNativeModule } from 'expo';
+import { Platform } from 'react-native';
 
 declare class BenchmarkHelperModule extends NativeModule {
   reportFullyDrawn(): void;


### PR DESCRIPTION
# Why

bare expo  currently does not run on web because Platform.OS (imported from expo) is undefined in https://github.com/expo/expo/blob/2e6bbcf5f9ef3661411562ab2c24d93ad9708e2f/apps/bare-expo/modules/benchmark-helper/src/index.ts#L11

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How



fix import

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

- bare expo on web

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)