### PR TITLE
[docs][file-system] Fix wrong examples

### DIFF
--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -142,7 +142,7 @@ Using the built-in `pickFileAsync` or `pickDirectoryAsync` method on Android:
 import { File } from 'expo-file-system';
 
 try {
-  const file = new File.pickFileAsync();
+  const file = await File.pickFileAsync();
   console.log(file.textSync());
 } catch (error) {
   console.error(error);

--- a/docs/pages/versions/unversioned/sdk/filesystem.mdx
+++ b/docs/pages/versions/unversioned/sdk/filesystem.mdx
@@ -228,11 +228,11 @@ try {
   file.create();
   console.log(file.uri); // '${documentDirectory}/example.txt'
   const copiedFile = new File(Paths.cache, 'example-copy.txt');
-  file.copy(copiedFile);
+  await file.copy(copiedFile); // or `file.copySync(copiedFile);` for synchronous call
   console.log(copiedFile.uri); // '${cacheDirectory}/example-copy.txt'
-  file.move(Paths.cache);
+  await file.move(Paths.cache); // or `file.moveSync(Paths.cache);` for synchronous call
   console.log(file.uri); // '${cacheDirectory}/example.txt'
-  file.move(new Directory(Paths.cache, 'newFolder'));
+  await file.move(new Directory(Paths.cache, 'newFolder'));
   console.log(file.uri); // '${cacheDirectory}/newFolder/example.txt'
 } catch (error) {
   console.error(error);

--- a/docs/pages/versions/v54.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v54.0.0/sdk/filesystem.mdx
@@ -79,7 +79,7 @@ Using the built-in `pickFileAsync` or `pickDirectoryAsync` method on Android:
 import { File } from 'expo-file-system';
 
 try {
-  const file = new File.pickFileAsync();
+  const file = await File.pickFileAsync();
   console.log(file.textSync());
 } catch (error) {
   console.error(error);

--- a/docs/pages/versions/v55.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v55.0.0/sdk/filesystem.mdx
@@ -142,7 +142,7 @@ Using the built-in `pickFileAsync` or `pickDirectoryAsync` method on Android:
 import { File } from 'expo-file-system';
 
 try {
-  const file = new File.pickFileAsync();
+  const file = await File.pickFileAsync();
   console.log(file.textSync());
 } catch (error) {
   console.error(error);

--- a/docs/pages/versions/v56.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/filesystem.mdx
@@ -142,7 +142,7 @@ Using the built-in `pickFileAsync` or `pickDirectoryAsync` method on Android:
 import { File } from 'expo-file-system';
 
 try {
-  const file = new File.pickFileAsync();
+  const file = await File.pickFileAsync();
   console.log(file.textSync());
 } catch (error) {
   console.error(error);

--- a/docs/pages/versions/v56.0.0/sdk/filesystem.mdx
+++ b/docs/pages/versions/v56.0.0/sdk/filesystem.mdx
@@ -228,11 +228,11 @@ try {
   file.create();
   console.log(file.uri); // '${documentDirectory}/example.txt'
   const copiedFile = new File(Paths.cache, 'example-copy.txt');
-  file.copy(copiedFile);
+  await file.copy(copiedFile); // or `file.copySync(copiedFile);` for synchronous call
   console.log(copiedFile.uri); // '${cacheDirectory}/example-copy.txt'
-  file.move(Paths.cache);
+  await file.move(Paths.cache); // or `file.moveSync(Paths.cache);` for synchronous call
   console.log(file.uri); // '${cacheDirectory}/example.txt'
-  file.move(new Directory(Paths.cache, 'newFolder'));
+  await file.move(new Directory(Paths.cache, 'newFolder'));
   console.log(file.uri); // '${cacheDirectory}/newFolder/example.txt'
 } catch (error) {
   console.error(error);


### PR DESCRIPTION
# Why

The example of `File.move()` and `File.copy()` became wrong after #44359. The old example treats them as sync functions
`const file = new File.pickFileAsync();` is wrong. This seems to be introduced in https://github.com/expo/expo/commit/3a926497ab83371d02569a6b8fc34c5f4df5e6dd#diff-867e916e054bea6dbdb5e0e0fe284927fdbef39aca76620b4a7ae2390948d514R81, SDK 54

# Checklist

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
