### PR TITLE
[android][cli] Expand dot-shorthand launch activity against build.gradle namespace

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Expand dot-shorthand Android launch activities against the module `namespace` so `expo run:android` succeeds when `namespace` differs from `applicationId` ([#46351](https://github.com/expo/expo/pull/46351) by [@avarayr](https://github.com/avarayr))
+
 ### 💡 Others
 
 ## 56.1.12 — 2026-05-26

--- a/packages/@expo/cli/src/run/android/__tests__/resolveLaunchProps-test.ts
+++ b/packages/@expo/cli/src/run/android/__tests__/resolveLaunchProps-test.ts
@@ -80,4 +80,49 @@ describe(resolveLaunchPropsAsync, () => {
       customAppId: 'dev.expo.test',
     });
   });
+
+  // AGP 7.3+ projects can declare a `namespace` that differs from the
+  // `applicationId` (e.g. when the install identifier is set per build flavor
+  // but the Kotlin/Java code lives under a single namespace). The launcher
+  // activity must be expanded against the namespace so `am start` resolves to
+  // a class that actually exists.
+  it(`expands dot-shorthand activity against build.gradle namespace`, async () => {
+    vol.fromJSON(
+      {
+        ...rnFixture,
+        'android/app/build.gradle': rnFixture['android/app/build.gradle'].replace(
+          'android {',
+          "android {\n          namespace 'com.reactnativeproject'"
+        ),
+      },
+      '/'
+    );
+
+    expect(await resolveLaunchPropsAsync('/', {})).toEqual({
+      launchActivity: 'com.bacon.mydevicefamilyproject/com.reactnativeproject.MainActivity',
+      mainActivity: '.MainActivity',
+      packageName: 'com.bacon.mydevicefamilyproject',
+      customAppId: undefined,
+    });
+  });
+
+  it(`expands dot-shorthand activity against namespace with custom app id`, async () => {
+    vol.fromJSON(
+      {
+        ...rnFixture,
+        'android/app/build.gradle': rnFixture['android/app/build.gradle'].replace(
+          'android {',
+          "android {\n          namespace 'com.reactnativeproject'"
+        ),
+      },
+      '/'
+    );
+
+    expect(await resolveLaunchPropsAsync('/', { appId: 'dev.expo.test' })).toEqual({
+      launchActivity: 'dev.expo.test/com.reactnativeproject.MainActivity',
+      mainActivity: '.MainActivity',
+      packageName: 'com.bacon.mydevicefamilyproject',
+      customAppId: 'dev.expo.test',
+    });
+  });
 });

--- a/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
+++ b/packages/@expo/cli/src/run/android/resolveLaunchProps.ts
@@ -32,6 +32,21 @@ function resolveCustomLaunchActivity(packageName: string, mainActivity: string):
   return mainActivity.startsWith('.') ? `${packageName}${mainActivity}` : mainActivity;
 }
 
