### PR TITLE
[docs] Add multi-pm (package managers)Terminal blocks in Home

### DIFF
--- a/docs/pages/config-plugins/development-for-libraries.mdx
+++ b/docs/pages/config-plugins/development-for-libraries.mdx
@@ -66,7 +66,14 @@ The most straightforward approach to leverage Expo's tooling is to use `expo` an
 - `expo` provides a config plugin API and types that your plugin will use.
 - `expo-module-scripts` provides build tooling specifically designed for Expo modules and config plugins. It also handles TypeScript compilation.
 
-<Terminal cmd={['$ npx expo install package']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install package'],
+    yarn: ['$ yarn expo install package'],
+    pnpm: ['$ pnpm expo install package'],
+    bun: ['$ bun expo install package'],
+  }}
+/>
 
 When using `expo-module-scripts`, it requires the following **package.json** configuration. For any already existing script with the same script name, replace it.
 

--- a/docs/pages/config-plugins/patch-project.mdx
+++ b/docs/pages/config-plugins/patch-project.mdx
@@ -21,7 +21,14 @@ This guide explains how to use `patch-project`, when to use it, and its limitati
 
 To get started, you need to install the tool in your project:
 
-<Terminal cmd={['$ npx expo install patch-project']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install patch-project'],
+    yarn: ['$ yarn expo install patch-project'],
+    pnpm: ['$ pnpm expo install patch-project'],
+    bun: ['$ bun expo install patch-project'],
+  }}
+/>
 
 This command will automatically add the `patch-project` config plugin to your [app config](/workflow/configuration/):
 
@@ -40,7 +47,14 @@ This command will automatically add the `patch-project` config plugin to your [a
 
 Let's assume you manually modified native directories (**android** and **ios**) in your project. To generate patches for these native directories, you can run the following command:
 
-<Terminal cmd={['$ npx patch-project']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx patch-project'],
+    yarn: ['$ yarn dlx patch-project'],
+    pnpm: ['$ pnpm dlx patch-project'],
+    bun: ['$ bunx patch-project'],
+  }}
+/>
 
 > **info** **Note**: In scenarios where you want to generate patches for a specific platform, you can use the `--platform` option and run `npx patch-project --platform android` or `npx patch-project --platform ios`.
 

--- a/docs/pages/config-plugins/plugins.mdx
+++ b/docs/pages/config-plugins/plugins.mdx
@@ -137,7 +137,14 @@ We recommend writing config plugins in TypeScript, since this will provide intel
 
 Install `tsx` library by running the following command:
 
-<Terminal cmd={['$ npm install --save-dev tsx']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --save-dev tsx'],
+    yarn: ['$ yarn add --dev tsx'],
+    pnpm: ['$ pnpm add --save-dev tsx'],
+    bun: ['$ bun add --dev tsx'],
+  }}
+/>
 
 Then, change the static app config (**app.json**) to the [dynamic app config (**app.config.ts**)](/workflow/configuration/#dynamic-configuration) file. You can do this by renaming the **app.json** file to **app.config.ts** and changing the content of the file as shown below. Ensure to add the following import statement at the top of your **app.config.ts** file:
 
@@ -176,7 +183,14 @@ module.exports = /* @info */({ config }: { config: ExpoConfig })/* @end */ => {
 
 To see the custom config applied in native projects, run the following command:
 
-<Terminal cmd={['$ npx expo prebuild --clean --no-install']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild --clean --no-install'],
+    yarn: ['$ yarn expo prebuild --clean --no-install'],
+    pnpm: ['$ pnpm expo prebuild --clean --no-install'],
+    bun: ['$ bun expo prebuild --clean --no-install'],
+  }}
+/>
 
 To verify the custom config plugins applied, open **android/app/src/main/AndroidManifest.xml** and **ios/\<your-project-name\>/Info.plist** files:
 
@@ -347,7 +361,14 @@ Expo config plugins are usually included in Node.js modules. You can install the
 
 For example, `expo-camera` has a plugin that adds camera permissions to the **AndroidManifest.xml** and **Info.plist**. To install it in your project, run the following command:
 
-<Terminal cmd={['$ npx expo install expo-camera']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-camera'],
+    yarn: ['$ yarn expo install expo-camera'],
+    pnpm: ['$ pnpm expo install expo-camera'],
+    bun: ['$ bun expo install expo-camera'],
+  }}
+/>
 
 In your [app config](/versions/latest/config/app/), you can add `expo-camera` to the list of plugins:
 

--- a/docs/pages/debugging/create-devtools-plugins.mdx
+++ b/docs/pages/debugging/create-devtools-plugins.mdx
@@ -30,7 +30,14 @@ Plugins can be distributed on npm or included inside your app's monorepo. They t
 
 `create-dev-plugin` will set up a new plugin project for you. Run the following command to create a new plugin project:
 
-<Terminal cmd={['$ npx create-dev-plugin@latest']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx create-dev-plugin@latest'],
+    yarn: ['$ yarn create dev-plugin'],
+    pnpm: ['$ pnpm create dev-plugin'],
+    bun: ['$ bun create dev-plugin'],
+  }}
+/>
 
 `create-dev-plugin` will prompt you for the name of your plugin, a description, and the name of the hook that will be used by consumers of your plugin.
 
