### PR TITLE
Update edgeToEdge package to call updateEdgeToEdgeFeatureFlag

### DIFF
--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- Update edge-to-edge package to call `updateEdgeToEdgeFeatureFlag` ([#46335](https://github.com/expo/expo/pull/46335) by [@zoontek](https://github.com/zoontek))
+
 ## 56.0.13 — 2026-05-26
 
 ### 🎉 New features

--- a/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/edgeToEdge/EdgeToEdgePackage.kt
+++ b/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/edgeToEdge/EdgeToEdgePackage.kt
@@ -2,67 +2,30 @@ package expo.modules.kotlin.edgeToEdge
 
 import android.app.Activity
 import android.content.Context
-import android.content.res.TypedArray
-import android.os.Build
 import android.os.Bundle
 import android.util.Log
-import android.view.Window
-import androidx.annotation.RequiresApi
 import expo.modules.core.BasePackage
 import expo.modules.core.interfaces.ReactActivityLifecycleListener
-import kotlin.Unit
 
 class EdgeToEdgePackage : BasePackage() {
   override fun createReactActivityLifecycleListeners(activityContext: Context?): List<ReactActivityLifecycleListener?> {
     return listOf(object : ReactActivityLifecycleListener {
       override fun onCreate(activity: Activity?, savedInstanceState: Bundle?) {
-        val edgeToEdgeEnabled = invokeWindowUtilKtMethod<Boolean>("isEdgeToEdgeFeatureFlagOn") ?: true
-
-        if (edgeToEdgeEnabled) {
-          invokeWindowUtilKtMethod<Unit>("enableEdgeToEdge", Pair(Window::class.java, activity?.window))
-
-          // React-native sets `window.isNavigationBarContrastEnforced` to `true` in `WindowUtilKt.enableEdgeToEdge`.
-          // We have to set it back to the value defined in the app styles, which comes from our config plugin.
-          activity?.enforceNavigationBarContrastFromTheme()
-        }
+        activity?.let { updateEdgeToEdgeFeatureFlag(it) }
       }
     })
   }
 }
 
-@RequiresApi(Build.VERSION_CODES.Q)
-private fun Activity.getEnforceContrastFromTheme(): Boolean {
-  val attrs = intArrayOf(android.R.attr.enforceNavigationBarContrast)
-  val typedArray: TypedArray = theme.obtainStyledAttributes(attrs)
+private fun updateEdgeToEdgeFeatureFlag(activity: Activity) {
+  val methodName = "updateEdgeToEdgeFeatureFlag"
+  val className = "com.facebook.react.views.view.WindowUtilKt"
 
-  return try {
-    typedArray.getBoolean(0, true)
-  } finally {
-    typedArray.recycle()
-  }
-}
-
-private fun Activity.enforceNavigationBarContrastFromTheme() {
-  if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-    window.isNavigationBarContrastEnforced = getEnforceContrastFromTheme()
-  }
-}
-
-private inline fun <reified T> invokeWindowUtilKtMethod(
-  methodName: String,
-  vararg args: Pair<Class<*>, Any?>
-): T? {
-  val windowUtilClassName = "com.facebook.react.views.view.WindowUtilKt"
-
-  return runCatching {
-    val windowUtilKtClass = Class.forName(windowUtilClassName)
-    val parameterTypes = args.map { it.first }.toTypedArray()
-    val parameterValues = args.map { it.second }.toTypedArray()
-    val method = windowUtilKtClass.getDeclaredMethod(methodName, *parameterTypes)
-
+  runCatching {
+    val method = Class.forName(className).getDeclaredMethod(methodName, Activity::class.java)
     method.isAccessible = true
-    method.invoke(null, *parameterValues) as? T
+    method.invoke(null, activity)
   }.onFailure {
-    Log.e("EdgeToEdgePackage", "Failed to invoke '$methodName' on $windowUtilClassName", it)
-  }.getOrNull()
+    Log.e("EdgeToEdgePackage", "Failed to invoke '$methodName' on $className", it)
+  }
 }


### PR DESCRIPTION
# Why

React Native now ships `WindowUtilKt.updateEdgeToEdgeFeatureFlag`, which combines the feature-flag check, the `enableEdgeToEdge` call, and theme-aware contrast handling into a single entry point. Our previous implementation predates that helper and reimplemented the same logic by hand, including a workaround that restored `window.isNavigationBarContrastEnforced` from the activity theme after RN had forced it to `true`. With the new helper, all of that becomes unnecessary.

# How

- Replaced the manual sequence (read flag via reflection, call `enableEdgeToEdge`, patch contrast back from the theme) with a single reflective call to `WindowUtilKt.updateEdgeToEdgeFeatureFlag(activity)`.
- Dropped the `enforceNavigationBarContrastFromTheme` helper and its supporting code, since RN now reads `android:enforceNavigationBarContrast` itself.

# Test Plan

Built a dev client and verified on an Android device that:

- `window.navigationBarColor` is `0` (transparent).
- `window.isNavigationBarContrastEnforced` is `false` (theme value respected).
- `WindowCompat.getInsetsController(...).isAppearanceLightNavigationBars` can still be flipped through `expo-navigation-bar.setStyle`, and the readback confirms the value sticks.

Note: emulator system images below API 35 do not repaint the navigation bar icons when the appearance flag changes (the call is honored, the surface just is not redrawn). Verified on a physical device that icons flip correctly, so this is unrelated to the change.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
