### PR TITLE
[et] Fix updateModuleTemplate failing on EJS syntax in $package.json

### DIFF
--- a/tools/src/publish-packages/tasks/updateModuleTemplate.ts
+++ b/tools/src/publish-packages/tasks/updateModuleTemplate.ts
@@ -86,7 +86,10 @@ async function updateTemplatePackageJsonAsync(
       `${cyan.bold(oldVersion)} -> ${cyan.bold(newVersionRange)}`
     );
 
-    updatedBody = updatedBody.replace(versionRegex, `$1${newVersionRange}$3`);
+    updatedBody = updatedBody.replace(
+      versionRegex,
+      (_, prefix, _old, suffix) => `${prefix}${newVersionRange}${suffix}`
+    );
   }
 
   if (updatedBody === devDepsBlock.body) {

--- a/tools/src/publish-packages/tasks/updateModuleTemplate.ts
+++ b/tools/src/publish-packages/tasks/updateModuleTemplate.ts
@@ -1,5 +1,5 @@
-import JsonFile from '@expo/json-file';
 import chalk from 'chalk';
+import fs from 'fs/promises';
 import path from 'path';
 
 import { selectPackagesToPublish } from './selectPackagesToPublish';
@@ -53,28 +53,77 @@ async function updateTemplatePackageJsonAsync(
   dependencies: Parcel[]
 ): Promise<void> {
   const packageJsonPath = path.join(templatePkg.path, TEMPLATE_PACKAGE_JSON_FILENAME);
-  const packageJson = await JsonFile.readAsync(packageJsonPath);
+  // The template uses EJS syntax (`<% if (usesExpoUI) { -%>`) and can't be
+  // parsed as JSON.  Update version strings via text replacement
+  const originalPackageJson = await fs.readFile(packageJsonPath, 'utf8');
 
+  const devDepsBlock = findBlock(originalPackageJson, 'devDependencies');
+  if (!devDepsBlock) {
+    logger.warn(`Could not find devDependencies block in ${packageJsonPath}, skipping update.`);
+    return;
+  }
+
+  let updatedBody = devDepsBlock.body;
   for (const { pkg, state } of dependencies) {
     const newVersion = state.releaseVersion;
-    const oldVersion = packageJson.devDependencies?.[pkg.packageName];
-
-    if (!newVersion || !oldVersion || oldVersion === newVersion) {
+    if (!newVersion) {
       continue;
     }
 
+    const versionRegex = new RegExp(`("${escapeRegExp(pkg.packageName)}"\\s*:\\s*")([^"]+)(")`);
+    const match = updatedBody.match(versionRegex);
+    if (!match) {
+      continue;
+    }
+    const oldVersion = match[2];
     const newVersionRange = options.canary ? newVersion : `^${newVersion}`;
+    if (oldVersion === newVersionRange) {
+      continue;
+    }
 
     logger.log(
       `   Updating dev dependency on ${green(pkg.packageName)}:`,
       `${cyan.bold(oldVersion)} -> ${cyan.bold(newVersionRange)}`
     );
 
-    if (packageJson.devDependencies) {
-      packageJson.devDependencies[pkg.packageName] = newVersionRange;
-    }
+    updatedBody = updatedBody.replace(versionRegex, `$1${newVersionRange}$3`);
   }
 
-  // Save the template for package.json
-  await JsonFile.writeAsync(packageJsonPath, packageJson);
+  if (updatedBody === devDepsBlock.body) {
+    return;
+  }
+
+  const updatedPackageJson =
+    originalPackageJson.slice(0, devDepsBlock.start) +
+    updatedBody +
+    originalPackageJson.slice(devDepsBlock.end);
+  await fs.writeFile(packageJsonPath, updatedPackageJson);
+}
+
+function findBlock(
+  source: string,
+  key: string
+): { start: number; end: number; body: string } | null {
+  const header = new RegExp(`"${escapeRegExp(key)}"\\s*:\\s*\\{`);
+  const headerMatch = source.match(header);
+  if (!headerMatch || headerMatch.index === undefined) {
+    return null;
+  }
+  const start = headerMatch.index + headerMatch[0].length;
+  let depth = 1;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return { start, end: i, body: source.slice(start, i) };
+      }
+    }
+  }
+  return null;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }


### PR DESCRIPTION
# Why

Canary publishing broke when we added EJS conditional blocks (`<% if (usesExpoUI) { -%>`) to `packages/expo-module-template/$package.json`. The `updateModuleTemplate` task reads that file with `JsonFile.readAsync`, which now throws because the template is no longer valid JSON

e.g. https://github.com/expo/expo/actions/runs/26419566624/job/77771270661

# How

No off-the-shelf parser handles JSON-with-embedded-EJS, so the task now reads the file as text and rewrites just the version strings it cares about.

# Test Plan

- Smoke-tested the regex/block extraction against the current `$package.json` template:
  - `devDependencies.expo` is updated from `^56.0.4` to the new canary range
  - `peerDependencies.expo: "*"` is left untouched
  - The `<% if (usesExpoUI) { -%> ... <% } -%>` conditional block is preserved verbatim