### PR TITLE
[docs] EAS workflows build job `refresh_ad_hoc_provisioning_profile` parameter documentation

### DIFF
--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -34,17 +34,19 @@ jobs:
       platform: android | ios # required
       profile: string # optional - default: production
       message: string # optional
+      refresh_ad_hoc_provisioning_profile: boolean # optional
 ```
 
 #### Parameters
 
 You can pass the following parameters into the `params` list:
 
-| Parameter | Type   | Description                                                                                                   |
-| --------- | ------ | ------------------------------------------------------------------------------------------------------------- |
-| platform  | string | **Required.** The platform to build for. Can be either `android` or `ios`.                                    |
-| profile   | string | Optional. The build profile to use. Defaults to `production`.                                                 |
-| message   | string | Optional. Custom message attached to the build. Corresponds to the `--message` flag when running `eas build`. |
+| Parameter                           | Type    | Description                                                                                                                                                                                                                                                                                                   |
+| ----------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| platform                            | string  | **Required.** The platform to build for. Can be either `android` or `ios`.                                                                                                                                                                                                                                    |
+| profile                             | string  | Optional. The build profile to use. Defaults to `production`.                                                                                                                                                                                                                                                 |
+| message                             | string  | Optional. Custom message attached to the build. Corresponds to the `--message` flag when running `eas build`.                                                                                                                                                                                                 |
+| refresh_ad_hoc_provisioning_profile | boolean | Optional. Refreshes the managed ad hoc provisioning profile before an iOS internal build starts. Corresponds to the [`--refresh-ad-hoc-provisioning-profile`](/eas/cli/#eas-build) flag when running `eas build`. See [internal distribution on CI](/build/internal-distribution/#automation-on-ci-optional). |
 
 #### Environment variables
 
@@ -175,6 +177,29 @@ jobs:
     params:
       platform: android
       profile: production
+```
+
+</Collapsible>
+
+<Collapsible summary="Internal iOS build with refreshed ad hoc profile">
+
+This workflow builds your iOS app for internal distribution and refreshes the ad hoc provisioning profile when you push to the main branch.
+
+```yaml .eas/workflows/build-ios-internal.yml
+name: Build iOS internal
+
+on:
+  push:
+    branches: ['main']
+
+jobs:
+  build_ios:
+    name: Build iOS Internal
+    type: build
+    params:
+      platform: ios
+      profile: preview
+      refresh_ad_hoc_provisioning_profile: true
 ```
 
 </Collapsible>

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -1038,6 +1038,7 @@ jobs:
       platform: ios | android # required
       profile: string # optional, default: production
       message: string # optional
+      refresh_ad_hoc_provisioning_profile: boolean # optional
 ```
 
 This job outputs the following properties:


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The base branch documents `eas build --refresh-ad-hoc-provisioning-profile` for internal iOS ad hoc builds on CI and links to EAS Workflows, but the workflows docs did not yet document `refresh_ad_hoc_provisioning_profile` on the build job.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Document `refresh_ad_hoc_provisioning_profile` on the `build job in pre-packaged-jobs.mdx` and `syntax.mdx` (syntax, parameters table, CLI flag mapping).
- Add an example workflow for an internal iOS build with profile refresh.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Verified it renders correctly:

<img width="1140" height="131" alt="image" src="https://github.com/user-attachments/assets/17bed5f7-a96f-4ab0-9795-2dda3c32f1b8" />

<img width="1126" height="523" alt="image" src="https://github.com/user-attachments/assets/db675229-fce7-4bfb-8ef9-2a3f52b614fe" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
