### PR TITLE
[docs] Add multi-pm (package managers)Terminal blocks in EAS

### DIFF
--- a/docs/pages/accounts/sso.mdx
+++ b/docs/pages/accounts/sso.mdx
@@ -89,7 +89,14 @@ You'll be prompted to select an Expo username. This will be the username for you
 
 When using the Expo CLI, you can run the following command to log in to your Expo account.
 
-<Terminal cmd={['$ npx expo login --sso']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo login --sso'],
+    yarn: ['$ yarn expo login --sso'],
+    pnpm: ['$ pnpm expo login --sso'],
+    bun: ['$ bun expo login --sso'],
+  }}
+/>
 
 You will be prompted to log in via the Expo website in a browser and will be redirected back to the CLI upon completion.
 

--- a/docs/pages/build-reference/troubleshooting.mdx
+++ b/docs/pages/build-reference/troubleshooting.mdx
@@ -155,13 +155,36 @@ If the logs weren't enough to immediately help you understand and fix the root c
 You can verify that your project builds on your local machine with the `npx expo run:android` and `npx expo run:ios` commands, with variant/configuration flags set to release to most faithfully reproduce what executes on EAS Build. For more information, see [Android build process](/build-reference/android-builds) and [iOS build process](/build-reference/ios-builds).
 
 <Terminal
