### PR TITLE
[expo-dev-launcher] Fix Platform.OS resolving to ios on react-native-macos

### DIFF
--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### 🐛 Bug fixes
 
-- [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro.
+- [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro. ([#46443](https://github.com/expo/expo/pull/46443) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-dev-launcher/CHANGELOG.md
+++ b/packages/expo-dev-launcher/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### 🐛 Bug fixes
 
+- [iOS] Use `RCTPlatformName` instead of hardcoding `ios` when requesting bundles from Metro.
 - [iOS] Cleared the deep-link URL from cached `launchOptions` after it is consumed ([#46265](https://github.com/expo/expo/pull/46265) by [@gabrieldonadel](https://github.com/gabrieldonadel))
 - [Android] Fixed a crash when cold-launching a development build from a deep link that carries intent categories (e.g. an App Link opened from a browser). ([#46314](https://github.com/expo/expo/pull/46314) by [@lilianchiassai-fc](https://github.com/lilianchiassai-fc) & [#46328](https://github.com/expo/expo/pull/46328) by [@lukmccall](https://github.com/lukmccall))
 

--- a/packages/expo-dev-launcher/ios/EXDevLauncherController.m
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherController.m
@@ -424,7 +424,8 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
     RCTDevLoadingViewSetEnabled(NO);
     [self.recentlyOpenedAppsRegistry appWasOpened:[expoUrl absoluteString] queryParams:devLauncherUrl.queryParams manifest:nil];
     if ([expoUrl.path isEqual:@"/"] || [expoUrl.path isEqual:@""]) {
-      [self _initAppWithUrl:expoUrl bundleUrl:[NSURL URLWithString:@"index.bundle?platform=ios&dev=true&minify=false" relativeToURL:expoUrl] manifest:nil];
+      NSString *bundlePath = [NSString stringWithFormat:@"index.bundle?platform=%@&dev=true&minify=false", RCTPlatformName];
+      [self _initAppWithUrl:expoUrl bundleUrl:[NSURL URLWithString:bundlePath relativeToURL:expoUrl] manifest:nil];
     } else {
       [self _initAppWithUrl:expoUrl bundleUrl:expoUrl manifest:nil];
     }
@@ -434,10 +435,11 @@ static const NSTimeInterval EXDevLauncherDefaultRequestTimeout = 10.0;
   };
 
   void (^launchExpoApp)(NSURL *, EXManifestsManifest *) = ^(NSURL *bundleURL, EXManifestsManifest *manifest) {
+    NSURL *resolvedBundleURL = [EXDevLauncherURLHelper bundleURL:bundleURL withResolvedPlatform:RCTPlatformName];
     self->_shouldPreferUpdatesInterfaceSourceUrl = !manifest.isUsingDeveloperTool;
     RCTDevLoadingViewSetEnabled(manifest.isUsingDeveloperTool);
     [self.recentlyOpenedAppsRegistry appWasOpened:[expoUrl absoluteString] queryParams:devLauncherUrl.queryParams manifest:manifest];
-    [self _initAppWithUrl:expoUrl bundleUrl:bundleURL manifest:manifest];
+    [self _initAppWithUrl:expoUrl bundleUrl:resolvedBundleURL manifest:manifest];
     if (onSuccess) {
       onSuccess();
     }

--- a/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
+++ b/packages/expo-dev-launcher/ios/EXDevLauncherURLHelper.swift
@@ -71,6 +71,28 @@ public class EXDevLauncherURLHelper: NSObject {
     return components.url ?? url
   }
 
+  // Expo CLI's manifest endpoint only accepts `ios`/`android`/`web`, so on
+  // platforms like `macos` we ask it for `ios` and rewrite the `platform`
+  // query param on the bundle URL it returns to match the actual runtime.
+  @objc
+  public static func bundleURL(_ bundleURL: URL, withResolvedPlatform platform: String) -> URL {
+    guard !bundleURL.isFileURL,
+          var components = URLComponents(url: bundleURL, resolvingAgainstBaseURL: false),
+          var queryItems = components.queryItems else {
+      return bundleURL
+    }
+    var didReplace = false
+    for i in queryItems.indices where queryItems[i].name == "platform" {
+      queryItems[i] = URLQueryItem(name: "platform", value: platform)
+      didReplace = true
+    }
+    guard didReplace else {
+      return bundleURL
+    }
+    components.queryItems = queryItems
+    return components.url ?? bundleURL
+  }
+
   @objc
   public static func getQueryParamsForUrl(_ url: URL) -> [String: String] {
     guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),

--- a/packages/expo-dev-launcher/ios/Unsafe/RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.m
+++ b/packages/expo-dev-launcher/ios/Unsafe/RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.m
@@ -7,6 +7,7 @@
 #import <EXDevLauncher/RCTPackagerConnection+EXDevLauncherPackagerConnectionInterceptor.h>
 #import <EXDevLauncher/EXDevLauncherController.h>
 
+#import <React/RCTConstants.h>
 #import <React/RCTReconnectingWebSocket.h>
 
 #import <objc/runtime.h>
@@ -22,7 +23,7 @@ static RCTReconnectingWebSocket *createSocketForURL(NSURL * url)
   components.scheme = ([scheme isEqualToString:@"https"] || [scheme isEqualToString:@"exps"]) ? @"https" : @"http";
   components.port =  [url port];
   components.path = @"/message";
-  components.queryItems = @[[NSURLQueryItem queryItemWithName:@"role" value:@"ios"]];
+  components.queryItems = @[[NSURLQueryItem queryItemWithName:@"role" value:RCTPlatformName]];
   static dispatch_queue_t queue;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{


### PR DESCRIPTION
# Why

When using dev-client on macos, `Platform.OS` gets resolved to `ios` and Metro served `App.tsx` instead of `App.macos.tsx`. The same project running without dev-client (straight `RCTBundleURLProvider`) resolved `macos` correctly, so the regression was isolated to the launcher.

Currently, `dev-launcher` hardcodes `ios` in three places when interacting with Metro. The hardcodes predate macOS support and don't need to exist.

# How

Update launcher to use `RCTPlatformName` instead of an `iOS` string directly in:

- `launchReactNativeApp` (`?platform=`).
- The packager-connection WebSocket `role` query, so HMR/reload messages register against the right client.
- The manifest-driven bundle URL in `launchExpoApp` 

In the future whenever we extend `RuntimePlatform` and the surrounding CLI plumbing to accept `macos` end-to-end, the rewrite step will become redundant, and we can remove it.


# Test Plan

- Built `apps/bare-expo/macos/` against react-native-macos and launched the dev-client.
- Opened a Metro dev URL through the dev-launcher and confirmed:
  - `Platform.OS` renders as `macos` in `App.macos.tsx`.
  - Metro logs the bundle request as `?platform=macos` and resolves the `.macos` variant.
  - HMR / reload commands work (packager-connection `role=macos` is accepted).
- Built the iOS variant of the same app and confirmed no behavior change: bundle request still goes out as `?platform=ios` and the iOS bundle loads as before.
