### PR TITLE
fix(metro-config): esm createRequire dependency resolution

### DIFF
--- a/packages/@expo/metro-config/CHANGELOG.md
+++ b/packages/@expo/metro-config/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 🐛 Bug fixes
 
+- Collect dependencies from `createRequire`-bound require calls in server bundles ([#46129](https://github.com/expo/expo/issues/46129) by [@jeferson-sb](https://github.com/jeferson-sb))
 - Respect `enableBabelRCLookup` in `loadBabelConfig` to skip Babel config file discovery ([#44841](https://github.com/expo/expo/pull/44841) by [@zoontek](https://github.com/zoontek))
 - Fix mangled async chunk filenames for catch-all routes ([#43547](https://github.com/expo/expo/pull/43547) by [@hassankhan](https://github.com/hassankhan))
 - Fixed DOM Components rendering issues on Android 9 devices. ([#43156](https://github.com/expo/expo/pull/43156) by [@kudo](https://github.com/kudo))

--- a/packages/@expo/metro-config/src/transform-worker/__tests__/collect-dependencies-upstream.test.ts
+++ b/packages/@expo/metro-config/src/transform-worker/__tests__/collect-dependencies-upstream.test.ts
@@ -1405,6 +1405,57 @@ it('ignores require functions defined defined by lower scopes', () => {
   );
 });
 
+it('collects dependencies from createRequire-bound require calls', () => {
+  const ast = astFromCode(`
+    import { createRequire } from 'node:module';
+    const require = createRequire(import.meta.url);
+    const version = require('../package.json').version;
+    const otherDep = require('some-module');
+  `);
+  const { dependencies, dependencyMapName } = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    { name: 'node:module', data: objectContaining({ asyncType: null }) },
+    { name: '../package.json', data: objectContaining({ asyncType: null }) },
+    { name: 'some-module', data: objectContaining({ asyncType: null }) },
+  ]);
+  expect(codeFromAst(ast)).toEqual(
+    comparableCode(`
+      import { createRequire } from 'node:module';
+      const require = createRequire(import.meta.url);
+      const version = require(${dependencyMapName}[1], "../package.json").version;
+      const otherDep = require(${dependencyMapName}[2], "some-module");
+    `)
+  );
+});
+
+it('collects dependencies from module.createRequire factory pattern', () => {
+  const ast = astFromCode(`
+    import module from 'node:module';
+    const require = module.createRequire(import.meta.url);
+    const data = require('./data.json');
+  `);
+  const { dependencies } = collectDependencies(ast, {
+    ...opts,
+    dynamicRequires: 'warn',
+  });
+  expect(dependencies).toEqual([
+    { name: 'node:module', data: objectContaining({ asyncType: null }) },
+    { name: './data.json', data: objectContaining({ asyncType: null }) },
+  ]);
+});
+
+it('still ignores require shadowed by function expression or parameter', () => {
+  const ast = astFromCode(`
+    const require = function(name) { return {}; };
+    require('should-be-ignored');
+  `);
+  const { dependencies } = collectDependencies(ast, opts);
+  expect(dependencies).toEqual([]);
+});
+
 it('collects imports', () => {
   const ast = astFromCode(`
     import b from 'b/lib/a';

--- a/packages/@expo/metro-config/src/transform-worker/collect-dependencies.ts
+++ b/packages/@expo/metro-config/src/transform-worker/collect-dependencies.ts
@@ -316,10 +316,12 @@ function collectDependencies<TAst extends t.File>(
           return;
         }
 
-        if (name != null && state.dependencyCalls.has(name) && !path.scope.getBinding(name)) {
-          processRequireCall(path, state);
-
-          visited.add(path.node);
+        if (name != null && state.dependencyCalls.has(name)) {
+          const binding = path.scope.getBinding(name);
+          if (!binding || isRequireFactoryBinding(binding)) {
+            processRequireCall(path, state);
+            visited.add(path.node);
+          }
         }
       },
 
@@ -679,6 +681,16 @@ function warnDynamicRequire({ node }: NodePath<t.CallExpression>, message = '') 
   console.warn(
     `Dynamic import at line ${line || '<unknown>'}: ${generate(node).code}. This module may not work as intended when deployed to a runtime. ${message}`.trim()
   );
+}
+
+
+function isRequireFactoryBinding(binding: { path: NodePath<any> }): boolean {
+  const bindingPath = binding.path;
+  if (!bindingPath.isVariableDeclarator()) {
+    return false;
+  }
+  const init = bindingPath.get('init');
+  return init.isCallExpression();
 }
 
 function processRequireCall(path: NodePath<t.CallExpression>, state: State): void {


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

Fix #46129 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Detects the pattern: `const require = createRequire(import.meta.url)`
ESM packages use this to emulate CJS require. Dependencies from such calls should still be collected by the bundler.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

Regular unit tests and the project from the issue: https://github.com/floklein/expo-server-sdk-packagejson-bug

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [x] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [x] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
