### PR TITLE
[core] Fix iPad supported orientation fallback to universal Info.plist key

### DIFF
--- a/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
+++ b/packages/expo-modules-core/ios/AppDelegates/ExpoAppDelegateSubscriberManager.swift
@@ -462,9 +462,7 @@ public class ExpoAppDelegateSubscriberManager: NSObject {
    */
   @objc
   public static func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
-    let deviceOrientationMask = allowedOrientations(for: UIDevice.current.userInterfaceIdiom)
-    let universalOrientationMask = allowedOrientations(for: .unspecified)
-    let infoPlistOrientations = deviceOrientationMask.isEmpty ? universalOrientationMask : deviceOrientationMask
+    let infoPlistOrientations = allowedOrientations(for: UIDevice.current.userInterfaceIdiom)
 
     let parsedSubscribers = ExpoAppDelegateSubscriberRepository.subscribers.filter {
       $0.responds(to: #selector(UIApplicationDelegate.application(_:supportedInterfaceOrientationsFor:)))
@@ -487,13 +485,24 @@ func allowedOrientations(
   for userInterfaceIdiom: UIUserInterfaceIdiom,
   infoDictionary: [String: Any]? = Bundle.main.infoDictionary
 ) -> UIInterfaceOrientationMask {
-  // For now only iPad-specific orientations are supported
-  let deviceString = userInterfaceIdiom == .pad ? "~ipad" : ""
-  var mask: UIInterfaceOrientationMask = []
-  guard let orientations = infoDictionary?["UISupportedInterfaceOrientations\(deviceString)"] as? [String] else {
+  // For now only iPad-specific orientations are supported. When the `~ipad` key is absent,
+  // fall back to the universal `UISupportedInterfaceOrientations` key, matching how UIKit
+  // resolves device-specific keys. We additionally fall back when `~ipad` is present but
+  // resolves to no orientations, treating a malformed entry as if it were absent.
+  if userInterfaceIdiom == .pad,
+    let mask = orientationMask(forKey: "UISupportedInterfaceOrientations~ipad", in: infoDictionary),
+    !mask.isEmpty {
     return mask
   }
+  return orientationMask(forKey: "UISupportedInterfaceOrientations", in: infoDictionary) ?? []
+}
 
+private func orientationMask(forKey key: String, in infoDictionary: [String: Any]?) -> UIInterfaceOrientationMask? {
+  guard let orientations = infoDictionary?[key] as? [String] else {
+    return nil
+  }
+
+  var mask: UIInterfaceOrientationMask = []
   for orientation in orientations {
     switch orientation {
     case "UIInterfaceOrientationPortrait":

--- a/packages/expo-modules-core/ios/Tests/ExpoAppDelegateSubscriberManagerTests.swift
+++ b/packages/expo-modules-core/ios/Tests/ExpoAppDelegateSubscriberManagerTests.swift
@@ -221,6 +221,34 @@ final class ExpoAppDelegateSubscriberManagerTests {
   }
 
   @Test
+  func `allowed orientations fall back to the universal Info.plist key when the iPad key is empty`() {
+    let infoDictionary: [String: Any] = [
+      "UISupportedInterfaceOrientations": [
+        "UIInterfaceOrientationLandscapeLeft",
+        "UIInterfaceOrientationLandscapeRight"
+      ],
+      "UISupportedInterfaceOrientations~ipad": [String]()
+    ]
+    let result = allowedOrientations(for: .pad, infoDictionary: infoDictionary)
+    #expect(result == [.landscapeLeft, .landscapeRight])
+  }
+
+  @Test
+  func `allowed orientations fall back to the universal Info.plist key when the iPad key has only unrecognized values`() {
+    let infoDictionary: [String: Any] = [
+      "UISupportedInterfaceOrientations": [
+        "UIInterfaceOrientationLandscapeLeft",
+        "UIInterfaceOrientationLandscapeRight"
+      ],
+      "UISupportedInterfaceOrientations~ipad": [
+        "UIInterfaceOrientationBogus"
+      ]
+    ]
+    let result = allowedOrientations(for: .pad, infoDictionary: infoDictionary)
+    #expect(result == [.landscapeLeft, .landscapeRight])
+  }
+
+  @Test
   func willContinueUserActivityWithType() {
     let result = ExpoAppDelegateSubscriberManager.application(UIApplication.shared, willContinueUserActivityWithType: "test")
     #expect(result == true)


### PR DESCRIPTION
# Why

[#46306](https://github.com/expo/expo/pull/46306) landed on `main` with a test that contradicts its implementation, turning the iOS unit test suite red ([example run](https://github.com/expo/expo/actions/runs/26695076291/job/78678102615)).

The `allowedOrientationsFallsBackToUniversalInfoPlistKeyForIPad` test calls `allowedOrientations(for: .pad, infoDictionary:)` with only the universal `UISupportedInterfaceOrientations` key set (no `~ipad` variant) and expects the function to fall back to it. But `allowedOrientations(for:infoDictionary:)` never implemented that fallback — for `.pad` it looked up `UISupportedInterfaceOrientations~ipad`, found nothing, and returned an empty mask. The fallback logic lived only in the caller `application(_:supportedInterfaceOrientationsFor:)`, which the test bypasses, so the test could never pass.

# How

- Move the fallback into `allowedOrientations(for:infoDictionary:)`: for `.pad`, use `~ipad` when it resolves to a non-empty mask, otherwise fall back to the universal key.
- Extract an `orientationMask(forKey:in:)` helper that parses a key into a mask (or `nil` when the key is absent).
- Simplify the caller, which no longer needs to make two calls and pick between them.

When the `~ipad` key is absent this matches how UIKit resolves device-specific keys. When `~ipad` is present but resolves to no orientations we additionally fall back, treating a malformed entry as if it were absent — this is slightly more lenient than UIKit (which would report no supported orientations), and matches the pre-[#46306](https://github.com/expo/expo/pull/46306) caller, which fell back whenever the device-specific mask was empty. Both tests from #46306 now pass.

# Test Plan

`ExpoAppDelegateSubscriberManagerTests` (`allowedOrientationsUsesIPadInfoPlistKey`, `allowedOrientationsFallsBackToUniversalInfoPlistKeyForIPad`) pass via the iOS unit test suite.

iOS unit tests are still failing, but I'm addressing it in #46437
