### PR TITLE
[modules-core][ios] Add ExpoNetworkConfiguration override hooks

### DIFF
--- a/packages/expo-asset/CHANGELOG.md
+++ b/packages/expo-asset/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Apply the app-wide `ExpoNetworkConfiguration` session configuration and request modifier to asset downloads. ([#46347](https://github.com/expo/expo/pull/46347) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.0.15 — 2026-05-26
 
 _This version does not introduce any user-facing changes._

--- a/packages/expo-asset/ios/AssetModule.swift
+++ b/packages/expo-asset/ios/AssetModule.swift
@@ -75,7 +75,9 @@ public class AssetModule: Module {
       return
     }
 
-    let downloadTask = URLSession.shared.downloadTask(with: url) { urlOrNil, _, _ in
+    let request = ExpoNetworkConfiguration.modifiedRequest(URLRequest(url: url))
+    let session = URLSession(configuration: ExpoNetworkConfiguration.configuration(default: .default))
+    let downloadTask = session.downloadTask(with: request) { urlOrNil, _, _ in
       guard let fileURL = urlOrNil else {
         promise.reject(UnableToDownloadAssetException(url))
         return
@@ -90,5 +92,7 @@ public class AssetModule: Module {
       }
     }
     downloadTask.resume()
+    // The session is created per download, so let it release once the task finishes.
+    session.finishTasksAndInvalidate()
   }
 }

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Apply the app-wide `ExpoNetworkConfiguration` request modifier to the dev-menu manifest fetch. ([#46347](https://github.com/expo/expo/pull/46347) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.0.15 — 2026-05-26
 
 ### 🎉 New features

--- a/packages/expo-brownfield/ios/ManifestProvider.swift
+++ b/packages/expo-brownfield/ios/ManifestProvider.swift
@@ -1,3 +1,5 @@
+import ExpoModulesCore
+
 public class ManifestProvider {
   /**
   * Fetches the manifest for brownfield setup
@@ -19,7 +21,7 @@ public class ManifestProvider {
 
       print("📡 Fetching manifest for dev-menu from: \(manifestURL.absoluteString)")
 
-      let task = URLSession.shared.dataTask(with: request) { data, response, error in
+      let task = URLSession.shared.dataTask(with: ExpoNetworkConfiguration.modifiedRequest(request)) { data, response, error in
         if let error = error {
           print("❌ Error fetching manifest: \(error.localizedDescription)")
           completion(nil, nil)

--- a/packages/expo-file-system/CHANGELOG.md
+++ b/packages/expo-file-system/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [iOS] Apply the app-wide `ExpoNetworkConfiguration` session configuration and request modifier to downloads and uploads. ([#46347](https://github.com/expo/expo/pull/46347) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.0.7 — 2026-05-20
 
 ### 🛠 Breaking changes

--- a/packages/expo-file-system/ios/FileSystemDownload.swift
+++ b/packages/expo-file-system/ios/FileSystemDownload.swift
@@ -48,7 +48,11 @@ class DownloadTaskStore: NSObject, URLSessionDownloadDelegate {
   func makeDownloadTask(with request: URLRequest) -> URLSessionDownloadTask {
     queue.sync {
       let currentSession = session ?? {
-        let newSession = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        let newSession = URLSession(
+        configuration: ExpoNetworkConfiguration.configuration(default: .default),
+        delegate: self,
+        delegateQueue: nil
+      )
         session = newSession
         return newSession
       }()
@@ -113,6 +117,7 @@ func downloadFileWithStore(
       request.addValue(value, forHTTPHeaderField: key)
     }
   }
+  request = ExpoNetworkConfiguration.modifiedRequest(request)
 
   if let downloadUuid {
     let delegate = DownloadDelegate(
@@ -130,7 +135,8 @@ func downloadFileWithStore(
     downloadStore.store(task: task, delegate: delegate, forUuid: downloadUuid)
     task.resume()
   } else {
-    let downloadTask = URLSession.shared.downloadTask(with: request) { urlOrNil, responseOrNil, errorOrNil in
+    let session = URLSession(configuration: ExpoNetworkConfiguration.configuration(default: .default))
+    let downloadTask = session.downloadTask(with: request) { urlOrNil, responseOrNil, errorOrNil in
       guard errorOrNil == nil else {
         return promise.reject(UnableToDownloadException(errorOrNil?.localizedDescription ?? "unspecified error"))
       }
@@ -168,6 +174,8 @@ func downloadFileWithStore(
       }
     }
     downloadTask.resume()
+    // The session is created per download, so let it release once the task finishes.
+    session.finishTasksAndInvalidate()
   }
 }
 

--- a/packages/expo-file-system/ios/FileSystemDownloadTask.swift
+++ b/packages/expo-file-system/ios/FileSystemDownloadTask.swift
@@ -258,6 +258,7 @@ class FileSystemDownloadTask: SharedObject {
         request.setValue(value, forHTTPHeaderField: key)
       }
     }
+    request = ExpoNetworkConfiguration.modifiedRequest(request)
 
     let task = session.downloadTask(with: request)
     downloadTask = task

--- a/packages/expo-file-system/ios/FileSystemUploadTask.swift
+++ b/packages/expo-file-system/ios/FileSystemUploadTask.swift
@@ -69,9 +69,9 @@ class FileSystemUploadTask: SharedObject {
         request.setValue("multipart/form-data; boundary=\(boundaryString)", forHTTPHeaderField: "Content-Type")
         tempFileURL = bodyFileURL
 
-        uploadTask = session.uploadTask(with: request, fromFile: bodyFileURL)
+        uploadTask = session.uploadTask(with: ExpoNetworkConfiguration.modifiedRequest(request), fromFile: bodyFileURL)
       } else {
-        uploadTask = session.uploadTask(with: request, fromFile: sourceUrl)
+        uploadTask = session.uploadTask(with: ExpoNetworkConfiguration.modifiedRequest(request), fromFile: sourceUrl)
       }
 
       guard let uploadTask else {

--- a/packages/expo-image/CHANGELOG.md
+++ b/packages/expo-image/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Apply the app-wide `ExpoNetworkConfiguration` request modifier to image downloads. ([#46347](https://github.com/expo/expo/pull/46347) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.0.9 — 2026-05-23
 
 ### 🐛 Bug fixes

--- a/packages/expo-image/ios/Utils/ImageUtils.swift
+++ b/packages/expo-image/ios/Utils/ImageUtils.swift
@@ -161,9 +161,13 @@ func createCacheKeyFilter(_ cacheKey: String?) -> SDWebImageCacheKeyFilter? {
 func createSDWebImageContext(forSource source: ImageSource, cachePolicy: ImageCachePolicy = .disk, useAppleWebpCodec: Bool = true) -> SDWebImageContext {
   var context = SDWebImageContext()
 
-  // Modify URL request to add headers.
-  if let headers = source.headers {
-    context[.downloadRequestModifier] = SDWebImageDownloaderRequestModifier(headers: headers)
+  // Modify the outgoing request to add the source headers and apply the app-wide request modifier.
+  context[.downloadRequestModifier] = SDWebImageDownloaderRequestModifier { request in
+    var request = request
+    source.headers?.forEach { key, value in
+      request.setValue(value, forHTTPHeaderField: key)
+    }
+    return ExpoNetworkConfiguration.modifiedRequest(request)
   }
 
   // Allow for custom cache key. If not specified in the source, its uri is used as the key.

--- a/packages/expo-modules-core/CHANGELOG.md
+++ b/packages/expo-modules-core/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- [iOS] Added `ExpoNetworkConfiguration` with process-wide hooks to override the `URLSessionConfiguration` and modify outgoing `URLRequest`s made by Expo modules. ([#46347](https://github.com/expo/expo/pull/46347) by [@tsapeta](https://github.com/tsapeta))
+
 ### 🐛 Bug fixes
 
 - [android] Fix nested `Host` double-composing children. ([#46304](https://github.com/expo/expo/pull/46304) by [@nishan](https://github.com/intergalacticspacehighway))

--- a/packages/expo-modules-core/ios/Tests/ExpoNetworkConfigurationTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ExpoNetworkConfigurationTests.swift
@@ -1,0 +1,83 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Testing
+import Foundation
+
+@testable import ExpoModulesCore
+
+// The hooks are process-wide static state, so run the cases serially and reset after each.
+@Suite("ExpoNetworkConfiguration", .serialized)
+struct ExpoNetworkConfigurationTests {
+  private func resetHooks() {
+    ExpoNetworkConfiguration.setURLSessionConfigurationProvider(nil)
+    ExpoNetworkConfiguration.setURLRequestModifier(nil)
+  }
+
+  @Test
+  func `falls back to the default configuration when no provider is registered`() {
+    resetHooks()
+    let fallback = URLSessionConfiguration.default
+    let resolved = ExpoNetworkConfiguration.configuration(default: fallback)
+    #expect(resolved === fallback)
+  }
+
+  @Test
+  func `uses the configuration from the registered provider`() {
+    resetHooks()
+    let custom = URLSessionConfiguration.ephemeral
+    ExpoNetworkConfiguration.setURLSessionConfigurationProvider { custom }
+
+    let resolved = ExpoNetworkConfiguration.configuration(default: .default)
+    #expect(resolved === custom)
+    resetHooks()
+  }
+
+  @Test
+  func `falls back to the default when the provider returns nil`() {
+    resetHooks()
+    let fallback = URLSessionConfiguration.default
+    ExpoNetworkConfiguration.setURLSessionConfigurationProvider { nil }
+
+    let resolved = ExpoNetworkConfiguration.configuration(default: fallback)
+    #expect(resolved === fallback)
+    resetHooks()
+  }
+
+  @Test
+  func `returns the request unchanged when no modifier is registered`() {
+    resetHooks()
+    let request = URLRequest(url: URL(string: "https://example.com")!)
+    let modified = ExpoNetworkConfiguration.modifiedRequest(request)
+    #expect(modified == request)
+  }
+
+  @Test
+  func `applies the registered request modifier`() {
+    resetHooks()
+    ExpoNetworkConfiguration.setURLRequestModifier { request in
+      var copy = request
+      copy.setValue("bar", forHTTPHeaderField: "X-Foo")
+      return copy
+    }
+
+    let request = URLRequest(url: URL(string: "https://example.com")!)
+    let modified = ExpoNetworkConfiguration.modifiedRequest(request)
+    #expect(modified.value(forHTTPHeaderField: "X-Foo") == "bar")
+    resetHooks()
+  }
+
+  @Test
+  func `clearing the modifier restores pass-through behavior`() {
+    resetHooks()
+    ExpoNetworkConfiguration.setURLRequestModifier { request in
+      var copy = request
+      copy.setValue("bar", forHTTPHeaderField: "X-Foo")
+      return copy
+    }
+    ExpoNetworkConfiguration.setURLRequestModifier(nil)
+
+    let request = URLRequest(url: URL(string: "https://example.com")!)
+    let modified = ExpoNetworkConfiguration.modifiedRequest(request)
+    #expect(modified.value(forHTTPHeaderField: "X-Foo") == nil)
+  }
+}

--- a/packages/expo-modules-core/ios/Utilities/ExpoNetworkConfiguration.swift
+++ b/packages/expo-modules-core/ios/Utilities/ExpoNetworkConfiguration.swift
@@ -1,0 +1,72 @@
+// Copyright 2025-present 650 Industries. All rights reserved.
+
+import Foundation
+
+/**
+ A block that supplies a custom `URLSessionConfiguration` for outgoing requests made by
+ Expo modules. Return `nil` to let the module use its own default configuration.
+ */
+public typealias ExpoURLSessionConfigurationProvider = @convention(block) () -> URLSessionConfiguration?
+
+/**
+ A block that receives an outgoing `URLRequest` just before it is sent and returns the
+ request to send instead. Use it to add headers or otherwise adjust the request. Return
+ the request unchanged to leave it as-is.
+ */
+public typealias ExpoURLRequestModifier = @convention(block) (URLRequest) -> URLRequest
+
+/**
+ Process-wide hooks that let the host app override how Expo modules make network requests.
+
+ Register the hooks once during app startup, before any requests are made. Two independent
+ hooks are available:
+ - ``setURLSessionConfigurationProvider(_:)`` to substitute the `URLSessionConfiguration`
+   used to create sessions (for example to supply an mTLS-capable configuration).
+ - ``setURLRequestModifier(_:)`` to adjust each outgoing request (for example to inject
+   development or authentication headers).
+
+ The hooks are consumed by Expo's networking modules (image, asset, file system, video, etc.).
+ Keep any app- or framework-specific logic inside the registered blocks so the modules stay
+ free of those dependencies.
+ */
+@objc(EXNetworkConfiguration)
+public final class ExpoNetworkConfiguration: NSObject {
+  private static let configurationProvider = Mutex<ExpoURLSessionConfigurationProvider?>(nil)
+  private static let requestModifier = Mutex<ExpoURLRequestModifier?>(nil)
+
+  /**
+   Registers a block that supplies the `URLSessionConfiguration` Expo modules use to create
+   their sessions. Pass `nil` to remove a previously registered provider.
+   */
+  @objc
+  public static func setURLSessionConfigurationProvider(_ provider: ExpoURLSessionConfigurationProvider?) {
+    configurationProvider.withLock { $0 = provider }
+  }
+
+  /**
+   Registers a block that modifies each outgoing `URLRequest` before it is sent. Pass `nil`
+   to remove a previously registered modifier.
+   */
+  @objc
+  public static func setURLRequestModifier(_ modifier: ExpoURLRequestModifier?) {
+    requestModifier.withLock { $0 = modifier }
+  }
+
+  /**
+   Returns the configuration to use for a new session: the one from the registered provider
+   if it returns a non-`nil` value, otherwise the given default.
+   */
+  public static func configuration(default defaultConfiguration: URLSessionConfiguration) -> URLSessionConfiguration {
+    let provider = configurationProvider.withLock { $0 }
+    return provider?() ?? defaultConfiguration
+  }
+
+  /**
+   Returns the request to send: the one returned by the registered modifier, or the given
+   request unchanged when no modifier is registered.
+   */
+  public static func modifiedRequest(_ request: URLRequest) -> URLRequest {
+    let modifier = requestModifier.withLock { $0 }
+    return modifier?(request) ?? request
+  }
+}

--- a/packages/expo-video/CHANGELOG.md
+++ b/packages/expo-video/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 💡 Others
 
+- [iOS] Apply the app-wide `ExpoNetworkConfiguration` session configuration and request modifier to cached media requests. ([#46347](https://github.com/expo/expo/pull/46347) by [@tsapeta](https://github.com/tsapeta))
+
 ## 56.1.2 — 2026-05-21
 
 ### 🐛 Bug fixes

--- a/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
+++ b/packages/expo-video/ios/Cache/ResourceLoaderDelegate.swift
@@ -43,7 +43,11 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
     self.urlRequestHeaders = urlRequestHeaders
     cachedResource = CachedResource(dataFileUrl: saveFilePath, resourceUrl: url, dataPath: saveFilePath)
     super.init()
-    self.session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    self.session = URLSession(
+      configuration: ExpoNetworkConfiguration.configuration(default: .default),
+      delegate: self,
+      delegateQueue: nil
+    )
   }
 
   deinit {
@@ -182,7 +186,7 @@ final class ResourceLoaderDelegate: NSObject, AVAssetResourceLoaderDelegate, URL
       return
     }
 
-    let dataTask = session.dataTask(with: request)
+    let dataTask = session.dataTask(with: ExpoNetworkConfiguration.modifiedRequest(request))
 
     // we can't do `if let loadingRequest = loadingRequest.dataRequest` as this would create new variable by copying
     if loadingRequest.dataRequest != nil {


### PR DESCRIPTION
# Why

Some apps need to override how Expo's native modules make network requests — for example to route requests through an mTLS-capable `URLSession`, or to inject development/authentication headers into every outgoing request. Today this requires patching individual packages in `node_modules` (hardcoding app-specific classes like `RCTDevSupportHttpHeaders` directly into Expo source), which is brittle and lost on upgrade.

# How

Adds `ExpoNetworkConfiguration` (ObjC: `EXNetworkConfiguration`) to `expo-modules-core` with two independent, process-wide hooks the host app registers once at startup:

- **`setURLSessionConfigurationProvider`** — supplies the `URLSessionConfiguration` modules use to create their sessions (e.g. an mTLS configuration). Modules keep creating their own session with their own delegate from it.
- **`setURLRequestModifier`** — adjusts each outgoing `URLRequest` just before it is sent (e.g. inject headers).

All app- or framework-specific logic stays inside the registered blocks, so the Expo packages gain **no** dependency on React or any app-specific class.

```swift
// Host app, once at startup:
ExpoNetworkConfiguration.setURLSessionConfigurationProvider {
  MyProxyConfig.configuredSession().configuration
}
ExpoNetworkConfiguration.setURLRequestModifier { request in
  var request = request
  request.setValue("…", forHTTPHeaderField: "X-Dev-Header")
  return request
}
```

The hooks are consumed by **expo-image**, **expo-asset**, **expo-file-system**, **expo-video**, and **expo-brownfield**.

# Notes / scope decisions

- **Delegate-backed background sessions** (file-system's session manager) only adopt the request modifier, not the configuration provider — swapping a `.background` session's configuration would break resume semantics.
- **expo-updates is intentionally excluded.** Its requests carry code-signing/protocol headers (`expo-expect-signature`, etc.); applying an arbitrary process-wide request modifier there has security implications and should be a separate, deliberate decision.

# Open question

The session hook hands back a `URLSessionConfiguration` rather than a built `URLSession`, so delegate-owning modules can keep their own delegate. This only carries mTLS if the client-certificate handling lives on the *configuration* rather than on a session delegate's `urlSession(_:didReceive:)` challenge callback. To confirm with consumers that need mTLS.

# Test Plan

- Added `ExpoNetworkConfigurationTests` covering provider/modifier registration, fallback when unset or returning `nil`, and clearing.
- Manually verify on iOS that registering a request modifier injects headers into image/asset/file-system/video downloads, and that an injected `URLSessionConfiguration` is used.
