### PR TITLE
[docs] Add multi-pm (package managers)Terminal blocks in Developer process and Expo Router

### DIFF
--- a/docs/pages/bare/install-dev-builds-in-bare.mdx
+++ b/docs/pages/bare/install-dev-builds-in-bare.mdx
@@ -15,7 +15,14 @@ The following guide explains how to install and configure `expo-dev-client` in a
 
 If you're starting with a new project, create it using the `with-dev-client` template:
 
-<Terminal cmd={['$ npx create-expo-app -e with-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-app -e with-dev-client'],
+    yarn: ['$ yarn create expo-app -e with-dev-client'],
+    pnpm: ['$ pnpm create expo-app -e with-dev-client'],
+    bun: ['$ bun create expo -e with-dev-client'],
+  }}
+/>
 
 </Collapsible>
 
@@ -39,11 +46,25 @@ To use `expo-dev-client` in a project that uses [CNG](/workflow/continuous-nativ
 
 Add the `expo-dev-client` library to your **package.json**:
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 If your project has an **ios** directory on disk, run the following command to fully install the native code for `expo-dev-client`:
 
-<Terminal cmd={['$ npx pod-install']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx pod-install'],
+    yarn: ['$ yarn dlx pod-install'],
+    pnpm: ['$ pnpm dlx pod-install'],
+    bun: ['$ bunx pod-install'],
+  }}
+/>
 
 If your project doesn't have an **ios** directory, you can skip this step.
 
@@ -58,13 +79,36 @@ Expo CLI uses a deep link to launch your project, and it's also useful if you us
 If you haven't configured a `scheme` for your app yet to support deep linking, then use `uri-scheme` library to do this for you.
 
 <Terminal
-  cmd={[
-    "# List your project's schemes",
-    '$ npx uri-scheme list',
-    '',
-    '# Add a scheme to your project',
-    '$ npx uri-scheme add your-scheme',
-  ]}
+  cmd={{
+    npm: [
+      "# List your project's schemes",
+      '$ npx uri-scheme list',
+      '',
+      '# Add a scheme to your project',
+      '$ npx uri-scheme add your-scheme',
+    ],
+    yarn: [
+      "# List your project's schemes",
+      '$ yarn dlx uri-scheme list',
+      '',
+      '# Add a scheme to your project',
+      '$ yarn dlx uri-scheme add your-scheme',
+    ],
+    pnpm: [
+      "# List your project's schemes",
+      '$ pnpm dlx uri-scheme list',
+      '',
+      '# Add a scheme to your project',
+      '$ pnpm dlx uri-scheme add your-scheme',
+    ],
+    bun: [
+      "# List your project's schemes",
+      '$ bunx uri-scheme list',
+      '',
+      '# Add a scheme to your project',
+      '$ bunx uri-scheme add your-scheme',
+    ],
+  }}
 />
 
 For more information, see the [`uri-scheme` library](https://www.npmjs.com/package/uri-scheme).

--- a/docs/pages/bare/installing-updates.mdx
+++ b/docs/pages/bare/installing-updates.mdx
@@ -28,11 +28,25 @@ You may be reading the wrong guide. To use `expo-updates` in a project that uses
 
 To get started, install `expo-updates`:
 
-<Terminal cmd={['$ npx expo install expo-updates']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-updates'],
+    yarn: ['$ yarn expo install expo-updates'],
+    pnpm: ['$ pnpm expo install expo-updates'],
+    bun: ['$ bun expo install expo-updates'],
+  }}
+/>
 
 Then, install pods for iOS:
 
-<Terminal cmd={['$ npx pod-install']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx pod-install'],
+    yarn: ['$ yarn dlx pod-install'],
+    pnpm: ['$ pnpm dlx pod-install'],
+    bun: ['$ bunx pod-install'],
+  }}
+/>
 
 ## Configuring expo-updates library
 

--- a/docs/pages/bare/using-expo-cli.mdx
+++ b/docs/pages/bare/using-expo-cli.mdx
@@ -21,7 +21,14 @@ It is strongly recommended to use Expo CLI when using other Expo tools. It is re
 
 In most cases, executing the following command in a project directory to install the package is all you need to do:
 
-<Terminal cmd={['$ npx install-expo-modules@latest']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx install-expo-modules@latest'],
+    yarn: ['$ yarn dlx install-expo-modules@latest'],
+    pnpm: ['$ pnpm dlx install-expo-modules@latest'],
+    bun: ['$ bunx install-expo-modules@latest'],
+  }}
+/>
 
 For a detailed installation guide, see [Install Expo modules](/bare/installing-expo-modules).
 
@@ -61,7 +68,12 @@ Windows and macOS. If building for these platforms, you can utilize Expo CLI for
 After installing the `expo` package, you can use the following commands which are alternatives to `npx react-native run-android` and `npx react-native run-ios`:
 
 <Terminal
-  cmd={['# for Android', '$ npx expo run:android', '', '# for iOS', '$ npx expo run:ios']}
+  cmd={{
+    npm: ['# for Android', '$ npx expo run:android', '', '# for iOS', '$ npx expo run:ios'],
+    yarn: ['# for Android', '$ yarn expo run:android', '', '# for iOS', '$ yarn expo run:ios'],
+    pnpm: ['# for Android', '$ pnpm expo run:android', '', '# for iOS', '$ pnpm expo run:ios'],
+    bun: ['# for Android', '$ bun expo run:android', '', '# for iOS', '$ bun expo run:ios'],
+  }}
 />
 
 When building your project, you can choose a device or simulator by using the `--device` flag. This also applies to any iOS device that is connected to your computer.

--- a/docs/pages/brownfield/integrated-approach.mdx
+++ b/docs/pages/brownfield/integrated-approach.mdx
@@ -43,7 +43,14 @@ Learn more from the [Set up environment guide](/get-started/set-up-your-environm
 
 First, create an Expo project inside your existing native project's root directory.
 
-<Terminal cmd={['$ npx create-expo-app@latest my-project --template default@sdk-56']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-app@latest my-project --template default@sdk-56'],
+    yarn: ['$ yarn create expo-app my-project --template default@sdk-56'],
+    pnpm: ['$ pnpm create expo-app my-project --template default@sdk-56'],
+    bun: ['$ bun create expo my-project --template default@sdk-56'],
+  }}
+/>
 
 This command creates a new directory named **my-project** that contains your new Expo project. While you can name the project anything, this guide uses **my-project** for consistency. The new project includes an example TypeScript application to help you get started.
 
@@ -507,6 +514,13 @@ class ViewController: UIViewController {
 
 You have completed all the basic steps to integrate React Native with your application. Now run the following command in the React Native directory to start the [Metro bundler](https://metrobundler.dev/)
 
-<Terminal cmd={['$ yarn start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm run start'],
+    yarn: ['$ yarn run start'],
+    pnpm: ['$ pnpm run start'],
+    bun: ['$ bun run start'],
+  }}
+/>
 
 Metro builds your TypeScript application code into a bundle, serves it through its HTTP server, and shares the bundle from `localhost` on your developer environment to a simulator or device, allowing for [hot reloading](https://reactnative.dev/blog/2016/03/24/introducing-hot-reloading). Now you can build and run your app as normal. Once you reach your React-powered Activity inside the app, it should load the JavaScript code from the development server.

--- a/docs/pages/brownfield/isolated-approach.mdx
+++ b/docs/pages/brownfield/isolated-approach.mdx
@@ -39,7 +39,14 @@ Learn more from the [Set up environment guide](/get-started/set-up-your-environm
 
 Run the following command to create a new directory named **my-project** that contains your new Expo project. While you can name the project anything, this guide uses **my-project** for consistency.
 
-<Terminal cmd={['$ npx create-expo-app@latest my-project --template default@sdk-56']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-app@latest my-project --template default@sdk-56'],
+    yarn: ['$ yarn create expo-app my-project --template default@sdk-56'],
+    pnpm: ['$ pnpm create expo-app my-project --template default@sdk-56'],
+    bun: ['$ bun create expo my-project --template default@sdk-56'],
+  }}
+/>
 
 The **my-project** does not need to live inside your existing native app and can be created in a separate repository or a monorepo. The new project includes an example TypeScript application to help you get started.
 
@@ -50,7 +57,14 @@ The **my-project** does not need to live inside your existing native app and can
 
 Navigate to your new Expo project and install the `expo-brownfield` library, which provides the tools to build your React Native code as native libraries and integrate them into your existing native app.
 
-<Terminal cmd={['$ npx expo install expo-brownfield']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-brownfield'],
+    yarn: ['$ yarn expo install expo-brownfield'],
+    pnpm: ['$ pnpm expo install expo-brownfield'],
+    bun: ['$ bun expo install expo-brownfield'],
+  }}
+/>
 
 </Step>
 
@@ -108,7 +122,14 @@ Once you have your Expo project set up, use the `expo-brownfield` CLI to build y
 
 From your Expo project directory, run:
 
-<Terminal cmd={['$ npx expo-brownfield build:android']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo-brownfield build:android'],
+    yarn: ['$ yarn dlx expo-brownfield build:android'],
+    pnpm: ['$ pnpm dlx expo-brownfield build:android'],
+    bun: ['$ bunx expo-brownfield build:android'],
+  }}
+/>
 
 This will build the AAR and publish it to a Maven repository. By default, it publishes to your local Maven repository (`~/.m2`), but it can also be configured to publish to a remote repository.
 The produced artifact name will be determined by your config plugin settings, in this case `com.username.myproject:brownfield:1.0.0`.
@@ -120,7 +141,14 @@ See the [API reference](/versions/latest/sdk/brownfield/) for more details on bu
 
 From your Expo project directory, run:
 
-<Terminal cmd={['$ npx expo-brownfield build:ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo-brownfield build:ios'],
+    yarn: ['$ yarn dlx expo-brownfield build:ios'],
+    pnpm: ['$ pnpm dlx expo-brownfield build:ios'],
+    bun: ['$ bunx expo-brownfield build:ios'],
+  }}
+/>
 
 This will build the XCFramework artifacts: compile the framework target for both device and simulator architectures, package them into XCFrameworks, and copy the Hermes engine framework.
 
@@ -135,7 +163,14 @@ See the [`expo-brownfield` API reference](/versions/latest/sdk/brownfield/) for 
 
 Pass the `--package [name]` flag to bundle the build output as a self-contained Swift Package instead of separate **.xcframework** directories. You can then add it to your host app as a local dependency in Xcode rather than manually dragging frameworks into the project.
 
-<Terminal cmd={['$ npx expo-brownfield build:ios --release --package MyAppPackage']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo-brownfield build:ios --release --package MyAppPackage'],
+    yarn: ['$ yarn dlx expo-brownfield build:ios --release --package MyAppPackage'],
+    pnpm: ['$ pnpm dlx expo-brownfield build:ios --release --package MyAppPackage'],
+    bun: ['$ bunx expo-brownfield build:ios --release --package MyAppPackage'],
+  }}
+/>
 
 The flag accepts an optional name. If omitted, the package defaults to **\{TargetName\}Artifacts**. The resulting directory is a complete Swift Package with this layout:
 
