### PR TITLE
[modules-jsi] Fix build framework for macOS

### DIFF
--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - [iOS] Fixed the xcframework build failing with a `sed` error when building in an environment that uses GNU `sed` instead of BSD `sed` (e.g. a Nix shell). ([#46389](https://github.com/expo/expo/pull/46389) by [@niteshbalusu11](https://github.com/niteshbalusu11))
 - [iOS] Propagate `JavaScriptPromise` setup failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
+- Fix build framework for macOS ([#46413](https://github.com/expo/expo/pull/46413) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -4,6 +4,7 @@
 #ifdef __cplusplus
 
 #include <hermes/hermes.h>
+#include <TargetConditionals.h>
 
 #include "HostFunctionClosure.h"
 #include "CppError.h"

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI-Cxx/include/JSIUtils.h
@@ -68,6 +68,16 @@ inline jsi::Value getProperty(jsi::IRuntime &runtime, const jsi::Array &array, c
   return array.getProperty(runtime, name);
 }
 
+#if TARGET_OS_OSX
+// react-native-macos (RN 0.81) lacks `jsi::Object::getProperty(Runtime&, const Value&)`,
+// so Swift can't look up a property by a JS Value. Provide a `const char*`-keyed wrapper
+// to use when iterating own property names.
+// TODO: remove when react-native-macos catches up to RN 0.85.
+inline jsi::Value getProperty(jsi::IRuntime &runtime, const jsi::Object &object, const char *name) {
+  return object.getProperty(runtime, name);
+}
+#endif
+
 inline jsi::Value valueFromArray(jsi::IRuntime &runtime, const jsi::Array &array) {
   return jsi::Value(runtime, array);
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
@@ -142,7 +142,12 @@ extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresenta
     for index in 0..<size {
       let jsiKey = propertyNames.getValueAtIndex(runtime, index)
       let key = String.fromJSIValue(jsiKey, in: runtime)
+      #if os(macOS)
+      // TODO: remove when bumping to react-native-macos 0.85
+      let jsiValue = expo.getProperty(runtime, object, key)
+      #else
       let jsiValue = object.getProperty(runtime, jsiKey)
+      #endif
 
       result[key] = Value.fromJSIValue(jsiValue, in: runtime)
     }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
@@ -75,7 +75,10 @@ extension UInt8: JSIRepresentableNumber {}
 extension UInt16: JSIRepresentableNumber {}
 extension UInt32: JSIRepresentableNumber {}
 extension UInt64: JSIRepresentableNumber {}
+#if !os(macOS)
+// Float16 is marked unavailable on macOS in the Swift standard library.
 extension Float16: JSIRepresentableNumber {}
+#endif
 extension Float32: JSIRepresentableNumber {}
 extension Float64: JSIRepresentableNumber {}
 extension CGFloat: JSIRepresentableNumber {}
@@ -127,6 +130,8 @@ extension Array: JSIRepresentable where Element: JSIRepresentable {
   }
 }
 
+// TODO: remove when bumping to react-native-macos 0.86
+#if !os(macOS)
 extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresentable {
   static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> [Key: Value] {
     let object = value.getObject(runtime)
@@ -154,3 +159,4 @@ extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresenta
     return facebook.jsi.Value(runtime, object)
   }
 }
+#endif

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Protocols/JSIRepresentable.swift
@@ -130,8 +130,6 @@ extension Array: JSIRepresentable where Element: JSIRepresentable {
   }
 }
 
-// TODO: remove when bumping to react-native-macos 0.86
-#if !os(macOS)
 extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresentable {
   static func fromJSIValue(_ value: borrowing facebook.jsi.Value, in runtime: facebook.jsi.IRuntime) -> [Key: Value] {
     let object = value.getObject(runtime)
@@ -164,4 +162,3 @@ extension Dictionary: JSIRepresentable where Key == String, Value: JSIRepresenta
     return facebook.jsi.Value(runtime, object)
   }
 }
-#endif

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -1,4 +1,4 @@
-// Copyright 2025-present 650 Industries. All rights reserved.
+``// Copyright 2025-present 650 Industries. All rights reserved.
 
 internal import ExpoModulesJSI_Cxx
 internal import jsi
@@ -243,12 +243,15 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
 
   /// Deletes a property with the given name. After calling this function,
   /// `hasProperty` will return `false`, and `getProperty` will return `undefined` value.
+  #if !os(macOS)
+  // TODO: remove when bumping to react-native-macos 0.86
   public func deleteProperty(_ name: String) {
     guard let runtime else {
       FatalError.runtimeLost()
     }
     pointee.deleteProperty(runtime.pointee, name)
   }
+  #endif
 
   public func defineProperty(_ name: String, descriptor: consuming JavaScriptObject) {
     guard let runtime else {

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -1,4 +1,4 @@
-``// Copyright 2025-present 650 Industries. All rights reserved.
+// Copyright 2025-present 650 Industries. All rights reserved.
 
 internal import ExpoModulesJSI_Cxx
 internal import jsi

--- a/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
+++ b/packages/expo-modules-jsi/apple/scripts/build-xcframework.sh
@@ -131,10 +131,20 @@ platform_slice_id() {
     iphonesimulator)  echo "ios-arm64_x86_64-simulator" ;;
     appletvos)        echo "tvos-arm64" ;;
     appletvsimulator) echo "tvos-arm64_x86_64-simulator" ;;
+    macosx)           echo "macos-arm64_x86_64" ;;
     *)
       log "error: No slice mapping for platform: $1"
       exit 1
       ;;
+  esac
+}
+
+# Resolves the xcodebuild build-products directory name for a given platform.
+# macOS uses no $EFFECTIVE_PLATFORM_NAME suffix; every other SDK appends one.
+platform_build_dir() {
+  case "$1" in
+    macosx)           echo "${CONFIGURATION}" ;;
+    *)                echo "${CONFIGURATION}-$1" ;;
   esac
 }
 