-  cmd={[
-    '# Locally compile and run the Android app in release mode',
-    '$ npx expo run:android --variant release',
-    '',
-    '# Locally compile and run the iOS app in release mode',
-    '$ npx expo run:ios --configuration Release',
-  ]}
+  cmd={{
+    npm: [
+      '# Locally compile and run the Android app in release mode',
+      '$ npx expo run:android --variant release',
+      '',
+      '# Locally compile and run the iOS app in release mode',
+      '$ npx expo run:ios --configuration Release',
+    ],
+    yarn: [
+      '# Locally compile and run the Android app in release mode',
+      '$ yarn expo run:android --variant release',
+      '',
+      '# Locally compile and run the iOS app in release mode',
+      '$ yarn expo run:ios --configuration Release',
+    ],
+    pnpm: [
+      '# Locally compile and run the Android app in release mode',
+      '$ pnpm expo run:android --variant release',
+      '',
+      '# Locally compile and run the iOS app in release mode',
+      '$ pnpm expo run:ios --configuration Release',
+    ],
+    bun: [
+      '# Locally compile and run the Android app in release mode',
+      '$ bun expo run:android --variant release',
+      '',
+      '# Locally compile and run the iOS app in release mode',
+      '$ bun expo run:ios --configuration Release',
+    ],
+  }}
 />
 
 > If use [CNG](/workflow/continuous-native-generation/), these commands will run `npx expo prebuild` to generate native projects to compile them.You likely want to [clean up the changes](https://expo.fyi/prebuild-cleanup) once you are done troubleshooting, unless you want to start managing these projects directly instead of generating them on demand.

--- a/docs/pages/build/setup.mdx
+++ b/docs/pages/build/setup.mdx
@@ -22,7 +22,14 @@ For a small app, builds for Android and iOS platforms trigger within a few minut
   <Requirement title="A React Native Android or iOS project">
     Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide:
 
-    <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-56']} />
+    <Terminal
+      cmd={{
+        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-56'],
+        yarn: ['$ yarn create expo-app my-app --template default@sdk-56'],
+        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-56'],
+        bun: ['$ bun create expo my-app --template default@sdk-56'],
+      }}
+    />
 
     EAS Build also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 
@@ -40,7 +47,14 @@ For a small app, builds for Android and iOS platforms trigger within a few minut
 
 EAS CLI is the command-line app that you will use to interact with EAS services from your terminal. To install it, run the command:
 
-<Terminal cmd={['$ npm install -g eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
@@ -70,7 +84,14 @@ To learn more about what happens behind the scenes, see [build configuration pro
 
 For development, we recommend creating a [development build](/develop/development-builds/introduction/), which is a debug build of your app and contains the [`expo-dev-client`](/versions/latest/sdk/dev-client/) library. It helps you iterate as quickly as possible and provides a more flexible, reliable, and complete development environment. To install the library, run the following command:
 
-<Terminal cmd={['$ npx expo install expo-dev-client']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-dev-client'],
+    yarn: ['$ yarn expo install expo-dev-client'],
+    pnpm: ['$ pnpm expo install expo-dev-client'],
+    bun: ['$ bun expo install expo-dev-client'],
+  }}
+/>
 
 Additional configuration may be required for some scenarios:
 

--- a/docs/pages/custom-builds/functions.mdx
+++ b/docs/pages/custom-builds/functions.mdx
@@ -18,7 +18,14 @@ EAS Build functions are a great way to extend the functionality of custom builds
 
 The easiest way to create an EAS Build function is to use the `create-eas-build-function` CLI tool. By running the following command from the same directory as your **eas.json** file, you can create a new custom TypeScript function:
 
-<Terminal cmd={['$ npx create-eas-build-function@latest ./.eas/build/myFunction']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx create-eas-build-function@latest ./.eas/build/myFunction'],
+    yarn: ['$ yarn create eas-build-function ./.eas/build/myFunction'],
+    pnpm: ['$ pnpm create eas-build-function ./.eas/build/myFunction'],
+    bun: ['$ bun create eas-build-function ./.eas/build/myFunction'],
+  }}
+/>
 
 This creates a new module called `myFunction` in the **.eas/build** directory. The module will contain a pre-generated module configuration and the **src** directory with the **index.ts** file containing the default TypeScript function template.
 
@@ -64,7 +71,14 @@ export default myFunction;
 
 Functions must be compiled to a single JavaScript file that can be run without installing any dependencies. The default `build` script for generated functions uses [ncc](https://github.com/vercel/ncc) to compile your function into a single file with all its dependencies. If you don't have the `ncc` installed globally on your machine, run `npm install -g @vercel/ncc` to install it. Next, run the build script in the **.eas/build/myFunction** directory:
 
-<Terminal cmd={['$ npm run build']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm run build'],
+    yarn: ['$ yarn run build'],
+    pnpm: ['$ pnpm run build'],
+    bun: ['$ bun run build'],
+  }}
+/>
 
 This command triggers the `build` script placed in the **package.json** file of your custom function module.
 

--- a/docs/pages/distribution/introduction.mdx
+++ b/docs/pages/distribution/introduction.mdx
@@ -17,17 +17,48 @@ import { Terminal } from '~/ui/components/Snippet';
 Get your app into the hands of users by submitting it to the app stores or with [Internal Distribution](/build/internal-distribution).
 
 <Terminal
-  cmd={[
-    '# Install the CLI',
-    '$ npm i -g eas-cli',
-    '',
-    '# Build and submit your app',
-    '$ eas build --auto-submit',
-    '',
-    '# OR -- Submit existing binaries',
-    '$ eas submit',
-  ]}
-  cmdCopy="npm i -g eas-cli && eas build --auto-submit"
+  cmd={{
+    npm: [
+      '# Install the CLI',
+      '$ npm install --global eas-cli',
+      '',
+      '# Build and submit your app',
+      '$ eas build --auto-submit',
+      '',
+      '# OR -- Submit existing binaries',
+      '$ eas submit',
+    ],
+    yarn: [
+      '# Install the CLI',
+      '$ yarn global add eas-cli',
+      '',
+      '# Build and submit your app',
+      '$ eas build --auto-submit',
+      '',
+      '# OR -- Submit existing binaries',
+      '$ eas submit',
+    ],
+    pnpm: [
+      '# Install the CLI',
+      '$ pnpm add --global eas-cli',
+      '',
+      '# Build and submit your app',
+      '$ eas build --auto-submit',
+      '',
+      '# OR -- Submit existing binaries',
+      '$ eas submit',
+    ],
+    bun: [
+      '# Install the CLI',
+      '$ bun add --global eas-cli',
+      '',
+      '# Build and submit your app',
+      '$ eas build --auto-submit',
+      '',
+      '# OR -- Submit existing binaries',
+      '$ eas submit',
+    ],
+  }}
 />
 
 You can run `eas build --auto-submit` with [EAS CLI](/eas) to build your app and automatically upload the binary for distribution on the Google Play Store and Apple App Store.

--- a/docs/pages/eas-insights/introduction.mdx
+++ b/docs/pages/eas-insights/introduction.mdx
@@ -25,16 +25,48 @@ Developers can add the `expo-insights` library to their projects and gain more p
 To use the `expo-insights`, make sure your app is linked to your EAS project in **app.json** / **app.config.js** by running `eas init`, then install the library.
 
 <Terminal
-  cmd={[
-    '# Install EAS CLI if you have not already',
-    '$ npm i -g eas-cli',
-    '',
-    '# Initialize your project EAS if you have not already ',
-    '$ eas init',
-    '',
-    '# Install the library',
-    '$ npx expo install expo-insights',
-  ]}
+  cmd={{
+    npm: [
+      '# Install EAS CLI if you have not already',
+      '$ npm install --global eas-cli',
+      '',
+      '# Initialize your project EAS if you have not already ',
+      '$ eas init',
+      '',
+      '# Install the library',
+      '$ npx expo install expo-insights',
+    ],
+    yarn: [
+      '# Install EAS CLI if you have not already',
+      '$ yarn global add eas-cli',
+      '',
+      '# Initialize your project EAS if you have not already ',
+      '$ eas init',
+      '',
+      '# Install the library',
+      '$ yarn expo install expo-insights',
+    ],
+    pnpm: [
+      '# Install EAS CLI if you have not already',
+      '$ pnpm add --global eas-cli',
+      '',
+      '# Initialize your project EAS if you have not already ',
+      '$ eas init',
+      '',
+      '# Install the library',
+      '$ pnpm expo install expo-insights',
+    ],
+    bun: [
+      '# Install EAS CLI if you have not already',
+      '$ bun add --global eas-cli',
+      '',
+      '# Initialize your project EAS if you have not already ',
+      '$ eas init',
+      '',
+      '# Install the library',
+      '$ bun expo install expo-insights',
+    ],
+  }}
 />
 
 After installing the library, create a build either with [EAS](/build/setup/) or [locally](/guides/local-app-development/). The library will automatically send events to EAS Insights when the app is launched.

--- a/docs/pages/eas-update/debug.mdx
+++ b/docs/pages/eas-update/debug.mdx
@@ -213,7 +213,14 @@ When we set up EAS Update, we likely ran `eas update:configure` to configure exp
 
 Finally, make sure that `expo-updates` is included in **package.json**. If it's not, run:
 
-<Terminal cmd={['$ npx expo install expo-updates']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install expo-updates'],
+    yarn: ['$ yarn expo install expo-updates'],
+    pnpm: ['$ pnpm expo install expo-updates'],
+    bun: ['$ bun expo install expo-updates'],
+  }}
+/>
 
 #### Inspecting expo-updates configuration after prebuild
 
@@ -449,7 +456,14 @@ It may be helpful to see which assets are included in our update bundle. We can 
 
 Or run locally:
 
-<Terminal cmd={['$ npx expo export']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export'],
+    yarn: ['$ yarn expo export'],
+    pnpm: ['$ pnpm expo export'],
+    bun: ['$ bun expo export'],
+  }}
+/>
 
 ## Mitigation steps
 

