### PR TITLE
[docs][android][brownfield] Update guide of using the integrated approach according to the bare minimum template

### DIFF
--- a/docs/public/static/diffs/brownfield/android/app-build-gradle.diff
+++ b/docs/public/static/diffs/brownfield/android/app-build-gradle.diff
@@ -23,7 +23,7 @@ index 57ed10f..cb9cbc6 100644
      debugImplementation libs.androidx.ui.test.manifest
  }
 
-+def projectRoot = rootDir.getAbsoluteFile().getAbsolutePath()
++def projectRoot = rootDir.getAbsoluteFile().getParentFile().getAbsolutePath()
 +react {
 +    entryFile = file(["node", "-e", "require('expo/scripts/resolveAppEntry')", projectRoot, "android", "absolute"].execute(null, rootDir).text.trim())
 +    reactNativeDir = new File(["node", "--print", "require.resolve('react-native/package.json')"].execute(null, rootDir).text.trim()).getParentFile().getAbsoluteFile()

--- a/docs/public/static/diffs/brownfield/android/main-application.diff
+++ b/docs/public/static/diffs/brownfield/android/main-application.diff
@@ -44,5 +44,5 @@ index f4a23c5..7f7d95c 100644
 +    override fun onConfigurationChanged(newConfig: Configuration) {
 +        super.onConfigurationChanged(newConfig)
 +        ApplicationLifecycleDispatcher.onConfigurationChanged(this, newConfig)
-     }
++    }
  }

--- a/docs/public/static/diffs/brownfield/android/main-application.diff
+++ b/docs/public/static/diffs/brownfield/android/main-application.diff
@@ -10,40 +10,36 @@ index f4a23c5..7f7d95c 100644
 +import com.facebook.react.PackageList
 +import com.facebook.react.ReactApplication
 +import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
-+import com.facebook.react.ReactNativeHost
 +import com.facebook.react.ReactPackage
 +import com.facebook.react.ReactHost
 +import com.facebook.react.common.ReleaseLevel
 +import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
-+import com.facebook.react.defaults.DefaultReactNativeHost
 +import expo.modules.ApplicationLifecycleDispatcher
-+import expo.modules.ReactNativeHostWrapper
++import expo.modules.ExpoReactHostFactory
 
 -class MainApplication : Application() {
 +class MainApplication : Application(), ReactApplication {
++
++    override val reactHost: ReactHost by lazy {
++        ExpoReactHostFactory.getDefaultReactHost(
++            context = applicationContext,
++            packageList =
++                PackageList(this).packages.apply {
++                    // Packages that cannot be autolinked yet can be added manually here, for example:
++                    // add(MyReactNativePackage())
++                }
++        )
++    }
      override fun onCreate() {
          super.onCreate()
++        DefaultNewArchitectureEntryPoint.releaseLevel = try {
++            ReleaseLevel.valueOf(BuildConfig.REACT_NATIVE_RELEASE_LEVEL.uppercase())
++        } catch (e: IllegalArgumentException) {
++            ReleaseLevel.STABLE
++        }
 +        loadReactNative(this)
 +        ApplicationLifecycleDispatcher.onApplicationCreate(this)
 +    }
-+    override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
-+        this,
-+        object : DefaultReactNativeHost(this) {
-+            override fun getPackages(): List<ReactPackage> =
-+                PackageList(this).packages.apply {
-+                // Packages that cannot be autolinked yet can be added manually here, for example:
-+                // add(MyReactNativePackage())
-+                }
-+            override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
-+            override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
-+            override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-+        }
-+    )
-+
-+    override val reactHost: ReactHost
-+        get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)
-+
-+
 +
 +    override fun onConfigurationChanged(newConfig: Configuration) {
 +        super.onConfigurationChanged(newConfig)

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -12,8 +12,6 @@
 
 ### 💡 Others
 
-- [docs][android] Update guide of using the integrated approach according to the [bare minimum template](https://github.com/expo/expo/blob/main/templates/expo-template-bare-minimum/android)
-
 ## 56.0.15 — 2026-05-26
 
 ### 🎉 New features

--- a/packages/expo-brownfield/CHANGELOG.md
+++ b/packages/expo-brownfield/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### 💡 Others
 
+- [docs][android] Update guide of using the integrated approach according to the [bare minimum template](https://github.com/expo/expo/blob/main/templates/expo-template-bare-minimum/android)
+
 ## 56.0.15 — 2026-05-26
 
 ### 🎉 New features


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->
It seems like the guide is still using some code before RN 0.82, and the `projectRoot` resolution in `build.gradle` missed a `.getParentFile()`. 

# How

<!--
How did you build this feature or fix this bug and why?
-->

Updated the diff files used by the docs according to the [bare minimum template](https://github.com/expo/expo/blob/main/templates/expo-template-bare-minimum/android)

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

- Ran`pnpm dev` in the docs folder and checked the page.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

Besides adding a `changelog.md` entry, I think the rest doesn't apply to editing code/diff blocks in the docs.

- [x] I added a `changelog.md` entry ~and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)~
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
