### PR TITLE
[contacts] Fix Android `Contact.getAllDetails` NPE when a row has an …

### DIFF
--- a/packages/expo-contacts/CHANGELOG.md
+++ b/packages/expo-contacts/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix Android `Contact.getAllDetails` crashing with a `NullPointerException` when a contact row has an unknown `TYPE` value and no custom `LABEL`. ([#46411](https://github.com/expo/expo/pull/46411) by [@mlecoq](https://github.com/mlecoq))
+
 ### 💡 Others
 
 ## 56.0.7 — 2026-05-21

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/event/EventField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/event/EventField.kt
@@ -33,7 +33,7 @@ object EventField : ExtractableField.Data<ExistingEvent> {
       Event.TYPE_BIRTHDAY -> EventLabel.Birthday
       Event.TYPE_OTHER -> EventLabel.Other
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Event.LABEL))
+        val customLabel = getString(getColumnIndexOrThrow(Event.LABEL)) ?: ""
         EventLabel.Custom(customLabel)
       }
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/nickname/NicknameField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/nickname/NicknameField.kt
@@ -32,7 +32,7 @@ object NicknameField : ExtractableField.Data<ExistingNickname> {
       Nickname.TYPE_SHORT_NAME -> NicknameLabel.ShortName
       Nickname.TYPE_INITIALS -> NicknameLabel.Initials
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Nickname.LABEL))
+        val customLabel = getString(getColumnIndexOrThrow(Nickname.LABEL)) ?: ""
         NicknameLabel.Custom(customLabel)
       }
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/phone/PhoneField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/phone/PhoneField.kt
@@ -47,7 +47,7 @@ object PhoneField : ExtractableField.Data<ExistingPhone> {
       Phone.TYPE_ASSISTANT -> PhoneLabel.Assistant
       Phone.TYPE_MMS -> PhoneLabel.Mms
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Phone.LABEL))
+        val customLabel = getString(getColumnIndexOrThrow(Phone.LABEL)) ?: ""
         PhoneLabel.Custom(customLabel)
       }
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/relationship/RelationField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/relationship/RelationField.kt
@@ -36,7 +36,7 @@ object RelationField : ExtractableField.Data<ExistingRelation> {
       Relation.TYPE_SISTER -> RelationLabel.Sister
       Relation.TYPE_SPOUSE -> RelationLabel.Spouse
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Relation.LABEL))
+        val customLabel = getString(getColumnIndexOrThrow(Relation.LABEL)) ?: ""
         RelationLabel.Custom(customLabel)
       }
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/structuredpostal/StructuredPostalField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/structuredpostal/StructuredPostalField.kt
@@ -38,7 +38,7 @@ object StructuredPostalField : ExtractableField.Data<ExistingStructuredPostal> {
       StructuredPostal.TYPE_WORK -> StructuredPostalLabel.Work
       StructuredPostal.TYPE_OTHER -> StructuredPostalLabel.Other
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(StructuredPostal.LABEL))
+        val customLabel = getString(getColumnIndexOrThrow(StructuredPostal.LABEL)) ?: ""
         StructuredPostalLabel.Custom(customLabel)
       }
     }

--- a/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/website/WebsiteField.kt
+++ b/packages/expo-contacts/android/src/main/java/expo/modules/contacts/next/domain/model/website/WebsiteField.kt
@@ -29,7 +29,7 @@ object WebsiteField : ExtractableField.Data<ExistingWebsite> {
       Website.TYPE_OTHER -> WebsiteLabel.Other
       Website.TYPE_PROFILE -> WebsiteLabel.Profile
       else -> {
-        val customLabel = getString(getColumnIndexOrThrow(Website.LABEL))
+        val customLabel = getString(getColumnIndexOrThrow(Website.LABEL)) ?: ""
         WebsiteLabel.Custom(customLabel)
       }
     }


### PR DESCRIPTION
…unknown TYPE with no LABEL (#46372)

# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

I encountered the same null pointer as described here:
https://github.com/expo/expo/issues/46372

# How

<!--
How did you build this feature or fix this bug and why?
-->
I had a feature which paginated all contacts from phone book. With legacy expo-contacts it was working and after migration I encountered a null pointer 

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

just run 
```
await getContactsAsync({
            pageSize: IMPORT_CONTACTS_PAGE_SIZE,
            pageOffset,
            fields: [
              Fields.Name,
              Fields.FirstName,
              Fields.LastName,
              Fields.PhoneNumbers,
              Fields.Image,
              Fields.Birthday,
              Fields.UrlAddresses,
              Fields.SocialProfiles,
              Fields.Emails,
              Fields.Addresses,
              Fields.JobTitle,
              Fields.Company,
            ],
            sort: SortTypes.FirstName,
            id: isImportingAllContacts.current ? undefined : selectedContacts,
          });
``` and check if the method returns contacts without error on android

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [x] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