@@ -156,7 +191,14 @@ The flag accepts an optional name. If omitted, the package defaults to **\{Targe
 
 If you need to debug native code of the Expo project targets, you can run `npx expo prebuild` to generate the native projects with the brownfield library targets, inside the **android** and **ios`** directories.
 
-<Terminal cmd={['$ npx expo prebuild']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild'],
+    yarn: ['$ yarn expo prebuild'],
+    pnpm: ['$ pnpm expo prebuild'],
+    bun: ['$ bun expo prebuild'],
+  }}
+/>
 
 The above command generates the following:
 
@@ -357,7 +399,14 @@ You have completed all the basic steps to integrate React Native with your appli
 
 Now run the following command in the React Native directory to start the [Metro bundler](https://metrobundler.dev/)
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 Then, build and run the native app from Android Studio or Xcode. When you navigate to the React Native screen, it will load from the Metro dev server with hot reloading support.
 

--- a/docs/pages/brownfield/lifecycle-listeners.mdx
+++ b/docs/pages/brownfield/lifecycle-listeners.mdx
@@ -45,7 +45,14 @@ Alternatively, if your `AppDelegate` doesn't already extend another class, you c
 
 To test if the callbacks are working correctly, install a module that relies on them. Install `expo-linking`, which uses lifecycle listeners to handle deep links:
 
-<Terminal cmd={['$ npx expo install expo-linking']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-linking'],
+    yarn: ['$ yarn expo install expo-linking'],
+    pnpm: ['$ pnpm expo install expo-linking'],
+    bun: ['$ bun expo install expo-linking'],
+  }}
+/>
 
 Add a listener for deep links in your code and observe the console when opening a deep link:
 
@@ -65,11 +72,34 @@ useEffect(() => {
 Run the following command to open a deep link to your app:
 
 <Terminal
-  cmd={[
-    '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
-    '$ npx uri-scheme open com.example.app://somepath/details --android',
-    '',
-    '# If you have a `scheme` defined in your app.json',
-    '$ npx uri-scheme open myapp://somepath/details --ios',
-  ]}
+  cmd={{
+    npm: [
+      '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+      '$ npx uri-scheme open com.example.app://somepath/details --android',
+      '',
+      '# If you have a `scheme` defined in your app.json',
+      '$ npx uri-scheme open myapp://somepath/details --ios',
+    ],
+    yarn: [
+      '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+      '$ yarn dlx uri-scheme open com.example.app://somepath/details --android',
+      '',
+      '# If you have a `scheme` defined in your app.json',
+      '$ yarn dlx uri-scheme open myapp://somepath/details --ios',
+    ],
+    pnpm: [
+      '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+      '$ pnpm dlx uri-scheme open com.example.app://somepath/details --android',
+      '',
+      '# If you have a `scheme` defined in your app.json',
+      '$ pnpm dlx uri-scheme open myapp://somepath/details --ios',
+    ],
+    bun: [
+      '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+      '$ bunx uri-scheme open com.example.app://somepath/details --android',
+      '',
+      '# If you have a `scheme` defined in your app.json',
+      '$ bunx uri-scheme open myapp://somepath/details --ios',
+    ],
+  }}
 />

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -62,7 +62,6 @@ Run the following command to regenerate the **android** and **ios** directories 
     pnpm: ['$ pnpm expo prebuild --clean'],
     bun: ['$ bun expo prebuild --clean'],
   }}
-  cmdCopy="npx expo prebuild --clean"
 />
 
 You can test that everything worked by building the projects locally:

--- a/docs/pages/guides/adopting-prebuild.mdx
+++ b/docs/pages/guides/adopting-prebuild.mdx
@@ -15,7 +15,14 @@ Adopting prebuild will automatically add support for developing modules with the
 
 The `expo` package contains the [`npx expo prebuild`](/more/expo-cli/#prebuild) command and indicates which [prebuild template](/workflow/continuous-native-generation#templates) to use:
 
-<Terminal cmd={['$ npm install expo']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install expo'],
+    yarn: ['$ yarn add expo'],
+    pnpm: ['$ pnpm add expo'],
+    bun: ['$ bun add expo'],
+  }}
+/>
 
 Ensure you install the version of `expo` that works for your currently installed [version of `react-native`](/versions/latest/#each-expo-sdk-version-depends-on-a-react-native-version).
 
@@ -48,18 +55,49 @@ If you're migrating an existing project, then you may want to refer to [**migrat
 
 Run the following command to regenerate the **android** and **ios** directories based on the app config (**app.json/app.config.js**) configuration:
 
-<Terminal cmd={['$ npx expo prebuild --clean']} cmdCopy="npx expo prebuild --clean" />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild --clean'],
+    yarn: ['$ yarn expo prebuild --clean'],
+    pnpm: ['$ pnpm expo prebuild --clean'],
+    bun: ['$ bun expo prebuild --clean'],
+  }}
+  cmdCopy="npx expo prebuild --clean"
+/>
 
 You can test that everything worked by building the projects locally:
 
 <Terminal
-  cmd={[
-    '# Build your native Android project',
-    '$ npx expo run:android',
-    '',
-    '# Build your native iOS project',
-    '$ npx expo run:ios',
-  ]}
+  cmd={{
+    npm: [
+      '# Build your native Android project',
+      '$ npx expo run:android',
+      '',
+      '# Build your native iOS project',
+      '$ npx expo run:ios',
+    ],
+    yarn: [
+      '# Build your native Android project',
+      '$ yarn expo run:android',
+      '',
+      '# Build your native iOS project',
+      '$ yarn expo run:ios',
+    ],
+    pnpm: [
+      '# Build your native Android project',
+      '$ pnpm expo run:android',
+      '',
+      '# Build your native iOS project',
+      '$ pnpm expo run:ios',
+    ],
+    bun: [
+      '# Build your native Android project',
+      '$ bun expo run:android',
+      '',
+      '# Build your native iOS project',
+      '$ bun expo run:ios',
+    ],
+  }}
 />
 
 > Learn more about [compiling native apps](/more/expo-cli/#compiling).

--- a/docs/pages/guides/analyzing-bundles.mdx
+++ b/docs/pages/guides/analyzing-bundles.mdx
@@ -25,7 +25,12 @@ You can use Expo Atlas with the local development server. This method allows Atl
 Once your app is running using the local development server on Android, iOS, and/or web, you can open Atlas through the [dev tools plugin menu](/debugging/devtools-plugins/#using-a-dev-tools-plugin) using <kbd>Shift</kbd> + <kbd>M</kbd>.
 
 <Terminal
-  cmd={['# Start the local development server with Atlas', '$ EXPO_ATLAS=true npx expo start']}
+  cmd={{
+    npm: ['# Start the local development server with Atlas', '$ EXPO_ATLAS=true npx expo start'],
+    yarn: ['# Start the local development server with Atlas', '$ EXPO_ATLAS=true yarn expo start'],
+    pnpm: ['# Start the local development server with Atlas', '$ EXPO_ATLAS=true pnpm expo start'],
+    bun: ['# Start the local development server with Atlas', '$ EXPO_ATLAS=true bun expo start'],
+  }}
 />
 
 #### Changing development mode to production
@@ -33,10 +38,24 @@ Once your app is running using the local development server on Android, iOS, and
 By default, Expo starts the local development server in [development mode](/workflow/development-mode/#development-mode). Development mode disables some optimizations that are enabled in [production mode](/workflow/development-mode/#production-mode). You can also start the local development server in production mode to get a more accurate representation of the production bundle size:
 
 <Terminal
-  cmd={[
-    '# Run the local development server in production mode',
-    '$ EXPO_ATLAS=true npx expo start --no-dev',
-  ]}
+  cmd={{
+    npm: [
+      '# Run the local development server in production mode',
+      '$ EXPO_ATLAS=true npx expo start --no-dev',
+    ],
+    yarn: [
+      '# Run the local development server in production mode',
+      '$ EXPO_ATLAS=true yarn expo start --no-dev',
+    ],
+    pnpm: [
+      '# Run the local development server in production mode',
+      '$ EXPO_ATLAS=true pnpm expo start --no-dev',
+    ],
+    bun: [
+      '# Run the local development server in production mode',
+      '$ EXPO_ATLAS=true bun expo start --no-dev',
+    ],
+  }}
 />
 
 ### Using Expo Atlas with `npx expo export`
@@ -44,13 +63,36 @@ By default, Expo starts the local development server in [development mode](/work
 You can also use Expo Atlas when generating a production bundle for your app or EAS Update. Atlas generates a **.expo/atlas.jsonl** file during export, which you can share and open without having access to the project.
 
 <Terminal
-  cmd={[
-    '# Export your app for all platforms',
-    '$ EXPO_ATLAS=true npx expo export',
-    '',
-    '# Open the generated Expo Atlas file',
-    '$ npx expo-atlas .expo/atlas.jsonl',
-  ]}
+  cmd={{
+    npm: [
+      '# Export your app for all platforms',
+      '$ EXPO_ATLAS=true npx expo export',
+      '',
+      '# Open the generated Expo Atlas file',
+      '$ npx expo-atlas .expo/atlas.jsonl',
+    ],
+    yarn: [
+      '# Export your app for all platforms',
+      '$ EXPO_ATLAS=true yarn expo export',
+      '',
+      '# Open the generated Expo Atlas file',
+      '$ yarn dlx expo-atlas .expo/atlas.jsonl',
+    ],
+    pnpm: [
+      '# Export your app for all platforms',
+      '$ EXPO_ATLAS=true pnpm expo export',
+      '',
+      '# Open the generated Expo Atlas file',
+      '$ pnpm dlx expo-atlas .expo/atlas.jsonl',
+    ],
+    bun: [
+      '# Export your app for all platforms',
+      '$ EXPO_ATLAS=true bun expo export',
+      '',
+      '# Open the generated Expo Atlas file',
+      '$ bunx expo-atlas .expo/atlas.jsonl',
+    ],
+  }}
 />
 
 You can also specify the platforms you want to analyze using the `--platform` option. Expo Atlas will gather the data for the exported platforms only.
@@ -71,7 +113,14 @@ If you are using SDK 50 or below, you can use the [`source-map-explorer`](https:
 
 To use source map explorer, run the following command to install it:
 
-<Terminal cmd={['$ npm i --save-dev source-map-explorer']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --save-dev source-map-explorer'],
+    yarn: ['$ yarn add --dev source-map-explorer'],
+    pnpm: ['$ pnpm add --save-dev source-map-explorer'],
+    bun: ['$ bun add --dev source-map-explorer'],
+  }}
+/>
 
 </Step>
 
@@ -92,9 +141,20 @@ Add a script to **package.json** to run it. You might have to adjust the input p
 If you are using the SDK 50 `server` output for web, then use the following to map web bundles:
 
 <Terminal
-  cmd={[
-    "$ npx source-map-explorer 'dist/client/_expo/static/js/web/*.js' 'dist/client/_expo/static/js/web/*.js.map'",
-  ]}
+  cmd={{
+    npm: [
+      "$ npx source-map-explorer 'dist/client/_expo/static/js/web/*.js' 'dist/client/_expo/static/js/web/*.js.map'",
+    ],
+    yarn: [
+      "$ yarn dlx source-map-explorer 'dist/client/_expo/static/js/web/*.js' 'dist/client/_expo/static/js/web/*.js.map'",
+    ],
+    pnpm: [
+      "$ pnpm dlx source-map-explorer 'dist/client/_expo/static/js/web/*.js' 'dist/client/_expo/static/js/web/*.js.map'",
+    ],
+    bun: [
+      "$ bunx source-map-explorer 'dist/client/_expo/static/js/web/*.js' 'dist/client/_expo/static/js/web/*.js.map'",
+    ],
+  }}
 />
 
 Web bundles are output to the **dist/client** subdirectory to prevent exposing server code to the client.
@@ -106,12 +166,32 @@ Web bundles are output to the **dist/client** subdirectory to prevent exposing s
 Export your production JavaScript bundle and include the `--source-maps` flag so that the source map explorer can read the source maps. For native apps using Hermes, you can use the `--no-bytecode` option to disable bytecode generation.
 
 <Terminal
-  cmd={[
-    '$ npx expo export --source-maps --platform web',
-    '',
-    '# Native apps using Hermes can disable bytecode for analyzing the JavaScript bundle.',
-    '$ npx expo export --source-maps --platform ios --no-bytecode',
-  ]}
+  cmd={{
+    npm: [
+      '$ npx expo export --source-maps --platform web',
+      '',
+      '# Native apps using Hermes can disable bytecode for analyzing the JavaScript bundle.',
+      '$ npx expo export --source-maps --platform ios --no-bytecode',
+    ],
+    yarn: [
+      '$ yarn expo export --source-maps --platform web',
+      '',
+      '# Native apps using Hermes can disable bytecode for analyzing the JavaScript bundle.',
+      '$ yarn expo export --source-maps --platform ios --no-bytecode',
+    ],
+    pnpm: [
+      '$ pnpm expo export --source-maps --platform web',
+      '',
+      '# Native apps using Hermes can disable bytecode for analyzing the JavaScript bundle.',
+      '$ pnpm expo export --source-maps --platform ios --no-bytecode',
+    ],
+    bun: [
+      '$ bun expo export --source-maps --platform web',
+      '',
+      '# Native apps using Hermes can disable bytecode for analyzing the JavaScript bundle.',
+      '$ bun expo export --source-maps --platform ios --no-bytecode',
+    ],
+  }}
 />
 
 This command shows the JavaScript bundle and source map paths in the output. In the next step, you will pass these paths to the source map explorer.
@@ -124,7 +204,14 @@ This command shows the JavaScript bundle and source map paths in the output. In 
 
 Run the script to analyze your bundle:
 
-<Terminal cmd={['$ npm run analyze:web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm run analyze:web'],
+    yarn: ['$ yarn run analyze:web'],
+    pnpm: ['$ pnpm run analyze:web'],
+    bun: ['$ bun run analyze:web'],
+  }}
+/>
 
 On running this command, you might see the following error:
 
@@ -145,11 +232,34 @@ Lighthouse is a great way to see how fast, accessible, and performant your websi
 After creating a production build with `npx expo export -p web` and serving it (using either `npx serve dist`, or production deployment, or custom server), run Lighthouse with the URL your site is hosted at.
 
 <Terminal
-  cmd={[
-    '# Install the lighthouse CLI',
-    '$ npm install -g lighthouse',
-    '',
-    '# Run the lighthouse CLI for your site',
-    '$ npx lighthouse <url> --view',
-  ]}
+  cmd={{
+    npm: [
+      '# Install the lighthouse CLI',
+      '$ npm install --global lighthouse',
+      '',
+      '# Run the lighthouse CLI for your site',
+      '$ npx lighthouse <url> --view',
+    ],
+    yarn: [
+      '# Install the lighthouse CLI',
+      '$ yarn global add lighthouse',
+      '',
+      '# Run the lighthouse CLI for your site',
+      '$ yarn dlx lighthouse <url> --view',
+    ],
+    pnpm: [
+      '# Install the lighthouse CLI',
+      '$ pnpm add --global lighthouse',
+      '',
+      '# Run the lighthouse CLI for your site',
+      '$ pnpm dlx lighthouse <url> --view',
+    ],
+    bun: [
+      '# Install the lighthouse CLI',
+      '$ bun add --global lighthouse',
+      '',
+      '# Run the lighthouse CLI for your site',
+      '$ bunx lighthouse <url> --view',
+    ],
+  }}
 />

--- a/docs/pages/guides/cache-builds-remotely.mdx
+++ b/docs/pages/guides/cache-builds-remotely.mdx
@@ -19,13 +19,27 @@ To use the EAS Build provider plugin, start by installing the `eas-build-cache-p
 
 <Tab label="macOS/Linux">
 
-<Terminal cmd={['$ npx expo install eas-build-cache-provider --dev']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install eas-build-cache-provider --dev'],
+    yarn: ['$ yarn expo install eas-build-cache-provider --dev'],
+    pnpm: ['$ pnpm expo install eas-build-cache-provider --dev'],
+    bun: ['$ bun expo install eas-build-cache-provider --dev'],
+  }}
+/>
 
 </Tab>
 
 <Tab label="Windows">
 
-<Terminal cmd={['$ npx expo install eas-build-cache-provider "--" --dev']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install eas-build-cache-provider "--" --dev'],
+    yarn: ['$ yarn expo install eas-build-cache-provider "--" --dev'],
+    pnpm: ['$ pnpm expo install eas-build-cache-provider "--" --dev'],
+    bun: ['$ bun expo install eas-build-cache-provider "--" --dev'],
+  }}
+/>
 
 </Tab>
 

--- a/docs/pages/guides/customizing-metro.mdx
+++ b/docs/pages/guides/customizing-metro.mdx
@@ -18,7 +18,14 @@ You can customize the Metro bundler by creating a **metro.config.js** file at th
 
 Run the following command to generate the template file:
 
-<Terminal cmd={['$ npx expo customize metro.config.js']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo customize metro.config.js'],
+    yarn: ['$ yarn expo customize metro.config.js'],
+    pnpm: ['$ pnpm expo customize metro.config.js'],
+    bun: ['$ bun expo customize metro.config.js'],
+  }}
+/>
 
 The **metro.config.js** file looks as below:
 
@@ -174,7 +181,14 @@ Modify your [app config](/workflow/configuration) to enable the feature using th
 
 To start the development server run the following command:
 
-<Terminal cmd={['$ npx expo start --web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --web'],
+    yarn: ['$ yarn expo start --web'],
+    pnpm: ['$ pnpm expo start --web'],
+    bun: ['$ bun expo start --web'],
+  }}
+/>
 
 Alternatively, press <kbd>W</kbd> in the Expo CLI terminal UI.
 

--- a/docs/pages/guides/dom-components.mdx
+++ b/docs/pages/guides/dom-components.mdx
@@ -23,7 +23,14 @@ While the Expo native runtime generally does not support elements like `<div>` o
         <Collapsible summary="How to opt out of @expo/dom-webview and use react-native-webview instead?">
         If you want to use `react-native-webview` instead, install it and opt out via the `dom` prop:
 
