### PR TITLE
[jsi] Clear build intermediates

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [iOS] Throw instead of aborting when `getPropertyAsFunction` targets a missing or non-callable property. ([#46437](https://github.com/expo/expo/pull/46437) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Throw instead of aborting when `getPropertyAsObject` targets a non-object property. ([#46438](https://github.com/expo/expo/pull/46438) by [@tsapeta](https://github.com/tsapeta))
 - [iOS] Include the Swift toolchain version in the xcframework cache key so upgrading Xcode rebuilds slices instead of reusing ones built by an older compiler. ([#46523](https://github.com/expo/expo/pull/46523) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Clear stale build intermediates before rebuilding xcframework slices to avoid compiler errors. ([#46399](https://github.com/expo/expo/pull/46399) by [@alanjhughes](https://github.com/alanjhughes))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -396,16 +396,15 @@ fi
 
 PLATFORMS=("${platforms_to_build[@]}")
 
-# Wipe stale intermediates before compiling: DerivedData's module cache, the
-# SwiftPM workspace/.build tree, and the generated modulemap can reference
-# headers or module layouts that no longer match (e.g. after switching branches). 
+# Wipe stale intermediates before compiling: DerivedData's module cache and the
+# SwiftPM workspace/.build tree carry over from earlier runs and can reference
+# headers or module layouts that no longer match (e.g. after switching branches).
 # Only runs when a slice needs rebuilding, so the up-to-date fast path is unaffected.
-# Products/ is preserved. build_slice replaces only the slice it rebuilds.
-log "Clearing stale build state (DerivedData, SwiftPM, generated) before rebuild"
-rm -rf "$DERIVED_DATA_PATH" "$SPM_BUILD_PATH" "$SPM_WORKSPACE_PATH" "$GENERATED_DIR"
-
-# Recreate the modulemap we just deleted.
-PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
+# Products/ is preserved. build_slice replaces only the slice it rebuilds. The
+# generated modulemap is left intact — it was already regenerated above for the
+# cache hash, so wiping it here would just force a redundant rebuild.
+log "Clearing stale build state (DerivedData, SwiftPM) before rebuild"
+rm -rf "$DERIVED_DATA_PATH" "$SPM_BUILD_PATH" "$SPM_WORKSPACE_PATH"
 
 SECONDS=0
 

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -33,6 +33,7 @@ CONFIGURATION="Release"
 DERIVED_DATA_PATH="${PACKAGE_DIR}/.DerivedData"
 SPM_BUILD_PATH="${PACKAGE_DIR}/.build"
 SPM_WORKSPACE_PATH="${PACKAGE_DIR}/.swiftpm"
+GENERATED_DIR="${PACKAGE_DIR}/.generated"
 BUILD_PRODUCTS_PATH="${DERIVED_DATA_PATH}/Build/Products"
 
 source "${PACKAGE_DIR}/scripts/xcframework-helpers.sh"
@@ -351,7 +352,7 @@ fi
 # parent `set -eo pipefail` doesn't catch that, the modulemap never gets
 # written, and xcodebuild later fails with `no such module 'jsi'`.
 PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
-GENERATED_MODULE_MAP="${PACKAGE_DIR}/.generated/module.modulemap"
+GENERATED_MODULE_MAP="${GENERATED_DIR}/module.modulemap"
 SOURCE_FILES+=("$GENERATED_MODULE_MAP")
 
 if [[ "$CLEAN" == true ]]; then
@@ -394,6 +395,17 @@ if [[ ${#platforms_to_build[@]} -eq 0 ]]; then
 fi
 
 PLATFORMS=("${platforms_to_build[@]}")
+
+# Wipe stale intermediates before compiling: DerivedData's module cache, the
+# SwiftPM workspace/.build tree, and the generated modulemap can reference
+# headers or module layouts that no longer match (e.g. after switching branches). 
+# Only runs when a slice needs rebuilding, so the up-to-date fast path is unaffected.
+# Products/ is preserved. build_slice replaces only the slice it rebuilds.
+log "Clearing stale build state (DerivedData, SwiftPM, generated) before rebuild"
+rm -rf "$DERIVED_DATA_PATH" "$SPM_BUILD_PATH" "$SPM_WORKSPACE_PATH" "$GENERATED_DIR"
+
+# Recreate the modulemap we just deleted.
+PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
 
 SECONDS=0
 

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -33,7 +33,6 @@ CONFIGURATION="Release"
 DERIVED_DATA_PATH="${PACKAGE_DIR}/.DerivedData"
 SPM_BUILD_PATH="${PACKAGE_DIR}/.build"
 SPM_WORKSPACE_PATH="${PACKAGE_DIR}/.swiftpm"
-GENERATED_DIR="${PACKAGE_DIR}/.generated"
 BUILD_PRODUCTS_PATH="${DERIVED_DATA_PATH}/Build/Products"
 
 source "${PACKAGE_DIR}/scripts/xcframework-helpers.sh"
@@ -352,7 +351,7 @@ fi
 # parent `set -eo pipefail` doesn't catch that, the modulemap never gets
 # written, and xcodebuild later fails with `no such module 'jsi'`.
 PODS_ROOT="$PODS_ROOT" RN_ROOT="$RN_ROOT" "${PACKAGE_DIR}/scripts/generate-modulemap.sh"
-GENERATED_MODULE_MAP="${GENERATED_DIR}/module.modulemap"
+GENERATED_MODULE_MAP="${PACKAGE_DIR}/.generated/module.modulemap"
 SOURCE_FILES+=("$GENERATED_MODULE_MAP")
 
 if [[ "$CLEAN" == true ]]; then


### PR DESCRIPTION
# Why
We sometimes run into compiler errors when opening in xcode. Seems to be caused by stale intermediates from a previous build.

# How
Clear these folders before building the slices

# Test Plan
Script is working as normal. 

