### PR TITLE
[docs] Fix four-backtick code fences and add Vale rule

### DIFF
--- a/docs/.vale/writing-styles/expo-docs/CodeFenceLength.yml
+++ b/docs/.vale/writing-styles/expo-docs/CodeFenceLength.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: 'Use triple backticks for code fences.'
+level: error
+scope: raw
+nonword: true
+tokens:
+  - '(?m)^[ \t]{0,3}`{4,}[^\n]*$'

--- a/docs/pages/tutorial/gestures.mdx
+++ b/docs/pages/tutorial/gestures.mdx
@@ -333,7 +333,7 @@ export default function EmojiSticker({ imageSize, stickerSource }: Props) {
     /* @tutinfo */</GestureDetector>/* @end */
   );
 }
-````
+```
 
 Let's take a look at our app on Android, iOS and the web:
 

--- a/docs/pages/versions/unversioned/sdk/media-library-legacy.mdx
+++ b/docs/pages/versions/unversioned/sdk/media-library-legacy.mdx
@@ -203,7 +203,7 @@ const styles = StyleSheet.create({
   },
 });
 /* @end */
-````
+```
 
 </SnackInline>
 

--- a/docs/pages/versions/v54.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/media-library.mdx
@@ -201,7 +201,7 @@ const styles = StyleSheet.create({
   },
 });
 /* @end */
-````
+```
 
 </SnackInline>
 

--- a/docs/pages/versions/v55.0.0/sdk/media-library.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/media-library.mdx
@@ -201,7 +201,7 @@ const styles = StyleSheet.create({
   },
 });
 /* @end */
-````
+```
 
 </SnackInline>
 

--- a/docs/pages/versions/v56.0.0/sdk/media-library-legacy.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/media-library-legacy.mdx
@@ -203,7 +203,7 @@ const styles = StyleSheet.create({
   },
 });
 /* @end */
-````
+```
 
 </SnackInline>
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

A handful of docs pages closed code blocks with four backticks (````) instead of three, and nothing in the lint setup caught the inconsistency.

<img width="1528" height="1582" alt="CleanShot 2026-05-29 at 14 00 04@2x" src="https://github.com/user-attachments/assets/5e6abd96-ccaf-4f53-b201-4342757fde8e" />

# How

Replace the four-backtick fences with three on the gestures tutorial and the `media-library` SDK pages (unversioned, v54, v55, v56), and add a `CodeFenceLength.yml` Vale rule  that errors on any fence opening with four or more backticks.

# Test Plan

Run `pnpm lint-prose` and there should be no warnings or errors.

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/nicknisi/dotfiles/wiki/Pull-Request-Guidelines).
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md).