--- a/docs/pages/eas-update/estimate-bandwidth.mdx
+++ b/docs/pages/eas-update/estimate-bandwidth.mdx
@@ -33,7 +33,14 @@ Given a bandwidth allocation, we estimate how many updates can be downloaded in 
 
 Start by generating your uncompressed production bundle with the following command:
 
-<Terminal cmd={['$ npx expo export']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export'],
+    yarn: ['$ yarn expo export'],
+    pnpm: ['$ pnpm expo export'],
+    bun: ['$ bun expo export'],
+  }}
+/>
 
 Then, look inside the **dist/\_expo/static/js** directory. There will be **android** and **ios** directories with a **.hbc** file in each. The size of the **.hbc** file is the uncompressed size of your Hermes bundle. Note that Android and iOS bundles may differ in size, especially if you make use of platform-specific code files.
 

--- a/docs/pages/eas-update/getting-started.mdx
+++ b/docs/pages/eas-update/getting-started.mdx
@@ -27,7 +27,14 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
   <Requirement title="A React Native project">
     Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide. Run the following command to create a new project:
 
-    <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-56']} />
+    <Terminal
+      cmd={{
+        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-56'],
+        yarn: ['$ yarn create expo-app my-app --template default@sdk-56'],
+        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-56'],
+        bun: ['$ bun create expo my-app --template default@sdk-56'],
+      }}
+    />
 
     EAS Update also works well with projects created by `npx create-react-native-app`, `npx react-native`, `ignite-cli`, and other project bootstrapping tools.
 