+/**
+ * Expand a dot-prefixed activity shorthand (`.MainActivity`) into its fully
+ * qualified class name using the module's `namespace` from `build.gradle`.
+ * AGP performs the same expansion at manifest merge time, but `am start` reads
+ * the raw `android:name` attribute and resolves dot shorthands against the
+ * applicationId — which can differ from the namespace and point at a class
+ * that does not exist.
+ */
+function expandDotShorthand(activityName: string, namespace: string | null): string {
+  if (!activityName.startsWith('.') || !namespace) {
+    return activityName;
+  }
+  return `${namespace}${activityName}`;
+}
+
 async function getMainActivityAsync(projectRoot: string): Promise<string> {
   const filePath = await AndroidConfig.Paths.getAndroidManifestAsync(projectRoot);
   const androidManifest = await AndroidConfig.Manifest.readAndroidManifestAsync(filePath);
@@ -55,12 +70,15 @@ export async function resolveLaunchPropsAsync(
 ): Promise<LaunchProps> {
   const mainActivity = await getMainActivityAsync(projectRoot);
   const packageName = await new AndroidAppIdResolver(projectRoot).getAppIdFromNativeAsync();
+  const namespace = await AndroidConfig.Package.getNamespaceAsync(projectRoot);
   const customAppId = options.appId;
+
+  const resolvedActivity = expandDotShorthand(mainActivity, namespace);
 
   const launchActivity =
     customAppId && customAppId !== packageName
-      ? `${customAppId}/${resolveCustomLaunchActivity(packageName, mainActivity)}`
-      : `${packageName}/${mainActivity}`;
+      ? `${customAppId}/${resolveCustomLaunchActivity(packageName, resolvedActivity)}`
+      : `${packageName}/${resolvedActivity}`;
 
   return {
     mainActivity,

--- a/packages/@expo/config-plugins/CHANGELOG.md
+++ b/packages/@expo/config-plugins/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🎉 New features
 
+- Export `AndroidConfig.Package.getNamespaceAsync` to read the `namespace` declared in the app module's `build.gradle` ([#46351](https://github.com/expo/expo/pull/46351) by [@avarayr](https://github.com/avarayr))
+
 ### 🐛 Bug fixes
 
 ### 💡 Others

--- a/packages/@expo/config-plugins/src/android/Package.ts
+++ b/packages/@expo/config-plugins/src/android/Package.ts
@@ -254,6 +254,23 @@ export async function getApplicationIdAsync(projectRoot: string): Promise<string
 }
 
 /**
+ * Reads the `namespace` declared in the app module's `build.gradle`. AGP 7.3+
+ * uses this as the Kotlin/Java package for the generated `R`/`BuildConfig` and
+ * as the prefix when expanding dot-shorthand class names in `AndroidManifest`.
+ * Returns `null` when no `namespace` is set (legacy projects relying on the
+ * deprecated `package=` attribute in the manifest).
+ */
+export async function getNamespaceAsync(projectRoot: string): Promise<string | null> {
+  const buildGradlePath = getAppBuildGradleFilePath(projectRoot);
+  if (!fs.existsSync(buildGradlePath)) {
+    return null;
+  }
+  const buildGradle = await fs.promises.readFile(buildGradlePath, 'utf8');
+  const matchResult = buildGradle.match(/namespace ['"](.*)['"]/);
+  return matchResult?.[1] ?? null;
+}
+
+/**
  * Replace the package name with the new package name, in the given source.
  * This has to be limited to avoid accidentally replacing imports when the old package name overlaps.
  */

--- a/packages/@expo/config-plugins/src/android/Package.ts
+++ b/packages/@expo/config-plugins/src/android/Package.ts
@@ -259,6 +259,10 @@ export async function getApplicationIdAsync(projectRoot: string): Promise<string
  * as the prefix when expanding dot-shorthand class names in `AndroidManifest`.
  * Returns `null` when no `namespace` is set (legacy projects relying on the
  * deprecated `package=` attribute in the manifest).
+ *
+ * The regex is anchored to the start of a line (multiline) so commented-out
+ * declarations and substring matches are ignored. Supports both Groovy
+ * (`namespace 'com.foo'`) and Kotlin DSL (`namespace = "com.foo"`) forms.
  */
 export async function getNamespaceAsync(projectRoot: string): Promise<string | null> {
   const buildGradlePath = getAppBuildGradleFilePath(projectRoot);
@@ -266,7 +270,7 @@ export async function getNamespaceAsync(projectRoot: string): Promise<string | n
     return null;
   }
   const buildGradle = await fs.promises.readFile(buildGradlePath, 'utf8');
-  const matchResult = buildGradle.match(/namespace ['"](.*)['"]/);
+  const matchResult = buildGradle.match(/^\s*namespace(?:\s+|\s*=\s*)['"]([^'"]+)['"]/m);
   return matchResult?.[1] ?? null;
 }
 

--- a/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
@@ -71,6 +71,38 @@ describe('package', () => {
     await expect(getNamespaceAsync(projectRoot)).resolves.toBe(null);
   });
 
+  it(`ignores commented-out namespace declarations`, async () => {
+    const projectRoot = '/';
+    vol.fromJSON(
+      {
+        ...rnFixture,
+        'android/app/build.gradle': rnFixture['android/app/build.gradle'].replace(
+          'namespace "com.helloworld"',
+          "// namespace 'com.commented.out'\n    namespace 'com.helloworld'"
+        ),
+      },
+      projectRoot
+    );
+
+    await expect(getNamespaceAsync(projectRoot)).resolves.toBe('com.helloworld');
+  });
+
+  it(`supports the Kotlin DSL form (namespace = "...")`, async () => {
+    const projectRoot = '/';
+    vol.fromJSON(
+      {
+        ...rnFixture,
+        'android/app/build.gradle': rnFixture['android/app/build.gradle'].replace(
+          'namespace "com.helloworld"',
+          'namespace = "com.helloworld"'
+        ),
+      },
+      projectRoot
+    );
+
+    await expect(getNamespaceAsync(projectRoot)).resolves.toBe('com.helloworld');
+  });
+
   it(`sets the applicationId in build.gradle if package is given`, () => {
     expect(
       setPackageInBuildGradle({ android: { package: 'my.new.app' } }, EXAMPLE_BUILD_GRADLE)

--- a/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
+++ b/packages/@expo/config-plugins/src/android/__tests__/Package-test.ts
@@ -3,6 +3,7 @@ import { vol } from 'memfs';
 import rnFixture from '../../plugins/__tests__/fixtures/react-native-project';
 import {
   getApplicationIdAsync,
+  getNamespaceAsync,
   getPackage,
   kotlinSanitized,
   renameJniOnDiskForType,
@@ -45,6 +46,29 @@ describe('package', () => {
     vol.fromJSON(rnFixture, projectRoot);
 
     expect(getApplicationIdAsync(projectRoot)).resolves.toBe('com.helloworld');
+  });
+
+  it(`returns the namespace defined in build.gradle`, async () => {
+    const projectRoot = '/';
+    vol.fromJSON(rnFixture, projectRoot);
+
+    await expect(getNamespaceAsync(projectRoot)).resolves.toBe('com.helloworld');
+  });
+
+  it(`returns null when build.gradle has no namespace declaration`, async () => {
+    const projectRoot = '/';
+    vol.fromJSON(
+      {
+        ...rnFixture,
+        'android/app/build.gradle': rnFixture['android/app/build.gradle'].replace(
+          /namespace ['"][^'"]*['"]\s*\n?/g,
+          ''
+        ),
+      },
+      projectRoot
+    );
+
+    await expect(getNamespaceAsync(projectRoot)).resolves.toBe(null);
   });
 
   it(`sets the applicationId in build.gradle if package is given`, () => {


### PR DESCRIPTION
# Why

Fixes #46349. `expo run:android` fails on launch when `namespace` ≠ `applicationId`. `resolveLaunchProps` reads `android:name` raw from the manifest and concatenates `${applicationId}/${mainActivity}` for `am start`. With dot-shorthand, `am start` resolves the dot against the applicationId — but MainActivity lives under the namespace, so the FQCN doesn't match the merged manifest and the launch fails with `Activity class does not exist`. AGP already does this expansion correctly at manifest merge time, which is why production launches via LAUNCHER intent are unaffected.

#45773 patched the `--app-id` branch; the default path still has the bug.

# How

- New `AndroidConfig.Package.getNamespaceAsync` in `@expo/config-plugins`, mirroring `getApplicationIdAsync` — reads `namespace` from the app module's `build.gradle`. Regex is anchored start-of-line (multiline) with a non-greedy capture, and supports both Groovy and Kotlin DSL forms.
- `resolveLaunchPropsAsync` expands `.X` shorthand against the namespace before constructing the launch intent. Falls back to the existing behavior when no namespace is declared, so legacy projects on AGP < 7.3 are unaffected.

# Test Plan

Repro repo: https://github.com/avarayr/expo-cli-android-namespace-bug-repro

```sh
pnpm --filter @expo/cli test -- src/run/android/__tests__/resolveLaunchProps-test.ts --runInBand
# 8 passed

pnpm --filter @expo/config-plugins test -- src/android/__tests__/Package-test.ts --runInBand
# 14 passed
```

New cases in `resolveLaunchProps-test.ts` cover both default and `--app-id` branches with namespace ≠ applicationId. New cases in `Package-test.ts` cover `getNamespaceAsync` with no namespace, commented-out lines, and Kotlin DSL syntax. Existing tests unchanged.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
