### PR TITLE
[metro-file-map] Ignore NativeWatcher directory events

### DIFF
--- a/packages/@expo/metro-file-map/CHANGELOG.md
+++ b/packages/@expo/metro-file-map/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Bug fixes
 
+- Ignore noisy directory events from the native file watcher to avoid unnecessary recrawls during development.
+
 ### 💡 Others
 
 ## 56.0.3 — 2026-05-15

--- a/packages/@expo/metro-file-map/build/watchers/NativeWatcher.js
+++ b/packages/@expo/metro-file-map/build/watchers/NativeWatcher.js
@@ -47,7 +47,6 @@ const common_1 = require("./common");
 const debug = require('debug')('Metro:NativeWatcher');
 const TOUCH_EVENT = 'touch';
 const DELETE_EVENT = 'delete';
-const RECRAWL_EVENT = 'recrawl';
 /**
  * NativeWatcher uses Node's native fs.watch API with recursive: true.
  *
@@ -114,24 +113,11 @@ class NativeWatcher extends AbstractWatcher_1.AbstractWatcher {
         try {
             const stat = await fs_1.promises.lstat(absolutePath);
             const type = (0, common_1.typeFromStat)(stat);
-            // Ignore files of an unrecognized type
-            if (!type) {
+            // Directory events are noisy and are ignored downstream by FileMap.
+            if (!type || type === 'd') {
                 return;
             }
             if (!(0, common_1.includedByGlob)(type, this.globs, this.dot, relativePath)) {
-                return;
-            }
-            // For directory "rename" events, notify that we need a recrawl since we
-            // wont' receive events for unmodified files underneath a moved (or
-            // cloned) directory. Renames are fired by the OS on moves, clones, and
-            // creations. We ignore "change" events because they indiciate a change
-            // to directory metadata, rather than its path or existence.
-            if (type === 'd' && event === 'rename') {
-                debug('Directory rename detected on %s, requesting recrawl', relativePath);
-                this.emitFileEvent({
-                    event: RECRAWL_EVENT,
-                    relativePath,
-                });
                 return;
             }
             this.emitFileEvent({

--- a/packages/@expo/metro-file-map/src/watchers/NativeWatcher.ts
+++ b/packages/@expo/metro-file-map/src/watchers/NativeWatcher.ts
@@ -18,7 +18,6 @@ const debug = require('debug')('Metro:NativeWatcher');
 
 const TOUCH_EVENT = 'touch';
 const DELETE_EVENT = 'delete';
-const RECRAWL_EVENT = 'recrawl';
 
 /**
  * NativeWatcher uses Node's native fs.watch API with recursive: true.
@@ -98,26 +97,12 @@ export default class NativeWatcher extends AbstractWatcher {
       const stat = await fsPromises.lstat(absolutePath);
       const type = typeFromStat(stat);
 
-      // Ignore files of an unrecognized type
-      if (!type) {
+      // Directory events are noisy and are ignored downstream by FileMap.
+      if (!type || type === 'd') {
         return;
       }
 
       if (!includedByGlob(type, this.globs, this.dot, relativePath)) {
-        return;
-      }
-
-      // For directory "rename" events, notify that we need a recrawl since we
-      // wont' receive events for unmodified files underneath a moved (or
-      // cloned) directory. Renames are fired by the OS on moves, clones, and
-      // creations. We ignore "change" events because they indiciate a change
-      // to directory metadata, rather than its path or existence.
-      if (type === 'd' && event === 'rename') {
-        debug('Directory rename detected on %s, requesting recrawl', relativePath);
-        this.emitFileEvent({
-          event: RECRAWL_EVENT,
-          relativePath,
-        });
         return;
       }
 

--- a/packages/@expo/metro-file-map/src/watchers/__tests__/NativeWatcher.test.ts
+++ b/packages/@expo/metro-file-map/src/watchers/__tests__/NativeWatcher.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 650 Industries, Inc. (Expo).
+ */
+
+import { vol } from 'memfs';
+
+import type { WatcherBackendChangeEvent } from '../../types';
+import NativeWatcher from '../NativeWatcher';
+
+function createWatcher(root: string): NativeWatcher {
+  return new NativeWatcher(root, {
+    dot: true,
+    globs: ['**/*.js'],
+    ignored: null,
+    watchmanDeferStates: [],
+  });
+}
+
+describe(NativeWatcher, () => {
+  const root = '/project';
+
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('does not emit changes for directory events', async () => {
+    vol.fromJSON({
+      '/project/src/file.js': '',
+    });
+
+    const watcher = createWatcher(root);
+    const events: WatcherBackendChangeEvent[] = [];
+    watcher.onFileEvent((event) => events.push(event));
+
+    await watcher._handleEvent('rename', 'src');
+
+    expect(events).toEqual([]);
+  });
+
+  it('still emits changes for watched files', async () => {
+    vol.fromJSON({
+      '/project/app.js': 'export default null;',
+    });
+
+    const watcher = createWatcher(root);
+    const events: WatcherBackendChangeEvent[] = [];
+    watcher.onFileEvent((event) => events.push(event));
+
+    await watcher._handleEvent('change', 'app.js');
+
+    expect(events).toEqual([
+      {
+        event: 'touch',
+        metadata: {
+          modifiedTime: expect.any(Number),
+          size: expect.any(Number),
+          type: 'f',
+        },
+        relativePath: 'app.js',
+        root,
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Why

Expo SDK 56 defaults to the Node native watcher path on macOS when Watchman is disabled. In that path, `NativeWatcher` currently turns directory `rename` events into `recrawl` events. Directory events from recursive `fs.watch`/FSEvents can be noisy during development, and a recrawl can surface unrelated generated or workspace files as Metro changes. That can cause repeated HMR invalidations or mobile UI flicker even when app source files did not change.

This follows the upstream Metro direction from facebook/metro#1646: watcher backends should not emit directory events while FileMap does not have consistent directory-change semantics downstream.

## What changed

- Ignore directory events in `NativeWatcher` instead of emitting `recrawl`.
- Keep regular watched file events unchanged.
- Add focused tests proving directory events are suppressed and `.js` file changes still emit.
- Add the package changelog entry and regenerated build output.

## Test Plan

- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map test -- src/watchers/__tests__/NativeWatcher.test.ts`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map test -- src/__tests__/Watcher.test.ts src/watchers/__tests__/NativeWatcher.test.ts`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map test`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map lint`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map typecheck`
- `mise x node@22.14.0 -- npm exec --yes pnpm@10 -- pnpm --filter @expo/metro-file-map build`
- `git diff --check`

Fixes #46429