### PR TITLE
[docs] update observe docs for Observe named export

### DIFF
--- a/docs/pages/eas/observe/configuration.mdx
+++ b/docs/pages/eas/observe/configuration.mdx
@@ -11,9 +11,9 @@ Configure EAS Observe at runtime to fit your app's build setup, environment, and
 Use the `configure()` method to control how EAS Observe behaves at runtime:
 
 ```tsx
-import ExpoObserve from 'expo-observe';
+import { Observe } from 'expo-observe';
 
-ExpoObserve.configure({
+Observe.configure({
   environment: 'production',
   dispatchingEnabled: true,
 });
@@ -33,9 +33,9 @@ Events are automatically dispatched when the app moves to the background. On And
 To flush events manually (for example, during testing or to ensure events are sent before a specific point), call `dispatchEvents()`:
 
 ```tsx
-import ExpoObserve from 'expo-observe';
+import { Observe } from 'expo-observe';
 
-await ExpoObserve.dispatchEvents();
+await Observe.dispatchEvents();
 ```
 
 ## Sampling
@@ -43,10 +43,10 @@ await ExpoObserve.dispatchEvents();
 By default, every installation dispatches its metrics. For high-volume apps, you can sample a fraction of installations by setting `sampleRate` to a value between `0` and `1`:
 
 ```tsx
-import ExpoObserve from 'expo-observe';
+import { Observe } from 'expo-observe';
 
 // Dispatch metrics from ~25% of installations.
