### PR TITLE
[cli][metro-file-map] Preserve Watchman default for file map

### DIFF
--- a/packages/@expo/cli/CHANGELOG.md
+++ b/packages/@expo/cli/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### 🐛 Bug fixes
 
+- Preserve Metro's `useWatchman: null | undefined` semantics when creating Expo's file map.
+
 ### 💡 Others
 
 ## 56.1.12 — 2026-05-26

--- a/packages/@expo/cli/src/start/server/metro/__tests__/createFileMap-fork.test.ts
+++ b/packages/@expo/cli/src/start/server/metro/__tests__/createFileMap-fork.test.ts
@@ -1,0 +1,76 @@
+import FileMap from '@expo/metro-file-map';
+
+import createFileMap from '../createFileMap-fork';
+
+jest.mock('@expo/metro-file-map', () => {
+  const MockFileMap = jest.fn();
+  (MockFileMap as any).H = {
+    NATIVE_PLATFORM: 'native',
+  };
+
+  return {
+    __esModule: true,
+    default: MockFileMap,
+    DependencyPlugin: jest.fn(),
+    DiskCacheManager: jest.fn(),
+    HastePlugin: jest.fn(),
+  };
+});
+
+function createConfig(useWatchman: boolean | null | undefined) {
+  return {
+    fileMapCacheDirectory: '/tmp/metro-cache',
+    hasteMapCacheDirectory: '/tmp/haste-cache',
+    maxWorkers: 1,
+    projectRoot: '/project',
+    resetCache: false,
+    resolver: {
+      assetExts: [],
+      blacklistRE: null,
+      blockList: null,
+      dependencyExtractor: null,
+      enableGlobalPackages: false,
+      hasteImplModulePath: null,
+      platforms: [],
+      sourceExts: ['js'],
+      unstable_onDemandFilesystem: true,
+      useWatchman,
+    },
+    server: {
+      unstable_serverRoot: '/project',
+    },
+    unstable_fileMapPlugins: [],
+    unstable_perfLoggerFactory: null,
+    watcher: {
+      additionalExts: [],
+      healthCheck: {
+        enabled: false,
+        filePrefix: '.metro-health-check',
+        interval: 30000,
+        timeout: 5000,
+      },
+      unstable_autoSaveCache: {
+        enabled: false,
+      },
+      unstable_lazySha1: true,
+      watchman: {
+        deferStates: [],
+      },
+    },
+  } as any;
+}
+
+describe(createFileMap, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([undefined, null, true, false])(
+    'passes resolver.useWatchman %s through to FileMap',
+    (useWatchman) => {
+      createFileMap(createConfig(useWatchman), { watch: true });
+
+      expect(FileMap).toHaveBeenCalledWith(expect.objectContaining({ useWatchman }));
+    }
+  );
+});