@@ -146,7 +156,8 @@ build_slice() {
   destination=$(platform_destination "$platform")
   local slice_id
   slice_id=$(platform_slice_id "$platform")
-  local build_dir_name="${CONFIGURATION}-${platform}"
+  local build_dir_name
+  build_dir_name=$(platform_build_dir "$platform")
 
   log "Building framework slice for ${platform}..."
 
@@ -180,7 +191,14 @@ build_slice() {
   local product_path="${BUILD_PRODUCTS_PATH}/${build_dir_name}"
   local framework_src="${product_path}/PackageFrameworks/${PACKAGE_NAME}.framework"
   local swiftmodule_src="${product_path}/${PACKAGE_NAME}.swiftmodule"
-  local generated_maps="${DERIVED_DATA_PATH}/Build/Intermediates.noindex/GeneratedModuleMaps-${platform}"
+  # GeneratedModuleMaps follows the same $EFFECTIVE_PLATFORM_NAME convention as
+  # build products: no suffix for macOS, "-${platform}" for everything else.
+  local generated_maps
+  if [[ "$platform" == "macosx" ]]; then
+    generated_maps="${DERIVED_DATA_PATH}/Build/Intermediates.noindex/GeneratedModuleMaps"
+  else
+    generated_maps="${DERIVED_DATA_PATH}/Build/Intermediates.noindex/GeneratedModuleMaps-${platform}"
+  fi
 
   if [[ ! -d "$framework_src" ]]; then
     log "error: xcodebuild did not produce ${framework_src}"
@@ -194,15 +212,28 @@ build_slice() {
   rm -rf "$staging_dir"
   mkdir -p "$staging_dir"
 
-  cp -r "$framework_src" "$staging_dir/"
+  # `cp -a` preserves symlinks, attributes, and timestamps. `cp -r` resolves
+  # symlinks into real files, which breaks the macOS versioned-framework bundle
+  # layout (top-level `Foo`, `Resources`, etc. must be symlinks into Versions/Current).
+  cp -a "$framework_src" "$staging_dir/"
   if [[ -d "${product_path}/${PACKAGE_NAME}.framework.dSYM" ]]; then
-    cp -r "${product_path}/${PACKAGE_NAME}.framework.dSYM" "$staging_dir/"
+    cp -a "${product_path}/${PACKAGE_NAME}.framework.dSYM" "$staging_dir/"
+  fi
+
+  # Modules and Headers live at the framework root on flat (iOS/tvOS) bundles
+  # and inside Versions/A on versioned (macOS) bundles.
+  local framework_root="${staging_dir}/${PACKAGE_NAME}.framework"
+  local content_root
+  if [[ "$platform" == "macosx" ]]; then
+    content_root="${framework_root}/Versions/A"
+  else
+    content_root="${framework_root}"
   fi
 
   # Copy Swift module interfaces and generated headers into the staged framework.
-  local modules_dir="${staging_dir}/${PACKAGE_NAME}.framework/Modules"
+  local modules_dir="${content_root}/Modules"
   mkdir -p "$modules_dir"
-  cp -r "$swiftmodule_src/" "${modules_dir}/${PACKAGE_NAME}.swiftmodule"
+  cp -a "$swiftmodule_src/" "${modules_dir}/${PACKAGE_NAME}.swiftmodule"
   rm -rf "${modules_dir}/${PACKAGE_NAME}.swiftmodule/Project"
 
   # Remove private/package interfaces which reference package-internal and C++ types
@@ -229,10 +260,19 @@ build_slice() {
     mv "$stripped_swiftinterface" "$swiftinterface"
   done < <(find "${modules_dir}/${PACKAGE_NAME}.swiftmodule" -name '*.swiftinterface')
 
-  local headers_dir="${staging_dir}/${PACKAGE_NAME}.framework/Headers"
+  local headers_dir="${content_root}/Headers"
   mkdir -p "$headers_dir"
   cp "${generated_maps}/${PACKAGE_NAME}-Swift.h" "$headers_dir/"
   cp "${generated_maps}/${PACKAGE_NAME}.modulemap" "$headers_dir/module.modulemap"
+
+  # Add the top-level Headers/Modules symlinks expected on versioned macOS
+  # frameworks. xcodebuild already set up ExpoModulesJSI -> Versions/Current/...
+  # and Resources -> Versions/Current/Resources, but not Headers/Modules since
+  # the SPM build doesn't emit those at that point.
+  if [[ "$platform" == "macosx" ]]; then
+    ln -sfn "Versions/Current/Headers" "${framework_root}/Headers"
+    ln -sfn "Versions/Current/Modules" "${framework_root}/Modules"
+  fi
 
   echo "$current_hash" > "${staging_dir}/.build-hash"
 

--- a/packages/expo-modules-jsi/apple/scripts/xcframework-helpers.sh
+++ b/packages/expo-modules-jsi/apple/scripts/xcframework-helpers.sh
@@ -33,6 +33,7 @@ EXPO_MODULES_JSI_KNOWN_SLICES=(
   "ios-arm64_x86_64-simulator|ios|simulator|arm64 x86_64"
   "tvos-arm64|tvos||arm64"
   "tvos-arm64_x86_64-simulator|tvos|simulator|arm64 x86_64"
+  "macos-arm64_x86_64|macos||arm64 x86_64"
 )
 
 # Slice IDs the xcframework must always declare, even when only a subset has
@@ -44,6 +45,7 @@ EXPO_MODULES_JSI_REQUIRED_SLICE_IDS=(
   "ios-arm64_x86_64-simulator"
   "tvos-arm64"
   "tvos-arm64_x86_64-simulator"
+  "macos-arm64_x86_64"
 )
 
 # xcframework_slice_descriptor SLICE_ID


### PR DESCRIPTION
# Why

While trying to get macOS running again on main, I ran into some issues building modules-jsi 

# How

Update build-xcframework scripts to work with macOS and add platform checks to JavaScriptObject/JSIRepresentable 


# Test Plan

Run BareExpo macOS locally 

<img width="1124" height="770" alt="image" src="https://github.com/user-attachments/assets/075f8273-d4f1-4a8a-bd20-aa3c3a6af9a4" />


# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
