### PR TITLE
Pass dev-launcher initialUrl to launched app

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [iOS] Explain why a project failed to load instead of showing a generic "Failed to connect" message. ([#46866](https://github.com/expo/expo/pull/46866) by [@alanjhughes](https://github.com/alanjhughes))
 - [iOS] Fix tvOS compile error in DevServersView. ([#47082](https://github.com/expo/expo/pull/47082) by [@douglowder](https://github.com/douglowder))
 - [Android] Fix auto-launching into the most recently opened project on startup. ([#47131](https://github.com/expo/expo/pull/47131) by [@alanjhughes](https://github.com/alanjhughes))
+- Pass `initialUrl` from dev-launcher deep links through to the loaded app. ([#19846](https://github.com/expo/expo/issues/19846) by [@mvincentong](https://github.com/mvincentong)) ([#46395](https://github.com/expo/expo/pull/46395) by [@mvincentong](https://github.com/mvincentong))
 
 ### 💡 Others
 

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/DevLauncherController.kt
@@ -302,7 +302,10 @@ class DevLauncherController private constructor(
 
         coroutineScope.launch {
           try {
-            pendingIntentRegistry.intent = intent
+            val devLauncherUrl = DevLauncherUrl(uri)
+            pendingIntentRegistry.intent = devLauncherUrl.initialUrl?.let { initialUrl ->
+              Intent(intent).apply { data = initialUrl }
+            } ?: intent
             loadApp(uri, activityToBeInvalidated)
           } catch (e: Throwable) {
             DevLauncherErrorActivity.showFatalError(context, DevLauncherAppError(e.message, e))

--- a/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherURLHelper.kt
+++ b/packages/expo-dev-launcher/android/src/debug/java/expo/modules/devlauncher/helpers/DevLauncherURLHelper.kt
@@ -12,11 +12,16 @@ fun hasUrlQueryParam(uri: Uri): Boolean {
 
 class DevLauncherUrl(var url: Uri) {
   val queryParams = mutableMapOf<String, String>()
+  val initialUrl: Uri?
 
   init {
     url.queryParameterNames.forEach { name ->
       queryParams[name] = url.getQueryParameter(name) ?: ""
     }
+
+    initialUrl = (queryParams["initialUrl"] ?: queryParams["initialURL"])
+      ?.takeIf { it.isNotEmpty() }
+      ?.let(Uri::parse)
 
     if (isDevLauncherUrl(url)) {
       if (queryParams["url"] != null) {

--- a/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherURLHelperTest.kt
+++ b/packages/expo-dev-launcher/android/src/test/java/expo/modules/devlauncher/helpers/DevLauncherURLHelperTest.kt
@@ -44,4 +44,24 @@ internal class DevLauncherURLHelperTest {
       )
     ).isFalse()
   }
+
+  @Test
+  fun `tests DevLauncherUrl reads initialUrl query param`() {
+    val devLauncherUrl = DevLauncherUrl(
+      Uri.parse("scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081&initialUrl=myapp%3A%2F%2Ffoo%2Fbar%3Fbaz%3D1")
+    )
+
+    Truth.assertThat(devLauncherUrl.url).isEqualTo(Uri.parse("http://localhost:8081"))
+    Truth.assertThat(devLauncherUrl.initialUrl).isEqualTo(Uri.parse("myapp://foo/bar?baz=1"))
+  }
+
+  @Test
+  fun `tests DevLauncherUrl reads initialURL query param alias`() {
+    val devLauncherUrl = DevLauncherUrl(
+      Uri.parse("scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081&initialURL=myapp%3A%2F%2Ffoo%2Fbar")
+    )
+
+    Truth.assertThat(devLauncherUrl.url).isEqualTo(Uri.parse("http://localhost:8081"))
+    Truth.assertThat(devLauncherUrl.initialUrl).isEqualTo(Uri.parse("myapp://foo/bar"))
+  }
 }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -320,6 +320,11 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
     return true;
   }
 
+  EXDevLauncherUrl *devLauncherUrl = [[EXDevLauncherUrl alloc] init:url];
+  if (devLauncherUrl.initialUrl) {
+    self.pendingDeepLinkRegistry.pendingDeepLink = devLauncherUrl.initialUrl;
+  }
+
   [self loadApp:url onSuccess:nil onError:^(NSError *error) {
     __weak typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -12,8 +12,15 @@ public class EXDevLauncherUrl: NSObject {
   public var queryParams: [String: String]
 
   @objc
+  public var initialUrl: URL?
+
+  @objc
   public init(_ url: URL) {
     self.queryParams = EXDevLauncherURLHelper.getQueryParamsForUrl(url)
+    let initialUrlParam = queryParams["initialUrl"] ?? queryParams["initialURL"]
+    if let initialUrlParam, !initialUrlParam.isEmpty {
+      self.initialUrl = URL(string: initialUrlParam)
+    }
 
     if EXDevLauncherURLHelper.isDevLauncherURL(url),
       let urlParam = queryParams["url"],

--- a/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
+++ b/packages/expo-dev-launcher/ios/Tests/EXDevLauncherURLHelperTests.swift
@@ -36,12 +36,21 @@ class EXDevLauncherURLHelperTests: XCTestCase {
   }
 
   func testDevLauncherUrlQueryParams() {
-    let url = "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081&updateMessage=123"
+    let url = "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081&initialUrl=myapp%3A%2F%2Ffoo%2Fbar%3Fbaz%3D1&updateMessage=123"
     let devLauncherUrl = EXDevLauncherUrl(URL(string: url)!)
     let queryParams = devLauncherUrl.queryParams
 
     XCTAssertEqual(queryParams["updateMessage"], "123")
     XCTAssertEqual(queryParams["url"], "http://localhost:8081")
+    XCTAssertEqual(devLauncherUrl.initialUrl?.absoluteString, "myapp://foo/bar?baz=1")
+  }
+
+  func testDevLauncherUrlInitialURLQueryParamAlias() {
+    let url = "scheme://expo-development-client/?url=http%3A%2F%2Flocalhost%3A8081&initialURL=myapp%3A%2F%2Ffoo%2Fbar"
+    let devLauncherUrl = EXDevLauncherUrl(URL(string: url)!)
+
+    XCTAssertEqual(devLauncherUrl.url.absoluteString, "http://localhost:8081")
+    XCTAssertEqual(devLauncherUrl.initialUrl?.absoluteString, "myapp://foo/bar")
   }
 
   //  HELPER


### PR DESCRIPTION
## Why

Fixes #19846. Dev-launcher URLs use the `expo-development-client` host to select and load a bundle through the launcher, but that consumed the full launch URL before the loaded app could observe an app-specific initial URL. This blocks CI and e2e flows that need to boot a development build through dev-client while still testing `Linking.getInitialURL()`.

## How

- Adds explicit `initialUrl` support to parsed dev-launcher URLs on Android and iOS.
- Accepts `initialURL` as an alias because React Native and Expo docs commonly refer to the concept as `initialURL`.
- Keeps the existing `url` query param as the bundle URL used by dev-launcher.
- When `initialUrl` is present, Android stores a copied pending intent with `data` set to that app URL before loading the bundle.
- When `initialUrl` is present, iOS stores the URL in the pending deep-link registry before loading the bundle.
- Adds Android and iOS helper coverage for both `initialUrl` and `initialURL`.

## Test Plan

- [x] `git diff --check upstream/main...HEAD`
- [x] `ANDROID_HOME=/Users/mvincentong/Library/Android/sdk ANDROID_SDK_ROOT=/Users/mvincentong/Library/Android/sdk ./gradlew :expo-dev-launcher:compileDebugKotlin` from `apps/bare-expo/android`
- [x] `xcrun swiftc -module-cache-path /private/tmp/expo-dev-launcher-46395-verify/module-cache -typecheck -I /private/tmp/expo-dev-launcher-46395-verify packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift` with a temporary stub `EXDevMenu` module
- [x] `ANDROID_HOME=/Users/mvincentong/Library/Android/sdk ANDROID_SDK_ROOT=/Users/mvincentong/Library/Android/sdk ./gradlew :expo-dev-launcher:testDebugUnitTest --tests expo.modules.devlauncher.helpers.DevLauncherURLHelperTest` from `apps/bare-expo/android`

## Risk

Seven-file `expo-dev-launcher` diff: Android source/test, iOS source/test, and changelog. No generated output. The behavior is opt-in through an explicit `initialUrl`/`initialURL` query param; existing dev-launcher URLs without that param keep the current bundle-loading behavior.
