### PR TITLE
[docs] EAS workflows Apple Device Registration Request jobs documentation

### DIFF
--- a/docs/pages/build/internal-distribution.mdx
+++ b/docs/pages/build/internal-distribution.mdx
@@ -56,6 +56,8 @@ Otherwise, after registering a device with [`eas device:create`](/eas/cli/#eas-d
 
 ### Managing devices
 
+With [EAS Workflows](/eas/workflows/get-started), you can pause a workflow until a tester enrolls an iOS device and a team member approves it using the [`apple-device-registration-request`](/eas/workflows/pre-packaged-jobs#apple-device-registration-request) job. Pair it with a `build` job that sets `refresh_ad_hoc_provisioning_profile: true` to include the new device in an internal distribution build.
+
 You can see any devices registered via `eas device:create` by running:
 
 <Terminal

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1624,6 +1624,103 @@ jobs:
 
 </Collapsible>
 
+## Apple device registration request
+
+Pause a workflow run until an iOS device enrolls for a specific [Apple Team](https://expo.fyi/apple-team) and a team member approves that enrollment on [expo.dev](https://expo.dev). Use this job to automate registering a device for [internal distribution](/build/internal-distribution/) inside EAS Workflows.
+
+When the workflow reaches this job, the job and the run enter `action-required` and stay paused until the flow completes:
+
+1. The workflow run page shows a QR code and a registration link for the device being enrolled.
+2. On the iPhone or iPad, the device downloads a provisioning profile and installs it through Settings. Only one profile is ready at a time, and it is removed if not installed within eight minutes.
+3. After installation, the unique device identifier (UDID) and metadata are collected.
+4. On the workflow run page, a team member approves or rejects the enrollment. Approval marks the job successful and exposes outputs (UDID, model, and more) to downstream jobs. Rejection fails the job and blocks jobs that use `needs`.
+
+If the UDID is already registered on your account, the job still waits for enrollment and approval before continuing.
+
+### Syntax
+
+```yaml
+jobs:
+  register_device:
+    type: apple-device-registration-request
+    params:
+      apple_team_identifier: string # optional
+```
+
+#### Parameters
+
+You can pass the following parameters into the `params` list:
+
+| Parameter             | Type   | Description                                                                                                                                                                                                                                                                                                                    |
+| --------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| apple_team_identifier | string | Optional. The Apple Team ID (for example, `ABCDE12345`). If you omit this parameter and your Expo account has exactly one Apple Team, that team is used. You must set this parameter when your account has no Apple Teams or has two or more Apple Teams. When provided, EAS resolves or creates the team from the identifier. |
+
+#### Outputs
+
+After a team member approves the enrolled device, you can reference the following outputs in subsequent jobs:
+
+| Output           | Type   | Description                                                      |
+| ---------------- | ------ | ---------------------------------------------------------------- |
+| apple_device_id  | string | Expo internal device ID.                                         |
+| identifier       | string | Device UDID.                                                     |
+| name             | string | Device name. May be empty.                                       |
+| model            | string | Hardware model string (for example, `iPhone11,2`). May be empty. |
+| device_class     | string | Device class: `iphone`, `ipad`, or `mac`. May be empty.          |
+| software_version | string | iOS version string. May be empty.                                |
+
+If a team member rejects the enrollment, the job fails and does not set outputs. Downstream jobs that use `needs` will not run.
+
+### Examples
+
+Here are some practical examples of using the Apple device registration request job:
+
+<Collapsible summary="Register a device and notify Slack">
+
+This workflow registers an iOS device and sends a Slack message with the device UDID and model from the job outputs.
+
+```yaml .eas/workflows/register-device-slack.yml
+name: Register iOS Device and notify Slack
+
+jobs:
+  register_device:
+    type: apple-device-registration-request
+    params:
+      apple_team_identifier: XX33YYZ44Z
+  notify_slack:
+    needs: [register_device]
+    type: slack
+    params:
+      webhook_url: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+      message: 'Registered device ${{ needs.register_device.outputs.identifier }} (${{ needs.register_device.outputs.model }})'
+```
+
+</Collapsible>
+
+<Collapsible summary="Register a device, then run an internal iOS build">
+
+This workflow registers a device and then runs an iOS internal distribution build that refreshes the ad hoc provisioning profile so the new device is included.
+
+```yaml .eas/workflows/register-device-build.yml
+name: Register device and build iOS internal
+
+jobs:
+  register_device:
+    type: apple-device-registration-request
+    params:
+      apple_team_identifier: ABCDE12345
+  build_ios:
+    needs: [register_device]
+    type: build
+    params:
+      platform: ios
+      profile: preview
+      refresh_ad_hoc_provisioning_profile: true
+```
+
+The `preview` profile must set [`distribution: internal`](/eas/json/#distribution) and use [credentials managed by EAS](/app-signing/app-credentials/). For CI, you also need an App Store Connect API key. See [internal distribution on CI](/build/internal-distribution/#automation-on-ci-optional) and [trigger builds from CI](/build/building-on-ci/).
+
+</Collapsible>
+
 ## Require Approval
 
 Require approval from a user before continuing with the workflow. A user can approve or reject which translates to success or failure of the job.

--- a/docs/pages/eas/workflows/pre-packaged-jobs.mdx
+++ b/docs/pages/eas/workflows/pre-packaged-jobs.mdx
@@ -1679,7 +1679,7 @@ Here are some practical examples of using the Apple device registration request 
 This workflow registers an iOS device and sends a Slack message with the device UDID and model from the job outputs.
 
 ```yaml .eas/workflows/register-device-slack.yml
-name: Register iOS Device and notify Slack
+name: Register iOS device and notify Slack
 
 jobs:
   register_device:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -428,7 +428,7 @@ jobs:
 
 ### `jobs.<job_id>.env`
 
-Sets environment variables for the job. The property is available on all jobs running a VM (all jobs except for the pre-packaged `apple-device-registration-request`, `require-approval`, `doc`, `get-build` and `slack` jobs).
+Sets environment variables for the job. The property is available on all jobs running a VM (all jobs except for the pre-packaged `apple-device-registration-request`, `require-approval`, `doc`, `get-build`, and `slack` jobs).
 
 ```yaml
 jobs:

--- a/docs/pages/eas/workflows/syntax.mdx
+++ b/docs/pages/eas/workflows/syntax.mdx
@@ -428,7 +428,7 @@ jobs:
 
 ### `jobs.<job_id>.env`
 
-Sets environment variables for the job. The property is available on all jobs running a VM (all jobs except for the pre-packaged `require-approval`, `doc`, `get-build` and `slack` jobs).
+Sets environment variables for the job. The property is available on all jobs running a VM (all jobs except for the pre-packaged `apple-device-registration-request`, `require-approval`, `doc`, `get-build` and `slack` jobs).
 
 ```yaml
 jobs:
@@ -1356,6 +1356,20 @@ This job outputs the following properties:
 {
   "comment_url": string | undefined  // URL of the posted GitHub comment
 }
+```
+
+#### `apple-device-registration-request`
+
+Pauses the workflow until an iOS device enrolls for an Apple Team and a team member approves the enrollment. See [Apple device registration request job documentation](/eas/workflows/pre-packaged-jobs#apple-device-registration-request) for detailed information and examples.
+
+```yaml
+jobs:
+  register_device:
+    # @info #
+    type: apple-device-registration-request
+    params:
+      apple_team_identifier: string # optional
+    # @end #
 ```
 
 #### `require-approval`


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

EAS Workflows supports an `apple-device-registration-request` pre-packaged job that pauses a run until a tester enrolls an iOS device and a team member approves it on expo.dev. That flow is useful for [internal distribution](/build/internal-distribution/) but was not documented alongside other workflow jobs.

This PR documents the job so teams can automate device registration in workflows instead of running `eas device:create` manually and coordinating builds separately.

# How

<!--
How did you build this feature or fix this bug and why?
-->

- Added an Apple device registration request section to pre-packaged jobs docs.
- Added a short `apple-device-registration-request` entry in workflow syntax jobs and listed it among jobs that do not run on a VM (so `env` does not apply).
- Cross-linked from internal distribution under "Managing devices", pointing readers to this job and pairing it with a `build` job that refreshes the ad hoc provisioning profile.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="1143" height="1238" alt="image" src="https://github.com/user-attachments/assets/fee92240-3517-4c01-9010-2a00b1c91955" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)