### PR TITLE
[contacts] Fix getDetails throwing NPE on malformed label

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix `getDetails` throwing NPE on malformed label ([#46405](https://github.com/expo/expo/pull/46405) by [@Wenszel](https://github.com/Wenszel))
+
 ### 💡 Others
 
 ## 56.0.7 — 2026-05-21

--- a/packages/expo-contacts/android/build.gradle
+++ b/packages/expo-contacts/android/build.gradle
@@ -13,3 +13,10 @@ android {
     versionName "56.0.7"
   }
 }
+
+dependencies {
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'io.mockk:mockk:1.13.5'
+  testImplementation "org.robolectric:robolectric:4.16"
+  testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
+}

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/ContactRepository.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/ContactRepository.kt
@@ -21,6 +21,8 @@ import expo.modules.contacts.next.domain.wrappers.RawContactId
 import expo.modules.contacts.next.extensions.asSequence
 import expo.modules.contacts.next.extensions.extractId
 import expo.modules.contacts.next.extensions.getContactIdFromRawContactId
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 import expo.modules.contacts.next.extensions.queryOne
 import expo.modules.contacts.next.extensions.safeApplyBatch
 import expo.modules.contacts.next.extensions.safeDelete
@@ -75,7 +77,7 @@ class ContactRepository(val contentResolver: ContentResolver) {
     ).use { cursor ->
       ensureActive()
       cursor.asSequence()
-        .map { it.getString(0) }
+        .map { it.getRequiredString(it.getColumnIndexOrThrow(ContactsContract.Data._ID)) }
         .map { DataId(it) }
         .toList()
     }
@@ -146,7 +148,7 @@ class ContactRepository(val contentResolver: ContentResolver) {
       cursor
         .asSequence()
         .take(limit ?: Int.MAX_VALUE)
-        .map { it.getString(it.getColumnIndexOrThrow(ContactId.COLUMN_IN_CONTACTS_TABLE)) }
+        .map { it.getRequiredString(it.getColumnIndexOrThrow(ContactId.COLUMN_IN_CONTACTS_TABLE)) }
         .map { ContactId(it) }
         .toList()
     }
@@ -272,7 +274,7 @@ class ContactRepository(val contentResolver: ContentResolver) {
     contentResolver.queryOne(
       uri = ContactsContract.Contacts.CONTENT_URI,
       column = ContactsContract.Contacts.LOOKUP_KEY,
-      extractor = Cursor::getString,
+      extractor = Cursor::getNullableString,
       selection = "${ContactId.COLUMN_IN_CONTACTS_TABLE} = ?",
       selectionArgs = arrayOf(contactId.value)
     )
@@ -286,7 +288,7 @@ class ContactRepository(val contentResolver: ContentResolver) {
     contentResolver.queryOne(
       uri = ContactsContract.RawContacts.CONTENT_URI,
       column = RawContactId.COLUMN_IN_RAW_CONTACTS_TABLE,
-      extractor = Cursor::getString,
+      extractor = Cursor::getRequiredString,
       selection = selectionBuilder.toString(),
       selectionArgs = arrayOf(contactId.value)
     )?.let {

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/email/EmailField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/email/EmailField.kt
@@ -5,6 +5,9 @@ import android.provider.ContactsContract.CommonDataKinds.Email
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.email.operations.ExistingEmail
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableInt
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object EmailField : ExtractableField.Data<ExistingEmail> {
   override val mimeType = Email.CONTENT_ITEM_TYPE
@@ -18,21 +21,25 @@ object EmailField : ExtractableField.Data<ExistingEmail> {
 
   override fun extract(cursor: Cursor): ExistingEmail = with(cursor) {
     return ExistingEmail(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
-      address = getString(getColumnIndexOrThrow(Email.ADDRESS)),
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      address = getNullableString(getColumnIndexOrThrow(Email.ADDRESS)),
       label = extractLabel()
     )
   }
 
   private fun Cursor.extractLabel(): EmailLabel =
-    when (getInt(getColumnIndexOrThrow(Email.TYPE))) {
+    when (getNullableInt(Email.TYPE)) {
       Email.TYPE_HOME -> EmailLabel.Home
       Email.TYPE_WORK -> EmailLabel.Work
       Email.TYPE_OTHER -> EmailLabel.Other
       Email.TYPE_MOBILE -> EmailLabel.Mobile
+      null -> {
+        val customLabel = getNullableString(getColumnIndexOrThrow(Email.LABEL))
+        EmailLabel.MalformedType(customLabel)
+      }
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Email.LABEL))
-        EmailLabel.Custom(customLabel ?: "")
+        val customLabel = getNullableString(getColumnIndexOrThrow(Email.LABEL))
+        customLabel?.let { EmailLabel.Custom(it) } ?: EmailLabel.MalformedCustom
       }
     }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/email/EmailLabel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/email/EmailLabel.kt
@@ -2,10 +2,15 @@ package expo.modules.contacts.next.domain.model.email
 
 import android.provider.ContactsContract.CommonDataKinds.Email
 
-sealed class EmailLabel(val type: Int, val label: String? = null) {
+sealed class EmailLabel(val type: Int?, val label: String? = null) {
   object Home : EmailLabel(Email.TYPE_HOME)
   object Work : EmailLabel(Email.TYPE_WORK)
   object Other : EmailLabel(Email.TYPE_OTHER)
   object Mobile : EmailLabel(Email.TYPE_MOBILE)
   class Custom(label: String) : EmailLabel(Email.TYPE_CUSTOM, label)
+
+  // Ideally these states would not be necessary, but Android does not enforce
+  // type and label columns as non-null, so malformed label data can exist there.
+  class MalformedType(label: String?) : EmailLabel(null, label)
+  object MalformedCustom : EmailLabel(Email.TYPE_CUSTOM)
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/event/EventField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/event/EventField.kt
@@ -6,6 +6,9 @@ import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.event.operations.ExistingEvent
 import expo.modules.contacts.next.domain.wrappers.ContactDate
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableInt
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object EventField : ExtractableField.Data<ExistingEvent> {
   override val mimeType = Event.CONTENT_ITEM_TYPE
@@ -18,23 +21,27 @@ object EventField : ExtractableField.Data<ExistingEvent> {
   )
 
   override fun extract(cursor: Cursor): ExistingEvent = with(cursor) {
-    val dateString = getString(getColumnIndexOrThrow(Event.START_DATE))
+    val dateString = getNullableString(getColumnIndexOrThrow(Event.START_DATE))
 
     return ExistingEvent(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
       startDate = if (dateString != null) ContactDate(dateString) else null,
       label = extractLabel()
     )
   }
 
   private fun Cursor.extractLabel(): EventLabel =
-    when (getInt(getColumnIndexOrThrow(Event.TYPE))) {
+    when (getNullableInt(Event.TYPE)) {
       Event.TYPE_ANNIVERSARY -> EventLabel.Anniversary
       Event.TYPE_BIRTHDAY -> EventLabel.Birthday
       Event.TYPE_OTHER -> EventLabel.Other
+      null -> {
+        val customLabel = getNullableString(getColumnIndexOrThrow(Event.LABEL))
+        EventLabel.MalformedType(customLabel)
+      }
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Event.LABEL))
-        EventLabel.Custom(customLabel)
+        val customLabel = getNullableString(getColumnIndexOrThrow(Event.LABEL))
+        customLabel?.let { EventLabel.Custom(it) } ?: EventLabel.MalformedCustom
       }
     }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/event/EventLabel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/event/EventLabel.kt
@@ -2,9 +2,14 @@ package expo.modules.contacts.next.domain.model.event
 
 import android.provider.ContactsContract.CommonDataKinds.Event
 
-sealed class EventLabel(val type: Int, val label: String? = null) {
+sealed class EventLabel(val type: Int?, val label: String? = null) {
   object Anniversary : EventLabel(Event.TYPE_ANNIVERSARY)
   object Birthday : EventLabel(Event.TYPE_BIRTHDAY)
   object Other : EventLabel(Event.TYPE_OTHER)
   class Custom(label: String) : EventLabel(Event.TYPE_CUSTOM, label)
+
+  // Ideally these states would not be necessary, but Android does not enforce
+  // type and label columns as non-null, so malformed label data can exist there.
+  class MalformedType(label: String?) : EventLabel(null, label)
+  object MalformedCustom : EventLabel(Event.TYPE_CUSTOM)
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/headers/DisplayNameField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/headers/DisplayNameField.kt
@@ -4,15 +4,14 @@ import android.database.Cursor
 import android.provider.ContactsContract.Contacts
 import expo.modules.contacts.next.domain.model.Extractable
 import expo.modules.contacts.next.domain.model.ExtractableField
+import expo.modules.contacts.next.extensions.getNullableString
 
 object DisplayNameField : ExtractableField.Contacts<DisplayName> {
   override val projection = arrayOf(Contacts.DISPLAY_NAME)
 
   override fun extract(cursor: Cursor) =
     DisplayName(
-      cursor.getString(
-        cursor.getColumnIndexOrThrow(Contacts.DISPLAY_NAME)
-      )
+      cursor.getNullableString(cursor.getColumnIndexOrThrow(Contacts.DISPLAY_NAME))
     )
 }
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/headers/PhotoThumbnailUriField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/headers/PhotoThumbnailUriField.kt
@@ -4,13 +4,14 @@ import android.database.Cursor
 import android.provider.ContactsContract.Contacts
 import expo.modules.contacts.next.domain.model.Extractable
 import expo.modules.contacts.next.domain.model.ExtractableField
+import expo.modules.contacts.next.extensions.getNullableString
 
 object PhotoThumbnailUriField : ExtractableField.Contacts<PhotoThumbnailUri> {
   override val projection = arrayOf(Contacts.PHOTO_THUMBNAIL_URI)
 
   override fun extract(cursor: Cursor) =
     PhotoThumbnailUri(
-      cursor.getString(cursor.getColumnIndexOrThrow(Contacts.PHOTO_THUMBNAIL_URI))
+      cursor.getNullableString(cursor.getColumnIndexOrThrow(Contacts.PHOTO_THUMBNAIL_URI))
     )
 }
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/headers/PhotoUriField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/headers/PhotoUriField.kt
@@ -4,15 +4,14 @@ import android.database.Cursor
 import android.provider.ContactsContract.Contacts
 import expo.modules.contacts.next.domain.model.Extractable
 import expo.modules.contacts.next.domain.model.ExtractableField
+import expo.modules.contacts.next.extensions.getNullableString
 
 object PhotoUriField : ExtractableField.Contacts<PhotoUri> {
   override val projection = arrayOf(Contacts.PHOTO_URI)
 
   override fun extract(cursor: Cursor) =
     PhotoUri(
-      cursor.getString(
-        cursor.getColumnIndexOrThrow(Contacts.PHOTO_URI)
-      )
+      cursor.getNullableString(cursor.getColumnIndexOrThrow(Contacts.PHOTO_URI))
     )
 }
 

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/nickname/NicknameField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/nickname/NicknameField.kt
@@ -5,6 +5,9 @@ import android.provider.ContactsContract.CommonDataKinds.Nickname
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.nickname.operations.ExistingNickname
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableInt
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object NicknameField : ExtractableField.Data<ExistingNickname> {
   override val mimeType = Nickname.CONTENT_ITEM_TYPE
@@ -18,22 +21,26 @@ object NicknameField : ExtractableField.Data<ExistingNickname> {
 
   override fun extract(cursor: Cursor): ExistingNickname = with(cursor) {
     return ExistingNickname(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
-      name = getString(getColumnIndexOrThrow(Nickname.NAME)),
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      name = getNullableString(getColumnIndexOrThrow(Nickname.NAME)),
       label = extractLabel()
     )
   }
 
   private fun Cursor.extractLabel(): NicknameLabel =
-    when (getInt(getColumnIndexOrThrow(Nickname.TYPE))) {
+    when (getNullableInt(Nickname.TYPE)) {
       Nickname.TYPE_DEFAULT -> NicknameLabel.Default
       Nickname.TYPE_OTHER_NAME -> NicknameLabel.OtherName
       Nickname.TYPE_MAIDEN_NAME -> NicknameLabel.MaidenName
       Nickname.TYPE_SHORT_NAME -> NicknameLabel.ShortName
       Nickname.TYPE_INITIALS -> NicknameLabel.Initials
+      null -> {
+        val customLabel = getNullableString(getColumnIndexOrThrow(Nickname.LABEL))
+        NicknameLabel.MalformedType(customLabel)
+      }
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Nickname.LABEL))
-        NicknameLabel.Custom(customLabel)
+        val customLabel = getNullableString(getColumnIndexOrThrow(Nickname.LABEL))
+        customLabel?.let { NicknameLabel.Custom(it) } ?: NicknameLabel.MalformedCustom
       }
     }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/nickname/NicknameLabel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/nickname/NicknameLabel.kt
@@ -2,11 +2,16 @@ package expo.modules.contacts.next.domain.model.nickname
 
 import android.provider.ContactsContract.CommonDataKinds.Nickname
 
-sealed class NicknameLabel(val type: Int, val label: String? = null) {
+sealed class NicknameLabel(val type: Int?, val label: String? = null) {
   object Default : NicknameLabel(Nickname.TYPE_DEFAULT)
   object OtherName : NicknameLabel(Nickname.TYPE_OTHER_NAME)
   object MaidenName : NicknameLabel(Nickname.TYPE_MAIDEN_NAME)
   object ShortName : NicknameLabel(Nickname.TYPE_SHORT_NAME)
   object Initials : NicknameLabel(Nickname.TYPE_INITIALS)
   class Custom(label: String) : NicknameLabel(Nickname.TYPE_CUSTOM, label)
+
+  // Ideally these states would not be necessary, but Android does not enforce
+  // type and label columns as non-null, so malformed label data can exist there.
+  class MalformedType(label: String?) : NicknameLabel(null, label)
+  object MalformedCustom : NicknameLabel(Nickname.TYPE_CUSTOM)
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/note/NoteField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/note/NoteField.kt
@@ -5,6 +5,8 @@ import android.provider.ContactsContract.CommonDataKinds.Note
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.note.operations.ExistingNote
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object NoteField : ExtractableField.Data<ExistingNote> {
   override val projection = arrayOf(
@@ -16,7 +18,7 @@ object NoteField : ExtractableField.Data<ExistingNote> {
 
   override fun extract(cursor: Cursor) =
     ExistingNote(
-      dataId = DataId(cursor.getString(cursor.getColumnIndexOrThrow(Note._ID))),
-      note = cursor.getString(cursor.getColumnIndexOrThrow(Note.NOTE))
+      dataId = DataId(cursor.getRequiredString(cursor.getColumnIndexOrThrow(Note._ID))),
+      note = cursor.getNullableString(cursor.getColumnIndexOrThrow(Note.NOTE))
     )
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/organization/OrganizationField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/organization/OrganizationField.kt
@@ -5,6 +5,8 @@ import android.provider.ContactsContract.CommonDataKinds.Organization
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.organization.operations.ExistingOrganization
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object OrganizationField : ExtractableField.Data<ExistingOrganization> {
   override val mimeType = Organization.CONTENT_ITEM_TYPE
@@ -19,11 +21,11 @@ object OrganizationField : ExtractableField.Data<ExistingOrganization> {
 
   override fun extract(cursor: Cursor): ExistingOrganization = with(cursor) {
     return ExistingOrganization(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
-      company = getString(getColumnIndexOrThrow(Organization.COMPANY)),
-      department = getString(getColumnIndexOrThrow(Organization.DEPARTMENT)),
-      jobTitle = getString(getColumnIndexOrThrow(Organization.TITLE)),
-      phoneticName = getString(getColumnIndexOrThrow(Organization.PHONETIC_NAME))
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      company = getNullableString(getColumnIndexOrThrow(Organization.COMPANY)),
+      department = getNullableString(getColumnIndexOrThrow(Organization.DEPARTMENT)),
+      jobTitle = getNullableString(getColumnIndexOrThrow(Organization.TITLE)),
+      phoneticName = getNullableString(getColumnIndexOrThrow(Organization.PHONETIC_NAME))
     )
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/phone/PhoneField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/phone/PhoneField.kt
@@ -5,6 +5,9 @@ import android.provider.ContactsContract.CommonDataKinds.Phone
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.phone.operations.ExistingPhone
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableInt
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object PhoneField : ExtractableField.Data<ExistingPhone> {
   override val mimeType = Phone.CONTENT_ITEM_TYPE
@@ -18,14 +21,14 @@ object PhoneField : ExtractableField.Data<ExistingPhone> {
 
   override fun extract(cursor: Cursor): ExistingPhone = with(cursor) {
     return ExistingPhone(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
-      number = getString(getColumnIndexOrThrow(Phone.NUMBER)),
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      number = getNullableString(getColumnIndexOrThrow(Phone.NUMBER)),
       label = extractLabel()
     )
   }
 
   private fun Cursor.extractLabel(): PhoneLabel =
-    when (getInt(getColumnIndexOrThrow(Phone.TYPE))) {
+    when (getNullableInt(Phone.TYPE)) {
       Phone.TYPE_HOME -> PhoneLabel.Home
       Phone.TYPE_MOBILE -> PhoneLabel.Mobile
       Phone.TYPE_WORK -> PhoneLabel.Work
@@ -46,9 +49,13 @@ object PhoneField : ExtractableField.Data<ExistingPhone> {
       Phone.TYPE_WORK_PAGER -> PhoneLabel.WorkPager
       Phone.TYPE_ASSISTANT -> PhoneLabel.Assistant
       Phone.TYPE_MMS -> PhoneLabel.Mms
+      null -> {
+        val customLabel = getNullableString(getColumnIndexOrThrow(Phone.LABEL))
+        PhoneLabel.MalformedType(customLabel)
+      }
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Phone.LABEL))
-        PhoneLabel.Custom(customLabel)
+        val customLabel = getNullableString(getColumnIndexOrThrow(Phone.LABEL))
+        customLabel?.let { PhoneLabel.Custom(it) } ?: PhoneLabel.MalformedCustom
       }
     }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/phone/PhoneLabel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/phone/PhoneLabel.kt
@@ -2,7 +2,7 @@ package expo.modules.contacts.next.domain.model.phone
 
 import android.provider.ContactsContract.CommonDataKinds.Phone
 
-sealed class PhoneLabel(val type: Int, val label: String? = null) {
+sealed class PhoneLabel(val type: Int?, val label: String? = null) {
   object Home : PhoneLabel(Phone.TYPE_HOME)
   object Mobile : PhoneLabel(Phone.TYPE_MOBILE)
   object Work : PhoneLabel(Phone.TYPE_WORK)
@@ -24,4 +24,9 @@ sealed class PhoneLabel(val type: Int, val label: String? = null) {
   object Assistant : PhoneLabel(Phone.TYPE_ASSISTANT)
   object Mms : PhoneLabel(Phone.TYPE_MMS)
   class Custom(label: String) : PhoneLabel(Phone.TYPE_CUSTOM, label)
+
+  // Ideally these states would not be necessary, but Android does not enforce
+  // type and label columns as non-null, so malformed label data can exist there.
+  class MalformedType(label: String?) : PhoneLabel(null, label)
+  object MalformedCustom : PhoneLabel(Phone.TYPE_CUSTOM)
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/photo/PhotoField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/photo/PhotoField.kt
@@ -5,6 +5,7 @@ import android.provider.ContactsContract.CommonDataKinds.Photo
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.photo.operations.ExistingPhoto
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object PhotoField : ExtractableField.Data<ExistingPhoto> {
   override val mimeType = Photo.CONTENT_ITEM_TYPE
@@ -16,7 +17,7 @@ object PhotoField : ExtractableField.Data<ExistingPhoto> {
 
   override fun extract(cursor: Cursor): ExistingPhoto = with(cursor) {
     return@with ExistingPhoto(
-      dataId = DataId(getString(getColumnIndexOrThrow(Photo._ID))),
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(Photo._ID))),
       photo = getBlob(getColumnIndexOrThrow(Photo.PHOTO))
     )
   }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/relationship/RelationField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/relationship/RelationField.kt
@@ -5,6 +5,9 @@ import android.provider.ContactsContract.CommonDataKinds.Relation
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.relationship.operations.ExistingRelation
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableInt
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object RelationField : ExtractableField.Data<ExistingRelation> {
   override val projection = arrayOf(Relation._ID, Relation.NAME, Relation.TYPE, Relation.LABEL)
@@ -13,14 +16,14 @@ object RelationField : ExtractableField.Data<ExistingRelation> {
 
   override fun extract(cursor: Cursor): ExistingRelation = with(cursor) {
     return ExistingRelation(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
-      name = getString(getColumnIndexOrThrow(Relation.NAME)),
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      name = getNullableString(getColumnIndexOrThrow(Relation.NAME)),
       label = extractLabel()
     )
   }
 
   private fun Cursor.extractLabel() =
-    when (getInt(getColumnIndexOrThrow(Relation.TYPE))) {
+    when (getNullableInt(Relation.TYPE)) {
       Relation.TYPE_ASSISTANT -> RelationLabel.Assistant
       Relation.TYPE_BROTHER -> RelationLabel.Brother
       Relation.TYPE_CHILD -> RelationLabel.Child
@@ -35,9 +38,13 @@ object RelationField : ExtractableField.Data<ExistingRelation> {
       Relation.TYPE_RELATIVE -> RelationLabel.Relative
       Relation.TYPE_SISTER -> RelationLabel.Sister
       Relation.TYPE_SPOUSE -> RelationLabel.Spouse
+      null -> {
+        val customLabel = getNullableString(getColumnIndexOrThrow(Relation.LABEL))
+        RelationLabel.MalformedType(customLabel)
+      }
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Relation.LABEL))
-        RelationLabel.Custom(customLabel)
+        val customLabel = getNullableString(getColumnIndexOrThrow(Relation.LABEL))
+        customLabel?.let { RelationLabel.Custom(it) } ?: RelationLabel.MalformedCustom
       }
     }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/relationship/RelationLabel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/relationship/RelationLabel.kt
@@ -2,7 +2,7 @@ package expo.modules.contacts.next.domain.model.relationship
 
 import android.provider.ContactsContract.CommonDataKinds.Relation
 
-sealed class RelationLabel(val type: Int, val label: String? = null) {
+sealed class RelationLabel(val type: Int?, val label: String? = null) {
   object Assistant : RelationLabel(Relation.TYPE_ASSISTANT)
   object Brother : RelationLabel(Relation.TYPE_BROTHER)
   object Child : RelationLabel(Relation.TYPE_CHILD)
@@ -18,4 +18,9 @@ sealed class RelationLabel(val type: Int, val label: String? = null) {
   object Sister : RelationLabel(Relation.TYPE_SISTER)
   object Spouse : RelationLabel(Relation.TYPE_SPOUSE)
   class Custom(label: String) : RelationLabel(Relation.TYPE_CUSTOM, label)
+
+  // Ideally these states would not be necessary, but Android does not enforce
+  // type and label columns as non-null, so malformed label data can exist there.
+  class MalformedType(label: String?) : RelationLabel(null, label)
+  object MalformedCustom : RelationLabel(Relation.TYPE_CUSTOM)
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/structuredname/StructuredNameField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/structuredname/StructuredNameField.kt
@@ -6,6 +6,8 @@ import android.provider.ContactsContract.CommonDataKinds.StructuredName
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.structuredname.operations.ExistingStructuredName
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object StructuredNameField : ExtractableField.Data<ExistingStructuredName> {
   override val mimeType = StructuredName.CONTENT_ITEM_TYPE
@@ -26,15 +28,15 @@ object StructuredNameField : ExtractableField.Data<ExistingStructuredName> {
 
   override fun extract(cursor: Cursor): ExistingStructuredName = with(cursor) {
     return ExistingStructuredName(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
-      givenName = getString(getColumnIndexOrThrow(StructuredName.GIVEN_NAME)),
-      familyName = getString(getColumnIndexOrThrow(StructuredName.FAMILY_NAME)),
-      middleName = getString(getColumnIndexOrThrow(StructuredName.MIDDLE_NAME)),
-      prefix = getString(getColumnIndexOrThrow(StructuredName.PREFIX)),
-      suffix = getString(getColumnIndexOrThrow(StructuredName.SUFFIX)),
-      phoneticGivenName = getString(getColumnIndexOrThrow(StructuredName.PHONETIC_GIVEN_NAME)),
-      phoneticMiddleName = getString(getColumnIndexOrThrow(StructuredName.PHONETIC_MIDDLE_NAME)),
-      phoneticFamilyName = getString(getColumnIndexOrThrow(StructuredName.PHONETIC_FAMILY_NAME))
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      givenName = getNullableString(getColumnIndexOrThrow(StructuredName.GIVEN_NAME)),
+      familyName = getNullableString(getColumnIndexOrThrow(StructuredName.FAMILY_NAME)),
+      middleName = getNullableString(getColumnIndexOrThrow(StructuredName.MIDDLE_NAME)),
+      prefix = getNullableString(getColumnIndexOrThrow(StructuredName.PREFIX)),
+      suffix = getNullableString(getColumnIndexOrThrow(StructuredName.SUFFIX)),
+      phoneticGivenName = getNullableString(getColumnIndexOrThrow(StructuredName.PHONETIC_GIVEN_NAME)),
+      phoneticMiddleName = getNullableString(getColumnIndexOrThrow(StructuredName.PHONETIC_MIDDLE_NAME)),
+      phoneticFamilyName = getNullableString(getColumnIndexOrThrow(StructuredName.PHONETIC_FAMILY_NAME))
     )
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/structuredpostal/StructuredPostalField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/structuredpostal/StructuredPostalField.kt
@@ -5,6 +5,9 @@ import android.provider.ContactsContract.CommonDataKinds.StructuredPostal
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.structuredpostal.operations.ExistingStructuredPostal
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableInt
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object StructuredPostalField : ExtractableField.Data<ExistingStructuredPostal> {
   override val mimeType = StructuredPostal.CONTENT_ITEM_TYPE
@@ -22,24 +25,28 @@ object StructuredPostalField : ExtractableField.Data<ExistingStructuredPostal> {
 
   override fun extract(cursor: Cursor): ExistingStructuredPostal = with(cursor) {
     return ExistingStructuredPostal(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
-      street = getString(getColumnIndexOrThrow(StructuredPostal.STREET)),
-      city = getString(getColumnIndexOrThrow(StructuredPostal.CITY)),
-      region = getString(getColumnIndexOrThrow(StructuredPostal.REGION)),
-      postcode = getString(getColumnIndexOrThrow(StructuredPostal.POSTCODE)),
-      country = getString(getColumnIndexOrThrow(StructuredPostal.COUNTRY)),
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      street = getNullableString(getColumnIndexOrThrow(StructuredPostal.STREET)),
+      city = getNullableString(getColumnIndexOrThrow(StructuredPostal.CITY)),
+      region = getNullableString(getColumnIndexOrThrow(StructuredPostal.REGION)),
+      postcode = getNullableString(getColumnIndexOrThrow(StructuredPostal.POSTCODE)),
+      country = getNullableString(getColumnIndexOrThrow(StructuredPostal.COUNTRY)),
       label = extractLabel()
     )
   }
 
   private fun Cursor.extractLabel() =
-    when (getInt(getColumnIndexOrThrow(StructuredPostal.TYPE))) {
+    when (getNullableInt(StructuredPostal.TYPE)) {
       StructuredPostal.TYPE_HOME -> StructuredPostalLabel.Home
       StructuredPostal.TYPE_WORK -> StructuredPostalLabel.Work
       StructuredPostal.TYPE_OTHER -> StructuredPostalLabel.Other
+      null -> {
+        val customLabel = getNullableString(getColumnIndexOrThrow(StructuredPostal.LABEL))
+        StructuredPostalLabel.MalformedType(customLabel)
+      }
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(StructuredPostal.LABEL))
-        StructuredPostalLabel.Custom(customLabel)
+        val customLabel = getNullableString(getColumnIndexOrThrow(StructuredPostal.LABEL))
+        customLabel?.let { StructuredPostalLabel.Custom(it) } ?: StructuredPostalLabel.MalformedCustom
       }
     }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/structuredpostal/StructuredPostalLabel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/structuredpostal/StructuredPostalLabel.kt
@@ -2,9 +2,14 @@ package expo.modules.contacts.next.domain.model.structuredpostal
 
 import android.provider.ContactsContract.CommonDataKinds.StructuredPostal
 
-sealed class StructuredPostalLabel(val type: Int, val label: String? = null) {
+sealed class StructuredPostalLabel(val type: Int?, val label: String? = null) {
   object Home : StructuredPostalLabel(StructuredPostal.TYPE_HOME)
   object Work : StructuredPostalLabel(StructuredPostal.TYPE_WORK)
   object Other : StructuredPostalLabel(StructuredPostal.TYPE_OTHER)
   class Custom(label: String) : StructuredPostalLabel(StructuredPostal.TYPE_CUSTOM, label)
+
+  // Ideally these states would not be necessary, but Android does not enforce
+  // type and label columns as non-null, so malformed label data can exist there.
+  class MalformedType(label: String?) : StructuredPostalLabel(null, label)
+  object MalformedCustom : StructuredPostalLabel(StructuredPostal.TYPE_CUSTOM)
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/website/WebsiteField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/website/WebsiteField.kt
@@ -5,6 +5,9 @@ import android.provider.ContactsContract.CommonDataKinds.Website
 import expo.modules.contacts.next.domain.model.ExtractableField
 import expo.modules.contacts.next.domain.model.website.operations.ExistingWebsite
 import expo.modules.contacts.next.domain.wrappers.DataId
+import expo.modules.contacts.next.extensions.getNullableInt
+import expo.modules.contacts.next.extensions.getNullableString
+import expo.modules.contacts.next.extensions.getRequiredString
 
 object WebsiteField : ExtractableField.Data<ExistingWebsite> {
   override val projection = arrayOf(Website._ID, Website.URL, Website.TYPE, Website.LABEL)
@@ -13,14 +16,14 @@ object WebsiteField : ExtractableField.Data<ExistingWebsite> {
 
   override fun extract(cursor: Cursor): ExistingWebsite = with(cursor) {
     return ExistingWebsite(
-      dataId = DataId(getString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
-      url = getString(getColumnIndexOrThrow(Website.URL)),
+      dataId = DataId(getRequiredString(getColumnIndexOrThrow(DataId.COLUMN_IN_DATA_TABLE))),
+      url = getNullableString(getColumnIndexOrThrow(Website.URL)),
       label = extractLabel()
     )
   }
 
   private fun Cursor.extractLabel() =
-    when (getInt(getColumnIndexOrThrow(Website.TYPE))) {
+    when (getNullableInt(Website.TYPE)) {
       Website.TYPE_HOMEPAGE -> WebsiteLabel.Homepage
       Website.TYPE_BLOG -> WebsiteLabel.Blog
       Website.TYPE_FTP -> WebsiteLabel.Ftp
@@ -28,9 +31,13 @@ object WebsiteField : ExtractableField.Data<ExistingWebsite> {
       Website.TYPE_WORK -> WebsiteLabel.Work
       Website.TYPE_OTHER -> WebsiteLabel.Other
       Website.TYPE_PROFILE -> WebsiteLabel.Profile
+      null -> {
+        val customLabel = getNullableString(getColumnIndexOrThrow(Website.LABEL))
+        WebsiteLabel.MalformedType(customLabel)
+      }
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Website.LABEL))
-        WebsiteLabel.Custom(customLabel)
+        val customLabel = getNullableString(getColumnIndexOrThrow(Website.LABEL))
+        customLabel?.let { WebsiteLabel.Custom(it) } ?: WebsiteLabel.MalformedCustom
       }
     }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/website/WebsiteLabel.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/website/WebsiteLabel.kt
@@ -2,7 +2,7 @@ package expo.modules.contacts.next.domain.model.website
 
 import android.provider.ContactsContract.CommonDataKinds.Website
 
-sealed class WebsiteLabel(val type: Int, val label: String? = null) {
+sealed class WebsiteLabel(val type: Int?, val label: String? = null) {
   object Homepage : WebsiteLabel(Website.TYPE_HOMEPAGE)
   object Blog : WebsiteLabel(Website.TYPE_BLOG)
   object Ftp : WebsiteLabel(Website.TYPE_FTP)
@@ -11,4 +11,9 @@ sealed class WebsiteLabel(val type: Int, val label: String? = null) {
   object Other : WebsiteLabel(Website.TYPE_OTHER)
   object Profile : WebsiteLabel(Website.TYPE_PROFILE)
   class Custom(label: String) : WebsiteLabel(Website.TYPE_CUSTOM, label)
+
+  // Ideally these states would not be necessary, but Android does not enforce
+  // type and label columns as non-null, so malformed label data can exist there.
+  class MalformedType(label: String?) : WebsiteLabel(null, label)
+  object MalformedCustom : WebsiteLabel(Website.TYPE_CUSTOM)
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/query/QueryAggregator.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/query/QueryAggregator.kt
@@ -21,6 +21,7 @@ import expo.modules.contacts.next.domain.model.structuredname.operations.Existin
 import expo.modules.contacts.next.domain.model.structuredpostal.operations.ExistingStructuredPostal
 import expo.modules.contacts.next.domain.model.website.operations.ExistingWebsite
 import expo.modules.contacts.next.domain.wrappers.ContactId
+import expo.modules.contacts.next.extensions.getRequiredString
 
 class QueryAggregator(extractableFields: Collection<ExtractableField<*>>) {
   private val contactsExtractableFields = extractableFields.filterIsInstance<ExtractableField.Contacts<*>>()
@@ -33,8 +34,8 @@ class QueryAggregator(extractableFields: Collection<ExtractableField<*>>) {
   fun buildContacts(): List<ExistingContact> = contactBuilders.values.map { it.build() }
 
   fun aggregateDataRow(cursor: Cursor) {
-    val contactId = cursor.getString(cursor.getColumnIndexOrThrow(ContactId.COLUMN_IN_DATA_TABLE))
-    val mime = cursor.getString(cursor.getColumnIndexOrThrow(ContactsContract.Data.MIMETYPE))
+    val contactId = cursor.getRequiredString(cursor.getColumnIndexOrThrow(ContactId.COLUMN_IN_DATA_TABLE))
+    val mime = cursor.getRequiredString(cursor.getColumnIndexOrThrow(ContactsContract.Data.MIMETYPE))
     val builder = contactBuilders.getOrPut(contactId) {
       ContactModelBuilder(ContactId(contactId))
     }
@@ -45,7 +46,7 @@ class QueryAggregator(extractableFields: Collection<ExtractableField<*>>) {
   }
 
   fun aggregateContactsRow(cursor: Cursor) {
-    val contactId = cursor.getString(cursor.getColumnIndexOrThrow(ContactId.COLUMN_IN_CONTACTS_TABLE))
+    val contactId = cursor.getRequiredString(cursor.getColumnIndexOrThrow(ContactId.COLUMN_IN_CONTACTS_TABLE))
     val builder = contactBuilders.getOrPut(contactId) {
       ContactModelBuilder(ContactId(contactId))
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/extensions/ContentResolverExtensions.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/extensions/ContentResolverExtensions.kt
@@ -50,7 +50,7 @@ suspend fun ContentResolver.getContactIdFromRawContactId(
   val contactIdString = queryOne(
     uri = ContactsContract.RawContacts.CONTENT_URI,
     column = ContactId.COLUMN_IN_RAW_CONTACTS_TABLE,
-    extractor = Cursor::getString,
+    extractor = Cursor::getRequiredString,
     selection = "${ContactsContract.RawContacts._ID} = ?",
     selectionArgs = arrayOf(rawContactId.value)
   )

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/extensions/CursorExtensions.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/extensions/CursorExtensions.kt
@@ -7,3 +7,16 @@ fun Cursor.asSequence(): Sequence<Cursor> = sequence {
     yield(this@asSequence)
   }
 }
+
+// This wrapper enforces null-safety, because the default getString() method returns String! type
+fun Cursor.getNullableString(columnIndex: Int): String? =
+  getString(columnIndex)
+
+fun Cursor.getRequiredString(columnIndex: Int): String =
+  getNullableString(columnIndex)
+    ?: throw IllegalStateException("Column at index $columnIndex was null")
+
+fun Cursor.getNullableInt(columnName: String): Int? {
+  val columnIndex = getColumnIndexOrThrow(columnName)
+  return if (isNull(columnIndex)) null else getInt(columnIndex)
+}

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/EmailLabelMapper.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/EmailLabelMapper.kt
@@ -30,6 +30,8 @@ object EmailLabelMapper {
       is EmailLabel.Mobile -> "mobile"
       is EmailLabel.Other -> "other"
       is EmailLabel.Custom -> label.label
+      is EmailLabel.MalformedType -> label.label
+      is EmailLabel.MalformedCustom -> null
     }
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/EventLabelMapper.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/EventLabelMapper.kt
@@ -29,6 +29,8 @@ object EventLabelMapper {
       is EventLabel.Birthday -> "birthday"
       is EventLabel.Other -> "other"
       is EventLabel.Custom -> label.label
+      is EventLabel.MalformedType -> label.label
+      is EventLabel.MalformedCustom -> null
     }
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/NicknameLabelMapper.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/NicknameLabelMapper.kt
@@ -32,6 +32,8 @@ object NicknameLabelMapper {
       is NicknameLabel.ShortName -> "shortName"
       is NicknameLabel.Initials -> "initials"
       is NicknameLabel.Custom -> label.label
+      is NicknameLabel.MalformedType -> label.label
+      is NicknameLabel.MalformedCustom -> null
     }
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/PhoneLabelMapper.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/PhoneLabelMapper.kt
@@ -62,6 +62,8 @@ object PhoneLabelMapper {
       is PhoneLabel.Assistant -> "assistant"
       is PhoneLabel.Mms -> "mms"
       is PhoneLabel.Custom -> label.label
+      is PhoneLabel.MalformedType -> label.label
+      is PhoneLabel.MalformedCustom -> null
     }
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/RelationshipLabelMapper.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/RelationshipLabelMapper.kt
@@ -50,6 +50,8 @@ object RelationshipLabelMapper {
       is RelationLabel.Sister -> "sister"
       is RelationLabel.Spouse -> "spouse"
       is RelationLabel.Custom -> label.label
+      is RelationLabel.MalformedType -> label.label
+      is RelationLabel.MalformedCustom -> null
     }
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/StructuredPostalLabelMapper.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/StructuredPostalLabelMapper.kt
@@ -28,6 +28,8 @@ object StructuredPostalLabelMapper {
       is StructuredPostalLabel.Work -> "work"
       is StructuredPostalLabel.Other -> "other"
       is StructuredPostalLabel.Custom -> label.label
+      is StructuredPostalLabel.MalformedType -> label.label
+      is StructuredPostalLabel.MalformedCustom -> null
     }
   }
 }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/WebsiteLabelMapper.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/mappers/domain/data/list/label/WebsiteLabelMapper.kt
@@ -36,6 +36,8 @@ object WebsiteLabelMapper {
       is WebsiteLabel.Other -> "other"
       is WebsiteLabel.Profile -> "profile"
       is WebsiteLabel.Custom -> label.label
+      is WebsiteLabel.MalformedType -> label.label
+      is WebsiteLabel.MalformedCustom -> null
     }
   }
 }

--- a/packages/expo-contacts/android/src/test/java/expo/modules/contacts/next/domain/ContactRepositoryTest.kt
+++ b/packages/expo-contacts/android/src/test/java/expo/modules/contacts/next/domain/ContactRepositoryTest.kt
@@ -1,0 +1,80 @@
+package expo.modules.contacts.next.domain
+
+import android.content.ContentResolver
+import android.database.Cursor
+import android.database.MatrixCursor
+import android.provider.ContactsContract.CommonDataKinds.Phone
+import expo.modules.contacts.next.domain.model.phone.PhoneField
+import expo.modules.contacts.next.domain.model.phone.PhoneLabel
+import expo.modules.contacts.next.domain.wrappers.ContactId
+import expo.modules.contacts.next.domain.wrappers.DataId
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class ContactRepositoryTest {
+  private val contentResolver = mockk<ContentResolver>()
+  private val repository = ContactRepository(contentResolver)
+
+  @Test
+  fun `given phone row with custom type and null label, when getFieldFromData, then maps to malformed custom`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      mapOf(
+        DataId.COLUMN_IN_DATA_TABLE to 10L,
+        Phone.NUMBER to "123456789",
+        Phone.TYPE to Phone.TYPE_CUSTOM,
+        Phone.LABEL to null
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.getFieldFromData(PhoneField, ContactId("1"))
+
+    // Then
+    Assert.assertEquals(1, result.size)
+    Assert.assertEquals(DataId("10"), result.first().dataId)
+    Assert.assertEquals("123456789", result.first().number)
+    Assert.assertTrue(result.first().label is PhoneLabel.MalformedCustom)
+  }
+
+  @Test
+  fun `given phone row with null type and non-null label, when getFieldFromData, then maps to malformed type with label`() = runTest {
+    // Given
+    val cursor = cursorWithRows(
+      mapOf(
+        DataId.COLUMN_IN_DATA_TABLE to 10L,
+        Phone.NUMBER to "123456789",
+        Phone.TYPE to null,
+        Phone.LABEL to "SomeLabel"
+      )
+    )
+    every { contentResolver.query(any(), any(), any(), any(), any()) } returns cursor
+
+    // When
+    val result = repository.getFieldFromData(PhoneField, ContactId("1"))
+
+    // Then
+    Assert.assertEquals(1, result.size)
+    Assert.assertTrue(result.first().label is PhoneLabel.MalformedType)
+    Assert.assertEquals("SomeLabel", (result.first().label as PhoneLabel.MalformedType).label)
+  }
+
+  private fun cursorWithRows(vararg rows: Map<String, Any?>): Cursor {
+    val columnNames = rows.first().keys.toTypedArray()
+    val cursor = MatrixCursor(columnNames)
+
+    for (row in rows) {
+      val rowValues = columnNames.map { columnName -> row[columnName] }.toTypedArray()
+      cursor.addRow(rowValues)
+    }
+
+    return cursor
+  }
+}


### PR DESCRIPTION
# Why
fixes: https://github.com/expo/expo/issues/46372
The current label domain representation doesn't have a way to represent malformed label/type data.
Many providers enforce these fields to be non-null, but in the database they aren't marked as such.
# How

 - Added `getRequiredString`, `getNullableString` to explicitly narrow the Java `getString` function to
  proper Kotlin nullability.
- Added the following fields to all label domain classes  to represent malformed data:
  ```kotlin 
  class MalformedType(label: String?) : EventLabel(null, label)
  object MalformedCustom : EventLabel(Event.TYPE_CUSTOM)
  ``` 
- Updated the mappers accordingly:
    - if label is null for a custom type, the API returns null
    - if type itself is null, it falls back to the value in the label column
# Test Plan
Added Android unit tests using `MatrixCursor` to verify that `ContactRepository` handles null fields
  without throwing NPE ✅