### PR TITLE
[docs] Update Xcode value in SDK compatibility table for SDK 56

### DIFF
--- a/docs/ui/components/SDKTables/sdk-versions.json
+++ b/docs/ui/components/SDKTables/sdk-versions.json
@@ -7,7 +7,7 @@
       "targetSdkVersion": "36",
       "buildToolsVersion": "36.0.0",
       "ios": "16.4+",
-      "xcode": "26.2+",
+      "xcode": "26.4+",
       "react-native": "0.85",
       "react-native-web": "0.21.0",
       "react-native-tvos": "0.85-stable",


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/46126

# How

<!--
How did you build this feature or fix this bug and why?
-->

Bump Xcode to 26.4+ for SDK 56.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