@@ -66,7 +73,14 @@ Setting up EAS Update allows you to push critical bug fixes and improvements tha
 
 EAS CLI is the command-line app you will use to interact with EAS services from your terminal. To install it, run the command:
 
-<Terminal cmd={['$ npm install --global eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
@@ -231,7 +245,14 @@ Once you have a build running on your device or a simulator, you are ready to se
 
 After creating the build, you are ready to iterate on the project. Start a local development server with the following command:
 
-<Terminal cmd={['$ npx expo start']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo start'],
+    yarn: ['$ yarn expo start'],
+    pnpm: ['$ pnpm expo start'],
+    bun: ['$ bun expo start'],
+  }}
+/>
 
 Then, make any desired changes to your project's JavaScript, styling, or image assets.
 

--- a/docs/pages/eas-update/integration-in-existing-native-apps.mdx
+++ b/docs/pages/eas-update/integration-in-existing-native-apps.mdx
@@ -78,7 +78,14 @@ Modify **android/gradle.properties** to set the property that disables automatic
 
 Pass in the environment variable to CocoaPods installation to disable automatic updates initialization.
 
-<Terminal cmd={['$ EX_UPDATES_CUSTOM_INIT=1 npx pod-install']} />
+<Terminal
+  cmd={{
+    npm: ['$ EX_UPDATES_CUSTOM_INIT=1 npx pod-install'],
+    yarn: ['$ EX_UPDATES_CUSTOM_INIT=1 yarn dlx pod-install'],
+    pnpm: ['$ EX_UPDATES_CUSTOM_INIT=1 pnpm dlx pod-install'],
+    bun: ['$ EX_UPDATES_CUSTOM_INIT=1 bunx pod-install'],
+  }}
+/>
 
 ## Set up your React Native app to use expo-updates for loading the release bundle
 

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -33,7 +33,6 @@ Install the `expo-updates` library and configure EAS Update:
     pnpm: ['$ pnpm expo install expo-updates', '', '$ eas update:configure'],
     bun: ['$ bun expo install expo-updates', '', '$ eas update:configure'],
   }}
-  cmdCopy="npx expo install expo-updates && eas update:configure"
 />
 
 You need to create a new build for Android or iOS to include the `expo-updates` library in your build. After that, you can push an update to the production channel:

--- a/docs/pages/eas-update/introduction.mdx
+++ b/docs/pages/eas-update/introduction.mdx
@@ -27,7 +27,12 @@ EAS Update makes fixing small bugs and pushing quick fixes a snap in between app
 Install the `expo-updates` library and configure EAS Update:
 
 <Terminal
-  cmd={['$ npx expo install expo-updates', '', '$ eas update:configure']}
+  cmd={{
+    npm: ['$ npx expo install expo-updates', '', '$ eas update:configure'],
+    yarn: ['$ yarn expo install expo-updates', '', '$ eas update:configure'],
+    pnpm: ['$ pnpm expo install expo-updates', '', '$ eas update:configure'],
+    bun: ['$ bun expo install expo-updates', '', '$ eas update:configure'],
+  }}
   cmdCopy="npx expo install expo-updates && eas update:configure"
 />
 

--- a/docs/pages/eas-update/migrate-from-classic-updates.mdx
+++ b/docs/pages/eas-update/migrate-from-classic-updates.mdx
@@ -29,7 +29,14 @@ EAS Update is the next generation of Expo's updates service. If you're using Cla
 <Step label="1">
 Install EAS CLI:
 