-        <Terminal cmd={['$ npx expo install react-native-webview']} />
+        <Terminal
+          cmd={{
+            npm: ['$ npx expo install react-native-webview'],
+            yarn: ['$ yarn expo install react-native-webview'],
+            pnpm: ['$ pnpm expo install react-native-webview'],
+            bun: ['$ bun expo install react-native-webview'],
+          }}
+        />
 
         ```tsx App.tsx (native)
         import DOMComponent from './my-component';
@@ -37,7 +44,14 @@ While the Expo native runtime generally does not support elements like `<div>` o
       </Tab>
       <Tab label="SDK 55 and earlier">
         Install `react-native-webview` in your project:
-        <Terminal cmd={['$ npx expo install react-native-webview']} />
+        <Terminal
+          cmd={{
+            npm: ['$ npx expo install react-native-webview'],
+            yarn: ['$ yarn expo install react-native-webview'],
+            pnpm: ['$ pnpm expo install react-native-webview'],
+            bun: ['$ bun expo install react-native-webview'],
+          }}
+        />
       </Tab>
     </Tabs>
 
@@ -47,7 +61,14 @@ While the Expo native runtime generally does not support elements like `<div>` o
 
     If you don't have the `expo` package in your project yet, install it by running the command below and [opt in to using Expo CLI and Metro Config](/bare/installing-expo-modules/#configure-expo-cli-for-bundling-on-android-and-ios):
 
-    <Terminal cmd={['$ npx install-expo-modules@latest']} />
+    <Terminal
+      cmd={{
+        npm: ['$ npx install-expo-modules@latest'],
+        yarn: ['$ yarn dlx install-expo-modules@latest'],
+        pnpm: ['$ pnpm dlx install-expo-modules@latest'],
+        bun: ['$ bunx install-expo-modules@latest'],
+      }}
+    />
 
     If the command fails, refer to the [Installing Expo modules](/bare/installing-expo-modules/#manual-installation) guide.
 
@@ -55,7 +76,14 @@ While the Expo native runtime generally does not support elements like `<div>` o
   <Requirement title="Expo Metro Runtime, React DOM, and React Native Web">
     If you are using Expo Router and Expo Web, you can skip this step. Otherwise, install the following packages:
 
-    <Terminal cmd={['$ npx expo install @expo/metro-runtime react-dom react-native-web']} />
+    <Terminal
+      cmd={{
+        npm: ['$ npx expo install @expo/metro-runtime react-dom react-native-web'],
+        yarn: ['$ yarn expo install @expo/metro-runtime react-dom react-native-web'],
+        pnpm: ['$ pnpm expo install @expo/metro-runtime react-dom react-native-web'],
+        bun: ['$ bun expo install @expo/metro-runtime react-dom react-native-web'],
+      }}
+    />
 
   </Requirement>
 </Prerequisites>
@@ -548,20 +576,64 @@ To ensure your DOM components run within a secure context, follow these guidelin
 **Example commands to tunnel DOM components over HTTPS:**
 
 <Terminal
-  cmd={[
-    '# Install expo-dev-client to enable connection to the remote development server:',
-    '$ npx expo install expo-dev-client',
-    '',
-    '# Run the app on Android:',
-    '$ npx expo run:android',
-    '# Press Ctrl + C to stop the server',
-    '$ npx expo start --tunnel -d -a',
-    '',
-    '# Run the app on iOS:',
-    '$ npx expo run:ios',
-    '# Press Ctrl + C to stop the server',
-    '$ npx expo start --tunnel -d -i',
-  ]}
+  cmd={{
+    npm: [
+      '# Install expo-dev-client to enable connection to the remote development server:',
+      '$ npx expo install expo-dev-client',
+      '',
+      '# Run the app on Android:',
+      '$ npx expo run:android',
+      '# Press Ctrl + C to stop the server',
+      '$ npx expo start --tunnel -d -a',
+      '',
+      '# Run the app on iOS:',
+      '$ npx expo run:ios',
+      '# Press Ctrl + C to stop the server',
+      '$ npx expo start --tunnel -d -i',
+    ],
+    yarn: [
+      '# Install expo-dev-client to enable connection to the remote development server:',
+      '$ yarn expo install expo-dev-client',
+      '',
+      '# Run the app on Android:',
+      '$ yarn expo run:android',
+      '# Press Ctrl + C to stop the server',
+      '$ yarn expo start --tunnel -d -a',
+      '',
+      '# Run the app on iOS:',
+      '$ yarn expo run:ios',
+      '# Press Ctrl + C to stop the server',
+      '$ yarn expo start --tunnel -d -i',
+    ],
+    pnpm: [
+      '# Install expo-dev-client to enable connection to the remote development server:',
+      '$ pnpm expo install expo-dev-client',
+      '',
+      '# Run the app on Android:',
+      '$ pnpm expo run:android',
+      '# Press Ctrl + C to stop the server',
+      '$ pnpm expo start --tunnel -d -a',
+      '',
+      '# Run the app on iOS:',
+      '$ pnpm expo run:ios',
+      '# Press Ctrl + C to stop the server',
+      '$ pnpm expo start --tunnel -d -i',
+    ],
+    bun: [
+      '# Install expo-dev-client to enable connection to the remote development server:',
+      '$ bun expo install expo-dev-client',
+      '',
+      '# Run the app on Android:',
+      '$ bun expo run:android',
+      '# Press Ctrl + C to stop the server',
+      '$ bun expo start --tunnel -d -a',
+      '',
+      '# Run the app on iOS:',
+      '$ bun expo run:ios',
+      '# Press Ctrl + C to stop the server',
+      '$ bun expo start --tunnel -d -i',
+    ],
+  }}
 />
 
 </Collapsible>

--- a/docs/pages/guides/local-app-development.mdx
+++ b/docs/pages/guides/local-app-development.mdx
@@ -32,12 +32,32 @@ To build your project into an app locally using your machine, you have to manual
 To build your project locally you can use compile commands from Expo CLI which generates the **android** and **ios** directories:
 
 <Terminal
-  cmd={[
-    '# Build native Android project',
-    '$ npx expo run:android',
-    '# Build native iOS project',
-    '$ npx expo run:ios',
-  ]}
+  cmd={{
+    npm: [
+      '# Build native Android project',
+      '$ npx expo run:android',
+      '# Build native iOS project',
+      '$ npx expo run:ios',
+    ],
+    yarn: [
+      '# Build native Android project',
+      '$ yarn expo run:android',
+      '# Build native iOS project',
+      '$ yarn expo run:ios',
+    ],
+    pnpm: [
+      '# Build native Android project',
+      '$ pnpm expo run:android',
+      '# Build native iOS project',
+      '$ pnpm expo run:ios',
+    ],
+    bun: [
+      '# Build native Android project',
+      '$ bun expo run:android',
+      '# Build native iOS project',
+      '$ bun expo run:ios',
+    ],
+  }}
 />
 
 The above commands compile your project, using your locally installed Android SDK or Xcode, into a debug build of your app. Each command performs two steps: it compiles and installs the native binary on your device or emulator, then starts the Metro bundler to serve your JavaScript or TypeScript code.
@@ -51,7 +71,14 @@ The above commands compile your project, using your locally installed Android SD
 
 Once the app is compiled and installed on your device or emulator, you don't need to rebuild every time you make a change. If you're only modifying JavaScript or TypeScript code, you can start the Metro bundler on its own:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 Then press <kbd>A</kbd> for Android or <kbd>I</kbd> for iOS in the terminal to launch the already-installed app. Metro serves your updated JavaScript bundle without recompiling native code, so the app loads in seconds instead of minutes.
 
@@ -89,7 +116,14 @@ To learn more about how compilation and prebuild works, see the following guides
 
 If you install [`expo-dev-client`](/develop/development-builds/introduction/) to your project, then a debug build of your project will include the `expo-dev-client` UI and tooling, and we call these development builds.
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 To create a development build, you can use [local app compilation](#local-app-compilation) commands (`npx expo run:[android|ios]`) which will create a debug build and start the development server.
 
@@ -100,16 +134,40 @@ If you have a custom Android project with multiple product flavors using differe
 The `--variant` flag can switch the Android build type from **debug** to **release**. This flag can also configure a product flavor and build type, when formatted in camelCase. For example, if you have both [**free** and **paid** product flavors](https://developer.android.com/build/build-variants#change-app-id), you can build a development version of your app with:
 
 <Terminal
-  cmd={[
-    '$ npx expo run:android --variant freeDebug',
-    '',
-    '$ npx expo run:android --variant paidDebug',
-  ]}
+  cmd={{
+    npm: [
+      '$ npx expo run:android --variant freeDebug',
+      '',
+      '$ npx expo run:android --variant paidDebug',
+    ],
+    yarn: [
+      '$ yarn expo run:android --variant freeDebug',
+      '',
+      '$ yarn expo run:android --variant paidDebug',
+    ],
+    pnpm: [
+      '$ pnpm expo run:android --variant freeDebug',
+      '',
+      '$ pnpm expo run:android --variant paidDebug',
+    ],
+    bun: [
+      '$ bun expo run:android --variant freeDebug',
+      '',
+      '$ bun expo run:android --variant paidDebug',
+    ],
+  }}
 />
 
 The `--app-id` flag can be used to launch the app after building using a customized application id. For example, if your product flavor **free** is using `applicationIdSuffix ".free"` or `applicationId "dev.expo.myapp.free"` you can run build and launch the app with:
 
-<Terminal cmd={['$ npx expo run:android --variant freeDebug --app-id dev.expo.myapp.free']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:android --variant freeDebug --app-id dev.expo.myapp.free'],
+    yarn: ['$ yarn expo run:android --variant freeDebug --app-id dev.expo.myapp.free'],
+    pnpm: ['$ pnpm expo run:android --variant freeDebug --app-id dev.expo.myapp.free'],
+    bun: ['$ bun expo run:android --variant freeDebug --app-id dev.expo.myapp.free'],
+  }}
+/>
 
 > **info** Customizing the Android build type is also possible, but that would break Expo's assumption that the build type **release** is used for production. You might build unoptimized code in your app using a different build type instead of **release**.
 

--- a/docs/pages/guides/local-https-development.mdx
+++ b/docs/pages/guides/local-https-development.mdx
@@ -37,14 +37,40 @@ When developing Expo web apps locally, you may need to use HTTPS with your local
 Create or navigate to your Expo project:
 
 <Terminal
-  cmd={[
-    '# Create a new project (if needed)',
-    '$ npx create-expo-app@latest example-app --template default@sdk-56',
-    '$ cd example-app',
-    '',
-    '# Or navigate to existing project',
-    '$ cd your-expo-project',
-  ]}
+  cmd={{
+    npm: [
+      '# Create a new project (if needed)',
+      '$ npx create-expo-app@latest example-app --template default@sdk-56',
+      '$ cd example-app',
+      '',
+      '# Or navigate to existing project',
+      '$ cd your-expo-project',
+    ],
+    yarn: [
+      '# Create a new project (if needed)',
+      '$ yarn create expo-app example-app --template default@sdk-56',
+      '$ cd example-app',
+      '',
+      '# Or navigate to existing project',
+      '$ cd your-expo-project',
+    ],
+    pnpm: [
+      '# Create a new project (if needed)',
+      '$ pnpm create expo-app example-app --template default@sdk-56',
+      '$ cd example-app',
+      '',
+      '# Or navigate to existing project',
+      '$ cd your-expo-project',
+    ],
+    bun: [
+      '# Create a new project (if needed)',
+      '$ bun create expo example-app --template default@sdk-56',
+      '$ cd example-app',
+      '',
+      '# Or navigate to existing project',
+      '$ cd your-expo-project',
+    ],
+  }}
 />
 
 </Step>
@@ -53,7 +79,14 @@ Create or navigate to your Expo project:
 
 Start your Expo development server:
 
-<Terminal cmd={['$ npx expo start --web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --web'],
+    yarn: ['$ yarn expo start --web'],
+    pnpm: ['$ pnpm expo start --web'],
+    bun: ['$ bun expo start --web'],
+  }}
+/>
 
 Your app will be running on `http://localhost:8081`. Keep this terminal window open.
 
@@ -76,9 +109,20 @@ This will generate two signed certificate files: `localhost.pem` (certificate) a
 Inside your project's root directory, run the following command to start the proxy:
 
 <Terminal
-  cmd={[
-    '$ npx local-ssl-proxy --source 443 --target 8081 --cert localhost.pem --key localhost-key.pem',
-  ]}
+  cmd={{
+    npm: [
+      '$ npx local-ssl-proxy --source 443 --target 8081 --cert localhost.pem --key localhost-key.pem',
+    ],
+    yarn: [
+      '$ yarn dlx local-ssl-proxy --source 443 --target 8081 --cert localhost.pem --key localhost-key.pem',
+    ],
+    pnpm: [
+      '$ pnpm dlx local-ssl-proxy --source 443 --target 8081 --cert localhost.pem --key localhost-key.pem',
+    ],
+    bun: [
+      '$ bunx local-ssl-proxy --source 443 --target 8081 --cert localhost.pem --key localhost-key.pem',
+    ],
+  }}
 />
 
 > **info** **Tip**: [`local-ssl-proxy`](https://github.com/cameronhunter/local-ssl-proxy) is a tool that creates a proxy server that forwards HTTPS traffic from port 443 to your Expo dev server on port 8081.

--- a/docs/pages/guides/minify.mdx
+++ b/docs/pages/guides/minify.mdx
@@ -63,7 +63,14 @@ Different minifiers have tradeoffs between speed and compression. You can custom
 
 To install Terser in a project, run the command:
 
-<Terminal cmd={['$ yarn add --dev metro-minify-terser']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --save-dev metro-minify-terser'],
+    yarn: ['$ yarn add --dev metro-minify-terser'],
+    pnpm: ['$ pnpm add --save-dev metro-minify-terser'],
+    bun: ['$ bun add --dev metro-minify-terser'],
+  }}
+/>
 
 </Step>
 
@@ -129,7 +136,14 @@ You can use [`uglify-es`](https://github.com/mishoo/UglifyJS) by following the s
 
 To install Uglify in a project, run the command:
 
-<Terminal cmd={['$ yarn add --dev metro-minify-uglify']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --save-dev metro-minify-uglify'],
+    yarn: ['$ yarn add --dev metro-minify-uglify'],
+    pnpm: ['$ pnpm add --save-dev metro-minify-uglify'],
+    bun: ['$ bun add --dev metro-minify-uglify'],
+  }}
+/>
 
 > Make sure the version of `metro-minify-uglify` matches the version of `metro` in your project.
 

--- a/docs/pages/guides/new-architecture.mdx
+++ b/docs/pages/guides/new-architecture.mdx
@@ -57,7 +57,14 @@ The compatibility status of many of the most popular libraries is tracked on [Re
 
 Run `npx expo-doctor` to check your dependencies against the data in React Native Directory.
 
-<Terminal cmd={['$ npx expo-doctor@latest']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo-doctor@latest'],
+    yarn: ['$ yarn dlx expo-doctor@latest'],
+    pnpm: ['$ pnpm dlx expo-doctor@latest'],
+    bun: ['$ bunx expo-doctor@latest'],
+  }}
+/>
 
 You can configure the React Native Directory check in your **package.json** file. For example, if you would like to exclude a package from validation:
 
