### PR TITLE
[docs] Remove broken Expo Icon Builder link

### DIFF
--- a/docs/pages/versions/unversioned/sdk/splash-screen.mdx
+++ b/docs/pages/versions/unversioned/sdk/splash-screen.mdx
@@ -20,7 +20,7 @@ The `SplashScreen` module from the `expo-splash-screen` library provides control
 
 > From **SDK 52**, due to changes supporting the latest Android splash screen API, Expo Go and development builds cannot fully replicate the splash screen experience your users will see in your [standalone app](/more/glossary-of-terms/#standalone-app). Expo Go will show your app icon instead of the splash screen, and the splash screen on development builds will not reflect all properties set in the config plugin. **It is highly recommended that you test your splash screen on a release build to ensure it looks as expected.**
 
-Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
+Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen).
 
 ## Installation
 

--- a/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/splash-screen.mdx
@@ -20,7 +20,7 @@ The `SplashScreen` module from the `expo-splash-screen` library provides control
 
 > From **SDK 52**, due to changes supporting the latest Android splash screen API, Expo Go and development builds cannot fully replicate the splash screen experience your users will see in your [standalone app](/more/glossary-of-terms/#standalone-app). Expo Go will show your app icon instead of the splash screen, and the splash screen on development builds will not reflect all properties set in the config plugin. **It is highly recommended that you test your splash screen on a release build to ensure it looks as expected.**
 
-Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
+Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen).
 
 ## Installation
 

--- a/docs/pages/versions/v55.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/splash-screen.mdx
@@ -20,7 +20,7 @@ The `SplashScreen` module from the `expo-splash-screen` library provides control
 
 > From **SDK 52**, due to changes supporting the latest Android splash screen API, Expo Go and development builds cannot fully replicate the splash screen experience your users will see in your [standalone app](/more/glossary-of-terms/#standalone-app). Expo Go will show your app icon instead of the splash screen, and the splash screen on development builds will not reflect all properties set in the config plugin. **It is highly recommended that you test your splash screen on a release build to ensure it looks as expected.**
 
-Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
+Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen).
 
 ## Installation
 

--- a/docs/pages/versions/v56.0.0/sdk/splash-screen.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/splash-screen.mdx
@@ -20,7 +20,7 @@ The `SplashScreen` module from the `expo-splash-screen` library provides control
 
 > From **SDK 52**, due to changes supporting the latest Android splash screen API, Expo Go and development builds cannot fully replicate the splash screen experience your users will see in your [standalone app](/more/glossary-of-terms/#standalone-app). Expo Go will show your app icon instead of the splash screen, and the splash screen on development builds will not reflect all properties set in the config plugin. **It is highly recommended that you test your splash screen on a release build to ensure it looks as expected.**
 
-Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen), or [quickly generate an icon and splash screen using your browser](https://buildicon.netlify.app/).
+Also, see the guide on [creating a splash screen image](/develop/user-interface/splash-screen-and-app-icon/#splash-screen).
 
 ## Installation
 


### PR DESCRIPTION
## Why

Closes #43760.

The SplashScreen docs link to the Expo Icon Builder at `buildicon.netlify.app`, but the referenced generator no longer produces a usable download. The docs already link to the maintained splash screen image guide, so keeping the external generator link creates a broken path for readers.

## How

Removed the external Expo Icon Builder link from the latest, SDK 56, SDK 55, and SDK 54 SplashScreen docs while keeping the official splash screen image guide link.

## Test Plan

- `curl -I -L --max-time 20 https://buildicon.netlify.app/` confirmed the external page still responds, but its app bundle contains an empty archive generation path for downloads.
- `rg -n "buildicon\.netlify\.app|quickly generate an icon and splash screen" docs/pages` returns no matches.
- `git diff --check`

## Checklist

- [x] Documentation is up to date to reflect these changes.
- [x] Conforms with the Documentation Writing Style Guide.