### PR TITLE
[expo] Restore RCTHostRuntimeDelegate conformance for react-native-macos

### DIFF
--- a/packages/expo/CHANGELOG.md
+++ b/packages/expo/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 💡 Others
 
+- Restore RCTHostRuntimeDelegate conformance for react-native-macos ([#46420](https://github.com/expo/expo/pull/46420) by [@gabrieldonadel](https://github.com/gabrieldonadel))
+
 ## 56.0.5 — 2026-05-26
 
 ### 💡 Others

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.h
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.h
@@ -7,6 +7,11 @@
 @protocol RCTHostRuntimeDelegate;
 
 NS_SWIFT_NAME(ExpoReactNativeFactoryObjC)
+#if !TARGET_OS_OSX
 @interface EXReactNativeFactory : RCTReactNativeFactory <RCTHostDelegate>
+#else
+// TODO: remove when bumping to react-native-macos 0.85
+@interface EXReactNativeFactory : RCTReactNativeFactory <RCTHostDelegate, RCTHostRuntimeDelegate>
+#endif
 
 @end

--- a/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
+++ b/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm
@@ -28,6 +28,14 @@
 
 #pragma mark - RCTHostDelegate
 
+#if TARGET_OS_OSX
+// TODO: remove when bumping react-native-macos to 0.85
+- (void)hostDidStart:(nonnull RCTHost *)host
+{
+  host.runtimeDelegate = self;
+}
+#endif
+
 // [JS thread]
 - (void)host:(nonnull RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime
 {


### PR DESCRIPTION
# Why

We dropped the `RCTHostRuntimeDelegate` conformance from `EXReactNativeFactory` while upgrading to React Native 0.85 because the protocol was merged into `RCTHostDelegate`.

The problem is that this is not available yet in `react-native-macos`, it still has `RCTHostDelegate` and `RCTHostRuntimeDelegate` as two separate protocols, and `host:didInitializeRuntime:` is only delivered to whatever object is assigned to `host.runtimeDelegate`. 

After #43838 the factory no longer conforms to that protocol and nothing assigns `runtimeDelegate`, so the callback never fires on macOS. That callback is the only place we call `AppContext.setRuntime`, which is the only place `global.expo` (and `EventEmitter`, `SharedObject`, `NativeModule`, the modules host object) gets installed, causing every Expo JS module to crash on first import because `globalThis.expo` is `undefined`.

# How

- Re-add `hostDidStart:`  when `TARGET_OS_OSX` so the host actually has somewhere to send `didInitializeRuntime:`.
-  Make`EXReactNativeFactory` conform to `RCTHostRuntimeDelegate` in addition to `RCTHostDelegate` when `TARGET_OS_OSX`.
 

Conditionally restore the workaround only when `TARGET_OS_OSX` is set:

# Test Plan

- macOS build: build and run `bare-expo` locally. Before this change the app loads the bundle and immediately throws `TypeError: Cannot read property 'EventEmitter' of undefined` from `expo-modules-core/src/EventEmitter.ts` because `globalThis.expo` is undefined. After this change `host:didInitializeRuntime:` fires, `AppContext.setRuntime` runs, `global.expo` is installed, and the JS bundle continues past that point.
 
- iOS build: should be a no-op. Verify `bare-expo` still builds and boots without compiler warnings about the protocol conformance.