### PR TITLE
Fix iPad supported orientation Info.plist lookup

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))
 - [iOS] Propagate async-function promise construction failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
+- [iOS] Read iPad-specific supported orientations from `UISupportedInterfaceOrientations~ipad`. ([#46281](https://github.com/expo/expo/issues/46281) by [@bryandent](https://github.com/bryandent)) ([#46306](https://github.com/expo/expo/pull/46306) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -483,11 +483,14 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
 }
 
 #if os(iOS)
-private func allowedOrientations(for userInterfaceIdiom: UIUserInterfaceIdiom) -> UIInterfaceOrientationMask {
+func allowedOrientations(
+  for userInterfaceIdiom: UIUserInterfaceIdiom,
+  infoDictionary: [String: Any]? = Bundle.main.infoDictionary
+) -> UIInterfaceOrientationMask {
   // For now only iPad-specific orientations are supported
-  let deviceString = userInterfaceIdiom == .pad ? "~pad" : ""
+  let deviceString = userInterfaceIdiom == .pad ? "~ipad" : ""
   var mask: UIInterfaceOrientationMask = []
-  guard let orientations = Bundle.main.infoDictionary?["UISupportedInterfaceOrientations\(deviceString)"] as? [String] else {
+  guard let orientations = infoDictionary?["UISupportedInterfaceOrientations\(deviceString)"] as? [String] else {
     return mask
   }
 

--- a/packages/expo-modules-core/ios/Tests/ExpoAppDelegateSubscriberManagerTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ExpoAppDelegateSubscriberManagerTests.swift
@@ -187,6 +187,26 @@ final class ExpoAppDelegateSubscriberManagerTests {
   }
 
   @Test
+  func allowedOrientationsUsesIPadInfoPlistKey() {
+    let infoDictionary: [String: Any] = [
+      "UISupportedInterfaceOrientations": [
+        "UIInterfaceOrientationPortrait"
+      ],
+      "UISupportedInterfaceOrientations~ipad": [
+        "UIInterfaceOrientationLandscapeLeft",
+        "UIInterfaceOrientationLandscapeRight"
+      ],
+      "UISupportedInterfaceOrientations~pad": [
+        "UIInterfaceOrientationPortraitUpsideDown"
+      ]
+    ]
+
+    let result = allowedOrientations(for: .pad, infoDictionary: infoDictionary)
+
+    #expect(result == [.landscapeLeft, .landscapeRight])
+  }
+
+  @Test
   func willContinueUserActivityWithType() {
     let result = ExpoAppDelegateSubscriberManager.application(UIApplication.shared, willContinueUserActivityWithType: "test")
     #expect(result == true)

--- a/packages/expo-modules-core/ios/Tests/ExpoAppDelegateSubscriberManagerTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ExpoAppDelegateSubscriberManagerTests.swift
@@ -207,6 +207,20 @@ final class ExpoAppDelegateSubscriberManagerTests {
   }
 
   @Test
+  func allowedOrientationsFallsBackToUniversalInfoPlistKeyForIPad() {
+    let infoDictionary: [String: Any] = [
+      "UISupportedInterfaceOrientations": [
+        "UIInterfaceOrientationLandscapeLeft",
+        "UIInterfaceOrientationLandscapeRight"
+      ]
+    ]
+
+    let result = allowedOrientations(for: .pad, infoDictionary: infoDictionary)
+
+    #expect(result == [.landscapeLeft, .landscapeRight])
+  }
+
+  @Test
   func willContinueUserActivityWithType() {
     let result = ExpoAppDelegateSubscriberManager.application(UIApplication.shared, willContinueUserActivityWithType: "test")
     #expect(result == true)


### PR DESCRIPTION
## Why

Fixes #46281. `ExpoAppDelegateSubscriberManager` looked for `UISupportedInterfaceOrientations~pad`, but iPad-specific Info.plist orientation entries use `UISupportedInterfaceOrientations~ipad`, so iPad builds could ignore their iPad orientation lock and fall back to the universal orientation list.

## How

Changed the iPad suffix from `~pad` to `~ipad` in `expo-modules-core`, and made the orientation parser accept an injected Info.plist dictionary so the key selection is covered by a focused unit test.

## Test Plan

- `xcrun swiftc -parse packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift packages/expo-modules-core/ios/Tests/ExpoAppDelegateSubscriberManagerTests.swift`
- `pnpm --filter expo-modules-core test -- --runInBand --passWithNoTests`
- `pnpm --filter expo-modules-core lint` exits 0 with existing unrelated Prettier warnings in `src/polyfill/CoreModule.ts` and `src/ts-declarations/SharedRef.ts`
- `git diff --check`

Native iOS unit execution was not run locally because `apps/native-tests/ios/Pods` is missing in this checkout.

## Risk

Low. This touches one package, changes only the Info.plist key suffix used for iPad orientation lookup, and adds a targeted parser test plus changelog entry.