-ExpoObserve.configure({
+Observe.configure({
   sampleRate: 0.25,
 });
 ```
@@ -64,9 +64,9 @@ A few details worth knowing:
 By default, metrics collected from debug builds are not dispatched. To dispatch them anyway (for example, while testing your EAS Observe integration), set `dispatchInDebug` to `true` when calling `configure()`:
 
 ```tsx
-import ExpoObserve from 'expo-observe';
+import { Observe } from 'expo-observe';
 
-ExpoObserve.configure({
+Observe.configure({
   dispatchInDebug: true,
 });
 ```

--- a/docs/pages/eas/observe/events.mdx
+++ b/docs/pages/eas/observe/events.mdx
@@ -11,13 +11,13 @@ Events are persisted on-device, batched, and dispatched on the next flush as Ope
 
 ## Log an event
 
-Call `AppMetrics.logEvent` from anywhere in your app:
+Call `Observe.logEvent` from anywhere in your app:
 
 ```tsx
-import { AppMetrics } from 'expo-observe';
+import { Observe } from 'expo-observe';
 
 function handleSignupComplete() {
-  AppMetrics.logEvent('signup.completed');
+  Observe.logEvent('signup.completed');
 }
 ```
 
@@ -28,7 +28,7 @@ The first argument is the event name. Use a stable, dot-separated identifier. Th
 Pass an `attributes` map to record context with the event:
 
 ```tsx
-AppMetrics.logEvent('cart.checkout', {
+Observe.logEvent('cart.checkout', {
   attributes: {
     itemCount: 3,
     totalUsd: 42.5,
@@ -45,7 +45,7 @@ Supported attribute value types: `string`, `number`, `boolean`, arrays, and nest
 Events default to `"info"` severity. Override with the `severity` option for warnings or errors you want to surface separately in the dashboard:
 
 ```tsx
-AppMetrics.logEvent('payment.failed', {
+Observe.logEvent('payment.failed', {
   severity: 'error',
   attributes: { reason: 'card_declined' },
 });
@@ -58,7 +58,7 @@ Supported severities, from lowest to highest: `"trace"`, `"debug"`, `"info"`, `"
 Use `body` for a free-form message that complements the structured attributes:
 
 ```tsx
-AppMetrics.logEvent('subscription.expired', {
+Observe.logEvent('subscription.expired', {
   body: 'Subscription expired while user was offline; downgrading to free tier.',
   severity: 'warn',
   attributes: { previousPlan: 'pro' },

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -226,7 +226,7 @@ You can also query metrics from the terminal using the EAS CLI:
 - `eas observe:versions`: Lists app versions along with their build IDs, update group IDs, and release dates. Useful for finding the version identifiers needed to filter the other commands.
 - `eas observe:metrics-summary`: Shows aggregated performance metric statistics (such as median, p75, and p95 values) grouped by app version. Use this to compare overall startup performance across releases.
 - `eas observe:metrics`: Shows individual performance metric events ordered by value, including session and device metadata. Use this to investigate specific slow sessions or outliers.
-- `eas observe:events`: Shows individual events emitted by your app via `AppMetrics.logEvent`. See [User-defined events](/eas/observe/events/) for details.
+- `eas observe:events`: Shows individual events emitted by your app via `Observe.logEvent`. See [User-defined events](/eas/observe/events/) for details.
 
 Run any of these commands with `--help` to see the available flags and arguments.
 

--- a/docs/pages/eas/observe/integrations/expo-router.mdx
+++ b/docs/pages/eas/observe/integrations/expo-router.mdx
@@ -32,12 +32,12 @@ EAS Observe ships an opt-in integration for [Expo Router](/router/introduction/)
 
 > **warning** The integration must be enabled before mount and cannot be toggled at runtime. Calling `configure()` after the app has mounted, or toggling the flag mid-session, throws an error.
 
-Call `ExpoObserve.configure()` with the `expo-router` integration flag at module scope, before any screen mounts:
+Call `Observe.configure()` with the `expo-router` integration flag at module scope, before any screen mounts:
 
 ```tsx src/app/_layout.tsx
-import ExpoObserve from 'expo-observe';
+import { Observe } from 'expo-observe';
 
-ExpoObserve.configure({
+Observe.configure({
   integrations: { 'expo-router': true },
 });
 ```
@@ -65,7 +65,7 @@ export default function Home() {
 }
 ```
 
-> **info** If the integration is disabled or `expo-router` is not installed, `useObserve()` falls back to the global `AppMetrics.markInteractive`. You can leave the hook in place regardless of integration state.
+> **info** If the integration is disabled or `expo-router` is not installed, `useObserve()` falls back to the global `Observe.markInteractive`. You can leave the hook in place regardless of integration state.
 
 </Step>
 
@@ -116,6 +116,6 @@ Emitted at most once per screen instance within a session.
 - `routeName` is a pattern (`/(tabs)/sessions/[sessionId]`), not a resolved URL (`/sessions/abc`). This keeps metrics stable across distinct param values so the dashboard buckets them together. Resolved values are still available on the event via `url` and `routeParams`.
 - Calls to `router.prefetch()` do not count as a user navigation and never seed a `cold_ttr` or `warm_ttr` measurement. The next user-driven navigation to that route emits `warm_ttr` because the screen has already rendered.
 - The integration only activates if `expo-router` is installed at runtime. If it is not installed, `useObserve()` and `ObserveRoot` continue to work but no per-route navigation metrics are emitted.
-- The integration must be enabled before mount via `ExpoObserve.configure({ integrations: { 'expo-router': true } })`. Toggling it after the app has mounted throws.
+- The integration must be enabled before mount via `Observe.configure({ integrations: { 'expo-router': true } })`. Toggling it after the app has mounted throws.
 - If `markInteractive()` logs `Calling markInteractive on unmounted screen` or `No metadata available for the current screen`, the call ran outside a screen component or after unmount. Move the call into a `useEffect` inside the screen component.
 - For general issues with EAS Observe, see [Troubleshooting](/eas/observe/reference/troubleshooting/).

--- a/docs/pages/eas/observe/reference/metrics.mdx
+++ b/docs/pages/eas/observe/reference/metrics.mdx
@@ -239,7 +239,7 @@ Param values can be strings, numbers, booleans, or other JSON-serializable value
 
 ### Offline collection
 
-Metrics collected while the device is offline are stored on the device. They are automatically sent to the server when the app moves to the background, provided there is connectivity. You can also call [`ExpoObserve.dispatchEvents()`](/eas/observe/configuration/#dispatchevents) to flush events manually at any time.
+Metrics collected while the device is offline are stored on the device. They are automatically sent to the server when the app moves to the background, provided there is connectivity. You can also call [`Observe.dispatchEvents()`](/eas/observe/configuration/#dispatchevents) to flush events manually at any time.
 
 ### Data retention
 


### PR DESCRIPTION
## Summary

Reflects #46120 across the EAS Observe documentation:

- The default `ExpoObserve` export is deprecated in favor of a named `Observe` export.
- `Observe` proxies through to `AppMetrics` for `logEvent`, `markInteractive`, etc., so SDK 56+ snippets can use a single `Observe` import everywhere.

### Changes

- **events.mdx** — `AppMetrics.logEvent` → `Observe.logEvent` (named import).
- **get-started.mdx** — CLI bullet referencing `AppMetrics.logEvent` → `Observe.logEvent`.
- **configuration.mdx** — `import ExpoObserve from 'expo-observe'` → `import { Observe } from 'expo-observe'`; all `ExpoObserve.x` calls → `Observe.x`.
- **integrations/expo-router.mdx** — same rename; the `useObserve()` fallback note now references `Observe.markInteractive`.
- **reference/metrics.mdx** — `ExpoObserve.dispatchEvents()` link label → `Observe.dispatchEvents()`.

### Left untouched

- SDK 55 tabs that still use `AppMetrics` / `AppMetricsRoot`.
- The `expo-eas-observe` migration block in `troubleshooting.mdx` (historical migration story).

## Test plan

- [ ] Render the docs site locally and spot-check the updated pages.