@@ -134,7 +141,14 @@ if (process.env.NODE_ENV !== 'production') {
 
 Since the plugin web UI is an Expo app, you can test it just like you would any other Expo app, with `npx expo start`, except that you will run it in the browser only. The template includes a convenience command to run the plugin in local development mode:
 
-<Terminal cmd={['$ npm run web:dev']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm run web:dev'],
+    yarn: ['$ yarn run web:dev'],
+    pnpm: ['$ pnpm run web:dev'],
+    bun: ['$ bun run web:dev'],
+  }}
+/>
 
 </Step>
 
@@ -144,7 +158,14 @@ Since the plugin web UI is an Expo app, you can test it just like you would any 
 
 To prepare your plugin for distribution or use within your monorepo, you will need to build the plugin with the following command:
 
-<Terminal cmd={['$ npm run build:all']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm run build:all'],
+    yarn: ['$ yarn run build:all'],
+    pnpm: ['$ pnpm run build:all'],
+    bun: ['$ bun run build:all'],
+  }}
+/>
 
 This command will build the hook code into the **build** directory, and the web user interface into the **dist** directory.
 

--- a/docs/pages/debugging/devtools-plugins.mdx
+++ b/docs/pages/debugging/devtools-plugins.mdx
@@ -73,7 +73,14 @@ Inspired by [`@react-navigation/devtools`](https://github.com/react-navigation/r
 
 To use the plugin, start by installing the package:
 
-<Terminal cmd={['$ npx expo install @dev-plugins/react-navigation']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @dev-plugins/react-navigation'],
+    yarn: ['$ yarn expo install @dev-plugins/react-navigation'],
+    pnpm: ['$ pnpm expo install @dev-plugins/react-navigation'],
+    bun: ['$ bun expo install @dev-plugins/react-navigation'],
+  }}
+/>
 
 Pass the navigation root to the plugin in your app's entry point:
 
@@ -127,7 +134,14 @@ Inspired by [`react-native-apollo-devtools`](https://github.com/razorpay/react-n
 
 To use the plugin, start by installing the package:
 
-<Terminal cmd={['$ npx expo install @dev-plugins/apollo-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @dev-plugins/apollo-client'],
+    yarn: ['$ yarn expo install @dev-plugins/apollo-client'],
+    pnpm: ['$ pnpm expo install @dev-plugins/apollo-client'],
+    bun: ['$ bun expo install @dev-plugins/apollo-client'],
+  }}
+/>
 
 Then pass your client instance to the plugin in your app's root component or where you wrap the rest of your app in the `ApolloProvider`:
 
@@ -155,7 +169,14 @@ Inspired by [`react-query-native-devtools`](https://github.com/bgaleotti/react-q
 
 To use the plugin, start by installing the package:
 
-<Terminal cmd={['$ npx expo install @dev-plugins/react-query']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @dev-plugins/react-query'],
+    yarn: ['$ yarn expo install @dev-plugins/react-query'],
+    pnpm: ['$ pnpm expo install @dev-plugins/react-query'],
+    bun: ['$ bun expo install @dev-plugins/react-query'],
+  }}
+/>
 
 Then pass your client instance to the plugin in your app's root component or where you wrap the rest of your app in the `QueryClientProvider`:
 
@@ -180,7 +201,14 @@ The `redux-devtools-expo-dev-plugin` is based on the [Redux DevTools](https://gi
 
 To use the plugin, start by installing the package:
 
-<Terminal cmd={['$ npx expo install redux-devtools-expo-dev-plugin']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install redux-devtools-expo-dev-plugin'],
+    yarn: ['$ yarn expo install redux-devtools-expo-dev-plugin'],
+    pnpm: ['$ pnpm expo install redux-devtools-expo-dev-plugin'],
+    bun: ['$ bun expo install redux-devtools-expo-dev-plugin'],
+  }}
+/>
 
 If you're using `@reduxjs/toolkit`, modify the `configureStore` call to disable the built-in dev tools by passing in `devTools: false`. Then, add in the Expo DevTools plugin enhancer by concatenating the `devToolsEnhancer()`. The `configureStore` call is going to look like the following:
 
@@ -204,7 +232,14 @@ The TinyBase dev tools plugin connects the TinyBase Store Inspector to your app,
 
 To use the plugin, start by installing the package:
 
-<Terminal cmd={['$ npx expo install @dev-plugins/tinybase']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @dev-plugins/tinybase'],
+    yarn: ['$ yarn expo install @dev-plugins/tinybase'],
+    pnpm: ['$ pnpm expo install @dev-plugins/tinybase'],
+    bun: ['$ bun expo install @dev-plugins/tinybase'],
+  }}
+/>
 
 Then pass your client instance to the plugin in your app's root component or where you wrap the rest of your app with the store's `Provider`:
 

