### PR TITLE
[ios][dev-menu] Make copy actions consistent

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuAppInfo.swift
@@ -30,12 +30,13 @@ struct DevMenuAppInfo: View {
         label: {
           HStack {
             Text(viewModel.clipboardMessage ?? "Copy system info")
-              .foregroundColor(.blue)
+              .foregroundColor(.primary)
             Spacer()
-            Image(systemName: "document.on.clipboard")
+            Image(systemName: "doc.on.clipboard")
               .resizable()
+              .scaledToFit()
               .frame(width: 16, height: 16)
-              .opacity(0.6)
+              .foregroundColor(.secondary)
           }
           .padding(.vertical)
           .disabled(viewModel.clipboardMessage != nil)

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -114,7 +114,7 @@ class DevMenuViewModel: ObservableObject {
   func copyToClipboard(_ content: String) {
     #if !os(tvOS) && !os(macOS)
     UIPasteboard.general.string = content
-    hostUrlCopiedMessage = "Copied!"
+    hostUrlCopiedMessage = "Copied to clipboard"
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       self.hostUrlCopiedMessage = nil
@@ -145,7 +145,7 @@ class DevMenuViewModel: ObservableObject {
     let jsonString = jsonData.flatMap { String(data: $0, encoding: .utf8) } ?? "Unable to serialize app info"
 
     UIPasteboard.general.string = jsonString
-    clipboardMessage = "Copied to clipboard!"
+    clipboardMessage = "Copied to clipboard"
 
     DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
       self.clipboardMessage = nil

--- a/packages/expo-dev-menu/ios/SwiftUI/HostUrl.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/HostUrl.swift
@@ -24,7 +24,10 @@ struct HostUrl: View {
         Spacer()
 
         Image(systemName: "doc.on.clipboard")
-          .foregroundColor(.secondary.opacity(0.7))
+          .resizable()
+          .scaledToFit()
+          .frame(width: 16, height: 16)
+          .foregroundColor(.secondary)
       }
       .padding()
       .background(Color.expoSecondarySystemBackground)


### PR DESCRIPTION
# Why
Follow up on a number of issues found by @ide https://exponent-internal.slack.com/archives/C011V63429H/p1780005948277179

# How
- Single confirmation string: **"Copied to clipboard"**.
- Same SF Symbol (`doc.on.clipboard`).
- Same neutral treatment (`.primary` text, `.secondary` icon).

# Test Plan
Bare expo