-<Terminal cmd={['$ npm install --global eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/eas-update/optimize-assets.mdx
+++ b/docs/pages/eas-update/optimize-assets.mdx
@@ -25,7 +25,14 @@ In **dist/bundles**, we can see the size of the **index.android.js** and **index
 
 App users will have to download any new images or other assets when they detect a new update if those assets are not already a part of their build. You can view all the assets uploaded to EAS servers in **dist/assets**. The assets there are hashed with their extensions removed, so it is difficult to know what assets are there. To see a pretty-printed list of assets, we can run:
 
-<Terminal cmd={['$ npx expo export']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export'],
+    yarn: ['$ yarn expo export'],
+    pnpm: ['$ pnpm expo export'],
+    bun: ['$ bun expo export'],
+  }}
+/>
 
 ### Optimizing image assets
 

--- a/docs/pages/eas/ai/mcp.mdx
+++ b/docs/pages/eas/ai/mcp.mdx
@@ -160,19 +160,60 @@ Use your Expo account username and password. In this case, the server will gener
 For the full MCP experience with advanced features like taking screenshots from your iOS Simulator, opening DevTools, and automation capabilities, set up a local Expo development server:
 
 <Terminal
-  cmd={[
-    '$ cd /path/to/your-project',
-    '',
-    '# Install the expo-mcp package',
-    '$ npx expo install expo-mcp --dev',
-    '',
-    '# Ensure you are logged in to Expo CLI with the same account as the one used to',
-    '# authenticate with the MCP server',
-    '$ npx expo whoami || npx expo login',
-    '',
-    '# Start the dev server with MCP capabilities',
-    '$ EXPO_UNSTABLE_MCP_SERVER=1 npx expo start',
-  ]}
+  cmd={{
+    npm: [
+      '$ cd /path/to/your-project',
+      '',
+      '# Install the expo-mcp package',
+      '$ npx expo install expo-mcp --dev',
+      '',
+      '# Ensure you are logged in to Expo CLI with the same account as the one used to',
+      '# authenticate with the MCP server',
+      '$ npx expo whoami || npx expo login',
+      '',
+      '# Start the dev server with MCP capabilities',
+      '$ EXPO_UNSTABLE_MCP_SERVER=1 npx expo start',
+    ],
+    yarn: [
+      '$ cd /path/to/your-project',
+      '',
+      '# Install the expo-mcp package',
+      '$ yarn expo install expo-mcp --dev',
+      '',
+      '# Ensure you are logged in to Expo CLI with the same account as the one used to',
+      '# authenticate with the MCP server',
+      '$ yarn expo whoami || yarn expo login',
+      '',
+      '# Start the dev server with MCP capabilities',
+      '$ EXPO_UNSTABLE_MCP_SERVER=1 yarn expo start',
+    ],
+    pnpm: [
+      '$ cd /path/to/your-project',
+      '',
+      '# Install the expo-mcp package',
+      '$ pnpm expo install expo-mcp --dev',
+      '',
+      '# Ensure you are logged in to Expo CLI with the same account as the one used to',
+      '# authenticate with the MCP server',
+      '$ pnpm expo whoami || pnpm expo login',
+      '',
+      '# Start the dev server with MCP capabilities',
+      '$ EXPO_UNSTABLE_MCP_SERVER=1 pnpm expo start',
+    ],
+    bun: [
+      '$ cd /path/to/your-project',
+      '',
+      '# Install the expo-mcp package',
+      '$ bun expo install expo-mcp --dev',
+      '',
+      '# Ensure you are logged in to Expo CLI with the same account as the one used to',
+      '# authenticate with the MCP server',
+      '$ bun expo whoami || bun expo login',
+      '',
+      '# Start the dev server with MCP capabilities',
+      '$ EXPO_UNSTABLE_MCP_SERVER=1 bun expo start',
+    ],
+  }}
 />
 
 > **important** Whenever you start or stop the development server, you need to **reconnect or restart** your MCP server connection in your AI-assisted tool to ensure the AI-assisted tool gets refreshed capabilities.

--- a/docs/pages/eas/hosting/get-started.mdx
+++ b/docs/pages/eas/hosting/get-started.mdx
@@ -33,7 +33,14 @@ This guide will walk you through the process of creating your first web deployme
   <Requirement title="An Expo Router web project">
     Don't have a project yet? It's quick and easy to create a "Hello world" app you can use with this guide. Run the following command to create a new project:
 
-    <Terminal cmd={['$ npx create-expo-app@latest my-app --template default@sdk-56']} />
+    <Terminal
+      cmd={{
+        npm: ['$ npx create-expo-app@latest my-app --template default@sdk-56'],
+        yarn: ['$ yarn create expo-app my-app --template default@sdk-56'],
+        pnpm: ['$ pnpm create expo-app my-app --template default@sdk-56'],
+        bun: ['$ bun create expo my-app --template default@sdk-56'],
+      }}
+    />
 
   </Requirement>
 </Prerequisites>
@@ -43,7 +50,14 @@ This guide will walk you through the process of creating your first web deployme
 
 EAS CLI is the command-line app you will use to interact with EAS services from your terminal. To install it, run the command:
 
-<Terminal cmd={['$ npm install --global eas-cli']} />
+<Terminal
+  cmd={{
+    npm: ['$ npm install --global eas-cli'],
+    yarn: ['$ yarn global add eas-cli'],
+    pnpm: ['$ pnpm add --global eas-cli'],
+    bun: ['$ bun add --global eas-cli'],
+  }}
+/>
 
 You can also use the above command to check if a new version of EAS CLI is available. We encourage you to always stay up to date with the latest version.
 
@@ -80,7 +94,14 @@ For your app config file's [`expo.web.output`](/versions/latest/config/app/#outp
 
 You need to export your web project into a **dist** directory. To do this, run:
 
-<Terminal cmd={['$ npx expo export --platform web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export --platform web'],
+    yarn: ['$ yarn expo export --platform web'],
+    pnpm: ['$ pnpm expo export --platform web'],
+    bun: ['$ bun expo export --platform web'],
+  }}
+/>
 
 > Remember to re-run this command every time before deploying.
 