--- a/packages/@expo/cli/src/start/server/metro/createFileMap-fork.ts
+++ b/packages/@expo/cli/src/start/server/metro/createFileMap-fork.ts
@@ -96,7 +96,7 @@ export default function createFileMap(config: ConfigT, options?: CreateFileMapOp
     resetCache: config.resetCache,
     rootDir: projectRoot,
     roots: config.watchFolders,
-    useWatchman: config.resolver.useWatchman ?? false,
+    useWatchman: config.resolver.useWatchman,
     watch,
     watchmanDeferStates: config.watcher.watchman.deferStates,
     // NOTE: (@expo/metro-file-map fork) New option is required for `scopeFallback: true` checks

--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Preserve Metro's `useWatchman: null | undefined` semantics so Watchman remains enabled by default while bypassing the native `find` code path.
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-15

--- a/packages/@expo/metro-file-map/build/index.js
+++ b/packages/@expo/metro-file-map/build/index.js
@@ -227,7 +227,7 @@ class FileMap extends events_1.default {
             healthCheck: options.healthCheck,
             perfLoggerFactory: options.perfLoggerFactory,
             resetCache: options.resetCache,
-            useWatchman: options.useWatchman ?? false,
+            useWatchman: options.useWatchman == null ? true : options.useWatchman,
             watch: !!options.watch,
             watchmanDeferStates: options.watchmanDeferStates ?? [],
             enableFallback,

--- a/packages/@expo/metro-file-map/src/__tests__/index.test.ts
+++ b/packages/@expo/metro-file-map/src/__tests__/index.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) 650 Industries, Inc. (Expo).
+ */
+
+import FileMap from '..';
+import nodeCrawl from '../crawlers/node';
+import watchmanCrawl from '../crawlers/watchman';
+import checkWatchmanCapabilities from '../lib/checkWatchmanCapabilities';
+
+jest.mock('../crawlers/node', () => jest.fn(async () => mockEmptyCrawlResult()));
+jest.mock('../crawlers/watchman', () => jest.fn(async () => mockEmptyCrawlResult()));
+jest.mock('../lib/checkWatchmanCapabilities', () =>
+  jest.fn(async () => ({ version: '2026.01.01.00' }))
+);
+
+function mockEmptyCrawlResult() {
+  return {
+    changedFiles: new Map(),
+    removedFiles: new Set(),
+    clocks: new Map(),
+  };
+}
+
+function createFileMap(useWatchman: boolean | null | undefined) {
+  return new FileMap({
+    cacheManagerFactory: () => ({
+      async read() {
+        return null;
+      },
+      async write() {},
+      async end() {},
+    }),
+    computeSha1: false,
+    enableSymlinks: false,
+    extensions: ['js'],
+    healthCheck: {
+      enabled: false,
+      filePrefix: '.metro-health-check',
+      interval: 30000,
+      timeout: 5000,
+    },
+    maxWorkers: 1,
+    resetCache: true,
+    retainAllFiles: true,
+    rootDir: '/project',
+    roots: ['/project'],
+    useWatchman,
+    watch: false,
+  });
+}
+
+describe(FileMap, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test.each([undefined, null])(
+    'treats useWatchman: %s as enabled to preserve Metro third-state semantics',
+    async (useWatchman) => {
+      await createFileMap(useWatchman).build();
+
+      expect(checkWatchmanCapabilities).toHaveBeenCalledTimes(1);
+      expect(watchmanCrawl).toHaveBeenCalledTimes(1);
+      expect(nodeCrawl).not.toHaveBeenCalled();
+    }
+  );
+
+  test('respects useWatchman: false', async () => {
+    await createFileMap(false).build();
+
+    expect(checkWatchmanCapabilities).not.toHaveBeenCalled();
+    expect(watchmanCrawl).not.toHaveBeenCalled();
+    expect(nodeCrawl).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@expo/metro-file-map/src/index.ts
+++ b/packages/@expo/metro-file-map/src/index.ts
@@ -322,7 +322,7 @@ export default class FileMap extends EventEmitter {
       healthCheck: options.healthCheck,
       perfLoggerFactory: options.perfLoggerFactory,
       resetCache: options.resetCache,
-      useWatchman: options.useWatchman ?? false,
+      useWatchman: options.useWatchman == null ? true : options.useWatchman,
       watch: !!options.watch,
       watchmanDeferStates: options.watchmanDeferStates ?? [],
       enableFallback,


### PR DESCRIPTION
# Why

Fixes #46429.

Expo SDK 56 intends to use Metro's `resolver.useWatchman` third state: `null | undefined` should still allow Watchman, while avoiding Metro's native `find` crawler path when Watchman is unavailable.

That state is currently lost in two places:

- `createFileMap-fork.ts` passes `config.resolver.useWatchman ?? false`
- `@expo/metro-file-map` stores `options.useWatchman ?? false`

As a result, the `null` value set by `@expo/metro-config` is collapsed to `false`, so projects that previously would have used Watchman now crawl with Node and watch with `NativeWatcher` on macOS. In Bun workspaces this can cause missed Fast Refresh updates and noisy refresh behavior.

# How

- Pass `resolver.useWatchman` through from Expo CLI to `@expo/metro-file-map` without nullish coalescing.
- Restore Metro's file-map semantics in the Expo fork: `useWatchman == null ? true : useWatchman`.
- Add tests for both the CLI handoff and `@expo/metro-file-map` behavior.

# Test Plan

- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/cli test -- src/start/server/metro/__tests__/createFileMap-fork.test.ts`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map test -- src/__tests__/index.test.ts`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/cli typecheck`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map typecheck`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/cli build`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map build`
