### PR TITLE
[docs] Update Android and iOS diffs for SDK 56

### DIFF
--- a/docs/pages/bare/installing-expo-modules.mdx
+++ b/docs/pages/bare/installing-expo-modules.mdx
@@ -38,7 +38,7 @@ To install and use Expo modules, the easiest way to get up and running is with t
 
 ## Manual installation
 
-The following instructions apply to installing the latest version of Expo modules in React Native 0.83. For previous versions, check the [native upgrade helper](/bare/upgrade) to see how these files are customized.
+The following instructions apply to installing the latest version of Expo modules in React Native 0.85. For previous versions, check the [native upgrade helper](/bare/upgrade) to see how these files are customized.
 
 <InstallSection packageName="expo" cmd={['$ npm install expo']} hideBareInstructions />
 
@@ -54,10 +54,10 @@ Once installation is complete, apply the changes from the following diffs to con
 
 Optionally, you can also add additional delegate methods to your **AppDelegate.swift**. Some libraries may require them, so unless you have a good reason to leave them out, it is recommended to add them. [See delegate methods in AppDelegate.swift](https://github.com/expo/expo/blob/sdk-54/templates/expo-template-bare-minimum/ios/HelloWorld/AppDelegate.swift#L24-L42).
 
-Save all of your changes and update your iOS Deployment Target in Xcode to <code>iOS 15.1</code>:
+Save all of your changes and update your iOS Deployment Target in Xcode to <code>iOS 16.4</code>:
 
 - Open **your-project-name.xcworkspace** in Xcode, select your project in the left sidebar.
-- Select **Targets** > **your-project-name** > **Build Settings** > **iOS Deployment Target** and set it to <code>iOS 15.1</code>.
+- Select **Targets** > **your-project-name** > **Build Settings** > **iOS Deployment Target** and ensure it is set to <code>iOS 16.4</code>.
 
 The last step is to install the project's CocoaPods again to pull in Expo modules that are detected by `use_expo_modules!` directive that we added to the **Podfile**:
 
@@ -153,7 +153,7 @@ You can verify that the installation was successful by logging a value from [`ex
 - Run `npx expo install expo-constants`
 - Then, run `npx expo run` and modify your app JavaScript code to add the following:
 
-```js
+```tsx
 import Constants from 'expo-constants';
 console.log(Constants.systemFonts);
 ```
@@ -169,7 +169,7 @@ The following Expo modules are brought in as dependencies of the `expo` package:
 - [`expo-asset`](/versions/latest/sdk/asset) - A JavaScript-only package that builds around `expo-file-system` and provides a common foundation for assets across all Expo modules.
 - [`expo-constants`](/versions/latest/sdk/constants) - Provides access to the manifest.
 - [`expo-file-system`](/versions/latest/sdk/filesystem) - Interact with the device file system. Used by `expo-asset` and many other Expo modules. Commonly used directly by developers in application code.
-- [`expo-font`](/versions/latest/sdk/font) - Load fonts at runtime. This module is optional and can be safely removed, however; it is recommended if you use `expo-dev-client` for development and it is required by `@expo/vector-icons`.
+- [`expo-font`](/versions/latest/sdk/font) - Load fonts at runtime. This module is optional and can be safely removed. However, it is recommended if you use `expo-dev-client` for development and it is required by `@expo/vector-icons`.
 - [`expo-keep-awake`](/versions/latest/sdk/keep-awake) - Prevents your device from going to sleep while developing your app. This module is optional and can be safely removed.
 
 To exclude any of these modules, refer to the following guide on [excluding modules from autolinking](#excluding-specific-modules-from-autolinking).

--- a/docs/public/static/diffs/expo-cli-android.diff
+++ b/docs/public/static/diffs/expo-cli-android.diff
@@ -1,5 +1,5 @@
 diff --git a/android/app/build.gradle b/android/app/build.gradle
-index 804b381..475de6a 100644
+index e441fee..6091cd1 100644
 --- a/android/app/build.gradle
 +++ b/android/app/build.gradle
 @@ -52,6 +52,11 @@ react {
@@ -12,3 +12,5 @@ index 804b381..475de6a 100644
 +    cliFile = new File(["node", "--print", "require.resolve('@expo/cli')"].execute(null, rootDir).text.trim())
 +    bundleCommand = "export:embed"
  }
+
+ /**

--- a/docs/public/static/diffs/expo-ios.diff
+++ b/docs/public/static/diffs/expo-ios.diff
@@ -1,5 +1,5 @@
 diff --git a/ios/Podfile b/ios/Podfile
-index c41f442..fdd2f97 100644
+index c41f442..6ec9f2c 100644
 --- a/ios/Podfile
 +++ b/ios/Podfile
 @@ -1,3 +1,4 @@
@@ -7,6 +7,15 @@ index c41f442..fdd2f97 100644
  # Resolve react_native_pods.rb with node to allow for hoisting
  require Pod::Executable.execute_command('node', ['-p',
    'require.resolve(
+@@ -5,7 +6,7 @@ require Pod::Executable.execute_command('node', ['-p',
+     {paths: [process.argv[1]]},
+   )', __dir__]).strip
+
+-platform :ios, min_ios_version_supported
++platform :ios, '16.4'
+ prepare_react_native_project!
+
+ linkage = ENV['USE_FRAMEWORKS']
 @@ -15,7 +16,24 @@ if linkage != nil
  end
 


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix ENG-21122

# How

<!--
How did you build this feature or fix this bug and why?
-->
Update Android and iOS diffs for manual steps in Install Expo modules in an existing React Native project guide.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Proofread.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