--- a/docs/pages/eas/hosting/introduction.mdx
+++ b/docs/pages/eas/hosting/introduction.mdx
@@ -23,7 +23,14 @@ EAS Hosting offers the fastest path from `npx create-expo-app` to a fully deploy
 
 To deploy your web app, you need to create a static build of your web project. Run the following command to export your web project into a **dist** directory:
 
-<Terminal cmd={['$ npx expo export --platform web']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo export --platform web'],
+    yarn: ['$ yarn expo export --platform web'],
+    pnpm: ['$ pnpm expo export --platform web'],
+    bun: ['$ bun expo export --platform web'],
+  }}
+/>
 
 To publish your web app, run the following command:
 

--- a/docs/pages/eas/observe/get-started.mdx
+++ b/docs/pages/eas/observe/get-started.mdx
@@ -39,7 +39,14 @@ EAS Observe tracks your app's startup performance in production. This guide walk
 
 Make sure you are using the latest version of `expo`, then install `expo-observe`:
 
-<Terminal cmd={['$ npx expo install --fix', '', '$ npx expo install expo-observe']} />
+<Terminal
+  cmd={{
+    npm: ['$ npx expo install --fix', '', '$ npx expo install expo-observe'],
+    yarn: ['$ yarn expo install --fix', '', '$ yarn expo install expo-observe'],
+    pnpm: ['$ pnpm expo install --fix', '', '$ pnpm expo install expo-observe'],
+    bun: ['$ bun expo install --fix', '', '$ bun expo install expo-observe'],
+  }}
+/>
 
 </Step>
 

--- a/docs/pages/eas/observe/introduction.mdx
+++ b/docs/pages/eas/observe/introduction.mdx
@@ -21,7 +21,14 @@ Debugging performance in React Native has traditionally been limited to developm
 
 ## Quick start
 
-<Terminal cmd={['# Install the library', '$ npx expo install expo-observe']} />
+<Terminal
+  cmd={{
+    npm: ['# Install the library', '$ npx expo install expo-observe'],
+    yarn: ['# Install the library', '$ yarn expo install expo-observe'],
+    pnpm: ['# Install the library', '$ pnpm expo install expo-observe'],
+    bun: ['# Install the library', '$ bun expo install expo-observe'],
+  }}
+/>
 
 Wrap your root layout with the `AppMetricsRoot` component (SDK 55) or the `ObserveRoot` component (SDK 56 and later) and call `markInteractive()` when your app is ready for user input. See [Get started](/eas/observe/get-started/) for the full setup guide.
 

--- a/docs/pages/eas/workflows/get-started.mdx
+++ b/docs/pages/eas/workflows/get-started.mdx
@@ -21,7 +21,14 @@ This page walks you through the process of creating your first EAS Workflows for
   <Requirement title="Create a project">
     You'll need to create a project with the following command:
 
