### PR TITLE
[expo] Fix message socket crash in embedded environments

### DIFF
--- a/packages/expo/src/async-require/messageSocket.native.ts
+++ b/packages/expo/src/async-require/messageSocket.native.ts
@@ -6,10 +6,11 @@ declare namespace globalThis {
 }
 
 if (__DEV__) {
-  const socket: WebSocket = (() => {
+  const socket: WebSocket | null = (() => {
     const devServer = getDevServer();
     if (!devServer.bundleLoadedFromServer) {
-      throw new Error('Cannot create devtools websocket connections in embedded environments.');
+      console.warn('Cannot create devtools websocket connections in embedded environments');
+      return null;
     }
 
     const devServerUrl = new URL(devServer.url);
@@ -17,24 +18,26 @@ if (__DEV__) {
     return new WebSocket(`${serverScheme}://${devServerUrl.host}/message`);
   })();
 
-  socket.onmessage = (message: { data: any }) => {
-    const data = JSON.parse(String(message.data));
-    switch (data.method) {
-      case 'sendDevCommand':
-        switch (data.params.name) {
-          case 'rsc-reload':
-            if (data.params.platform && data.params.platform !== process.env.EXPO_OS) {
-              return;
-            }
-            if (!globalThis.__EXPO_RSC_RELOAD_LISTENERS__) {
-              // server function-only mode
-            } else {
-              globalThis.__EXPO_RSC_RELOAD_LISTENERS__?.forEach((l) => l());
-            }
-            break;
-        }
-        break;
-      // NOTE: All other cases are handled in the native runtime.
-    }
-  };
+  if (socket) {
+    socket.onmessage = (message: { data: any }) => {
+      const data = JSON.parse(String(message.data));
+      switch (data.method) {
+        case 'sendDevCommand':
+          switch (data.params.name) {
+            case 'rsc-reload':
+              if (data.params.platform && data.params.platform !== process.env.EXPO_OS) {
+                return;
+              }
+              if (!globalThis.__EXPO_RSC_RELOAD_LISTENERS__) {
+                // server function-only mode
+              } else {
+                globalThis.__EXPO_RSC_RELOAD_LISTENERS__?.forEach((l) => l());
+              }
+              break;
+          }
+          break;
+        // NOTE: All other cases are handled in the native runtime.
+      }
+    };
+  }
 }


### PR DESCRIPTION
# Why

Fixed message socket crash in embedded environments, which we need to handle for internal usage. 

# How

- Replace a thrown error with a console.warn and early null return when the dev server bundle wasn't loaded from a server (embedded environments). Previously, this would crash the app during module evaluation.
- Guard socket.onmessage assignment behind a null check to handle the new nullable socket.

# Test Plan

- bare-expo ✅ 