### PR TITLE
[sdk-52][notifications] Fix thread-safe static initialization in EXNotificationSerializer

### DIFF
--- a/packages/expo-notifications/CHANGELOG.md
+++ b/packages/expo-notifications/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- [ios] Fix `EXC_BAD_ACCESS` crash in `EXNotificationSerializer` caused by thread-unsafe static `NSDictionary` initialization during cold launch from notification tap. ([#46385](https://github.com/expo/expo/pull/46385) by [@SJvaca30](https://github.com/SJvaca30))
+
 ### 💡 Others
 
 ## 0.29.14 — 2025-03-11

--- a/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m
+++ b/packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m
@@ -64,15 +64,16 @@ static NSString * const EXNotificationResponseDefaultActionIdentifier = @"expo.m
 
 + (NSString *)serializedInterruptionLevel:(UNNotificationInterruptionLevel)interruptionLevel API_AVAILABLE(ios(15.0)) {
   static NSDictionary<NSNumber *, NSString *> *interruptionLevelMap;
-  if (!interruptionLevelMap) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     interruptionLevelMap = @{
       @(UNNotificationInterruptionLevelPassive): @"passive",
       @(UNNotificationInterruptionLevelActive): @"active",
       @(UNNotificationInterruptionLevelTimeSensitive): @"timeSensitive",
       @(UNNotificationInterruptionLevelCritical): @"critical"
     };
-  }
-  
+  });
+
   return [interruptionLevelMap objectForKey:@(interruptionLevel)];
 }
 
@@ -169,7 +170,8 @@ static NSString * const EXNotificationResponseDefaultActionIdentifier = @"expo.m
 + (NSDictionary *)calendarUnitsConversionMap
 {
   static NSDictionary *keysMap = nil;
-  if (!keysMap) {
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
     keysMap = @{
       @(NSCalendarUnitEra): @"era",
       @(NSCalendarUnitYear): @"year",
@@ -188,7 +190,7 @@ static NSString * const EXNotificationResponseDefaultActionIdentifier = @"expo.m
       // NSCalendarUnitCalendar and NSCalendarUnitTimeZone
       // should be handled separately
     };
-  }
+  });
   return keysMap;
 }
 


### PR DESCRIPTION
# Why

Fixes #43096 for SDK 52.

This backports the SDK 53 fix from #43342 to the `sdk-52` branch. `EXNotificationSerializer` still initializes two static `NSDictionary` instances with bare `if (!map)` checks on SDK 52, which can be unsafe when cold-launch notification serialization happens concurrently.

# How

Replaced the bare static dictionary guards with `dispatch_once` in:

- `serializedInterruptionLevel:`
- `calendarUnitsConversionMap`

This keeps the existing mapping behavior while making initialization one-time and thread-safe.

# Test Plan

- `git diff --check`
- `rg -n "if \\(!interruptionLevelMap\\)|if \\(!keysMap\\)|dispatch_once|serializedInterruptionLevel|calendarUnitsConversionMap" packages/expo-notifications/ios/EXNotifications/Notifications/EXNotificationSerializer.m`
- Confirmed this matches the already-merged SDK 53 fix in #43342.

# Checklist

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)