### PR TITLE
[JSI] Throw instead of aborting on missing or non-callable property

### DIFF
--- a/packages/expo-modules-core/ios/Core/Conversions.swift
+++ b/packages/expo-modules-core/ios/Core/Conversions.swift
@@ -218,7 +218,7 @@ public struct Conversions {
         memcpy(arrayBuffer.data(), baseAddress, data.count)
       }
     }
-    let uint8ArrayCtor = runtime.global().getPropertyAsFunction("Uint8Array")
+    let uint8ArrayCtor = try runtime.global().getPropertyAsFunction("Uint8Array")
     return try uint8ArrayCtor.callAsConstructor(arrayBuffer.asValue())
   }
 

--- a/packages/expo-modules-core/ios/Tests/EventEmitterTests.swift
+++ b/packages/expo-modules-core/ios/Tests/EventEmitterTests.swift
@@ -285,10 +285,15 @@ private struct EventObserver: ~Copyable {
   let removeListener: JavaScriptFunction
   let removeAllListeners: JavaScriptFunction
 
-  init(emitter: consuming JavaScriptObject) {
-    self.addListener = emitter.getPropertyAsFunction("addListener")
-    self.removeListener = emitter.getPropertyAsFunction("removeListener")
-    self.removeAllListeners = emitter.getPropertyAsFunction("removeAllListeners")
+  init(emitter: consuming JavaScriptObject) throws {
+    // Resolve everything that can throw into locals first, then assign the stored properties in one
+    // uninterrupted block — a `~Copyable` type can't be left partially initialized on a throwing path.
+    let addListener = try emitter.getPropertyAsFunction("addListener")
+    let removeListener = try emitter.getPropertyAsFunction("removeListener")
+    let removeAllListeners = try emitter.getPropertyAsFunction("removeAllListeners")
+    self.addListener = addListener
+    self.removeListener = removeListener
+    self.removeAllListeners = removeAllListeners
     self.emitter = emitter
   }
 }
@@ -307,5 +312,5 @@ private func setupEventObserver(
 
   emitter.setProperty(functionName, value: observingFunction)
 
-  return EventObserver(emitter: emitter)
+  return try EventObserver(emitter: emitter)
 }

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [iOS] Propagate `JavaScriptPromise` setup failures instead of trapping the app. ([#46106](https://github.com/expo/expo/issues/46106) by [@qutrek](https://github.com/qutrek)) ([#46145](https://github.com/expo/expo/pull/46145) by [@mvincentong](https://github.com/mvincentong))
 - Fix build framework for macOS ([#46413](https://github.com/expo/expo/pull/46413) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix build framework for Mac Catalyst ([#46289](https://github.com/expo/expo/pull/46289) by [@theeket](https://github.com/theeket))
+- [iOS] Throw instead of aborting when `getPropertyAsFunction` targets a missing or non-callable property. ([#46437](https://github.com/expo/expo/pull/46437) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -117,6 +117,15 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptValue(runtime, pointee.getProperty(runtime.pointee, name))
   }
 
+  /// Returns the property of the object with the given prop name id,
+  /// or `undefined` value if the name is not a property of the object.
+  public func getProperty(_ propName: JavaScriptPropNameID) -> JavaScriptValue {
+    guard let runtime else {
+      FatalError.runtimeLost()
+    }
+    return JavaScriptValue(runtime, pointee.getProperty(runtime.pointee, propName.pointee))
+  }
+
   /// Accesses nested properties in a single subscript operation by traversing the object chain.
   /// This subscript provides a convenient way to access deeply nested properties without
   /// multiple chained calls to `getProperty()`. Each key in the chain is accessed sequentially,
@@ -174,22 +183,24 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     return JavaScriptObject(runtime, pointee.getProperty(runtime.pointee, propName.pointee).getObject(runtime.pointee))
   }
 
-  /// Same as `getProperty(name).getObject().getFunction()`.
-  public func getPropertyAsFunction(_ name: String) -> JavaScriptFunction {
-    guard let runtime else {
-      FatalError.runtimeLost()
+  /// Same as `getProperty(name).getObject().getFunction()`, but throws instead of aborting when the
+  /// property is missing or not callable.
+  public func getPropertyAsFunction(_ name: String) throws -> JavaScriptFunction {
+    let property = getProperty(name)
+    guard property.isFunction() else {
+      throw PropertyNotFunctionError(name: name)
     }
-    return JavaScriptFunction(runtime, pointee.getPropertyAsFunction(runtime.pointee, name))
+    return property.getFunction()
   }
 
-  /// Same as `getProperty(propName).getObject().getFunction()`.
-  public func getPropertyAsFunction(_ propName: JavaScriptPropNameID) -> JavaScriptFunction {
-    guard let runtime else {
-      FatalError.runtimeLost()
+  /// Same as `getProperty(propName).getObject().getFunction()`, but throws instead of aborting when the
+  /// property is missing or not callable.
+  public func getPropertyAsFunction(_ propName: JavaScriptPropNameID) throws -> JavaScriptFunction {
+    let property = getProperty(propName)
+    guard property.isFunction() else {
+      throw PropertyNotFunctionError(name: propName.utf8())
     }
-    let jsiFunction = pointee.getProperty(runtime.pointee, propName.pointee).getObject(runtime.pointee).getFunction(
-      runtime.pointee)
-    return JavaScriptFunction(runtime, jsiFunction)
+    return property.getFunction()
   }
 
   /// Returns a prototype of the object. Same as `Object.getPrototypeOf(object)` in JS.
@@ -526,5 +537,17 @@ extension JavaScriptObject: JSIRepresentable {
 
   func toJSIValue(in runtime: facebook.jsi.IRuntime) -> facebook.jsi.Value {
     return asJSIValue()
+  }
+}
+
+// MARK: - Errors
+
+extension JavaScriptObject {
+  public struct PropertyNotFunctionError: Error, CustomStringConvertible {
+    let name: String
+
+    public var description: String {
+      return "Property '\(name)' is not a function"
+    }
   }
 }

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptValue.swift
@@ -154,10 +154,22 @@ public final class JavaScriptValue: JavaScriptType, Equatable, Escapable, Error 
     guard let runtime else {
       FatalError.runtimeLost()
     }
+    // A primitive can't be an instance of anything, so bail out before touching globals — this keeps
+    // the predicate side-effect free for non-objects (e.g. it won't trigger a replaced constructor's getter).
+    guard isObject() else {
+      return false
+    }
+
     // Since the type names are limited to global constructors (Promise, Error, Array, etc.),
     // caching them to avoid creating new prop names on each call makes a lot of sense.
     let propName = JavaScriptPropNameID.cached(runtime, typeName)
-    return isObject() && getObject().instanceOf(runtime.global().getPropertyAsFunction(propName))
+
+    // A missing or non-callable global constructor means the value can't be its instance, so swallow
+    // the lookup error and report `false` rather than propagating it out of this predicate.
+    guard let constructor = try? runtime.global().getPropertyAsFunction(propName) else {
+      return false
+    }
+    return getObject().instanceOf(constructor)
   }
 
   // MARK: - Asserting conversions ("get functions")

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptArrayTests.swift
@@ -370,7 +370,7 @@ struct JavaScriptArrayTests {
   @Test
   func `array as value can be passed to functions`() throws {
     let array = try runtime.eval("[1, 2, 3]").getArray()
-    let stringify = runtime.global()
+    let stringify = try runtime.global()
       .getPropertyAsObject("JSON")
       .getPropertyAsFunction("stringify")
 
@@ -565,7 +565,7 @@ struct JavaScriptArrayTests {
   @Test
   func `array instanceof Array`() throws {
     let array = try runtime.eval("[1, 2, 3]").getArray()
-    let arrayConstructor = runtime.global().getPropertyAsFunction("Array")
+    let arrayConstructor = try runtime.global().getPropertyAsFunction("Array")
     #expect(array.asValue().getObject().instanceOf(arrayConstructor) == true)
   }
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptFunctionTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptFunctionTests.swift
@@ -11,7 +11,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.testFn = function() { return 42; }")
 
-    let fn = runtime.global().getPropertyAsFunction("testFn")
+    let fn = try runtime.global().getPropertyAsFunction("testFn")
     let result = try fn.call()
 
     #expect(result.isNumber() == true)
@@ -23,7 +23,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.double = function(x) { return x * 2; }")
 
-    let fn = runtime.global().getPropertyAsFunction("double")
+    let fn = try runtime.global().getPropertyAsFunction("double")
     let result = try fn.call(arguments: 21)
 
     #expect(result.getInt() == 42)
@@ -34,7 +34,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.sum = function(a, b, c) { return a + b + c; }")
 
-    let fn = runtime.global().getPropertyAsFunction("sum")
+    let fn = try runtime.global().getPropertyAsFunction("sum")
     let result = try fn.call(arguments: 10, 20, 12)
 
     #expect(result.getInt() == 42)
@@ -48,7 +48,7 @@ struct JavaScriptFunctionTests {
       "globalThis.obj = { value: 42 };"
     )
 
-    let fn = runtime.global().getPropertyAsFunction("getValue")
+    let fn = try runtime.global().getPropertyAsFunction("getValue")
     let obj = runtime.global().getPropertyAsObject("obj")
     let result = try fn.call(this: obj)
 
@@ -63,7 +63,7 @@ struct JavaScriptFunctionTests {
       "globalThis.obj = { value: 40 };"
     )
 
-    let fn = runtime.global().getPropertyAsFunction("add")
+    let fn = try runtime.global().getPropertyAsFunction("add")
     let obj = runtime.global().getPropertyAsObject("obj")
     let result = try fn.call(this: obj, arguments: 2)
 
@@ -75,7 +75,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.concat = function(a, b) { return a + ' ' + b; };")
 
-    let fn = runtime.global().getPropertyAsFunction("concat")
+    let fn = try runtime.global().getPropertyAsFunction("concat")
     let result = try fn.call(arguments: "hello", "world")
 
     #expect(result.getString() == "hello world")
@@ -86,7 +86,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.format = function(name, age) { return name + ' is ' + age + ' years old'; };")
 
-    let fn = runtime.global().getPropertyAsFunction("format")
+    let fn = try runtime.global().getPropertyAsFunction("format")
     let result = try fn.call(arguments: "Alice", 30)
 
     #expect(result.getString() == "Alice is 30 years old")
@@ -97,7 +97,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.makeObj = function(x) { return { value: x }; };")
 
-    let fn = runtime.global().getPropertyAsFunction("makeObj")
+    let fn = try runtime.global().getPropertyAsFunction("makeObj")
     let result = try fn.call(arguments: 42)
 
     #expect(result.isObject() == true)
@@ -109,7 +109,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.makeArray = function(a, b) { return [a, b]; };")
 
-    let fn = runtime.global().getPropertyAsFunction("makeArray")
+    let fn = try runtime.global().getPropertyAsFunction("makeArray")
     let result = try fn.call(arguments: 1, 2)
 
     #expect(result.isObject() == true)
@@ -124,7 +124,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.throwError = function() { throw new Error('Test error'); };")
 
-    let fn = runtime.global().getPropertyAsFunction("throwError")
+    let fn = try runtime.global().getPropertyAsFunction("throwError")
 
     #expect(throws: Error.self) {
       try fn.call()
@@ -136,7 +136,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.Person = function(name) { this.name = name; };")
 
-    let constructor = runtime.global().getPropertyAsFunction("Person")
+    let constructor = try runtime.global().getPropertyAsFunction("Person")
     let result = try constructor.callAsConstructor("Alice")
 
     #expect(result.isObject() == true)
@@ -148,7 +148,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.Point = function(x, y) { this.x = x; this.y = y; };")
 
-    let constructor = runtime.global().getPropertyAsFunction("Point")
+    let constructor = try runtime.global().getPropertyAsFunction("Point")
     let result = try constructor.callAsConstructor(10, 20)
 
     #expect(result.isObject() == true)
@@ -161,7 +161,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.Empty = function() { this.initialized = true; };")
 
-    let constructor = runtime.global().getPropertyAsFunction("Empty")
+    let constructor = try runtime.global().getPropertyAsFunction("Empty")
     let result = try constructor.callAsConstructor()
 
     #expect(result.isObject() == true)
@@ -173,7 +173,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.testFn = function() { return 1; }")
 
-    let fn = runtime.global().getPropertyAsFunction("testFn")
+    let fn = try runtime.global().getPropertyAsFunction("testFn")
     let value = fn.asValue()
 
     #expect(value.isObject() == true)
@@ -184,7 +184,7 @@ struct JavaScriptFunctionTests {
   func `asObject returns JavaScriptObject`() throws {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.testFn = function testFn() { return 1; }")
-    let fn = runtime.global().getPropertyAsFunction("testFn")
+    let fn = try runtime.global().getPropertyAsFunction("testFn")
 
     // Functions are objects in JavaScript
     #expect(fn.asObject().getProperty("name").getString() == "testFn")
@@ -203,7 +203,7 @@ struct JavaScriptFunctionTests {
       "globalThis.counter = globalThis.makeCounter();"
     )
 
-    let counter = runtime.global().getPropertyAsFunction("counter")
+    let counter = try runtime.global().getPropertyAsFunction("counter")
 
     let result1 = try counter.call()
     #expect(result1.getInt() == 1)
@@ -220,7 +220,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.noReturn = function() { let x = 1 + 1; };")
 
-    let fn = runtime.global().getPropertyAsFunction("noReturn")
+    let fn = try runtime.global().getPropertyAsFunction("noReturn")
     let result = try fn.call()
 
     #expect(result.isUndefined() == true)
@@ -231,7 +231,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.arrow = (x, y) => x + y;")
 
-    let fn = runtime.global().getPropertyAsFunction("arrow")
+    let fn = try runtime.global().getPropertyAsFunction("arrow")
     let result = try fn.call(arguments: 20, 22)
 
     #expect(result.getInt() == 42)
@@ -242,7 +242,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.asyncFn = async function(x) { return x * 2; };")
 
-    let fn = runtime.global().getPropertyAsFunction("asyncFn")
+    let fn = try runtime.global().getPropertyAsFunction("asyncFn")
     let result = try fn.call(arguments: 21)
 
     #expect(result.isObject() == true)
@@ -265,7 +265,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.testFn = function() { return 42; }")
 
-    let fn = runtime.global().getPropertyAsFunction("testFn")
+    let fn = try runtime.global().getPropertyAsFunction("testFn")
     let value = fn.toJavaScriptValue(in: runtime)
 
     #expect(value.isFunction() == true)
@@ -280,7 +280,7 @@ struct JavaScriptFunctionTests {
       "globalThis.myFunction.customProp = 'custom';"
     )
 
-    let fn = runtime.global().getPropertyAsFunction("myFunction")
+    let fn = try runtime.global().getPropertyAsFunction("myFunction")
     let obj = fn.asObject()
 
     // Functions have properties like 'name' and 'length'
@@ -293,7 +293,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.testBool = function(a, b) { return a && !b; };")
 
-    let fn = runtime.global().getPropertyAsFunction("testBool")
+    let fn = try runtime.global().getPropertyAsFunction("testBool")
     let result = try fn.call(arguments: true, false)
 
     #expect(result.getBool() == true)
@@ -304,7 +304,7 @@ struct JavaScriptFunctionTests {
     let runtime = JavaScriptRuntime()
     try runtime.eval("globalThis.checkArgs = function(a, b) { return [a === null, b === undefined]; };")
 
-    let fn = runtime.global().getPropertyAsFunction("checkArgs")
+    let fn = try runtime.global().getPropertyAsFunction("checkArgs")
     let result = try fn.call(arguments: JavaScriptValue.null, JavaScriptValue.undefined)
     let array = result.getArray()
 

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
@@ -101,7 +101,7 @@ struct JavaScriptObjectTests {
       let object = JavaScriptObject(runtime)
       let result = try runtime.eval("(function(x) { return x * 2; })")
       object.setProperty("double", value: result)
-      let fn = object.getPropertyAsFunction("double")
+      let fn = try object.getPropertyAsFunction("double")
       let callResult = try fn.call(arguments: 21)
       #expect(callResult.getInt() == 42)
     }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptRuntimeTests.swift
@@ -473,7 +473,7 @@ struct JavaScriptRuntimeTests {
           throw e;
         };
       """)
-    let throwTagged = runtime.global().getPropertyAsFunction("throwTagged")
+    let throwTagged = try runtime.global().getPropertyAsFunction("throwTagged")
 
     let hostObject = runtime.createHostObject(
       get: { _ in
@@ -505,7 +505,7 @@ struct JavaScriptRuntimeTests {
           throw e;
         };
       """)
-    let throwTagged = runtime.global().getPropertyAsFunction("throwTagged")
+    let throwTagged = try runtime.global().getPropertyAsFunction("throwTagged")
 
     let hostObject = runtime.createHostObject(
       get: { _ in .undefined },


### PR DESCRIPTION
# Why

The iOS unit test suite (`ExpoModulesJSI-Unit-Tests`) crashes the test host with `signal abrt`, cascade-failing the whole bundle (~428 reported "failures" that are really one process abort). Two negative-path tests added in [#46145](https://github.com/expo/expo/pull/46145) trigger it:

- `JavaScriptRuntimeTests.async function propagates promise construction failure` — sets `globalThis.Promise = undefined`, then constructing a `JavaScriptPromise` looks up `Promise`.
- `JavaScriptPromiseTests.wrapped promise setup throws when then is unavailable` — sets `promise.then = undefined`, then `setUpCallbacks()` looks up `then`.

Both bottom out in `JavaScriptObject.getPropertyAsFunction(...)`, which resolved the property with an unchecked `getProperty(...).getObject().getFunction()` chain. JSI's `Value::getObject()` is a hard `assert(isObject())` that calls `abort()` when the property is `undefined` or not callable — so instead of throwing a catchable error (the whole point of #46145), the process dies.

# How

The fix is entirely in Swift — no C++ changes:

- **`JavaScriptObject.getPropertyAsFunction(...)`** (both the `String` and `JavaScriptPropNameID` overloads): guard with the non-asserting `isFunction()` check (which is `isObject() && getObject().isFunction()`, safe on any value) before calling the asserting `getFunction()` conversion. On failure throw `PropertyNotFunctionError`. Both overloads are now `throws`. Because the bad case is caught before the assert, no C++ exception is ever raised and no error-bridging wrapper is needed.
- Added a `getProperty(_ propName:)` Swift helper so the prop-name overload composes from existing pieces.
- **`JavaScriptValue.is(_:)`**: kept as a non-throwing predicate — a missing/non-callable global constructor means "not an instance", so it returns `false` via `try?`.
- Production call sites already had `try`/`try!` covering their chains; updated the test call sites that store the function before calling it.
- `getPropertyAsFunction` is now throwing, so its `expo-modules-core` callers (`Conversions.dataToUint8Array`, `EventObserver` in tests) gain `try`.

> [!NOTE]
> `getPropertyAsObject` has the same latent assert-and-abort bug but isn't exercised by any current test, so it's left for a follow-up to keep this PR focused.

# Test Plan

Full `expo-modules-jsi` target (`pnpm test`) on the iOS Simulator: **469/469 tests pass across 24 suites**, both parallel (CI configuration) and serial — no `signal abrt`, no `getObject` assertion. The two previously-crashing tests now pass as designed.

<!-- disable:changelog-checks -->