### PR TITLE
[docs] rename server name from expo-mcp to expo

### DIFF
--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -86,7 +86,7 @@ Expo MCP Server supports integration with various AI-assisted tools. Use the gen
 
 <Collapsible summary="Claude Code setup">
 
-<Terminal cmd={['$ claude mcp add --transport http expo-mcp https://mcp.expo.dev/mcp']} />
+<Terminal cmd={['$ claude mcp add --transport http expo https://mcp.expo.dev/mcp']} />
 
 After installation, run `/mcp` in your Claude Code session to authenticate.
 
@@ -96,7 +96,7 @@ After installation, run `/mcp` in your Claude Code session to authenticate.
 
 Click the following link to install the MCP server for Cursor:
 
-<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=expo-mcp&config=eyJ1cmwiOiJodHRwczovL21jcC5leHBvLmRldi9tY3AifQ%3D%3D">
+<a href="cursor://anysphere.cursor-deeplink/mcp/install?name=expo&config=eyJ1cmwiOiJodHRwczovL21jcC5leHBvLmRldi9tY3AifQ%3D%3D">
   <img
     src="https://cursor.com/deeplink/mcp-install-light.svg"
     alt="Install MCP Server"
@@ -118,13 +118,13 @@ Click the following link to install the MCP server for Cursor:
 3. Select **HTTP**
 4. Enter the server details:
    - **URL**: `https://mcp.expo.dev/mcp`
-   - **Name**: expo-mcp
+   - **Name**: expo
 
 </Collapsible>
 
 <Collapsible summary="Codex setup">
 
-<Terminal cmd={['$ codex mcp add expo-mcp --url https://mcp.expo.dev/mcp']} />
+<Terminal cmd={['$ codex mcp add expo --url https://mcp.expo.dev/mcp']} />
 
 The above command adds the MCP server to your Codex configuration file and prompts you to authenticate with your Expo account.
 


### PR DESCRIPTION
# Why

follow up comment https://exponent-internal.slack.com/archives/C09H0RW2SJG/p1779860431488519

# How

rename expo-mcp to just expo

# Test Plan

ci passed

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
