### PR TITLE
[ios][core] Fix iPad orientation Info.plist lookup

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### 🐛 Bug fixes
 
 - [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))
+- [iOS] Fix iPad-specific supported orientation lookup to read `UISupportedInterfaceOrientations~ipad`.
 
 ### 💡 Others
 

--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -485,7 +485,7 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
 #if os(iOS)
 private func allowedOrientations(for userInterfaceIdiom: UIUserInterfaceIdiom) -> UIInterfaceOrientationMask {
   // For now only iPad-specific orientations are supported
-  let deviceString = userInterfaceIdiom == .pad ? "~pad" : ""
+  let deviceString = userInterfaceIdiom == .pad ? "~ipad" : ""
   var mask: UIInterfaceOrientationMask = []
   guard let orientations = Bundle.main.infoDictionary?["UISupportedInterfaceOrientations\(deviceString)"] as? [String] else {
     return mask


### PR DESCRIPTION
# Why

Closes #46281.

`ExpoAppDelegateSubscriberManager` currently looks for `UISupportedInterfaceOrientations~pad` when resolving iPad-specific orientations. The documented Info.plist key is `UISupportedInterfaceOrientations~ipad`, so iPad-specific orientation locks are ignored.

# How

Use the `~ipad` suffix when `UIDevice.current.userInterfaceIdiom` is `.pad`.

# Test Plan

Not run locally; this checkout only contains the touched files and does not include the full native project setup. The change is limited to the Info.plist key suffix identified in the issue reproduction.

# Checklist

- [x] I added a `CHANGELOG.md` entry for `expo-modules-core`.
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (not applicable: no config plugin or prebuild output changes).