@@ -85,7 +92,14 @@ You can configure the React Native Directory check in your **package.json** file
 
 **As of SDK 52**, all new projects will be initialized with the New Architecture enabled by default.
 
-<Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-56']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
+    yarn: ['$ yarn create expo-app --template default@sdk-56'],
+    pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
+    bun: ['$ bun create expo --template default@sdk-56'],
+  }}
+/>
 
 ## Enable the New Architecture in an existing project
 
@@ -126,22 +140,62 @@ You can configure the React Native Directory check in your **package.json** file
       <Tabs tabs={['Android', 'iOS']}>
         <Tab>
           <Terminal
-            cmd={[
-              '# Run a clean prebuild and start a local build, if you like',
-              '$ npx expo prebuild --clean && npx expo run:android',
-              '# Run a build with EAS if you prefer',
-              '$ eas build -p android',
-            ]}
+            cmd={{
+              npm: [
+                '# Run a clean prebuild and start a local build, if you like',
+                '$ npx expo prebuild --clean && npx expo run:android',
+                '# Run a build with EAS if you prefer',
+                '$ eas build -p android',
+              ],
+              yarn: [
+                '# Run a clean prebuild and start a local build, if you like',
+                '$ yarn expo prebuild --clean && yarn expo run:android',
+                '# Run a build with EAS if you prefer',
+                '$ eas build -p android',
+              ],
+              pnpm: [
+                '# Run a clean prebuild and start a local build, if you like',
+                '$ pnpm expo prebuild --clean && pnpm expo run:android',
+                '# Run a build with EAS if you prefer',
+                '$ eas build -p android',
+              ],
+              bun: [
+                '# Run a clean prebuild and start a local build, if you like',
+                '$ bun expo prebuild --clean && bun expo run:android',
+                '# Run a build with EAS if you prefer',
+                '$ eas build -p android',
+              ],
+            }}
           />
         </Tab>
         <Tab>
           <Terminal
-            cmd={[
-              '# Run a clean prebuild and start a local build, if you like',
-              '$ npx expo prebuild --clean && npx expo run:ios',
-              '# Run a build with EAS if you prefer',
-              '$ eas build -p ios',
-            ]}
+            cmd={{
+              npm: [
+                '# Run a clean prebuild and start a local build, if you like',
+                '$ npx expo prebuild --clean && npx expo run:ios',
+                '# Run a build with EAS if you prefer',
+                '$ eas build -p ios',
+              ],
+              yarn: [
+                '# Run a clean prebuild and start a local build, if you like',
+                '$ yarn expo prebuild --clean && yarn expo run:ios',
+                '# Run a build with EAS if you prefer',
+                '$ eas build -p ios',
+              ],
+              pnpm: [
+                '# Run a clean prebuild and start a local build, if you like',
+                '$ pnpm expo prebuild --clean && pnpm expo run:ios',
+                '# Run a build with EAS if you prefer',
+                '$ eas build -p ios',
+              ],
+              bun: [
+                '# Run a clean prebuild and start a local build, if you like',
+                '$ bun expo prebuild --clean && bun expo run:ios',
+                '# Run a build with EAS if you prefer',
+                '$ eas build -p ios',
+              ],
+            }}
           />
         </Tab>
       </Tabs>

--- a/docs/pages/guides/progressive-web-apps.mdx
+++ b/docs/pages/guides/progressive-web-apps.mdx
@@ -89,7 +89,12 @@ Now link the manifest in your HTML file. The method here depends on the output m
 If you're using a single-page app, you can link the manifest in your HTML file by first creating a template HTML in **public/index.html**:
 
 <Terminal
-  cmd={['$ npx expo customize public/index.html']}
+  cmd={{
+    npm: ['$ npx expo customize public/index.html'],
+    yarn: ['$ yarn expo customize public/index.html'],
+    pnpm: ['$ pnpm expo customize public/index.html'],
+    bun: ['$ bun expo customize public/index.html'],
+  }}
   cmdCopy="npx expo customize public/index.html"
 />
 
@@ -157,7 +162,12 @@ For example, here's a possible flow for setting up Workbox:
 Create a new project with the following command:
 
 <Terminal
-  cmd={['$ npm create expo -t tabs my-app', '', '$ cd my-app']}
+  cmd={{
+    npm: ['$ npm create expo -t tabs my-app', '', '$ cd my-app'],
+    yarn: ['$ yarn create expo -t tabs my-app', '', '$ cd my-app'],
+    pnpm: ['$ pnpm create expo -t tabs my-app', '', '$ cd my-app'],
+    bun: ['$ bun create expo -t tabs my-app', '', '$ cd my-app'],
+  }}
   cmdCopy="npm create expo -t tabs my-app && cd my-app"
 />
 
@@ -176,7 +186,12 @@ Next add a service worker registration script to the root **index.html**.
 First create a template HTML in **public/index.html** if one does not already exist:
 
 <Terminal
-  cmd={['$ npx expo customize public/index.html']}
+  cmd={{
+    npm: ['$ npx expo customize public/index.html'],
+    yarn: ['$ yarn expo customize public/index.html'],
+    pnpm: ['$ pnpm expo customize public/index.html'],
+    bun: ['$ bun expo customize public/index.html'],
+  }}
   cmdCopy="npx expo customize public/index.html"
 />
 
@@ -260,7 +275,14 @@ if ('serviceWorker' in navigator) {
 
 Now build the website before running the wizard:
 
-<Terminal cmd={['$ npx expo export -p web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export -p web'],
+    yarn: ['$ yarn expo export -p web'],
+    pnpm: ['$ pnpm expo export -p web'],
+    bun: ['$ bun expo export -p web'],
+  }}
+/>
 
 </Step>
 
@@ -269,15 +291,44 @@ Now build the website before running the wizard:
 Run the wizard command, select `dist` as the root of the app, and the defaults for everything else:
 
 <Terminal
-  cmd={[
-    '$ npx workbox-cli wizard',
-    '',
-    '? What is the root of your web app (that is which directory do you deploy)? dist/',
-    '? Which file types would you like to precache? js, html, ttf, ico, json',
-    '? Where would you like your service worker file to be saved? dist/sw.js',
-    '? Where would you like to save these configuration options? workbox-config.js',
-    "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
-  ]}
+  cmd={{
+    npm: [
+      '$ npx workbox-cli wizard',
+      '',
+      '? What is the root of your web app (that is which directory do you deploy)? dist/',
+      '? Which file types would you like to precache? js, html, ttf, ico, json',
+      '? Where would you like your service worker file to be saved? dist/sw.js',
+      '? Where would you like to save these configuration options? workbox-config.js',
+      "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    ],
+    yarn: [
+      '$ yarn dlx workbox-cli wizard',
+      '',
+      '? What is the root of your web app (that is which directory do you deploy)? dist/',
+      '? Which file types would you like to precache? js, html, ttf, ico, json',
+      '? Where would you like your service worker file to be saved? dist/sw.js',
+      '? Where would you like to save these configuration options? workbox-config.js',
+      "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    ],
+    pnpm: [
+      '$ pnpm dlx workbox-cli wizard',
+      '',
+      '? What is the root of your web app (that is which directory do you deploy)? dist/',
+      '? Which file types would you like to precache? js, html, ttf, ico, json',
+      '? Where would you like your service worker file to be saved? dist/sw.js',
+      '? Where would you like to save these configuration options? workbox-config.js',
+      "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    ],
+    bun: [
+      '$ bunx workbox-cli wizard',
+      '',
+      '? What is the root of your web app (that is which directory do you deploy)? dist/',
+      '? Which file types would you like to precache? js, html, ttf, ico, json',
+      '? Where would you like your service worker file to be saved? dist/sw.js',
+      '? Where would you like to save these configuration options? workbox-config.js',
+      "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    ],
+  }}
 />
 
 </Step>

--- a/docs/pages/guides/progressive-web-apps.mdx
+++ b/docs/pages/guides/progressive-web-apps.mdx
@@ -95,7 +95,6 @@ If you're using a single-page app, you can link the manifest in your HTML file b
     pnpm: ['$ pnpm expo customize public/index.html'],
     bun: ['$ bun expo customize public/index.html'],
   }}
-  cmdCopy="npx expo customize public/index.html"
 />
 
 Then add the manifest to the `<head>` tag:
@@ -168,7 +167,6 @@ Create a new project with the following command:
     pnpm: ['$ pnpm create expo -t tabs my-app', '', '$ cd my-app'],
     bun: ['$ bun create expo -t tabs my-app', '', '$ cd my-app'],
   }}
-  cmdCopy="npm create expo -t tabs my-app && cd my-app"
 />
 
 </Step>
@@ -192,7 +190,6 @@ First create a template HTML in **public/index.html** if one does not already ex
     pnpm: ['$ pnpm expo customize public/index.html'],
     bun: ['$ bun expo customize public/index.html'],
   }}
-  cmdCopy="npx expo customize public/index.html"
 />
 
 Then create the service worker registration script in the `<head>` tag:

--- a/docs/pages/guides/publishing-websites.mdx
+++ b/docs/pages/guides/publishing-websites.mdx
@@ -53,7 +53,14 @@ Creating a build of the project is the first step to publishing a web app. Wheth
 
 Run the universal export command to compile the project for web:
 
-<Terminal cmd={['$ npx expo export -p web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export -p web'],
+    yarn: ['$ yarn expo export -p web'],
+    pnpm: ['$ pnpm expo export -p web'],
+    bun: ['$ bun expo export -p web'],
+  }}
+/>
 
 The resulting project files are located in the **dist** directory. Any files inside the **public** directory are also copied to the **dist** directory.
 
@@ -63,7 +70,14 @@ The resulting project files are located in the **dist** directory. Any files ins
 
 Use `npx expo serve` to quickly test locally how your website will be hosted in production. Run the following command to serve the static bundle:
 
-<Terminal cmd={['$ npx expo serve']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo serve'],
+    yarn: ['$ yarn expo serve'],
+    pnpm: ['$ pnpm expo serve'],
+    bun: ['$ bun expo serve'],
+  }}
+/>
 
 Open [`http://localhost:8081`](http://localhost:8081) to see your project in action. This is **HTTP only**, so permissions, camera, location, and many other secure features may not work as expected.
 
@@ -90,7 +104,14 @@ When you're ready to go to production, you can instantly deploy your website wit
 
 Install the Netlify CLI by running the following command:
 
-<Terminal cmd={['$ npm install -g netlify-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global netlify-cli'],
+    yarn: ['$ yarn global add netlify-cli'],
+    pnpm: ['$ pnpm add --global netlify-cli'],
+    bun: ['$ bun add --global netlify-cli'],
+  }}
+/>
 
 </Step>
 
@@ -136,7 +157,14 @@ Netlify can also build and deploy when you push to git or open a new pull reques
 
 Install the [Vercel CLI](https://vercel.com/docs/cli).
 
-<Terminal cmd={['$ npm install -g vercel@latest']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global vercel@latest'],
+    yarn: ['$ yarn global add vercel@latest'],
+    pnpm: ['$ pnpm add --global vercel@latest'],
+    bun: ['$ bun add --global vercel@latest'],
+  }}
+/>
 
 </Step>
 <Step label="2">
@@ -263,7 +291,14 @@ In the existing `scripts` property of **package.json**, add `predeploy` and `dep
 
 To deploy, run the following command:
 
-<Terminal cmd={['$ npm run deploy-hosting']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm run deploy-hosting'],
+    yarn: ['$ yarn run deploy-hosting'],
+    pnpm: ['$ pnpm run deploy-hosting'],
+    bun: ['$ bun run deploy-hosting'],
+  }}
+/>
 
 Open the URL from the console output to check your deployment, for example: `https://project-name.firebaseapp.com`.
 

