### PR TITLE
[expo-modules-core][android] Fix nested Host double-rendering in Compose

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))
+
 ### 💡 Others
 
 ## 56.0.13 — 2026-05-26

--- a/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
+++ b/packages/expo-modules-core/android/src/compose/expo/modules/kotlin/views/ExpoComposeView.kt
@@ -128,6 +128,8 @@ abstract class ExpoComposeView<T : ComposeProps>(
     recomposeScope = currentRecomposeScope
     for (index in 0..<this.size) {
       val child = getChildAt(index) as? ExpoComposeView<*> ?: continue
+      // Hosting children render themselves via their own ComposeView; skip to avoid double-rendering.
+      if (child.shouldUseAndroidLayout) continue
       key(child) {
         with(composableScope ?: ComposableScope()) {
           with(child) {
@@ -143,6 +145,7 @@ abstract class ExpoComposeView<T : ComposeProps>(
     recomposeScope = currentRecomposeScope
     for (index in 0..<this.size) {
       val child = getChildAt(index) as? ExpoComposeView<*> ?: continue
+      if (child.shouldUseAndroidLayout) continue
       if (!filter(child)) {
         continue
       }
@@ -160,6 +163,7 @@ abstract class ExpoComposeView<T : ComposeProps>(
   fun Child(composableScope: ComposableScope, index: Int) {
     recomposeScope = currentRecomposeScope
     val child = getChildAt(index) as? ExpoComposeView<*> ?: return
+    if (child.shouldUseAndroidLayout) return
     key(child) {
       with(composableScope) {
         with(child) {


### PR DESCRIPTION
# Why

Resolves - https://github.com/expo/expo/issues/46282

Direct nesting of two hosting Compose views (`<Host><Host>...</Host></Host>`) double-renders everything inside the inner Host. Each hosting view already runs its own composition via its own `ComposeView.setContent { Content() }`, but the outer Host's `Children()` iteration was also invoking `child.Content()` on it, producing a second, parallel composition of the entire subtree.

We added a built in `Host` in BottomSheet [here](https://github.com/expo/expo/pull/46031), so when we add another `Host` above it, it can create the double rendering issue.

 

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

In `ExpoComposeView.Children()` / `Child()`, skip children that own their own composition root (`shouldUseAndroidLayout == true`). They render themselves; composing them again from the parent duplicates their subtree.


<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested in the user repro and examples in NCL
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