--- a/docs/pages/debugging/runtime-issues.mdx
+++ b/docs/pages/debugging/runtime-issues.mdx
@@ -45,7 +45,14 @@ You can perform full native debugging with Android Studio and Xcode by generatin
 
 Generate the native code for your project by running the following command:
 
-<Terminal cmd={['$ npx expo prebuild -p android']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild -p android'],
+    yarn: ['$ yarn expo prebuild -p android'],
+    pnpm: ['$ pnpm expo prebuild -p android'],
+    bun: ['$ bun expo prebuild -p android'],
+  }}
+/>
 
 This will add an **android** directory at the root of your project.
 
@@ -75,7 +82,14 @@ Build the app from Android Studio and connect the debugger. See [Google's docume
 
 Generate the native code for your project by running the following command:
 
-<Terminal cmd={['$ npx expo prebuild -p ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild -p ios'],
+    yarn: ['$ yarn expo prebuild -p ios'],
+    pnpm: ['$ pnpm expo prebuild -p ios'],
+    bun: ['$ bun expo prebuild -p ios'],
+  }}
+/>
 
 This will add an **ios** directory at the root of your project.
 

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -43,7 +43,6 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
     Install EAS CLI and login with your Expo account:
 
     <Terminal
-      cmdCopy="npm install --global eas-cli && eas login"
       cmd={{
         npm: ['$ npm install --global eas-cli && eas login'],
         yarn: ['$ yarn global add eas-cli && eas login'],
@@ -87,7 +86,6 @@ The command will lead you step by step through the process of submitting the app
     Install EAS CLI and login with your Expo account:
 
     <Terminal
-      cmdCopy="npm install --global eas-cli && eas login"
       cmd={{
         npm: ['$ npm install --global eas-cli && eas login'],
         yarn: ['$ yarn global add eas-cli && eas login'],

--- a/docs/pages/deploy/submit-to-app-stores.mdx
+++ b/docs/pages/deploy/submit-to-app-stores.mdx
@@ -42,7 +42,15 @@ import { VideoBoxLink } from '~/ui/components/VideoBoxLink';
   <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
 
-    <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+    <Terminal
+      cmdCopy="npm install --global eas-cli && eas login"
+      cmd={{
+        npm: ['$ npm install --global eas-cli && eas login'],
+        yarn: ['$ yarn global add eas-cli && eas login'],
+        pnpm: ['$ pnpm add --global eas-cli && eas login'],
+        bun: ['$ bun add --global eas-cli && eas login'],
+      }}
+    />
 
   </Requirement>
   <Requirement title="Build a production app">
@@ -78,7 +86,15 @@ The command will lead you step by step through the process of submitting the app
   <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
 
-    <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+    <Terminal
+      cmdCopy="npm install --global eas-cli && eas login"
+      cmd={{
+        npm: ['$ npm install --global eas-cli && eas login'],
+        yarn: ['$ yarn global add eas-cli && eas login'],
+        pnpm: ['$ pnpm add --global eas-cli && eas login'],
+        bun: ['$ bun add --global eas-cli && eas login'],
+      }}
+    />
 
   </Requirement>
   <Requirement title="Include a package name in app.json">

--- a/docs/pages/deploy/web.mdx
+++ b/docs/pages/deploy/web.mdx
@@ -27,7 +27,14 @@ If you are building a universal app, you can quickly deploy your web app using [
 
 To deploy your web app, you need to create a static build of your web project. Export your web project into a **dist** directory by running the following command:
 
-<Terminal cmd={['$ npx expo export --platform web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export --platform web'],
+    yarn: ['$ yarn expo export --platform web'],
+    pnpm: ['$ pnpm expo export --platform web'],
+    bun: ['$ bun expo export --platform web'],
+  }}
+/>
 
 > Remember to re-run this command every time before deploying when you make changes to your web app.
 

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -109,7 +109,6 @@ Apps that don't use [Continuous Native Generation](/workflow/continuous-native-g
   <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
     <Terminal
-      cmdCopy="npm install --global eas-cli && eas login"
       cmd={{
         npm: ['$ npm install --global eas-cli && eas login'],
         yarn: ['$ yarn global add eas-cli && eas login'],
@@ -141,7 +140,6 @@ Read more about [Android builds on EAS](/tutorial/eas/android-development-build)
   <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
     <Terminal
-      cmdCopy="npm install --global eas-cli && eas login"
       cmd={{
         npm: ['$ npm install --global eas-cli && eas login'],
         yarn: ['$ yarn global add eas-cli && eas login'],
@@ -188,7 +186,6 @@ Read more about [iOS Simulator builds on EAS](/tutorial/eas/ios-development-buil
   <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
     <Terminal
-      cmdCopy="npm install --global eas-cli && eas login"
       cmd={{
         npm: ['$ npm install --global eas-cli && eas login'],
         yarn: ['$ yarn global add eas-cli && eas login'],

--- a/docs/pages/develop/development-builds/create-a-build.mdx
+++ b/docs/pages/develop/development-builds/create-a-build.mdx
@@ -81,7 +81,14 @@ For detailed, step-by-step instructions, see our [EAS Tutorial](/tutorial/eas/in
 
 ### Install expo-dev-client
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 <Collapsible summary="Are you using this library in an existing (bare) React Native app?">
 
@@ -101,7 +108,15 @@ Apps that don't use [Continuous Native Generation](/workflow/continuous-native-g
   </Requirement>
   <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
-    <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+    <Terminal
+      cmdCopy="npm install --global eas-cli && eas login"
+      cmd={{
+        npm: ['$ npm install --global eas-cli && eas login'],
+        yarn: ['$ yarn global add eas-cli && eas login'],
+        pnpm: ['$ pnpm add --global eas-cli && eas login'],
+        bun: ['$ bun add --global eas-cli && eas login'],
+      }}
+    />
   </Requirement>
   <Requirement title="An Android Emulator (optional)">
     An [Android Emulator](/workflow/android-studio-emulator/) is optional if you want to test your
@@ -125,7 +140,15 @@ Read more about [Android builds on EAS](/tutorial/eas/android-development-build)
   </Requirement>
   <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
-    <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+    <Terminal
+      cmdCopy="npm install --global eas-cli && eas login"
+      cmd={{
+        npm: ['$ npm install --global eas-cli && eas login'],
+        yarn: ['$ yarn global add eas-cli && eas login'],
+        pnpm: ['$ pnpm add --global eas-cli && eas login'],
+        bun: ['$ bun add --global eas-cli && eas login'],
+      }}
+    />
   </Requirement>
   <Requirement title="macOS with iOS Simulator installed">
     iOS Simulators are available only on macOS. Make sure you have the [iOS
@@ -164,7 +187,15 @@ Read more about [iOS Simulator builds on EAS](/tutorial/eas/ios-development-buil
   </Requirement>
   <Requirement title="EAS CLI">
     The [EAS CLI](/build/setup/#install-the-latest-eas-cli) installed and logged in.
-    <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+    <Terminal
+      cmdCopy="npm install --global eas-cli && eas login"
+      cmd={{
+        npm: ['$ npm install --global eas-cli && eas login'],
+        yarn: ['$ yarn global add eas-cli && eas login'],
+        pnpm: ['$ pnpm add --global eas-cli && eas login'],
+        bun: ['$ bun add --global eas-cli && eas login'],
+      }}
+    />
   </Requirement>
   <Requirement title="Apple Developer account">
     A paid [Apple Developer](https://developer.apple.com/) account for creating [signing
@@ -203,7 +234,14 @@ The development client built in **step 2** is the native side of your app (basic
 
 Depending on how you built the app, this may already be running, but if you close the process for any reason, there is no need to rebuild your development client. Simply restart the JavaScript bundler with:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 This is the same command you would have used with Expo Go. It detects whether your project has `expo-dev-client` installed, in which case it will default to targeting your development build instead of Expo Go.
 

--- a/docs/pages/develop/development-builds/development-workflows.mdx
+++ b/docs/pages/develop/development-builds/development-workflows.mdx
@@ -133,7 +133,14 @@ This will create a new section in the dev menu that includes the buttons you hav
 
 The EAS Update extension provides the ability to view and load published updates in your development client. To install it, you'll need the most recent publish of `expo-updates`:
 
-<Terminal cmd={['$ npx expo install expo-dev-client expo-updates']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client expo-updates'],
+    yarn: ['$ yarn expo install expo-dev-client expo-updates'],
+    pnpm: ['$ pnpm expo install expo-dev-client expo-updates'],
+    bun: ['$ bun expo install expo-dev-client expo-updates'],
+  }}
+/>
 
 #### Configure EAS Update
 

--- a/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
+++ b/docs/pages/develop/development-builds/expo-go-to-dev-build.mdx
@@ -20,7 +20,14 @@ To switch from Expo Go to a development build, you'll need to follow the steps b
 
 The Expo Dev Client library includes the launcher UI (shown in the screenshots below), dev menu, extensions to test over-the-air updates, and more. The Expo Go app has the dev menu built in, and that's why you need to install it separately for a development build.
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 <ContentSpotlight
   alt="expo-dev-client launcher and menu UIs on Android and iOS."
@@ -55,13 +62,27 @@ Once you have everything set up, run the following command:
 
 <Tab label="Build for Android">
 
-<Terminal cmd={['$ npx expo run:android']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:android'],
+    yarn: ['$ yarn expo run:android'],
+    pnpm: ['$ pnpm expo run:android'],
+    bun: ['$ bun expo run:android'],
+  }}
+/>
 
 </Tab>
 
 <Tab label="Build for iOS">
 
-<Terminal cmd={['$ npx expo run:ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:ios'],
+    yarn: ['$ yarn expo run:ios'],
+    pnpm: ['$ pnpm expo run:ios'],
+    bun: ['$ bun expo run:ios'],
+  }}
+/>
 
 </Tab>
 </Tabs>
@@ -91,7 +112,14 @@ Building on EAS servers is useful when:
 
 After building locally, `npx expo run:android|ios` will start the bundler automatically. But if you closed the bundler or are working on a dev client you built earlier, (re)start the Metro bundler with:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 When your project has `expo-dev-client` installed, the bundler will print out **Using development build**, and the QR code it shows will link into the development build you created instead of Expo Go.
 
@@ -111,7 +139,14 @@ You will need to run prebuild locally if you are building via `npx expo run:andr
 
 In these cases, you'll want to rebuild the native directories with:
 
-<Terminal cmd={['$ npx expo prebuild --clean']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild --clean'],
+    yarn: ['$ yarn expo prebuild --clean'],
+    pnpm: ['$ pnpm expo prebuild --clean'],
+    bun: ['$ bun expo prebuild --clean'],
+  }}
+/>
 
 Then, rebuild your app with the updated native code, with:
 
@@ -119,13 +154,27 @@ Then, rebuild your app with the updated native code, with:
 
 <Tab label="Build for Android">
 
-<Terminal cmd={['$ npx expo run:android']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:android'],
+    yarn: ['$ yarn expo run:android'],
+    pnpm: ['$ pnpm expo run:android'],
+    bun: ['$ bun expo run:android'],
+  }}
+/>
 
 </Tab>
 
 <Tab label="Build for iOS">
 
-<Terminal cmd={['$ npx expo run:ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:ios'],
+    yarn: ['$ yarn expo run:ios'],
+    pnpm: ['$ pnpm expo run:ios'],
+    bun: ['$ bun expo run:ios'],
+  }}
+/>
 
 </Tab>
 </Tabs>

--- a/docs/pages/develop/development-builds/use-development-builds.mdx
+++ b/docs/pages/develop/development-builds/use-development-builds.mdx
@@ -13,7 +13,14 @@ Usually, creating a new native build from scratch takes long enough that you'll 
 
 To start developing, run the following command to start the development server:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 To open the project inside your development client:
 

--- a/docs/pages/develop/tools.mdx
+++ b/docs/pages/develop/tools.mdx
@@ -45,7 +45,14 @@ EAS CLI is used to log in to your Expo account and compile your app using differ
 
 To use EAS CLI, you need to install it globally on your local machine by running the command:
 
-<Terminal cmd={['$ npm install -g eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 You can use `eas --help` in your terminal window to learn more about the available commands. For a complete reference, see [`eas-cli` npm page](https://www.npmjs.com/package/eas-cli).
 
@@ -53,7 +60,14 @@ You can use `eas --help` in your terminal window to learn more about the availab
 
 Expo Doctor is a command-line tool used to diagnose issues in your Expo project. To use it, run the following command in your project's root directory:
 
-<Terminal cmd={['$ npx expo-doctor']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo-doctor'],
+    yarn: ['$ yarn dlx expo-doctor'],
+    pnpm: ['$ pnpm dlx expo-doctor'],
+    bun: ['$ bunx expo-doctor'],
+  }}
+/>
 
 This command performs checks and analyzes your project's codebase for common issues in [app config](/workflow/configuration/) and **package.json** files, dependency compatibility, configuration files, and the overall health of the project. Once the check is complete, Expo Doctor outputs the results.
 

--- a/docs/pages/develop/unit-testing.mdx
+++ b/docs/pages/develop/unit-testing.mdx
@@ -33,13 +33,27 @@ Install `jest-expo` and other required dev dependencies in your project. Run the
 
 <Tab label="macOS/Linux">
 
-<Terminal cmd={['$ npx expo install jest-expo jest @types/jest --dev']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install jest-expo jest @types/jest --dev'],
+    yarn: ['$ yarn expo install jest-expo jest @types/jest --dev'],
+    pnpm: ['$ pnpm expo install jest-expo jest @types/jest --dev'],
+    bun: ['$ bun expo install jest-expo jest @types/jest --dev'],
+  }}
+/>
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal cmd={['$ npx expo install jest-expo jest @types/jest "--" --dev']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install jest-expo jest @types/jest "--" --dev'],
+    yarn: ['$ yarn expo install jest-expo jest @types/jest "--" --dev'],
+    pnpm: ['$ pnpm expo install jest-expo jest @types/jest "--" --dev'],
+    bun: ['$ bun expo install jest-expo jest @types/jest "--" --dev'],
+  }}
+/>
 
 </Tab>
 
@@ -143,13 +157,27 @@ To install it, run the following command:
 
 <Tab label="macOS/Linux">
 
-<Terminal cmd={['$ npx expo install @testing-library/react-native --dev']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @testing-library/react-native --dev'],
+    yarn: ['$ yarn expo install @testing-library/react-native --dev'],
+    pnpm: ['$ pnpm expo install @testing-library/react-native --dev'],
+    bun: ['$ bun expo install @testing-library/react-native --dev'],
+  }}
+/>
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal cmd={['$ npx expo install @testing-library/react-native "--" --dev']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @testing-library/react-native "--" --dev'],
+    yarn: ['$ yarn expo install @testing-library/react-native "--" --dev'],
+    pnpm: ['$ pnpm expo install @testing-library/react-native "--" --dev'],
+    bun: ['$ bun expo install @testing-library/react-native "--" --dev'],
+  }}
+/>
 
 </Tab>
 
@@ -223,7 +251,14 @@ In the above example, the `getByText` query helps your tests find relevant eleme
 
 Run the following command in a terminal window to execute the test:
 
-<Terminal cmd={['$ npm run test']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm run test'],
+    yarn: ['$ yarn run test'],
+    pnpm: ['$ pnpm run test'],
+    bun: ['$ bun run test'],
+  }}
+/>
 
 You will see one test being passed.
 

--- a/docs/pages/develop/user-interface/animation.mdx
+++ b/docs/pages/develop/user-interface/animation.mdx
@@ -11,7 +11,14 @@ Animations are a great way to enhance and provide a better user experience. In y
 
 You can skip installing `react-native-reanimated` if you have created a project using [the default template](/get-started/create-a-project/). This library is already installed. Otherwise, install it by running the following command:
 
-<Terminal cmd={['$ npx expo install react-native-reanimated']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install react-native-reanimated'],
+    yarn: ['$ yarn expo install react-native-reanimated'],
+    pnpm: ['$ pnpm expo install react-native-reanimated'],
+    bun: ['$ bun expo install react-native-reanimated'],
+  }}
+/>
 
 ## Usage
 

--- a/docs/pages/develop/user-interface/assets.mdx
+++ b/docs/pages/develop/user-interface/assets.mdx
@@ -36,7 +36,14 @@ To load an asset at build time, you can use the [config plugin](/versions/latest
 
 Install the `expo-asset` library.
 
-<Terminal cmd={['$ npx expo install expo-asset']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-asset'],
+    yarn: ['$ yarn expo install expo-asset'],
+    pnpm: ['$ pnpm expo install expo-asset'],
+    bun: ['$ bun expo install expo-asset'],
+  }}
+/>
 
 </Step>
 
@@ -92,7 +99,14 @@ The `useAssets` hook from `expo-asset` library allows loading assets asynchronou
 
 Install the `expo-asset` library.
 
-<Terminal cmd={['$ npx expo install expo-asset']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-asset'],
+    yarn: ['$ yarn expo install expo-asset'],
+    pnpm: ['$ pnpm expo install expo-asset'],
+    bun: ['$ bun expo install expo-asset'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/develop/user-interface/color-themes.mdx
+++ b/docs/pages/develop/user-interface/color-themes.mdx
@@ -33,7 +33,14 @@ You can also configure `userInterfaceStyle` property for a specific platforms by
 
 When you are creating a development build, you have to install [`expo-system-ui`](/versions/latest/sdk/system-ui/#installation) to support the appearance styles for Android. Otherwise, the `userInterfaceStyle` property is ignored.
 
-<Terminal cmd={['$ npx expo install expo-system-ui']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-system-ui'],
+    yarn: ['$ yarn expo install expo-system-ui'],
+    pnpm: ['$ pnpm expo install expo-system-ui'],
+    bun: ['$ bun expo install expo-system-ui'],
+  }}
+/>
 
 If the project is misconfigured and doesn't have `expo-system-ui` installed, the following warning will be shown in the terminal:
 
@@ -45,7 +52,14 @@ If the project is misconfigured and doesn't have `expo-system-ui` installed, the
 
 You can also use the following command to check if the project is misconfigured:
 
-<Terminal cmd={['$ npx expo config --type introspect']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo config --type introspect'],
+    yarn: ['$ yarn expo config --type introspect'],
+    pnpm: ['$ pnpm expo config --type introspect'],
+    bun: ['$ bun expo config --type introspect'],
+  }}
+/>
 
 <Collapsible summary="Using bare React Native app?">
 

--- a/docs/pages/develop/user-interface/fonts.mdx
+++ b/docs/pages/develop/user-interface/fonts.mdx
@@ -70,7 +70,14 @@ To embed a font in a project, follow the steps below:
 
 After adding a custom font file in your project, install the `expo-font` library.
 
-<Terminal cmd={['$ npx expo install expo-font']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-font'],
+    yarn: ['$ yarn expo install expo-font'],
+    pnpm: ['$ pnpm expo install expo-font'],
+    bun: ['$ bun expo install expo-font'],
+  }}
+/>
 
 </Step>
 
@@ -179,7 +186,14 @@ It works with all Expo SDK versions and with Expo Go. To load a font in a projec
 
 After adding a custom font file in your project, install the `expo-font` and `expo-splash-screen` libraries.
 
-<Terminal cmd={['$ npx expo install expo-font expo-splash-screen']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-font expo-splash-screen'],
+    yarn: ['$ yarn expo install expo-font expo-splash-screen'],
+    pnpm: ['$ pnpm expo install expo-font expo-splash-screen'],
+    bun: ['$ bun expo install expo-font expo-splash-screen'],
+  }}
+/>
 
 The [`expo-splash-screen`](/versions/latest/sdk/splash-screen/) library provides `SplashScreen` component that you can use to prevent rendering the app until the font is loaded and ready.
 
@@ -252,7 +266,14 @@ Two ways to use a Google Font in your project:
 
 Install the font package. For example, to use Inter Black font, install the [`@expo-google-fonts/inter`](https://www.npmjs.com/package/@expo-google-fonts/inter) package with the command below.
 
-<Terminal cmd={['$ npx expo install expo-font @expo-google-fonts/inter']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-font @expo-google-fonts/inter'],
+    yarn: ['$ yarn expo install expo-font @expo-google-fonts/inter'],
+    pnpm: ['$ pnpm expo install expo-font @expo-google-fonts/inter'],
+    bun: ['$ bun expo install expo-font @expo-google-fonts/inter'],
+  }}
+/>
 
 </Step>
 
@@ -313,7 +334,14 @@ Each Google Fonts package provides the `useFonts` hook to load the fonts asynchr
 
 Install the Google Fonts package, `expo-font` and `expo-splash-screen` libraries.
 
-<Terminal cmd={['$ npx expo install @expo-google-fonts/inter expo-font expo-splash-screen']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @expo-google-fonts/inter expo-font expo-splash-screen'],
+    yarn: ['$ yarn expo install @expo-google-fonts/inter expo-font expo-splash-screen'],
+    pnpm: ['$ pnpm expo install @expo-google-fonts/inter expo-font expo-splash-screen'],
+    bun: ['$ bun expo install @expo-google-fonts/inter expo-font expo-splash-screen'],
+  }}
+/>
 
 The [`expo-splash-screen`](/versions/latest/sdk/splash-screen/) library provides `SplashScreen` component that you can use to prevent rendering the app until the font is loaded and ready.
 

--- a/docs/pages/develop/user-interface/safe-areas.mdx
+++ b/docs/pages/develop/user-interface/safe-areas.mdx
@@ -33,7 +33,14 @@ Using the library, the result of the previous example changes as it displays the
 
 You can skip installing `react-native-safe-area-context` if you have created a project using [the default template](/get-started/create-a-project/). This library is installed as peer dependency for Expo Router library. Otherwise, install it by running the following command:
 
-<Terminal cmd={['$ npx expo install react-native-safe-area-context']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install react-native-safe-area-context'],
+    yarn: ['$ yarn expo install react-native-safe-area-context'],
+    pnpm: ['$ pnpm expo install react-native-safe-area-context'],
+    bun: ['$ bun expo install react-native-safe-area-context'],
+  }}
+/>
 
 ### Usage
 

--- a/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
+++ b/docs/pages/develop/user-interface/splash-screen-and-app-icon.mdx
@@ -136,7 +136,14 @@ If your app does not use [Expo Prebuild](/more/glossary-of-terms/#prebuild) to g
 
 For SDK 52 and earlier, in iOS development builds, launch screens can sometimes remain cached between builds, making it harder to test new images. Apple recommends clearing the _derived data_ directory before rebuilding, this can be done with Expo CLI by running:
 
-<Terminal cmd={['$ npx expo run:ios --no-build-cache']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:ios --no-build-cache'],
+    yarn: ['$ yarn expo run:ios --no-build-cache'],
+    pnpm: ['$ pnpm expo run:ios --no-build-cache'],
+    bun: ['$ bun expo run:ios --no-build-cache'],
+  }}
+/>
 
 See [Apple's guide on testing launch screens](https://developer.apple.com/documentation/technotes/tn3118-debugging-your-apps-launch-screen) for more information.
 

--- a/docs/pages/eas/cli.mdx
+++ b/docs/pages/eas/cli.mdx
@@ -18,8 +18,8 @@ You need to install the EAS CLI globally on your machine. You do this by running
   cmd={{
     npm: ['$ npm install --global eas-cli'],
     yarn: ['$ yarn global add eas-cli'],
-    pnpm: ['$ pnpm add -g eas-cli'],
-    bun: ['$ bun add -g eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
   }}
 />
 

--- a/docs/pages/get-started/create-a-project.mdx
+++ b/docs/pages/get-started/create-a-project.mdx
@@ -19,7 +19,14 @@ We recommend starting with the default project created by `create-expo-app`. The
 
 To create a new project, run the following command:
 
-<Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-56']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
+    yarn: ['$ yarn create expo-app --template default@sdk-56'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
+    bun: ['$ bun create expo --template default@sdk-56'],
+  }}
+/>
 
 > **Note:** During the SDK 56 transition period, `create-expo-app@latest` without the `--template` flag creates an SDK 55 project. If you plan to use Expo Go on a physical device, use an SDK 55 project. Otherwise, use `--template default@sdk-56` to create an SDK 56 project. You can also choose a different template by adding the [`--template` option](/more/create-expo/#--template).
 

--- a/docs/pages/get-started/next-steps.mdx
+++ b/docs/pages/get-started/next-steps.mdx
@@ -12,7 +12,14 @@ Here are next steps to continue building your app:
 
 You can remove the boilerplate code and start fresh with a new project. Run the following command to reset your project:
 
-<Terminal cmd={['$ npm run reset-project']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm run reset-project'],
+    yarn: ['$ yarn run reset-project'],
+    pnpm: ['$ pnpm run reset-project'],
+    bun: ['$ bun run reset-project'],
+  }}
+/>
 
 This command will move the existing files in **app** to **app-example**, then create a new **app** directory with a new **index.tsx** file.
 

--- a/docs/pages/get-started/start-developing.mdx
+++ b/docs/pages/get-started/start-developing.mdx
@@ -15,7 +15,14 @@ import { Step } from '~/ui/components/Step';
 ## Start a development server
 To start the development server, run the following command:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 </Step>
 
@@ -32,7 +39,14 @@ Make sure you are on the same Wi-Fi network on your computer and your device.
 
 If it still doesn't work, it may be due to the router configuration — this is common for public networks. You can work around this by choosing the **Tunnel** connection type when starting the development server, then scanning the QR code again.
 
-<Terminal cmd={['$ npx expo start --tunnel']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --tunnel'],
+    yarn: ['$ yarn expo start --tunnel'],
+    pnpm: ['$ pnpm expo start --tunnel'],
+    bun: ['$ bun expo start --tunnel'],
+  }}
+/>
 
 > Using the **Tunnel** connection type will make the app reloads considerably slower than on **LAN** or **Local**, so it's best to avoid tunnel when possible. You may want to install and use an emulator or simulator to speed up development if **Tunnel** is required to access your machine from another device on your network.
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuild.mdx
@@ -13,7 +13,14 @@ import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 To build your app, you will need to install EAS CLI. You can do this by running the following command in your terminal:
 
-<Terminal cmd={['$ npm install -g eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 </Step>
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidPhysicalDevelopmentBuildLocal.mdx
@@ -21,7 +21,14 @@ import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 Run the following command in your project's root directory:
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 </Step>
 
@@ -51,7 +58,14 @@ Check that your device is properly connecting to ADB, the Android Debug Bridge, 
 
 Run the following from your terminal:
 
-<Terminal cmd={['$ npx expo run:android']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:android'],
+    yarn: ['$ yarn expo run:android'],
+    pnpm: ['$ pnpm expo run:android'],
+    bun: ['$ bun expo run:android'],
+  }}
+/>
 
 > This command runs a development server after building your app. You can skip running `npx expo start` on the next page.
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuild.mdx
@@ -20,7 +20,14 @@ import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 To build your app, you will need to install EAS CLI. You can do this by running the following command in your terminal:
 
-<Terminal cmd={['$ npm install -g eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 </Step>
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/androidSimulatedDevelopmentBuildLocal.mdx
@@ -24,7 +24,14 @@ import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 Run the following command in your project's root directory:
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 </Step>
 
@@ -32,7 +39,14 @@ Run the following command in your project's root directory:
 
 Run the following from your terminal:
 
-<Terminal cmd={['$ npx expo run:android']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:android'],
+    yarn: ['$ yarn expo run:android'],
+    pnpm: ['$ pnpm expo run:android'],
+    bun: ['$ bun expo run:android'],
+  }}
+/>
 
 > This command runs a development server after building your app. You can skip running `npx expo start` on the next page.
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuild.mdx
@@ -19,7 +19,14 @@ To install a development build on your iOS device, you will need an active subsc
 
 To build your app, you will need to install EAS CLI. You can do this by running the following command in your terminal:
 
-<Terminal cmd={['$ npm install -g eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 </Step>
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosPhysicalDevelopmentBuildLocal.mdx
@@ -20,7 +20,14 @@ import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 Run the following command in your project's root directory:
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 </Step>
 
@@ -48,7 +55,14 @@ Run the following command in your project's root directory:
 
 2. Run the following command in your project's root directory and select your plugged in device from the list:
 
-<Terminal cmd={['$ npx expo run:ios --device']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:ios --device'],
+    yarn: ['$ yarn expo run:ios --device'],
+    pnpm: ['$ pnpm expo run:ios --device'],
+    bun: ['$ bun expo run:ios --device'],
+  }}
+/>
 
 > This command runs a development server after building your app. You can skip running `npx expo start` on the next page.
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuild.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuild.mdx
@@ -19,7 +19,14 @@ import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 To build your app, you will need to install EAS CLI. You can do this by running the following command in your terminal:
 
-<Terminal cmd={['$ npm install -g eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 </Step>
 

--- a/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuildLocal.mdx
+++ b/docs/scenes/get-started/set-up-your-environment/instructions/iosSimulatedDevelopmentBuildLocal.mdx
@@ -20,7 +20,14 @@ import { BuildEnvironmentSwitch } from '../BuildEnvironmentSwitch';
 
 Run the following command in your project's root directory:
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 </Step>
 
@@ -28,7 +35,14 @@ Run the following command in your project's root directory:
 
 Run the following from your terminal:
 
-<Terminal cmd={['$ npx expo run:ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:ios'],
+    yarn: ['$ yarn expo run:ios'],
+    pnpm: ['$ pnpm expo run:ios'],
+    bun: ['$ bun expo run:ios'],
+  }}
+/>
 
 > This command runs a development server after building your app. You can skip running `npx expo start` on the next page.
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

On-going ENG-21434

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update Home section Terminal references to include npm, yarn, pnpm, and bun variants where Expo docs conventions call for multi-package-manager commands.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
