### PR TITLE
[docs] Document build cache provider limitations

### DIFF
--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -87,6 +87,16 @@ type CalculateFingerprintHashProps = {
 
 A reference implementation using GitHub Releases to cache builds can be found in the [Build Cache Provider Example](https://github.com/expo/examples/tree/master/with-github-remote-build-cache-provider).
 
+## Limitations
+
+The build cache provider is consulted only by local `npx expo run:[android|ios]` commands. Builds triggered with `eas build` are not affected — they always produce fresh artifacts and never invoke the cache provider plugin.
+
+Some local builds are also skipped:
+
+- **iOS physical device builds.** A device build is only valid on devices that match its provisioning profile, so reusing one across machines or devices is unsafe. `npx expo run:ios` therefore skips both the cache lookup and the post-build upload when the target is a physical device. Only iOS simulator builds participate in caching.
+
+If you're using `appVersionSource: "remote"` in **eas.json**, note that the `buildNumber` (iOS) and `versionCode` (Android) live on EAS servers rather than in your project source, so they are not part of the fingerprint inputs. This is fine for normal dev iteration — local `npx expo run:*` invocations don't auto-increment those values — but be aware that a cached artifact retains whatever build number was embedded when it was originally built.
+
 ## Creating a custom build provider
 
 Start by creating a **provider** directory for writing the provider plugin in TypeScript and add a **provider.plugin.js** file in the project root, which will be the plugin's entry point.

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -93,7 +93,7 @@ The build cache provider is consulted only by local `npx expo run:[android|ios]`
 
 Some local builds are also skipped:
 
-- **iOS physical device builds.** A device build is only valid on devices that match its provisioning profile, so reusing one across machines or devices is unsafe. `npx expo run:ios` therefore skips both the cache lookup and the post-build upload when the target is a physical device. Only iOS simulator builds participate in caching.
+- **iOS physical device builds.** A device build is only valid on devices that match its provisioning profile, so reusing one across machines or devices is unsafe. `npx expo run:ios` therefore skips both the cache lookup and the post-build upload when the target is a physical device. Only iOS Simulator builds participate in caching.
 
 If you're using `appVersionSource: "remote"` in **eas.json**, note that the `versionCode` (Android) and `buildNumber` (iOS) live on EAS servers rather than in your project source, so they are not part of the fingerprint inputs. This is fine for normal development iteration. Local `npx expo run:*` invocations don't auto-increment those values, but be aware that a cached artifact retains whatever build number was embedded when it was originally built.
 

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -89,13 +89,13 @@ A reference implementation using GitHub Releases to cache builds can be found in
 
 ## Limitations
 
-The build cache provider is consulted only by local `npx expo run:[android|ios]` commands. Builds triggered with `eas build` are not affected — they always produce fresh artifacts and never invoke the cache provider plugin.
+The build cache provider is consulted only by local `npx expo run:[android|ios]` commands. Builds triggered with `eas build` are not affected. They always produce fresh artifacts and never invoke the cache provider plugin.
 
 Some local builds are also skipped:
 
 - **iOS physical device builds.** A device build is only valid on devices that match its provisioning profile, so reusing one across machines or devices is unsafe. `npx expo run:ios` therefore skips both the cache lookup and the post-build upload when the target is a physical device. Only iOS simulator builds participate in caching.
 
-If you're using `appVersionSource: "remote"` in **eas.json**, note that the `buildNumber` (iOS) and `versionCode` (Android) live on EAS servers rather than in your project source, so they are not part of the fingerprint inputs. This is fine for normal dev iteration — local `npx expo run:*` invocations don't auto-increment those values — but be aware that a cached artifact retains whatever build number was embedded when it was originally built.
+If you're using `appVersionSource: "remote"` in **eas.json**, note that the `versionCode` (Android) and `buildNumber` (iOS) live on EAS servers rather than in your project source, so they are not part of the fingerprint inputs. This is fine for normal development iteration. Local `npx expo run:*` invocations don't auto-increment those values, but be aware that a cached artifact retains whatever build number was embedded when it was originally built.
 
 ## Creating a custom build provider
 


### PR DESCRIPTION
# Why

The [build cache providers guide](https://docs.expo.dev/guides/cache-builds-remotely/) currently doesn't surface three real behaviours that affect users:

1. **Only `npx expo run:[android|ios]` consults the provider.** Builds triggered with `eas build` are unaffected. I verified by searching `expo/eas-cli` for `buildCacheProvider`/`resolveBuildCache`/`uploadBuildCache` — the only matches are inside the `eas-build-cache-provider` package itself. There's no consumer on the `eas-cli` side, so cloud builds never invoke the plugin.

2. **iOS physical device builds are intentionally skipped.** Implemented in [`71281551`](https://github.com/expo/expo/commit/71281551720afc7618edb8265d5b51c37c723914) (preventing device builds from being remotely cached) for the reason called out in [#40476](https://github.com/expo/expo/issues/40476): a device build is only usable on devices matching its provisioning profile. The commit also turns off the post-build upload in this case. The guide doesn't mention this — and on that issue, @gabrieldonadel noted *"We will update our docs to include a section on limitation of build cache providers."* This is that section.

3. **`appVersionSource: "remote"` decouples build number from the fingerprint.** With remote app version source, `buildNumber`/`versionCode` live on EAS servers — they're not in the source files that `@expo/fingerprint` hashes. For normal dev iteration this is fine, but a user running `npx expo run:* --configuration Release` locally with the intent to ship that binary should know about it. Mentioned briefly with a pointer to `EXPO_NO_CACHE=1` as the per-invocation escape hatch.

# How

Added a `## Limitations` section to **docs/pages/guides/cache-builds-remotely.mdx** between the existing "Using EAS as a build provider" and "Creating a custom build provider" sections.

# Test Plan

Docs-only change — no code paths affected. Rendered preview should show the new section in the build cache providers guide.