### PR TITLE
chore(TV): bump RNTV dependency in CI

### DIFF
--- a/packages/expo-updates/e2e/setup/project.ts
+++ b/packages/expo-updates/e2e/setup/project.ts
@@ -361,7 +361,7 @@ async function preparePackageJson(
       dependencies: {
         ...packageJson.dependencies,
         glob: '^11.0.0',
-        'react-native': 'npm:react-native-tvos@0.85.2-0',
+        'react-native': 'npm:react-native-tvos@0.86.0-0rc2',
         '@react-native-tvos/config-tv': '^0.1.6',
       },
       expo: {


### PR DESCRIPTION
Bump React Native TV dependency to align with the current core version in main.