### PR TITLE
[JSI] Throw instead of aborting on non-object property

### DIFF
--- a/packages/expo-modules-core/ios/Core/AppContext.swift
+++ b/packages/expo-modules-core/ios/Core/AppContext.swift
@@ -529,8 +529,8 @@ public final class AppContext: NSObject, EXAppContextProtocol, @unchecked Sendab
    */
   @JavaScriptActor
   private func installModuleClasses(in runtime: JavaScriptRuntime) throws {
-    let coreObject = runtime.global().getPropertyAsObject(EXGlobalCoreObjectPropertyName)
-    let sharedObjectClass = coreObject.getPropertyAsObject("SharedObject")
+    let coreObject = try runtime.global().getPropertyAsObject(EXGlobalCoreObjectPropertyName)
+    let sharedObjectClass = try coreObject.getPropertyAsObject("SharedObject")
     let sharedObjectBaseProto = sharedObjectClass.getProperty("prototype")
 
     // Stored as JavaScriptValue (a class) because JavaScriptObject is ~Copyable

--- a/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
+++ b/packages/expo-modules-core/ios/Core/DynamicTypes/DynamicSharedObjectType.swift
@@ -95,7 +95,7 @@ private func getBaseSharedType(_ appContext: AppContext, nativeType: AnySharedOb
 
 private func newBaseSharedObject(_ appContext: AppContext, nativeType: AnySharedObject.Type) throws -> JavaScriptObject? {
   let jsClass = try getBaseSharedType(appContext, nativeType: nativeType)
-  let prototype = jsClass.asObject().getPropertyAsObject("prototype")
+  let prototype = try jsClass.asObject().getPropertyAsObject("prototype")
   return try appContext.runtime.createObject(prototype: prototype)
 }
 

--- a/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
+++ b/packages/expo-modules-core/ios/JS/ExpoRuntimeInstaller.swift
@@ -30,7 +30,7 @@ internal class ExpoRuntimeInstaller: EXJavaScriptRuntimeManager {
    */
   @JavaScriptActor
   internal func installExpoModulesHostObject() throws {
-    let coreObject = runtime.global().getPropertyAsObject(EXGlobalCoreObjectPropertyName)
+    let coreObject = try runtime.global().getPropertyAsObject(EXGlobalCoreObjectPropertyName)
 
     if coreObject.hasProperty("modules") {
       // Host object already installed

--- a/packages/expo-modules-core/ios/Tests/JSValueEncoderTests.swift
+++ b/packages/expo-modules-core/ios/Tests/JSValueEncoderTests.swift
@@ -82,7 +82,7 @@ struct JSValueEncoderTests {
     let result = try encode(Outer(id: 1, inner: Inner(label: "hello"))).getObject()
 
     #expect(result.getProperty("id").getInt() == 1)
-    #expect(result.getPropertyAsObject("inner").getProperty("label").getString() == "hello")
+    #expect(try result.getPropertyAsObject("inner").getProperty("label").getString() == "hello")
   }
 
   // MARK: - Arrays
@@ -121,7 +121,7 @@ struct JSValueEncoderTests {
       let counts: [String: Int]
     }
     let result = try encode(Wrapper(counts: ["a": 1, "b": 2])).getObject()
-    let counts = result.getPropertyAsObject("counts")
+    let counts = try result.getPropertyAsObject("counts")
 
     #expect(counts.getProperty("a").getInt() == 1)
     #expect(counts.getProperty("b").getInt() == 2)
@@ -328,7 +328,7 @@ struct JSValueEncoderTests {
     }
 
     let result = try encode(Wrapper(point: CGPoint(x: 10, y: 20))).getObject()
-    let point = result.getPropertyAsObject("point")
+    let point = try result.getPropertyAsObject("point")
 
     #expect(point.getProperty("x").getDouble() == 10)
     #expect(point.getProperty("y").getDouble() == 20)
@@ -341,7 +341,7 @@ struct JSValueEncoderTests {
     }
 
     let result = try encode(Wrapper(size: CGSize(width: 100, height: 200))).getObject()
-    let size = result.getPropertyAsObject("size")
+    let size = try result.getPropertyAsObject("size")
 
     #expect(size.getProperty("width").getDouble() == 100)
     #expect(size.getProperty("height").getDouble() == 200)
@@ -354,7 +354,7 @@ struct JSValueEncoderTests {
     }
 
     let result = try encode(Wrapper(rect: CGRect(x: 1, y: 2, width: 3, height: 4))).getObject()
-    let rect = result.getPropertyAsObject("rect")
+    let rect = try result.getPropertyAsObject("rect")
 
     #expect(rect.getProperty("x").getDouble() == 1)
     #expect(rect.getProperty("y").getDouble() == 2)

--- a/packages/expo-modules-jsi/CHANGELOG.md
+++ b/packages/expo-modules-jsi/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix build framework for macOS ([#46413](https://github.com/expo/expo/pull/46413) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - Fix build framework for Mac Catalyst ([#46289](https://github.com/expo/expo/pull/46289) by [@theeket](https://github.com/theeket))
 - [iOS] Throw instead of aborting when `getPropertyAsFunction` targets a missing or non-callable property. ([#46437](https://github.com/expo/expo/pull/46437) by [@tsapeta](https://github.com/tsapeta))
+- [iOS] Throw instead of aborting when `getPropertyAsObject` targets a non-object property. ([#46438](https://github.com/expo/expo/pull/46438) by [@tsapeta](https://github.com/tsapeta))
 
 ### 💡 Others
 

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/JavaScriptRuntime.swift
@@ -284,7 +284,7 @@ open class JavaScriptRuntime: Equatable, @unchecked Sendable {
     }
 
     // Set native constructor as read-only, non-configurable, non-enumerable, non-writable property.
-    let prototype = klassObject.getPropertyAsObject("prototype")
+    let prototype = try klassObject.getPropertyAsObject("prototype")
     prototype.defineProperty(nativeConstructorKey, value: nativeConstructor)
 
     // If the base class is provided, set the inherited prototype.

--- a/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
+++ b/packages/expo-modules-jsi/apple/Sources/ExpoModulesJSI/Runtime/Values/JavaScriptObject.swift
@@ -167,20 +167,24 @@ public struct JavaScriptObject: JavaScriptType, Sendable, ~Copyable {
     }
   }
 
-  /// Same as `getProperty(name).getObject()`.
-  public func getPropertyAsObject(_ name: String) -> JavaScriptObject {
-    guard let runtime else {
-      FatalError.runtimeLost()
+  /// Same as `getProperty(name).getObject()`, but throws instead of aborting when the property is
+  /// not an object.
+  public func getPropertyAsObject(_ name: String) throws -> JavaScriptObject {
+    let property = getProperty(name)
+    guard property.isObject() else {
+      throw PropertyNotObjectError(name: name)
     }
-    return JavaScriptObject(runtime, pointee.getPropertyAsObject(runtime.pointee, name))
+    return property.getObject()
   }
 
-  /// Same as `getProperty(propName).getObject()`.
-  public func getPropertyAsObject(_ propName: JavaScriptPropNameID) -> JavaScriptObject {
-    guard let runtime else {
-      FatalError.runtimeLost()
+  /// Same as `getProperty(propName).getObject()`, but throws instead of aborting when the property is
+  /// not an object.
+  public func getPropertyAsObject(_ propName: JavaScriptPropNameID) throws -> JavaScriptObject {
+    let property = getProperty(propName)
+    guard property.isObject() else {
+      throw PropertyNotObjectError(name: propName.utf8())
     }
-    return JavaScriptObject(runtime, pointee.getProperty(runtime.pointee, propName.pointee).getObject(runtime.pointee))
+    return property.getObject()
   }
 
   /// Same as `getProperty(name).getObject().getFunction()`, but throws instead of aborting when the
@@ -548,6 +552,14 @@ extension JavaScriptObject {
 
     public var description: String {
       return "Property '\(name)' is not a function"
+    }
+  }
+
+  public struct PropertyNotObjectError: Error, CustomStringConvertible {
+    let name: String
+
+    public var description: String {
+      return "Property '\(name)' is not an object"
     }
   }
 }

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptFunctionTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptFunctionTests.swift
@@ -49,7 +49,7 @@ struct JavaScriptFunctionTests {
     )
 
     let fn = try runtime.global().getPropertyAsFunction("getValue")
-    let obj = runtime.global().getPropertyAsObject("obj")
+    let obj = try runtime.global().getPropertyAsObject("obj")
     let result = try fn.call(this: obj)
 
     #expect(result.getInt() == 42)
@@ -64,7 +64,7 @@ struct JavaScriptFunctionTests {
     )
 
     let fn = try runtime.global().getPropertyAsFunction("add")
-    let obj = runtime.global().getPropertyAsObject("obj")
+    let obj = try runtime.global().getPropertyAsObject("obj")
     let result = try fn.call(this: obj, arguments: 2)
 
     #expect(result.getInt() == 42)

--- a/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
+++ b/packages/expo-modules-jsi/apple/Tests/JavaScriptObjectTests.swift
@@ -86,13 +86,23 @@ struct JavaScriptObjectTests {
     }
 
     @Test
-    func `get property as object`() {
+    func `get property as object`() throws {
       let object = JavaScriptObject(runtime)
       let nested = JavaScriptObject(runtime)
       nested.setProperty("inner", value: "value")
       object.setProperty("nested", nested)
-      let retrieved = object.getPropertyAsObject("nested")
+      let retrieved = try object.getPropertyAsObject("nested")
       #expect(retrieved.getProperty("inner").getString() == "value")
+    }
+
+    @Test
+    func `get property as object throws when property is not an object`() {
+      let object = JavaScriptObject(runtime)
+      object.setProperty("notAnObject", value: 42)
+
+      #expect(throws: Error.self) {
+        _ = try object.getPropertyAsObject("notAnObject")
+      }
     }
 
     @Test
@@ -205,12 +215,12 @@ struct JavaScriptObjectTests {
     }
 
     @Test
-    func `set property with object`() {
+    func `set property with object`() throws {
       let object = JavaScriptObject(runtime)
       let nested = JavaScriptObject(runtime)
       nested.setProperty("value", value: 42.0)
       object.setProperty("nested", nested)
-      #expect(object.getPropertyAsObject("nested").getProperty("value").getInt() == 42)
+      #expect(try object.getPropertyAsObject("nested").getProperty("value").getInt() == 42)
     }
 
     @Test


### PR DESCRIPTION
# Why

Follow-up to #46437. `JavaScriptObject.getPropertyAsObject` has the same latent assert-and-abort bug that #46437 fixed for `getPropertyAsFunction`: it resolved the property via an unchecked `getProperty(...).getObject()` chain, and JSI's `Value::getObject()` is a hard `assert(isObject())` that calls `abort()` when the property isn't an object. No current test exercises it, but any negative-path lookup (a non-object property) would crash the process instead of throwing.

> [!NOTE]
> Stacked on top of #46437 (base branch `tsapeta/jsi-throw-on-missing-property`). Review/merge that one first.

# How

Mirrors the `getPropertyAsFunction` fix — entirely in Swift, no C++:

- **`JavaScriptObject.getPropertyAsObject(...)`** (both `String` and `JavaScriptPropNameID` overloads): guard with the non-asserting `isObject()` check before the asserting `getObject()` conversion. On failure throw `PropertyNotObjectError`. Both overloads are now `throws`.
- Updated the call sites that weren't already covered by a `try`/`try!` in their expression.
- Added a test asserting the throw for a non-object property.
- `getPropertyAsObject` is now throwing, so its `expo-modules-core` callers (`AppContext`, `DynamicSharedObjectType`, `ExpoRuntimeInstaller`, and tests) gain `try`.

# Test Plan

Full `expo-modules-jsi` target (`pnpm test`) on the iOS Simulator: **470/470 tests pass across 24 suites** (the +1 is the new throwing-case test) — no `signal abrt`, no `getObject` assertion.

