### PR TITLE
[ios][dev-menu] Refresh dev settings when menu is shown

### DIFF
--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuRootView.swift
@@ -33,6 +33,7 @@ struct DevMenuRootView: View {
     .id(navigationId)
     .onReceive(DevMenuManager.shared.menuWillShowPublisher) { _ in
       navigationId = UUID()
+      viewModel.refresh()
     }
 #else
     NavigationStack {
@@ -41,6 +42,7 @@ struct DevMenuRootView: View {
     .id(navigationId)
     .onReceive(DevMenuManager.shared.menuWillShowPublisher) { _ in
       navigationId = UUID()
+      viewModel.refresh()
     }
 #endif
   }

--- a/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
+++ b/packages/expo-dev-menu/ios/SwiftUI/DevMenuViewModel.swift
@@ -32,6 +32,10 @@ class DevMenuViewModel: ObservableObject {
     loadFloatingActionButtonState()
   }
 
+  func refresh() {
+    loadData()
+  }
+
   private func loadAppInfo() {
     let appInfoDict = devMenuManager.getAppInfo()
 


### PR DESCRIPTION
# Why
Found an issue where the dev settings were not read correctly when returning to the launcher and then going back into the app. Toggle performance monitor etc would be disabled.

# How
Reload the settings every time the menu is about to be presented

# Test Plan
Bare expo
