### PR TITLE
[expo-dev-launcher][android] Fix NPE on deep link cold launch

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc))
+
 ### 💡 Others
 
 ## 56.0.16 — 2026-05-26

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -423,8 +423,8 @@ class DevLauncherController private constructor(
           intent.extras?.let {
             putExtras(it)
           }
-          intent.categories?.let {
-            categories.addAll(it)
+          intent.categories?.let { categories ->
+            categories.forEach { addCategory(it) }
           }
         } ?: run {
         // If no pending intent is available, use the extras from the intent that was used to launch the app.


### PR DESCRIPTION
Fixes #46313.

# How

`DevLauncherController.createAppIntent()` copied the pending intent's categories onto a freshly built relaunch intent via `categories.addAll(it)`. The bare `categories` resolves to the relaunch intent's `getCategories()`, which Android returns as `null` until `addCategory()` is first called — so cold-launching from a deep link that carries intent categories (e.g. an App Link opened from a browser) crashed with an `addAll`-on-null NPE.

Switch to `addCategory()`, which lazily allocates the backing set:

```kotlin
intent.categories?.let { categories ->
  categories.forEach { addCategory(it) }
}
```

See #46313 for the full root-cause analysis, reproduction, and test plan.

# Checklist

- [x] I added a `CHANGELOG.md` entry.
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (Kotlin-only change, no config/plugin impact).