### PR TITLE
[expo-splash-screen] Remove applyImageToSplashScreenXML arg defaults

### DIFF
--- a/packages/expo-splash-screen/plugin/build/InterfaceBuilder.d.ts
+++ b/packages/expo-splash-screen/plugin/build/InterfaceBuilder.d.ts
@@ -224,9 +224,9 @@ export declare function removeImageFromSplashScreen(xml: IBSplashScreenDocument,
 export declare function applyImageToSplashScreenXML(xml: IBSplashScreenDocument, { imageName, contentMode, backgroundColor, enableFullScreenImage, imageWidth, }: {
     imageName: string;
     contentMode: ImageContentMode;
-    backgroundColor?: string;
+    backgroundColor: string;
     enableFullScreenImage: boolean;
-    imageWidth?: number;
+    imageWidth: number;
 }): IBSplashScreenDocument;
 /**
  * IB does not allow two items to have the same ID.

--- a/packages/expo-splash-screen/plugin/build/InterfaceBuilder.js
+++ b/packages/expo-splash-screen/plugin/build/InterfaceBuilder.js
@@ -71,7 +71,7 @@ function getAbsoluteConstraints(childId, parentId, legacy = false) {
         createConstraint([childId, 'centerY'], [parentId, 'centerY']),
     ];
 }
-function applyImageToSplashScreenXML(xml, { imageName, contentMode, backgroundColor = '#ffffff', enableFullScreenImage, imageWidth = 100, }) {
+function applyImageToSplashScreenXML(xml, { imageName, contentMode, backgroundColor, enableFullScreenImage, imageWidth, }) {
     const mainView = xml.document.scenes[0]?.scene[0]?.objects[0]?.viewController[0]?.view[0];
     const rect = mainView?.rect[0];
     const width = enableFullScreenImage ? 414 : imageWidth;

--- a/packages/expo-splash-screen/plugin/src/InterfaceBuilder.ts
+++ b/packages/expo-splash-screen/plugin/src/InterfaceBuilder.ts
@@ -352,15 +352,15 @@ export function applyImageToSplashScreenXML(
   {
     imageName,
     contentMode,
-    backgroundColor = '#ffffff',
+    backgroundColor,
     enableFullScreenImage,
-    imageWidth = 100,
+    imageWidth,
   }: {
     imageName: string;
     contentMode: ImageContentMode;
-    backgroundColor?: string;
+    backgroundColor: string;
     enableFullScreenImage: boolean;
-    imageWidth?: number;
+    imageWidth: number;
   }
 ): IBSplashScreenDocument {
   const mainView = xml.document.scenes[0]?.scene[0]?.objects[0]?.viewController[0]?.view[0];


### PR DESCRIPTION
# Why

Remove `applyImageToSplashScreenXML` `backgroundColor` and `imageWidth` defaults. Those are now handled in one place: `getAndroidSplashConfig.ts` / `getIosSplashConfig.ts` and never `undefined`.

# How

Remove record properties optionality.

# Test Plan

- Run typecheck

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
