### PR TITLE
[et] Ensure checkEnvironmentTask check exits correctly

### DIFF
--- a/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
+++ b/tools/src/publish-packages/tasks/checkEnvironmentTask.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 
-import logger from '../../Logger';
 import * as Npm from '../../Npm';
 import { Task } from '../../TasksRunner';
 import { TaskArgs } from '../types';
@@ -19,10 +18,9 @@ export const checkEnvironmentTask = new Task<TaskArgs>(
     const npmUser = await Npm.whoamiAsync();
 
     if (!npmUser) {
-      logger.error(
+      throw new Error(
         '❗️ You must be logged in to NPM to publish packages, please run `npm login` first'
       );
-      return Task.STOP;
     }
 
     // `npm team ls` command fails on the access token that we use on the CI.
@@ -33,10 +31,9 @@ export const checkEnvironmentTask = new Task<TaskArgs>(
     const teamMembers = await Npm.getTeamMembersAsync(Npm.EXPO_DEVELOPERS_TEAM_NAME);
 
     if (!teamMembers.includes(npmUser)) {
-      logger.error(
+      throw new Error(
         `❗️ You must be in ${cyan(Npm.EXPO_DEVELOPERS_TEAM_NAME)} team to publish packages`
       );
-      return Task.STOP;
     }
   }
 );


### PR DESCRIPTION
# Why

The nightly `publish-canaries` GitHub Actions workflow was reporting success even when canary publishing silently failed at the npm authentication step. 

e.g. https://github.com/expo/expo/actions/runs/26418089557/job/77766786076

# How

In `checkEnvironmentTask`, throw an `Error` instead of returning `Task.STOP`.   

# Test Plan

Running  `publish-canaries` GitHub Actions workflow  should now fail
