### PR TITLE
[docs] EAS CLI build `--refresh-ad-hoc-provisioning-profile` flag documentation

### DIFF
--- a/docs/pages/build/building-on-ci.mdx
+++ b/docs/pages/build/building-on-ci.mdx
@@ -96,6 +96,8 @@ Using the information you've gathered, pass it into the build command through en
 - `EXPO_APPLE_TEAM_ID`: Your Apple Team ID. For example, `77KQ969CHE`.
 - `EXPO_APPLE_TEAM_TYPE`: Your Apple Team Type. Valid types are `IN_HOUSE`, `COMPANY_OR_ORGANIZATION`, or `INDIVIDUAL`.
 
+If you run [internal distribution](/build/internal-distribution/) builds on CI with ad hoc provisioning, refresh the ad hoc provisioning profile so registered devices added after the last build are included. For `eas build`, pass [`--refresh-ad-hoc-provisioning-profile`](/eas/cli/#eas-build) with `--non-interactive`. For [EAS Workflows](/eas/workflows/get-started), set `refresh_ad_hoc_provisioning_profile: true` in the build job's `params` ([build job parameters](/eas/workflows/pre-packaged-jobs#build)). See [Automation on CI](/build/internal-distribution/#automation-on-ci-optional) for requirements and an example command.
+
 ### Trigger new builds
 
 Now that we're authenticated with Expo CLI, we can create the build step.

--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -30,7 +30,29 @@ See the tutorial on Internal distribution with EAS Build below for more informat
 
 ### Automation on CI (optional)
 
-It's possible to run internal distribution builds non-interactively in CI using the `--non-interactive` flag. However, if you are using ad hoc provisioning on iOS you will not be able to add new devices to your provisioning profile when using this flag. After registering a device through `eas device:create`, you need to run `eas build` interactively and authenticate with Apple in order for EAS to add the device to your provisioning profile. [Learn more about triggering builds from CI](/build/building-on-ci).
+You can run internal distribution builds non-interactively in CI with the [`--non-interactive`](/eas/cli/#eas-build) flag. [Learn more about triggering builds from CI](/build/building-on-ci).
+
+For iOS ad hoc builds, `eas build --non-interactive` reuses a valid provisioning profile without updating its device list. The build can succeed, but the app may not install on registered devices added after the profile was last updated.
+
+Pass `--refresh-ad-hoc-provisioning-profile` with `--non-interactive` to update the Expo-managed ad hoc provisioning profile on the Apple Developer Portal before the build.
+
+> **info** `--refresh-ad-hoc-provisioning-profile` requires EAS CLI 19.1.0 or later.
+
+EAS authenticates with an App Store Connect API key. It reads devices registered on EAS for your Apple team. It registers any missing UDIDs on the portal. Then it refreshes the profile device list.
+
+When you use this flag, EAS selects all matching devices for the build target's Apple platform: iPhone and iPad for iOS, Mac for macOS.
+
+<Terminal
+  cmd={[
+    '$ eas build --platform ios --profile preview --non-interactive --refresh-ad-hoc-provisioning-profile',
+  ]}
+/>
+
+For [EAS Workflows](/eas/workflows/get-started), set `refresh_ad_hoc_provisioning_profile: true` in the build job's `params` with the same profile requirements. See the [build job parameters](/eas/workflows/pre-packaged-jobs#build).
+
+The profile must set [`"distribution": "internal"`](/eas/json/#distribution) and use [credentials managed by EAS](/app-signing/app-credentials/). You need at least one device from [`eas device:create`](/eas/cli/#eas-devicecreate) and an App Store Connect API key in CI through [environment variables](/build/building-on-ci/#optional-provide-an-asc-api-token-for-your-apple-team) (`EXPO_ASC_API_KEY_PATH`, `EXPO_ASC_KEY_ID`, and `EXPO_ASC_ISSUER_ID`) or a key stored in EAS for submissions on the project.
+
+Otherwise, after registering a device with [`eas device:create`](/eas/cli/#eas-devicecreate), run [`eas build`](/eas/cli/#eas-build) interactively and sign in with your Apple account so EAS can update the ad hoc provisioning profile.
 
 ### Managing devices
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

EAS CLI 19.1.0 adds `eas build --refresh-ad-hoc-provisioning-profile`, so non-interactive CI builds can refresh ad hoc provisioning profiles when an App Store Connect API key is set up. Our docs still say you must run `eas build` interactively after registering a device; this PR documents the new workflow.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Document the flag, prerequisites, and an example in [internal distribution](https://docs.expo.dev/build/internal-distribution/) (Automation on CI).
- Cross-link from [building on CI](https://docs.expo.dev/build/building-on-ci/).

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders correctly:

<img width="1146" height="672" alt="Screenshot 2026-05-26 at 15 05 47" src="https://github.com/user-attachments/assets/a33778ff-a76d-4766-afb7-43e7a57e1a2a" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
