### PR TITLE
[docs] Reverse the tabs in observe

### DIFF
--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -51,21 +51,6 @@ Wrap your root layout with `AppMetricsRoot` (SDK 55) or `ObserveRoot` (SDK 56 an
 
 <Tabs>
 
-<Tab label="SDK 55">
-
-```tsx app/_layout.tsx
-import { Stack } from 'expo-router';
-import { AppMetricsRoot } from 'expo-observe';
-
-function RootLayout() {
-  return <Stack />;
-}
-
-export default AppMetricsRoot.wrap(RootLayout);
-```
-
-</Tab>
-
 <Tab label="SDK 56 and later">
 
 ```tsx app/_layout.tsx
@@ -77,6 +62,21 @@ function RootLayout() {
 }
 
 export default ObserveRoot.wrap(RootLayout);
+```
+
+</Tab>
+
+<Tab label="SDK 55">
+
+```tsx app/_layout.tsx
+import { Stack } from 'expo-router';
+import { AppMetricsRoot } from 'expo-observe';
+
+function RootLayout() {
+  return <Stack />;
+}
+
+export default AppMetricsRoot.wrap(RootLayout);
 ```
 
 </Tab>
@@ -97,54 +97,6 @@ Call `markInteractive()` when your app is fully ready for user interaction. This
 - Animating the splash screen
 
 <Tabs>
-
-<Tab label="SDK 55">
-
-```tsx app/_layout.tsx
-import { Stack } from 'expo-router';
-import * as SplashScreen from 'expo-splash-screen';
-import { AppMetrics, AppMetricsRoot } from 'expo-observe';
-import { useEffect, useState } from 'react';
-
-// Keep the splash screen visible while we fetch resources
-SplashScreen.preventAutoHideAsync();
-
-function RootLayout() {
-  const [isReady, setIsReady] = useState(false);
-
-  useEffect(() => {
-    async function prepare() {
-      try {
-        await authenticateUser();
-        await fetchInitialData();
-      } catch (e) {
-        console.warn(e);
-      } finally {
-        setIsReady(true);
-      }
-    }
-
-    prepare();
-  }, []);
-
-  useEffect(() => {
-    if (isReady) {
-      SplashScreen.hide();
-      AppMetrics.markInteractive();
-    }
-  }, [isReady]);
-
-  if (!isReady) {
-    return null;
-  }
-
-  return <Stack />;
-}
-
-export default AppMetricsRoot.wrap(RootLayout);
-```
-
-</Tab>
 
 <Tab label="SDK 56">
 
@@ -191,6 +143,54 @@ function RootLayout() {
 }
 
 export default ObserveRoot.wrap(RootLayout);
+```
+
+</Tab>
+
+<Tab label="SDK 55">
+
+```tsx app/_layout.tsx
+import { Stack } from 'expo-router';
+import * as SplashScreen from 'expo-splash-screen';
+import { AppMetrics, AppMetricsRoot } from 'expo-observe';
+import { useEffect, useState } from 'react';
+
+// Keep the splash screen visible while we fetch resources
+SplashScreen.preventAutoHideAsync();
+
+function RootLayout() {
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    async function prepare() {
+      try {
+        await authenticateUser();
+        await fetchInitialData();
+      } catch (e) {
+        console.warn(e);
+      } finally {
+        setIsReady(true);
+      }
+    }
+
+    prepare();
+  }, []);
+
+  useEffect(() => {
+    if (isReady) {
+      SplashScreen.hide();
+      AppMetrics.markInteractive();
+    }
+  }, [isReady]);
+
+  if (!isReady) {
+    return null;
+  }
+
+  return <Stack />;
+}
+
+export default AppMetricsRoot.wrap(RootLayout);
 ```
 
 </Tab>

--- a/docs/pages/eas/observe/reference/metrics.mdx
+++ b/docs/pages/eas/observe/reference/metrics.mdx
@@ -102,15 +102,15 @@ This metric is not reported automatically. To start measuring it, call `markInte
 
 <Tabs>
 
-<Tab label="SDK 55">
-
-Call `AppMetrics.markInteractive()` from anywhere in your app.
-
-</Tab>
-
 <Tab label="SDK 56 and later">
 
 Call `markInteractive()` from the `useObserve()` hook inside a component.
+
+</Tab>
+
+<Tab label="SDK 55">
+
+Call `AppMetrics.markInteractive()` from anywhere in your app.
 
 </Tab>
 
@@ -163,12 +163,14 @@ You can attach your own params to the TTI event by passing them to `markInteract
 
 <Tabs>
 
-<Tab label="SDK 55">
+<Tab label="SDK 56 and later">
 
 ```tsx