--- a/docs/pages/guides/react-compiler.mdx
+++ b/docs/pages/guides/react-compiler.mdx
@@ -15,7 +15,14 @@ The new [React Compiler](https://react.dev/learn/react-compiler) automatically m
 
 [Check how compatible](https://react.dev/learn/react-compiler#checking-compatibility) your project is with the React Compiler.
 
-<Terminal cmd={['$ npx react-compiler-healthcheck@latest']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx react-compiler-healthcheck@latest'],
+    yarn: ['$ yarn dlx react-compiler-healthcheck@latest'],
+    pnpm: ['$ pnpm dlx react-compiler-healthcheck@latest'],
+    bun: ['$ bunx react-compiler-healthcheck@latest'],
+  }}
+/>
 
 This will generally verify if your app is following the [**rules of React**](https://react.dev/reference/rules).
 
@@ -32,11 +39,23 @@ Install `babel-plugin-react-compiler` and the React compiler runtime in your pro
 
   </Tab>
   <Tab>
-    <Terminal cmd={['$ npx expo install babel-plugin-react-compiler@beta']} />
+    <Terminal
+      cmd={{
+        npm: ['$ npx expo install babel-plugin-react-compiler@beta'],
+        yarn: ['$ yarn expo install babel-plugin-react-compiler@beta'],
+        pnpm: ['$ pnpm expo install babel-plugin-react-compiler@beta'],
+        bun: ['$ bun expo install babel-plugin-react-compiler@beta'],
+      }}
+    />
   </Tab>
   <Tab>
     <Terminal
-      cmd={['$ npx expo install babel-plugin-react-compiler@beta react-compiler-runtime@beta']}
+      cmd={{
+        npm: ['$ npx expo install babel-plugin-react-compiler@beta react-compiler-runtime@beta'],
+        yarn: ['$ yarn expo install babel-plugin-react-compiler@beta react-compiler-runtime@beta'],
+        pnpm: ['$ pnpm expo install babel-plugin-react-compiler@beta react-compiler-runtime@beta'],
+        bun: ['$ bun expo install babel-plugin-react-compiler@beta react-compiler-runtime@beta'],
+      }}
     />
   </Tab>
 </Tabs>
@@ -75,7 +94,14 @@ Run [`npx expo lint`](/guides/using-eslint/#eslint) to set up ESLint in your app
 
     Install the ESLint plugin for React Compiler:
 
-    <Terminal cmd={['$ npx expo install eslint-plugin-react-compiler -- -D']} />
+    <Terminal
+      cmd={{
+        npm: ['$ npx expo install eslint-plugin-react-compiler -- -D'],
+        yarn: ['$ yarn expo install eslint-plugin-react-compiler -- -D'],
+        pnpm: ['$ pnpm expo install eslint-plugin-react-compiler -- -D'],
+        bun: ['$ bun expo install eslint-plugin-react-compiler -- -D'],
+      }}
+    />
 
     Update your [ESLint configuration](/guides/using-eslint/) to include the plugin:
 
@@ -132,7 +158,14 @@ module.exports = function (api) {
 
 Whenever you change your **babel.config.js** file, you need to restart the Metro bundler to apply the changes:
 
-<Terminal cmd={['$ npx expo start --clear']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --clear'],
+    yarn: ['$ yarn expo start --clear'],
+    pnpm: ['$ pnpm expo start --clear'],
+    bun: ['$ bun expo start --clear'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/guides/tailwind.mdx
+++ b/docs/pages/guides/tailwind.mdx
@@ -48,13 +48,36 @@ Configure Tailwind CSS in your Expo project according to the [Tailwind PostCSS d
 Install `tailwindcss` and its required peer dependencies. Then, run the initialization command to create **tailwind.config.js** and **post.config.js** files in the root of your project.
 
 <Terminal
-  cmd={[
-    '# Install Tailwind and its peer dependencies',
-    '$ npx expo install tailwindcss@3 postcss autoprefixer --dev',
-    '',
-    '# Create a Tailwind config file',
-    '$ npx tailwindcss init -p',
-  ]}
+  cmd={{
+    npm: [
+      '# Install Tailwind and its peer dependencies',
+      '$ npx expo install tailwindcss@3 postcss autoprefixer --dev',
+      '',
+      '# Create a Tailwind config file',
+      '$ npx tailwindcss init -p',
+    ],
+    yarn: [
+      '# Install Tailwind and its peer dependencies',
+      '$ yarn expo install tailwindcss@3 postcss autoprefixer --dev',
+      '',
+      '# Create a Tailwind config file',
+      '$ yarn dlx tailwindcss init -p',
+    ],
+    pnpm: [
+      '# Install Tailwind and its peer dependencies',
+      '$ pnpm expo install tailwindcss@3 postcss autoprefixer --dev',
+      '',
+      '# Create a Tailwind config file',
+      '$ pnpm dlx tailwindcss init -p',
+    ],
+    bun: [
+      '# Install Tailwind and its peer dependencies',
+      '$ bun expo install tailwindcss@3 postcss autoprefixer --dev',
+      '',
+      '# Create a Tailwind config file',
+      '$ bunx tailwindcss init -p',
+    ],
+  }}
 />
 
 </Step>
@@ -123,7 +146,14 @@ import './global.css';
 
 You now start your project and use Tailwind CSS classes in your components.
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 </Step>
 
@@ -136,10 +166,24 @@ You now start your project and use Tailwind CSS classes in your components.
 Install `tailwindcss` and its required peer dependencies:
 
 <Terminal
-  cmd={[
-    '# Install Tailwind and its peer dependencies',
-    '$ npx expo install tailwindcss @tailwindcss/postcss postcss --dev',
-  ]}
+  cmd={{
+    npm: [
+      '# Install Tailwind and its peer dependencies',
+      '$ npx expo install tailwindcss @tailwindcss/postcss postcss --dev',
+    ],
+    yarn: [
+      '# Install Tailwind and its peer dependencies',
+      '$ yarn expo install tailwindcss @tailwindcss/postcss postcss --dev',
+    ],
+    pnpm: [
+      '# Install Tailwind and its peer dependencies',
+      '$ pnpm expo install tailwindcss @tailwindcss/postcss postcss --dev',
+    ],
+    bun: [
+      '# Install Tailwind and its peer dependencies',
+      '$ bun expo install tailwindcss @tailwindcss/postcss postcss --dev',
+    ],
+  }}
 />
 
 </Step>
@@ -198,7 +242,14 @@ import './global.css';
 
 You now start your project and use Tailwind CSS classes in your components.
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/guides/tree-shaking.mdx
+++ b/docs/pages/guides/tree-shaking.mdx
@@ -335,7 +335,14 @@ This will only be used in production mode.
 
 Bundle your app in production mode to see the effects of tree shaking.
 
-<Terminal cmd={['$ npx expo export']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export'],
+    yarn: ['$ yarn expo export'],
+    pnpm: ['$ pnpm expo export'],
+    bun: ['$ bun expo export'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/linking/android-app-links.mdx
+++ b/docs/pages/linking/android-app-links.mdx
@@ -152,7 +152,14 @@ Add `intentFilters` to your app config as [described above](#add-intentfilters-t
 
 Start your dev server with the `--tunnel` flag:
 
-<Terminal cmd={['$ npx expo start --tunnel']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --tunnel'],
+    yarn: ['$ yarn expo start --tunnel'],
+    pnpm: ['$ pnpm expo start --tunnel'],
+    bun: ['$ bun expo start --tunnel'],
+  }}
+/>
 
 </Step>
 
@@ -160,7 +167,14 @@ Start your dev server with the `--tunnel` flag:
 
 Compile the development build on your device:
 
-<Terminal cmd={['$ npx expo run:android']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:android'],
+    yarn: ['$ yarn expo run:android'],
+    pnpm: ['$ pnpm expo run:android'],
+    bun: ['$ bun expo run:android'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/linking/into-your-app.mdx
+++ b/docs/pages/linking/into-your-app.mdx
@@ -36,13 +36,36 @@ You can test a link that opens your app using [`npx uri-scheme`](https://github.
 For example, if your app has a `/details` screen that you want to open when a user taps on a link (either through another app or a web browser), you can test this behavior by running the following command:
 
 <Terminal
-  cmd={[
-    '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
-    '$ npx uri-scheme open com.example.app://somepath/details --android',
-    '',
-    '# If you have a `scheme` defined in your app.json',
-    '$ npx uri-scheme open myapp://somepath/details --ios',
-  ]}
+  cmd={{
+    npm: [
+      '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+      '$ npx uri-scheme open com.example.app://somepath/details --android',
+      '',
+      '# If you have a `scheme` defined in your app.json',
+      '$ npx uri-scheme open myapp://somepath/details --ios',
+    ],
+    yarn: [
+      '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+      '$ yarn dlx uri-scheme open com.example.app://somepath/details --android',
+      '',
+      '# If you have a `scheme` defined in your app.json',
+      '$ yarn dlx uri-scheme open myapp://somepath/details --ios',
+    ],
+    pnpm: [
+      '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+      '$ pnpm dlx uri-scheme open com.example.app://somepath/details --android',
+      '',
+      '# If you have a `scheme` defined in your app.json',
+      '$ pnpm dlx uri-scheme open myapp://somepath/details --ios',
+    ],
+    bun: [
+      '# If you have `android.package` or `ios.bundleIdentifier` defined in your app.json',
+      '$ bunx uri-scheme open com.example.app://somepath/details --android',
+      '',
+      '# If you have a `scheme` defined in your app.json',
+      '$ bunx uri-scheme open myapp://somepath/details --ios',
+    ],
+  }}
 />
 
 Running the above command:
@@ -58,7 +81,16 @@ By default, [Expo Go](https://expo.dev/go) uses the `exp://` scheme. If you link
 To open the `/details` screen while testing on Expo Go, you can use `npx uri-scheme`:
 
 <Terminal
-  cmd={['$ npx uri-scheme open exp://127.0.0.1:8081/--/somepath/into/app?hello=world --ios']}
+  cmd={{
+    npm: ['$ npx uri-scheme open exp://127.0.0.1:8081/--/somepath/into/app?hello=world --ios'],
+    yarn: [
+      '$ yarn dlx uri-scheme open exp://127.0.0.1:8081/--/somepath/into/app?hello=world --ios',
+    ],
+    pnpm: [
+      '$ pnpm dlx uri-scheme open exp://127.0.0.1:8081/--/somepath/into/app?hello=world --ios',
+    ],
+    bun: ['$ bunx uri-scheme open exp://127.0.0.1:8081/--/somepath/into/app?hello=world --ios'],
+  }}
 />
 
 In Expo Go, `/--/` is added to the URL when a path is specified. This indicates to Expo Go that the substring after it corresponds to the deep link path and is not part of the path to the app itself.

--- a/docs/pages/linking/ios-universal-links.mdx
+++ b/docs/pages/linking/ios-universal-links.mdx
@@ -177,7 +177,14 @@ To enable the banner, add the following meta tag to the `<head>` of your website
 
 If you're having trouble setting up the banner, run the following command to automatically generate the meta tag for your project:
 
-<Terminal cmd={['$ npx setup-safari']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx setup-safari'],
+    yarn: ['$ yarn dlx setup-safari'],
+    pnpm: ['$ pnpm dlx setup-safari'],
+    bun: ['$ bunx setup-safari'],
+  }}
+/>
 
 ### Add the meta tag to your statically rendered website
 
@@ -223,7 +230,14 @@ Add `associatedDomains` to your app config as [described above](#native-app-conf
 
 Start your dev server with the `--tunnel` flag:
 
-<Terminal cmd={['$ npx expo start --tunnel']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --tunnel'],
+    yarn: ['$ yarn expo start --tunnel'],
+    pnpm: ['$ pnpm expo start --tunnel'],
+    bun: ['$ bun expo start --tunnel'],
+  }}
+/>
 
 </Step>
 
@@ -231,7 +245,14 @@ Start your dev server with the `--tunnel` flag:
 
 Compile the development build on your device:
 
-<Terminal cmd={['$ npx expo run:ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo run:ios'],
+    yarn: ['$ yarn expo run:ios'],
+    pnpm: ['$ pnpm expo run:ios'],
+    bun: ['$ bun expo run:ios'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/router/advanced/apple-handoff.mdx
+++ b/docs/pages/router/advanced/apple-handoff.mdx
@@ -49,7 +49,14 @@ To ensure that the **public/.well-known/apple-app-site-association** file is con
 
 You can use the following command to generate the **apple-app-site-association** file based on your [app config](/versions/latest/config/app/):
 
-<Terminal cmd={['$ npx setup-safari']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx setup-safari'],
+    yarn: ['$ yarn dlx setup-safari'],
+    pnpm: ['$ pnpm dlx setup-safari'],
+    bun: ['$ bunx setup-safari'],
+  }}
+/>
 
 See [Test the deep link](/linking/into-your-app/#test-the-deep-link) guide to test handoff in development.
 
@@ -97,7 +104,14 @@ module.exports = {
 
 After configuring the app config, regenerate your native project with the following command:
 
-<Terminal cmd={['$ npx expo prebuild -p ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild -p ios'],
+    yarn: ['$ yarn expo prebuild -p ios'],
+    pnpm: ['$ pnpm expo prebuild -p ios'],
+    bun: ['$ bun expo prebuild -p ios'],
+  }}
+/>
 
 In development, you must start the website **before installing the app on your device**. This is because when you install the app, the OS will trigger Apple's servers to ping your website for the **.well-known/apple-app-site-association** file. If the website is not running, the OS will not be able to find the file and handoff will not work. If this happens, rebuild the native app with `npx expo run:ios -d`.
 

--- a/docs/pages/router/advanced/drawer.mdx
+++ b/docs/pages/router/advanced/drawer.mdx
@@ -27,9 +27,20 @@ On Android and iOS, the drawer requires `react-native-reanimated` and `react-nat
 To use the drawer navigator, install these dependencies if you do not have them already:
 
 <Terminal
-  cmd={[
-    '$ npx expo install react-native-reanimated react-native-worklets react-native-gesture-handler',
-  ]}
+  cmd={{
+    npm: [
+      '$ npx expo install react-native-reanimated react-native-worklets react-native-gesture-handler',
+    ],
+    yarn: [
+      '$ yarn expo install react-native-reanimated react-native-worklets react-native-gesture-handler',
+    ],
+    pnpm: [
+      '$ pnpm expo install react-native-reanimated react-native-worklets react-native-gesture-handler',
+    ],
+    bun: [
+      '$ bun expo install react-native-reanimated react-native-worklets react-native-gesture-handler',
+    ],
+  }}
 />
 
 </Tab>
@@ -39,9 +50,20 @@ To use the drawer navigator, install these dependencies if you do not have them 
 To use [drawer navigator](https://reactnavigation.org/docs/drawer-navigator), install these dependencies if you do not have them already:
 
 <Terminal
-  cmd={[
-    '$ npx expo install @react-navigation/drawer react-native-reanimated react-native-worklets react-native-gesture-handler',
-  ]}
+  cmd={{
+    npm: [
+      '$ npx expo install @react-navigation/drawer react-native-reanimated react-native-worklets react-native-gesture-handler',
+    ],
+    yarn: [
+      '$ yarn expo install @react-navigation/drawer react-native-reanimated react-native-worklets react-native-gesture-handler',
+    ],
+    pnpm: [
+      '$ pnpm expo install @react-navigation/drawer react-native-reanimated react-native-worklets react-native-gesture-handler',
+    ],
+    bun: [
+      '$ bun expo install @react-navigation/drawer react-native-reanimated react-native-worklets react-native-gesture-handler',
+    ],
+  }}
 />
 
 </Tab>
@@ -51,9 +73,20 @@ To use [drawer navigator](https://reactnavigation.org/docs/drawer-navigator), in
 To use [drawer navigator](https://reactnavigation.org/docs/drawer-navigator), install these dependencies if you do not have them already:
 
 <Terminal
-  cmd={[
-    '$ npx expo install @react-navigation/drawer react-native-reanimated react-native-gesture-handler',
-  ]}
+  cmd={{
+    npm: [
+      '$ npx expo install @react-navigation/drawer react-native-reanimated react-native-gesture-handler',
+    ],
+    yarn: [
+      '$ yarn expo install @react-navigation/drawer react-native-reanimated react-native-gesture-handler',
+    ],
+    pnpm: [
+      '$ pnpm expo install @react-navigation/drawer react-native-reanimated react-native-gesture-handler',
+    ],
+    bun: [
+      '$ bun expo install @react-navigation/drawer react-native-reanimated react-native-gesture-handler',
+    ],
+  }}
 />
 
 </Tab>

--- a/docs/pages/router/advanced/stack-toolbar.mdx
+++ b/docs/pages/router/advanced/stack-toolbar.mdx
@@ -114,7 +114,14 @@ You can browse available symbols in Apple's SF Symbols app.
 
 The recommended source of icons for Android is [`@expo/material-symbols`](https://www.npmjs.com/package/@expo/material-symbols) library. It ships Google's [Material Symbols](https://fonts.google.com/icons) as individual asset subpaths, so Metro only bundles the icons you actually import.
 
-<Terminal cmd={['$ npx expo install @expo/material-symbols']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @expo/material-symbols'],
+    yarn: ['$ yarn expo install @expo/material-symbols'],
+    pnpm: ['$ pnpm expo install @expo/material-symbols'],
+    bun: ['$ bun expo install @expo/material-symbols'],
+  }}
+/>
 
 Import any icon directly from its own subpath and pass it to the `icon` prop:
 

--- a/docs/pages/router/installation.mdx
+++ b/docs/pages/router/installation.mdx
@@ -26,9 +26,20 @@ Follow the steps below if you have an existing project and want to add Expo Rout
 You'll need to install the following dependencies:
 
 <Terminal
-  cmd={[
-    '$ npx expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar',
-  ]}
+  cmd={{
+    npm: [
+      '$ npx expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar',
+    ],
+    yarn: [
+      '$ yarn expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar',
+    ],
+    pnpm: [
+      '$ pnpm expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar',
+    ],
+    bun: [
+      '$ bun expo install expo-router react-native-safe-area-context react-native-screens expo-linking expo-constants expo-status-bar',
+    ],
+  }}
 />
 
 The above command will install versions of these libraries that are compatible with the Expo SDK version your project is using.
@@ -101,7 +112,14 @@ Add a deep linking `scheme` and enable [typed routes](/router/reference/typed-ro
 
 If you are developing your app for web, install the following dependencies:
 
-<Terminal cmd={['$ npx expo install react-native-web react-dom']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install react-native-web react-dom'],
+    yarn: ['$ yarn expo install react-native-web react-dom'],
+    pnpm: ['$ pnpm expo install react-native-web react-dom'],
+    bun: ['$ bun expo install react-native-web react-dom'],
+  }}
+/>
 
 Then, enable [Metro web](/guides/customizing-metro/#adding-web-support-to-metro) support by adding the following to your [app config](/workflow/configuration/):
 
@@ -163,7 +181,14 @@ The `@/*` alias maps to the **src** directory in the above example.
 
 After updating the configuration, run the following command to clear the bundler cache:
 
-<Terminal cmd={['$ npx expo start --clear']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --clear'],
+    yarn: ['$ yarn expo start --clear'],
+    pnpm: ['$ pnpm expo start --clear'],
+    bun: ['$ bun expo start --clear'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/router/introduction.mdx
+++ b/docs/pages/router/introduction.mdx
@@ -44,7 +44,14 @@ We recommend creating a new Expo app using `create-expo-app` to create a project
 
 Now, you can start your project by running:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 - To view your app on a mobile device, we recommend starting with [Expo Go](/get-started/set-up-your-environment/#how-would-you-like-to-develop). As your application grows in complexity and you need more control, you can create a [development build](/develop/development-builds/introduction/).
 - Open the project in a web browser by pressing <kbd>W</kbd> in the Terminal UI. Press <kbd>A</kbd> for Android (Android Studio is required), or <kbd>I</kbd> for iOS (macOS with Xcode is required).

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -168,7 +168,12 @@ Workbox doesn't have a Metro integration, but because Workbox doesn't require on
 For example, here's a possible flow for setting up Workbox. Create a new project with the following command:
 
 <Terminal
-  cmd={['$ npm create expo -t tabs my-app', '', '$ cd my-app']}
+  cmd={{
+    npm: ['$ npm create expo -t tabs my-app', '', '$ cd my-app'],
+    yarn: ['$ yarn create expo -t tabs my-app', '', '$ cd my-app'],
+    pnpm: ['$ pnpm create expo -t tabs my-app', '', '$ cd my-app'],
+    bun: ['$ bun create expo -t tabs my-app', '', '$ cd my-app'],
+  }}
   cmdCopy="npm create expo -t tabs my-app && cd my-app"
 />
 
@@ -221,20 +226,56 @@ if ('serviceWorker' in navigator) {
 
 Now build the app before running the wizard:
 
-<Terminal cmd={['$ npx expo export -p web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export -p web'],
+    yarn: ['$ yarn expo export -p web'],
+    pnpm: ['$ pnpm expo export -p web'],
+    bun: ['$ bun expo export -p web'],
+  }}
+/>
 
 Run the wizard command, select `dist` as the root of the app, and the defaults for everything else:
 
 <Terminal
-  cmd={[
-    '$ npx workbox-cli wizard',
-    '',
-    '$ ? What is the root of your web app (that is which directory do you deploy)? dist/',
-    '$ ? Which file types would you like to precache? js, html, ttf, ico, json',
-    '$ ? Where would you like your service worker file to be saved? dist/sw.js',
-    '$ ? Where would you like to save these configuration options? workbox-config.js',
-    "$ ? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
-  ]}
+  cmd={{
+    npm: [
+      '$ npx workbox-cli wizard',
+      '',
+      '? What is the root of your web app (that is which directory do you deploy)? dist/',
+      '? Which file types would you like to precache? js, html, ttf, ico, json',
+      '? Where would you like your service worker file to be saved? dist/sw.js',
+      '? Where would you like to save these configuration options? workbox-config.js',
+      "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    ],
+    yarn: [
+      '$ yarn dlx workbox-cli wizard',
+      '',
+      '? What is the root of your web app (that is which directory do you deploy)? dist/',
+      '? Which file types would you like to precache? js, html, ttf, ico, json',
+      '? Where would you like your service worker file to be saved? dist/sw.js',
+      '? Where would you like to save these configuration options? workbox-config.js',
+      "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    ],
+    pnpm: [
+      '$ pnpm dlx workbox-cli wizard',
+      '',
+      '? What is the root of your web app (that is which directory do you deploy)? dist/',
+      '? Which file types would you like to precache? js, html, ttf, ico, json',
+      '? Where would you like your service worker file to be saved? dist/sw.js',
+      '? Where would you like to save these configuration options? workbox-config.js',
+      "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    ],
+    bun: [
+      '$ bunx workbox-cli wizard',
+      '',
+      '? What is the root of your web app (that is which directory do you deploy)? dist/',
+      '? Which file types would you like to precache? js, html, ttf, ico, json',
+      '? Where would you like your service worker file to be saved? dist/sw.js',
+      '? Where would you like to save these configuration options? workbox-config.js',
+      "? Does your web app manifest include search parameter(s) in the 'start_url', other than 'utm_' or 'fbclid' (like '?source=pwa')? No",
+    ],
+  }}
 />
 
 Finally, run `npx workbox-cli generateSW workbox-config.js` to generate the service worker config. Going forward, you can add a build script in **package.json** to run both scripts in the correct order:

--- a/docs/pages/router/migrate/from-expo-webpack.mdx
+++ b/docs/pages/router/migrate/from-expo-webpack.mdx
@@ -174,7 +174,6 @@ For example, here's a possible flow for setting up Workbox. Create a new project
     pnpm: ['$ pnpm create expo -t tabs my-app', '', '$ cd my-app'],
     bun: ['$ bun create expo -t tabs my-app', '', '$ cd my-app'],
   }}
-  cmdCopy="npm create expo -t tabs my-app && cd my-app"
 />
 
 Next, create a root HTML file for the app and add the service worker registration script:

--- a/docs/pages/router/migrate/sdk-55-to-56.mdx
+++ b/docs/pages/router/migrate/sdk-55-to-56.mdx
@@ -12,7 +12,14 @@ In **SDK 56 and later**, Expo Router no longer supports importing from external 
 
 Run the codemod from the root of your project. It rewrites `@react-navigation/*` imports in your application code to the matching `expo-router` entry points.
 
-<Terminal cmd={['$ npx expo-codemod sdk-56-expo-router-react-navigation-replace src']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo-codemod sdk-56-expo-router-react-navigation-replace src'],
+    yarn: ['$ yarn dlx expo-codemod sdk-56-expo-router-react-navigation-replace src'],
+    pnpm: ['$ pnpm dlx expo-codemod sdk-56-expo-router-react-navigation-replace src'],
+    bun: ['$ bunx expo-codemod sdk-56-expo-router-react-navigation-replace src'],
+  }}
+/>
 
 Replace `src` with the directory or glob that contains your application code.
 
@@ -52,4 +59,11 @@ This is a temporary compatibility shim. A dedicated library migration guide will
 
 To opt out, set `EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1` in your environment before starting the bundler. This also disables the bundler error for application code that imports from `@react-navigation/*`.
 
-<Terminal cmd={['$ EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1 npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1 npx expo start'],
+    yarn: ['$ EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1 yarn expo start'],
+    pnpm: ['$ EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1 pnpm expo start'],
+    bun: ['$ EXPO_ROUTER_DISABLE_RN_NAVIGATION_CHECK=1 bun expo start'],
+  }}
+/>

--- a/docs/pages/router/reference/sitemap.mdx
+++ b/docs/pages/router/reference/sitemap.mdx
@@ -11,7 +11,14 @@ On native, you can use the [`uri-scheme`](https://www.npmjs.com/package/uri-sche
 
 For example, if you want to launch the Expo Go app on iOS to the `/form-sheet` route, run:
 
-<Terminal cmd={['$ npx uri-scheme open exp://192.168.87.39:19000/--/form-sheet --ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx uri-scheme open exp://192.168.87.39:19000/--/form-sheet --ios'],
+    yarn: ['$ yarn dlx uri-scheme open exp://192.168.87.39:19000/--/form-sheet --ios'],
+    pnpm: ['$ pnpm dlx uri-scheme open exp://192.168.87.39:19000/--/form-sheet --ios'],
+    bun: ['$ bunx uri-scheme open exp://192.168.87.39:19000/--/form-sheet --ios'],
+  }}
+/>
 
 > Replace `192.168.87.39:19000` with the IP address shown when running `npx expo start`.
 

--- a/docs/pages/router/reference/src-directory.mdx
+++ b/docs/pages/router/reference/src-directory.mdx
@@ -46,12 +46,34 @@ This keeps `@/` imports working after moving your app directory into **src**.
 Restart your development server.
 
 {/* prettier-ignore */}
-<Terminal cmd={[
-  '$ npx expo start',
-  '',
-  '# Or export for production',
-  '$ npx expo export'
-]} />
+<Terminal
+  cmd={{
+    npm: [
+      '$ npx expo start',
+      '',
+      '# Or export for production',
+      '$ npx expo export',
+    ],
+    yarn: [
+      '$ yarn expo start',
+      '',
+      '# Or export for production',
+      '$ yarn expo export',
+    ],
+    pnpm: [
+      '$ pnpm expo start',
+      '',
+      '# Or export for production',
+      '$ pnpm expo export',
+    ],
+    bun: [
+      '$ bun expo start',
+      '',
+      '# Or export for production',
+      '$ bun expo export',
+    ],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/router/reference/troubleshooting.mdx
+++ b/docs/pages/router/reference/troubleshooting.mdx
@@ -27,7 +27,14 @@ If `process.env.EXPO_ROUTER_APP_ROOT` is not defined you'll see the following er
 
 This can happen when the Babel plugin `expo-router/babel` is not used in the project **babel.config.js**. You can try clearing the cache with:
 
-<Terminal cmd={['$ npx expo start --clear']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --clear'],
+    yarn: ['$ yarn expo start --clear'],
+    pnpm: ['$ pnpm expo start --clear'],
+    bun: ['$ bun expo start --clear'],
+  }}
+/>
 
 Alternatively, you can circumvent this issue by creating an **index.js** file in the root of your project with the following contents:
 

--- a/docs/pages/router/web/api-routes.mdx
+++ b/docs/pages/router/web/api-routes.mdx
@@ -73,7 +73,14 @@ You can export any of the following functions `GET`, `POST`, `PUT`, `PATCH`, `DE
 
 Start the development server with Expo CLI:
 
-<Terminal cmd={['$ npx expo']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo'],
+    yarn: ['$ yarn expo'],
+    pnpm: ['$ pnpm expo'],
+    bun: ['$ bun expo'],
+  }}
+/>
 
 </Step>
 
@@ -203,7 +210,14 @@ Making requests with an undefined method will automatically return `405: Method 
 
 You can use the [`expo-server`](/versions/latest/sdk/server/) library to use several utilities and code patterns that work in any server-side Expo code. This includes utilities to get request metadata, for scheduling tasks, and for error handling.
 
-<Terminal cmd={['$ npx expo install expo-server']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-server'],
+    yarn: ['$ yarn expo install expo-server'],
+    pnpm: ['$ pnpm expo install expo-server'],
+    bun: ['$ bun expo install expo-server'],
+  }}
+/>
 
 Using `expo-server` is not limited to API routes and it can be used in any other server code as well, for example, in [server middleware](/router/web/middleware/).
 
@@ -376,14 +390,28 @@ Route handlers are executed in a sandboxed environment that is isolated from the
 
 When you're ready to deploy to production, run the following command to create the server bundle in the **dist** directory (see the [Expo CLI documentation](/more/expo-cli#exporting) for more details):
 
-<Terminal cmd={['$ npx expo export --platform web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export --platform web'],
+    yarn: ['$ yarn expo export --platform web'],
+    pnpm: ['$ pnpm expo export --platform web'],
+    bun: ['$ bun expo export --platform web'],
+  }}
+/>
 
 This server can be tested locally with `npx expo serve`, visit the URL in a web browser or create a native build with the `origin` set to the local server URL.
 You can deploy the server for production using [EAS Hosting](/eas/hosting/get-started) or another third-party service.
 
 If you want to export API routes and skip generating a website version of your app, you can use the following command, which will generate a **dist** directory containing only the server code of your project.
 
-<Terminal cmd={['$ npx expo export --platform web --no-ssg']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export --platform web --no-ssg'],
+    yarn: ['$ yarn expo export --platform web --no-ssg'],
+    pnpm: ['$ pnpm expo export --platform web --no-ssg'],
+    bun: ['$ bun expo export --platform web --no-ssg'],
+  }}
+/>
 
 <BoxLink
   title="Deploy instantly with EAS"
@@ -414,7 +442,14 @@ Ensure the `origin` field is **NOT** set in the **app.json** or in the `expo.ext
 
 Setup [EAS Hosting](/eas/hosting/get-started) for the project by deploying once locally first.
 
-<Terminal cmd={['$ npx expo export -p web', '$ eas deploy']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export -p web', '$ eas deploy'],
+    yarn: ['$ yarn expo export -p web', '$ eas deploy'],
+    pnpm: ['$ pnpm expo export -p web', '$ eas deploy'],
+    bun: ['$ bun expo export -p web', '$ eas deploy'],
+  }}
+/>
 
 </Step>
 
@@ -437,13 +472,36 @@ You're now ready to use automatic server deployment! Run the build command to st
 You can also run this locally with:
 
 <Terminal
-  cmd={[
-    '# Android',
-    '$ npx expo run:android --variant release',
-    '',
-    '# iOS',
-    '$ npx expo run:ios --configuration Release',
-  ]}
+  cmd={{
+    npm: [
+      '# Android',
+      '$ npx expo run:android --variant release',
+      '',
+      '# iOS',
+      '$ npx expo run:ios --configuration Release',
+    ],
+    yarn: [
+      '# Android',
+      '$ yarn expo run:android --variant release',
+      '',
+      '# iOS',
+      '$ yarn expo run:ios --configuration Release',
+    ],
+    pnpm: [
+      '# Android',
+      '$ pnpm expo run:android --variant release',
+      '',
+      '# iOS',
+      '$ pnpm expo run:ios --configuration Release',
+    ],
+    bun: [
+      '# Android',
+      '$ bun expo run:android --variant release',
+      '',
+      '# iOS',
+      '$ bun expo run:ios --configuration Release',
+    ],
+  }}
 />
 
 </Step>
@@ -465,14 +523,28 @@ It can often be useful to test the production build against a local dev server t
 
 Export the production server:
 
-<Terminal cmd={['$ npx expo export']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export'],
+    yarn: ['$ yarn expo export'],
+    pnpm: ['$ pnpm expo export'],
+    bun: ['$ bun expo export'],
+  }}
+/>
 
 </Step>
 <Step label="2">
 
 Host the production server locally:
 
-<Terminal cmd={['$ npx expo serve']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo serve'],
+    yarn: ['$ yarn expo serve'],
+    pnpm: ['$ pnpm expo serve'],
+    bun: ['$ bun expo serve'],
+  }}
+/>
 
 </Step>
 
@@ -503,7 +575,14 @@ Remember to remove this `origin` value when deploying to production.
 
 Build the app in release mode on to a simulator:
 
-<Terminal cmd={['$ EXPO_NO_DEPLOY=1 npx expo run:ios --configuration Release']} />
+<Terminal
+  cmd={{
+    npm: ['$ EXPO_NO_DEPLOY=1 npx expo run:ios --configuration Release'],
+    yarn: ['$ EXPO_NO_DEPLOY=1 yarn expo run:ios --configuration Release'],
+    pnpm: ['$ EXPO_NO_DEPLOY=1 pnpm expo run:ios --configuration Release'],
+    bun: ['$ EXPO_NO_DEPLOY=1 bun expo run:ios --configuration Release'],
+  }}
+/>
 
 </Step>
 
@@ -531,7 +610,14 @@ Before deploying to these providers, it may be good to be familiar with the basi
 
 The `expo-server` library contains adapters for various providers and runtimes. Before proceeding with any of the below sections, install the `expo-server` library.
 
-<Terminal cmd={['$ npx expo install expo-server']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-server'],
+    yarn: ['$ yarn expo install expo-server'],
+    pnpm: ['$ pnpm expo install expo-server'],
+    bun: ['$ bun expo install expo-server'],
+  }}
+/>
 
 ### Bun
 
@@ -591,7 +677,14 @@ Start the server with `bun`:
 
 Install the required dependencies:
 
-<Terminal cmd={['$ npm i -D express compression morgan']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --save-dev express compression morgan'],
+    yarn: ['$ yarn add --dev express compression morgan'],
+    pnpm: ['$ pnpm add --save-dev express compression morgan'],
+    bun: ['$ bun add --dev express compression morgan'],
+  }}
+/>
 
 </Step>
 
@@ -599,7 +692,14 @@ Install the required dependencies:
 
 Export the website for production:
 
-<Terminal cmd={['$ npx expo export -p web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export -p web'],
+    yarn: ['$ yarn expo export -p web'],
+    pnpm: ['$ pnpm expo export -p web'],
+    bun: ['$ bun expo export -p web'],
+  }}
+/>
 
 </Step>
 
@@ -714,7 +814,14 @@ Create a Netlify configuration file at the root of your project to redirect all 
 
 After you have created the configuration files, you can build the website and functions with Expo CLI:
 
-<Terminal cmd={['$ npx expo export -p web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export -p web'],
+    yarn: ['$ yarn expo export -p web'],
+    pnpm: ['$ pnpm expo export -p web'],
+    bun: ['$ bun expo export -p web'],
+  }}
+/>
 
 </Step>
 
@@ -723,12 +830,32 @@ After you have created the configuration files, you can build the website and fu
 Deploy to Netlify with the [Netlify CLI](https://docs.netlify.com/cli/get-started/).
 
 <Terminal
-  cmd={[
-    '# Install the Netlify CLI globally if needed.',
-    '$ npm install netlify-cli -g',
-    '# Deploy the website.',
-    '$ netlify deploy',
-  ]}
+  cmd={{
+    npm: [
+      '# Install the Netlify CLI globally if needed.',
+      '$ npm install --global netlify-cli',
+      '# Deploy the website.',
+      '$ netlify deploy',
+    ],
+    yarn: [
+      '# Install the Netlify CLI globally if needed.',
+      '$ yarn global add netlify-cli',
+      '# Deploy the website.',
+      '$ netlify deploy',
+    ],
+    pnpm: [
+      '# Install the Netlify CLI globally if needed.',
+      '$ pnpm add --global netlify-cli',
+      '# Deploy the website.',
+      '$ netlify deploy',
+    ],
+    bun: [
+      '# Install the Netlify CLI globally if needed.',
+      '$ bun add --global netlify-cli',
+      '# Deploy the website.',
+      '$ netlify deploy',
+    ],
+  }}
 />
 
 You can now visit your website at the URL provided by Netlify CLI. Running `netlify deploy --prod` will publish to the production URL.
@@ -844,14 +971,40 @@ After you have created the configuration files, add a `vercel-build` script to y
 Deploy to Vercel with the [Vercel CLI](https://vercel.com/docs/cli).
 
 <Terminal
-  cmd={[
-    '# Install the Vercel CLI globally if needed.',
-    '$ npm install vercel -g',
-    '# Build the website.',
-    '$ vercel build',
-    '# Deploy the website.',
-    '$ vercel deploy --prebuilt',
-  ]}
+  cmd={{
+    npm: [
+      '# Install the Vercel CLI globally if needed.',
+      '$ npm install --global vercel',
+      '# Build the website.',
+      '$ vercel build',
+      '# Deploy the website.',
+      '$ vercel deploy --prebuilt',
+    ],
+    yarn: [
+      '# Install the Vercel CLI globally if needed.',
+      '$ yarn global add vercel',
+      '# Build the website.',
+      '$ vercel build',
+      '# Deploy the website.',
+      '$ vercel deploy --prebuilt',
+    ],
+    pnpm: [
+      '# Install the Vercel CLI globally if needed.',
+      '$ pnpm add --global vercel',
+      '# Build the website.',
+      '$ vercel build',
+      '# Deploy the website.',
+      '$ vercel deploy --prebuilt',
+    ],
+    bun: [
+      '# Install the Vercel CLI globally if needed.',
+      '$ bun add --global vercel',
+      '# Build the website.',
+      '$ vercel build',
+      '# Deploy the website.',
+      '$ vercel deploy --prebuilt',
+    ],
+  }}
 />
 
 You can now visit your website at the URL provided by the Vercel CLI.

--- a/docs/pages/router/web/async-routes.mdx
+++ b/docs/pages/router/web/async-routes.mdx
@@ -78,7 +78,12 @@ You can set platform-specific settings (`default`, `android`, `ios` or `web`) fo
 Then, when you are about to start your project, you can use the `--clear` flag to clear the Metro cache. This will ensure that the routes are loaded asynchronously:
 
 <Terminal
-  cmd={['$ npx expo start --clear', '', '# Or when exporting', '$ npx expo export --clear']}
+  cmd={{
+    npm: ['$ npx expo start --clear', '', '# Or when exporting', '$ npx expo export --clear'],
+    yarn: ['$ yarn expo start --clear', '', '# Or when exporting', '$ yarn expo export --clear'],
+    pnpm: ['$ pnpm expo start --clear', '', '# Or when exporting', '$ pnpm expo export --clear'],
+    bun: ['$ bun expo start --clear', '', '# Or when exporting', '$ bun expo export --clear'],
+  }}
 />
 
 ## Static rendering

--- a/docs/pages/router/web/data-loaders.mdx
+++ b/docs/pages/router/web/data-loaders.mdx
@@ -67,7 +67,14 @@ Configure your web output mode. Data loaders work with both [static rendering](/
 
 Start the development server:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/router/web/middleware.mdx
+++ b/docs/pages/router/web/middleware.mdx
@@ -69,7 +69,14 @@ The middleware function must be the default export of the file. It receives an [
 
 Run your development server to test the middleware:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 Your middleware will now run for all requests to your app.
 

--- a/docs/pages/router/web/server-headers.mdx
+++ b/docs/pages/router/web/server-headers.mdx
@@ -44,7 +44,12 @@ Configure headers in the `expo-router` plugin in your [app config](/versions/lat
 Start the development server or export for production:
 
 <Terminal
-  cmd={['$ npx expo start', '', '# Or export for production', '$ npx expo export -p web']}
+  cmd={{
+    npm: ['$ npx expo start', '', '# Or export for production', '$ npx expo export -p web'],
+    yarn: ['$ yarn expo start', '', '# Or export for production', '$ yarn expo export -p web'],
+    pnpm: ['$ pnpm expo start', '', '# Or export for production', '$ pnpm expo export -p web'],
+    bun: ['$ bun expo start', '', '# Or export for production', '$ bun expo export -p web'],
+  }}
 />
 
 Headers are automatically applied to all HTML and API route responses.

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -51,7 +51,14 @@ Enable server rendering in your project's [app config](/versions/latest/config/a
 
 Start the development server:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 </Step>
 
@@ -59,7 +66,14 @@ Start the development server:
 
 To export your app for production, run the export command:
 
-<Terminal cmd={['$ npx expo export --platform web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export --platform web'],
+    yarn: ['$ yarn expo export --platform web'],
+    pnpm: ['$ pnpm expo export --platform web'],
+    bun: ['$ bun expo export --platform web'],
+  }}
+/>
 
 This creates a **dist** directory with your server-rendered application. Unlike static rendering, no HTML files are pre-generated. Instead, the output includes a similar directory structure as shown below:
 
@@ -79,7 +93,14 @@ In output above includes the following directories inside **dist** directory:
 
 You can test the production build locally by running the following command and opening the linked URL in your browser:
 
-<Terminal cmd={['$ npx expo serve']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo serve'],
+    yarn: ['$ yarn expo serve'],
+    pnpm: ['$ pnpm expo serve'],
+    bun: ['$ bun expo serve'],
+  }}
+/>
 
 The above command starts a local server that renders pages on each request, simulating a production environment.
 
@@ -219,7 +240,12 @@ Server-side rendering requires a runtime server to render pages on each request.
 EAS Hosting supports server rendering out of the box. Export your app and deploy with:
 
 <Terminal
-  cmd={['$ npx expo export --platform web', '', '$ npx eas-cli@latest hosting:deploy dist']}
+  cmd={{
+    npm: ['$ npx expo export --platform web', '', '$ npx eas-cli@latest hosting:deploy dist'],
+    yarn: ['$ yarn expo export --platform web', '', '$ yarn dlx eas-cli@latest hosting:deploy dist'],
+    pnpm: ['$ pnpm expo export --platform web', '', '$ pnpm dlx eas-cli@latest hosting:deploy dist'],
+    bun: ['$ bun expo export --platform web', '', '$ bunx eas-cli@latest hosting:deploy dist'],
+  }}
 />
 
 </Collapsible>

--- a/docs/pages/router/web/server-rendering.mdx
+++ b/docs/pages/router/web/server-rendering.mdx
@@ -242,8 +242,16 @@ EAS Hosting supports server rendering out of the box. Export your app and deploy
 <Terminal
   cmd={{
     npm: ['$ npx expo export --platform web', '', '$ npx eas-cli@latest hosting:deploy dist'],
-    yarn: ['$ yarn expo export --platform web', '', '$ yarn dlx eas-cli@latest hosting:deploy dist'],
-    pnpm: ['$ pnpm expo export --platform web', '', '$ pnpm dlx eas-cli@latest hosting:deploy dist'],
+    yarn: [
+      '$ yarn expo export --platform web',
+      '',
+      '$ yarn dlx eas-cli@latest hosting:deploy dist',
+    ],
+    pnpm: [
+      '$ pnpm expo export --platform web',
+      '',
+      '$ pnpm dlx eas-cli@latest hosting:deploy dist',
+    ],
     bun: ['$ bun expo export --platform web', '', '$ bunx eas-cli@latest hosting:deploy dist'],
   }}
 />

--- a/docs/pages/router/web/static-rendering.mdx
+++ b/docs/pages/router/web/static-rendering.mdx
@@ -36,7 +36,14 @@ Enable static rendering in your project's [app config](/versions/latest/config/a
 
 Start the development server:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 </Step>
 
@@ -44,12 +51,26 @@ Start the development server:
 
 To bundle your static website for production, run the export command:
 
-<Terminal cmd={['$ npx expo export --platform web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export --platform web'],
+    yarn: ['$ yarn expo export --platform web'],
+    pnpm: ['$ pnpm expo export --platform web'],
+    bun: ['$ bun expo export --platform web'],
+  }}
+/>
 
 This will create a **dist** directory with your statically rendered website. If you have files in a local **public** directory, these will be copied over as well.
 You can test the production build locally by running the following command and opening the linked URL in your browser:
 
-<Terminal cmd={['$ npx serve dist']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx serve dist'],
+    yarn: ['$ yarn dlx serve dist'],
+    pnpm: ['$ pnpm dlx serve dist'],
+    bun: ['$ bunx serve dist'],
+  }}
+/>
 
 This project can be deployed to almost every hosting service. Note that this is not a single-page application, nor does it contain a custom server API. This means dynamic routes (for example, **src/app/[id].tsx**) will not arbitrarily work. You may need to build a serverless function to handle dynamic routes.
 

--- a/docs/pages/workflow/configuration.mdx
+++ b/docs/pages/workflow/configuration.mdx
@@ -143,7 +143,14 @@ To use this configuration with Expo CLI commands, set the environment variable e
 
 This is not anything unique to Expo CLI. On Windows you can approximate the above command with:
 
-<Terminal cmd={['$ npx cross-env MY_ENVIRONMENT=production eas update']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx cross-env MY_ENVIRONMENT=production eas update'],
+    yarn: ['$ yarn dlx cross-env MY_ENVIRONMENT=production eas update'],
+    pnpm: ['$ pnpm dlx cross-env MY_ENVIRONMENT=production eas update'],
+    bun: ['$ bunx cross-env MY_ENVIRONMENT=production eas update'],
+  }}
+/>
 
 Or you can use any other mechanism that you are comfortable with for environment variables.
 

--- a/docs/pages/workflow/continuous-native-generation.mdx
+++ b/docs/pages/workflow/continuous-native-generation.mdx
@@ -33,7 +33,14 @@ The end result is a workflow where a developer can express any native applicatio
 
 Prebuild can be used by running:
 
-<Terminal cmd={['$ npx expo prebuild']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild'],
+    yarn: ['$ yarn expo prebuild'],
+    pnpm: ['$ pnpm expo prebuild'],
+    bun: ['$ bun expo prebuild'],
+  }}
+/>
 
 This creates the **android** and **ios** directories for running your React code. If you modify the generated directories manually then you risk losing your changes the next time you run `npx expo prebuild --clean`. Instead, use [config plugins](/config-plugins/introduction/) , which are functions that perform modifications on native projects during prebuild.
 
@@ -62,13 +69,36 @@ If you troubleshoot your app by [compiling it locally](/guides/local-app-develop
 You can perform a native build locally by running:
 
 <Terminal
-  cmd={[
-    '# Build your native Android project',
-    '$ npx expo run:android',
-    '',
-    '# Build your native iOS project',
-    '$ npx expo run:ios',
-  ]}
+  cmd={{
+    npm: [
+      '# Build your native Android project',
+      '$ npx expo run:android',
+      '',
+      '# Build your native iOS project',
+      '$ npx expo run:ios',
+    ],
+    yarn: [
+      '# Build your native Android project',
+      '$ yarn expo run:android',
+      '',
+      '# Build your native iOS project',
+      '$ yarn expo run:ios',
+    ],
+    pnpm: [
+      '# Build your native Android project',
+      '$ pnpm expo run:android',
+      '',
+      '# Build your native iOS project',
+      '$ pnpm expo run:ios',
+    ],
+    bun: [
+      '# Build your native Android project',
+      '$ bun expo run:android',
+      '',
+      '# Build your native iOS project',
+      '$ bun expo run:ios',
+    ],
+  }}
 />
 
 If native directories are absent, `npx expo prebuild` will run once for the specific platform. On subsequent uses of these `run` commands, manually run `npx expo prebuild --clean` to ensure the native code is freshly synchronized with your local configuration.
@@ -77,7 +107,14 @@ If native directories are absent, `npx expo prebuild` will run once for the spec
 
 Prebuild currently supports Android and iOS. Web support is not required because there is no native project to generate for the web and the web app it runs in a web browser. Use the `--platform` option to run prebuild for individual platforms:
 
-<Terminal cmd={['$ npx expo prebuild --platform ios']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild --platform ios'],
+    yarn: ['$ yarn expo prebuild --platform ios'],
+    pnpm: ['$ pnpm expo prebuild --platform ios'],
+    bun: ['$ bun expo prebuild --platform ios'],
+  }}
+/>
 
 ## Dependencies
 
@@ -85,7 +122,14 @@ Prebuild begins by initializing new native projects from a template correspondin
 
 You can skip changing npm package versions with the `--skip-dependency-update` option:
 
-<Terminal cmd={['$ npx expo prebuild --skip-dependency-update react-native,react']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo prebuild --skip-dependency-update react-native,react'],
+    yarn: ['$ yarn expo prebuild --skip-dependency-update react-native,react'],
+    pnpm: ['$ pnpm expo prebuild --skip-dependency-update react-native,react'],
+    bun: ['$ bun expo prebuild --skip-dependency-update react-native,react'],
+  }}
+/>
 
 ## Package managers
 

--- a/docs/pages/workflow/customizing.mdx
+++ b/docs/pages/workflow/customizing.mdx
@@ -85,7 +85,14 @@ If you intend to use your native module in a single app (you can always change y
 
 Creating a local module scaffolds a Swift and Kotlin module inside the `modules` directory in your project, and these modules are automatically linked to your app.
 
-<Terminal cmd={['$ npx create-expo-module@latest --local', '$ npx expo run']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx create-expo-module@latest --local', '$ npx expo run'],
+    yarn: ['$ yarn create expo-module --local', '$ yarn expo run'],
+    pnpm: ['$ pnpm create expo-module --local', '$ pnpm expo run'],
+    bun: ['$ bun create expo-module --local', '$ bun expo run'],
+  }}
+/>
 
 ### Sharing a module with multiple apps
 

--- a/docs/pages/workflow/development-mode.mdx
+++ b/docs/pages/workflow/development-mode.mdx
@@ -33,7 +33,14 @@ Production mode is most useful for two things:
 
 The easiest way to simulate how your project will run on end users' devices is with the command:
 
-<Terminal cmd={['$ npx expo start --no-dev --minify']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --no-dev --minify'],
+    yarn: ['$ yarn expo start --no-dev --minify'],
+    pnpm: ['$ pnpm expo start --no-dev --minify'],
+    bun: ['$ bun expo start --no-dev --minify'],
+  }}
+/>
 
 It runs the JavaScript of your app in production mode (which tells the Metro bundler to set the `__DEV__` environment variable to `false`, among a few other things). The `--minify` flag minifies your app. This flag also eliminates unnecessary data such as comments, formatting, and unused code. If you are getting an error or crash in your standalone app, running your project with this command can save you a lot of time in finding the root cause.
 

--- a/docs/pages/workflow/ios-simulator.mdx
+++ b/docs/pages/workflow/ios-simulator.mdx
@@ -85,13 +85,36 @@ The first time you install the app in the simulator, iOS will ask if you'd like 
 Create a project with the desired SDK version and open it in a simulator to install a particular version of Expo Go.
 
 <Terminal
-  cmd={[
-    '# Bootstrap an SDK 53 project',
-    '$ npx create-expo-app --template blank@53',
-    '',
-    '# Open the app on a simulator to install the required Expo Go app',
-    '$ npx expo start --ios',
-  ]}
+  cmd={{
+    npm: [
+      '# Bootstrap an SDK 53 project',
+      '$ npx create-expo-app --template blank@53',
+      '',
+      '# Open the app on a simulator to install the required Expo Go app',
+      '$ npx expo start --ios',
+    ],
+    yarn: [
+      '# Bootstrap an SDK 53 project',
+      '$ yarn create expo-app --template blank@53',
+      '',
+      '# Open the app on a simulator to install the required Expo Go app',
+      '$ yarn expo start --ios',
+    ],
+    pnpm: [
+      '# Bootstrap an SDK 53 project',
+      '$ pnpm create expo-app --template blank@53',
+      '',
+      '# Open the app on a simulator to install the required Expo Go app',
+      '$ pnpm expo start --ios',
+    ],
+    bun: [
+      '# Bootstrap an SDK 53 project',
+      '$ bun create expo --template blank@53',
+      '',
+      '# Open the app on a simulator to install the required Expo Go app',
+      '$ bun expo start --ios',
+    ],
+  }}
 />
 
 ### Expo CLI is printing an error message about `xcrun`, what do I do?

--- a/docs/pages/workflow/logging.mdx
+++ b/docs/pages/workflow/logging.mdx
@@ -22,10 +22,30 @@ You can view native runtime logs in Android Studio and Xcode by compiling the na
 While it's usually not necessary, if you want to see logs for everything happening on your device, for example, even the logs from other apps and the OS, you can use the following commands:
 
 <Terminal
-  cmd={[
-    '# Show system logs for an Android device with adb logcat',
-    '$ npx react-native log-android',
-    '# Show system logs for an iOS device',
-    '$ npx react-native log-ios',
-  ]}
+  cmd={{
+    npm: [
+      '# Show system logs for an Android device with adb logcat',
+      '$ npx react-native log-android',
+      '# Show system logs for an iOS device',
+      '$ npx react-native log-ios',
+    ],
+    yarn: [
+      '# Show system logs for an Android device with adb logcat',
+      '$ yarn dlx react-native log-android',
+      '# Show system logs for an iOS device',
+      '$ yarn dlx react-native log-ios',
+    ],
+    pnpm: [
+      '# Show system logs for an Android device with adb logcat',
+      '$ pnpm dlx react-native log-android',
+      '# Show system logs for an iOS device',
+      '$ pnpm dlx react-native log-ios',
+    ],
+    bun: [
+      '# Show system logs for an Android device with adb logcat',
+      '$ bunx react-native log-android',
+      '# Show system logs for an iOS device',
+      '$ bunx react-native log-ios',
+    ],
+  }}
 />

--- a/docs/pages/workflow/overview.mdx
+++ b/docs/pages/workflow/overview.mdx
@@ -104,13 +104,36 @@ The default behavior encourages the use of [Continuous Native Generation](/workf
 The following three commands result in more or less the same project:
 
 <Terminal
-  cmd={[
-    '$ npx create-expo-app@latest --template default@sdk-56 MyApp && cd MyApp && npx expo prebuild',
-    '',
-    '$ npx create-expo-app --template bare-minimum',
-    '',
-    '$ npx @react-native-community/cli@latest init MyApp && cd MyApp && npx install-expo-modules',
-  ]}
+  cmd={{
+    npm: [
+      '$ npx create-expo-app@latest --template default@sdk-56 MyApp && cd MyApp && npx expo prebuild',
+      '',
+      '$ npx create-expo-app --template bare-minimum',
+      '',
+      '$ npx @react-native-community/cli@latest init MyApp && cd MyApp && npx install-expo-modules',
+    ],
+    yarn: [
+      '$ yarn create expo-app --template default@sdk-56 MyApp && cd MyApp && yarn expo prebuild',
+      '',
+      '$ yarn create expo-app --template bare-minimum',
+      '',
+      '$ yarn dlx @react-native-community/cli@latest init MyApp && cd MyApp && yarn dlx install-expo-modules',
+    ],
+    pnpm: [
+      '$ pnpm create expo-app --template default@sdk-56 MyApp && cd MyApp && pnpm expo prebuild',
+      '',
+      '$ pnpm create expo-app --template bare-minimum',
+      '',
+      '$ pnpm dlx @react-native-community/cli@latest init MyApp && cd MyApp && pnpm dlx install-expo-modules',
+    ],
+    bun: [
+      '$ bun create expo --template default@sdk-56 MyApp && cd MyApp && bun expo prebuild',
+      '',
+      '$ bun create expo --template bare-minimum',
+      '',
+      '$ bunx @react-native-community/cli@latest init MyApp && cd MyApp && bunx install-expo-modules',
+    ],
+  }}
 />
 
 </Collapsible>

--- a/docs/pages/workflow/using-libraries.mdx
+++ b/docs/pages/workflow/using-libraries.mdx
@@ -93,7 +93,14 @@ To determine if a new dependency changes native project directories, you can che
 
 **Not listed on the directory?** You can find the project on GitHub. A simple way to do this is with `npx npm-home --github <package-name>`. For example, to open the GitHub page for `react-native-localize`, run:
 
-<Terminal cmd={['$ npx npm-home --github react-native-localize']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx npm-home --github react-native-localize'],
+    yarn: ['$ yarn dlx npm-home --github react-native-localize'],
+    pnpm: ['$ pnpm dlx npm-home --github react-native-localize'],
+    bun: ['$ bunx npm-home --github react-native-localize'],
+  }}
+/>
 
 > If you want some help determining library compatibility, [create an issue on the React Native Directory repository](https://github.com/react-native-community/directory/issues/new/choose) and let us know. This will not just help you, it will also help other developers have an easy answer in the future!
 
@@ -103,11 +110,25 @@ To determine if a new dependency changes native project directories, you can che
 
 Once you have determined if the library is compatible with React Native, use [Expo CLI](/more/expo-cli/) to install the package:
 
-<Terminal cmd={['$ npx expo install @react-navigation/native']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install @react-navigation/native'],
+    yarn: ['$ yarn expo install @react-navigation/native'],
+    pnpm: ['$ pnpm expo install @react-navigation/native'],
+    bun: ['$ bun expo install @react-navigation/native'],
+  }}
+/>
 
 Be sure to follow the project website or README for any additional configuration and usage instructions. You can get to the README quickly using this command:
 
-<Terminal cmd={['$ npx npm-home @react-navigation/native']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx npm-home @react-navigation/native'],
+    yarn: ['$ yarn dlx npm-home @react-navigation/native'],
+    pnpm: ['$ pnpm dlx npm-home @react-navigation/native'],
+    bun: ['$ bunx npm-home @react-navigation/native'],
+  }}
+/>
 
 If the module needs additional native configuration, you can do so using [config plugins](/config-plugins/introduction/). Some packages require a config plugin but they don't have one yet, you can refer to the list of [out-of-tree config plugins](https://github.com/expo/config-plugins/).
 

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -114,7 +114,6 @@ You can now start the dev server and develop in the browser with:
     pnpm: ['$ pnpm expo start --web'],
     bun: ['$ bun expo start --web'],
   }}
-  cmdCopy="npx expo start --web"
 />
 
 The app can be exported as a production website with:
@@ -126,7 +125,6 @@ The app can be exported as a production website with:
     pnpm: ['$ pnpm expo export --platform web'],
     bun: ['$ bun expo export --platform web'],
   }}
-  cmdCopy="npx expo export --platform web"
 />
 
 ## Next

--- a/docs/pages/workflow/web.mdx
+++ b/docs/pages/workflow/web.mdx
@@ -61,7 +61,14 @@ Development features like Fast Refresh, debugging, environment variables, and [b
 
 ### Install web dependencies
 
-<Terminal cmd={['$ npx expo install react-dom react-native-web @expo/metro-runtime']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install react-dom react-native-web @expo/metro-runtime'],
+    yarn: ['$ yarn expo install react-dom react-native-web @expo/metro-runtime'],
+    pnpm: ['$ pnpm expo install react-dom react-native-web @expo/metro-runtime'],
+    bun: ['$ bun expo install react-dom react-native-web @expo/metro-runtime'],
+  }}
+/>
 
 <Collapsible summary={<>Not using the <CODE>expo</CODE> package in your app yet?</>}>
 
@@ -69,7 +76,14 @@ If you haven't added Expo to your React Native app yet, you can either [install 
 
 1. Install [Expo CLI](/more/expo-cli/) in your project:
 
-<Terminal cmd={['$ npm install expo']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install expo'],
+    yarn: ['$ yarn add expo'],
+    pnpm: ['$ pnpm add expo'],
+    bun: ['$ bun add expo'],
+  }}
+/>
 
 2. Modify the entry file to use [`registerRootComponent`](/versions/latest/sdk/expo/#registerrootcomponentcomponent) instead of `AppRegistry.registerComponent`:
 
@@ -93,11 +107,27 @@ import App from './App';
 
 You can now start the dev server and develop in the browser with:
 
-<Terminal cmd={['$ npx expo start --web']} cmdCopy="npx expo start --web" />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start --web'],
+    yarn: ['$ yarn expo start --web'],
+    pnpm: ['$ pnpm expo start --web'],
+    bun: ['$ bun expo start --web'],
+  }}
+  cmdCopy="npx expo start --web"
+/>
 
 The app can be exported as a production website with:
 
-<Terminal cmd={['$ npx expo export --platform web']} cmdCopy="npx expo export --platform web" />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export --platform web'],
+    yarn: ['$ yarn expo export --platform web'],
+    pnpm: ['$ pnpm expo export --platform web'],
+    bun: ['$ bun expo export --platform web'],
+  }}
+  cmdCopy="npx expo export --platform web"
+/>
 
 ## Next
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/46338

# How

<!--
How did you build this feature or fix this bug and why?
-->

Under Guides, update Developer process and Expo Router sections Terminal references to include npm, yarn, pnpm, and bun variants where Expo docs conventions call for multi-package-manager commands.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