-    <Terminal cmd={['$ npx create-expo-app@latest --template default@sdk-56']} />
+    <Terminal
+      cmd={{
+        npm: ['$ npx create-expo-app@latest --template default@sdk-56'],
+        yarn: ['$ yarn create expo-app --template default@sdk-56'],
+        pnpm: ['$ pnpm create expo-app --template default@sdk-56'],
+        bun: ['$ bun create expo --template default@sdk-56'],
+      }}
+    />
 
   </Requirement>
   <Requirement title="Sync the project with EAS">

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -26,7 +26,6 @@ This guide outlines how to submit your app to the Google Play Store from your co
     Install EAS CLI and login with your Expo account:
 
     <Terminal
-      cmdCopy="npm install -g eas-cli && eas login"
       cmd={{
         npm: ['$ npm install --global eas-cli && eas login'],
         yarn: ['$ yarn global add eas-cli && eas login'],
@@ -94,7 +93,6 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
     Install EAS CLI and login with your Expo account:
 
     <Terminal
-      cmdCopy="npm install -g eas-cli && eas login"
       cmd={{
         npm: ['$ npm install --global eas-cli && eas login'],
         yarn: ['$ yarn global add eas-cli && eas login'],

--- a/docs/pages/submit/android.mdx
+++ b/docs/pages/submit/android.mdx
@@ -25,7 +25,15 @@ This guide outlines how to submit your app to the Google Play Store from your co
   <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
 
-    <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+    <Terminal
+      cmdCopy="npm install -g eas-cli && eas login"
+      cmd={{
+        npm: ['$ npm install --global eas-cli && eas login'],
+        yarn: ['$ yarn global add eas-cli && eas login'],
+        pnpm: ['$ pnpm add --global eas-cli && eas login'],
+        bun: ['$ bun add --global eas-cli && eas login'],
+      }}
+    />
 
   </Requirement>
   <Requirement title="Include a package name in app.json">
@@ -85,7 +93,15 @@ Learn more about the `--auto-submit` flag in the [automate submissions](/build/a
   <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
 
-    <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+    <Terminal
+      cmdCopy="npm install -g eas-cli && eas login"
+      cmd={{
+        npm: ['$ npm install --global eas-cli && eas login'],
+        yarn: ['$ yarn global add eas-cli && eas login'],
+        pnpm: ['$ pnpm add --global eas-cli && eas login'],
+        bun: ['$ bun add --global eas-cli && eas login'],
+      }}
+    />
 
   </Requirement>
   <Requirement title="Include a package name in app.json">

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -33,7 +33,6 @@ This guide outlines how to submit your app to the Apple App Store from your comp
     Install EAS CLI and login with your Expo account:
     
     <Terminal
-      cmdCopy="npm install -g eas-cli && eas login"
       cmd={{
         npm: ['$ npm install --global eas-cli && eas login'],
         yarn: ['$ yarn global add eas-cli && eas login'],

--- a/docs/pages/submit/ios.mdx
+++ b/docs/pages/submit/ios.mdx
@@ -32,7 +32,15 @@ This guide outlines how to submit your app to the Apple App Store from your comp
   <Requirement title="Install EAS CLI and authenticate with your Expo account">
     Install EAS CLI and login with your Expo account:
     
-    <Terminal cmd={['$ npm install -g eas-cli && eas login']} />
+    <Terminal
+      cmdCopy="npm install -g eas-cli && eas login"
+      cmd={{
+        npm: ['$ npm install --global eas-cli && eas login'],
+        yarn: ['$ yarn global add eas-cli && eas login'],
+        pnpm: ['$ pnpm add --global eas-cli && eas login'],
+        bun: ['$ bun add --global eas-cli && eas login'],
+      }}
+    />
   </Requirement>
   <Requirement title="Build a production app">
     You'll need a production build ready for store submission. You can create one using [EAS Build](/build/introduction/):


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Follow-up https://github.com/expo/expo/pull/46338

# How

<!--
How did you build this feature or fix this bug and why?
-->

Update EAS section Terminal references to include npm, yarn, pnpm, and bun variants where Expo docs conventions call for multi-package-manager commands.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

See preview.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
