### PR TITLE
[ios][dev-launcher] Use http url scheme and url keyboard

### DIFF
--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/compose/ui/ServerUrlInput.kt
@@ -98,7 +98,7 @@ fun ServerUrlInput(
       TextInput(
         placeholder = {
           NewText(
-            text = "exp://",
+            text = "http://",
             style = NewAppTheme.font.md,
             color = NewAppTheme.colors.text.secondary
           )

--- a/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
+++ b/packages/expo-dev-launcher/ios/SwiftUI/DevServersView.swift
@@ -100,12 +100,13 @@ struct DevServersView: View {
       }
 
       if showingURLInput {
-        TextField("exp://", text: $urlText)
+        TextField("http://", text: $urlText)
           .onSubmit {
             connectToURL()
           }
           .submitLabel(.go)
         #if !os(macOS)
+          .keyboardType(.URL)
           .autocapitalization(.none)
         #endif
           .disableAutocorrection(true)

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_runUpdate.yml
@@ -19,7 +19,7 @@ onFlowStart:
           text: Enter URL manually
       - tapOn:
           label: Tap on "Updates URL" text field
-          text: '.*exp:.*'
+          text: '.*http:.*'
           below: Enter URL manually
 - runFlow:
     when:
@@ -31,7 +31,7 @@ onFlowStart:
           optional: true
       - tapOn:
           label: Tap on "Updates URL" text field
-          text: '.*exp:.*'
+          text: '.*http:.*'
 - inputText:
     label: Input local update server URL
     text: "http://localhost:4747/update\n"

--- a/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
+++ b/packages/expo-updates/e2e/fixtures/project_files/maestro/tests/devClient_verifyState.yml
@@ -14,7 +14,7 @@ onFlowStart:
           text: Enter URL manually
       - tapOn:
           label: Tap on "Updates URL" text field
-          text: '.*exp:.*'
+          text: '.*http:.*'
           below: Enter URL manually
 - runFlow:
     when:
@@ -26,7 +26,7 @@ onFlowStart:
           optional: true
       - tapOn:
           label: Tap on "Updates URL" text field
-          text: '.*exp:.*'
+          text: '.*http:.*'
 - inputText:
     label: Input local update server URL
     text: "http://localhost:8081\n"


### PR DESCRIPTION
# Why
Follow up on a number of issues found by @ide https://exponent-internal.slack.com/archives/C011V63429H/p1780005948277179

# How
- Changed the `TextField` placeholder from `exp://` to `http://`. 
- Added `.keyboardType(.URL)`

# Test Plan
Bare expo