-import { AppMetrics } from 'expo-observe';
+import { useObserve } from 'expo-observe';
 
-AppMetrics.markInteractive({
+const { markInteractive } = useObserve();
+
+markInteractive({
   params: {
     tenant: 'acme',
     cohort: 'beta',
@@ -179,14 +181,12 @@ AppMetrics.markInteractive({
 
 </Tab>
 
-<Tab label="SDK 56 and later">
+<Tab label="SDK 55">
 
 ```tsx
-import { useObserve } from 'expo-observe';
+import { AppMetrics } from 'expo-observe';
 
-const { markInteractive } = useObserve();
-
-markInteractive({
+AppMetrics.markInteractive({
   params: {
     tenant: 'acme',
     cohort: 'beta',
@@ -203,19 +203,6 @@ You can also override the route name attached to the event, which is otherwise p
 
 <Tabs>
 
-<Tab label="SDK 55">
-
-```tsx
-import { AppMetrics } from 'expo-observe';
-
-AppMetrics.markInteractive({
-  routeName: '/feed',
-  params: { cacheHit: true },
-});
-```
-
-</Tab>
-
 <Tab label="SDK 56 and later">
 
 ```tsx
@@ -224,6 +211,19 @@ import { useObserve } from 'expo-observe';
 const { markInteractive } = useObserve();
 
 markInteractive({
+  routeName: '/feed',
+  params: { cacheHit: true },
+});
+```
+
+</Tab>
+
+<Tab label="SDK 55">
+
+```tsx
+import { AppMetrics } from 'expo-observe';
+
+AppMetrics.markInteractive({
   routeName: '/feed',
   params: { cacheHit: true },
 });

--- a/docs/pages/eas/observe/reference/troubleshooting.mdx
+++ b/docs/pages/eas/observe/reference/troubleshooting.mdx
@@ -23,20 +23,6 @@ Verify that your root layout is wrapped with the root HOC:
 
 <Tabs>
 
-<Tab label="SDK 55">
-
-```jsx
-import { AppMetricsRoot } from 'expo-observe';
-
-function RootLayout() {
-  return (/* your layout */);
-}
-
-export default AppMetricsRoot.wrap(RootLayout);
-```
-
-</Tab>
-
 <Tab label="SDK 56 and later">
 
 ```jsx
@@ -51,6 +37,20 @@ export default ObserveRoot.wrap(RootLayout);
 
 </Tab>
 
+<Tab label="SDK 55">
+
+```jsx
+import { AppMetricsRoot } from 'expo-observe';
+
+function RootLayout() {
+  return (/* your layout */);
+}
+
+export default AppMetricsRoot.wrap(RootLayout);
+```
+
+</Tab>
+
 </Tabs>
 
 ### Time to interactive not showing
@@ -59,16 +59,16 @@ This metric requires manual instrumentation. Verify that:
 
 <Tabs>
 
-<Tab label="SDK 55">
+<Tab label="SDK 56">
 
-1. You are calling `AppMetrics.markInteractive()` after your splash screen is hidden.
+1. You are calling `markInteractive()` (from `useObserve()`) after your splash screen is hidden.
 2. The call is actually being executed (add a `console.log` to verify).
 
 </Tab>
 
-<Tab label="SDK 56">
+<Tab label="SDK 55">
 
-1. You are calling `markInteractive()` (from `useObserve()`) after your splash screen is hidden.
+1. You are calling `AppMetrics.markInteractive()` after your splash screen is hidden.
 2. The call is actually being executed (add a `console.log` to verify).
 
 </Tab>
@@ -127,20 +127,6 @@ After:
 
 <Tabs>
 
-<Tab label="SDK 55">
-
-```jsx
-import { AppMetricsRoot } from 'expo-observe';
-
-function RootLayout() {
-  return (/* your layout */);
-}
-
-export default AppMetricsRoot.wrap(RootLayout);
-```
-
-</Tab>
-
 <Tab label="SDK 56 and later">
 
 ```jsx
@@ -151,6 +137,20 @@ function RootLayout() {
 }
 
 export default ObserveRoot.wrap(RootLayout);
+```
+
+</Tab>
+
+<Tab label="SDK 55">
+
+```jsx
+import { AppMetricsRoot } from 'expo-observe';
+
+function RootLayout() {
+  return (/* your layout */);
+}
+
+export default AppMetricsRoot.wrap(RootLayout);
 ```
 
 </Tab>


### PR DESCRIPTION
# Why

We currently show 55 instructions first in tabs, but should be the opposite

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Reverse the tabs

<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

👀 

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
