### PR TITLE
[widgets][Android] Create a JS bundle for widgets

### DIFF
--- a/packages/expo-widgets/CHANGELOG.md
+++ b/packages/expo-widgets/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [Android] Create base android package. ([#46090](https://github.com/expo/expo/pull/46090) by [@jakex7](https://github.com/jakex7))
 - [plugin] Create config plugin for android. ([#46091](https://github.com/expo/expo/pull/46091) by [@jakex7](https://github.com/jakex7))
+- [Android] Create a JS bundle for widgets. ([#46286](https://github.com/expo/expo/pull/46286) by [@jakex7](https://github.com/jakex7))
 
 ### 🐛 Bug fixes
 

--- a/packages/expo-widgets/android/build.gradle
+++ b/packages/expo-widgets/android/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.taskdefs.condition.Os
+
 buildscript {
   repositories {
     google()
@@ -15,6 +17,19 @@ apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 group = 'expo.modules.widgets'
 version = '56.0.11'
 
+def expoWidgetsPackageDirFile = project.projectDir.parentFile
+def expoWidgetsPackageDir = expoWidgetsPackageDirFile.absolutePath
+def expoWidgetsProjectRoot = rootDir.absoluteFile.parentFile.absolutePath
+def expoWidgetsGeneratedResDir = objects.directoryProperty()
+expoWidgetsGeneratedResDir.set(layout.buildDirectory.dir("generated/expo-widgets/res"))
+def expoWidgetsBundleOutput = expoWidgetsGeneratedResDir
+  .file("raw/expo_widgets_bundle.bundle")
+  .get()
+  .asFile
+
+def config = project.hasProperty("react") ? project.react : []
+def nodeExecutableAndArgs = config.nodeExecutableAndArgs ?: ["node"]
+
 expoModule {
   canBePublished false
 }
@@ -29,6 +44,39 @@ android {
   buildFeatures {
     prefab true
     compose true
+  }
+}
+
+def generateExpoWidgetsBundle = tasks.register("generateExpoWidgetsBundle", Exec) {
+  description = "expo-widgets: Generate the Android widget JS bundle resource."
+
+  inputs.dir project.fileTree(file("$expoWidgetsPackageDir/bundle")) {
+    exclude "build/**"
+  }
+  inputs.file file("$expoWidgetsPackageDir/metro.config.js")
+  inputs.file file("$expoWidgetsPackageDir/scripts/build-bundle.mjs")
+  outputs.dir(expoWidgetsGeneratedResDir)
+
+  def command = [
+    *nodeExecutableAndArgs,
+    "$expoWidgetsPackageDir/scripts/build-bundle.mjs",
+    expoWidgetsProjectRoot,
+    "android",
+    expoWidgetsBundleOutput.absolutePath
+  ]
+
+  if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+    commandLine("cmd", "/c", *command)
+  } else {
+    commandLine(*command)
+  }
+}
+
+androidComponents {
+  onVariants(selector().all()) { variant ->
+    variant.sources.res.addGeneratedSourceDirectory(generateExpoWidgetsBundle) {
+      expoWidgetsGeneratedResDir
+    }
   }
 }
 

--- a/packages/expo-widgets/scripts/build-bundle.mjs
+++ b/packages/expo-widgets/scripts/build-bundle.mjs
@@ -11,7 +11,7 @@ import { argv } from 'node:process';
 import { fileURLToPath } from 'node:url';
 
 // NOTE: Modified from expo-constants/expo-updates entrypoint. We cd into the right folder anyway
-const possibleProjectRoot = process.argv[2] ?? process.cwd();
+const [, , possibleProjectRoot = process.cwd(), platform = 'ios', bundleOutput] = argv;
 
 // TODO: Verify we can remove projectRoot validation, now that we no longer
 // support React Native <= 62
@@ -33,9 +33,11 @@ const require = createRequire(__dirname);
 // NODE_BINARY is set for Xcode builds via the `with-node.sh` script.
 const nodePath = process.env.NODE_BINARY || 'node';
 const outputDir = path.join(__dirname, '../bundle/build');
-const appBundlePath = path.join(outputDir, 'ExpoWidgets.bundle');
+const defaultBundleOutput = path.join(outputDir, 'ExpoWidgets.bundle');
+const appBundlePath = path.resolve(projectRoot, bundleOutput ?? defaultBundleOutput);
 
-await fs.promises.rm(outputDir, { recursive: true, force: true });
+await fs.promises.rm(appBundlePath, { recursive: true, force: true });
+await fs.promises.mkdir(path.dirname(appBundlePath), { recursive: true });
 
 const result = await spawn(
   nodePath,
@@ -43,7 +45,7 @@ const result = await spawn(
     require.resolve('expo/bin/cli'),
     'export:embed',
     '--platform',
-    'ios',
+    platform,
     '--bundle-output',
     appBundlePath,
     '--entry-file',
@@ -51,7 +53,6 @@ const result = await spawn(
     '--dev',
     'false',
     '--skip-server',
-    ...argv.slice(2),
   ],
   {
     stdio: 'inherit',


### PR DESCRIPTION
# Why

Widgets on Android needs it's own bundle. 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Register a gradle task that wil generate the bundle in the `expo-widgets/res` directory. 

![image.png](https://app.graphite.com/user-attachments/assets/d571255f-a8af-4350-ba2f-33efd14041bb.png)



<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Build Android with expo-widgets and inspect in Android Studio.

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)