### PR TITLE
[docs] Clarify template selection in Expo tutorial for SDK 54

### DIFF
--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -52,7 +52,10 @@ We'll use [`create-expo-app`](/more/create-expo/) to initialize a new Expo app. 
 <Terminal
   cmd={[
     '# Create a project named StickerSmash',
-    '$ npx create-expo-app@latest StickerSmash',
+    '$ npx create-expo-app@latest',
+    '',
+    '# CLI will prompt you to choose a template. Select SDK 54',
+    '$ Select an Expo SDK version > SDK 54',
     '',
     '# Navigate to the project directory',
     '$ cd StickerSmash',
@@ -60,9 +63,9 @@ We'll use [`create-expo-app`](/more/create-expo/) to initialize a new Expo app. 
   cmdCopy="npx create-expo-app@latest StickerSmash && cd StickerSmash"
 />
 
-This command will create a new project directory named StickerSmash, using the [default](/more/create-expo/#--template) template. This template has essential boilerplate code and libraries needed to build our app, including Expo Router. We'll continue to add more libraries throughout this tutorial as needed.
+> **info** `create-expo-app@latest` currently asks to select an Expo SDK template. This tutorial is designed for SDK 54, so make sure to select the SDK 54 template.
 
-> **info** `create-expo-app@latest` currently creates an SDK 54 project. This tutorial is designed for SDK 54, so no `--template` flag is needed.
+This command will create a new project directory named StickerSmash, using the [SDK 54's default](/more/create-expo/#--template) template. This template has essential boilerplate code and libraries needed to build our app, including Expo Router and allows us to test our app with Expo Go installed on our devices. We'll continue to add more libraries throughout this tutorial as needed.
 
 <Collapsible summary="Benefits of using the default template">
 

--- a/docs/pages/tutorial/create-your-first-app.mdx
+++ b/docs/pages/tutorial/create-your-first-app.mdx
@@ -54,7 +54,7 @@ We'll use [`create-expo-app`](/more/create-expo/) to initialize a new Expo app. 
     '# Create a project named StickerSmash',
     '$ npx create-expo-app@latest',
     '',
-    '# CLI will prompt you to choose a template. Select SDK 54',
+    '# CLI will prompt you to choose a template. Select SDK 54.',
     '$ Select an Expo SDK version > SDK 54',
     '',
     '# Navigate to the project directory',


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

In Expo tutorial, we need to specify which template to select when creating a new app.


# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<img width="2386" height="1290" alt="CleanShot 2026-05-29 at 19 13 12@2x" src="https://github.com/user-attachments/assets/acd126e1-db49-4248-bbe2-5f28c139d3f4" />

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
