### PR TITLE
[docs] update mcp for GA

### DIFF
--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -14,8 +14,6 @@ import { Terminal } from '~/ui/components/Snippet';
 import { Step } from '~/ui/components/Step';
 import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
 
-> **info** Expo MCP Server requires an [EAS paid plan](https://expo.dev/pricing).
-
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is a standard protocol that allows AI models to integrate with external data sources, providing enhanced context for more precise responses. It enables AI-assisted tools like agents to understand your development environment more deeply, allowing them to provide better assistance with your codebase.
 
 Expo MCP Server is a remote MCP server hosted by Expo that integrates with popular AI-assisted tools such as Claude Code, Cursor, VS Code, and others, enabling them to interact directly with your Expo projects.
@@ -62,8 +60,8 @@ Your AI-assisted tools can autonomously write the code, capture screenshots to v
 The complete table of [MCP capabilities](#available-mcp-capabilities) documents the tools and prompts Expo MCP Server provides to AI-assisted tools.
 
 <Prerequisites>
-  <Requirement title="Expo account with an EAS paid plan">
-    An [EAS paid plan](https://expo.dev/pricing) is required to use Expo MCP Server.
+  <Requirement title="Expo account">
+    An Expo account is required to use Expo MCP Server.
   </Requirement>
   <Requirement title="An Expo project on the latest SDK">
     Create a project with `npx create-expo-app@latest --template default@sdk-56`, or ensure your
@@ -187,7 +185,7 @@ Expo MCP Server provides two types of capabilities depending on your setup:
 
 ### Server capabilities
 
-Server capabilities are available with just the remote MCP server connection, without needing to set up a local development server. The **search_documentation** tool is an example of a server capability.
+Server capabilities are available with just the remote MCP server connection, without needing to set up a local development server.
 
 ### Local capabilities
 

--- a/docs/ui/components/ExpoMCPToolsTable/data/expo-mcp-tools.json
+++ b/docs/ui/components/ExpoMCPToolsTable/data/expo-mcp-tools.json
@@ -17,7 +17,8 @@
       "name": "search_documentation",
       "description": "Search the official Expo documentation and return page URLs ranked by relevance for a user query. Use read_documentation to fetch the full content of specific pages, starting from the top.",
       "examplePrompt": "search documentation for CNG",
-      "availability": "Server"
+      "availability": "Server",
+      "requirements": "requires an EAS paid plan"
     },
     {
       "name": "read_documentation",

--- a/docs/ui/components/ExpoMCPToolsTable/sync-expo-mcp-tools.js
+++ b/docs/ui/components/ExpoMCPToolsTable/sync-expo-mcp-tools.js
@@ -29,6 +29,14 @@ const LOCAL_REQUIREMENTS = {
 };
 
 /**
+ * Requirements for server tools that have plan-specific availability.
+ * Keyed by tool name.
+ */
+const SERVER_REQUIREMENTS = {
+  search_documentation: 'requires an EAS paid plan',
+};
+
+/**
  * Example prompts for server tools (docs-only, not from MCP server).
  * Keyed by tool name.
  */
@@ -125,6 +133,7 @@ async function fetchServerTools() {
       description: ensureTrailingPeriod(tool.description),
       examplePrompt: SERVER_EXAMPLE_PROMPTS[tool.name] ?? '',
       availability: 'Server',
+      ...(SERVER_REQUIREMENTS[tool.name] && { requirements: SERVER_REQUIREMENTS[tool.name] }),
     }));
 }
 


### PR DESCRIPTION
# Why

mcp is GA now

# How

- remove paid account info
- "search_documentation" has a cost which may or may not limit to paid accounts only. update the doc and script for it

# Test Plan

ci passed and local preview

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
