### PR TITLE
[ui][docs] Use `useCallback` instead of `useEffectEvent` for worklet callbacks

### DIFF
--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -170,7 +170,7 @@ export default function KeyboardActionsExample() {
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: (text) => setSubmitted(text),
+          onSearch: text => setSubmitted(text),
         }}>
         <TextField.Label>
           <Text>Search</Text>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -170,7 +170,7 @@ export default function KeyboardActionsExample() {
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: text => setSubmitted(text),
+          onSearch: (text) => setSubmitted(text),
         }}>
         <TextField.Label>
           <Text>Search</Text>
@@ -269,21 +269,24 @@ export default function WorkletPhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleValueChange = useCallback((v: string) => {
-    'worklet';
-    const digits = v.replace(/\D/g, '').slice(0, 10);
-    let formatted = digits;
-    if (digits.length > 6) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-    } else if (digits.length > 3) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-    }
-    if (formatted !== v) {
-      phone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [phone, selection]);
+  const handleValueChange = useCallback(
+    (v: string) => {
+      'worklet';
+      const digits = v.replace(/\D/g, '').slice(0, 10);
+      let formatted = digits;
+      if (digits.length > 6) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+      } else if (digits.length > 3) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+      }
+      if (formatted !== v) {
+        phone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [phone, selection]
+  );
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/textfield.mdx
@@ -263,13 +263,13 @@ When `onValueChange` is marked with the `'worklet'` directive, it runs synchrono
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth } from '@expo/ui/jetpack-compose/modifiers';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function WorkletPhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleValueChange = useEffectEvent((v: string) => {
+  const handleValueChange = useCallback((v: string) => {
     'worklet';
     const digits = v.replace(/\D/g, '').slice(0, 10);
     let formatted = digits;
@@ -283,7 +283,7 @@ export default function WorkletPhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [phone, selection]);
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -24,13 +24,13 @@ The example below masks a phone number as the user types. The formatting and the
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, Text as ComposeText, useNativeState } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth } from '@expo/ui/jetpack-compose/modifiers';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function WorkletPhoneMaskExample() {
   const maskedPhone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleValueChange = useEffectEvent((v: string) => {
+  const handleValueChange = useCallback((v: string) => {
     'worklet';
     const digits = v.replace(/\D/g, '').slice(0, 10);
     let formatted: string;
@@ -48,7 +48,7 @@ export default function WorkletPhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [maskedPhone, selection]);
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -30,25 +30,28 @@ export default function WorkletPhoneMaskExample() {
   const maskedPhone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleValueChange = useCallback((v: string) => {
-    'worklet';
-    const digits = v.replace(/\D/g, '').slice(0, 10);
-    let formatted: string;
-    if (digits.length === 0) {
-      formatted = '';
-    } else if (digits.length <= 3) {
-      formatted = digits;
-    } else if (digits.length <= 6) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-    } else {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-    }
-    if (formatted !== v) {
-      maskedPhone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [maskedPhone, selection]);
+  const handleValueChange = useCallback(
+    (v: string) => {
+      'worklet';
+      const digits = v.replace(/\D/g, '').slice(0, 10);
+      let formatted: string;
+      if (digits.length === 0) {
+        formatted = '';
+      } else if (digits.length <= 3) {
+        formatted = digits;
+      } else if (digits.length <= 6) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+      } else {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+      }
+      if (formatted !== v) {
+        maskedPhone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [maskedPhone, selection]
+  );
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
@@ -193,21 +193,24 @@ export default function WorkletPhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleTextChange = useCallback((v: string) => {
-    'worklet';
-    const digits = v.replace(/\D/g, '').slice(0, 10);
-    let formatted = digits;
-    if (digits.length > 6) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-    } else if (digits.length > 3) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-    }
-    if (formatted !== v) {
-      phone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [phone, selection]);
+  const handleTextChange = useCallback(
+    (v: string) => {
+      'worklet';
+      const digits = v.replace(/\D/g, '').slice(0, 10);
+      let formatted = digits;
+      if (digits.length > 6) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+      } else if (digits.length > 3) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+      }
+      if (formatted !== v) {
+        phone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [phone, selection]
+  );
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/textfield.mdx
@@ -187,13 +187,13 @@ When `onTextChange` is marked with the `'worklet'` directive, it runs synchronou
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { keyboardType } from '@expo/ui/swift-ui/modifiers';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function WorkletPhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleTextChange = useEffectEvent((v: string) => {
+  const handleTextChange = useCallback((v: string) => {
     'worklet';
     const digits = v.replace(/\D/g, '').slice(0, 10);
     let formatted = digits;
@@ -207,7 +207,7 @@ export default function WorkletPhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [phone, selection]);
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/usenativestate.mdx
@@ -24,13 +24,13 @@ The example below masks a phone number as the user types. The formatting and the
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { keyboardType } from '@expo/ui/swift-ui/modifiers';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function WorkletPhoneMaskExample() {
   const maskedPhone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleTextChange = useEffectEvent((v: string) => {
+  const handleTextChange = useCallback((v: string) => {
     'worklet';
     const digits = v.replace(/\D/g, '').slice(0, 10);
     let formatted: string;
@@ -48,7 +48,7 @@ export default function WorkletPhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [maskedPhone, selection]);
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/unversioned/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/swift-ui/usenativestate.mdx
@@ -30,25 +30,28 @@ export default function WorkletPhoneMaskExample() {
   const maskedPhone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleTextChange = useCallback((v: string) => {
-    'worklet';
-    const digits = v.replace(/\D/g, '').slice(0, 10);
-    let formatted: string;
-    if (digits.length === 0) {
-      formatted = '';
-    } else if (digits.length <= 3) {
-      formatted = digits;
-    } else if (digits.length <= 6) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-    } else {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-    }
-    if (formatted !== v) {
-      maskedPhone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [maskedPhone, selection]);
+  const handleTextChange = useCallback(
+    (v: string) => {
+      'worklet';
+      const digits = v.replace(/\D/g, '').slice(0, 10);
+      let formatted: string;
+      if (digits.length === 0) {
+        formatted = '';
+      } else if (digits.length <= 3) {
+        formatted = digits;
+      } else if (digits.length <= 6) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+      } else {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+      }
+      if (formatted !== v) {
+        maskedPhone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [maskedPhone, selection]
+  );
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/unversioned/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/textinput.mdx
@@ -52,15 +52,15 @@ Pass [`value`](#value) to drive the field from a `useNativeState` observable. Th
 
 ```tsx ControlledTextInputExample.tsx
 import { Host, TextInput, useNativeState } from '@expo/ui';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function ControlledTextInputExample() {
   const text = useNativeState('');
 
-  const handleChangeText = useEffectEvent((value: string) => {
+  const handleChangeText = useCallback((value: string) => {
     'worklet';
     text.value = value === 'Hello' ? 'World' : value;
-  });
+  }, [text]);
 
   return (
     <Host matchContents={{ vertical: true }}>
@@ -78,7 +78,7 @@ Add the `'worklet'` directive to [`onChangeText`](#onchangetext) for synchronous
 
 ```tsx PhoneMaskExample.tsx
 import { Host, TextInput, useNativeState } from '@expo/ui';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 function formatPhone(input: string) {
   'worklet';
@@ -92,7 +92,7 @@ export default function PhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleChangeText = useEffectEvent((value: string) => {
+  const handleChangeText = useCallback((value: string) => {
     'worklet';
     const formatted = formatPhone(value);
     if (formatted !== value) {
@@ -100,7 +100,7 @@ export default function PhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [phone, selection]);
 
   return (
     <Host matchContents={{ vertical: true }}>

--- a/docs/pages/versions/unversioned/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/textinput.mdx
@@ -37,7 +37,7 @@ export default function UncontrolledTextInputExample() {
           ref={inputRef}
           defaultValue="hello"
           placeholder="Type here"
-          onChangeText={value => console.log(value)}
+          onChangeText={(value) => console.log(value)}
         />
         <Button label="Clear" onPress={() => inputRef.current?.clear()} />
       </Column>
@@ -57,10 +57,13 @@ import { useCallback } from 'react';
 export default function ControlledTextInputExample() {
   const text = useNativeState('');
 
-  const handleChangeText = useCallback((value: string) => {
-    'worklet';
-    text.value = value === 'Hello' ? 'World' : value;
-  }, [text]);
+  const handleChangeText = useCallback(
+    (value: string) => {
+      'worklet';
+      text.value = value === 'Hello' ? 'World' : value;
+    },
+    [text]
+  );
 
   return (
     <Host matchContents={{ vertical: true }}>
@@ -92,15 +95,18 @@ export default function PhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleChangeText = useCallback((value: string) => {
-    'worklet';
-    const formatted = formatPhone(value);
-    if (formatted !== value) {
-      phone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [phone, selection]);
+  const handleChangeText = useCallback(
+    (value: string) => {
+      'worklet';
+      const formatted = formatPhone(value);
+      if (formatted !== value) {
+        phone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [phone, selection]
+  );
 
   return (
     <Host matchContents={{ vertical: true }}>

--- a/docs/pages/versions/unversioned/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/unversioned/sdk/ui/universal/textinput.mdx
@@ -37,7 +37,7 @@ export default function UncontrolledTextInputExample() {
           ref={inputRef}
           defaultValue="hello"
           placeholder="Type here"
-          onChangeText={(value) => console.log(value)}
+          onChangeText={value => console.log(value)}
         />
         <Button label="Clear" onPress={() => inputRef.current?.clear()} />
       </Column>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -170,7 +170,7 @@ export default function KeyboardActionsExample() {
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: (text) => setSubmitted(text),
+          onSearch: text => setSubmitted(text),
         }}>
         <TextField.Label>
           <Text>Search</Text>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -170,7 +170,7 @@ export default function KeyboardActionsExample() {
         singleLine
         keyboardOptions={{ imeAction: 'search' }}
         keyboardActions={{
-          onSearch: text => setSubmitted(text),
+          onSearch: (text) => setSubmitted(text),
         }}>
         <TextField.Label>
           <Text>Search</Text>
@@ -269,21 +269,24 @@ export default function WorkletPhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleValueChange = useCallback((v: string) => {
-    'worklet';
-    const digits = v.replace(/\D/g, '').slice(0, 10);
-    let formatted = digits;
-    if (digits.length > 6) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-    } else if (digits.length > 3) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-    }
-    if (formatted !== v) {
-      phone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [phone, selection]);
+  const handleValueChange = useCallback(
+    (v: string) => {
+      'worklet';
+      const digits = v.replace(/\D/g, '').slice(0, 10);
+      let formatted = digits;
+      if (digits.length > 6) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+      } else if (digits.length > 3) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+      }
+      if (formatted !== v) {
+        phone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [phone, selection]
+  );
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/textfield.mdx
@@ -263,13 +263,13 @@ When `onValueChange` is marked with the `'worklet'` directive, it runs synchrono
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, Text, useNativeState } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth } from '@expo/ui/jetpack-compose/modifiers';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function WorkletPhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleValueChange = useEffectEvent((v: string) => {
+  const handleValueChange = useCallback((v: string) => {
     'worklet';
     const digits = v.replace(/\D/g, '').slice(0, 10);
     let formatted = digits;
@@ -283,7 +283,7 @@ export default function WorkletPhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [phone, selection]);
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -24,13 +24,13 @@ The example below masks a phone number as the user types. The formatting and the
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, Text as ComposeText, useNativeState } from '@expo/ui/jetpack-compose';
 import { fillMaxWidth } from '@expo/ui/jetpack-compose/modifiers';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function WorkletPhoneMaskExample() {
   const maskedPhone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleValueChange = useEffectEvent((v: string) => {
+  const handleValueChange = useCallback((v: string) => {
     'worklet';
     const digits = v.replace(/\D/g, '').slice(0, 10);
     let formatted: string;
@@ -48,7 +48,7 @@ export default function WorkletPhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [maskedPhone, selection]);
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/jetpack-compose/usenativestate.mdx
@@ -30,25 +30,28 @@ export default function WorkletPhoneMaskExample() {
   const maskedPhone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleValueChange = useCallback((v: string) => {
-    'worklet';
-    const digits = v.replace(/\D/g, '').slice(0, 10);
-    let formatted: string;
-    if (digits.length === 0) {
-      formatted = '';
-    } else if (digits.length <= 3) {
-      formatted = digits;
-    } else if (digits.length <= 6) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-    } else {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-    }
-    if (formatted !== v) {
-      maskedPhone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [maskedPhone, selection]);
+  const handleValueChange = useCallback(
+    (v: string) => {
+      'worklet';
+      const digits = v.replace(/\D/g, '').slice(0, 10);
+      let formatted: string;
+      if (digits.length === 0) {
+        formatted = '';
+      } else if (digits.length <= 3) {
+        formatted = digits;
+      } else if (digits.length <= 6) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+      } else {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+      }
+      if (formatted !== v) {
+        maskedPhone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [maskedPhone, selection]
+  );
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
@@ -193,21 +193,24 @@ export default function WorkletPhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleTextChange = useCallback((v: string) => {
-    'worklet';
-    const digits = v.replace(/\D/g, '').slice(0, 10);
-    let formatted = digits;
-    if (digits.length > 6) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-    } else if (digits.length > 3) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-    }
-    if (formatted !== v) {
-      phone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [phone, selection]);
+  const handleTextChange = useCallback(
+    (v: string) => {
+      'worklet';
+      const digits = v.replace(/\D/g, '').slice(0, 10);
+      let formatted = digits;
+      if (digits.length > 6) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+      } else if (digits.length > 3) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+      }
+      if (formatted !== v) {
+        phone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [phone, selection]
+  );
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/textfield.mdx
@@ -187,13 +187,13 @@ When `onTextChange` is marked with the `'worklet'` directive, it runs synchronou
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { keyboardType } from '@expo/ui/swift-ui/modifiers';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function WorkletPhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleTextChange = useEffectEvent((v: string) => {
+  const handleTextChange = useCallback((v: string) => {
     'worklet';
     const digits = v.replace(/\D/g, '').slice(0, 10);
     let formatted = digits;
@@ -207,7 +207,7 @@ export default function WorkletPhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [phone, selection]);
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/usenativestate.mdx
@@ -24,13 +24,13 @@ The example below masks a phone number as the user types. The formatting and the
 ```tsx WorkletPhoneMaskExample.tsx
 import { Host, TextField, useNativeState } from '@expo/ui/swift-ui';
 import { keyboardType } from '@expo/ui/swift-ui/modifiers';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function WorkletPhoneMaskExample() {
   const maskedPhone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleTextChange = useEffectEvent((v: string) => {
+  const handleTextChange = useCallback((v: string) => {
     'worklet';
     const digits = v.replace(/\D/g, '').slice(0, 10);
     let formatted: string;
@@ -48,7 +48,7 @@ export default function WorkletPhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [maskedPhone, selection]);
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/usenativestate.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/swift-ui/usenativestate.mdx
@@ -30,25 +30,28 @@ export default function WorkletPhoneMaskExample() {
   const maskedPhone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleTextChange = useCallback((v: string) => {
-    'worklet';
-    const digits = v.replace(/\D/g, '').slice(0, 10);
-    let formatted: string;
-    if (digits.length === 0) {
-      formatted = '';
-    } else if (digits.length <= 3) {
-      formatted = digits;
-    } else if (digits.length <= 6) {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
-    } else {
-      formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-    }
-    if (formatted !== v) {
-      maskedPhone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [maskedPhone, selection]);
+  const handleTextChange = useCallback(
+    (v: string) => {
+      'worklet';
+      const digits = v.replace(/\D/g, '').slice(0, 10);
+      let formatted: string;
+      if (digits.length === 0) {
+        formatted = '';
+      } else if (digits.length <= 3) {
+        formatted = digits;
+      } else if (digits.length <= 6) {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3)}`;
+      } else {
+        formatted = `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+      }
+      if (formatted !== v) {
+        maskedPhone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [maskedPhone, selection]
+  );
 
   return (
     <Host matchContents>

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/textinput.mdx
@@ -52,15 +52,15 @@ Pass [`value`](#value) to drive the field from a `useNativeState` observable. Th
 
 ```tsx ControlledTextInputExample.tsx
 import { Host, TextInput, useNativeState } from '@expo/ui';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 export default function ControlledTextInputExample() {
   const text = useNativeState('');
 
-  const handleChangeText = useEffectEvent((value: string) => {
+  const handleChangeText = useCallback((value: string) => {
     'worklet';
     text.value = value === 'Hello' ? 'World' : value;
-  });
+  }, [text]);
 
   return (
     <Host matchContents={{ vertical: true }}>
@@ -78,7 +78,7 @@ Add the `'worklet'` directive to [`onChangeText`](#onchangetext) for synchronous
 
 ```tsx PhoneMaskExample.tsx
 import { Host, TextInput, useNativeState } from '@expo/ui';
-import { useEffectEvent } from 'react';
+import { useCallback } from 'react';
 
 function formatPhone(input: string) {
   'worklet';
@@ -92,7 +92,7 @@ export default function PhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleChangeText = useEffectEvent((value: string) => {
+  const handleChangeText = useCallback((value: string) => {
     'worklet';
     const formatted = formatPhone(value);
     if (formatted !== value) {
@@ -100,7 +100,7 @@ export default function PhoneMaskExample() {
       // Snaps to end for demo. Real masks need smarter cursor handling.
       selection.value = { start: formatted.length, end: formatted.length };
     }
-  });
+  }, [phone, selection]);
 
   return (
     <Host matchContents={{ vertical: true }}>

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/textinput.mdx
@@ -37,7 +37,7 @@ export default function UncontrolledTextInputExample() {
           ref={inputRef}
           defaultValue="hello"
           placeholder="Type here"
-          onChangeText={value => console.log(value)}
+          onChangeText={(value) => console.log(value)}
         />
         <Button label="Clear" onPress={() => inputRef.current?.clear()} />
       </Column>
@@ -57,10 +57,13 @@ import { useCallback } from 'react';
 export default function ControlledTextInputExample() {
   const text = useNativeState('');
 
-  const handleChangeText = useCallback((value: string) => {
-    'worklet';
-    text.value = value === 'Hello' ? 'World' : value;
-  }, [text]);
+  const handleChangeText = useCallback(
+    (value: string) => {
+      'worklet';
+      text.value = value === 'Hello' ? 'World' : value;
+    },
+    [text]
+  );
 
   return (
     <Host matchContents={{ vertical: true }}>
@@ -92,15 +95,18 @@ export default function PhoneMaskExample() {
   const phone = useNativeState('');
   const selection = useNativeState({ start: 0, end: 0 });
 
-  const handleChangeText = useCallback((value: string) => {
-    'worklet';
-    const formatted = formatPhone(value);
-    if (formatted !== value) {
-      phone.value = formatted;
-      // Snaps to end for demo. Real masks need smarter cursor handling.
-      selection.value = { start: formatted.length, end: formatted.length };
-    }
-  }, [phone, selection]);
+  const handleChangeText = useCallback(
+    (value: string) => {
+      'worklet';
+      const formatted = formatPhone(value);
+      if (formatted !== value) {
+        phone.value = formatted;
+        // Snaps to end for demo. Real masks need smarter cursor handling.
+        selection.value = { start: formatted.length, end: formatted.length };
+      }
+    },
+    [phone, selection]
+  );
 
   return (
     <Host matchContents={{ vertical: true }}>

--- a/docs/pages/versions/v56.0.0/sdk/ui/universal/textinput.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/ui/universal/textinput.mdx
@@ -37,7 +37,7 @@ export default function UncontrolledTextInputExample() {
           ref={inputRef}
           defaultValue="hello"
           placeholder="Type here"
-          onChangeText={(value) => console.log(value)}
+          onChangeText={value => console.log(value)}
         />
         <Button label="Clear" onPress={() => inputRef.current?.clear()} />
       </Column>


### PR DESCRIPTION
# Why
Resolves - https://github.com/expo/expo/issues/46269

When using worklet inside of `useEffectEvent` we get a non worklet callback. So the flicker issue still happens, it was hard to reproduce on simulator. 


<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

# How

Replace `useEffectEvent` with `useCallback`
<!--
How did you build this feature or fix this bug and why?
-->

# Test Plan

Tested the example on real device. It does not flicker after the change
<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
